### PR TITLE
Fix: three ways the app-side transcript reader can go stale or splice

### DIFF
--- a/Sources/TBDApp/Panes/Transcript/Table/TableTranscriptPaneView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Table/TableTranscriptPaneView.swift
@@ -358,10 +358,16 @@ struct TableTranscriptPaneView: View {
                 state.touchSessionTranscript(sessionID)
             }
         }
+        // One token per run of this task, so the hold belongs to *this* pane.
+        // The deregistration at the bottom happens whenever this task notices
+        // its own cancellation, which can be well after a replacement pane for
+        // the same session has registered; the token is what keeps that late
+        // call from tearing the replacement's polling down.
+        let token = TranscriptPaneToken()
         var tier = currentPollTier()
         await TranscriptPaneRegistration.apply(
             enabled: true, sessionID: sid, path: path,
-            tier: tier, scheduler: scheduler)
+            tier: tier, token: token, scheduler: scheduler)
 
         // Publish once immediately so the pane is not blank until the first tick.
         await source.refresh(sessionID: sid, path: path)
@@ -376,9 +382,9 @@ struct TableTranscriptPaneView: View {
         // and re-declare the tier whenever this pane's visibility changes. A
         // pane the viewer-slot LRU keeps mounted after the selection moves
         // elsewhere must drop to the background cadence without being torn
-        // down; `register` replaces rather than duplicates, so re-declaring is
-        // exactly that gesture (the same one `setAppActive` makes for the whole
-        // registry).
+        // down; re-registering under the same token updates this pane's own
+        // hold rather than taking a second one, so re-declaring is exactly that
+        // gesture (the same one `setAppActive` makes for the whole registry).
         //
         // Polled here rather than watched with an `.onChange` in `body` for two
         // reasons: an observation dependency taken inside this task would not
@@ -395,9 +401,9 @@ struct TableTranscriptPaneView: View {
             let latest = currentPollTier()
             guard latest != tier else { continue }
             tier = latest
-            await scheduler.register(sessionID: sid, path: path, tier: tier)
+            await scheduler.register(sessionID: sid, path: path, tier: tier, token: token)
         }
-        await scheduler.deregister(sessionID: sid)
+        await scheduler.deregister(sessionID: sid, token: token)
     }
 
     /// This pane's cadence tier right now: foreground while its worktree is on

--- a/Sources/TBDApp/TranscriptSource/TranscriptFileWindow.swift
+++ b/Sources/TBDApp/TranscriptSource/TranscriptFileWindow.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 /// One incremental read of a growing JSONL.
 ///
@@ -7,7 +8,27 @@ import Foundation
 /// chunk boundary can never split a multi-byte character, so the decode cannot
 /// fail spuriously; and a half-written trailing line is simply re-read whole on
 /// the next tick instead of being parsed as garbage.
+///
+/// That truncation also makes every window **line-aligned at both ends**:
+/// `offset` is either zero or one past a newline this type itself returned, and
+/// the decoded region always ends at a newline. So a decode failure here is
+/// never a transient split — those bytes sit past the last newline and are not
+/// in the region being decoded. It can only be bytes between two newlines that
+/// are not valid UTF-8, and re-reading them on the next tick produces exactly
+/// the same failure. Reporting that as "no news" forever would wedge the
+/// session: the offset never advances, every tick re-reads the same bad window,
+/// and the pane silently stops updating.
+///
+/// So an undecodable window falls back to decoding line by line, keeping every
+/// line that decodes and skipping the ones that do not, then advancing past the
+/// whole window. Nothing is lost that would have survived anyway — the JSONL
+/// parser downstream rejects a line that is not valid UTF-8 too — and no line
+/// is decoded lossily, because a repaired line could parse into a *wrong* item
+/// rather than failing loudly. The skip is logged, so a session that hit this
+/// leaves a trace rather than quietly dropping content.
 enum TranscriptFileWindow {
+
+    private static let log = Logger(subsystem: "com.tbd.app", category: "transcript-source")
 
     struct Read {
         let lines: [String]
@@ -27,11 +48,45 @@ enum TranscriptFileWindow {
                 return Read(lines: [], newOffset: offset)
             }
             let complete = data[data.startIndex...lastNewline]
-            guard let text = String(data: complete, encoding: .utf8) else { return nil }
+            let newOffset = offset + UInt64(complete.count)
+            guard let text = String(data: complete, encoding: .utf8) else {
+                return skippingUndecodableLines(complete, newOffset: newOffset, path: path)
+            }
             let lines = text.components(separatedBy: "\n").filter { !$0.isEmpty }
-            return Read(lines: lines, newOffset: offset + UInt64(complete.count))
+            return Read(lines: lines, newOffset: newOffset)
         } catch {
             return nil
         }
+    }
+
+    /// The recovery path for a window that is not valid UTF-8 as a whole.
+    ///
+    /// Splits on the newline byte and decodes each line on its own. `0x0A`
+    /// cannot occur inside a multi-byte UTF-8 sequence — every continuation
+    /// byte is `>= 0x80` — so splitting the raw bytes yields exactly the lines
+    /// a successful whole-window decode would have, and the ones that are valid
+    /// come back byte-accurate.
+    ///
+    /// Always returns a `Read`: the offset must advance past the offending
+    /// bytes, or the next tick re-reads them and the session stays wedged.
+    private static func skippingUndecodableLines(
+        _ complete: Data.SubSequence, newOffset: UInt64, path: String
+    ) -> Read {
+        var lines: [String] = []
+        var skipped = 0
+        for lineBytes in complete.split(separator: UInt8(ascii: "\n")) {
+            if let line = String(data: Data(lineBytes), encoding: .utf8) {
+                lines.append(line)
+            } else {
+                skipped += 1
+            }
+        }
+        log.error(
+            """
+            transcript window is not valid UTF-8: skipped \(skipped, privacy: .public) line(s), \
+            kept \(lines.count, privacy: .public), advancing to offset \
+            \(newOffset, privacy: .public) path=\(path, privacy: .public)
+            """)
+        return Read(lines: lines, newOffset: newOffset)
     }
 }

--- a/Sources/TBDApp/TranscriptSource/TranscriptPaneRegistration.swift
+++ b/Sources/TBDApp/TranscriptSource/TranscriptPaneRegistration.swift
@@ -8,19 +8,23 @@ import Foundation
 /// the guarded path matters as much as registering on the happy one: a pane
 /// whose session loses its transcript path — or whose flag is turned off while
 /// it is open — must stop being polled, not merely stop being re-registered.
+///
+/// `token` identifies the calling pane on both branches, so the guarded one
+/// releases that pane's own hold and nobody else's — see `TranscriptPaneToken`.
 enum TranscriptPaneRegistration {
     static func apply(
         enabled: Bool,
         sessionID: String,
         path: String?,
         tier: TranscriptPollTier,
+        token: TranscriptPaneToken,
         scheduler: TranscriptPollScheduler
     ) async {
         guard enabled, let path, !path.isEmpty else {
-            await scheduler.deregister(sessionID: sessionID)
+            await scheduler.deregister(sessionID: sessionID, token: token)
             return
         }
-        await scheduler.register(sessionID: sessionID, path: path, tier: tier)
+        await scheduler.register(sessionID: sessionID, path: path, tier: tier, token: token)
     }
 }
 

--- a/Sources/TBDApp/TranscriptSource/TranscriptPollScheduler.swift
+++ b/Sources/TBDApp/TranscriptSource/TranscriptPollScheduler.swift
@@ -13,6 +13,31 @@ enum TranscriptPollTier: Sendable, Equatable {
     case background
 }
 
+/// Identifies *which pane* holds a session registered.
+///
+/// Registrations are refcounted by this token, so the scheduler can tell one
+/// pane's hold on a session from another's. Two things make that necessary:
+/// the viewer-slot LRU permits two panes onto one session at once, and — the
+/// reachable case — a pane that closes and immediately reopens tears its old
+/// SwiftUI task down at an arbitrarily later moment than the new one starts,
+/// so the outgoing `deregister` can land after the incoming `register`.
+/// Keyed by session id alone, that late call tore down the fresh pane's
+/// polling and left it silently stale.
+///
+/// Deliberately *not* the `Registration.generation`. The two answer opposite
+/// questions: a generation must change whenever the entry becomes a new
+/// incarnation, so an in-flight tick can recognise itself as stale, while a
+/// token must stay stable across exactly those changes — a pane re-declaring
+/// its tier is the same holder, not a second one — and must differ between two
+/// panes sharing one live entry, which a single per-entry generation cannot
+/// express. Minted by the pane rather than handed back by the scheduler so the
+/// hold has one owner for its whole life, and `register`/`deregister` stay
+/// symmetric.
+struct TranscriptPaneToken: Hashable, Sendable {
+    private let id: UUID
+    init() { id = UUID() }
+}
+
 /// The cadence policy, as a pure function so it can be asserted without timing.
 enum TranscriptPollPolicy {
     static let foreground = Duration.milliseconds(100)
@@ -40,13 +65,27 @@ actor TranscriptPollScheduler {
 
     private struct Registration {
         var path: String
-        var tier: TranscriptPollTier
+        /// Every pane holding this session open right now, and the tier each
+        /// one declared. Held inside the entry, so it is dropped whole when the
+        /// last holder leaves — nothing accumulates per retired pane.
+        var holders: [TranscriptPaneToken: TranscriptPollTier]
         /// Which incarnation of this session id this registration is. Minted
-        /// fresh by every `register` and never reused, so a tick that started
-        /// under a registration which has since been dropped or replaced can
-        /// recognise itself as stale — see `finishTick`.
+        /// when the entry is created and again when its path changes — the two
+        /// cases where work already in flight was computed against something
+        /// this entry no longer is — so such a tick can recognise itself as
+        /// stale. See `finishTick`. Holders coming and going do not mint one:
+        /// the entry is still the same entry, and a tick that outlives one of
+        /// several holders is still owed to the rest.
         var generation: UInt64
         var task: Task<Void, Never>?
+
+        /// The cadence the session actually gets: the most aggressive tier any
+        /// live holder declared. A session one pane is showing on screen and
+        /// another is merely holding warm must poll at `.foreground` — the
+        /// on-screen pane's freshness is not the other pane's to relax.
+        var tier: TranscriptPollTier {
+            holders.values.contains(.foreground) ? .foreground : .background
+        }
     }
 
     private var registrations: [String: Registration] = [:]
@@ -70,19 +109,30 @@ actor TranscriptPollScheduler {
 
     var registeredSessionIDs: Set<String> { Set(registrations.keys) }
 
-    /// The tier a session is registered at right now, or nil when it is not
-    /// registered. Read-only — the scheduler still never derives a tier, it
-    /// only reports back the one the pane declared.
+    /// The tier a session is polled at right now, or nil when it is not
+    /// registered. Read-only — the scheduler still never derives a tier from
+    /// anything of its own, it only reports back the most aggressive one its
+    /// holders declared.
     func registeredTier(sessionID: String) -> TranscriptPollTier? {
         registrations[sessionID]?.tier
+    }
+
+    /// How many panes are holding `sessionID` registered. Zero when it is not
+    /// registered at all.
+    ///
+    /// Read-only, and here so a test can pin that a hold was actually released
+    /// — or actually ignored, when a stale token asks. Nothing in the app reads
+    /// it.
+    func holderCount(sessionID: String) -> Int {
+        registrations[sessionID]?.holders.count ?? 0
     }
 
     /// The generation of the live registration for `sessionID`, or nil when it
     /// is not registered.
     ///
-    /// Read-only, and here so a test can drive `finishTick` with the same token
-    /// a real poll task carries — the stale-tick interleaving is otherwise only
-    /// reachable by winning a race. Nothing in the app reads it.
+    /// Read-only, and here so a test can drive `finishTick` with the same
+    /// generation a real poll task carries — the stale-tick interleaving is
+    /// otherwise only reachable by winning a race. Nothing in the app reads it.
     func registeredGeneration(sessionID: String) -> UInt64? {
         registrations[sessionID]?.generation
     }
@@ -91,15 +141,37 @@ actor TranscriptPollScheduler {
         onChange = handler
     }
 
-    func register(sessionID: String, path: String, tier: TranscriptPollTier) {
-        registrations[sessionID]?.task?.cancel()
-        lastGeneration += 1
-        registrations[sessionID] = Registration(
-            path: path, tier: tier, generation: lastGeneration, task: nil)
+    /// Adds `token`'s hold on `sessionID`, at the tier that pane declares.
+    ///
+    /// Idempotent per token: a pane re-declaring its tier updates its own hold
+    /// rather than taking a second one, which is what makes the holder set
+    /// bounded by "panes currently open", not by "tier changes ever made".
+    func register(
+        sessionID: String, path: String, tier: TranscriptPollTier, token: TranscriptPaneToken
+    ) {
+        var registration: Registration
+        if let existing = registrations[sessionID] {
+            registration = existing
+            if registration.path != path {
+                // The same session id under a different file. Whatever a tick
+                // in flight built, it built against the old path; mint a new
+                // incarnation so it can tell.
+                lastGeneration += 1
+                registration.generation = lastGeneration
+                registration.path = path
+            }
+        } else {
+            lastGeneration += 1
+            registration = Registration(
+                path: path, holders: [:], generation: lastGeneration, task: nil)
+        }
+        registration.holders[token] = tier
+        registrations[sessionID] = registration
         startPolling(sessionID: sessionID)
     }
 
-    /// Stops polling `sessionID` **and** drops what the source built for it.
+    /// Releases `token`'s hold on `sessionID`, and — only when it was the last
+    /// one — stops polling **and** drops what the source built for it.
     ///
     /// The two belong together. `TranscriptSource` keeps every `TranscriptItem`
     /// it has parsed, plus `IncrementalTranscript`'s retained rows for
@@ -126,8 +198,33 @@ actor TranscriptPollScheduler {
     /// defined order against it — so the bound above is not established here
     /// alone. `finishTick` closes that half; the removal of the registration is
     /// what it keys off.
-    func deregister(sessionID: String) async {
-        registrations[sessionID]?.task?.cancel()
+    ///
+    /// A token that holds nothing releases nothing, and that is the whole fix
+    /// for the reopen race: `TableTranscriptPaneView` deregisters when its own
+    /// task observes cancellation, an arbitrarily later moment than the one
+    /// SwiftUI tore it down at, so a pane that closes and immediately reopens
+    /// can have its outgoing `deregister` land *after* the incoming pane's
+    /// `register`. Keyed by session id alone that call tore down the live
+    /// pane's polling and nothing self-corrected it; keyed by the token, the
+    /// outgoing pane is simply no longer a holder and the call does nothing.
+    /// The generation guard in `finishTick` does not cover this — it gates a
+    /// tick, not a deregistration.
+    ///
+    /// Making the teardown conditional on the holder set emptying settles the
+    /// two-panes-on-one-session case by the same stroke: either may leave, and
+    /// the session keeps polling for whoever is left.
+    func deregister(sessionID: String, token: TranscriptPaneToken) async {
+        guard var registration = registrations[sessionID] else { return }
+        guard registration.holders.removeValue(forKey: token) != nil else { return }
+        guard registration.holders.isEmpty else {
+            // Somebody is still watching. Write the shrunken holder set back
+            // and re-derive the cadence: losing the on-screen pane must relax
+            // the survivors to their own tier.
+            registrations[sessionID] = registration
+            startPolling(sessionID: sessionID)
+            return
+        }
+        registration.task?.cancel()
         registrations.removeValue(forKey: sessionID)
         await source.forget(sessionID: sessionID)
     }
@@ -144,8 +241,10 @@ actor TranscriptPollScheduler {
         let path = registration.path
         // Carried by the task, not re-read from `registrations` inside it: the
         // whole point is to compare against what the registry says *later*.
-        // Restarting a task (`setAppActive`) deliberately keeps the generation
-        // — the registration is the same one, only its cadence changed.
+        // Restarting a task (`setAppActive`, a re-declared tier, a holder
+        // arriving or leaving) deliberately keeps the generation — the entry is
+        // the same entry, only its cadence changed, and a tick in flight is
+        // still owed to whoever holds it.
         let generation = registration.generation
         let interval = TranscriptPollPolicy.interval(tier: registration.tier, appActive: appActive)
         let clock = self.clock

--- a/Sources/TBDApp/TranscriptSource/TranscriptSource.swift
+++ b/Sources/TBDApp/TranscriptSource/TranscriptSource.swift
@@ -24,22 +24,54 @@ actor TranscriptSource {
     /// must not scale with the transcript.
     private static let verificationWindowBytes: UInt64 = 512
 
+    /// What an entry knows about the bytes it has already consumed — the input
+    /// to the next tick's rewrite-versus-append check.
+    ///
+    /// The two cases must stay distinguishable. Collapsing them into a nullable
+    /// `Data` reads "nothing to verify" and "verification unavailable" the same
+    /// way, and the second one silently licenses the splice this whole
+    /// mechanism exists to prevent.
+    private enum ConsumedTail {
+        /// The last `verificationWindowBytes` bytes immediately BEFORE
+        /// `offset`, as they read when this entry consumed them. Empty when
+        /// nothing has been consumed yet (`offset == 0`) — legitimately
+        /// verifiable, because there is no earlier content a rewrite could
+        /// have altered.
+        case captured(Data)
+
+        /// Bytes WERE consumed, but the window that would prove the next growth
+        /// is an append could not be read back. Nothing exists to compare
+        /// against, so the next growth must be re-read from byte zero rather
+        /// than trusted.
+        case unavailable
+    }
+
     private struct Entry {
         var path: String
         var offset: UInt64
         var lastSize: UInt64
         var lastModified: Date
-        /// The last `verificationWindowBytes` bytes immediately BEFORE
-        /// `offset`, as they read when this entry consumed them. nil only when
-        /// nothing has been consumed yet, or when the window could not be
-        /// captured — either way there is nothing to compare against.
-        var consumedTail: Data?
+        var consumedTail: ConsumedTail
         var transcript: IncrementalTranscript
     }
 
     private var entries: [String: Entry] = [:]
 
-    init() {}
+    /// Reads the verification window back off disk. Injected so a test can make
+    /// the capture fail without racing the filesystem: in production the window
+    /// is lost only when the file is replaced or removed in the instant between
+    /// the main read and this one.
+    private let captureTail: @Sendable (String, UInt64) -> Data?
+
+    init() {
+        self.captureTail = { path, offset in
+            TranscriptSource.diskTailWindow(path: path, endingAt: offset)
+        }
+    }
+
+    init(captureTail: @escaping @Sendable (String, UInt64) -> Data?) {
+        self.captureTail = captureTail
+    }
 
     func items(sessionID: String) -> [TranscriptItem] {
         entries[sessionID]?.transcript.items ?? []
@@ -109,10 +141,10 @@ actor TranscriptSource {
                 // bytes changed, the file is a different file and resuming from
                 // `offset` would splice rows from the old transcript onto a
                 // suffix of the new one.
-                if let intact = Self.consumedTailIsIntact(path: path, entry: existing) {
+                if let intact = consumedTailIsIntact(path: path, entry: existing) {
                     if !intact {
                         Self.log.debug(
-                            "consumed bytes changed, resetting session=\(sessionID, privacy: .public)")
+                            "consumed bytes unverified, resetting session=\(sessionID, privacy: .public)")
                         entry = nil
                     }
                 } else {
@@ -128,7 +160,7 @@ actor TranscriptSource {
         var working = entry ?? Entry(
             path: path, offset: 0, lastSize: 0,
             lastModified: Date(timeIntervalSince1970: 0),
-            consumedTail: nil,
+            consumedTail: .captured(Data()),
             transcript: IncrementalTranscript())
 
         guard isFirstRead || size != working.lastSize else {
@@ -147,26 +179,40 @@ actor TranscriptSource {
         working.lastSize = size
         working.lastModified = modified
         working.path = path
-        working.consumedTail = Self.tailWindow(path: path, endingAt: read.newOffset)
+        // Capture the window the NEXT tick will verify against. A failure here
+        // is not "nothing to verify": the file was replaced or removed in the
+        // instant since the read above, and the bytes just consumed can no
+        // longer be proven to be a prefix of what is on disk. Record that, so
+        // the next growth resets instead of being trusted as an append.
+        if let tail = captureTail(path, read.newOffset) {
+            working.consumedTail = .captured(tail)
+        } else {
+            working.consumedTail = .unavailable
+        }
         entries[sessionID] = working
         return change
     }
 
     /// Whether the bytes `entry` has already consumed still read the same.
     ///
-    /// Returns nil when the window could not be read at all, which the caller
-    /// must report as "no news" rather than resetting: an unreadable file is
-    /// not evidence that the file was rewritten.
-    private static func consumedTailIsIntact(path: String, entry: Entry) -> Bool? {
-        guard let expected = entry.consumedTail, !expected.isEmpty else { return true }
-        guard let actual = tailWindow(path: path, endingAt: entry.offset) else { return nil }
+    /// Returns false when they do not, and also when the entry never captured
+    /// them — both mean this growth cannot be served by appending, and the
+    /// caller must re-read from byte zero. Returns nil when the window cannot
+    /// be read right now, which the caller must report as "no news" rather than
+    /// resetting: an unreadable file is not evidence that the file was
+    /// rewritten.
+    private func consumedTailIsIntact(path: String, entry: Entry) -> Bool? {
+        guard case .captured(let expected) = entry.consumedTail else { return false }
+        guard !expected.isEmpty else { return true }
+        guard let actual = captureTail(path, entry.offset) else { return nil }
         return actual == expected
     }
 
     /// The last `verificationWindowBytes` bytes before `offset` — fewer when
     /// the file is shorter than that, which is itself a mismatch worth seeing.
-    /// nil on any read failure.
-    private static func tailWindow(path: String, endingAt offset: UInt64) -> Data? {
+    /// Empty — not nil — when nothing has been consumed yet; nil on a read
+    /// failure, which the caller records as `.unavailable`.
+    private static func diskTailWindow(path: String, endingAt offset: UInt64) -> Data? {
         guard offset > 0 else { return Data() }
         let length = min(verificationWindowBytes, offset)
         guard let handle = FileHandle(forReadingAtPath: path) else { return nil }

--- a/Tests/TBDAppTests/AppSideTranscriptFlagTests.swift
+++ b/Tests/TBDAppTests/AppSideTranscriptFlagTests.swift
@@ -47,29 +47,31 @@ struct AppSideTranscriptFlagTests {
         let scheduler = TranscriptPollScheduler(source: TranscriptSource())
         await TranscriptPaneRegistration.apply(
             enabled: false, sessionID: "s1", path: "/tmp/whatever",
-            tier: .foreground, scheduler: scheduler)
+            tier: .foreground, token: TranscriptPaneToken(), scheduler: scheduler)
         #expect(await scheduler.registeredSessionIDs.isEmpty)
     }
 
     @Test("with the flag on the session registers")
     func flagOnRegisters() async {
         let scheduler = TranscriptPollScheduler(source: TranscriptSource())
+        let pane = TranscriptPaneToken()
         await TranscriptPaneRegistration.apply(
             enabled: true, sessionID: "s1", path: "/tmp/whatever",
-            tier: .foreground, scheduler: scheduler)
+            tier: .foreground, token: pane, scheduler: scheduler)
         #expect(await scheduler.registeredSessionIDs == ["s1"])
-        await scheduler.deregister(sessionID: "s1")
+        await scheduler.deregister(sessionID: "s1", token: pane)
     }
 
     @Test("a nil or empty path never registers, even with the flag on")
     func missingPathDoesNotRegister() async {
         let scheduler = TranscriptPollScheduler(source: TranscriptSource())
+        let pane = TranscriptPaneToken()
         await TranscriptPaneRegistration.apply(
             enabled: true, sessionID: "s1", path: nil,
-            tier: .foreground, scheduler: scheduler)
+            tier: .foreground, token: pane, scheduler: scheduler)
         await TranscriptPaneRegistration.apply(
             enabled: true, sessionID: "s2", path: "",
-            tier: .foreground, scheduler: scheduler)
+            tier: .foreground, token: pane, scheduler: scheduler)
         #expect(await scheduler.registeredSessionIDs.isEmpty)
     }
 
@@ -94,16 +96,19 @@ struct AppSideTranscriptFlagTests {
         #expect(TranscriptPaneTransport.resolve(appSideEnabled: false, path: nil) == .daemonPoll)
     }
 
+    /// The same pane on both sides — it is the flag under it that changed, so
+    /// it releases the hold it took, and the session stops being polled.
     @Test("turning the flag off deregisters a pane that had registered")
     func flagOffDeregistersAnExistingRegistration() async {
         let scheduler = TranscriptPollScheduler(source: TranscriptSource())
+        let pane = TranscriptPaneToken()
         await TranscriptPaneRegistration.apply(
             enabled: true, sessionID: "s1", path: "/tmp/whatever",
-            tier: .foreground, scheduler: scheduler)
+            tier: .foreground, token: pane, scheduler: scheduler)
         #expect(await scheduler.registeredSessionIDs == ["s1"])
         await TranscriptPaneRegistration.apply(
             enabled: false, sessionID: "s1", path: "/tmp/whatever",
-            tier: .foreground, scheduler: scheduler)
+            tier: .foreground, token: pane, scheduler: scheduler)
         #expect(await scheduler.registeredSessionIDs.isEmpty)
     }
 }

--- a/Tests/TBDAppTests/TranscriptFileWindowTests.swift
+++ b/Tests/TBDAppTests/TranscriptFileWindowTests.swift
@@ -1,0 +1,150 @@
+import Foundation
+import Testing
+@testable import TBDApp
+@testable import TBDShared
+
+/// The window reader's byte-level contract: what it withholds, what it skips,
+/// and that the offset always ends up somewhere the next read can resume from.
+@Suite("TranscriptFileWindow")
+struct TranscriptFileWindowTests {
+
+    private static let newline: UInt8 = 0x0A
+
+    /// Joins raw line bodies into a JSONL blob, newline-terminating each one.
+    /// Takes `Data` rather than `String` so a deliberately undecodable line can
+    /// sit among valid ones.
+    private func jsonl(_ lines: [Data]) -> Data {
+        var out = Data()
+        for line in lines {
+            out.append(line)
+            out.append(Self.newline)
+        }
+        return out
+    }
+
+    private func tempFile(_ bytes: Data) throws -> String {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("tbd-window-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let file = dir.appendingPathComponent("session.jsonl")
+        try bytes.write(to: file)
+        return file.path
+    }
+
+    private func append(_ bytes: Data, to path: String) throws {
+        let handle = try FileHandle(forWritingTo: URL(fileURLWithPath: path))
+        try handle.seekToEnd()
+        try handle.write(contentsOf: bytes)
+        try handle.close()
+    }
+
+    private func promptTexts(_ items: [TranscriptItem]) -> [String] {
+        items.compactMap { item -> String? in
+            if case .userPrompt(_, let text, _) = item { return text }
+            return nil
+        }
+    }
+
+    private let lineA = #"{"type":"user","uuid":"a","timestamp":"2026-08-26T10:00:00.000Z","message":{"role":"user","content":"hello"}}"#
+    private let lineB = #"{"type":"user","uuid":"b","timestamp":"2026-08-26T10:00:01.000Z","message":{"role":"user","content":"second"}}"#
+    private let lineC = #"{"type":"user","uuid":"c","timestamp":"2026-08-26T10:00:02.000Z","message":{"role":"user","content":"third"}}"#
+
+    /// A line with the right JSON shape whose content byte is `0xFF` — a byte
+    /// that can never appear in valid UTF-8, so the sequence stays invalid no
+    /// matter what follows it and no later tick can decode it. Synthetic; not
+    /// captured from any real session.
+    private var undecodableLine: Data {
+        var line = Data(#"{"type":"user","uuid":"x","timestamp":"2026-08-26T10:00:03.000Z","message":{"role":"user","content":""#.utf8)
+        line.append(UInt8(0xFF))
+        line.append(contentsOf: Data(#""}}"#.utf8))
+        return line
+    }
+
+    /// Fails against the current code: the whole window is decoded in one
+    /// `String(data:encoding:.utf8)`, which returns nil for these bytes, so
+    /// `read` returns nil — "no news" — and the offset never moves past the bad
+    /// line. Every later tick re-reads the identical window and fails the same
+    /// way, so `lineB` is never delivered and the session is wedged forever.
+    @Test("an undecodable line is skipped and the offset advances past it")
+    func undecodableLineIsSkipped() throws {
+        let bytes = jsonl([Data(lineA.utf8), undecodableLine, Data(lineB.utf8)])
+        let path = try tempFile(bytes)
+
+        let read = try #require(TranscriptFileWindow.read(path: path, from: 0),
+                                "an undecodable line must not be reported as 'no news'")
+        #expect(read.lines == [lineA, lineB], "every decodable line survives, byte-accurate")
+        #expect(read.newOffset == UInt64(bytes.count),
+                "the offset must clear the whole window, or the next tick re-reads the same bad bytes")
+    }
+
+    /// Fails against the current code for the same reason, one layer up: the
+    /// first `refresh` gets nil from the window reader, so nothing is stored,
+    /// `items` stays empty, and the later append is never picked up either —
+    /// the pane silently stops updating with no recovery path.
+    @Test("a session with an undecodable line still advances on later appends")
+    func sessionRecoversAndKeepsReading() async throws {
+        let path = try tempFile(jsonl([Data(lineA.utf8), undecodableLine, Data(lineB.utf8)]))
+        let source = TranscriptSource()
+
+        let first = await source.refresh(sessionID: "s1", path: path)
+        #expect(first != nil, "the bad line must not be reported as a read failure")
+        #expect(promptTexts(await source.items(sessionID: "s1")) == ["hello", "second"])
+
+        try append(jsonl([Data(lineC.utf8)]), to: path)
+        let second = await source.refresh(sessionID: "s1", path: path)
+        #expect(second?.appended.count == 1,
+                "having skipped the bad line, the reader resumes reading only the delta")
+        #expect(promptTexts(await source.items(sessionID: "s1")) == ["hello", "second", "third"])
+    }
+
+    /// A regression guard rather than a failing-first test: it passes against
+    /// the current code, and pins the behaviour the recovery path must not
+    /// cost. It fails against the two obvious wrong implementations — decoding
+    /// the *untruncated* buffer lossily, which delivers a mangled half line now
+    /// instead of the whole line later, and treating any decode failure as a
+    /// skippable line, which drops the split line permanently.
+    @Test("a line split mid-character is withheld, then delivered whole")
+    func partialMultiByteTailIsWithheld() throws {
+        let accented = #"{"type":"user","uuid":"e","timestamp":"2026-08-26T10:00:04.000Z","message":{"role":"user","content":"café"}}"#
+        let accentedBytes = Data(accented.utf8)
+        // Cut one byte into the two-byte "é" (0xC3 0xA9): the lead byte has
+        // landed, its continuation byte has not.
+        let lead = try #require(accentedBytes.firstIndex(of: UInt8(0xC3)))
+        let cut = accentedBytes.index(after: lead)
+        let head = Data(accentedBytes[accentedBytes.startIndex..<cut])
+        var tail = Data(accentedBytes[cut...])
+
+        let path = try tempFile(jsonl([Data(lineA.utf8)]))
+        try append(head, to: path)
+
+        let first = try #require(TranscriptFileWindow.read(path: path, from: 0))
+        #expect(first.lines == [lineA], "a line cut mid-character must not be parsed")
+        #expect(first.newOffset == UInt64(lineA.utf8.count + 1),
+                "the offset stops at the last newline, so the split line is re-read whole")
+
+        tail.append(Self.newline)
+        try append(tail, to: path)
+        let second = try #require(TranscriptFileWindow.read(path: path, from: first.newOffset))
+        #expect(second.lines == [accented], "the completed line arrives whole and unmangled")
+    }
+
+    /// Fails against the current code: the undecodable line poisons the
+    /// whole-window decode, so `read` returns nil and neither non-ASCII line is
+    /// ever delivered. It also pins that the recovery splits on the newline
+    /// BYTE and measures the offset in bytes — splitting or counting by
+    /// `Character` would mangle these lines or leave the offset short.
+    @Test("valid multi-byte content survives the skip path intact")
+    func multiByteContentSurvivesRecovery() throws {
+        let cjk = #"{"type":"user","uuid":"m1","timestamp":"2026-08-26T10:00:05.000Z","message":{"role":"user","content":"日本語のテスト"}}"#
+        let mixed = #"{"type":"user","uuid":"m2","timestamp":"2026-08-26T10:00:06.000Z","message":{"role":"user","content":"café 🌊 ünïcode"}}"#
+        #expect(cjk.utf8.count > cjk.count && mixed.utf8.count > mixed.count,
+                "the fixture only exercises byte-vs-character counting if the lines are multi-byte")
+
+        let bytes = jsonl([Data(cjk.utf8), undecodableLine, Data(mixed.utf8)])
+        let path = try tempFile(bytes)
+
+        let read = try #require(TranscriptFileWindow.read(path: path, from: 0))
+        #expect(read.lines == [cjk, mixed], "non-ASCII lines must come back byte-accurate")
+        #expect(read.newOffset == UInt64(bytes.count), "the offset is a byte count, not a character count")
+    }
+}

--- a/Tests/TBDAppTests/TranscriptPaneVisibilityTests.swift
+++ b/Tests/TBDAppTests/TranscriptPaneVisibilityTests.swift
@@ -73,13 +73,14 @@ struct TranscriptPaneVisibilityTests {
     func declaredTierReachesTheScheduler() async {
         let scheduler = TranscriptPollScheduler(source: TranscriptSource())
         let worktree = UUID()
+        let pane = TranscriptPaneToken()
         await TranscriptPaneRegistration.apply(
             enabled: true, sessionID: "s1", path: "/tmp/tbd-tier-test-s1.jsonl",
             tier: TranscriptPaneVisibility.tier(
                 worktreeID: worktree, selectedWorktreeIDs: [UUID()]),
-            scheduler: scheduler)
+            token: pane, scheduler: scheduler)
         #expect(await scheduler.registeredTier(sessionID: "s1") == .background)
-        await scheduler.deregister(sessionID: "s1")
+        await scheduler.deregister(sessionID: "s1", token: pane)
     }
 
     /// Losing the selection must re-tier a live registration in place — the
@@ -90,12 +91,15 @@ struct TranscriptPaneVisibilityTests {
         let scheduler = TranscriptPollScheduler(source: TranscriptSource())
         let worktree = UUID()
         let path = "/tmp/tbd-tier-test-s2.jsonl"
+        // One pane across all three declarations, so it re-declares its own
+        // hold rather than piling up new ones.
+        let pane = TranscriptPaneToken()
 
         await TranscriptPaneRegistration.apply(
             enabled: true, sessionID: "s2", path: path,
             tier: TranscriptPaneVisibility.tier(
                 worktreeID: worktree, selectedWorktreeIDs: [worktree]),
-            scheduler: scheduler)
+            token: pane, scheduler: scheduler)
         #expect(await scheduler.registeredTier(sessionID: "s2") == .foreground)
 
         // Selection moves to another worktree; this pane stays mounted.
@@ -103,9 +107,11 @@ struct TranscriptPaneVisibilityTests {
             enabled: true, sessionID: "s2", path: path,
             tier: TranscriptPaneVisibility.tier(
                 worktreeID: worktree, selectedWorktreeIDs: [UUID()]),
-            scheduler: scheduler)
+            token: pane, scheduler: scheduler)
         #expect(await scheduler.registeredSessionIDs == ["s2"],
                 "re-declaring a tier must replace the registration, not duplicate it")
+        #expect(await scheduler.holderCount(sessionID: "s2") == 1,
+                "and the same pane must still be its only holder")
         #expect(await scheduler.registeredTier(sessionID: "s2") == .background)
 
         // And back again when the pane returns to screen.
@@ -113,8 +119,8 @@ struct TranscriptPaneVisibilityTests {
             enabled: true, sessionID: "s2", path: path,
             tier: TranscriptPaneVisibility.tier(
                 worktreeID: worktree, selectedWorktreeIDs: [worktree]),
-            scheduler: scheduler)
+            token: pane, scheduler: scheduler)
         #expect(await scheduler.registeredTier(sessionID: "s2") == .foreground)
-        await scheduler.deregister(sessionID: "s2")
+        await scheduler.deregister(sessionID: "s2", token: pane)
     }
 }

--- a/Tests/TBDAppTests/TranscriptPollSchedulerTests.swift
+++ b/Tests/TBDAppTests/TranscriptPollSchedulerTests.swift
@@ -38,17 +38,23 @@ struct TranscriptPollSchedulerTests {
     @Test("deregistering a session stops tracking it")
     func deregisterStops() async {
         let scheduler = TranscriptPollScheduler(source: TranscriptSource())
-        await scheduler.register(sessionID: "s1", path: "/nonexistent", tier: .background)
-        await scheduler.deregister(sessionID: "s1")
+        let pane = TranscriptPaneToken()
+        await scheduler.register(
+            sessionID: "s1", path: "/nonexistent", tier: .background, token: pane)
+        await scheduler.deregister(sessionID: "s1", token: pane)
         #expect(await scheduler.registeredSessionIDs.isEmpty)
     }
 
-    @Test("registering twice replaces rather than duplicates")
+    @Test("one pane registering twice replaces its own hold rather than duplicating it")
     func registerIsIdempotent() async {
         let scheduler = TranscriptPollScheduler(source: TranscriptSource())
-        await scheduler.register(sessionID: "s1", path: "/a", tier: .background)
-        await scheduler.register(sessionID: "s1", path: "/b", tier: .foreground)
+        let pane = TranscriptPaneToken()
+        await scheduler.register(sessionID: "s1", path: "/a", tier: .background, token: pane)
+        await scheduler.register(sessionID: "s1", path: "/b", tier: .foreground, token: pane)
         #expect(await scheduler.registeredSessionIDs == ["s1"])
+        #expect(await scheduler.holderCount(sessionID: "s1") == 1,
+                "re-declaring is the same pane, so it must not become a second holder")
+        #expect(await scheduler.registeredTier(sessionID: "s1") == .foreground)
     }
 
     @Test("nothing unregistered is tracked")
@@ -78,12 +84,13 @@ struct TranscriptPollSchedulerTests {
         let source = TranscriptSource()
         let scheduler = TranscriptPollScheduler(source: source)
 
-        await scheduler.register(sessionID: "s1", path: path, tier: .background)
+        let pane = TranscriptPaneToken()
+        await scheduler.register(sessionID: "s1", path: path, tier: .background, token: pane)
         await source.refresh(sessionID: "s1", path: path)
         #expect(await source.items(sessionID: "s1").isEmpty == false)
         #expect(await source.trackedSessionCount == 1)
 
-        await scheduler.deregister(sessionID: "s1")
+        await scheduler.deregister(sessionID: "s1", token: pane)
         #expect(await source.items(sessionID: "s1").isEmpty)
         #expect(await source.trackedSessionCount == 0,
                 "a deregistered session must leave nothing resident")
@@ -102,17 +109,20 @@ struct TranscriptPollSchedulerTests {
         let source = TranscriptSource()
         let scheduler = TranscriptPollScheduler(source: source)
 
+        let before = TranscriptPaneToken()
+        let after = TranscriptPaneToken()
         await TranscriptPaneRegistration.apply(
             enabled: true, sessionID: "old", path: oldPath,
-            tier: .foreground, scheduler: scheduler)
+            tier: .foreground, token: before, scheduler: scheduler)
         await source.refresh(sessionID: "old", path: oldPath)
         #expect(await source.trackedSessionCount == 1)
 
-        // The pane's task is torn down and rebuilt under the new id.
-        await scheduler.deregister(sessionID: "old")
+        // The pane's task is torn down and rebuilt under the new id, so the
+        // rebuilt one holds its registration under a token of its own.
+        await scheduler.deregister(sessionID: "old", token: before)
         await TranscriptPaneRegistration.apply(
             enabled: true, sessionID: "new", path: newPath,
-            tier: .foreground, scheduler: scheduler)
+            tier: .foreground, token: after, scheduler: scheduler)
         await source.refresh(sessionID: "new", path: newPath)
 
         #expect(await source.items(sessionID: "old").isEmpty,
@@ -121,7 +131,7 @@ struct TranscriptPollSchedulerTests {
                 "exactly the live session, not one entry per rollover")
         #expect(await scheduler.registeredSessionIDs == ["new"])
 
-        await scheduler.deregister(sessionID: "new")
+        await scheduler.deregister(sessionID: "new", token: after)
         #expect(await source.trackedSessionCount == 0)
     }
 
@@ -152,11 +162,12 @@ struct TranscriptPollSchedulerTests {
         let source = TranscriptSource()
         let scheduler = TranscriptPollScheduler(source: source)
 
-        await scheduler.register(sessionID: "s1", path: path, tier: .background)
+        let pane = TranscriptPaneToken()
+        await scheduler.register(sessionID: "s1", path: path, tier: .background, token: pane)
         let generation = try #require(await scheduler.registeredGeneration(sessionID: "s1"))
         await source.refresh(sessionID: "s1", path: path)
 
-        await scheduler.deregister(sessionID: "s1")
+        await scheduler.deregister(sessionID: "s1", token: pane)
         #expect(await source.trackedSessionCount == 0)
 
         await source.refresh(sessionID: "s1", path: path)
@@ -182,9 +193,11 @@ struct TranscriptPollSchedulerTests {
         let recorder = NotifyRecorder()
         await scheduler.setOnChange { await recorder.record($0) }
 
-        await scheduler.register(sessionID: "s1", path: "/nonexistent", tier: .background)
+        let pane = TranscriptPaneToken()
+        await scheduler.register(
+            sessionID: "s1", path: "/nonexistent", tier: .background, token: pane)
         let generation = try #require(await scheduler.registeredGeneration(sessionID: "s1"))
-        await scheduler.deregister(sessionID: "s1")
+        await scheduler.deregister(sessionID: "s1", token: pane)
 
         await scheduler.finishTick(sessionID: "s1", generation: generation, hasNews: true)
         #expect(await recorder.published.isEmpty,
@@ -200,21 +213,24 @@ struct TranscriptPollSchedulerTests {
         let recorder = NotifyRecorder()
         await scheduler.setOnChange { await recorder.record($0) }
 
-        await scheduler.register(sessionID: "s1", path: "/nonexistent", tier: .background)
+        let pane = TranscriptPaneToken()
+        await scheduler.register(
+            sessionID: "s1", path: "/nonexistent", tier: .background, token: pane)
         let generation = try #require(await scheduler.registeredGeneration(sessionID: "s1"))
 
         await scheduler.finishTick(sessionID: "s1", generation: generation, hasNews: true)
         #expect(await recorder.published == ["s1"])
 
-        await scheduler.deregister(sessionID: "s1")
+        await scheduler.deregister(sessionID: "s1", token: pane)
     }
 
-    /// A re-registration is not a deregistration. The outgoing tick must not
-    /// sweep away an entry the incoming registration now covers — that would be
-    /// a re-parse from byte zero every time a pane re-declares itself — but it
-    /// must not publish under the new registration's name either, since its
-    /// change was computed against what the old one declared.
-    @Test("a tick superseded by a re-registration neither publishes nor evicts")
+    /// A closed-and-reopened pane is not a deregistration as far as the tick
+    /// left over from the closed one is concerned: it must not sweep away the
+    /// entry the reopened pane now covers — that would be a re-parse from byte
+    /// zero on every reopen — but it must not publish under the new
+    /// registration's name either, since its change was computed for a pane
+    /// that is gone.
+    @Test("a tick superseded by a fresh registration neither publishes nor evicts")
     func supersededTickLeavesTheNewRegistrationAlone() async throws {
         let path = try tempTranscript("s1")
         let source = TranscriptSource()
@@ -222,17 +238,141 @@ struct TranscriptPollSchedulerTests {
         let recorder = NotifyRecorder()
         await scheduler.setOnChange { await recorder.record($0) }
 
-        await scheduler.register(sessionID: "s1", path: path, tier: .background)
+        let closing = TranscriptPaneToken()
+        let reopened = TranscriptPaneToken()
+        await scheduler.register(sessionID: "s1", path: path, tier: .background, token: closing)
         let stale = try #require(await scheduler.registeredGeneration(sessionID: "s1"))
         await source.refresh(sessionID: "s1", path: path)
-        await scheduler.register(sessionID: "s1", path: path, tier: .background)
+
+        // The pane closes — entry and all — and another opens on the same
+        // session, which is a fresh incarnation of the entry.
+        await scheduler.deregister(sessionID: "s1", token: closing)
+        await scheduler.register(sessionID: "s1", path: path, tier: .background, token: reopened)
+        await source.refresh(sessionID: "s1", path: path)
 
         await scheduler.finishTick(sessionID: "s1", generation: stale, hasNews: true)
         #expect(await source.trackedSessionCount == 1,
                 "the live registration's entry must survive the superseded tick")
         #expect(await recorder.published.isEmpty)
 
-        await scheduler.deregister(sessionID: "s1")
+        await scheduler.deregister(sessionID: "s1", token: reopened)
         #expect(await source.trackedSessionCount == 0)
+    }
+
+    /// The reopen race the token exists for. A pane's `.task` deregisters when
+    /// it notices its own cancellation, which is an arbitrarily later moment
+    /// than the one SwiftUI tore it down at — so closing and immediately
+    /// reopening a session can order the outgoing `deregister` *after* the
+    /// incoming `register`.
+    ///
+    /// Fails against the pre-fix scheduler, which removed by session id
+    /// unconditionally: the late call tore down the reopened pane's
+    /// registration and forgot its transcript, leaving a pane that renders
+    /// whatever it had and never updates again, with nothing to self-correct
+    /// it. The `finishTick` generation guard does not cover it — that gates a
+    /// tick, not a deregistration.
+    @Test("a late deregister from a closed pane leaves the reopened pane polling")
+    func lateDeregisterDoesNotStealAFresherRegistration() async throws {
+        let path = try tempTranscript("s1")
+        let source = TranscriptSource()
+        let scheduler = TranscriptPollScheduler(source: source)
+        let recorder = NotifyRecorder()
+        await scheduler.setOnChange { await recorder.record($0) }
+
+        // The cadence is beside the point here; the slow tier is what keeps a
+        // real poll tick from reaching the recorder while the test runs.
+        let closing = TranscriptPaneToken()
+        let reopened = TranscriptPaneToken()
+        await scheduler.register(sessionID: "s1", path: path, tier: .background, token: closing)
+        await scheduler.register(sessionID: "s1", path: path, tier: .background, token: reopened)
+        await source.refresh(sessionID: "s1", path: path)
+
+        // Only now does the outgoing task get around to letting go.
+        await scheduler.deregister(sessionID: "s1", token: closing)
+
+        #expect(await scheduler.registeredSessionIDs == ["s1"])
+        #expect(await scheduler.holderCount(sessionID: "s1") == 1,
+                "the closed pane's hold, and only that one, is released")
+        #expect(await source.trackedSessionCount == 1,
+                "the reopened pane's transcript must not be forgotten under it")
+
+        let generation = try #require(await scheduler.registeredGeneration(sessionID: "s1"))
+        await scheduler.finishTick(sessionID: "s1", generation: generation, hasNews: true)
+        #expect(await recorder.published == ["s1"],
+                "the reopened pane must still be published to")
+
+        await scheduler.deregister(sessionID: "s1", token: reopened)
+        #expect(await source.trackedSessionCount == 0)
+    }
+
+    /// The viewer-slot LRU permits two panes onto one session at once. Neither
+    /// may end the other's polling, and the bound `deregister` establishes must
+    /// still close when the second one goes.
+    ///
+    /// Fails against the pre-fix scheduler on the first assertion after the
+    /// first `deregister`: removing by session id ended the surviving pane's
+    /// registration and forgot its transcript too.
+    @Test("with two panes on one session, only the last to leave ends the polling")
+    func lastHolderEndsTheRegistration() async throws {
+        let path = try tempTranscript("s1")
+        let source = TranscriptSource()
+        let scheduler = TranscriptPollScheduler(source: source)
+        let recorder = NotifyRecorder()
+        await scheduler.setOnChange { await recorder.record($0) }
+
+        let first = TranscriptPaneToken()
+        let second = TranscriptPaneToken()
+        await scheduler.register(sessionID: "s1", path: path, tier: .background, token: first)
+        await scheduler.register(sessionID: "s1", path: path, tier: .background, token: second)
+        await source.refresh(sessionID: "s1", path: path)
+        #expect(await scheduler.holderCount(sessionID: "s1") == 2)
+
+        await scheduler.deregister(sessionID: "s1", token: first)
+        #expect(await scheduler.registeredSessionIDs == ["s1"])
+        #expect(await source.trackedSessionCount == 1,
+                "the surviving pane's transcript must stay resident")
+        let generation = try #require(await scheduler.registeredGeneration(sessionID: "s1"))
+        await scheduler.finishTick(sessionID: "s1", generation: generation, hasNews: true)
+        #expect(await recorder.published == ["s1"],
+                "the surviving pane must still be published to")
+
+        await scheduler.deregister(sessionID: "s1", token: second)
+        #expect(await scheduler.registeredSessionIDs.isEmpty)
+        #expect(await source.trackedSessionCount == 0,
+                "the last holder leaving must still forget the session")
+    }
+
+    /// A session one pane shows on screen while another merely holds it warm
+    /// polls at the on-screen pane's cadence. The freshness the visible pane
+    /// declared is not the warm one's to relax.
+    ///
+    /// Fails against the pre-fix scheduler, where the second `register`
+    /// replaced the first: the warm pane re-declaring itself demoted the whole
+    /// session to `.background` while the on-screen pane still held it, and the
+    /// first `deregister` left `registeredTier` nil rather than `.background`.
+    @Test("a session two panes hold polls at the most aggressive tier either declared")
+    func effectiveTierIsTheMostAggressiveHolder() async {
+        let scheduler = TranscriptPollScheduler(source: TranscriptSource())
+        let warm = TranscriptPaneToken()
+        let onScreen = TranscriptPaneToken()
+
+        await scheduler.register(
+            sessionID: "s1", path: "/nonexistent", tier: .background, token: warm)
+        await scheduler.register(
+            sessionID: "s1", path: "/nonexistent", tier: .foreground, token: onScreen)
+        #expect(await scheduler.registeredTier(sessionID: "s1") == .foreground)
+
+        // Order must not matter: the warm pane re-declaring its own tier cannot
+        // demote a session the on-screen pane is still holding.
+        await scheduler.register(
+            sessionID: "s1", path: "/nonexistent", tier: .background, token: warm)
+        #expect(await scheduler.registeredTier(sessionID: "s1") == .foreground)
+
+        await scheduler.deregister(sessionID: "s1", token: onScreen)
+        #expect(await scheduler.registeredTier(sessionID: "s1") == .background,
+                "with the on-screen pane gone the survivor drops to its own cadence")
+
+        await scheduler.deregister(sessionID: "s1", token: warm)
+        #expect(await scheduler.registeredSessionIDs.isEmpty)
     }
 }

--- a/Tests/TBDAppTests/TranscriptSourceTests.swift
+++ b/Tests/TBDAppTests/TranscriptSourceTests.swift
@@ -201,6 +201,68 @@ struct TranscriptSourceTests {
                                                                     "second"])
     }
 
+    /// A capture that always fails, standing in for the production race the
+    /// window cannot be captured through: the transcript replaced or removed in
+    /// the instant between the incremental read and the capture that follows
+    /// it. Bytes are consumed, and nothing is left to verify the next growth
+    /// against.
+    private let noTailCapture: @Sendable (String, UInt64) -> Data? = { _, _ in nil }
+
+    @Test("a failed tail capture forces a re-read rather than trusting the next growth")
+    func failedTailCaptureForcesReset() async throws {
+        let path = try tempFile(lineA + "\n")
+        let source = TranscriptSource(captureTail: noTailCapture)
+        _ = await source.refresh(sessionID: "s1", path: path)
+        #expect(promptTexts(await source.items(sessionID: "s1")) == ["hello"])
+
+        // A whole-file rewrite landing LARGER — size and mtime alone read
+        // exactly like an append, and the verification that would tell them
+        // apart has no captured window to work from.
+        try (lineC + "\n" + lineD + "\n").write(
+            to: URL(fileURLWithPath: path), atomically: true, encoding: .utf8)
+        try setModified(path, secondsFromNow: 5)
+        _ = await source.refresh(sessionID: "s1", path: path)
+        #expect(promptTexts(await source.items(sessionID: "s1")) == ["third prompt, deliberately long",
+                                                                    "fourth prompt, deliberately long"],
+                "an uncapturable window must force a full re-read, not an append onto stale rows")
+    }
+
+    @Test("a forced re-read whose read fails still retains the prior items")
+    func failedTailCaptureResetDoesNotBlank() async throws {
+        let path = try tempFile(lineA + "\n")
+        let source = TranscriptSource(captureTail: noTailCapture)
+        _ = await source.refresh(sessionID: "s1", path: path)
+
+        try append(lineB + "\n", to: path)
+        try FileManager.default.setAttributes([.posixPermissions: 0o000], ofItemAtPath: path)
+        defer { try? FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: path) }
+        try setModified(path, secondsFromNow: 5)
+
+        let change = await source.refresh(sessionID: "s1", path: path)
+        #expect(change == nil, "an unreadable file reports no change")
+        #expect(promptTexts(await source.items(sessionID: "s1")) == ["hello"],
+                "forcing a re-read means 'start from byte zero next time', never 'publish empty now'")
+    }
+
+    @Test("a read that consumed nothing still verifies, and the next growth appends")
+    func nothingConsumedStillVerifies() async throws {
+        let path = try tempFile("")
+        let source = TranscriptSource()
+        _ = await source.refresh(sessionID: "s1", path: path)
+        #expect(await source.items(sessionID: "s1").isEmpty)
+
+        try append(lineA + "\n", to: path)
+        let grown = await source.refresh(sessionID: "s1", path: path)
+        #expect(grown?.appended.count == 1,
+                "an empty capture is 'nothing to verify', which passes — not 'unverifiable'")
+        #expect(promptTexts(await source.items(sessionID: "s1")) == ["hello"])
+
+        try append(lineB + "\n", to: path)
+        let appended = await source.refresh(sessionID: "s1", path: path)
+        #expect(appended?.appended.count == 1, "the following tick must still read only the delta")
+        #expect(promptTexts(await source.items(sessionID: "s1")) == ["hello", "second"])
+    }
+
     @Test("forget drops retained state")
     func forgetDropsState() async throws {
         let path = try tempFile(lineA + "\n")


### PR DESCRIPTION
## What's broken

Three defects in the app-side transcript reader that #752 shipped, all reachable only with `appSideTranscriptRead` on (still default-off). Each was found by the review gate on that PR and deferred here rather than growing it further.

**A transcript can silently splice old rows onto a new session.** `TranscriptSource` verifies that the bytes it already consumed are still the same bytes before trusting growth as an append. That verification is skipped whenever the check itself is unavailable — so if the file is replaced in the narrow window between the main read and the tail capture that follows it, the next tick trusts the growth, resumes at a stale offset, and splices rows from the old transcript onto a suffix of the new one.

**Closing and quickly reopening a pane leaves it permanently stale.** The pane deregisters when its task notices cancellation, which is an arbitrarily later point than when SwiftUI tore the task down. If the same session is reopened in between, the outgoing deregistration removes the *incoming* pane's registration. Nothing self-corrects: the reopened pane never polls again.

**One invalid byte stops a session updating forever.** A byte sequence that is not valid UTF-8 makes the window decode fail, which the reader reports as "no news". The offset never advances past it, so every subsequent tick re-reads the same bad window and the pane silently stops updating, with no recovery and no diagnostic.

## Why it happens

The first two share a shape: a value that means two different things.

`consumedTail` was a `Data?` where `nil` meant both "nothing consumed yet, nothing to verify" and "the capture failed". The verification helper answered *intact* for both, so an unavailable check was indistinguishable from a passing one.

The poll registry was keyed by Claude session id alone, with no notion of which pane asked. `deregister(sessionID:)` therefore removed unconditionally — it could not tell the outgoing pane's teardown from a live registration belonging to someone else. The generation guard added late in #752 stops a stale *tick* from publishing or resurrecting an entry, but it gates the tick, not the deregistration, so it does not reach this.

The third is different. The read window is line-aligned at both ends — the offset is always one byte past a newline this same type returned, and the region is truncated at its last newline — so a transient chunk split lives *past* the decoded region and can never cause a decode failure. Any failure that does occur is therefore bytes between two newlines that will fail identically on every future tick. There was no path that ever advanced past them.

## What this PR does

- **Replaces `consumedTail`'s nullable with a two-case enum** (`.captured(Data)` / `.unavailable`), so the two states cannot merge by construction, and treats `.unavailable` as a forced reset — re-read from byte zero next tick rather than trust the growth.
- **Refcounts poll registrations by a per-pane token.** A session's registration holds a set of holders; `deregister` removes one token and tears down only when the last leaves. The effective cadence is the most aggressive tier among live holders. This also makes two panes on one session a first-class state rather than a mutual-starvation bug.
- **Skips undecodable lines instead of wedging.** On a decode failure the window is split on the newline *byte* (`0x0A` cannot appear inside a multi-byte UTF-8 sequence), each line decoded on its own, the bad ones dropped, and the offset advanced past the whole window. Logged at `.error` with counts, so a recovery leaves a trace rather than silently dropping content.

Skipping rather than lossy-decoding is deliberate: this JSONL feeds `JSONSerialization`, which rejects invalid UTF-8 too, so a skipped line is one the parser would have dropped anyway — skipping loses nothing that would have survived. Lossy repair could instead turn a corrupt line into syntactically valid JSON that parses into a *wrong* item, which is a new failure mode rather than a recovery.

Generation and token are deliberately not merged. They answer opposite questions: a generation must *change* whenever an entry becomes a new incarnation, so an in-flight tick recognises itself as stale; a token must stay *stable* across exactly those changes and differ between two panes sharing one entry. Generation is now minted on entry creation and path change rather than on every `register`, so a tier re-declaration no longer invalidates an in-flight tick and no longer drops its publish.

## Assumptions

- **Assumes the read window stays line-aligned at both ends.** The UTF-8 recovery relies on it: it is what makes a decode failure necessarily persistent rather than possibly transient. If a future change hands this type a window that can begin or end mid-line, a transient split would start being skipped as garbage.
- **Assumes `JSONSerialization` rejects every byte sequence that fails UTF-8 decoding.** That is what makes skipping lossless relative to the parser. If it ever accepted such input, a skipped line would become real data loss.

## Evidence & verification

- **Each fix has a test that fails against the code before it.** The splice test rewrites a file to different, *larger* content with a newer mtime — indistinguishable from an append by stat alone — with the capture forced to fail, and asserts the items are the new content rather than the old first row spliced onto the new tail. The stale-deregistration test asserts a fresher registration survives an outgoing pane's late teardown. The wedge tests assert the reader advances and later appends still arrive.
- **Two tests deliberately pass against current code and are labelled as such**: an empty capture must still verify as "nothing to verify" rather than "unverifiable", and a transient multi-byte split must still be withheld and later delivered whole. Both exist to fail against the plausible over-reaching fixes — mapping offset-0 to unavailable, and treating any decode failure as skippable.
- **Not verified live.** No restart was performed, so nobody has watched a pane stream rows or a tool card resolve with the flag on — that gap carries over from #752 and is not closed here.
- These are bug fixes restoring the system to its existing theory, so no spec accompanies them.

[20260826-pleased-egret](https://cheapsteak.github.io/tbd/open/?worktree=FD0529A5-B8DF-42CE-8483-B360B9C1E12E)

https://claude.ai/code/session_01DWGCWLjdf94L32QqF2mXkh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcript polling when multiple panes share the same session.
  * Prevented canceled or stale pane tasks from affecting replacement panes.
  * Fixed duplicate polling registrations during pane updates.
  * Improved recovery from invalid UTF-8 transcript data while preserving valid lines.
  * Ensured transcript refreshes correctly re-read files when content verification is unavailable.

* **Tests**
  * Expanded coverage for pane ownership, polling lifecycle, stale updates, shared sessions, and transcript recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->