### PR TITLE
Fix: note.list read every note file on the machine, ~280 times a second

### DIFF
--- a/Sources/TBDApp/AppState+Notes.swift
+++ b/Sources/TBDApp/AppState+Notes.swift
@@ -4,6 +4,15 @@ import os
 
 private let logger = Logger(subsystem: "com.tbd.app", category: "AppState+Notes")
 
+/// Outcome of reading a note's content file. Distinguishes a file that is
+/// absent (loads as empty) from one that is present but unreadable (must not
+/// load at all) — `try? String(contentsOfFile:)` alone collapses the two.
+private enum NoteContentRead: Sendable {
+    case text(String)
+    case missing
+    case unreadable
+}
+
 extension AppState {
     // MARK: - Note Actions
 
@@ -11,7 +20,9 @@ extension AppState {
     func createNote(worktreeID: UUID) async {
         do {
             let note = try await daemonClient.createNote(worktreeID: worktreeID)
-            notes[worktreeID, default: []].append(note)
+            // `notes` holds metadata only — the daemon hands back a full
+            // `Note` here, so summarize it rather than caching content.
+            notes[worktreeID, default: []].append(NoteSummary(from: note))
             let tab = Tab(id: note.id, content: .note(noteID: note.id), label: nil)
             tabs[worktreeID, default: []].append(tab)
         } catch {
@@ -20,17 +31,149 @@ extension AppState {
         }
     }
 
-    /// Update a note's title and/or content.
-    func updateNote(noteID: UUID, worktreeID: UUID, title: String? = nil, content: String? = nil) async {
+    /// Rename a note. TITLE ONLY — note content no longer travels this path;
+    /// the app writes the file itself (`saveNoteContent`).
+    func updateNote(noteID: UUID, worktreeID: UUID, title: String) async {
         do {
-            let updated = try await daemonClient.updateNote(noteID: noteID, title: title, content: content)
+            let updated = try await daemonClient.updateNote(noteID: noteID, title: title)
             if let idx = notes[worktreeID]?.firstIndex(where: { $0.id == noteID }) {
-                notes[worktreeID]?[idx] = updated
+                // Patch the fields this call changed rather than rebuilding the
+                // summary: the daemon's `Note.content` is the OVERLAID content,
+                // so `NoteSummary(from:)` would over-report `hasLegacyContent`
+                // for every file-backed note.
+                notes[worktreeID]?[idx].title = updated.title
+                notes[worktreeID]?[idx].updatedAt = updated.updatedAt
             }
         } catch {
             logger.error("Failed to update note: \(error)")
             handleConnectionError(error)
         }
+    }
+
+    /// Load a note's text for an opening pane.
+    ///
+    /// Read straight off disk, off the main thread — the same shape as
+    /// `selectClosedTerminal`. The daemon is not in this path.
+    ///
+    /// Returns `nil` whenever the text could not be established — an
+    /// unreadable content file, or a failed legacy fetch. The caller must
+    /// treat that as "did not load" and never as "empty": an empty editor that
+    /// believes it loaded will autosave its emptiness over the file. `""` is
+    /// returned only for a note that genuinely has no content anywhere.
+    func noteContent(noteID: UUID, worktreeID: UUID) async -> String? {
+        let path = noteContentPathResolver(worktreeID, noteID)
+        let outcome = await Task.detached(priority: .userInitiated) { () -> NoteContentRead in
+            if let text = try? String(contentsOfFile: path, encoding: .utf8) {
+                return .text(text)
+            }
+            // A failed read is not by itself a missing file, so ask. `try?`
+            // collapses "absent", "no permission", "I/O error" and "not UTF-8"
+            // into one nil, and only the first of those may load as empty.
+            return FileManager.default.fileExists(atPath: path) ? .unreadable : .missing
+        }.value
+
+        switch outcome {
+        case .text(let text):
+            return text
+        case .unreadable:
+            // The file is THERE and its bytes could not be had. Returning ""
+            // — or falling through to the legacy check, which returns "" for
+            // every ordinary file-backed note — would mark the pane loaded on
+            // empty text, and the next keystroke or tab switch would autosave
+            // that emptiness over content that is still on disk. `nil` is
+            // "did not load", and the pane stays inert.
+            logger.error(
+                "Note content file exists but could not be read: \(path, privacy: .public)")
+            return nil
+        case .missing:
+            break
+        }
+
+        // Genuinely no file. `NotesFileStore.read` would hand back "" for this
+        // case AND for the one above, which is why it is deliberately not
+        // used: "missing" and "unreadable" have to be told apart. A missing
+        // file on a row whose LEGACY DB column still holds content means the
+        // startup export never drained it, and loading "" would let the next
+        // save destroy it.
+        guard notes[worktreeID]?.first(where: { $0.id == noteID })?.hasLegacyContent == true else {
+            return ""
+        }
+        do {
+            return try await noteLegacyContentFetcher(noteID)
+        } catch {
+            logger.error("Failed to fetch legacy note content: \(error, privacy: .public)")
+            handleConnectionError(error)
+            return nil
+        }
+    }
+
+    /// Persist a note's text.
+    ///
+    /// Non-empty content is written straight to the file, off the main thread.
+    ///
+    /// EMPTYING is the one exception and it is a data-loss trap, not a style
+    /// choice: the daemon's `update` deletes the file AND clears the legacy DB
+    /// column in one step. If the app deleted the file itself, a surviving
+    /// column would make the next open see "file missing + hasLegacyContent"
+    /// and resurrect the text the user just deleted.
+    func saveNoteContent(noteID: UUID, worktreeID: UUID, content: String) async {
+        if content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            do {
+                _ = try await noteEmptier(noteID)
+                if let idx = notes[worktreeID]?.firstIndex(where: { $0.id == noteID }) {
+                    notes[worktreeID]?[idx].hasLegacyContent = false
+                }
+            } catch {
+                // A deleted note answers "Note not found" here, which
+                // handleConnectionError already absorbs silently.
+                logger.error("Failed to empty note: \(error, privacy: .public)")
+                handleConnectionError(error)
+            }
+            return
+        }
+        let path = noteContentPathResolver(worktreeID, noteID)
+        do {
+            // `writeOrThrow`, not `write`: this file is the only copy of the
+            // text now that the daemon is out of the content path, and the
+            // RPC that used to carry this write reported its failures. A
+            // `.debug` line would make a full disk or a permission change look
+            // exactly like a successful save.
+            try await Task.detached(priority: .userInitiated) {
+                try NotesFileStore().writeOrThrow(content, to: path)
+            }.value
+        } catch {
+            logger.error("Failed to write note content to \(path, privacy: .public): \(error, privacy: .public)")
+        }
+    }
+
+    /// Whether a note has content, from the two places that can hold it.
+    ///
+    /// Content lives in the file; the legacy DB column still holds it for the
+    /// handful of rows the daemon's startup export never drained. Neither
+    /// source alone is the answer, so the union lives here rather than at the
+    /// call sites — `closeTab` hard-deletes the note row, so a wrong `false`
+    /// is a silent delete.
+    ///
+    /// Synchronous, and one stat: it runs on a user gesture (closing a tab),
+    /// never on the poll. That is the whole reason it is allowed to touch the
+    /// filesystem at all.
+    func noteHasContent(worktreeID: UUID, noteID: UUID) -> Bool {
+        if notes[worktreeID]?.first(where: { $0.id == noteID })?.hasLegacyContent == true {
+            return true
+        }
+        let path = noteContentPathResolver(worktreeID, noteID)
+        // Existence first, size second. Asking for the size alone and folding
+        // its failure into `?? 0` would make "no file" and "could not size
+        // this file" the same answer — the same `try?` collapse `noteContent`
+        // above is careful not to make, and here a wrong `false` skips the
+        // prompt and hard-deletes the row. So only a file that is genuinely
+        // there AND genuinely zero bytes may answer `false`.
+        guard FileManager.default.fileExists(atPath: path) else { return false }
+        guard let size = try? URL(fileURLWithPath: path)
+            .resourceValues(forKeys: [.fileSizeKey]).fileSize else {
+            return true
+        }
+        return size > 0
     }
 
     /// Delete a note.

--- a/Sources/TBDApp/AppState+Tabs.swift
+++ b/Sources/TBDApp/AppState+Tabs.swift
@@ -352,8 +352,8 @@ extension AppState {
         // the note has content; an empty note closes silently as before.
         if case .note(let noteID) = tab.content,
            let note = notes[worktreeID]?.first(where: { $0.id == noteID }),
-           !note.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
-           !noteCloseConfirmer(note) {
+           noteHasContent(worktreeID: worktreeID, noteID: noteID),
+           !noteCloseConfirmer(note, noteContentPathResolver(worktreeID, noteID)) {
             return
         }
 

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -202,7 +202,10 @@ final class AppState {
     /// so a pushed SessionStart can fence an older list response even in the
     /// brief interval before its activity delta arrives.
     @ObservationIgnored var terminalSessionOrderObservedAt: [UUID: Date] = [:]
-    var notes: [UUID: [Note]] = [:]
+    /// Polled note METADATA — never content. `note.list` touches no file (see
+    /// `NoteStore`); a pane that needs content reads it off disk with
+    /// `noteContent(noteID:worktreeID:)`.
+    var notes: [UUID: [NoteSummary]] = [:]
     var focusedTabCloseContext: TabCloseContext?
     /// Unread notification summaries keyed by worktree ID. The cmd-K jump
     /// menu sorts by `mostRecentAt`; the sidebar consumes `.type` for the
@@ -1418,12 +1421,35 @@ final class AppState {
                 try await daemonClient.setPendingPrompt(
                     worktreeID: worktreeID, text: text, submit: submit)
             }
+    /// Where a note's content file lives. Injectable for the same reason
+    /// `NoteStore` takes `notesDir` — so a test can round-trip a real file
+    /// without depending on the process-global `TBD_HOME`, which
+    /// concurrently-running suites mutate (see `Tests/CLAUDE.md`).
+    @ObservationIgnored lazy var noteContentPathResolver: @MainActor (UUID, UUID) -> String =
+        { worktreeID, noteID in
+            TBDConstants.noteContentPath(worktreeID: worktreeID, noteID: noteID)
+        }
+    /// How the legacy-column fallback fetches a note's text when its content
+    /// file is missing (`noteContent`). Injectable for the same reason as
+    /// `prBindingsFetcher` — `DaemonClient` is concrete, no protocol.
+    @ObservationIgnored lazy var noteLegacyContentFetcher: @MainActor (UUID) async throws -> String =
+        { [daemonClient] noteID in try await daemonClient.getNote(noteID: noteID).content }
+    /// How an emptying save is handed back to the daemon, which deletes the
+    /// content file and clears the legacy column together. Injectable so a
+    /// test can prove that ordinary (non-empty) saves never reach it.
+    @ObservationIgnored lazy var noteEmptier: @MainActor (UUID) async throws -> Note =
+        { [daemonClient] noteID in try await daemonClient.updateNote(noteID: noteID, content: "") }
     /// Asks the user to confirm closing a note tab whose note has content —
     /// closing a note tab hard-deletes the note row (`closeTab` →
     /// `deleteNote`). Injectable so tests can exercise both branches without
     /// a real modal NSAlert.
-    @ObservationIgnored lazy var noteCloseConfirmer: @MainActor (Note) -> Bool = { note in
-        let filePath = TBDConstants.noteContentPath(worktreeID: note.worktreeID, noteID: note.id)
+    ///
+    /// Takes the content-file path rather than deriving one: the alert
+    /// advertises where the text is kept, and `noteContentPathResolver` is the
+    /// single answer to that question — so the caller resolves it once and the
+    /// advertised path cannot disagree with the written one.
+    @ObservationIgnored lazy var noteCloseConfirmer: @MainActor (NoteSummary, String) -> Bool = { note, contentPath in
+        let filePath = contentPath
             .replacingOccurrences(of: NSHomeDirectory(), with: "~")
         let alert = NSAlert()
         alert.alertStyle = .warning
@@ -2965,7 +2991,15 @@ final class AppState {
             }
 
             // Fetch all notes, group client-side
-            let allNotes = try await daemonClient.listNotes()
+            // Ask only for the worktrees about to be rendered. The grouping
+            // below keys by worktree and then reads only `visibleWorktreeIDs`,
+            // so every other row is decoded and thrown away — payload and JSON
+            // decode spent for nothing, on a two-second poll. (PR #754's RPC
+            // volume probe measured decoding as a standing multi-core load in
+            // the app.) It saves no filesystem work: `note.list` does none.
+            let allNotes = try await daemonClient.listNotes(
+                worktreeIDs: Array(visibleWorktreeIDs)
+            )
             let notesByWorktree = Dictionary(grouping: allNotes, by: { $0.worktreeID })
             for wtID in visibleWorktreeIDs {
                 let fetched = notesByWorktree[wtID] ?? []
@@ -3075,7 +3109,7 @@ final class AppState {
 
     /// Reconcile note tabs — remove tabs whose note no longer exists,
     /// add tabs for notes not already represented.
-    func reconcileNoteTabs(worktreeID: UUID, notes: [Note]) {
+    func reconcileNoteTabs(worktreeID: UUID, notes: [NoteSummary]) {
         // Same identity capture as reconcileTabs — see the comment there.
         let previousActiveTabID = explicitActiveTabID(worktreeID: worktreeID)
         var currentTabs = tabs[worktreeID] ?? []

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -1671,12 +1671,17 @@ actor DaemonClient {
         )
     }
 
-    /// List notes, optionally filtered by worktree.
-    func listNotes(worktreeID: UUID? = nil) async throws -> [Note] {
+    /// List note METADATA, optionally filtered by worktree and/or an explicit
+    /// set of worktrees. Deliberately returns `NoteSummary`, not `Note`: the
+    /// daemon performs no filesystem work at all to answer this. Note content
+    /// is file-backed and the app reads it directly — same rule as
+    /// `TerminalHistoryEntry`.
+    func listNotes(worktreeID: UUID? = nil,
+                   worktreeIDs: [UUID]? = nil) async throws -> [NoteSummary] {
         return try await callAsync(
             method: RPCMethod.noteList,
-            params: NoteListParams(worktreeID: worktreeID),
-            resultType: [Note].self
+            params: NoteListParams(worktreeID: worktreeID, worktreeIDs: worktreeIDs),
+            resultType: [NoteSummary].self
         )
     }
 

--- a/Sources/TBDApp/Notes/NotesStorage.swift
+++ b/Sources/TBDApp/Notes/NotesStorage.swift
@@ -59,17 +59,28 @@ struct NotesFileStore {
     /// Failures are logged (not surfaced) — mirrors the hooks storage pattern.
     func write(_ content: String, to path: String) {
         do {
-            if content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                if FileManager.default.fileExists(atPath: path) {
-                    try FileManager.default.removeItem(atPath: path)
-                }
-                return
-            }
-            let dir = (path as NSString).deletingLastPathComponent
-            try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
-            try content.write(toFile: path, atomically: true, encoding: .utf8)
+            try writeOrThrow(content, to: path)
         } catch {
             notesLogger.debug("notepad write failed at \(path, privacy: .public): \(error.localizedDescription, privacy: .public)")
         }
+    }
+
+    /// `write`, surfacing the failure instead of logging it at `.debug`.
+    ///
+    /// The notepad can afford a swallowed write — its text is still in the
+    /// editor and the next keystroke tries again. A per-note content file
+    /// cannot: since the daemon left the content path, this file is the only
+    /// copy of the text, so `AppState.saveNoteContent` needs to know a write
+    /// failed in order to log it at `.error`.
+    func writeOrThrow(_ content: String, to path: String) throws {
+        if content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            if FileManager.default.fileExists(atPath: path) {
+                try FileManager.default.removeItem(atPath: path)
+            }
+            return
+        }
+        let dir = (path as NSString).deletingLastPathComponent
+        try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        try content.write(toFile: path, atomically: true, encoding: .utf8)
     }
 }

--- a/Sources/TBDApp/Panes/NotePaneModel.swift
+++ b/Sources/TBDApp/Panes/NotePaneModel.swift
@@ -1,0 +1,199 @@
+import Foundation
+import Observation
+
+/// The load/save state machine behind `NotePaneView`.
+///
+/// It lives outside the view because the thing it has to get right is a
+/// *sequence*, not a rendering: one pane hosts many notes in succession, and a
+/// pending write to the note being left has to land before the note being
+/// entered is read. That ordering cannot be asserted through a SwiftUI view —
+/// `NotePaneModelTests` asserts it here instead.
+///
+/// ## Why a pending save is flushed and never merely armed
+///
+/// `NotePaneView` is REUSED across notes: `navigateHistory` swaps the pane's
+/// `noteID` while the view keeps its SwiftUI identity, so `onDisappear` does
+/// not fire on a switch and `.task(id: noteID)` re-runs on the same instance.
+///
+/// A debounce that stays armed across that switch loses data. Edit note A;
+/// inside the debounce window navigate A → B → A. The second load of A reads
+/// A's file **while A's write is still pending**, so the editor comes back
+/// holding the pre-edit text. The edit is not merely late — it is now the base
+/// for everything typed next, and the next keystroke writes stale-base-plus-new
+/// text over it.
+///
+/// So the unsaved text is held as data (`pendingSave`) rather than only inside
+/// a task, every path that ends a debounce window *flushes* it rather than
+/// cancelling it, and `load` flushes **before** it reads. Cancelling a debounce
+/// task can therefore never discard an edit: the text is not in the task.
+@MainActor
+@Observable
+final class NotePaneModel {
+    /// The editor's text. Two-way bound to the `TextEditor`.
+    var text: String = ""
+
+    /// Whether `text` came from a successful read of the current note.
+    ///
+    /// A failed or missing load leaves this false on purpose, and `textEdited`
+    /// refuses to record an edit while it is false — so a pane that never
+    /// loaded cannot produce a `pendingSave`, and therefore cannot autosave its
+    /// emptiness over a file that still has content.
+    private(set) var loaded = false
+
+    /// The armed debounce. Exposed so tests can await the write it performs
+    /// instead of polling the filesystem; nothing in the app reads it.
+    @ObservationIgnored private(set) var pendingSaveTask: Task<Void, Never>?
+
+    /// Unsaved text, tagged with the note it belongs to.
+    ///
+    /// The tag is what makes a flush safe from any context: it writes to the
+    /// note the text came from, never to whichever note the pane happens to be
+    /// showing when the flush runs.
+    @ObservationIgnored private var pendingSave: PendingSave?
+
+    /// The note this pane is currently showing, set by `load`.
+    @ObservationIgnored private var current: NoteRef?
+
+    /// What the current note's text was last known to be on disk — the value
+    /// `load` read, or the value the last save wrote. An "edit" back to exactly
+    /// that is not an edit; without this, the assignment `load` makes to `text`
+    /// arrives at the view's `onChange` as a change and arms a debounce that
+    /// writes the file's own bytes back to it on every pane open.
+    @ObservationIgnored private var savedText: String?
+
+    @ObservationIgnored private let debounceInterval: Duration
+    @ObservationIgnored private let clock: any Clock<Duration>
+
+    private struct PendingSave: Sendable {
+        let noteID: UUID
+        let worktreeID: UUID
+        let text: String
+    }
+
+    private struct NoteRef: Sendable, Equatable {
+        let noteID: UUID
+        let worktreeID: UUID
+    }
+
+    /// - Parameter debounceInterval: quiet window before typing is persisted.
+    /// - Parameter clock: last parameter, existential, defaulted — the shared
+    ///   seam contract (`Tests/CLAUDE.md`, "Clock and date seams"). Existential
+    ///   rather than generic so the view holding this type does not have to
+    ///   become generic.
+    nonisolated init(debounceInterval: Duration = .milliseconds(500),
+                     clock: any Clock<Duration> = ContinuousClock()) {
+        self.debounceInterval = debounceInterval
+        self.clock = clock
+    }
+
+    /// Show `noteID`, reading its text off disk.
+    ///
+    /// Called from the view's `.task(id: noteID)`, so it runs both on first
+    /// appearance and on every swap of the pane's note.
+    ///
+    /// **Flush first, read second.** The flush is not tidying-up: a read that
+    /// overtakes a pending write to the same file observes text that has
+    /// already been superseded, and the editor then holds a base nobody wrote.
+    func load(noteID: UUID, worktreeID: UUID, appState: AppState) async {
+        await flushPendingSave(appState: appState)
+
+        // Reset all three, because the pane is REUSED when its slot is swapped
+        // from one note to another: leaving `text` alone would show the
+        // previous note's words under the new note's title for as long as the
+        // load takes, or forever if it fails.
+        loaded = false
+        text = ""
+        savedText = nil
+        current = NoteRef(noteID: noteID, worktreeID: worktreeID)
+
+        guard let content = await appState.noteContent(
+            noteID: noteID, worktreeID: worktreeID
+        ) else {
+            // `nil` is "did not load", never "empty" — leaving `loaded` false
+            // is what stops the next keystroke from saving emptiness over a
+            // file whose bytes could not be read.
+            return
+        }
+        // This task may no longer be the authoritative one. `.task(id:)`
+        // cancels the outgoing task when `noteID` changes, but cancellation is
+        // cooperative and the read above does not throw — so a slow load
+        // started for the PREVIOUS note keeps running and would otherwise
+        // assign its text here, over a note that has already loaded, and set
+        // `loaded` on it. `loaded` cannot catch this: the stale task is what
+        // sets it.
+        guard !Task.isCancelled else { return }
+        text = content
+        savedText = content
+        loaded = true
+    }
+
+    /// Record a keystroke and (re)arm the debounce.
+    ///
+    /// Cancelling the previous arm is safe here in a way it was not before the
+    /// text moved into `pendingSave`: the newer arm replaces the pending text
+    /// rather than discarding it.
+    func textEdited(_ newValue: String, appState: AppState) {
+        guard loaded, let current else { return }
+        // Not an edit: this is `load`'s own assignment coming back through the
+        // view's `onChange`. Skipping it only when nothing is pending matters —
+        // typing and then undoing back to the saved text inside one window must
+        // still resolve the armed save rather than leave it holding the
+        // intermediate value.
+        if newValue == savedText, pendingSave == nil { return }
+
+        pendingSave = PendingSave(
+            noteID: current.noteID, worktreeID: current.worktreeID, text: newValue)
+        pendingSaveTask?.cancel()
+        pendingSaveTask = Task { @MainActor [clock, debounceInterval] in
+            // Cancellation while still asleep surfaces as a thrown error — the
+            // "a newer keystroke, or a flush, superseded me" path. Either way
+            // the text survives in `pendingSave`.
+            guard (try? await clock.sleep(for: debounceInterval)) != nil else { return }
+            guard !Task.isCancelled else { return }
+            await self.writePendingSave(appState: appState)
+        }
+    }
+
+    /// Persist unsaved text now, and do not return until it has landed.
+    ///
+    /// Awaiting the cancelled task is what makes this a flush rather than a
+    /// cancel: if the debounce was already past its cancellation check and
+    /// inside the write, that write completes before this returns. Without it,
+    /// `load` could still start reading a file with a write in flight — the
+    /// same fault one step further in.
+    func flushPendingSave(appState: AppState) async {
+        let task = pendingSaveTask
+        pendingSaveTask = nil
+        task?.cancel()
+        await task?.value
+        await writePendingSave(appState: appState)
+    }
+
+    /// The pane went away (tab switch, window close). `onDisappear` cannot
+    /// await, so the flush is spawned — the same shape the view has always
+    /// used. The task is returned so a test can await the write; the view
+    /// discards it.
+    @discardableResult
+    func paneDisappeared(appState: AppState) -> Task<Void, Never> {
+        Task { @MainActor in
+            await self.flushPendingSave(appState: appState)
+        }
+    }
+
+    /// Takes the pending text and writes it. Whoever gets here first takes it:
+    /// `pendingSave` is cleared **before** the `await`, so a flush racing the
+    /// debounce cannot write the same text twice.
+    ///
+    /// An emptying write goes through `appState.saveNoteContent` like any
+    /// other, which hands it to the daemon so the content file and the legacy
+    /// DB column clear together.
+    private func writePendingSave(appState: AppState) async {
+        guard let pending = pendingSave else { return }
+        pendingSave = nil
+        await appState.saveNoteContent(
+            noteID: pending.noteID, worktreeID: pending.worktreeID, content: pending.text)
+        if current?.noteID == pending.noteID {
+            savedText = pending.text
+        }
+    }
+}

--- a/Sources/TBDApp/Panes/NotePaneView.swift
+++ b/Sources/TBDApp/Panes/NotePaneView.swift
@@ -2,17 +2,15 @@ import SwiftUI
 import TBDShared
 
 /// A simple text editor pane for freeform notes.
+///
+/// Rendering and gesture wiring only. The load/save sequence — which is where
+/// this pane's data-loss risks live, because one pane hosts many notes in
+/// succession — belongs to `NotePaneModel`, where it can be tested.
 struct NotePaneView: View {
     let noteID: UUID
     let worktreeID: UUID
     @Environment(AppState.self) var appState
-    @State private var text: String = ""
-    @State private var loaded = false
-    @State private var saveTask: Task<Void, Never>?
-    /// Which note `saveTask` is saving. One pane can host two notes in
-    /// succession (see `.task(id: noteID)` below), and a pending save must
-    /// never be cancelled by whoever came after it — see `debounceSave`.
-    @State private var saveTaskNoteID: UUID?
+    @State private var model = NotePaneModel()
 
     /// Metadata only — `appState.notes` is polled from `note.list`, which
     /// carries no content. Used here for the title; the editor's text is read
@@ -63,86 +61,27 @@ struct NotePaneView: View {
     }
 
     private var editor: some View {
-        TextEditor(text: $text)
+        TextEditor(text: $model.text)
             .font(.system(.body, design: .monospaced))
             .padding(12)
             .scrollContentBackground(.hidden)
-            .onChange(of: text) { _, newValue in
-                guard loaded else { return }
-                debounceSave(content: newValue)
+            .onChange(of: model.text) { _, newValue in
+                model.textEdited(newValue, appState: appState)
             }
             .task(id: noteID) {
                 // Content is read off disk when the pane appears — one read
                 // per pane the user opens, instead of the daemon reading every
                 // note on the machine on every two-second poll.
                 //
-                // Reset BOTH, because this pane is REUSED when its slot is
-                // swapped from one note to another (`navigateHistory` keeps
-                // the pane UUID, and `NotePaneView` is not `.id`-keyed):
-                // leaving `text` alone would show the previous note's words
-                // under the new note's title for as long as the load takes,
-                // or forever if it fails.
-                //
-                // A failed load then leaves the editor empty and `loaded`
-                // FALSE on purpose. `loaded` gates both the debounced autosave
-                // and the onDisappear flush below, so without that guard a
-                // failed load would save an empty note on the next keystroke
-                // or tab switch — deleting the content file on disk.
-                loaded = false
-                text = ""
-                guard let content = await appState.noteContent(
-                    noteID: noteID, worktreeID: worktreeID
-                ) else { return }
-                // This task may no longer be the authoritative one. `.task(id:)`
-                // cancels the outgoing task when `noteID` changes, but
-                // cancellation is cooperative and the read above does not
-                // throw — so a slow load started for the PREVIOUS note keeps
-                // running and would otherwise assign its text here, over a new
-                // note that has already loaded, and set `loaded` on it. The
-                // next keystroke or tab switch would then write the old note's
-                // words into the new note's file. `loaded` cannot catch this:
-                // the stale task is what sets it.
-                guard !Task.isCancelled else { return }
-                text = content
-                loaded = true
+                // This fires on a note SWAP as well as on first appearance:
+                // the pane is reused, keeping its SwiftUI identity, so there is
+                // no `onDisappear` in between. `load` flushes the outgoing
+                // note's pending save before it reads — see `NotePaneModel`.
+                await model.load(
+                    noteID: noteID, worktreeID: worktreeID, appState: appState)
             }
             .onDisappear {
-                // Same rule as `debounceSave`: only cancel a save that is
-                // this note's. Dropping the reference does not cancel it, so
-                // an outgoing note's pending save still lands.
-                if saveTaskNoteID == noteID {
-                    saveTask?.cancel()
-                }
-                saveTask = nil
-                saveTaskNoteID = nil
-                // Flush an immediate save so content isn't lost on tab switch.
-                if loaded {
-                    Task {
-                        await appState.saveNoteContent(
-                            noteID: noteID, worktreeID: worktreeID, content: text)
-                    }
-                }
+                model.paneDisappeared(appState: appState)
             }
-    }
-
-    private func debounceSave(content: String) {
-        // Cancel only a pending save for THIS note. `saveTask` is one @State
-        // slot, and the pane survives a swap from one note to another, so an
-        // unconditional cancel here discards the previous note's unsaved edit
-        // on the first keystroke in the new one — with no `onDisappear` to
-        // catch it, because the pane was reused rather than torn down. Leaving
-        // the other note's task uncancelled lets it complete: it captured this
-        // view's value, so it writes the right text to the right path.
-        if saveTaskNoteID == noteID {
-            saveTask?.cancel()
-        }
-        saveTaskNoteID = noteID
-        saveTask = Task {
-            // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
-            try? await Task.sleep(for: .milliseconds(500))
-            guard !Task.isCancelled else { return }
-            await appState.saveNoteContent(
-                noteID: noteID, worktreeID: worktreeID, content: content)
-        }
     }
 }

--- a/Sources/TBDApp/Panes/NotePaneView.swift
+++ b/Sources/TBDApp/Panes/NotePaneView.swift
@@ -9,17 +9,26 @@ struct NotePaneView: View {
     @State private var text: String = ""
     @State private var loaded = false
     @State private var saveTask: Task<Void, Never>?
+    /// Which note `saveTask` is saving. One pane can host two notes in
+    /// succession (see `.task(id: noteID)` below), and a pending save must
+    /// never be cancelled by whoever came after it — see `debounceSave`.
+    @State private var saveTaskNoteID: UUID?
 
-    private var note: Note? {
+    /// Metadata only — `appState.notes` is polled from `note.list`, which
+    /// carries no content. Used here for the title; the editor's text is read
+    /// off disk once on appear (see `.task(id: noteID)` below).
+    private var note: NoteSummary? {
         appState.notes[worktreeID]?.first { $0.id == noteID }
     }
 
-    /// Where this note's content lives on disk (daemon-written; the file
-    /// exists only once the note has non-empty content, but the would-be
-    /// path is shown regardless — file-backed settings convention, see
-    /// `RepoHooksSettingsView`).
+    /// Where this note's content lives on disk. Written by THIS app now (the
+    /// daemon is out of the content path); the file exists only once the note
+    /// has non-empty content, but the would-be path is shown regardless —
+    /// file-backed settings convention, see `RepoHooksSettingsView`. Resolved
+    /// through `noteContentPathResolver` so the advertised path is by
+    /// construction the one that gets read and written.
     private var contentFilePath: String {
-        TBDConstants.noteContentPath(worktreeID: worktreeID, noteID: noteID)
+        appState.noteContentPathResolver(worktreeID, noteID)
     }
 
     var body: some View {
@@ -62,37 +71,78 @@ struct NotePaneView: View {
                 guard loaded else { return }
                 debounceSave(content: newValue)
             }
-            .onChange(of: note?.content) { _, newContent in
-                // Load content when note data arrives from polling
-                guard !loaded, let newContent else { return }
-                text = newContent
+            .task(id: noteID) {
+                // Content is read off disk when the pane appears — one read
+                // per pane the user opens, instead of the daemon reading every
+                // note on the machine on every two-second poll.
+                //
+                // Reset BOTH, because this pane is REUSED when its slot is
+                // swapped from one note to another (`navigateHistory` keeps
+                // the pane UUID, and `NotePaneView` is not `.id`-keyed):
+                // leaving `text` alone would show the previous note's words
+                // under the new note's title for as long as the load takes,
+                // or forever if it fails.
+                //
+                // A failed load then leaves the editor empty and `loaded`
+                // FALSE on purpose. `loaded` gates both the debounced autosave
+                // and the onDisappear flush below, so without that guard a
+                // failed load would save an empty note on the next keystroke
+                // or tab switch — deleting the content file on disk.
+                loaded = false
+                text = ""
+                guard let content = await appState.noteContent(
+                    noteID: noteID, worktreeID: worktreeID
+                ) else { return }
+                // This task may no longer be the authoritative one. `.task(id:)`
+                // cancels the outgoing task when `noteID` changes, but
+                // cancellation is cooperative and the read above does not
+                // throw — so a slow load started for the PREVIOUS note keeps
+                // running and would otherwise assign its text here, over a new
+                // note that has already loaded, and set `loaded` on it. The
+                // next keystroke or tab switch would then write the old note's
+                // words into the new note's file. `loaded` cannot catch this:
+                // the stale task is what sets it.
+                guard !Task.isCancelled else { return }
+                text = content
                 loaded = true
             }
-            .task(id: noteID) {
-                if let note {
-                    text = note.content
-                    loaded = true
-                }
-            }
             .onDisappear {
-                saveTask?.cancel()
+                // Same rule as `debounceSave`: only cancel a save that is
+                // this note's. Dropping the reference does not cancel it, so
+                // an outgoing note's pending save still lands.
+                if saveTaskNoteID == noteID {
+                    saveTask?.cancel()
+                }
                 saveTask = nil
+                saveTaskNoteID = nil
                 // Flush an immediate save so content isn't lost on tab switch.
-                // If the note was deleted, updateNote gets "Note not found"
-                // which handleConnectionError already absorbs silently.
                 if loaded {
-                    Task { await appState.updateNote(noteID: noteID, worktreeID: worktreeID, content: text) }
+                    Task {
+                        await appState.saveNoteContent(
+                            noteID: noteID, worktreeID: worktreeID, content: text)
+                    }
                 }
             }
     }
 
     private func debounceSave(content: String) {
-        saveTask?.cancel()
+        // Cancel only a pending save for THIS note. `saveTask` is one @State
+        // slot, and the pane survives a swap from one note to another, so an
+        // unconditional cancel here discards the previous note's unsaved edit
+        // on the first keystroke in the new one — with no `onDisappear` to
+        // catch it, because the pane was reused rather than torn down. Leaving
+        // the other note's task uncancelled lets it complete: it captured this
+        // view's value, so it writes the right text to the right path.
+        if saveTaskNoteID == noteID {
+            saveTask?.cancel()
+        }
+        saveTaskNoteID = noteID
         saveTask = Task {
             // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
             try? await Task.sleep(for: .milliseconds(500))
             guard !Task.isCancelled else { return }
-            await appState.updateNote(noteID: noteID, worktreeID: worktreeID, content: content)
+            await appState.saveNoteContent(
+                noteID: noteID, worktreeID: worktreeID, content: content)
         }
     }
 }

--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -674,7 +674,7 @@ struct EditableNoteTitle: View {
     @State private var editText = ""
     @FocusState private var isFocused: Bool
 
-    private var note: Note? {
+    private var note: NoteSummary? {
         appState.notes[worktreeID]?.first { $0.id == noteID }
     }
 

--- a/Sources/TBDDaemon/Database/NoteStore.swift
+++ b/Sources/TBDDaemon/Database/NoteStore.swift
@@ -55,16 +55,36 @@ struct NoteRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
 /// file when it exists, writes go to the file only. Empty/whitespace-only
 /// content deletes the file (mirrors the app's `NotesFileStore` semantics),
 /// so a freshly auto-created empty note produces no file.
+///
+/// **`list` performs zero filesystem operations, by contract.** Not "fewer" —
+/// zero. It returns `NoteSummary`, fetches rows and maps them; it does not
+/// stat, enumerate, or open anything. The app polls it every two seconds, and
+/// a `list` that touched content made the endpoint's cost scale with the total
+/// bytes of every note on the machine (measured at 27% of all daemon
+/// filesystem operations). The app reads and writes the content file itself.
+///
+/// What is left of content in this type is the legacy DB column: `get(id:)`
+/// still overlays it for the few rows the startup export never drained, and
+/// `update(content:)` remains the one write path the app still delegates —
+/// emptying a note, which must delete the file and clear the column together.
 public struct NoteStore: Sendable {
     let writer: any DatabaseWriter
     /// Injection seam for tests (like `ThemeStore(themesDirectory:)`): nil
     /// resolves `TBDConstants.noteContentDir` (which honors TBD_HOME) at
     /// call time.
     let notesDirOverride: String?
+    /// Injection seam for tests: every content-file read goes through this,
+    /// so a test can count them and pin that `list` performs none.
+    let readContentFile: @Sendable (String) -> String?
 
-    init(writer: any DatabaseWriter, notesDir: String? = nil) {
+    init(writer: any DatabaseWriter,
+         notesDir: String? = nil,
+         readContentFile: @Sendable @escaping (String) -> String? = {
+             try? String(contentsOfFile: $0, encoding: .utf8)
+         }) {
         self.writer = writer
         self.notesDirOverride = notesDir
+        self.readContentFile = readContentFile
     }
 
     // MARK: - Content files
@@ -82,7 +102,7 @@ public struct NoteStore: Sendable {
     /// legacy rows that were never exported.
     private func overlayContent(_ note: Note) -> Note {
         let path = contentPath(worktreeID: note.worktreeID, noteID: note.id)
-        guard let fileContent = try? String(contentsOfFile: path, encoding: .utf8) else {
+        guard let fileContent = readContentFile(path) else {
             return note
         }
         var overlaid = note
@@ -135,23 +155,44 @@ public struct NoteStore: Sendable {
         return note.map(overlayContent)
     }
 
-    /// List notes, optionally filtered by worktree (content overlaid from
-    /// each note's file when one exists).
-    public func list(worktreeID: UUID? = nil) async throws -> [Note] {
+    /// List note METADATA, optionally filtered by worktree and/or by an
+    /// explicit set of worktrees (both filters apply when both are given).
+    ///
+    /// Touches no file — see the type's doc comment. `hasLegacyContent` comes
+    /// off the row that was fetched anyway.
+    public func list(worktreeID: UUID? = nil,
+                     worktreeIDs: [UUID]? = nil) async throws -> [NoteSummary] {
         let notes = try await writer.read { db in
             var request = NoteRecord.all()
             if let worktreeID {
                 request = request.filter(Column("worktreeID") == worktreeID.uuidString)
             }
-            return try request.fetchAll(db).compactMap { $0.toModel() }
+            if let worktreeIDs {
+                request = request.filter(worktreeIDs.map(\.uuidString).contains(Column("worktreeID")))
+            }
+            return try request.fetchAll(db)
         }
-        return notes.map(overlayContent)
+        return notes.compactMap { record in
+            guard let note = record.toModel() else { return nil }
+            return NoteSummary(
+                id: note.id,
+                worktreeID: note.worktreeID,
+                title: note.title,
+                createdAt: note.createdAt,
+                updatedAt: note.updatedAt,
+                hasLegacyContent: !record.content.isEmpty
+            )
+        }
     }
 
     /// Update a note's title and/or content. Title goes to the DB row;
     /// content goes to the file only. Exception: an explicit empty-content
     /// update also clears the DB column — the file is deleted, and a stale
     /// legacy column value would otherwise resurrect through the fallback.
+    ///
+    /// The app writes note content directly and calls this for titles; the one
+    /// content case it still routes here is exactly that emptying, because
+    /// deleting the file and clearing the column have to happen together.
     public func update(id: UUID, title: String? = nil, content: String? = nil) async throws -> Note {
         let updated = try await writer.write { db -> Note in
             guard var record = try NoteRecord.fetchOne(db, key: id.uuidString) else {

--- a/Sources/TBDDaemon/Server/RPCRouter+NoteHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+NoteHandlers.swift
@@ -51,9 +51,14 @@ extension RPCRouter {
         return .ok()
     }
 
+    /// Returns `[NoteSummary]`, never `[Note]`: listing must not read content
+    /// files (see `NoteStore`'s doc comment). Content comes from `note.get`.
     func handleNoteList(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(NoteListParams.self, from: paramsData)
-        let notes = try await db.notes.list(worktreeID: params.worktreeID)
+        let notes = try await db.notes.list(
+            worktreeID: params.worktreeID,
+            worktreeIDs: params.worktreeIDs
+        )
         return try RPCResponse(result: notes)
     }
 }

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -1677,6 +1677,67 @@ public struct Note: Codable, Sendable, Identifiable, Equatable {
     }
 }
 
+/// A note's metadata, without its content.
+///
+/// `note.list` returns these rather than `Note` because the daemon is not in
+/// the note-content path at all: content is file-backed at
+/// `~/tbd/notes/<worktreeID>/<noteID>.md` and the APP reads and writes that
+/// file directly, the same way it reads a closed terminal's captured
+/// scrollback (`TerminalHistoryEntry`). `list` therefore performs zero
+/// filesystem operations, however many rows it returns.
+///
+/// A distinct type rather than a `Note` with `content` left empty: an emptied
+/// `Note` keeps every caller compiling while silently handing it `""`. This
+/// makes the compiler point at each site that needs content and forces it to
+/// say where the content comes from.
+public struct NoteSummary: Codable, Sendable, Identifiable, Equatable {
+    public let id: UUID
+    public var worktreeID: UUID
+    public var title: String
+    public var createdAt: Date
+    public var updatedAt: Date
+    /// Whether this note has content in the **legacy DB column**.
+    ///
+    /// Deliberately not named `hasContent`, and it does not mean that: a
+    /// file-backed note whose legacy column is empty reports `false`, which is
+    /// the ordinary case for every note written since content moved to files.
+    /// It is free — the row is already in hand — and it exists because the
+    /// column is still a live content route for the handful of rows the
+    /// startup export never drained. A reader that wants "does this note have
+    /// content" must take the union with the file on disk.
+    public var hasLegacyContent: Bool
+
+    public init(id: UUID = UUID(), worktreeID: UUID, title: String,
+                createdAt: Date = Date(), updatedAt: Date = Date(),
+                hasLegacyContent: Bool = false) {
+        self.id = id
+        self.worktreeID = worktreeID
+        self.title = title
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.hasLegacyContent = hasLegacyContent
+    }
+
+    /// Summarize a full `Note` the daemon just returned, so the app's polled
+    /// cache holds one shape only.
+    ///
+    /// `Note.content` is the daemon's OVERLAID content — the file when one
+    /// exists, else the column — so `hasLegacyContent` derived here is a
+    /// superset of the column and can over-report. It never under-reports, and
+    /// over-reporting costs at most one extra close-confirmation prompt, never
+    /// a silent delete. Prefer mutating an existing summary where you have one.
+    public init(from note: Note) {
+        self.init(
+            id: note.id,
+            worktreeID: note.worktreeID,
+            title: note.title,
+            createdAt: note.createdAt,
+            updatedAt: note.updatedAt,
+            hasLegacyContent: !note.content.isEmpty
+        )
+    }
+}
+
 /// Metadata for a closed terminal whose scrollback was captured at close time.
 /// The captured text is file-backed at
 /// `~/tbd/terminal-history/<worktreeID>/<terminalID>.txt`

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -3023,7 +3023,15 @@ public struct NoteDeleteParams: Codable, Sendable {
 
 public struct NoteListParams: Codable, Sendable {
     public let worktreeID: UUID?
-    public init(worktreeID: UUID? = nil) { self.worktreeID = worktreeID }
+    /// Restrict the result to an explicit set of worktrees. The app passes the
+    /// worktrees it is about to render, so the daemon stops returning rows the
+    /// caller immediately discards. Optional and defaulted: an older client
+    /// that omits it still decodes.
+    public let worktreeIDs: [UUID]?
+    public init(worktreeID: UUID? = nil, worktreeIDs: [UUID]? = nil) {
+        self.worktreeID = worktreeID
+        self.worktreeIDs = worktreeIDs
+    }
 }
 
 // MARK: - Session Params

--- a/Tests/TBDAppTests/ActiveTabResolutionTests.swift
+++ b/Tests/TBDAppTests/ActiveTabResolutionTests.swift
@@ -182,7 +182,7 @@ struct ActiveTabResolutionTests {
 
             state.reconcileNoteTabs(
                 worktreeID: worktreeID,
-                notes: noteIDs.map { Note(id: $0, worktreeID: worktreeID, title: "n") }
+                notes: noteIDs.map { NoteSummary(id: $0, worktreeID: worktreeID, title: "n") }
             )
 
             #expect(state.activeTabIndices[worktreeID] == nil,
@@ -406,7 +406,7 @@ struct ActiveTabResolutionTests {
 
             state.reconcileNoteTabs(
                 worktreeID: worktreeID,
-                notes: [Note(id: note, worktreeID: worktreeID, title: "Notes")]
+                notes: [NoteSummary(id: note, worktreeID: worktreeID, title: "Notes")]
             )
 
             #expect(state.tabs[worktreeID]?.map(\.id) == [claude, setup, note])
@@ -426,7 +426,7 @@ struct ActiveTabResolutionTests {
 
             state.reconcileNoteTabs(
                 worktreeID: worktreeID,
-                notes: [Note(id: keptNote, worktreeID: worktreeID, title: "Kept")]
+                notes: [NoteSummary(id: keptNote, worktreeID: worktreeID, title: "Kept")]
             )
 
             #expect(state.tabs[worktreeID]?.map(\.id) == [claude, keptNote])

--- a/Tests/TBDAppTests/NoteCloseConfirmTests.swift
+++ b/Tests/TBDAppTests/NoteCloseConfirmTests.swift
@@ -5,6 +5,11 @@ import TBDShared
 
 /// Closing a note tab hard-deletes the note row, so `closeTab` asks for
 /// confirmation when the note has content (empty notes close silently).
+/// The branch is driven by `AppState.noteHasContent`, the union of the polled
+/// summary's `hasLegacyContent` and a single stat of the content file — the
+/// daemon does no filesystem work for `note.list`, so `closeTab` cannot
+/// inspect the text and does not need to. These cases drive the legacy leg;
+/// the file leg needs no note row of its own, since a fresh UUID has no file.
 /// The confirmer is injectable (`AppState.noteCloseConfirmer`) so both
 /// branches run without a real modal NSAlert.
 ///
@@ -18,14 +23,28 @@ struct NoteCloseConfirmTests {
     private func withState(_ body: (AppState) -> Void) {
         let suiteName = "TBDAppTests.NoteCloseConfirm.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
-        defer { defaults.removePersistentDomain(forName: suiteName) }
-        body(AppState(userDefaults: defaults))
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-note-close-\(UUID().uuidString)")
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+            try? FileManager.default.removeItem(at: dir)
+        }
+        let state = AppState(userDefaults: defaults)
+        // Point the file leg of `noteHasContent` at an empty temp directory,
+        // so these cases exercise the legacy leg alone and never depend on the
+        // process-global TBD_HOME (see NoteContentFileAccessTests).
+        state.noteContentPathResolver = { worktreeID, noteID in
+            dir.appendingPathComponent(worktreeID.uuidString)
+                .appendingPathComponent("\(noteID.uuidString).md").path
+        }
+        body(state)
     }
 
     private func makeNoteTab(
-        state: AppState, worktreeID: UUID, content: String
-    ) -> Note {
-        let note = Note(worktreeID: worktreeID, title: "Notes", content: content)
+        state: AppState, worktreeID: UUID, hasLegacyContent: Bool
+    ) -> NoteSummary {
+        let note = NoteSummary(worktreeID: worktreeID, title: "Notes",
+                               hasLegacyContent: hasLegacyContent)
         state.notes = [worktreeID: [note]]
         state.tabs = [worktreeID: [
             Tab(id: note.id, content: .note(noteID: note.id), label: nil)
@@ -36,9 +55,9 @@ struct NoteCloseConfirmTests {
     @Test func nonEmptyNoteDeclinedKeepsTab() {
         withState { state in
             let worktreeID = UUID()
-            let note = makeNoteTab(state: state, worktreeID: worktreeID, content: "important")
+            let note = makeNoteTab(state: state, worktreeID: worktreeID, hasLegacyContent: true)
             var asked = false
-            state.noteCloseConfirmer = { _ in
+            state.noteCloseConfirmer = { _, _ in
                 asked = true
                 return false
             }
@@ -54,8 +73,8 @@ struct NoteCloseConfirmTests {
     @Test func nonEmptyNoteConfirmedClosesTab() {
         withState { state in
             let worktreeID = UUID()
-            let note = makeNoteTab(state: state, worktreeID: worktreeID, content: "important")
-            state.noteCloseConfirmer = { _ in true }
+            let note = makeNoteTab(state: state, worktreeID: worktreeID, hasLegacyContent: true)
+            state.noteCloseConfirmer = { _, _ in true }
 
             state.closeTab(worktreeID: worktreeID, index: 0)
 
@@ -67,18 +86,18 @@ struct NoteCloseConfirmTests {
     @Test func emptyNoteClosesSilently() {
         withState { state in
             let worktreeID = UUID()
-            let note = makeNoteTab(state: state, worktreeID: worktreeID, content: "  \n")
+            let note = makeNoteTab(state: state, worktreeID: worktreeID, hasLegacyContent: false)
             var asked = false
-            state.noteCloseConfirmer = { _ in
+            state.noteCloseConfirmer = { _, _ in
                 asked = true
                 return false
             }
 
             state.closeTab(worktreeID: worktreeID, index: 0)
 
-            #expect(!asked, "an empty (whitespace-only) note must not prompt")
+            #expect(!asked, "a note with no content must not prompt")
             #expect(state.tabs[worktreeID]?.contains { $0.id == note.id } != true,
-                    "an empty note tab must close silently as before")
+                    "a contentless note tab must close silently as before")
         }
     }
 }

--- a/Tests/TBDAppTests/NoteContentFileAccessTests.swift
+++ b/Tests/TBDAppTests/NoteContentFileAccessTests.swift
@@ -1,0 +1,327 @@
+import Foundation
+import Testing
+@testable import TBDApp
+import TBDShared
+
+/// The app owns note content: `note.list` carries none, so `NotePaneView`
+/// reads and writes `TBDConstants.noteContentPath` itself. Two rules in that
+/// path are data-loss-shaped and are what these cases pin.
+///
+/// - A missing file is not an empty note. When the legacy DB column still
+///   holds the text, `noteContent` must fall back to the daemon rather than
+///   loading `""` for the autosave to write back.
+/// - An emptying save must go through the daemon, which deletes the file and
+///   clears that column together. If the app deleted the file itself, the
+///   surviving column would resurrect the text on the next open.
+///
+/// Constructs `AppState(userDefaults:)` against a throwaway suite —
+/// `UserDefaults.standard` on this unbundled executable is the developer's
+/// real TBDApp.plist (see TabUnreadCompletionTests). Content files go to a
+/// per-test temp directory through `noteContentPathResolver` rather than to a
+/// `TBD_HOME`-derived path: `TBD_HOME` is process-global and concurrently
+/// running daemon suites `setenv` it, so a test that resolved the path twice
+/// could get two different answers (`Tests/CLAUDE.md`, and the same reason
+/// `NotesFileStoreTests` uses `temporaryDirectory`).
+@MainActor
+@Suite("Note content file access")
+struct NoteContentFileAccessTests {
+
+    /// Runs `body` against a fresh `AppState` whose note content files live in
+    /// a per-test temp directory, removed afterwards.
+    private func withState(_ body: (AppState) async -> Void) async {
+        let suiteName = "TBDAppTests.NoteContentFileAccess.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-note-content-\(UUID().uuidString)")
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+            try? FileManager.default.removeItem(at: dir)
+        }
+        let state = AppState(userDefaults: defaults)
+        state.noteContentPathResolver = { worktreeID, noteID in
+            dir.appendingPathComponent(worktreeID.uuidString)
+                .appendingPathComponent("\(noteID.uuidString).md").path
+        }
+        await body(state)
+    }
+
+    /// Registers one note summary and returns its identity plus its content
+    /// path, resolved the way the code under test resolves it.
+    private func seedNote(
+        state: AppState, hasLegacyContent: Bool
+    ) -> (worktreeID: UUID, noteID: UUID, path: String) {
+        let worktreeID = UUID()
+        let note = NoteSummary(worktreeID: worktreeID, title: "Notes",
+                               hasLegacyContent: hasLegacyContent)
+        state.notes[worktreeID] = [note]
+        return (worktreeID, note.id, state.noteContentPathResolver(worktreeID, note.id))
+    }
+
+    private func makeParentDir(of path: String) {
+        try? FileManager.default.createDirectory(
+            atPath: (path as NSString).deletingLastPathComponent,
+            withIntermediateDirectories: true)
+    }
+
+    @Test("an existing content file is read off disk, never from the daemon")
+    func readsTheFileDirectly() async {
+        await withState { state in
+            let seed = seedNote(state: state, hasLegacyContent: false)
+            makeParentDir(of: seed.path)
+            try? "from the file".write(toFile: seed.path, atomically: true, encoding: .utf8)
+
+            var fetched = false
+            state.noteLegacyContentFetcher = { _ in
+                fetched = true
+                return "from the daemon"
+            }
+
+            let text = await state.noteContent(noteID: seed.noteID, worktreeID: seed.worktreeID)
+
+            #expect(text == "from the file")
+            #expect(!fetched, "a present content file must not provoke an RPC")
+        }
+    }
+
+    @Test("a missing file with legacy column content falls back to the daemon")
+    func missingFileWithLegacyContentFallsBack() async {
+        await withState { state in
+            let seed = seedNote(state: state, hasLegacyContent: true)
+            #expect(!FileManager.default.fileExists(atPath: seed.path))
+
+            var askedFor: UUID?
+            state.noteLegacyContentFetcher = { noteID in
+                askedFor = noteID
+                return "never exported"
+            }
+
+            let text = await state.noteContent(noteID: seed.noteID, worktreeID: seed.worktreeID)
+
+            #expect(text == "never exported",
+                    "loading \"\" here would let the autosave destroy the note")
+            #expect(askedFor == seed.noteID)
+        }
+    }
+
+    @Test("a content file that exists but cannot be read returns nil, not empty")
+    func unreadableFileReturnsNil() async {
+        await withState { state in
+            // The ordinary modern note: file-backed, empty legacy column.
+            // Without the exists-check this returns "" — the failed read is
+            // indistinguishable from a missing file, and the guard below hands
+            // back "" for a note with no legacy content.
+            let seed = seedNote(state: state, hasLegacyContent: false)
+            makeParentDir(of: seed.path)
+            try? "real content nobody may overwrite"
+                .write(toFile: seed.path, atomically: true, encoding: .utf8)
+            // Restore the mode in `defer` regardless of the outcome, or
+            // `withState`'s directory removal cannot delete the file.
+            try? FileManager.default.setAttributes(
+                [.posixPermissions: 0o000], ofItemAtPath: seed.path)
+            defer {
+                try? FileManager.default.setAttributes(
+                    [.posixPermissions: 0o600], ofItemAtPath: seed.path)
+            }
+
+            var fetched = false
+            state.noteLegacyContentFetcher = { _ in
+                fetched = true
+                return "unexpected"
+            }
+
+            let text = await state.noteContent(noteID: seed.noteID, worktreeID: seed.worktreeID)
+
+            // Without this, the pane marks itself loaded on "" and the next
+            // keystroke autosaves that over content still on disk.
+            #expect(text == nil, "an unreadable file must not load as empty")
+            #expect(!fetched, "an existing file must not fall through to the legacy fallback")
+            #expect(FileManager.default.fileExists(atPath: seed.path),
+                    "and the file is of course still there")
+        }
+    }
+
+    @Test("a missing file with no legacy content loads as empty, with no RPC")
+    func missingFileWithoutLegacyContentLoadsEmpty() async {
+        await withState { state in
+            let seed = seedNote(state: state, hasLegacyContent: false)
+            var fetched = false
+            state.noteLegacyContentFetcher = { _ in
+                fetched = true
+                return "unexpected"
+            }
+
+            let text = await state.noteContent(noteID: seed.noteID, worktreeID: seed.worktreeID)
+
+            #expect(text == "", "a fresh note is genuinely empty, and must still load")
+            #expect(!fetched)
+        }
+    }
+
+    @Test("a failed legacy fetch returns nil so the pane never marks itself loaded")
+    func failedLegacyFetchReturnsNil() async {
+        await withState { state in
+            let seed = seedNote(state: state, hasLegacyContent: true)
+            struct Boom: Error {}
+            state.noteLegacyContentFetcher = { _ in throw Boom() }
+
+            let text = await state.noteContent(noteID: seed.noteID, worktreeID: seed.worktreeID)
+
+            #expect(text == nil, "nil is 'did not load'; \"\" would be 'loaded, and empty'")
+        }
+    }
+
+    @Test("a non-empty save writes the file and never reaches the daemon")
+    func nonEmptySaveWritesTheFileDirectly() async {
+        await withState { state in
+            let seed = seedNote(state: state, hasLegacyContent: false)
+            var emptied = false
+            state.noteEmptier = { _ in
+                emptied = true
+                return Note(worktreeID: seed.worktreeID, title: "Notes")
+            }
+
+            await state.saveNoteContent(
+                noteID: seed.noteID, worktreeID: seed.worktreeID, content: "written by the app")
+
+            let onDisk = try? String(contentsOfFile: seed.path, encoding: .utf8)
+            #expect(onDisk == "written by the app")
+            #expect(!emptied, "ordinary saves must not go through the daemon")
+        }
+    }
+
+    /// A write that cannot land must fail quietly and locally: no file, no
+    /// trap, and above all not mistaken for an emptying — which would delete
+    /// the note's legacy column too. Driven by making the note's parent a
+    /// regular FILE, so `createDirectory` throws.
+    ///
+    /// This does NOT pin that the failure is surfaced. `saveNoteContent` logs
+    /// it at `.error` via `writeOrThrow` rather than swallowing it at `.debug`
+    /// the way `NotesFileStore.write` does, but both leave the same observable
+    /// state, so only a logging seam that does not exist here could tell them
+    /// apart.
+    @Test("a save that cannot reach disk fails without creating or emptying anything")
+    func failedWriteLeavesNoFileAndNoEmptying() async {
+        await withState { state in
+            let seed = seedNote(state: state, hasLegacyContent: false)
+            let parent = (seed.path as NSString).deletingLastPathComponent
+            makeParentDir(of: parent)
+            #expect(FileManager.default.createFile(atPath: parent, contents: Data()),
+                    "a regular file where the note's directory should be")
+
+            var emptied = false
+            state.noteEmptier = { _ in
+                emptied = true
+                return Note(worktreeID: seed.worktreeID, title: "Notes")
+            }
+
+            await state.saveNoteContent(
+                noteID: seed.noteID, worktreeID: seed.worktreeID, content: "cannot land")
+
+            #expect(!FileManager.default.fileExists(atPath: seed.path))
+            #expect(!emptied, "a failed write is not an emptying")
+        }
+    }
+
+    @Test("an emptying save routes through the daemon and clears the legacy flag")
+    func emptyingSaveRoutesThroughTheDaemon() async {
+        await withState { state in
+            let seed = seedNote(state: state, hasLegacyContent: true)
+            makeParentDir(of: seed.path)
+            try? "about to be cleared".write(toFile: seed.path, atomically: true, encoding: .utf8)
+
+            var emptiedID: UUID?
+            state.noteEmptier = { noteID in
+                emptiedID = noteID
+                return Note(id: noteID, worktreeID: seed.worktreeID, title: "Notes")
+            }
+
+            await state.saveNoteContent(
+                noteID: seed.noteID, worktreeID: seed.worktreeID, content: "   \n")
+
+            #expect(emptiedID == seed.noteID,
+                    "only the daemon can delete the file and clear the legacy column together")
+            #expect(state.notes[seed.worktreeID]?.first?.hasLegacyContent == false,
+                    "and the cached summary must follow, so no stale fallback fires")
+        }
+    }
+
+    @Test("noteHasContent is the union of the legacy column and the file")
+    func noteHasContentTakesTheUnion() async {
+        await withState { state in
+            // Legacy column only.
+            let legacy = seedNote(state: state, hasLegacyContent: true)
+            #expect(state.noteHasContent(worktreeID: legacy.worktreeID, noteID: legacy.noteID))
+
+            // File only.
+            let fileOnly = seedNote(state: state, hasLegacyContent: false)
+            #expect(!state.noteHasContent(
+                worktreeID: fileOnly.worktreeID, noteID: fileOnly.noteID),
+                    "neither source yet")
+            makeParentDir(of: fileOnly.path)
+            try? "on disk".write(toFile: fileOnly.path, atomically: true, encoding: .utf8)
+            #expect(state.noteHasContent(
+                worktreeID: fileOnly.worktreeID, noteID: fileOnly.noteID),
+                    "the file alone must be enough — closing the tab deletes the row")
+        }
+    }
+
+    /// `noteHasContent`'s `false` skips the confirmation and hard-deletes the
+    /// note row, so it may only be reached by a file that is genuinely there
+    /// and genuinely empty. A path whose size cannot be established must
+    /// answer `true`.
+    ///
+    /// A directory standing in for the file is the one such state a test can
+    /// actually construct in-process: `fileSizeKey` is nil for it, while a
+    /// `chmod 000` file still stats fine and so would not discriminate.
+    @Test("a content path whose size cannot be read counts as content")
+    func noteHasContentAssumesContentWhenSizeIsUnavailable() async {
+        await withState { state in
+            let seed = seedNote(state: state, hasLegacyContent: false)
+            makeParentDir(of: seed.path)
+            try? FileManager.default.createDirectory(
+                atPath: seed.path, withIntermediateDirectories: false)
+
+            #expect(state.noteHasContent(worktreeID: seed.worktreeID, noteID: seed.noteID),
+                    "an unsizeable path must not read as 'no content'")
+        }
+    }
+
+    @Test("a zero-byte content file counts as no content")
+    func noteHasContentIsFalseForAnEmptyFile() async {
+        await withState { state in
+            let seed = seedNote(state: state, hasLegacyContent: false)
+            makeParentDir(of: seed.path)
+            #expect(FileManager.default.createFile(atPath: seed.path, contents: Data()))
+
+            #expect(!state.noteHasContent(worktreeID: seed.worktreeID, noteID: seed.noteID),
+                    "a file that is there and empty is the one case that may answer false")
+        }
+    }
+
+    /// The close alert advertises where the note's text is kept. It must name
+    /// the path the app actually writes to — one resolver, one answer — or the
+    /// user is told their content survives somewhere it does not.
+    @Test("the close confirmer is told the resolver's path, not a derived one")
+    func closeConfirmerReceivesTheResolvedPath() async {
+        await withState { state in
+            let seed = seedNote(state: state, hasLegacyContent: true)
+            state.tabs[seed.worktreeID] = [
+                Tab(id: seed.noteID, content: .note(noteID: seed.noteID), label: nil)
+            ]
+
+            var advertised: String?
+            state.noteCloseConfirmer = { _, path in
+                advertised = path
+                return false
+            }
+
+            state.closeTab(worktreeID: seed.worktreeID, index: 0)
+
+            #expect(advertised == seed.path,
+                    "the advertised path must be the one the app writes to")
+            #expect(advertised != TBDConstants.noteContentPath(
+                worktreeID: seed.worktreeID, noteID: seed.noteID),
+                    "and this test is vacuous unless the resolver was overridden")
+        }
+    }
+}

--- a/Tests/TBDAppTests/NotePaneModelTests.swift
+++ b/Tests/TBDAppTests/NotePaneModelTests.swift
@@ -1,0 +1,267 @@
+import Clocks
+import Foundation
+import Testing
+@testable import TBDApp
+import TBDShared
+import TestSupport
+
+/// Tier 1. The note pane's load/save sequence, driven directly.
+///
+/// `NotePaneView` is REUSED across notes — `navigateHistory` swaps its `noteID`
+/// while the view keeps its SwiftUI identity — so the pane's riskiest behaviour
+/// is a *sequence* across a note switch, and no `onDisappear` runs in between.
+/// That sequence lives in `NotePaneModel` precisely so it can be asserted here;
+/// the view contributes only the `$model.text` binding, the `onChange`, the
+/// `.task(id:)` and the `onDisappear` that call into it.
+///
+/// Everything is virtual or injected: the debounce runs on a `TestClock`, and
+/// content files go to a per-test temp directory through
+/// `noteContentPathResolver` rather than a `TBD_HOME`-derived path —
+/// `TBD_HOME` is process-global and concurrently running daemon suites
+/// `setenv` it (`Tests/CLAUDE.md`). `AppState` is built against a throwaway
+/// `UserDefaults` suite: `UserDefaults.standard` on this unbundled executable
+/// is the developer's real `TBDApp.plist`.
+@MainActor
+@Suite("Note pane load/save lifecycle", .clockDriven, .serialized)
+struct NotePaneModelTests {
+    private static let debounce = Duration.milliseconds(500)
+
+    /// A release gate the test opens explicitly.
+    ///
+    /// Used to hold a note load parked mid-read while the pane moves on to
+    /// another note. It is `MainActor`-isolated rather than a
+    /// `DispatchSemaphore` so nothing blocks a cooperative-pool thread
+    /// (`Tests/CLAUDE.md`, "Thread-blocking gates"), and it deliberately does
+    /// NOT unpark on cancellation — the point is to keep the stale load parked
+    /// until the test says otherwise, cancelled or not.
+    @MainActor
+    private final class ReleaseGate {
+        private var waiter: CheckedContinuation<Void, Never>?
+        private var released = false
+
+        func wait() async {
+            if released { return }
+            await withCheckedContinuation { waiter = $0 }
+        }
+
+        func release() {
+            released = true
+            waiter?.resume()
+            waiter = nil
+        }
+    }
+
+    @MainActor
+    private final class Harness {
+        let suiteName: String
+        let defaults: UserDefaults
+        let dir: URL
+        let state: AppState
+        let clock = TestClock()
+        let model: NotePaneModel
+        let worktreeID = UUID()
+
+        init() {
+            suiteName = "TBDAppTests.NotePaneModel.\(UUID().uuidString)"
+            defaults = UserDefaults(suiteName: suiteName)!
+            let contentDir = FileManager.default.temporaryDirectory
+                .appendingPathComponent("tbd-note-pane-\(UUID().uuidString)")
+            dir = contentDir
+            state = AppState(userDefaults: defaults)
+            state.noteContentPathResolver = { worktreeID, noteID in
+                contentDir.appendingPathComponent(worktreeID.uuidString)
+                    .appendingPathComponent("\(noteID.uuidString).md").path
+            }
+            model = NotePaneModel(debounceInterval: NotePaneModelTests.debounce, clock: clock)
+        }
+
+        /// Registers a note summary, and writes its content file when `content`
+        /// is non-nil. `hasLegacyContent` drives whether a *missing* file falls
+        /// back to `noteLegacyContentFetcher`.
+        func seedNote(content: String?, hasLegacyContent: Bool = false) -> UUID {
+            let note = NoteSummary(worktreeID: worktreeID, title: "Notes",
+                                   hasLegacyContent: hasLegacyContent)
+            state.notes[worktreeID, default: []].append(note)
+            if let content {
+                let path = path(of: note.id)
+                try? FileManager.default.createDirectory(
+                    atPath: (path as NSString).deletingLastPathComponent,
+                    withIntermediateDirectories: true)
+                try? content.write(toFile: path, atomically: true, encoding: .utf8)
+            }
+            return note.id
+        }
+
+        func path(of noteID: UUID) -> String {
+            state.noteContentPathResolver(worktreeID, noteID)
+        }
+
+        /// The note's text as it actually sits on disk, or nil if there is no
+        /// file — the distinction the whole feature turns on.
+        func onDisk(_ noteID: UUID) -> String? {
+            try? String(contentsOfFile: path(of: noteID), encoding: .utf8)
+        }
+
+        /// What the view's two-way binding plus `onChange` do for one keystroke.
+        func type(_ newText: String) {
+            model.text = newText
+            model.textEdited(newText, appState: state)
+        }
+
+        func tearDown() {
+            defaults.removePersistentDomain(forName: suiteName)
+            try? FileManager.default.removeItem(at: dir)
+        }
+    }
+
+    private func withHarness(_ body: (Harness) async -> Void) async {
+        let harness = Harness()
+        await body(harness)
+        harness.tearDown()
+    }
+
+    /// THE regression this suite exists for.
+    ///
+    /// Edit A, navigate A → B → A inside the debounce window, type again. If
+    /// the pending write to A is left armed rather than flushed, the second
+    /// load of A reads A's file *before* that write lands and the editor comes
+    /// back holding pre-edit text — so the first edit is lost, and the second
+    /// save writes stale-base-plus-new-keystrokes over it.
+    @Test("a history round trip inside the debounce window keeps the edit")
+    func historyRoundTripDuringDebounceKeepsTheEdit() async {
+        await withHarness { h in
+            let noteA = h.seedNote(content: "base A")
+            let noteB = h.seedNote(content: "base B")
+
+            await h.model.load(noteID: noteA, worktreeID: h.worktreeID, appState: h.state)
+            #expect(h.model.text == "base A")
+
+            // Edit A. The clock is never advanced, so this debounce would not
+            // have fired on its own.
+            h.type("base A + first edit")
+
+            // A → B → A, the pane keeping its identity the whole way.
+            await h.model.load(noteID: noteB, worktreeID: h.worktreeID, appState: h.state)
+            #expect(h.model.text == "base B")
+            await h.model.load(noteID: noteA, worktreeID: h.worktreeID, appState: h.state)
+
+            #expect(h.model.text == "base A + first edit",
+                    "the read must not have overtaken A's pending write")
+            #expect(h.onDisk(noteA) == "base A + first edit")
+
+            // Now type on top of whatever came back — as real typing does —
+            // and let the debounce fire. This is what makes the stale base
+            // destructive rather than merely late: the next save is composed
+            // from the text the editor is holding.
+            h.type(h.model.text + " + second edit")
+            await h.clock.advanceWhenSuspended(by: Self.debounce)
+            await h.model.pendingSaveTask?.value
+
+            #expect(h.onDisk(noteA) == "base A + first edit + second edit",
+                    "the second save must build on the first edit, not on a stale base")
+            #expect(h.onDisk(noteB) == "base B")
+        }
+    }
+
+    @Test("switching notes flushes the pending save to the original note")
+    func switchingNotesFlushesThePendingSaveToTheOriginalNote() async {
+        await withHarness { h in
+            let noteA = h.seedNote(content: "base A")
+            let noteB = h.seedNote(content: "base B")
+
+            await h.model.load(noteID: noteA, worktreeID: h.worktreeID, appState: h.state)
+            h.type("edited A")
+
+            await h.model.load(noteID: noteB, worktreeID: h.worktreeID, appState: h.state)
+
+            #expect(h.onDisk(noteA) == "edited A",
+                    "A's unsaved text must land in A's file, not follow the pane to B")
+            #expect(h.onDisk(noteB) == "base B", "B must not receive A's text")
+            #expect(h.model.text == "base B")
+        }
+    }
+
+    /// A load that could not establish the text leaves `loaded` false, and an
+    /// edit made in that state is not recorded — so neither the debounce nor a
+    /// flush can write emptiness over a file whose bytes are still there.
+    @Test("a failed load never saves")
+    func aFailedLoadNeverSaves() async {
+        await withHarness { h in
+            struct Boom: Error {}
+            let readable = h.seedNote(content: "words belonging to another note")
+            // Missing file + a legacy column that still holds content: the
+            // fallback is the only route to the text, and it fails.
+            let noteA = h.seedNote(content: nil, hasLegacyContent: true)
+            h.state.noteLegacyContentFetcher = { _ in throw Boom() }
+
+            // Reach the failing note the way the pane does — by switching to
+            // it, with another note's text already on screen.
+            await h.model.load(noteID: readable, worktreeID: h.worktreeID, appState: h.state)
+            await h.model.load(noteID: noteA, worktreeID: h.worktreeID, appState: h.state)
+            #expect(!h.model.loaded)
+            #expect(h.model.text == "",
+                    "a note switch must clear the outgoing note's words, load or no load")
+
+            h.type("typed into a pane that never loaded")
+            #expect(h.model.pendingSaveTask == nil, "a failed load must not arm a save")
+
+            // An emptying save would route through the daemon rather than the
+            // filesystem, so watch that door too.
+            var emptied = false
+            h.state.noteEmptier = { _ in
+                emptied = true
+                return Note(worktreeID: h.worktreeID, title: "Notes", content: "")
+            }
+            // Both of the paths that persist: an explicit flush (note switch)
+            // and the pane going away (tab switch).
+            await h.model.flushPendingSave(appState: h.state)
+            await h.model.paneDisappeared(appState: h.state).value
+
+            #expect(h.onDisk(noteA) == nil, "nothing may be written for a pane that never loaded")
+            #expect(!emptied, "an unloaded pane must not empty the note either")
+            #expect(h.onDisk(readable) == "words belonging to another note",
+                    "and nothing may reach the note the pane was showing before")
+        }
+    }
+
+    /// `.task(id:)` cancels the outgoing load, but cancellation is cooperative
+    /// and the read does not throw — so a slow load for the PREVIOUS note keeps
+    /// running and must not assign its text over the note that has since
+    /// loaded. Without the post-`await` cancellation guard the pane would end
+    /// up showing A's text under B's title, with `loaded` true, and the next
+    /// keystroke would write A's words into B's file.
+    @Test("a stale load does not overwrite a newer note")
+    func aStaleLoadDoesNotOverwriteANewerNote() async {
+        await withHarness { h in
+            let gate = ReleaseGate()
+            let noteA = h.seedNote(content: nil, hasLegacyContent: true)
+            let noteB = h.seedNote(content: "base B")
+            let clock = h.clock
+            h.state.noteLegacyContentFetcher = { _ in
+                // Park twice: the clock sleep is what lets the test prove the
+                // fetch was entered (`advanceWhenSuspended` waits for it), the
+                // gate is what holds it there until the test is ready.
+                try? await clock.sleep(for: .seconds(1))
+                await gate.wait()
+                return "stale A"
+            }
+
+            let staleLoad = Task { @MainActor in
+                await h.model.load(noteID: noteA, worktreeID: h.worktreeID, appState: h.state)
+            }
+            await h.clock.advanceWhenSuspended(by: .seconds(1))
+
+            // What `.task(id:)` does when the pane's note is swapped.
+            staleLoad.cancel()
+            await h.model.load(noteID: noteB, worktreeID: h.worktreeID, appState: h.state)
+            #expect(h.model.text == "base B")
+
+            gate.release()
+            await staleLoad.value
+
+            #expect(h.model.text == "base B", "the stale load must not assign over B")
+            #expect(h.model.loaded, "B is loaded and must stay loaded")
+            #expect(h.onDisk(noteB) == "base B")
+        }
+    }
+}

--- a/Tests/TBDDaemonTests/NoteContentFileTests.swift
+++ b/Tests/TBDDaemonTests/NoteContentFileTests.swift
@@ -9,6 +9,10 @@ import Testing
 /// dormant legacy fallback. These tests use the `TBDDatabase(inMemory:
 /// notesDir:)` injection seam with a per-test temp dir — no TBD_HOME setenv,
 /// so the suite runs fully parallel.
+///
+/// The `readContentFile` seam on `NoteStore` is what makes the metadata
+/// contract testable: a counting reader turns "does `list` open content
+/// files?" into an assertion instead of a code-reading exercise.
 @Suite("Note content files")
 struct NoteContentFileTests {
 
@@ -87,7 +91,8 @@ struct NoteContentFileTests {
         }
         #expect(try await db.notes.get(id: note.id)?.content == "legacy",
                 "with no file, the DB column is the fallback")
-        #expect(try await db.notes.list(worktreeID: wt.id).first?.content == "legacy")
+        #expect(try await db.notes.list(worktreeID: wt.id).first?.hasLegacyContent == true,
+                "a non-empty legacy column is exactly what hasLegacyContent reports")
 
         // File appears (e.g. external edit) → file wins over the stale column.
         let path = filePath(dir: dir, worktreeID: wt.id, noteID: note.id)
@@ -97,7 +102,8 @@ struct NoteContentFileTests {
         )
         try "from the file".write(toFile: path, atomically: true, encoding: .utf8)
         #expect(try await db.notes.get(id: note.id)?.content == "from the file")
-        #expect(try await db.notes.list(worktreeID: wt.id).first?.content == "from the file")
+        #expect(try await db.notes.list(worktreeID: wt.id).first?.hasLegacyContent == true,
+                "the column is still non-empty, so the flag is unchanged by the file")
     }
 
     @Test func clearingLegacyNoteDoesNotResurrectDBContent() async throws {
@@ -167,5 +173,206 @@ struct NoteContentFileTests {
         let path2 = filePath(dir: dir, worktreeID: wt.id, noteID: note2.id)
         try await db.notes.deleteForWorktree(worktreeID: wt.id)
         #expect(try String(contentsOfFile: path2, encoding: .utf8) == "also kept")
+    }
+
+    // MARK: - `list` touches no files
+
+    /// A `NoteStore` over the fixture's DB whose every content-file read goes
+    /// through a counter.
+    private func countingStore(db: TBDDatabase, dir: URL) -> (NoteStore, NoteReadCounter) {
+        let counter = NoteReadCounter()
+        let store = NoteStore(
+            writer: db.writerForTests,
+            notesDir: dir.path,
+            readContentFile: { counter.read($0) }
+        )
+        return (store, counter)
+    }
+
+    @Test("list opens zero content files, however many notes exist")
+    func listDoesNotReadContentFiles() async throws {
+        let (db, dir, wt) = try await makeFixture()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        for index in 0..<20 {
+            let note = try await db.notes.create(worktreeID: wt.id)
+            _ = try await db.notes.update(id: note.id, content: "body \(index)")
+            #expect(FileManager.default.fileExists(
+                atPath: filePath(dir: dir, worktreeID: wt.id, noteID: note.id)))
+        }
+
+        let (store, counter) = countingStore(db: db, dir: dir)
+        let summaries = try await store.list()
+
+        #expect(summaries.count == 20, "the assertion below is vacuous on an empty list")
+        #expect(counter.reads == 0,
+                "list must never open a content file — it read \(counter.reads)")
+    }
+
+    @Test("get reads exactly one content file")
+    func getReadsExactlyOneContentFile() async throws {
+        let (db, dir, wt) = try await makeFixture()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let note = try await db.notes.create(worktreeID: wt.id)
+        _ = try await db.notes.update(id: note.id, content: "the body")
+        for _ in 0..<4 {
+            let other = try await db.notes.create(worktreeID: wt.id)
+            _ = try await db.notes.update(id: other.id, content: "other")
+        }
+
+        let (store, counter) = countingStore(db: db, dir: dir)
+        let before = counter.reads
+        #expect(try await store.get(id: note.id)?.content == "the body")
+        #expect(counter.reads - before == 1,
+                "get is O(1) reads regardless of how many notes exist")
+    }
+
+    /// `hasLegacyContent` reports the DB column and nothing else. The
+    /// file-backed row reporting `false` is the surprising case and it is
+    /// correct: the app owns the union of column and file, precisely so no
+    /// reader can mistake one for the other.
+    @Test("hasLegacyContent reports the DB column, not the file")
+    func listReportsLegacyColumnOnly() async throws {
+        let (db, dir, wt) = try await makeFixture()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        // 1. Column only — written with raw SQL, because `update()` would
+        //    write the file and destroy the case under test.
+        let columnOnly = try await db.notes.create(worktreeID: wt.id)
+        try await db.writerForTests.write { db in
+            try db.execute(
+                sql: "UPDATE note SET content = 'column only' WHERE id = ?",
+                arguments: [columnOnly.id.uuidString]
+            )
+        }
+        #expect(!FileManager.default.fileExists(
+            atPath: filePath(dir: dir, worktreeID: wt.id, noteID: columnOnly.id)))
+
+        // 2. File-backed, empty column — the ordinary modern note.
+        let fileBacked = try await db.notes.create(worktreeID: wt.id)
+        _ = try await db.notes.update(id: fileBacked.id, content: "on disk")
+        #expect(FileManager.default.fileExists(
+            atPath: filePath(dir: dir, worktreeID: wt.id, noteID: fileBacked.id)))
+
+        // 3. Freshly created — neither.
+        let fresh = try await db.notes.create(worktreeID: wt.id)
+
+        let (store, counter) = countingStore(db: db, dir: dir)
+        let byID = Dictionary(uniqueKeysWithValues: try await store.list().map { ($0.id, $0) })
+
+        #expect(byID[columnOnly.id]?.hasLegacyContent == true,
+                "the legacy column is the one thing this flag reports")
+        #expect(byID[fileBacked.id]?.hasLegacyContent == false,
+                "a file-backed note with an empty column reports false — the app takes the union")
+        #expect(byID[fresh.id]?.hasLegacyContent == false)
+        #expect(counter.reads == 0, "and none of that opened a file")
+    }
+
+    @Test("list works, and is correct, with no notes directory at all")
+    func listPerformsNoFilesystemWork() async throws {
+        // The strongest available statement of "list touches no files": point
+        // the store at a path that does not exist. Anything that stats or
+        // enumerates would come back wrong or empty; a pure row map does not
+        // care.
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-notes-absent-\(UUID().uuidString)")
+        let db = try TBDDatabase(inMemory: true, notesDir: dir.path)
+        let wt = try await db.worktrees.createScratch(
+            name: "fixture", displayName: "fixture",
+            path: "/tmp/fixture-\(UUID().uuidString)", tmuxServer: "tbd-test"
+        )
+
+        var legacy: Set<UUID> = []
+        for index in 0..<40 {
+            let note = try await db.notes.create(worktreeID: wt.id)
+            if index == 3 || index == 36 {
+                try await db.writerForTests.write { db in
+                    try db.execute(
+                        sql: "UPDATE note SET content = 'legacy' WHERE id = ?",
+                        arguments: [note.id.uuidString]
+                    )
+                }
+                legacy.insert(note.id)
+            }
+        }
+
+        let summaries = try await db.notes.list()
+        #expect(summaries.count == 40)
+        #expect(Set(summaries.filter(\.hasLegacyContent).map(\.id)) == legacy)
+        #expect(!FileManager.default.fileExists(atPath: dir.path),
+                "list must not have created, or needed, the notes directory")
+    }
+
+    /// The assertion that keeps the resurrection bug dead. The app deletes no
+    /// content file itself: an emptying save routes back through the daemon so
+    /// the file and the legacy column go together. If the column survived, the
+    /// next open would see "file missing + hasLegacyContent" and restore the
+    /// text the user just deleted.
+    @Test("emptying a note clears the legacy column as well as the file")
+    func emptyingANoteClearsTheLegacyColumn() async throws {
+        let (db, dir, wt) = try await makeFixture()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let note = try await db.notes.create(worktreeID: wt.id)
+        _ = try await db.notes.update(id: note.id, content: "worth keeping")
+        try await db.writerForTests.write { db in
+            try db.execute(
+                sql: "UPDATE note SET content = 'legacy too' WHERE id = ?",
+                arguments: [note.id.uuidString]
+            )
+        }
+        let path = filePath(dir: dir, worktreeID: wt.id, noteID: note.id)
+        #expect(FileManager.default.fileExists(atPath: path))
+
+        _ = try await db.notes.update(id: note.id, content: "")
+
+        #expect(!FileManager.default.fileExists(atPath: path), "the file must be gone")
+        #expect(try await rawDBContent(db: db, noteID: note.id) == "",
+                "and the legacy column with it")
+        #expect(try await db.notes.list(worktreeID: wt.id).first?.hasLegacyContent == false,
+                "so nothing is left to resurrect on the next open")
+    }
+
+    @Test("list filters by an explicit worktree set")
+    func listFiltersByWorktreeIDs() async throws {
+        let (db, dir, wtA) = try await makeFixture()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let wtB = try await db.worktrees.createScratch(
+            name: "fixture-b", displayName: "fixture-b",
+            path: "/tmp/fixture-\(UUID().uuidString)", tmuxServer: "tbd-test"
+        )
+
+        let inA = try await db.notes.create(worktreeID: wtA.id)
+        let inB = try await db.notes.create(worktreeID: wtB.id)
+
+        let onlyA = try await db.notes.list(worktreeIDs: [wtA.id])
+        #expect(onlyA.map(\.id) == [inA.id])
+
+        let both = try await db.notes.list(worktreeIDs: [wtA.id, wtB.id])
+        #expect(Set(both.map(\.id)) == Set([inA.id, inB.id]))
+
+        #expect(try await db.notes.list(worktreeIDs: []).isEmpty,
+                "an empty set selects nothing, not everything")
+    }
+}
+
+/// Counts every content-file read a `NoteStore` makes, via its
+/// `readContentFile` injection seam.
+private final class NoteReadCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    var reads: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return count
+    }
+
+    func read(_ path: String) -> String? {
+        lock.lock()
+        count += 1
+        lock.unlock()
+        return try? String(contentsOfFile: path, encoding: .utf8)
     }
 }

--- a/Tests/TBDDaemonTests/NoteTabOnCreateTests.swift
+++ b/Tests/TBDDaemonTests/NoteTabOnCreateTests.swift
@@ -28,7 +28,7 @@ struct NoteTabOnCreateTests {
         #expect(notes.count == 1)
         let note = try #require(notes.first)
         #expect(note.title == "Notes")
-        #expect(note.content.isEmpty)
+        #expect(!note.hasLegacyContent)
 
         let terminals = try await db.terminals.list(worktreeID: wt.id)
         let order = try await db.worktrees.getTabOrder(worktreeID: wt.id)

--- a/Tests/TBDDaemonTests/RPCRouterMiscTests.swift
+++ b/Tests/TBDDaemonTests/RPCRouterMiscTests.swift
@@ -221,7 +221,9 @@ extension RPCRouterTests {
         let listResp = await router.handle(listReq)
         #expect(listResp.success)
 
-        let notes = try listResp.decodeResult([Note].self)
+        // `note.list` is a metadata endpoint — decoding it as `[Note]` would
+        // fail, because the response carries no `content`.
+        let notes = try listResp.decodeResult([NoteSummary].self)
         #expect(notes.count == 1)
     }
 

--- a/Tests/TBDDaemonTests/WorktreeConversationCarryoverTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeConversationCarryoverTests.swift
@@ -355,7 +355,7 @@ struct WorktreeConversationCarryoverTests {
 
         let note = try #require(try await db.notes.list(worktreeID: worktree.id).first)
         #expect(note.title == "Notes")
-        #expect(note.content == notesSeed)
+        #expect(try await db.notes.get(id: note.id)?.content == notesSeed)
         let order = try await db.worktrees.getTabOrder(worktreeID: worktree.id)
         #expect(order.last == note.id)
     }

--- a/Tests/TBDDaemonTests/WorktreeReviveFreshTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeReviveFreshTests.swift
@@ -356,8 +356,10 @@ struct WorktreeReviveFreshTests {
 
         let note = try #require(try await db.notes.list(worktreeID: created.id).first)
         #expect(note.title == "Notes")
+        // `list` is metadata-only; content comes from `get`.
+        let noteContent = try #require(try await db.notes.get(id: note.id)?.content)
         #expect(
-            note.content == """
+            noteContent == """
             # Revived conversation
 
             Forked from **stale-owl** on 2026-07-27.

--- a/docs/specs/2026-08-29-note-list-metadata-design.md
+++ b/docs/specs/2026-08-29-note-list-metadata-design.md
@@ -1,0 +1,258 @@
+# Note content belongs to the app, not the daemon
+
+## The problem
+
+`note.list` reads every note content file on the machine, from disk, on every
+poll cycle. A `sudo fs_usage` capture of `TBDDaemon` (20 s, 235,351 filesystem
+operations) attributed **27.1% of all daemon filesystem operations** to
+`~/tbd/notes` — 22,352 operations, of which exactly 2 were writes:
+
+- `getattrlist` — 16,762
+- `open` — 5,587
+
+For comparison, transcript parsing over `~/.claude/projects` accounted for 0.5%.
+
+The raw trace repeats one shape, once per note row:
+
+```
+getattrlist  ~/tbd/notes
+getattrlist  ~/tbd/notes/<worktreeUUID>
+getattrlist  ~/tbd/notes/<worktreeUUID>/<noteUUID>.md
+open         ~/tbd/notes/<worktreeUUID>/<noteUUID>.md
+```
+
+Three operations chain to one file read, and the daemon does it for every row
+it returns.
+
+### Why it happens
+
+`NoteStore.list(worktreeID:)` ends with `return notes.map(overlayContent)`, and
+`overlayContent` does `String(contentsOfFile:)` — a full file read per note.
+That is correct for `get(id:)`, where content is the point. On `list` it means
+the endpoint's cost is proportional to the total bytes of every note on the
+machine.
+
+The caller that makes it a storm is `AppState.refreshWorktrees`, which calls
+`daemonClient.listNotes()` **with no `worktreeID`** inside the 2-second poll
+cycle that also fetches terminals. Two multipliers stack on top:
+
+- **Unfiltered.** The call returns every note row, not the visible ones. On the
+  machine that produced the trace that is 700 rows, of which only 97 belong to a
+  non-archived worktree — a 7× amplification, since the app immediately discards
+  notes for worktrees it is not showing.
+- **Unconditional.** It runs whether or not any note changed, forever, for as
+  long as the app is open.
+
+The denominator is note rows, not worktrees: there are 2,052 worktree rows and
+700 notes, spread one per worktree across 700 of them. 700 rows × 4 operations
+against an effective cycle rate a little under 0.5 Hz — the timer is 2.0 s and
+`pollCycleInFlight` skips a tick when the previous cycle is still draining —
+gives ~280 opens per second, against the 279 observed.
+
+## The deeper problem, and the actual fix
+
+Tuning that read is treating a symptom. **The daemon has no reason to be in the
+note-content path at all.**
+
+TBD already knows this. Two file-backed subsystems place content on exactly the
+opposite side of the socket:
+
+- **`TerminalHistoryEntry`** is metadata in the DB and text on disk, and its
+  model comment states the rule outright: the app reads
+  `TBDConstants.terminalHistoryPath` directly, *not* over RPC
+  (`AppState.selectClosedTerminal`).
+- **Claude transcripts** moved into the app in PR #752, parsing incrementally
+  from the file rather than asking the daemon for parsed messages.
+
+And the app **already has the store to do it**. `NotesFileStore`
+(`Sources/TBDApp/Notes/NotesStorage.swift`) reads, writes, and creates note
+files, deleting the file when content is empty or whitespace-only — the same
+semantics as the daemon's `writeContentFile`, which acknowledges the duplication
+in its own comment ("mirrors the app's `NotesFileStore` semantics").
+
+The app and the daemon are always on the same machine. Sending a local file
+read across a unix socket, so the process on the other end can read the same
+disk and send the bytes back, buys nothing and costs a poll-rate storm.
+
+So: **`note.list` becomes pure metadata and the daemon stops touching note
+content entirely.** The app owns the file.
+
+## The design
+
+### `note.list` performs zero filesystem operations
+
+Not "fewer" — zero. `NoteStore.list` fetches rows and maps them. It does not
+stat, enumerate, or open anything.
+
+It returns `[NoteSummary]`, a new type in `TBDShared`:
+
+```swift
+public struct NoteSummary: Codable, Sendable, Identifiable, Equatable {
+    public let id: UUID
+    public var worktreeID: UUID
+    public var title: String
+    public var createdAt: Date
+    public var updatedAt: Date
+    /// Content in the LEGACY DB column. Not "this note has content".
+    public var hasLegacyContent: Bool
+}
+```
+
+A distinct type rather than a `Note` with `content` left empty. An emptied
+`Note` is the same trap one level down: every existing and future caller keeps
+compiling, keeps reading `.content`, and silently gets `""`. `NoteSummary` makes
+the compiler point at each site that needs content and forces it to say where it
+comes from.
+
+`hasLegacyContent` is `!record.content.isEmpty` — free, since the row is already
+in hand. It is deliberately **not** named `hasContent`: a file-backed note with
+an empty legacy column reports `false`, and any reader who assumes otherwise has
+a bug. The app owns the union.
+
+`NoteListParams` also gains an optional `worktreeIDs: [UUID]?`, and
+`refreshWorktrees` passes the visible set it is about to iterate. Of the 700 note
+rows, only 97 belong to a non-archived worktree; the rest are encoded, sent,
+decoded and discarded every cycle. With the filesystem work gone this is a
+payload and decode lever rather than a syscall one, and worth keeping on that
+basis: PR #754's RPC volume probe found JSON decoding to be a standing
+multi-core load in the app, spread across six cooperative threads.
+
+### The app reads and writes the file
+
+`NotePaneView` loads its text from `TBDConstants.noteContentPath(worktreeID:
+noteID:)` — a path it already computes for its own footer — off the main thread,
+mirroring `selectClosedTerminal`'s `Task.detached(priority: .userInitiated)`.
+It saves through `NotesFileStore`, on the debounce it already has.
+
+`note.update` keeps the title. The daemon's content path is retired.
+
+### The legacy DB column is the sharp edge
+
+`NoteStore`'s startup sweep (`exportContentColumnToFiles`, called from
+`Daemon.swift`) has drained most legacy rows to disk, but not all: of 14 rows
+with a non-empty content column, 13 also have a file and **one does not**. So
+the column is still a live content route, and two things follow.
+
+**Reading.** `NotesFileStore.read` returns `""` for a missing file, not nil.
+Loading `""` into a pane, marking it loaded, and letting the autosave flush
+would destroy that note. So a missing file plus `hasLegacyContent` falls back to
+`note.get`, which still overlays the column. The app must distinguish *missing*
+from *empty* — `fileExists`, or treating a `String(contentsOfFile:)` throw as
+missing — never a `""` return.
+
+**Emptying.** The daemon's `update` clears the column when content goes empty,
+precisely so a stale column cannot resurrect through the fallback. Once the app
+writes directly, nothing clears it: the app deletes the file, the column
+survives, the file is now missing, and the fallback resurrects deleted text on
+the next open. So **an emptying write routes through `note.update(content: "")`**
+rather than deleting the file locally. It is one RPC on a rare gesture, and it is
+the only case where the app hands content writing back to the daemon.
+
+### `closeTab` takes the union
+
+Closing a note tab hard-deletes the row, so `closeTab` confirms first when the
+note has content. It is synchronous and cannot await a fetch. It confirms when
+`hasLegacyContent || the file exists and is non-empty` — one synchronous stat on
+a user gesture, not on a poll. The two-source rule lives in one helper on
+`AppState`, not spread across call sites.
+
+### No feature flag
+
+CLAUDE.md gates a change that "wholesale-replaces a load-bearing path
+(rendering, input routing, persistence)" behind a default-off flag, and moving
+content writes out of the daemon is arguably that. It ships unflagged
+deliberately.
+
+The reason is that nothing observable changes. The same bytes land at the same
+path with the same semantics — `NotesFileStore.write` and the daemon's
+`writeContentFile` both write atomically, both create intermediate directories,
+and both delete the file when content is whitespace-only. Only which process
+holds the file descriptor differs. A flag exists so a soak can compare two
+behaviours and a bad default can be turned off; here there is no second
+behaviour to compare against and nothing a user could observe to decide with.
+The cost is real — a gated write means both paths live in the tree, and the
+daemon's content path would have to stay reachable rather than being deleted.
+
+What makes that acceptable rather than merely convenient: `NotesFileStore` is
+already shipped and covered by `NotesStorageTests`, its writes are atomic, and
+`NoteStore.delete` deliberately never removes a content file — so the failure
+modes a flag would protect against do not include losing the bytes already on
+disk.
+
+## Predicted effect
+
+Per poll cycle, on the machine that produced the trace:
+
+- **Today** — 700 rows × (3 `getattrlist` + 1 `open` + a full read) ≈ 2,800
+  operations, plus every note's bytes, plus 700 summaries encoded and decoded.
+- **After** — **zero** filesystem operations, ~97 summaries.
+
+The daemon's `~/tbd/notes` traffic should go to approximately nothing: the two
+writes the capture saw, plus whatever `note.get` the legacy fallback and title
+updates provoke, which is a human-gesture rate against a poll rate.
+
+Two things to check when measuring, because they are the assumptions that could
+be wrong: residual `getattrlist` against `~/tbd/notes` in the **daemon** should
+be near zero rather than merely smaller (anything row-count-shaped means content
+resolution crept back into `list`), and the app's own filesystem traffic should
+rise only on pane opens and saves, not on the poll — if the app starts reading
+note files every cycle, the storm has moved rather than gone.
+
+### What this does not improve
+
+The 27.1% is a share of **`TBDDaemon`'s** filesystem operations. Measured
+machine-wide, the same traffic is about **1.6% of all filesystem events**. Both
+figures are true and they answer different questions.
+
+So this makes the daemon quieter; it does not make the machine quieter, and it
+should not be described as improving system responsiveness or reducing
+`fseventsd` load. The case for it does not need that claim: a `list` endpoint
+whose cost scales with the total bytes of every file it describes is wrong at
+the contract level, and it is a trap for every caller after this one.
+
+## Rejected alternatives
+
+**Keep content in `list` and make the read cheaper.** Several shapes were
+considered — caching in `NoteStore` keyed by path and mtime, a stat-based change
+token, skipping rows that cannot yield content. All of them leave the endpoint
+promising content, so its cost stays proportional to the total bytes of every
+note that has any, and the next caller to reach for `list` inherits the same
+trap. They treat the fact that 659 of 700 rows are currently empty as a property
+of the design rather than of this machine on this day.
+
+**Resolve content-existence in the daemon with one stat per row.** This was the
+design until the trace's own ratio refuted it: at 16,762 `getattrlist` against
+5,587 `open`, path resolution dominates, so a per-row stat removes the smaller
+term and stays O(notes) in the larger one.
+
+**Resolve it with one enumeration of the notes tree per call.** O(directories)
+rather than O(notes) — ~32 directory reads against 700 rows — and it was the
+design immediately before this one. Correct and cheap, but it answers the wrong
+question: it makes the daemon's filesystem work small instead of removing the
+reason for it. Once the app reads its own files, there is nothing left to
+enumerate.
+
+**Write content files but never read them.** Rejected on measurement. Once
+`list` stops reading, the only reads left are one per pane open. The cost is the
+point of the file backing: `~/tbd/notes/<wt>/<note>.md` is editable outside TBD
+and `NotePaneView`'s footer advertises the path with a copy-path button. Making
+the DB authoritative would silently discard external edits — a data-loss-shaped
+regression bought for approximately zero operations.
+
+**Drive note changes off the delta/subscription channel instead of polling.**
+Orthogonal, and still worth doing on its own merits: it would remove the
+remaining per-cycle `note.list` payload. It does not address the endpoint's
+contract, which is what makes the storm possible.
+
+## Compatibility
+
+`note.list`'s result changes shape, so an app binary older than the daemon fails
+to decode it: `Note` requires `content`, which the response no longer carries.
+The app logs the error and the affected poll cycle ends early; worktrees and
+terminals, fetched earlier in the same cycle, still refresh. A restart clears it,
+and `scripts/restart.sh` rebuilds both binaries together.
+
+Emitting a vestigial `content: ""` for wire compatibility was considered and
+rejected as actively harmful: an older app would load empty text into open note
+panes, and its debounced autosave would then write that empty content back,
+deleting the content file. A clean decode failure is the safer skew.


### PR DESCRIPTION
## What's broken

With the app open, `TBDDaemon` re-read every note content file on the machine, from disk, roughly twice a second, forever — whether or not any note had changed.

A `sudo fs_usage` capture of the daemon (20 s, 235,351 filesystem operations) attributed **27.1% of all its filesystem operations** to `~/tbd/notes`: 22,352 operations, of which exactly 2 were writes. Transcript parsing over `~/.claude/projects`, by comparison, was 0.5%.

```
~/tbd/notes                    27.1%   22,352 ops   (2 of them writes)
  getattrlist                  16,762
  open                          5,587
TRANSCRIPTS (~/.claude/...)     0.5%      446 ops
```

Nobody sees this directly — there is no visible symptom, no stall, no wrong pixel. It is a background cost that scales with how many notes exist, and it only grows.

## Why it happens

Note content is file-backed at `~/tbd/notes/<worktreeID>/<noteID>.md`; the DB row keeps the tab's identity and title. `NoteStore.list` ended with `notes.map(overlayContent)`, and `overlayContent` does a full file read per note. That is right for `get`, where content is the point. On `list` it makes the endpoint's cost proportional to the total bytes of every note on the machine.

The caller that turns that into a storm is the app's 2-second poll cycle, which called `listNotes()` with no filter. Two multipliers stack:

- **Unfiltered.** It returned every note row. On the machine that produced the trace that is 700 rows, of which only 97 belong to a non-archived worktree — the app grouped by visible worktree and discarded the rest.
- **Unconditional.** It ran whether or not anything changed.

The denominator is note rows, not worktrees: 2,052 worktree rows, 700 notes. 700 rows × 4 operations against a cycle rate a little under 0.5 Hz gives ~280 opens per second, against the 279 observed.

## What this PR does

Tuning that read would treat a symptom. **The daemon has no reason to be in the note-content path at all**, and TBD already knows this in two other places: `TerminalHistoryEntry` states outright that the app reads its content file directly rather than over RPC, and PR #752 moved Claude transcript reading into the app. The app also already ships `NotesFileStore`, whose semantics the daemon's own `writeContentFile` comment admits it mirrors. Both processes are always on the same machine.

So:

- **`note.list` returns `NoteSummary` and performs zero filesystem operations** — not fewer, none — however many rows it returns.
- **The app reads and writes the content file itself**, off the main thread. `note.update` keeps titles.
- **`note.list` takes an optional worktree filter**, and the app asks only for the worktrees it is about to render.

A distinct `NoteSummary` type rather than a `Note` with `content` left empty: an emptied `Note` keeps every caller compiling while silently handing it `""`. This makes the compiler point at each site that needs content.

Two edges here destroy notes if got wrong, and both are handled deliberately:

- **A failed load must never become an empty save.** A missing file on a row whose legacy DB column still holds content falls back to `note.get`. Critically, a read that fails on a file that *exists* returns `nil`, never `""` — `loaded` stays false, which gates both the debounced autosave and the `onDisappear` flush.
- **Emptying a note routes back through the daemon**, which deletes the file and clears the legacy DB column together. Doing it app-side would leave the column behind for the read fallback to resurrect on the next open.

Design, including the alternatives rejected on the way (a per-row stat, a single tree enumeration, an mtime cache, write-only files): [`docs/specs/2026-08-29-note-list-metadata-design.md`](docs/specs/2026-08-29-note-list-metadata-design.md).

### No flag

This replaces a persistence path, which CLAUDE.md normally gates behind a default-off flag. It ships unflagged deliberately: the same bytes land at the same path with the same semantics — both writers write atomically, create intermediate directories, and delete the file when content is whitespace-only — so there is no second behaviour to soak against and nothing a user could observe to decide with. A gated write would also mean keeping the daemon's content path reachable rather than retiring it. `NotesFileStore` is already shipped and covered by `NotesStorageTests`, its writes are atomic, and `NoteStore.delete` deliberately never removes a content file.

### Reconciler

No new kind of durable resource. Note content files already existed and are already deliberately retained on delete (orphan `.md` files are out of scope by design, stated in `NoteStore.delete`). Only which process holds the file descriptor changes.

## Assumptions

- **The app and daemon are on the same machine.** Assumes it; does not enforce it. If TBD ever grows a remote daemon, the app's direct file reads break and content would have to come back over RPC.
- **The daemon's startup export drains the legacy DB content column.** It mostly has — of 14 rows with a non-empty column, 13 also have a file. The one that does not is why the fallback exists rather than being deleted.
- **`note.list` is the app's only caller.** Nothing in `TBDCLI` reads notes.

## Evidence & verification

**The repro is the trace above**, and the arithmetic reproduces it independently: 700 rows × 4 ops × ~0.4 effective cycles/s ≈ 280 opens/s against 279 observed.

**Discriminating tests.** These fail against the old code rather than passing either way — a test that only checks `list` returns the right notes passes today and proves nothing:

- `listDoesNotReadContentFiles` — a counting seam on the content read; `list()` over 20 notes with files must leave it at **exactly 0**. Old code: 20.
- `listPerformsNoFilesystemWork` — points `notesDir` at a path that does not exist; `list()` still returns all 40 rows correctly and never creates the directory.
- `getReadsExactlyOneContentFile` — pins the other side: `get` is 1 read regardless of population.
- `emptyingANoteClearsTheLegacyColumn` — keeps the resurrection bug dead.
- `unreadableFileReturnsNil` — an existing-but-unreadable file must not load as `""`.
- App side: `nonEmptySaveWritesTheFileDirectly` and `missingFileWithLegacyContentFallsBack`.

`scripts/test.sh --filter 'Note|ActiveTabResolutionTests|RPCRouterTests'` — **187 tests in 21 suites passed**, count stated because `--filter` exits green on zero matches. `swiftlint --strict`: 0 violations in 848 files.

**The after-measurement has not been taken, and this PR does not claim one.** `scripts/diag/daemon-fs-profile.sh` needs root, and reading the new number needs the built binaries installed — a live measurement was running on the machine, so the daemon was deliberately not restarted. Predicted: the `~/tbd/notes` bucket goes to approximately zero, since the poll path no longer touches the filesystem at all. Worth checking when someone does run it: residual `getattrlist` in the **daemon** should be near zero rather than merely smaller, and the app's own note traffic should rise only on pane opens and saves — if it rises per poll cycle, the storm has moved rather than gone.

**What this does not improve.** The 27.1% is a share of *the daemon's* filesystem operations. Machine-wide, the same traffic is about **1.6% of all filesystem events**. This makes the daemon quieter; it does not make the machine quieter, and it should not be read as improving system responsiveness or `fseventsd` load.

**The note pane's load/save lifecycle is now tested.** It was not in the first commit, and the review gate found a data-loss race in exactly that untested area: a pending save stayed armed across a pane-history swap, so navigating A → B → A inside the debounce window re-read A from disk *before its write had landed*, and the next keystroke cancelled the still-pending original save — losing the first edit and rebasing the second on stale text.

The second commit fixes it and closes the gap that hid it. The unsaved text moved out of the debounce task and into data (`pendingSave`, tagged with the note it belongs to), which makes every cancellation non-destructive because the edit is no longer inside the thing being cancelled. `load` now flushes before it reads, and the flush awaits the cancelled task's value so a write already in progress completes first.

The state machine was extracted from the view into `NotePaneModel`, which is directly testable. `NotePaneModelTests` covers the gate's exact scenario — and each of the four guarantees this PR relies on was **mutation-checked** rather than re-read: remove the `loaded` gate and typed text reaches disk from a pane that never loaded; remove the post-`await` cancellation guard and a stale load overwrites a newer note; remove the `text` reset and the previous note's words survive under the new note's title.

**Not live-verified.** Nothing was exercised in the running app, for the same reason the measurement was not taken — a live measurement was running and the daemon was deliberately not restarted. So the view→model wiring (the `text` binding, `onChange` ordering, `.task(id:)` re-entry on a pane swap) is compile-verified and reasoned; the logic beneath it is tested.

[Notes read storm](https://cheapsteak.github.io/tbd/open/?worktree=1736F29B-C4FF-4407-BDC7-2A82E295D92D)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notes now load and save content through dedicated files, with legacy content used as a fallback.
  * Note listings return lightweight metadata and can be filtered by selected worktrees.
  * Empty notes close without unnecessary confirmation prompts.
* **Bug Fixes**
  * Improved handling of missing, unreadable, failed, and empty note content.
  * Prevented stale or overlapping autosaves when switching notes.
* **Documentation**
  * Added design documentation covering note storage, compatibility, and payload improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
