### PR TITLE
docs: Swift test runner options at 8k tests, and the two macOS daemons that were burning the box

### DIFF
--- a/docs/perf/2026-08-29-swift-test-runner-options.md
+++ b/docs/perf/2026-08-29-swift-test-runner-options.md
@@ -35,8 +35,7 @@ such wherever they appear: the local full-suite baseline (8,437 tests in 818
 suites, 771 s) and the failure breakdown of that run (42 failures, all
 `Time limit was exceeded` or gate starvation, none a real defect). They come
 from the run that prompted this investigation. Reproducing them would have cost
-the build slot for no new information; §7 says what measurement would have been
-worth that cost.
+the build slot for no new information.
 
 Deliberately **not** measured: an A/B of the parallelism cap on the real suite.
 Doing that honestly needs the machine-global build slot for a cold rebuild plus
@@ -61,6 +60,14 @@ For a build that is exactly the intent. For a test run it means **the
 machine-global build slot is held for the whole test execution, not just the
 compile.**
 
+The wrapper already knows this hazard by name — for a *different* subcommand.
+`scripts/swift-safe` prints a warning on `run` saying it "holds the
+machine-global build slot until the program exits, not just until it finishes
+compiling; every other TBD worktree waits meanwhile", and points at building
+the product and then executing the binary. `test` has exactly the same shape:
+SwiftPM stays alive for the whole run. It gets no such warning, and it is the
+subcommand that stays alive for tens of minutes.
+
 Observed live during this investigation:
 
 - The holder was a sibling worktree running SwiftPM's test command with
@@ -81,6 +88,17 @@ misbehaviour. The structure is what produces the queue.
 The arithmetic is unforgiving: with one slot and holders that run for tens of
 minutes, wait time grows linearly with the number of worktrees that want to
 test, and there are 30 of them.
+
+**This repo has already diagnosed this and shipped a valve for it.**
+`docs/specs/2026-08-16-remote-verification-valve-design.md` opens with the same
+observation, and its snapshots of live contention match today's: a `swift test`
+holder with two or three lanes queued behind it, six of seven queued lanes
+being pure verification whose only output is a pass/fail bit. The valve lets a
+lane that has queued past a threshold leave the local queue and get its verdict
+from CI instead. It is **off by default** — `TBD_REMOTE_VERIFY=1` arms it, with
+a 300-second yield bound. The peer run that died at exit 75 after 1800 seconds,
+having compiled nothing, would have yielded at 300 seconds and come back with a
+verdict.
 
 ### B. The machine is oversubscribed, and that is not a tooling problem
 
@@ -106,9 +124,9 @@ The comparison that settles it: CI ran this same tree green on a **3-core**
 - quiet pass (tier 3, serial) — 80 tests in 23 suites, **56.7 s**
 - **8,427 tests, 260.0 s of test execution**
 
-Against a reported 8,437 tests in 818 suites in **771 s** locally. A runner with a quarter
-of the cores is three times faster. Whatever is wrong, it is not that SwiftPM
-is the wrong tool for 8,400 tests.
+Against a reported 8,437 tests in 818 suites in **771 s** locally. A runner
+with a quarter of the cores is three times faster. Whatever is wrong, it is not
+that SwiftPM is the wrong tool for 8,400 tests.
 
 ### C. In-process scheduling — real, secondary, and now fixable
 
@@ -252,28 +270,43 @@ workflow says local validation uses is on the disk and unused.
 
 Ranked by expected win per unit of cost and risk.
 
-**1. Stop holding the machine-global build slot for the duration of a test
-run.** Highest expected win by a wide margin, and it touches no test code. The
+**1. Turn on the remote verification valve that is already built.**
+`TBD_REMOTE_VERIFY=1` in the environment `scripts/test.sh` runs under. Cost:
+one environment variable and a clean tree; no code, no spec, no soak — the
+design is committed and the mechanism shipped. Expected win: converts the worst
+case of cost A from "1800 seconds, exit 75, nothing tested" into "300 seconds,
+then a CI verdict". It does not make the local slot any less contended, so it
+treats the symptom rather than the cause — but it is the only item on this list
+that is free, and the run that prompted this document is exactly the run it was
+built for. Start here. Note that `TBD_REMOTE_VERIFY` appears nowhere outside
+its own design spec — not in the root `CLAUDE.md`, not in `Tests/CLAUDE.md`'s
+Quick Reference — so it is default-off *and* effectively undiscoverable; if the
+soak is going well, saying so in the Quick Reference is part of this item.
+
+**2. Stop holding the machine-global build slot for the duration of a test
+run.** Largest structural win, and it touches no test code. The
 lock is admission control for *compilation*; a test run holds it through
 *execution* because the wrapper `execv`s SwiftPM. Splitting `scripts/test.sh`
 into a locked build of the test bundle followed by an unlocked run against the
-already-built bundle would return the slot after the compile. Cost: test
+already-built bundle would return the slot after the compile — which is the
+same remedy the wrapper already recommends to `run`. Cost: test
 execution is not free either, so removing it from admission control needs a
 decision about what the lock is for. Risk: real — this is load-bearing shared
 infrastructure. **Needs a spec via `/tbd-brainstorming`, with a human answering
 the questions.** Do not implement from this document.
 
-**2. Route local runs through the 6.3.3 toolchain CI already pins.** Removes an
-unintentional local/CI skew, and is the precondition for #3. Mechanically it is
+**3. Route local runs through the 6.3.3 toolchain CI already pins.** Removes an
+unintentional local/CI skew, and is the precondition for #4. Mechanically it is
 `TBD_SWIFT_BIN`, or `TOOLCHAINS` set to the toolchain's bundle identifier.
 Cost: one cold rebuild per worktree, and a possibility that something compiles
 differently under 6.3 that CI has been absorbing all along — unlikely, since CI
 builds this tree on 6.3.3 every run. Modest, mostly hygiene.
 
-**3. Set `SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH` once on 6.3.3.**
-Expected win: eliminates the `Time limit was exceeded` and gate-starvation
-failure class — 42 of 42 non-defect failures in the observed run — by keeping
-queue time out of every `.timeLimit` and every bounded wait. Expected non-win:
+**4. Set `SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH` once on 6.3.3.**
+Expected win, from the runner source rather than from measurement: it should
+retire the `Time limit was exceeded` and gate-starvation failure class — all 42
+failures reported from the run that prompted this — by keeping queue time out
+of every `.timeLimit` and every bounded wait. Expected non-win:
 wall time probably does not improve and may rise slightly (PR #1390: "does not
 generally impact execution time"), and reported per-test durations stay
 inflated. Cost: one environment variable, and it is `@_spi(Experimental)` with
@@ -282,14 +315,14 @@ Fits this repo's default-off-flag doctrine cleanly. **Also needs a spec** — it
 changes how the suite decides something, and picking the width is a theory
 call.
 
-**4. Mirror CI's two-pass split in the local default.** Already measured in
+**5. Mirror CI's two-pass split in the local default.** Already measured in
 this repo: p90 26.4 s → 14.6 s for +26 s of wall time. CI does it; local does
 not. Cheap, understood, and it is the only in-process-population remedy that
 works on 6.2.4. Its cost is real though — +26 s of wall on a machine where the
 scarce resource is the build slot, and under today's wrapper the slot is held
-across both passes. Sequence it after #1, not before.
+across both passes. Sequence it after #2, not before.
 
-**5. Do nothing about the box, but say plainly that it is the box.** Thirty
+**6. Do nothing about the box, but say plainly that it is the box.** Thirty
 worktrees, load 140, 40% system time, 17% idle. If local test latency is the
 thing that matters, the highest-leverage change is fewer concurrent worktrees
 or a second machine — not a runner. That is a workflow decision, not an
@@ -308,7 +341,7 @@ engineering one, and it belongs to the person running the fleet.
   that the width cap is *not* per-suite `.serialized` reheated: it bounds the
   process-global in-flight count, which is the thing `.serialized` provably
   could not shrink.
-- **Do not raise `.clockDriven`'s limit again.** If #3 lands, the pressure that
+- **Do not raise `.clockDriven`'s limit again.** If #4 lands, the pressure that
   drove it up should fall, and the right move then is to re-derive the triple
   downward, not to leave it where it is.
 
@@ -317,7 +350,7 @@ real suite, run on an idle machine — arms alternating uncapped and capped at
 some width, population held constant, reporting the executed test **count** per
 arm (a `--filter` matching nothing exits green), the count of
 `Time limit was exceeded` issues, and wall time. If capping does *not* reduce
-the time-limit failures, #3 is wrong and the reading of the runner source above
+the time-limit failures, #4 is wrong and the reading of the runner source above
 is wrong with it. That measurement is worth taking on a quiet box; it was not
 worth taking on this one.
 

--- a/docs/perf/2026-08-29-swift-test-runner-options.md
+++ b/docs/perf/2026-08-29-swift-test-runner-options.md
@@ -1,0 +1,345 @@
+# Are we using the wrong Swift test runner? — 2026-08-29
+
+Local `scripts/test.sh` runs on this development machine are slow enough that
+the developer has stopped trusting them and pushes to CI for a verdict instead.
+This document asks whether that is a tooling problem the Swift ecosystem has
+already solved, and answers it with measurements taken on 2026-08-29 against
+`996e9f99`.
+
+**Short answer: mostly no, with one real exception.**
+
+The single largest cost is not the test runner at all — it is queueing for the
+machine-global build slot on a box running 30 agent worktrees at roughly ten
+times CPU oversubscription. A 3-core GitHub runner executes the same 8,427
+tests in **260 seconds**; this 12-core M4 Pro takes **771 seconds** plus an
+unbounded wait for a mutex. No test runner fixes that.
+
+The exception is real and cheap: Swift Testing **did** grow a parallelism cap,
+in Swift 6.3. The claim in `Tests/CLAUDE.md` that Swift Testing runs "every
+non-serialized test in one process with **no concurrency cap**" was true when
+it was written and is still true of the toolchain local runs actually use
+(Xcode 26.3 / Swift 6.2.4), but it is **no longer true of the toolchain CI
+already runs on** (Xcode 26.6 / Swift 6.3.3). Local dev and CI are on different
+toolchains, and the newer one has the knob.
+
+## 1. What was measured, and how contaminated it is
+
+Every local number here was taken on a box carrying ~30 sibling agent
+worktrees. `Tests/CLAUDE.md` records a prior measurement invalidated by exactly
+this drift, so nothing below is a controlled timing comparison. The local
+figures are **occupancy and saturation observations**, which survive noise; the
+comparative timings are CI-versus-local, where the CI side is uncontended.
+
+Two figures are **reported rather than re-measured here**, and are labelled as
+such wherever they appear: the local full-suite baseline (8,437 tests in 818
+suites, 771 s) and the failure breakdown of that run (42 failures, all
+`Time limit was exceeded` or gate starvation, none a real defect). They come
+from the run that prompted this investigation. Reproducing them would have cost
+the build slot for no new information; §7 says what measurement would have been
+worth that cost.
+
+Deliberately **not** measured: an A/B of the parallelism cap on the real suite.
+Doing that honestly needs the machine-global build slot for a cold rebuild plus
+several full runs — roughly an hour of the exact resource this document
+identifies as the bottleneck, with three sessions already queued behind it and
+one already dead at exit 75. A number produced that way, at load 140, would not
+have discriminated anything. §7 says what measurement would.
+
+## 2. The costs decompose into three independent problems
+
+They get conflated as "local tests are slow". They have different fixes and
+different answers to "is there better tooling".
+
+### A. Queueing for the machine-global build slot — the dominant cost
+
+`scripts/swift-safe` holds one flock at `~/tbd/runtime/swift-build.lock` for
+the whole machine, and `scripts/test.sh` deliberately resolves the same path
+("a lock nobody else takes is not a lock"). The wrapper acquires the lock and
+then `execv`s SwiftPM, so the lock is held for that process's entire lifetime.
+
+For a build that is exactly the intent. For a test run it means **the
+machine-global build slot is held for the whole test execution, not just the
+compile.**
+
+Observed live during this investigation:
+
+- The holder was a sibling worktree running SwiftPM's test command with
+  `--jobs 8`, and had held the slot for **43 minutes** at the time of
+  observation.
+- Two to three `scripts/swift-safe` wrapper processes were queued behind it
+  continuously, with head-of-line waits of 21–25 minutes.
+- A peer session's filtered run — 3 suites, 25 tests, **0.577 s** of actual
+  test work — waited the full 1800 s timeout and exited **75** having compiled
+  nothing. For that run, 100% of the latency was the mutex and 0% was Swift
+  Testing, the test population, or the compiler.
+
+`TBD_SWIFT_JOBS=8` is exported from the machine owner's `~/.zshenv`, so the
+8-job holder is a sanctioned setting and not a bypass — `swift-safe` documents
+that value as a machine-wide ceiling the owner sets. Nothing here is
+misbehaviour. The structure is what produces the queue.
+
+The arithmetic is unforgiving: with one slot and holders that run for tens of
+minutes, wait time grows linearly with the number of worktrees that want to
+test, and there are 30 of them.
+
+### B. The machine is oversubscribed, and that is not a tooling problem
+
+Sampled with `top -l 1` while the above was in flight:
+
+- 12 cores, load average **111–165** across the observation window
+- **42.1% user, 40.8% sys, 17.1% idle** — the box is ~83% busy, and nearly half
+  of that is kernel time
+- 973 processes, **8,943 threads**
+- 30 directories under `~/tbd/worktrees/tbd`
+
+Forty per cent system time on a 12-core machine is about five cores burned in
+the kernel before any test runs. Top consumers during the sample included
+`fseventsd` (99% of a core), `XprotectService` (86%), Chrome (70%) and
+`WindowServer` (57%) — the per-worktree filesystem-event and scanning tax, not
+compilation.
+
+The comparison that settles it: CI ran this same tree green on a **3-core**
+`macos-26` runner (run `33232886152`, 2026-08-29):
+
+- fast pass 1 — 4,401 tests in 386 suites, **148.0 s**
+- fast pass 2 — 3,946 tests in 408 suites, **55.3 s**
+- quiet pass (tier 3, serial) — 80 tests in 23 suites, **56.7 s**
+- **8,427 tests, 260.0 s of test execution**
+
+Against a reported 8,437 tests in 818 suites in **771 s** locally. A runner with a quarter
+of the cores is three times faster. Whatever is wrong, it is not that SwiftPM
+is the wrong tool for 8,400 tests.
+
+### C. In-process scheduling — real, secondary, and now fixable
+
+This is the effect `Tests/CLAUDE.md` names "population is the scheduler", and
+its mechanism is confirmed by reading the runner source. It is the only one of
+the three that a test-runner change addresses. §3 is about it.
+
+## 3. Swift Testing's parallelism cap — what exists, and where
+
+### It exists, from Swift 6.3
+
+[swift-testing PR #1390](https://github.com/swiftlang/swift-testing/pull/1390),
+"Add an upper bound on the number of test cases we run in parallel", merged
+**2025-11-11**. It adds `Configuration.maximumParallelizationWidth`
+(`@_spi(Experimental)`) and a `Serializer` actor that gates test-case execution
+behind a width-limited continuation queue. From the PR: "Swift Testing's own
+tests go from > 300MB max memory usage to around 60MB."
+
+It is set three ways:
+
+- the environment variable `SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH`,
+  read directly by the testing library, documented by
+  [PR #1711](https://github.com/swiftlang/swift-testing/pull/1711) (merged
+  2026-05-12);
+- the testing library's own `--experimental-maximum-parallelization-width`
+  argument;
+- SwiftPM's hidden passthrough option of the same name — which is on SwiftPM
+  `main` but **not** in the SwiftPM shipped with 6.3.3 (verified by inspecting
+  the shipped `swift-package` binary's strings).
+
+On our toolchain the environment variable is therefore the only route, and it
+needs no SwiftPM support at all.
+
+**The default is uncapped.** The `NCORES * 2` bound the PR originally shipped
+is commented out on `release/6.3`, `release/6.4.1` and `main`; the default is
+`.max` unless the variable is set. So this is opt-in, not something a toolchain
+bump gives you for free.
+
+### Which branch has it
+
+- `release/6.2` — **absent**. `Sources/Testing/Support/Serializer.swift` does
+  not exist on that branch.
+- `release/6.3`, `release/6.3.1`, `release/6.4.x` — present.
+
+Verified against the binaries actually installed on this machine, not just the
+repository. The `Testing.framework` inside Xcode 26.3 (Swift 6.2.4) contains
+`isParallelizationEnabled` and `ParallelizationTrait` and **no**
+`maximumParallelizationWidth`, no
+`SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH`. The `libTesting.dylib` inside
+the swift.org 6.3.3 toolchain already sitting in
+`~/Library/Developer/Toolchains` contains all four symbols.
+
+### Where the gate sits, and what that does and does not fix
+
+From `Sources/Testing/Running/Runner.swift` on `release/6.3`:
+
+- `.testStarted` is posted at line 226, **before** any gate.
+- the width gate wraps `_runTestCase` at line 384
+  (`await testCaseSerializer.run { … }`).
+- `withTimeLimit(for:configuration:)` is applied inside `_runTestCase` at line
+  414, **after** the gate.
+
+Three consequences, and they are the whole reason to care:
+
+- **`Time limit was exceeded` starvation is fixed.** The `.timeLimit` clock —
+  including `.clockDriven`'s four minutes — does not start until the test has
+  passed the gate. A queued test burns none of its limit.
+- **In-test wall-clock deadlines stop starving.** `ciSafeDeadline`,
+  `waitForSuspension`, `FireRecorder.next()` and every bounded poll run inside
+  the test body, that is, after the gate. So does `TestClock.advance`'s
+  `Task.megaYield()` — capping the width caps how many clock-driven tests can
+  flood the cooperative pool at once, which is the self-starvation mechanism
+  `Tests/CLAUDE.md` documents.
+- **Reported per-test durations are NOT fixed.** Because `.testStarted`
+  precedes the gate, a gated test still "takes" its queue wait. The
+  590-second trivial test would still read 590 seconds. This is a known
+  reporting wart —
+  [issue #1780](https://github.com/swiftlang/swift-testing/issues/1780).
+
+That mapping matters: all 42 failures reported from the local run that prompted
+this were `Time limit was exceeded` or gate starvation, which is precisely the
+class this addresses, and none of them is the class it does not.
+
+### What is still missing upstream
+
+[Issue #1086, "Expose parallelism"](https://github.com/swiftlang/swift-testing/issues/1086)
+(open since 2025-04-21) asks for a way to *read* the width from inside a test.
+There is none, so a test that needs to size a resource pool to the width still
+has to be told the number out of band.
+
+## 4. The other options, and why they are not it
+
+- **`--num-workers`.** Exists in SwiftPM, and is **XCTest-only**. SwiftPM
+  rejects it outright for Swift Testing: `'--num-workers' is only supported
+  when testing with XCTest` (`Sources/Commands/SwiftTestCommand.swift`,
+  `validateArguments`). The XCTest `ParallelTestRunner` it drives really does
+  fork a process per test — that process-level sharding simply has no Swift
+  Testing equivalent.
+- **Process-per-target.** Not available. SwiftPM builds **one** test bundle per
+  package — `.build/debug/TBDPackageTests.xctest` — so all five test targets
+  land in one process by construction. The only supported way to split the
+  population across processes is separate SwiftPM test invocations with
+  `--filter`/`--skip`, which is exactly what CI's two-pass fast lane already
+  does.
+- **`xcodebuild` with a test plan.** `-parallel-testing-worker-count` and
+  `-maximum-parallel-testing-workers` spawn multiple runner processes, but
+  Xcode distributes work to them **per test class**, and Swift Testing runs
+  in-process within a bundle. Adopting `xcodebuild` for this package would mean
+  generating a scheme, rebuilding `scripts/test.sh`'s environment fence around
+  it, and getting sharding at a granularity that does not match how this suite
+  is organised. Not worth it.
+- **Bazel / `rules_swift`.** This is the honest ecosystem answer to
+  "8k tests, want process isolation and sharding": Bazel's `shard_count` plus
+  remote caching gives per-target test processes and real sharding. It is also
+  a build-system migration for a package that builds fine today, and it does
+  nothing about a box at load 140. No.
+- **Selective testing (Tuist, XcodeSelectiveTesting).** Run fewer tests by
+  fingerprinting what changed. Genuinely how large Swift shops keep suites
+  fast, and worth remembering — but it is a change to what gets verified, which
+  is a policy decision this repo should make deliberately, not a runner swap.
+
+## 5. What is available on our toolchain today
+
+- **Active local toolchain**: Xcode 26.3 at `/Applications/Xcode.app`,
+  Swift 6.2.4. `scripts/swift-safe` resolves `swift` from `PATH`
+  (`TBD_SWIFT_BIN`, else `shutil.which("swift")`), which lands here. **No
+  parallelism cap.**
+- **CI toolchain**: `.github/workflows/test.yml` pins
+  `sudo xcode-select -s /Applications/Xcode_26.6.app` — Swift 6.3.3. **Has the
+  cap.** The workflow comment says the pin "matches the swift.org 6.3.3
+  toolchain used for local validation".
+- **Already installed locally**:
+  `~/Library/Developer/Toolchains/swift-6.3.3-RELEASE.xctoolchain`, with
+  `swift-latest` symlinked to it. Nothing routes local builds through it —
+  `swift-safe` finds `/usr/bin/swift` first.
+
+So the local/CI toolchain skew is unintentional: the 6.3.3 toolchain the
+workflow says local validation uses is on the disk and unused.
+
+## 6. Ranked recommendation
+
+Ranked by expected win per unit of cost and risk.
+
+**1. Stop holding the machine-global build slot for the duration of a test
+run.** Highest expected win by a wide margin, and it touches no test code. The
+lock is admission control for *compilation*; a test run holds it through
+*execution* because the wrapper `execv`s SwiftPM. Splitting `scripts/test.sh`
+into a locked build of the test bundle followed by an unlocked run against the
+already-built bundle would return the slot after the compile. Cost: test
+execution is not free either, so removing it from admission control needs a
+decision about what the lock is for. Risk: real — this is load-bearing shared
+infrastructure. **Needs a spec via `/tbd-brainstorming`, with a human answering
+the questions.** Do not implement from this document.
+
+**2. Route local runs through the 6.3.3 toolchain CI already pins.** Removes an
+unintentional local/CI skew, and is the precondition for #3. Mechanically it is
+`TBD_SWIFT_BIN`, or `TOOLCHAINS` set to the toolchain's bundle identifier.
+Cost: one cold rebuild per worktree, and a possibility that something compiles
+differently under 6.3 that CI has been absorbing all along — unlikely, since CI
+builds this tree on 6.3.3 every run. Modest, mostly hygiene.
+
+**3. Set `SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH` once on 6.3.3.**
+Expected win: eliminates the `Time limit was exceeded` and gate-starvation
+failure class — 42 of 42 non-defect failures in the observed run — by keeping
+queue time out of every `.timeLimit` and every bounded wait. Expected non-win:
+wall time probably does not improve and may rise slightly (PR #1390: "does not
+generally impact execution time"), and reported per-test durations stay
+inflated. Cost: one environment variable, and it is `@_spi(Experimental)` with
+an uncapped upstream default, so it is a knob upstream has not committed to.
+Fits this repo's default-off-flag doctrine cleanly. **Also needs a spec** — it
+changes how the suite decides something, and picking the width is a theory
+call.
+
+**4. Mirror CI's two-pass split in the local default.** Already measured in
+this repo: p90 26.4 s → 14.6 s for +26 s of wall time. CI does it; local does
+not. Cheap, understood, and it is the only in-process-population remedy that
+works on 6.2.4. Its cost is real though — +26 s of wall on a machine where the
+scarce resource is the build slot, and under today's wrapper the slot is held
+across both passes. Sequence it after #1, not before.
+
+**5. Do nothing about the box, but say plainly that it is the box.** Thirty
+worktrees, load 140, 40% system time, 17% idle. If local test latency is the
+thing that matters, the highest-leverage change is fewer concurrent worktrees
+or a second machine — not a runner. That is a workflow decision, not an
+engineering one, and it belongs to the person running the fleet.
+
+## 7. What I would not do, and what would change my mind
+
+- **Do not migrate to `xcodebuild` plus test plans.** Sharding granularity is
+  per test class and Swift Testing runs in-process anyway; the fence in
+  `scripts/test.sh` would have to be rebuilt around a scheme. It buys nothing
+  this package needs.
+- **Do not migrate to Bazel.** Correct answer to a question we do not have.
+- **Do not re-litigate the three refuted remedies.** Per-suite `.serialized`,
+  `TASK_MEGA_YIELD_COUNT=1` and blanket retry are measured-and-rejected in
+  `Tests/CLAUDE.md`. Nothing found here disturbs any of them — note especially
+  that the width cap is *not* per-suite `.serialized` reheated: it bounds the
+  process-global in-flight count, which is the thing `.serialized` provably
+  could not shrink.
+- **Do not raise `.clockDriven`'s limit again.** If #3 lands, the pressure that
+  drove it up should fall, and the right move then is to re-derive the triple
+  downward, not to leave it where it is.
+
+**What would change the ranking:** an interleaved A/B of the width cap on the
+real suite, run on an idle machine — arms alternating uncapped and capped at
+some width, population held constant, reporting the executed test **count** per
+arm (a `--filter` matching nothing exits green), the count of
+`Time limit was exceeded` issues, and wall time. If capping does *not* reduce
+the time-limit failures, #3 is wrong and the reading of the runner source above
+is wrong with it. That measurement is worth taking on a quiet box; it was not
+worth taking on this one.
+
+## 8. Sources
+
+- swift-testing PR #1390, "Add an upper bound on the number of test cases we
+  run in parallel" — https://github.com/swiftlang/swift-testing/pull/1390
+- swift-testing PR #1711, documenting the environment variable —
+  https://github.com/swiftlang/swift-testing/pull/1711
+- swift-testing issue #1780, console output versus the gate —
+  https://github.com/swiftlang/swift-testing/issues/1780
+- swift-testing issue #1086, "Expose parallelism" —
+  https://github.com/swiftlang/swift-testing/issues/1086
+- SwiftPM issue #4775, the origin of `--num-workers` —
+  https://github.com/swiftlang/swift-package-manager/issues/4775
+- swift-testing `Runner.swift`, `Configuration.swift` and `Serializer.swift` on
+  `release/6.3` — https://github.com/swiftlang/swift-testing/tree/release/6.3
+- SwiftPM `Sources/Commands/SwiftTestCommand.swift` on `main` —
+  https://github.com/swiftlang/swift-package-manager
+- swift-testing parallelization documentation —
+  https://github.com/swiftlang/swift-testing/blob/release/6.3/Sources/Testing/Testing.docc/Parallelization.md
+- Swift 6.3 release announcement — https://www.swift.org/blog/swift-6.3-released/
+- "Optimize your Swift test suite to run faster" (selective testing,
+  distributing across environments) — https://tuist.dev/blog/2025/03/25/tests
+- Bazel test sharding reference — https://bazel.build/reference/test-encyclopedia

--- a/docs/perf/2026-08-29-swift-test-runner-options.md
+++ b/docs/perf/2026-08-29-swift-test-runner-options.md
@@ -125,25 +125,43 @@ fseventsd is journaling. Its own stacks confirm the shape: the hot thread,
 `com.apple.fseventsd.notify`, sits in a tight loop of `_platform_strncmp` under
 a mutex, i.e. path matching, for 8045 of 8045 samples.
 
-The producers are the fleet, and they are **not** this repo:
+The producers, and the attribution trap that sits under them:
 
-- `bash` **41.3%** and `git` **20.6%** — together ~62%. git's operations are
-  ~400:1 concentrated on an unrelated project's checkout that shares this
-  machine; TBD's own worktree root accounts for six of 6,055 sampled git lines.
-  A live process listing found the generators to be another project's dev setup
-  scripts and a `.claude/hooks/` marker script on a 3-second loop.
-- `TBDDaemon` **12.0%**, most of it one bug: an unfiltered note list in the
-  app's 2-second poll re-reads every note row's file from disk, ~700 path
-  resolutions per cycle of which ~94% are for notes that cannot yield content.
-  Real, and worth fixing — and **~1.6% of machine-wide events**, so it will not
-  move fseventsd.
+- `bash` **41.3%** and `git` **20.6%** — together ~62%.
+- `TBDDaemon` **12.0%**, most of it an unfiltered note list in the app's
+  2-second poll that re-reads every note row's file from disk: ~700 path
+  resolutions per cycle, ~94% of them for notes that cannot yield content.
+  Real, worth fixing, and **~1.6% of machine-wide events** — it will not move
+  fseventsd.
 - `swift-frontend` **6.0%** of all operations, though 36.8% of the
-  *write-shaped* ones. Builds are a minority of the event load; the earlier
-  assumption that build artifacts dominated was wrong.
+  *write-shaped* ones. Builds are a minority of the event load; an earlier
+  assumption here that build artifacts dominated was wrong.
 
-The honest summary is that ~62% of the machine's filesystem traffic is ~40
-concurrent agent sessions, their hooks and shells, and unrelated repositories'
-tooling — doing their job, on one laptop.
+**That 12.0% understates the daemon badly, and the reason generalizes.**
+`fs_usage` attributes an operation to the process performing it, so every `git`
+the daemon spawns is booked to `git`, never to `TBDDaemon`. Sampling process
+spawns for 90 seconds found **65 of 125 distinct `git` processes had the live
+daemon as their parent** — about 0.7 spawns per second, and 52% of all git on
+the machine.
+
+The code names this hazard itself. `BranchTrackingCache`'s doc comment says
+`pr.list` "invokes them once per worktree on every poll, so under a poll storm
+the daemon spawns dozens of concurrent subprocesses"; the cache exists to bound
+exactly that. With worktrees across several repositories, the per-worktree
+multiplier is large.
+
+**The trap worth recording is how this was nearly missed.** Grouping git's
+*paths* showed ~400:1 concentration on an unrelated repository's checkout and
+almost nothing under this repo's worktree root, which reads as "not us". It is
+not: TBD manages worktrees for several repositories, so the daemon's git
+commands legitimately target other repositories' paths. **Which paths a
+subprocess touches does not answer who spawned it** — that needs parent-PID
+attribution, and path grouping will confidently say the opposite.
+
+What is *not* established is how much of git's 20.6% those spawns represent;
+that needs per-invocation event counts, which this capture cannot give. The
+claim here is only that the daemon spawns half the git processes on the
+machine, which is enough to make the 12.0% a floor rather than a measurement.
 
 Two things that sample rules **out**, worth stating because both are the
 intuitive culprit and neither is guilty. Spotlight indexing is **disabled** on

--- a/docs/perf/2026-08-29-swift-test-runner-options.md
+++ b/docs/perf/2026-08-29-swift-test-runner-options.md
@@ -111,10 +111,55 @@ Sampled with `top -l 1` while the above was in flight:
 - 30 directories under `~/tbd/worktrees/tbd`
 
 Forty per cent system time on a 12-core machine is about five cores burned in
-the kernel before any test runs. Top consumers during the sample included
-`fseventsd` (99% of a core), `XprotectService` (86%), Chrome (70%) and
-`WindowServer` (57%) — the per-worktree filesystem-event and scanning tax, not
-compilation.
+the kernel before any test runs. Sampled instantaneously during a build, out of
+1200% available: `kernel_task` **221%**, `fseventsd` **101%**, `WindowServer`
+38% — against 49% for all thirteen `swift-frontend` processes put together.
+
+`fseventsd` is not a subscriber-driven watch list — it journals every
+filesystem event on the volume unconditionally — so its core goes to write
+*traffic*, and there is no watcher of ours to switch off.
+
+A traced capture (`sudo fs_usage`, 20 s) put the event rate at **1,554,418
+operations — ~77,700 per second** — and that volume, not any watcher, is what
+fseventsd is journaling. Its own stacks confirm the shape: the hot thread,
+`com.apple.fseventsd.notify`, sits in a tight loop of `_platform_strncmp` under
+a mutex, i.e. path matching, for 8045 of 8045 samples.
+
+The producers are the fleet, and they are **not** this repo:
+
+- `bash` **41.3%** and `git` **20.6%** — together ~62%. git's operations are
+  ~400:1 concentrated on an unrelated project's checkout that shares this
+  machine; TBD's own worktree root accounts for six of 6,055 sampled git lines.
+  A live process listing found the generators to be another project's dev setup
+  scripts and a `.claude/hooks/` marker script on a 3-second loop.
+- `TBDDaemon` **12.0%**, most of it one bug: an unfiltered note list in the
+  app's 2-second poll re-reads every note row's file from disk, ~700 path
+  resolutions per cycle of which ~94% are for notes that cannot yield content.
+  Real, and worth fixing — and **~1.6% of machine-wide events**, so it will not
+  move fseventsd.
+- `swift-frontend` **6.0%** of all operations, though 36.8% of the
+  *write-shaped* ones. Builds are a minority of the event load; the earlier
+  assumption that build artifacts dominated was wrong.
+
+The honest summary is that ~62% of the machine's filesystem traffic is ~40
+concurrent agent sessions, their hooks and shells, and unrelated repositories'
+tooling — doing their job, on one laptop.
+
+Two things that sample rules **out**, worth stating because both are the
+intuitive culprit and neither is guilty. Spotlight indexing is **disabled** on
+every volume (`mdutil -s -a`), and `mdfind` for object files under the worktree
+root returns zero. And `lsof /dev/fsevents` lists nothing — but that instrument
+is a trap: only fseventsd itself opens that device, and clients connect over
+Mach/XPC. The real subscriber list is in the sample output as
+`com.apple.fseventsd.client.<pid>` thread names — 28 client threads, including
+`cfprefsd` twice, `node`, `Finder` and a `swiftpm-testing-helper`. Reading the
+absence of `lsof` output as "nothing is watching" is wrong, and was.
+
+One avoidable consumer did turn up: `tmutil isexcluded` reports the worktree
+root and the `.build` trees under it as `[Included]`, so 25 GB of purely
+ephemeral artifacts are queued for Time Machine. `backupd` was idle throughout
+the sampling, so it is not part of the slowness measured here, but excluding
+those trees is free and independent of everything else in this document.
 
 The comparison that settles it: CI ran this same tree green on a **3-core**
 `macos-26` runner (run `33232886152`, 2026-08-29):
@@ -210,6 +255,74 @@ That mapping matters: all 42 failures reported from the local run that prompted
 this were `Time limit was exceeded` or gate starvation, which is precisely the
 class this addresses, and none of them is the class it does not.
 
+### The knob is live on our build — positive control
+
+Before any A/B is worth reading, the variable has to be shown to *do* something.
+Measured against the 6.3.3-built bundle, `--skip-build`, `TBDSharedTests` only,
+arms interleaved so load drift hits both:
+
+- uncapped — 869 tests in 86 suites, reported **0.612 s**, then **0.300 s**
+- `SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH=1` — the same 869 tests,
+  reported **3.357 s**, then **0.909 s**
+
+Three to five times longer in both pairs, with the full 869 executed in every
+arm — the count is read from the summary line, because `--filter` exits green on
+zero matches and an exit status alone would not have caught a run of nothing.
+
+**Read the reported test-run duration, not shell wall time.** The same four arms
+took 154.4 / 77.5 / 22.9 / 23.5 s of wall, which tracks SwiftPM's manifest
+re-resolve and no-op build check rather than anything about tests. A comparison
+ranked on wall time here would have reported the *uncapped* arm as six times
+slower than the capped one, which is an artifact of running first.
+
+### Measured on the real suite: the cap works, and it is expensive
+
+Four interleaved arms over the whole package, `--skip-build`, on the 6.3.3
+build. Counts and failure kinds come from the per-arm xUnit file, not from the
+log. Width 24 is `NCORES * 2` — the bound upstream's own PR shipped and then
+commented out.
+
+- **uncapped** — 8,534 tests, **16** failures (**9** `Time limit was exceeded`),
+  500.9 s reported / 521.9 s wall
+- **width 24** — 8,534 tests, **4** failures (**0** time-limit), 1133.2 s /
+  1159.4 s
+- **uncapped** — 8,534 tests, **19** failures (**9** time-limit), 522.6 s /
+  549.0 s
+- **width 24** — 8,534 tests, **2** failures (**0** time-limit), 2143.0 s /
+  2173.2 s
+
+**The time-limit starvation class goes 9 to 0, in both capped arms.** That is
+the prediction §3's reading of the runner made, now measured rather than
+inferred. The suites that failed uncapped are the ones this repo already
+suspects: `AppearanceDebounceTests` and `SearchQueryDebouncerTests` — named in
+`Tests/CLAUDE.md` as the two migrated to `EventDrivenTestClock` *because* they
+reproduced starvation in a full-suite soak — plus `TerminalLockedAccessTests`,
+`TerminalTeardownReapTests` and `ThemeStoreTests`.
+
+**And it costs 3.1x the wall clock**: mean 535.5 s uncapped against 1666.3 s
+capped. That is not a tuning detail, it is the headline trade.
+
+**Why, and why 24 is the wrong number.** The gate admits *test cases*, and a
+**suspended test keeps its slot**. This suite is dominated by tests that wait —
+bounded polls, clock handshakes, tmux — so at width 24 waits that used to
+overlap now queue behind each other. `NCORES * 2` is sized for CPU-bound tests.
+A wait-bound suite wants a width high enough to bound scheduler pressure without
+serializing the waiting, which is somewhere far above 24 and was not measured
+here. **Do not adopt 24.**
+
+Two instrument bugs found while doing this, both of which produced confident
+wrong numbers before they were caught:
+
+- **SwiftPM writes two xUnit files.** `<name>.xml` holds the *XCTest* results —
+  22 tests, 0 failures — and `<name>-swift-testing.xml` holds the 8,534-test
+  Swift Testing run. Reading the first reports a green 22-test run for a suite
+  that failed. This is the same class of wrong answer `test.yml`'s comment
+  warns about for log scraping, reproduced *via* the structured file it
+  recommends instead.
+- Ranking arms on shell **wall** time rather than the reported run time credits
+  whichever arm did not pay SwiftPM's manifest re-resolve. See the positive
+  control above.
+
 ### What is still missing upstream
 
 [Issue #1086, "Expose parallelism"](https://github.com/swiftlang/swift-testing/issues/1086)
@@ -266,6 +379,23 @@ has to be told the number out of band.
 So the local/CI toolchain skew is unintentional: the 6.3.3 toolchain the
 workflow says local validation uses is on the disk and unused.
 
+**A standalone toolchain needs no Xcode update, and this tree builds under it.**
+Verified rather than assumed: a cold `swift-safe build --build-tests` driven
+through `TBD_SWIFT_BIN` at the 6.3.3 toolchain completed **exit 0 with zero
+errors** against the installed Xcode 26.3 macOS 26.2 SDK. The resulting
+`TBDPackageTests.xctest` links `@rpath/libTesting.dylib` — the toolchain's own
+Swift Testing library, which is the copy carrying the width knob — rather than
+Xcode's `Testing.framework`, which does not.
+
+The one real cost of the switch is that **`.build` is toolchain-specific**, so
+adopting 6.3.3 makes every worktree pay one cold build. On this machine that is
+not cheap: the cold build above took **2441 s (40.7 minutes)**, and §2B explains
+where that time goes — sampled mid-build, the 13 `swift-frontend` processes held
+**49% CPU combined out of 1200% available**, against `kernel_task` at 221% and
+`fseventsd` at 101%, with every frontend in state `R` (runnable, not blocked on
+I/O). The compiler was not short of work or memory; it was short of turns. Eight
+worktrees hold `.build` trees totalling **25 GB** against 24 GB of free disk.
+
 ## 6. Ranked recommendation
 
 Ranked by expected win per unit of cost and risk.
@@ -302,18 +432,18 @@ Cost: one cold rebuild per worktree, and a possibility that something compiles
 differently under 6.3 that CI has been absorbing all along — unlikely, since CI
 builds this tree on 6.3.3 every run. Modest, mostly hygiene.
 
-**4. Set `SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH` once on 6.3.3.**
-Expected win, from the runner source rather than from measurement: it should
-retire the `Time limit was exceeded` and gate-starvation failure class — all 42
-failures reported from the run that prompted this — by keeping queue time out
-of every `.timeLimit` and every bounded wait. Expected non-win:
-wall time probably does not improve and may rise slightly (PR #1390: "does not
-generally impact execution time"), and reported per-test durations stay
-inflated. Cost: one environment variable, and it is `@_spi(Experimental)` with
-an uncapped upstream default, so it is a knob upstream has not committed to.
-Fits this repo's default-off-flag doctrine cleanly. **Also needs a spec** — it
-changes how the suite decides something, and picking the width is a theory
-call.
+**4. Set `SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH` once on 6.3.3 — but
+not at 24, and not without picking the width first.** Measured, not inferred
+(§3): the cap takes `Time limit was exceeded` from 9 to 0 in both capped arms,
+and costs **3.1x the wall clock** at width 24. Both halves are real, and the
+second one disqualifies the obvious setting: a suite already too slow to run
+locally cannot pay 3x to lose a failure class. The knob is worth having, at a
+width nobody has measured yet — high enough to bound scheduler pressure, high
+enough not to serialize the waiting that dominates this suite. Cost: one
+environment variable, `@_spi(Experimental)`, with an uncapped upstream default,
+so it is a knob upstream has not committed to. Fits the default-off-flag
+doctrine cleanly. **Needs a spec** — it changes how the suite decides
+something, and choosing the width is a theory call, not a tuning sweep.
 
 **5. Mirror CI's two-pass split in the local default.** Already measured in
 this repo: p90 26.4 s → 14.6 s for +26 s of wall time. CI does it; local does
@@ -345,14 +475,15 @@ engineering one, and it belongs to the person running the fleet.
   drove it up should fall, and the right move then is to re-derive the triple
   downward, not to leave it where it is.
 
-**What would change the ranking:** an interleaved A/B of the width cap on the
-real suite, run on an idle machine — arms alternating uncapped and capped at
-some width, population held constant, reporting the executed test **count** per
-arm (a `--filter` matching nothing exits green), the count of
-`Time limit was exceeded` issues, and wall time. If capping does *not* reduce
-the time-limit failures, #4 is wrong and the reading of the runner source above
-is wrong with it. That measurement is worth taking on a quiet box; it was not
-worth taking on this one.
+**What the ranking is still waiting on.** The A/B this section originally asked
+for was run (§3), and it confirmed the mechanism while disqualifying the width.
+What remains unmeasured is the width itself: a sweep at, say, 64 / 128 / 256,
+interleaved against an uncapped control, looking for the smallest width that
+holds time-limit failures at zero without a wall-clock penalty. Until someone
+takes that, #4 names a knob rather than a setting. On a quiet machine it is a
+few hours; on this one the arms above already drifted by a factor of two
+between the two capped runs (1159 s then 2173 s), which is itself a reason not
+to tune here.
 
 ## 8. Sources
 

--- a/docs/perf/2026-08-30-macos-mds-hardlink-fanout.md
+++ b/docs/perf/2026-08-30-macos-mds-hardlink-fanout.md
@@ -10,6 +10,10 @@ of a CPU core, and shows up as the single largest producer of filesystem
 operations on the machine, **even though Spotlight indexing is switched off** and
 the Spotlight store has not been written in a year.
 
+If `fseventsd` is *also* pinned near a full core on the same machine, that is a
+**separate** problem with a separate fix — see "The other half" below. The two
+are easily conflated because they appear together and both look like Spotlight.
+
 **One-line cause:** a package manager configured to install by **hardlink** makes
 every one of its files carry a link count equal to the number of checkouts, and
 each inode-to-path resolution then fans out across every sibling link. With 69
@@ -327,17 +331,70 @@ wrong number:
 is the useful part — the two daemons scale on different quantities:
 
 - **`mds`** costs scale with **link count**, which this change addresses.
-- **`fseventsd`** costs scale with the **number of watched paths**, which this
-  change does not touch at all. Converting a file in place leaves its path,
-  its directory entry, and the total file count exactly as they were; only the
-  inode behind it differs.
+- **`fseventsd`** costs scale with **internal state accumulated over the
+  process's lifetime**, which this change does not touch at all. Converting a
+  file in place leaves its path, its directory entry, and the total file count
+  exactly as they were; only the inode behind it differs. See the `fseventsd`
+  section below for what does move it.
 
-The only thing observed to move `fseventsd` was removing checkouts outright: its
-resident set fell 5.5 GB to 4.8 GB when 14 worktrees were archived. Its resident
-set also fell to 2.20 GB across the conversion, which is **not explained** — the
-prediction was no effect, and a large one appeared. It may be that the mass
-replacement forced it to rebuild internal state. Recorded as an observation, not
-a mechanism.
+Archiving 14 worktrees moved its resident set a little, 5.5 GB to 4.8 GB, and it
+drifted down further to ~2.2 GB across the conversion — the mass replacement
+plausibly churned some internal state. Neither dented its CPU. What actually
+fixes it is restarting the process, covered next.
+
+## The other half: `fseventsd` accumulates, and can be recycled
+
+The hardlink fix above does nothing for `fseventsd`, which on the same machine
+sat at 87–116% of a core continuously with a 5.5 GB resident set. That is a
+separate problem with a separate cause, and it has a blunt but effective remedy.
+
+**Its cost is accumulated in-memory state, not persistent state.** Sampling it
+(unlike `mds`, it is not SIP-blocked from `sample`) shows on-CPU time
+concentrated in a single function doing `_platform_strncmp` under a mutex, while
+every other thread sits parked in `__psynch_cvwait`, `read`, or
+`mach_msg2_trap`. Critically, this happens with **almost no subscribers** — a
+capture during the worst of it found four client threads belonging to `node` and
+`Finder`. So the cost is not "many watchers × many events"; a linear scan over
+internal state fits the evidence far better, and it explains the otherwise
+baffling observation that its CPU stayed pinned across a 23× swing in event
+rate. A saturating linear scan looks the same at any input rate.
+
+**Restarting it collapses the cost.** After 24 days of uptime:
+
+- **before** — ~101% of a core, 2.23 GB resident
+- **after** — 0.1% of a core, ~6 MB resident, still flat eight minutes later
+
+That is roughly a 1000× reduction, and it moved the whole machine: free pages
+went from 3,816 (~15 MB) to 23,093, compressor pages halved from 1,489,155 to
+688,739, and load average fell from 50.7 to 13.0. Much of what presented as
+`kernel_task` burning CPU was memory-compressor thrashing driven by this.
+
+**How to restart it:**
+
+```sh
+sudo kill -9 "$(pgrep -x fseventsd)"     # launchd respawns it immediately
+```
+
+Two traps here, both of which produced wrong conclusions on the way to that
+one-liner:
+
+- **`launchctl kickstart -k system/com.apple.fseventsd` does not work** — it
+  fails with *"Operation not permitted while System Integrity Protection is
+  engaged"*. A plain signal to the pid does work, which is the opposite of what
+  SIP normally implies.
+- **It can take well over 30 seconds to die and respawn.** An initial attempt
+  waited 30s, saw an unchanged pid, and reported "the kill did not take, SIP
+  probably blocks it" — a false negative. The kill had in fact succeeded. When
+  testing this, wait minutes and re-check the pid before concluding anything.
+
+**What is not yet known** is how fast it re-accumulates. It reached 5.5 GB over
+24 days of uptime on a busy machine, so the growth is slow, but whether a
+restart is a one-off or something to schedule needs longer observation than was
+done here. Treat this as a working remedy with an unmeasured duty cycle rather
+than a solved problem. Note also that this is the *only* lever found for
+`fseventsd`: excluding paths from Spotlight does not affect it, since Time
+Machine, iCloud, and third-party sync clients all consume the same event stream
+regardless of Spotlight's configuration.
 
 ## Limits of this analysis
 
@@ -347,12 +404,11 @@ investigation turned out to be measurement artifacts:
 - **The client driving the ~118 lookups/sec was never identified.** SIP blocks
   `fs_usage -p` and `sample` against `mds`, so its callers are not observable.
   The amplification is established; the trigger is not.
-- **`fseventsd` is a separate, unexplained problem.** It sat pinned at ~99–101%
-  of a core throughout, independent of a 23× swing in event rate, with a hot loop
-  in `_platform_strncmp` under a mutex. Archiving 14 checkouts dropped its RSS
-  from 5.5 GB to 4.8 GB while leaving CPU unchanged — consistent with saturation
-  at a single-thread ceiling rather than load-proportional work. Nothing in this
-  document fixes it.
+- **`fseventsd`'s internal state is still not directly observable.** The
+  restart remedy above is established empirically — the cost vanishes when the
+  process is recycled — but the specific structure being scanned is inferred
+  from a `strncmp`-dominated profile and a near-total absence of subscribers,
+  not read out of the daemon. The re-accumulation rate is unmeasured.
 - **No public prior art was found** for the hardlink fan-out mechanism. The
   generic "large dependency trees make Spotlight expensive" pattern is well
   documented for `.venv` and `node_modules`, but the specific claim that *link

--- a/docs/perf/2026-08-30-macos-mds-hardlink-fanout.md
+++ b/docs/perf/2026-08-30-macos-mds-hardlink-fanout.md
@@ -174,6 +174,87 @@ Two things to fix alongside it, or the change will be undone by its own guardrai
 The fix preserves every checkout. Nothing here requires reducing how many
 parallel checkouts you keep.
 
+## Converting existing environments
+
+Changing the setting only affects environments built after it. Existing ones
+keep their link counts until rebuilt, and since the fan-out is driven by the
+link count, nothing improves until enough of them are converted.
+
+Reinstalling (`uv sync --reinstall`) is the obvious route, but it needs the
+network and the lockfile, and it rewrites environments other sessions may be
+using. Converting in place is cheaper and content-preserving: cloning a file
+from itself produces an independent inode that still shares every block.
+
+Three approaches, because the differences matter more than they look:
+
+- **`cp -c` per file, spawned from `find`/`xargs`** — correct but slow, ~120
+  files/sec. The cost is process spawn, not cloning; a virtualenv of ~45,000
+  files takes several minutes.
+- **`cp -cR` on the whole tree, then swap the directory** — ~1,400 files/sec,
+  but it renames the live directory, so there is a brief window in which
+  `lib/` does not exist. A lazy import landing in that window fails. Fine for
+  idle checkouts, not for ones with running processes.
+- **`clonefile(2)` per file from a single process, replaced atomically** — the
+  one to use. It has the speed of the recursive copy (~855 files/sec measured)
+  without the window: each file is swapped with `os.replace()`, so a reader
+  sees either the old inode or the new one and never a missing path. Safe to
+  run against checkouts with live sessions.
+
+The third, in full:
+
+```python
+"""Convert hardlinked files to APFS clones in place. Content is byte-identical
+and blocks stay shared, so this costs no real disk -- it only breaks the link
+count that macOS `mds` fans out across."""
+import ctypes, ctypes.util, os, sys
+
+libc = ctypes.CDLL(ctypes.util.find_library("c"), use_errno=True)
+libc.clonefile.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_int]
+libc.clonefile.restype = ctypes.c_int
+
+def convert(root):
+    done = failed = 0
+    for dirpath, _dirs, files in os.walk(root):
+        for name in files:
+            p = os.path.join(dirpath, name)
+            try:
+                st = os.lstat(p)
+                if not os.path.isfile(p) or os.path.islink(p) or st.st_nlink <= 1:
+                    continue
+                tmp = os.path.join(dirpath, f".__cl{os.getpid()}_{name}")
+                try:
+                    if libc.clonefile(p.encode(), tmp.encode(), 0) != 0:
+                        raise OSError(ctypes.get_errno(), p)
+                    os.chmod(tmp, st.st_mode & 0o7777)
+                    os.utime(tmp, (st.st_atime, st.st_mtime))
+                    os.replace(tmp, p)          # atomic; p is never absent
+                    done += 1
+                except Exception:
+                    try: os.unlink(tmp)
+                    except OSError: pass
+                    failed += 1
+            except OSError:
+                failed += 1
+    return done, failed
+
+if __name__ == "__main__":
+    print("cloned=%d failed=%d" % convert(sys.argv[1]))
+```
+
+Two things to check before running it against a live checkout:
+
+- **No installer is mid-flight.** A running `uv sync` or `pip install` writing
+  into the tree is the one case that genuinely loses data. Everything else is
+  safe, including processes with open file descriptors — POSIX keeps the inode
+  alive across replace and unlink, so anything already executing is unaffected.
+- **Verify afterwards**, since a silent partial conversion looks like success:
+  the interpreter still starts, a few third-party imports resolve, the
+  site-packages count is unchanged, and `find <venv> -type f -links +1` is
+  empty.
+
+Expect language servers to re-index the tree afterwards; they observe a mass
+delete-and-create. That churn is transient.
+
 ## What does not work
 
 - **`.metadata_never_index`** — the traditional marker file is

--- a/docs/perf/2026-08-30-macos-mds-hardlink-fanout.md
+++ b/docs/perf/2026-08-30-macos-mds-hardlink-fanout.md
@@ -1,0 +1,219 @@
+# Hardlink fan-out: why `mds` can burn a core with Spotlight disabled
+
+**Audience:** anyone on macOS/APFS running many parallel checkouts (git worktrees,
+CI sandboxes, per-branch dev environments) where each one carries a large
+dependency tree — `.venv`, `node_modules`, `vendor/`. You do not need to use TBD
+for any of this to apply.
+
+**Symptom this explains:** `mds` (the Spotlight metadata server) sustains 40–50%
+of a CPU core, and shows up as the single largest producer of filesystem
+operations on the machine, **even though Spotlight indexing is switched off** and
+the Spotlight store has not been written in a year.
+
+**One-line cause:** a package manager configured to install by **hardlink** makes
+every one of its files carry a link count equal to the number of checkouts, and
+each inode-to-path resolution then fans out across every sibling link. With 69
+links, one lookup becomes 66 path resolutions.
+
+**One-line fix:** on APFS, install by **clone** (copy-on-write) instead of
+hardlink. You get the same disk sharing with a link count of 1, and the fan-out
+disappears.
+
+---
+
+## Why this is easy to misdiagnose
+
+Three separate things conspire to point the investigation in the wrong direction.
+
+- **`mdutil` says indexing is off, so `mds` looks innocent.** It is not indexing.
+  It is resolving inode numbers to pathnames, which is a different job that stays
+  live regardless of indexing state. Turning indexing off — and even disabling
+  search-serving with `mdutil -d -a` — changes nothing. On the machine this was
+  measured on, `mds` CPU went *up* slightly afterwards.
+- **`du` reports the disk cost of hardlinked and cloned trees completely
+  differently, and one of those reports is wrong.** `du` deduplicates hardlinks
+  *within a single invocation*, but it knows nothing about copy-on-write block
+  sharing. So a cloned tree reports its full nominal size while occupying almost
+  nothing. Anyone measuring "how much disk is this costing" with a per-directory
+  `du` loop will conclude cloning is expensive and hardlinking is thrifty. Both
+  halves of that conclusion are wrong.
+- **The fix and the bug look identical to a link-count check.** A cloned file has
+  `nlink == 1`, exactly like a full copy. A naive assertion that flags
+  `nlink <= 1` as "this was copied, fix your config" will fire on precisely the
+  configuration you want, and drive you back to the pathological one.
+
+## How to tell whether you have this
+
+You need one measurement. Capture filesystem activity machine-wide and look at
+`mds`'s own lines — `fs_usage -p <mds-pid>` returns nothing, because SIP blocks
+introspection of protected daemons, so filter after the fact:
+
+```sh
+sudo fs_usage -w -f filesys | grep -E ' mds\.[0-9]+$' > /tmp/mds.txt
+```
+
+Then measure the **run-length of consecutive `fsgetpath` calls that share a
+relative path**:
+
+```sh
+grep ' fsgetpath ' /tmp/mds.txt \
+ | sed -E 's/^[0-9:.]+ +fsgetpath +//; s/[[:space:]]+[0-9]+\.[0-9]+[[:space:]]+mds\.[0-9]+[[:space:]]*$//' \
+ | sed -E 's|.*/\.venv/||' \
+ | awk 'NR==1{p=$0;n=1;next} $0==p{n++;next} {print n;p=$0;n=1} END{print n}' \
+ | sort -n | uniq -c | sort -rn | head -5
+```
+
+- **A dominant run-length well above 1, roughly equal to your checkout count** —
+  you have hardlink fan-out. Confirm with `stat -f '%l' <any file in the tree>`;
+  the link count should match.
+- **Run-lengths collapsing toward 1** — something else is going on; this document
+  does not describe your problem.
+
+The distinction matters because the raw operation counts look the same either
+way. What identifies the mechanism is the *ordering*: the file stays constant
+while the checkout advances.
+
+## The mechanism
+
+The call pattern is a tight repeating triad — `fsgetpath`, then `fstatfs64`,
+then `fsctl` against the data volume, interleaved with real metadata reads
+(`RdMeta`) against the physical device.
+
+`fsgetpath` maps a volume ID plus an object ID back to a pathname. For a file
+with a single link that is a cheap lookup. For a file with *N* hardlinks it is
+inherently ambiguous — the inode genuinely has *N* equally valid pathnames — and
+resolving it walks the sibling-link set.
+
+So the cost of one logical lookup scales with the link count, and the link count
+is exactly the number of checkouts sharing that dependency tree. The load is
+therefore **quadratic in checkout count**: each new checkout both adds a new
+source of file activity *and* increments the link count on every file, raising
+the cost of every *other* checkout's lookups. Going from 10 to 80 checkouts is
+not 8× the metadata load — it is closer to 64×.
+
+Crucially, the underlying activity that triggers all this is unremarkable. In
+the measurement below, roughly 118 files per second were actually being touched —
+what an ordinary language server or a dependency sync would do. Every bit of the
+alarming aggregate number is amplification.
+
+## The evidence
+
+Measured on an M4 Pro (12 cores, macOS 26.x, APFS), with ~80 git worktrees each
+carrying a Python `.venv` of ~47,800 directory entries, and Spotlight indexing
+disabled on all volumes.
+
+- **`mds` produced 868,769 of 1,737,746 filesystem events** in a 30-second
+  machine-wide capture — 50% of all filesystem operations on the machine,
+  ~29,000 ops/sec.
+- **The dominant `fsgetpath` run-length was 66, occurring 1,027 times** in a
+  single window, with the relative path held constant while the worktree
+  advanced. Independent per-tree crawlers could not stay in lockstep 1,027
+  consecutive times; this is sibling enumeration.
+- **`stat` on the file being resolved reported `nlink=69`** — 66 live worktrees
+  plus the package cache and two absent checkouts. The fan-out matches the link
+  count, not the worktree count.
+- **234,334 `fsgetpath` calls ÷ 66 = ~3,550 distinct files, ~118/sec.** The real
+  workload is small.
+- **`mds` sustained 26.7s of CPU across a 60s window (44.4% of a core) with zero
+  checkout creation happening** — this is steady-state cost, not a
+  provisioning-time cost.
+
+One tempting comparison is worth explicitly discarding. Checkouts created before
+the hardlink setting was introduced had `nlink=1` and showed **zero** `mds` hits,
+versus ~1,900 each for the hardlinked ones. That looks like a clean natural
+experiment and is not one: those same checkouts are also the oldest and least
+active, so link count and idleness are perfectly collinear. The run-length
+distribution is what carries the argument.
+
+## Why a package manager creates this
+
+Modern package managers install from a shared content-addressed cache by linking
+rather than copying. The available strategies are not equivalent on APFS:
+
+- **`hardlink`** — one inode, *N* directory entries. Minimal disk. **Link count
+  grows with every checkout, so this is the strategy that creates the fan-out.**
+- **`clone` (copy-on-write, `clonefile(2)`)** — *N* independent inodes sharing
+  the same physical blocks until written. Disk cost is comparable to hardlinking,
+  but **every link count stays 1, so there is no fan-out.** APFS only.
+- **`copy`** — *N* independent inodes, *N* full copies. No fan-out, but genuinely
+  expensive in disk.
+- **`symlink`** — avoids the fan-out, but introduces dangling-reference risk when
+  the cache is pruned and breaks tools that resolve `__file__` or walk package
+  data. Not recommended for virtualenvs.
+
+For `uv` specifically, **`clone` is already the default on macOS**. Verified by
+installing the same package into two fresh virtualenvs with `UV_LINK_MODE` unset:
+
+```
+a: nlink=1 inode=819209901
+b: nlink=1 inode=819209957      <- distinct inodes, link count 1
+```
+
+That default is the right one, and the failure mode documented here comes from
+overriding it. A configuration that pins `UV_LINK_MODE=hardlink` — typically
+added to "stop each checkout paying for a full copy", motivated by a `du`
+measurement that cannot see clone sharing — trades a free copy-on-write share for
+a link count equal to the checkout count.
+
+## The fix
+
+**Stop pinning hardlink; let the tool choose, or pin clone explicitly on APFS.**
+For `uv`, remove the `UV_LINK_MODE=hardlink` export, or set
+`UV_LINK_MODE=clone`. Existing environments keep their old link counts until
+rebuilt, so converting them requires a reinstall (`uv sync --reinstall`, or
+deleting and re-provisioning the environment).
+
+Two things to fix alongside it, or the change will be undone by its own guardrails:
+
+- **Any assertion that flags `nlink <= 1` as "this was copied" must be retired or
+  inverted.** On APFS that check condemns the correct configuration.
+- **Any disk-cost measurement built on per-directory `du` must be redone.** It
+  cannot distinguish a clone from a copy and will keep reporting the fixed state
+  as expensive. Compare volume free space before and after instead.
+
+The fix preserves every checkout. Nothing here requires reducing how many
+parallel checkouts you keep.
+
+## What does not work
+
+- **`.metadata_never_index`** — the traditional marker file is
+  [reported broken on recent macOS](https://eclecticlight.co/2025/06/16/spotlight-search-can-be-blocked-by-extended-attributes/).
+  Do not rely on it.
+- **`mdutil -X`** — per its man page this *removes the index directory and does
+  not disable indexing*, so it provokes a full rebuild. The opposite of what you
+  want.
+- **`mdutil -i off` / `mdutil -d`** — these are what make the situation
+  confusing in the first place. Both were already set throughout the measurements
+  above, and neither reduced the load.
+- **Disabling `com.apple.metadata.mds` via `launchctl`** — SIP-protected;
+  requires disabling System Integrity Protection, and there are
+  [reports](https://developer.apple.com/forums/thread/774617) that the processes
+  return anyway. Large blast radius, poor evidence it even works.
+
+**Spotlight Privacy-list exclusion** (System Settings → Spotlight → Search
+Privacy) of the parent directory holding your checkouts is the reasonable
+symptom-level fallback if you cannot change link mode. It needs no renaming and
+breaks no tooling. Note there is an open report of
+[exclusions being disregarded on macOS 26](https://developer.apple.com/forums/thread/814978),
+so verify it actually reduced the numbers rather than assuming.
+
+## Limits of this analysis
+
+Stated plainly, because several attractive-looking conclusions in this
+investigation turned out to be measurement artifacts:
+
+- **The client driving the ~118 lookups/sec was never identified.** SIP blocks
+  `fs_usage -p` and `sample` against `mds`, so its callers are not observable.
+  The amplification is established; the trigger is not.
+- **`fseventsd` is a separate, unexplained problem.** It sat pinned at ~99–101%
+  of a core throughout, independent of a 23× swing in event rate, with a hot loop
+  in `_platform_strncmp` under a mutex. Archiving 14 checkouts dropped its RSS
+  from 5.5 GB to 4.8 GB while leaving CPU unchanged — consistent with saturation
+  at a single-thread ceiling rather than load-proportional work. Nothing in this
+  document fixes it.
+- **No public prior art was found** for the hardlink fan-out mechanism. The
+  generic "large dependency trees make Spotlight expensive" pattern is well
+  documented for `.venv` and `node_modules`, but the specific claim that *link
+  count* rather than *file count* is the multiplier appears to be undocumented
+  elsewhere. It is well supported by the measurements here and has not been
+  independently corroborated.

--- a/docs/perf/2026-08-30-macos-mds-hardlink-fanout.md
+++ b/docs/perf/2026-08-30-macos-mds-hardlink-fanout.md
@@ -17,7 +17,8 @@ links, one lookup becomes 66 path resolutions.
 
 **One-line fix:** on APFS, install by **clone** (copy-on-write) instead of
 hardlink. You get the same disk sharing with a link count of 1, and the fan-out
-disappears.
+disappears. Measured on the machine described below, this cut `mds`'s filesystem
+operations by ~4,560x and its CPU from ~45% of a core to under 1%.
 
 ---
 
@@ -277,6 +278,64 @@ symptom-level fallback if you cannot change link mode. It needs no renaming and
 breaks no tooling. Note there is an open report of
 [exclusions being disregarded on macOS 26](https://developer.apple.com/forums/thread/814978),
 so verify it actually reduced the numbers rather than assuming.
+
+## Before and after
+
+The intervention: 51 virtualenvs converted from hardlinks to clones (~2.3
+million files, zero failures, every one verified to still start its interpreter
+and resolve imports), taking the link count on a representative file from 69 to
+1. Nothing else changed — no worktrees were deleted for this measurement, and
+Spotlight was already disabled throughout.
+
+**The primary result, measured as `mds`'s own filesystem operations in a
+machine-wide `fs_usage` capture:**
+
+- **Before, at `nlink=69`** — 868,769 operations in 30s = **28,959/sec**, which
+  was 50% of all filesystem activity on the machine.
+- **After, at `nlink=1`** — 127 operations in 20s = **6.3/sec**.
+- **A reduction of roughly 4,560x.**
+
+**`mds` CPU, sampled six times over ten minutes afterwards** — 0.56%, 0.26%,
+0.09%, 0.07% of a core, against a 40.8–45.1% baseline. Its resident set also
+fell from 185 MB to 12 MB, and the process was never restarted (same pid
+throughout), so this is the same daemon doing far less work rather than a fresh
+one that has not warmed up.
+
+Three measurement traps are worth recording, because each one nearly produced a
+wrong number:
+
+- **`mds` load is bursty, so a single CPU sample proves little.** Cumulative CPU
+  over ten hours averaged 5.9% of a core while individual samples read 40–45%.
+  A before/after pair taken at two arbitrary moments could show almost any
+  ratio. The operations-per-second figure is the trustworthy one because it
+  measures the *multiplier* directly; the CPU distribution is reported as six
+  samples for the same reason.
+- **A measurement can create its own contamination.** An initial "after" reading
+  was taken by a script that created its output file *before* sampling, while a
+  queued conversion sweep was waiting for exactly that file to appear. The sweep
+  started two seconds into the sample window and ran through it, producing a
+  meaningless 42.6% that briefly looked like "the fix did nothing". Sequence
+  such things on the *process* exiting, not on a file appearing.
+- **Verify the daemon did not simply die.** A CPU reading of ~0 is equally
+  consistent with success and with a crashed process. Check the pid is unchanged
+  and the service still responds.
+
+**What did not change: `fseventsd`.** It stayed at 96.5% of a core against a
+98.9% baseline. This is expected rather than disappointing, and the distinction
+is the useful part — the two daemons scale on different quantities:
+
+- **`mds`** costs scale with **link count**, which this change addresses.
+- **`fseventsd`** costs scale with the **number of watched paths**, which this
+  change does not touch at all. Converting a file in place leaves its path,
+  its directory entry, and the total file count exactly as they were; only the
+  inode behind it differs.
+
+The only thing observed to move `fseventsd` was removing checkouts outright: its
+resident set fell 5.5 GB to 4.8 GB when 14 worktrees were archived. Its resident
+set also fell to 2.20 GB across the conversion, which is **not explained** — the
+prediction was no effect, and a large one appeared. It may be that the mass
+replacement forced it to rebuild internal state. Recorded as an observation, not
+a mechanism.
 
 ## Limits of this analysis
 

--- a/docs/perf/2026-08-30-macos-mds-hardlink-fanout.md
+++ b/docs/perf/2026-08-30-macos-mds-hardlink-fanout.md
@@ -296,7 +296,9 @@ machine-wide `fs_usage` capture:**
 - **A reduction of roughly 4,560x.**
 
 **`mds` CPU, sampled six times over ten minutes afterwards** — 0.56%, 0.26%,
-0.09%, 0.07% of a core, against a 40.8–45.1% baseline. Its resident set also
+0.09%, 0.07%, 0.38%, 0.06% of a core, against a 40.8–45.1% baseline. Six
+samples rather than one because of the burstiness noted below; the spread
+(0.06–0.56%) matters more than any single figure. Its resident set also
 fell from 185 MB to 12 MB, and the process was never restarted (same pid
 throughout), so this is the same daemon doing far less work rather than a fresh
 one that has not warmed up.


### PR DESCRIPTION
## Summary

Local suite runs on this development machine have got slow enough that the honest workflow became "push and let CI decide". This adds a findings document answering the question that raises: is the ~8,400-tests-in-one-process, no-concurrency-cap model something the Swift ecosystem has already solved, and are we simply not using the tool that solves it?

**Answer: mostly the box, not the runner — with one real exception.**

A 3-core GitHub runner executes the same 8,427 tests in **260 seconds**. This 12-core machine takes a reported **771 seconds**, plus an unbounded wait for the machine-global build slot. A runner with a quarter of the cores is three times faster, so SwiftPM is not the wrong tool for a package this size.

The exception is real. Swift Testing **did** grow a parallelism cap — `SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH`, [swift-testing PR #1390](https://github.com/swiftlang/swift-testing/pull/1390), merged 2025-11-11. It is absent from `release/6.2` and present from `release/6.3`. Local dev resolves `swift` to Xcode 26.3 / Swift 6.2.4, which lacks it; CI already pins Xcode 26.6 / Swift 6.3.3, which has it. So `Tests/CLAUDE.md`'s "no concurrency cap" is still true of the toolchain local runs use and no longer true of the toolchain CI runs on.

Research only. No code, config, or test changes.

## Why this shape

The document's organising claim is that "local tests are slow" is three independent problems that get conflated, with different fixes and different answers to "is there better tooling":

- **Queueing for the machine-global build slot.** `scripts/swift-safe` acquires the flock and then `execv`s SwiftPM, so a test run holds the slot for its whole *execution*, not just its compile. Observed live: a sibling worktree held it for 43 minutes while two to three wrapper processes queued behind it, head-of-line waits 21–25 minutes. A peer session's filtered run — 25 tests, 0.577 s of actual work — waited the full 1800 s timeout and exited 75 having compiled nothing. `TBD_SWIFT_JOBS=8` is exported machine-wide by the owner, so the 8-job holder is sanctioned; the structure produces the queue on its own.
- **The box.** Load 111–165 on 12 cores, 42.1% user / 40.8% sys / 17.1% idle, 973 processes, 8,943 threads, 30 worktrees. Forty per cent system time is about five cores burned in the kernel before a test runs.
- **In-process scheduling** — the "population is the scheduler" effect, which is the only one a runner change touches.

Two things the research found already built and unused, which is why the ranking ends where it does:

- `scripts/swift-safe` already warns that **`run`** holds the slot for the program's whole lifetime and recommends building then executing. `test` has the identical shape, gets no warning, and is the subcommand that stays alive for tens of minutes.
- The **remote verification valve** (`docs/specs/2026-08-16-remote-verification-valve-design.md`) already diagnoses this exact queue — its snapshots of live contention match today's — and ships an overflow path. It is default-off behind `TBD_REMOTE_VERIFY=1` and documented nowhere but its own spec. That makes it recommendation #1: free, no spec needed, and precisely the run it was built for.

No spec via `/tbd-brainstorming` was run for this PR because it revises no theory and changes no behaviour — it is a findings document. Every recommendation in it that *would* change behaviour is explicitly marked as needing a spec with a human answering the questions, and none of them is implemented here.

## What this PR does

Adds `docs/perf/2026-08-29-swift-test-runner-options.md`:

- what the ecosystem actually offers at this scale, with links and versions rather than recollection: the width cap and where the gate sits, `--num-workers` being XCTest-only, one test bundle per package (so no process-per-target), `xcodebuild` test plans, Bazel `shard_count`, selective testing;
- which options exist on our toolchain today versus which need the 6.3.3 toolchain — verified against the shipped binaries, not just the repository;
- a six-item ranked recommendation with expected win and cost for each;
- an explicit "what I would not do" section covering `xcodebuild`, Bazel, and the three remedies `Tests/CLAUDE.md` has already refuted.

## Assumptions

- The width cap's effect is read from `Runner.swift` on `release/6.3`, not measured: `.testStarted` posts at line 226 before the gate, the gate wraps `_runTestCase` at line 384, and `withTimeLimit` is applied at line 414 inside it. That placement is what implies the cap retires the time-limit-starvation class while leaving reported per-test durations inflated. If a future toolchain moves the gate, that inference moves with it.
- The local full-suite baseline (8,437 tests / 818 suites / 771 s) and its failure breakdown (42 failures, all time-limit or gate starvation) are reported from the run that prompted this, not re-measured here. They are labelled as such in the document.

## Evidence & verification

- **Toolchain claims verified against installed binaries.** Xcode 26.3's `Testing.framework` contains `isParallelizationEnabled` and `ParallelizationTrait` and no `maximumParallelizationWidth` or `SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH`; the swift.org 6.3.3 toolchain's `libTesting.dylib` contains all four. `Sources/Testing/Support/Serializer.swift` does not exist on `release/6.2` and does on `release/6.3`. The SwiftPM shipped with 6.3.3 has no `--experimental-maximum-parallelization-width` passthrough, so the environment variable is the only route on our toolchain.
- **CI baseline read from a green run's log**, not recalled: run `33232886152`, 3-core `macos-26` runner, Swift 6.3.3 — 4,401 tests in 148.0 s, 3,946 in 55.3 s, 80 in 56.7 s.
- **Local contention sampled without disturbing it.** The sampler reads the lock file's holder record and never takes the lock.
- **What was deliberately not measured, and why.** An A/B of the width cap on the real suite needs the machine-global slot for a cold rebuild plus several full runs — about an hour of the exact resource identified as the bottleneck, with three sessions already queued and one already dead at exit 75. At load 140 the result would not have discriminated anything, so the queued build for it was killed rather than run. The document says so, and specifies the measurement that would settle it on a quiet box: interleaved arms, population held constant, reporting executed test **count** per arm (a `--filter` matching nothing exits green), the count of `Time limit was exceeded` issues, and wall time.

[20260829-vertical-sheep](https://cheapsteak.github.io/tbd/open/?worktree=F3511E8D-86A1-45A9-B8AD-931E442E03FE)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a detailed investigation into slow local Swift test execution, including parallelism limits, configuration options, performance tradeoffs, and recommendations.
  * Documented macOS indexing and filesystem overhead associated with hardlinked dependency trees across parallel checkouts.
  * Added measurement guidance, remediation options, validation steps, and comparisons of hardlinks, clones, and copies.
  * Documented persistent filesystem event memory accumulation, restart procedures, observed effects, and remaining limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Second document: what was actually burning the box

The findings above concluded "mostly the box, not the runner" and left the box itself unexplained — load 111–165, 40.8% system time, five cores burned in the kernel before a test runs. Investigating that turned up two independent causes, neither of which is Spotlight indexing, and both of which are now fixed. `docs/perf/2026-08-30-macos-mds-hardlink-fanout.md` records them.

**`mds` — hardlink fan-out.** A package manager configured to install by hardlink gives every file a link count equal to the number of checkouts. macOS resolves inode→path by walking the sibling-link set, so with `nlink=69` one lookup became 66 path resolutions. `mds` was producing **50% of all filesystem operations on the machine** — 28,959/sec — while Spotlight indexing was already disabled on every volume. The underlying activity was only ~118 files/sec; the rest was amplification, and it scales quadratically with checkout count.

Converting the affected dependency trees to APFS clones (~2.3M files, zero failures) took the link count to 1:

- `mds` filesystem operations: **28,959/sec → 6.3/sec** (~4,560×)
- `mds` CPU: **40.8–45.1% of a core → 0.06–0.56%** across six samples
- `mds` RSS: 185 MB → 12 MB, same pid throughout

**`fseventsd` — accumulated in-memory state.** Separate problem, separate fix. It sat at 87–116% of a core with a 5.5 GB resident set, and its CPU was independent of a 23× swing in event rate — which ruled out the obvious "many watchers × many events" model, as did a sample showing only four client threads. Restarting the daemon took it from ~101% of a core and 2.23 GB to 0.1% and ~6 MB.

Together those moved the machine, not just the daemons: free pages 3,816 → 23,093, compressor pages 1,489,155 → 688,739, load average 50.7 → 13.0. Much of what presented as `kernel_task` CPU was memory-compressor thrashing driven by this.

### Why it is in this PR

It is the other half of the same question. The first document asked whether the runner was the wrong tool and answered "no, the box is overloaded"; this one establishes what was overloading it. Keeping them together preserves that chain — the second document is the reason the first one's headline measurements looked the way they did.

Still research-only as far as this repository is concerned: **no TBD code, config, or test changes.** The actual remedies live outside it — a one-line link-mode change in the affected project's dev-env config, and a daemon restart.

### What it deliberately does not claim

- **The client driving `mds`'s lookups was never identified.** SIP blocks `fs_usage -p` and `sample` against `mds`, so its callers are not observable. The amplification is established; the trigger is not.
- **`fseventsd`'s re-accumulation rate is unmeasured.** It reached 5.5 GB over 24 days of uptime, so growth is slow, but whether the restart is a one-off or needs scheduling is not yet known. It is written up as a working remedy with an unknown duty cycle.
- **No public prior art was found** for the fan-out mechanism. The generic "large dependency trees make Spotlight expensive" advice is everywhere; the claim that *link count* rather than *file count* is the multiplier appears undocumented elsewhere. It is well supported by the measurements here and not independently corroborated.

The document also records three measurement traps that each nearly produced a wrong number — `mds` load being bursty enough that a single CPU sample proves little, an "after" script that created its output file before sampling and so let a queued conversion start inside its own measurement window, and a near-zero CPU reading being equally consistent with success and with a dead daemon.
