### PR TITLE
docs: make the remote verification valve discoverable in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,34 @@ The main chat session agent should not write code directly. Delegate all impleme
   concurrent default `-j12` builds can exhaust this development machine. The
   two wrappers are orthogonal — admission control and filesystem isolation —
   and compose rather than replace each other.
+- **When the local build queue is starving a test run, `scripts/test.sh` can get
+  the verdict from CI instead.** This *remote verification valve* is default-off;
+  arm it by exporting `TBD_REMOTE_VERIFY=1` in the shell your test runs start
+  from. Armed, a run that has queued for the machine-global build slot for
+  `TBD_REMOTE_VERIFY_YIELD_SECONDS` (default 300) **without ever acquiring it**
+  gives up its place, pushes the commit to an inert `preflight/` ref, and reports
+  the verdict CI returns. It bounds **queue** time, never run time, so a yield
+  discards nothing — a wait that never acquired the slot has compiled nothing —
+  and 300 is sized against GitHub's macOS concurrency rather than impatience.
+  Four things about it are easy to state wrongly and each is load-bearing:
+  - **It is an optimisation, never a gate.** A refused precondition (dirty tree,
+    no `gh`, no pushable ref) exits 78, names itself, and the run falls back to
+    the local queue. A refusal must never fail a run.
+  - **75 is not 76.** 76 means "yielded the queue, verify remotely" and is the
+    only status that routes. 75 means the wait timed out or was abandoned; it is
+    propagated untouched, it is **not** green, and it is not a request to verify
+    elsewhere. Conflating the two is a silent wrong answer.
+  - **Only `scripts/test.sh` opts in**, because its whole output is a verdict.
+    `scripts/restart.sh` and every other artifact build stay local permanently —
+    a binary has to land on this disk.
+  - **A remote run is always the whole suite**; the dispatch cannot carry
+    `--filter`. A green whole-suite verdict is sound for a narrowed caller, since
+    every subset of a passing suite passes. A red one is not — the failures may
+    lie outside what the caller selected — so a narrowed run that comes back red
+    is re-run locally and the local verdict is the one reported.
+
+  The knobs, the capacity model behind 300, and the soak evidence graduation
+  waits on: [`docs/specs/2026-08-16-remote-verification-valve-design.md`](docs/specs/2026-08-16-remote-verification-valve-design.md).
 - When adding a branching conditional that gates behavior (feature flags, toggles, mode switches), add a test for each branch. Verify the gated behavior is off when the flag is off, and that ungated behavior still works.
 
 ### Compile only what user-land cannot do well
@@ -191,6 +219,7 @@ Enforced mechanically by two SwiftLint custom rules in `.swiftlint.yml` (`no_tui
 - **Build**: `scripts/swift-safe build`
 - **Test**: `scripts/test.sh` (fences `~/tbd`, `~/.claude`, `~/.codex` and the tmux socket dir, then runs SwiftPM through `scripts/swift-safe`)
 - **Restart**: `scripts/restart.sh`
+- **Send a starving test run to CI instead of waiting**: `export TBD_REMOTE_VERIFY=1` (default off; needs a clean tree). See the remote verification valve under "Workflow" above.
 - **Install git hooks** (one-time setup after cloning): `scripts/install-hooks.sh`
 - **Diagnostics**: see [`docs/diagnostics-strategy.md`](docs/diagnostics-strategy.md). Quick recipes:
   - Stream one feature area live: `log stream --level debug --predicate 'subsystem BEGINSWITH "com.tbd" AND category == "markdown"'`


### PR DESCRIPTION
## Summary

Every build and test run on a development machine passes through `scripts/swift-safe`, a machine-global admission lock that admits one run at a time. On a busy box that queue has no ceiling, and the lanes stuck in it are overwhelmingly *verification* — runs whose entire output is a pass/fail bit that nothing on this disk needs.

`scripts/test.sh` has shipped a way out of that since the remote verification valve landed: past a queue-time threshold, a clean-tree run gives up its place in the local queue and gets the same verdict from CI. It is default-off behind `TBD_REMOTE_VERIFY=1`, and until this PR it was documented **nowhere outside its own design spec** — not in the root `CLAUDE.md`, not in `Tests/CLAUDE.md`'s Quick Reference. The mechanism existed, worked, and was invisible to anyone who had not read that one spec.

This PR is documentation only. It puts the valve where someone looking for it would find it, so a starving agent or developer can arm it instead of riding a lock timeout.

The contention it addresses, measured on a development machine on 2026-08-29:

- `scripts/swift-safe` acquires the lock and then `execv`s SwiftPM, so a **test** run holds the slot for its whole execution, not just its compile. A sibling worktree was observed holding it for **43 minutes** running tests, with two to three wrapper processes queued behind it continuously and head-of-line waits of 21-25 minutes.
- A filtered run — 3 suites, 25 tests, **0.577 s** of actual test work — waited the full 1800 s lock timeout and exited **75** having compiled nothing. With the valve armed it would have yielded at 300 s and come back with a verdict from CI.
- The machine carries ~30 worktrees and sat at load 110-165 on 12 cores with 10-17% idle.

The valve's own spec reaches the same conclusion independently: of seven queued lanes across two contention snapshots, six were pure verification.

## Why this shape

**No `/tbd-brainstorming` spec was needed.** This revises no theory and changes no behaviour — it documents a shipped, already-specced mechanism, and the thinking it describes was already done and committed in [`docs/specs/2026-08-16-remote-verification-valve-design.md`](docs/specs/2026-08-16-remote-verification-valve-design.md). The spec remains the authority; this is a pointer to it plus the handful of facts a reader needs before deciding to click through.

**The default deliberately stays off.** Flipping it in `scripts/test.sh` would be graduation, and graduation is a separate decision that wants soak evidence we do not have. Enabling it in a shell *is* the soak. That non-goal is recorded here so a future reader does not mistake the omission for an oversight.

**Placement is the `## Workflow` list, beside the `scripts/test.sh` bullet it modifies**, with a one-line pointer in `## Quick Reference` next to Build/Test/Restart. Root `CLAUDE.md` is already long, so the entry carries only what cannot be deferred to the spec link: four facts that are load-bearing and easy to state wrongly, each of which produces a silently wrong answer if a reader gets it backwards.

- **It bounds queue time, never run time.** A yield discards nothing, because a wait that never acquired the slot has compiled nothing.
- **It is an optimisation, never a gate.** A refused precondition exits 78 and falls back to the local queue; a refusal must never fail a run.
- **75 is not 76.** 76 means "yielded the queue, verify remotely" and is the only status that routes. 75 means the wait timed out or was abandoned, is propagated untouched, and is *not* green.
- **A remote run is always the whole suite.** The dispatch cannot carry `--filter`, so a green whole-suite verdict is sound for a narrowed caller while a red one is not, and a narrowed run that comes back red is re-run locally.

The remaining knobs, the capacity model behind the 300 s default, and the graduation criteria are left to the spec rather than duplicated — a second copy of those numbers is a second thing to keep true.

## What this PR does

- Adds a `## Workflow` bullet to the root `CLAUDE.md`, immediately after the existing `scripts/test.sh` bullet, describing the valve, how to arm it (`export TBD_REMOTE_VERIFY=1` in the shell your test runs start from), and the four facts above, linking the design spec for the rest.
- Adds a `## Quick Reference` line beside Build, Test and Restart pointing at the same thing.

29 added lines in one file. No code, no flag, no migration, no behaviour change.

## Flag & rollout

The flag already exists and this PR does not touch it. Recorded here because the default is a deliberate non-goal of this change:

- **Flag**: `TBD_REMOTE_VERIFY`, environment variable read by `scripts/test.sh`. **Default: off** — unset, every path behaves exactly as it did before the valve existed, and no yield bound is forwarded to `scripts/swift-safe`.
- **Enabling it for the soak**: export `TBD_REMOTE_VERIFY=1` in the shell your test runs start from. That is the soak.
- **Graduation** — the open follow-up, deliberately not taken here: flipping the shipped default requires evidence from the soak that a green remote verdict never stood in for a suite that did not run, that a red one never named tests outside the caller's request, and that the local ticket pool rather than GitHub's own queue was the binding constraint. Absent that, the default stays off.

## Assumptions

- The four facts documented are transcribed from `scripts/test.sh` and `scripts/remote-verify.sh` as they are at this commit. If the exit contract ever changes, this entry becomes wrong in the specific way it warns about — a doc that misstates which exit code means what is worse than no doc — so a change to those statuses must update this entry too.

## Evidence & verification

**This is a markdown-only change: nothing to compile and no suite to run.** No build was taken, and none is claimed. That is deliberate as well as sufficient — roughly thirty worktrees are contending for the machine-global build slot, which is the very problem this PR documents, so spending it to render prose would have been the wrong trade.

What was verified instead is the thing that can actually be wrong here — whether every claim matches the implementation. Each was checked against `scripts/test.sh`, `scripts/remote-verify.sh`, `scripts/swift-safe`, and the design spec:

- `TBD_REMOTE_VERIFY=1` arms it; the enable flag defaults to off unless the variable is literally `"1"`.
- `TBD_REMOTE_VERIFY_YIELD_SECONDS` defaults to 300, matching the spec's capacity model.
- 76 routes and is the only status that does; 75 is propagated untouched; 78 is a refusal that falls back to the local queue. All three match `swift-safe`'s exit meanings and `remote-verify.sh`'s `{0, 1, 78}` contract.
- The green/red asymmetry is stated in the correct direction against the routing block in `scripts/test.sh`.
- `dispatch_ref_for` always computes `preflight/<branch>` and never the branch itself.
- `scripts/test.sh` is genuinely the only opt-in caller: a repo-wide grep finds no other arming site, `scripts/nightly-flake-stress.sh` explicitly *disarms* the valve when it shells out to `test.sh`, and no CI workflow references the variable.

Repo doc conventions also checked: no prose tables, no revision-history narration, no banned words, and the spec link resolves.

[Remote verify valve docs](https://cheapsteak.github.io/tbd/open/?worktree=45CEAF1E-924F-43A1-A8E4-617493EC7BE7)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for enabling optional remote verification during queued test runs.
  - Documented configurable timeout behavior, local fallback handling, and status outcomes.
  - Clarified when verification is routed remotely and when failures are rerun locally.
  - Added a quick-reference section for configuring the feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->