### PR TITLE
Compound: Spec the tmux replacement that stays flat under load (per-session pty holders)

### DIFF
--- a/docs/research/2026-08-30-terminal-session-persistence/iterm2-session-restoration.md
+++ b/docs/research/2026-08-30-terminal-session-persistence/iterm2-session-restoration.md
@@ -407,6 +407,57 @@ rediscovered by anyone building the same thing:
   "disclaim children" advanced setting
   (`sources/Tasks/iTermFileDescriptorMultiClient+MRR.m:245-250`).
 
+## Forcing a repaint after reattach: the size jiggle
+
+A reattached session inherits a live pty but no screen contents, so anything
+already drawn is gone unless the program redraws it. iTerm2's lever for that is
+a deliberate window-size perturbation, and it is worth reading closely because
+what it does *not* cover is as instructive as what it does.
+
+- **The mechanism.** `WinSizeController` (ObjC name `iTermWinSizeController`,
+  `sources/Tasks/WinSizeController.swift:17-18`) exposes `jiggle()` (`:116-124`)
+  and `forceJiggle()` (`:110-114`) over the private `reallyJiggle()`
+  (`:126-140`), which grows the last-known grid by one column, sets it, then
+  sets it straight back. Two size changes, so the child gets a SIGWINCH and
+  full-screen programs repaint.
+- **Same-size resizes are suppressed at two layers**, which is why the
+  perturbation is necessary at all rather than just re-asserting the size.
+  `WinSizeController.set(_:)` returns early when the request matches the current
+  grid, view size and scale factor (`WinSizeController.swift:171-177`), and
+  below it `iTermSetTerminalSize` only calls through to
+  `iTermForceSetTerminalSize` when the requested size differs from what
+  `ioctl(TIOCGWINSZ)` reports (`sources/Tasks/iTermTTYState.c:104-109`); the
+  sole `TIOCSWINSZ` lives at `:101`. A reattach re-inherits the same master fd
+  with its kernel-tracked winsize intact, so asking for the same geometry
+  issues no ioctl and delivers no SIGWINCH.
+- **The ordinary reattach path does not jiggle.** Restoring a saved window
+  arrangement goes through `-tryToAttachToServerWithProcessId:tty:`
+  (`sources/PTYSession.m:2657-2671`),
+  `-tryToAttachToMultiserverWithRestorationIdentifier:` (`:2673-2687`) and
+  `-tryToFinishAttachingToMultiserverWithPartialAttachment:`, none of which
+  reference `jiggle`, `forceJiggle`, or `_jiggleUponAttach`. Combined with the
+  same-size suppression above, a same-geometry reattach heals nothing.
+- **Orphan adoption does jiggle,** by arming a flag first.
+  `-showOrphanAnnouncement` (`sources/PTYSession.m:2540-2547`) calls `jiggle`
+  and sets `_jiggleUponAttach = YES`; that flag is read once, in
+  `-attachToServer:completion:` (`:2701-2702`), which calls `forceJiggle`. Its
+  only callers are the two orphan-adoption delegate methods in
+  `sources/iTermApplicationDelegate.m:3782` and `:3816`.
+- **Two unrelated triggers exist,** so "the jiggle is the orphan-adoption
+  mechanism" would overstate it: the Clear Buffer command jiggles when the
+  `jiggleTTYSizeOnClearBuffer` advanced setting is on, and it defaults off
+  (`sources/PTYSession.m:6767-6768`, `sources/iTermAdvancedSettingsModel.m:494`);
+  and a light/dark or background-color change jiggles as a workaround for
+  iTerm2 issue 9855 (`sources/PTYSession.m:14093-14150`). Neither has anything
+  to do with attachment.
+- **Do not confuse it with `-[PTYTextView mouseHandlerJiggle:]`**
+  (`sources/PTYTextView.m:8197`), which only scrolls a line up and down to
+  force a scrollbar redraw and never touches `WinSizeController`.
+
+The reading for TBD: the mechanism is proven and cheap, but iTerm2 wires it to
+the recovery path and not to the common one. Applying it at *every* reader
+handoff is a small, deliberate divergence rather than an invention.
+
 ## What iTerm2 does not get that tmux does
 
 Being fair to tmux here matters, because TBD ships a feature that depends on

--- a/docs/research/2026-08-30-terminal-session-persistence/iterm2-session-restoration.md
+++ b/docs/research/2026-08-30-terminal-session-persistence/iterm2-session-restoration.md
@@ -1,0 +1,517 @@
+# How iTerm2 makes terminal sessions survive an app restart
+
+**Status:** Research only. No design, no spec, no implementation.
+
+**Source read:** 2026-08-30, against the iTerm2 source tree at commit
+`1dc93ca3`. Every claim about iTerm2 cites `file:line` in that tree, so a reader
+can check it without re-deriving. Paths are relative to the root of the iTerm2
+checkout.
+
+**TBD code read:** the same day, against this worktree. Claims about TBD cite
+`file:line` here.
+
+**Not recoverable from this checkout:** the checkout's git history begins at a
+squash (`b3dd6d2b`, "Organize source code into directories", 2026-04-21;
+1309 commits total), so commit rationale from the 2015-2020 era — when both the
+per-session server and the multi-server were written — is not available. Where
+that matters the section says so and falls back to what the code itself states.
+
+## The decision-critical answer
+
+**Once a session is running, the iTerm2 app reads and writes the pty master
+directly, through a file descriptor it received over `SCM_RIGHTS`. No session
+I/O relays through the server process.** The server is involved at launch and at
+attach, and never again for as long as the app stays alive.
+
+The chain, end to end:
+
+- The server calls `forkpty()` and keeps the master fd in its child table
+  (`sources/Tasks/iTermFileDescriptorMultiServer.c:201` and `:234`, stored at
+  `:143`).
+- It hands that master to the app in the `sendmsg()` control message of the
+  launch response (`:289-299`) and again, for every surviving child, in each
+  `ReportChild` message during the attach handshake (`:415-424`). Both go through
+  `iTermFileDescriptorServerWriteLengthAndBufferAndFileDescriptor`, which builds
+  a `SOL_SOCKET`/`SCM_RIGHTS` cmsg
+  (`sources/Tasks/iTermFileDescriptorServerShared.c:229-252`).
+- The app pulls the fd out of the received cmsg
+  (`sources/Tasks/iTermFileDescriptorMultiClient.m:1240-1246`), the protocol
+  parser routes it to `launch.fd` or `reportChild.fd`
+  (`sources/Tasks/iTermMultiServerProtocol.c:437` and `:444`), and the child
+  object takes ownership: `_fd = report->fd`
+  (`sources/Tasks/iTermFileDescriptorMultiClientChild.m:52`).
+- That fd is what `PTYTask.fd` resolves to, via the job manager
+  (`sources/Tasks/PTYTask.m:158-161`,
+  `sources/Tasks/iTermMultiServerJobManager.m:227-230`).
+- A dedicated app thread runs its own `select()` over every task's fd
+  (`sources/Tasks/TaskNotifier.m:290-342`) and calls `processRead`
+  (`:145`), which does `read(self.fd, …)`
+  (`sources/Tasks/PTYTask.m:428`). Output goes out through
+  `write(self.fd, …)` (`sources/Tasks/PTYTask.m:468`). Window resizes are an
+  `ioctl` on the same fd (`sources/Tasks/PTYTask.m:942`).
+
+The server's own event loop selects on exactly three descriptors — a SIGCHLD
+self-pipe, the listening socket, and the client's request pipe
+(`sources/Tasks/iTermFileDescriptorMultiServer.c:743-747`). The pty master is
+not among them. A grep for `masterFd` across the whole server shows it is
+stored, sent, and closed, and never read from or written to.
+
+**What this implies for TBD.** The precedent holds: a supervisor process that
+merely *holds* pty masters costs zero extra process wakeups on the interactive
+path. Persistence and raw-pty latency are not in tension. The supervisor pays
+only at launch, at attach, and at child death. Two caveats sit at the end of
+this document, in [Implications for TBD](#implications-for-tbd) — the biggest
+being that a holder-only supervisor cannot buffer output while the app is gone,
+because it never reads the pty.
+
+## Process model
+
+### What owns the pty
+
+One server process per *socket number*, holding many children. The current
+design ("multi-server") is a small standalone binary named
+`iTermServer-<bundle version>` (`sources/Tasks/iTermServerDeleter.swift:10-18`),
+enabled by default (`sources/Settings/iTermAdvancedSettingsModel.m:884`, still
+filed under the experimental section) and selected in preference to the older
+per-session server whenever it is available (`sources/Tasks/PTYTask.m:87-93`).
+
+The server keeps an array of `iTermMultiServerChild`, each holding the launch
+request, the child pid, the pty master fd, and the tty name
+(`sources/Tasks/iTermFileDescriptorMultiServer.c:70-77`). It calls `forkpty()`
+itself, so it is both the pty master owner and the child's parent, and it reaps
+children with `waitpid` off a SIGCHLD self-pipe (`:87-88`, `:444-481`).
+
+Normally there is one server. The app tries socket number 1 and increments on
+failure, giving up after five failures (`sources/Tasks/iTermMultiServerConnection.m:116-141`).
+
+### How it is spawned
+
+A single `fork()` from the app, then `setsid()`, then `iTermExec`
+(`sources/Tasks/iTermFileDescriptorMultiClient+MRR.m:262`, `:289`). Five file
+descriptors are handed over positionally
+(`sources/Tasks/iTermFileDescriptorMultiClient+MRR.m:253-259`), and the server
+reads them by index (`sources/Tasks/iTermFileDescriptorMultiServer.c:37-48`):
+the listening socket, an already-accepted connection to write on, a dead man's
+pipe, a pipe to read requests from, and an advisory lock fd.
+
+Three deliberate choices in that sequence are worth naming:
+
+- **It is not daemonized.** A `iTermFileDescriptorMultiServerDaemonize` function
+  exists (`sources/Tasks/iTermFileDescriptorMultiServer.c:1032-1050`) but is
+  compiled out by `const int daemonize = 0`
+  (`:1063`). The comment at
+  `sources/Tasks/iTermFileDescriptorMultiClient+MRR.m:279-288` explains why:
+  tools walk the shell's parent chain up to the app, so the server must remain
+  the app's child. When the app exits, the server is reparented to launchd like
+  any orphan; nothing in the source arranges that, it is just Unix.
+- **`setsid()` is what detaches it.** Same comment: without it, an app launched
+  from a terminal shares that terminal's foreground process group, so a `^C` to
+  the app also kills the server, and the sessions become un-reattachable. The
+  comment also notes `setsid` is async-signal-safe, which matters between fork
+  and exec.
+- **SIGHUP is ignored** — "We get this when iTerm2 crashes. Ignore it."
+  (`sources/Tasks/iTermFileDescriptorMultiServer.c:945-951`). SIGPIPE too, so a
+  `sendmsg()` into a dead app does not kill the server (`:1070`).
+
+Because the server is an ordinary child, the app has to reap it. It installs a
+`DISPATCH_SOURCE_TYPE_PROC` / `DISPATCH_PROC_EXIT` source that `waitpid`s and
+logs the exit status, on the grounds that a server death takes down every
+session on that connection and this is the only place that learns why
+(`sources/Tasks/iTermFileDescriptorMultiClient.m:932-958`).
+
+### The server the multi-server replaced
+
+The older design ("mono-server") is still in the tree and still used whenever
+the multi-server is unavailable. It is a different shape in three ways:
+
+- **One server process per session, not per app.** The app re-execs *its own
+  binary* as `iTerm2 --server <program> <args>` (`sources/Tasks/PTYTask.m:272-287`),
+  which `main` dispatches into `iterm2_server`
+  (`sources/AppKit/main.m:39-41`, `sources/Tasks/legacy_server.c:217-262`). Each
+  such server carries the whole app binary's image and supervises exactly one
+  child (`sources/Tasks/iTermFileDescriptorServer.c:18`).
+- **Its rendezvous lives in a shared world-writable directory.**
+  `/var/tmp/iTerm2.socket.<pid>` (`sources/Tasks/iTermFileDescriptorSocketPath.c:69-72`),
+  chosen deliberately over `/tmp` and `$TMPDIR` because those get swept; the
+  long comment at `:34-63` records the reasoning. The consequence is a security
+  problem the multi-server does not have — see
+  [Failure modes](#failure-modes-and-hard-won-details).
+- **It survives GUI logout on purpose.** Before forking, it moves itself from
+  the per-session Aqua Mach bootstrap namespace up to the per-user one
+  (`sources/Tasks/legacy_server.c:189-215`, an extensively commented fix for
+  what the comment calls issue 4147). The multi-server does the opposite: it
+  polls its bootstrap port and quits cleanly when it goes dead, precisely
+  because a logout leaves it "unusable"
+  (`sources/Tasks/iTermFileDescriptorMultiServer.c:989-1004`).
+
+**Why the change happened** is not recoverable from this checkout's history.
+The only statement of purpose in the tree is the advanced setting's own
+description — "A new implementation of session restoration that combines daemon
+processes" (`sources/Settings/iTermAdvancedSettingsModel.m:884`) — and the
+structural differences above: one process instead of one per session, a
+purpose-built standalone binary instead of a re-exec of the whole app, and a private
+per-user directory instead of a shared one. One further difference is stated in
+a code comment: killing modes differ because "Monoserver needs to ensure the
+server dies even when the child is persistent, but multiserver can survive its
+children" (`sources/Tasks/iTermMultiServerJobManager.m:557-559`).
+
+The lifetime rule follows from that: a multi-server exits when it has no
+reportable children *and* no client
+(`sources/Tasks/iTermFileDescriptorMultiServer.c:864-868`), unlinking its socket
+on the way out (`:1052-1060`).
+
+## Rendezvous and reattachment
+
+### Where the socket lives
+
+`~/Library/Application Support/iTerm2/iterm2-daemon-<N>.socket`
+(`sources/Tasks/iTermMultiServerConnection.m:257-286`). If that path will not
+fit in `sockaddr_un.sun_path`, it falls back to `~/.iterm2/<N>.socket`
+(`:288-315`). The fit test is explicit — `strlen(path) + 1 < sizeof(addr.sun_path)`
+(`:249-255`) — and it is load-bearing enough that the entire multi-server
+implementation declares itself unavailable when even a synthetic
+`pathForNumber:1000` would not fit (`:154-156`), falling the whole app back to
+the mono-server.
+
+The socket is bound under `umask(S_IRWXG | S_IRWXO)` so only the owning user can
+connect (`sources/Tasks/iTermFileDescriptorServerShared.c:347`), and any
+existing file at the path is `unlink()`ed immediately before `bind()` (`:353`) —
+which is the whole of the stale-socket reclamation story.
+
+### Proving which server owns which session
+
+Each session's saved arrangement carries a restoration identifier: a dictionary
+of `{Type: "multiserver", Version: 1, Socket: <N>, "Child PID": <pid>}`
+(`sources/Tasks/iTermMultiServerJobManager.m:21-28`, built at `:293-303`,
+parsed back at `:66-89`). Identity is therefore *(socket number, child pid)* and
+nothing more.
+
+Pid reuse is not a hazard here, because the pid is only an index into the
+server's own child table, never a lookup into the OS process table
+(`sources/Tasks/iTermFileDescriptorMultiServer.c:548-555`). A child that has
+exited is still in the table, marked `terminated`, and is reported as such — so
+the app learns "your process is gone" rather than attaching to a stranger
+(`sources/Tasks/iTermMultiServerJobManager.m:466-486`).
+
+### The attach handshake
+
+Connecting is a three-step dance
+(`sources/Tasks/iTermFileDescriptorMultiClient.m:178-234`):
+
+1. `connect()` to the socket, non-blocking "so connect can fail fast if another
+   iTerm2 is connected to this server"
+   (`sources/Tasks/iTermFileDescriptorMultiClient+MRR.m:64-68`).
+2. Read the server's first message, whose control data carries the *write end of
+   a fresh pipe*; the client uses that for writes and keeps the socket for reads
+   (`sources/Tasks/iTermFileDescriptorMultiServer.c:782-818`). The client code
+   carries a bare `TODO: why? Unix domain sockets are bidirectional`
+   (`sources/Tasks/iTermFileDescriptorMultiClient.m:199`). Nothing in the tree
+   explains it.
+3. Send a handshake naming the maximum protocol version; the server replies with
+   its version, its pid, and a child count, then streams one `ReportChild`
+   message per surviving child — each carrying that child's pty master fd
+   (`sources/Tasks/iTermFileDescriptorMultiServer.c:505-544`,
+   `sources/Tasks/iTermFileDescriptorMultiClient.m:370-426`).
+
+If the connection fails, the client launches a new server and handshakes with
+that instead (`sources/Tasks/iTermFileDescriptorMultiClient.m:147-173`).
+
+### How restoration is sequenced around it
+
+The app deliberately does not block window restoration on the server. The order
+is: bring up an *empty* window first, then walk the saved arrangement as plain
+dictionaries and kick off one asynchronous "partial attach" per leaf session,
+then build the real sessions only once those resolve. A session is created
+already knowing whether it will adopt a surviving process or launch a fresh one;
+there is no state where a session exists but is waiting for an attachment.
+
+The wait is bounded by `timeoutForDaemonAttachment`, default 10 seconds
+(`sources/Settings/iTermAdvancedSettingsModel.m:665`). Whichever fires first —
+all attaches complete, or the timer — restoration proceeds with whatever
+arrived. iTerm2's own write-up of this flow, including the file-by-file map of
+the restoration path and the reasoning behind the split, is in the tree at
+`docs/session-restoration-and-process-reattachment.md`; it attributes the design
+to a wedged-daemon hazard ("if the daemon is not feeling well, it can take
+forever") and it matches the code read here.
+
+The synchronous attach still exists but is a `dispatch_group_wait(…,
+DISPATCH_TIME_FOREVER)` around the same async path
+(`sources/Tasks/iTermMultiServerJobManager.m:373-386`), and is not on the launch
+path.
+
+## What is preserved, and what is lost
+
+**Preserved by the server:** the live process, its pty, its controlling
+terminal, its tty name, and a copy of its launch request — path, argv, envp,
+working directory, UTF-8 flag — which it replays on every reattach
+(`sources/Tasks/iTermFileDescriptorMultiServer.c:111-148`, replayed at
+`:383-399`, reconstituted app-side at
+`sources/Tasks/iTermFileDescriptorMultiClientChild.m:20-58`).
+
+**Not preserved by the server: any screen content at all.** Scrollback, the
+current screen, the selection, and the window layout live entirely in the app's
+own SQLite database at
+`~/Library/Application Support/iTerm2/SavedState/restorable-state.sqlite`
+(`sources/StateRestoration/iTermRestorableStateController.m:107-122`). Session
+contents are encoded from the live screen into the arrangement under a
+`Contents` key (`sources/PTYSession/PTYSession.m:6978-6985`) and read back on
+restore (`:2297-2300`).
+
+That database is written when the app resigns active
+(`sources/AppKit/iTermApplicationDelegate.m:1272`) and synchronously at
+termination (`sources/StateRestoration/iTermRestorableStateController.m:217-230`).
+The consequence is a **skew that is structural, not a bug**: after a crash the
+*process* is current and the *scrollback* is as of the last time the app lost
+focus. The two do not agree, and nothing reconciles them.
+
+**Output produced while the app is dead appears to be lost.** The server never
+reads the pty master — it only stores, sends, and closes it. So once the
+kernel's tty buffer fills, the child blocks in `write()`, and nothing anywhere
+retains those bytes. This is an inference from the absence of any read of
+`masterFd` in the server, not from an experiment; it is the single most
+consequential difference from tmux, so treat it as high-confidence but
+unmeasured.
+
+**Nothing survives a reboot.** There is no launchd job for the server, and its
+own daemonize path is compiled out. The socket files persist as ordinary files
+in Application Support and are reclaimed lazily by the `unlink()` before the
+next `bind()`.
+
+**Nothing survives a GUI logout either,** in the current design: the server
+polls its Mach bootstrap port and quits when it goes dead
+(`sources/Tasks/iTermFileDescriptorMultiServer.c:989-1004`). The mono-server
+went to considerable trouble to survive exactly that
+(`sources/Tasks/legacy_server.c:189-215`); the multi-server gave the property up.
+
+## Orphan reclamation
+
+A surviving child that no restored session claims is an *orphan*. iTerm2 has
+three mechanisms, all in `sources/Tasks/iTermOrphanServerAdopter.m` except the
+last.
+
+- **Self-termination** – a server with no reportable children and no connected
+  client exits and unlinks its socket
+  (`sources/Tasks/iTermFileDescriptorMultiServer.c:864-868`, `:1052-1060`). This
+  is the common case and it needs no external sweeper.
+- **Late partial attachments** – results that arrive after the 10 s restore
+  timeout are handed to `adoptPartialAttachments:`
+  (`sources/Tasks/iTermOrphanServerAdopter.m:246-256`) and opened as fresh
+  sessions rather than retrofitted into the window that was meant to hold them.
+- **A filesystem sweep at launch** – at construction the adopter asynchronously
+  scans for mono-server sockets by name prefix in `/var/tmp` (`:41-55`) and for
+  multi-server sockets by the glob `iterm2-daemon-*.socket` in Application
+  Support (`:57-84`). After restoration completes it connects to each and adopts
+  the connection's `unattachedChildren` — by construction, exactly the children
+  no restored session claimed (`:216-239`). Adopted sessions get a default
+  profile, a non-activating new tab, and a banner; they recover the process but
+  not the arrangement's visual state.
+- **A reclaimer for the copied binaries** – the server executable is copied out
+  of the app bundle into Application Support, because the auto-updater would
+  otherwise delete it out from under a running server
+  (`sources/Tasks/iTermFileDescriptorMultiClient.m:829`, copy at `:831-908`).
+  That makes the copies a durable resource in their own right, and
+  `iTermServerDeleter` is their reclaimer: it deletes every `iTermServer-*` in
+  those folders that is neither the current version nor the executable of a
+  running process (`sources/Tasks/iTermServerDeleter.swift:43-76`).
+
+Two gaps are worth naming. **The sweep is launch-only** — there is no periodic
+reconciler, so a server whose app never comes back keeps running until the next
+launch or until logout kills it. And **stale socket files are never actively
+removed**; a `SIGKILL`ed server leaves its socket behind until something binds
+that exact path again.
+
+## Failure modes and hard-won details
+
+Things in this code that read as scar tissue, each of which would have to be
+rediscovered by anyone building the same thing:
+
+- **The fd rides on a one-byte `sendmsg`.** `sendmsg` has been observed failing
+  with `EMSGSIZE` at buffer sizes the man page says are fine — the theory in the
+  comment is that the control block counts against the limit — and an *empty*
+  message fails the same way. So the payload cap for the fd-carrying message is
+  set to exactly one byte, and the rest of the message goes out with a plain
+  `write()` afterwards
+  (`sources/Tasks/iTermFileDescriptorServerShared.c:184-217`). There is a second
+  guard immediately after: on a short `sendmsg`, send the remainder with
+  `write()` and never re-send the fd, "or it will create multiple file
+  descriptors in the recipient" (`:256-261`).
+- **Reads must be serialized by construction.** Messages are length-prefixed
+  with a 1 MiB cap, and the comment states that exactly one method may call the
+  low-level read after the handshake, "otherwise, reads could get intermingled"
+  (`sources/Tasks/iTermFileDescriptorMultiClient.m:1126-1127`). Partial reads
+  are accumulated in a builder that separately carries the received fd
+  (`:1210-1274`).
+- **The mono-server's rendezvous directory forces a peer check.** Because
+  `/var/tmp` is world-writable with a predictable socket name, a local attacker
+  of any uid can pre-create the socket and hand back an attacker-controlled pty
+  master. The defense is `getpeereid()` on the established connection, and the
+  comment is explicit that the `lstat()` before it is *only* a cheap early
+  reject, "inherently TOCTOU with the `connect()` that follows, so do not rely on
+  it" (`sources/Tasks/iTermFileDescriptorClient.c:100-130`, the real check at
+  `:160-185`). The multi-server client does no such check
+  (`sources/Tasks/iTermFileDescriptorMultiClient+MRR.m:37-98`) — it does not need
+  one, because its socket lives in a per-user directory.
+- **Two apps racing for one server.** Creation is serialized by an advisory
+  lock: the app opens `<socket>.lock` with `O_CREAT|O_TRUNC|O_EXLOCK|O_NONBLOCK`
+  before binding (`sources/Tasks/iTermFileDescriptorMultiClient+MRR.m:102-118`,
+  `sources/Tasks/iTermFileDescriptorServerShared.c:371-384`) and passes the lock
+  fd into the server, which holds it for its whole life. A loser of that race
+  moves on to the next socket number. *Connecting* to a server that already has
+  a client is handled differently: the server accepts and immediately rejects,
+  replying with a sentinel "rejected" protocol version and closing
+  (`sources/Tasks/iTermFileDescriptorMultiServer.c:701-740`); the client reads
+  the version mismatch and treats the attach as failed
+  (`sources/Tasks/iTermFileDescriptorMultiClient.m:351-354`). **One client at a
+  time, enforced at the server.**
+- **`SIGHUP` is not enough on user-initiated close.** Closing a session sends
+  `SIGKILL`, not `SIGHUP`, because "we must ensure servers get killed on
+  user-initiated quit. If we just HUP the shell then the server won't notice
+  until it becomes attached as an orphan on the next launch"
+  (`sources/PTYSession/PTYSession.m:3712-3716`). Separately, tearing down a
+  `PTYTask` `killpg`s the process group, with a `TODO` admitting nobody
+  remembers why `killpg` is used there and nowhere else
+  (`sources/Tasks/PTYTask.m:100-106`).
+- **Preemptive wait is how a killed session stops being adoptable.** The app can
+  ask the server to forget a child before it dies; the server closes the master
+  fd and stops reporting the child, so a later reattach cannot resurrect it
+  (`sources/Tasks/iTermFileDescriptorMultiServer.c:569-575`, requested at
+  `sources/Tasks/iTermMultiServerJobManager.m:563-570`).
+- **The restore timeout has an asymmetry.** After the 10 s timeout the
+  partial-attachment dictionary is non-nil but missing the slow session, so that
+  session launches a *fresh* process while its old one is separately adopted
+  into an orphan window. The user ends up with two sessions where they expected
+  one, and the adopted one has no scrollback.
+- **`sun_path` shapes the whole feature.** Beyond the fallback path and the
+  wholesale `+available` check described above, the connect path re-checks the
+  length before every `strcpy` into `sun_path`
+  (`sources/Tasks/iTermFileDescriptorMultiClient+MRR.m:47-50`), and the mono
+  client `assert(0); exit(1)`s rather than overflow
+  (`sources/Tasks/iTermFileDescriptorClient.c:142-145`).
+- **A leaked descriptor, apparently.** The app creates a dead man's pipe before
+  forking the server, passes the write end in as fd 2, and closes the write end
+  in both fork branches — but never closes the read end and never selects on it
+  (`sources/Tasks/iTermFileDescriptorMultiClient+MRR.m:242`, `:256`, `:270`,
+  `:306`). The server's own header comment for that slot says "Do nothing with
+  it" (`sources/Tasks/iTermFileDescriptorMultiServer.c:45`). So the mechanism
+  looks vestigial in the multi-server — the mono-server does use its dead man's
+  pipe, during the handshake read
+  (`sources/Tasks/iTermMonoServerJobManager.m:192-196`) — and one descriptor
+  appears to leak per daemon launch. This is from reading, not from measurement,
+  and an indirect close may have escaped the grep.
+- **Liveness checks are lazy.** The bootstrap-port death check only runs when
+  `select()` returns (`sources/Tasks/iTermFileDescriptorMultiServer.c:751`), so a
+  fully idle server can outlive its session's namespace until something pokes it.
+- **A fork/spawn toggle exists for TCC reasons.** `ITERM_FDMS_USE_SPAWN` selects
+  `posix_spawn` over `fork` for launching children
+  (`sources/Tasks/iTermFileDescriptorMultiServer.c:1027`, `:223-252`), set from a
+  "disclaim children" advanced setting
+  (`sources/Tasks/iTermFileDescriptorMultiClient+MRR.m:245-250`).
+
+## What iTerm2 does not get that tmux does
+
+Being fair to tmux here matters, because TBD ships a feature that depends on
+several of these.
+
+- **No multiplexing and no second viewer.** Exactly one client connection per
+  server, enforced by rejecting the second
+  (`sources/Tasks/iTermFileDescriptorMultiServer.c:701-740`). Two windows cannot
+  show one session; there are no read-only observers.
+- **No attach from another terminal emulator, ever.** The wire protocol is a
+  private binary format over a Unix socket, and the payload is a pty master file
+  descriptor. Only a local process of the same uid can consume it, and only one
+  at a time. There is no equivalent of `tmux attach`.
+- **No remote or ssh attach.** A Unix socket and a file descriptor cannot cross
+  a machine boundary. TBD's external-tmux-attach feature has no analogue in this
+  design and could not be built on it.
+- **No buffering while detached.** tmux keeps reading the pty and keeps
+  `history-limit` lines regardless of whether a client is attached. A
+  holder-only server reads nothing, so a detached session's output stops at the
+  tty buffer and the writer blocks.
+- **No scrollback ownership.** tmux owns the history; here the app owns it, and
+  it is only as fresh as the last save.
+- **No survival of logout.** tmux survives; this server quits itself.
+- **iTerm2 uses tmux anyway, for exactly these cases.** It ships a separate tmux
+  control-mode integration with its own job manager
+  (`sources/tmux/iTermTmuxJobManager.m`, wired at
+  `sources/Tasks/PTYTask.m:315-321` through a read-only fd). The two mechanisms
+  coexist; the fd-passing server is not presented as a replacement for tmux.
+
+## How this compares with what TBD already has
+
+TBD already passes file descriptors from daemon to app over a Unix socket with
+`SCM_RIGHTS`. The mechanism is in place; what differs is *which* descriptor
+crosses and what sits behind it.
+
+- **The channel.** `FDVendingServer` binds a Unix socket, accepts one client at
+  a time, and vends descriptors inside length-prefixed frames
+  (`Sources/TBDDaemon/Server/FDVendingServer.swift:143-193` for the listener,
+  `:255-274` for `send(fd:header:)`). The app side connects, receives, and
+  demultiplexes frames on a dedicated thread
+  (`Sources/TBDApp/Terminal/FDSidecarClient.swift:48`, `:192-281`). Like
+  iTerm2's, it is a one-client channel, and both ends carry careful commentary
+  about fd-number recycling and connection-epoch races.
+- **The descriptor.** TBD vends **the read end of a per-pane pipe**, allocated by
+  the tmux control-mode fanout — not a pty master
+  (`Sources/TBDDaemon/Tmux/ControlMode/TmuxControlSupervisor.swift:264-266`,
+  vended at `Sources/TBDDaemon/Server/RPCRouter+AttachHandlers.swift:82-96`).
+  It is read-only and one-directional.
+- **The input path.** Because the vended fd carries no write side, keystrokes go
+  the other way as framed `.input` and `.paste` messages over the same socket
+  (`Sources/TBDApp/Terminal/FDSidecarClient.swift:117`, `:161`), decoded on the
+  daemon's receive thread and routed to the tmux server.
+
+So today, in the steady state, TBD's keystroke path is app → daemon → tmux
+server → pty, and its paint path is pty → tmux server → daemon → pipe → app.
+The daemon is a process wakeup in both directions, layered on top of tmux's own.
+iTerm2's steady-state hop count after attach is zero in both directions.
+
+The gap TBD would have to close is therefore not the fd-passing plumbing — that
+exists and is battle-hardened here — but what the vended descriptor *is*, and
+which process owns the pty behind it.
+
+## Implications for TBD
+
+Deliberately short, and clearly separated from the research above. This document
+is a record, not a proposal.
+
+- **The core hypothesis is confirmed by precedent.** A supervisor that only
+  holds pty masters and hands them over by `SCM_RIGHTS` gives restart survival
+  at zero steady-state process wakeups. iTerm2 has shipped this for years, on by
+  default.
+- **The cost is that the app owns the byte stream.** Whoever holds the fd must
+  run the `select`/`read` loop and the terminal emulator. TBD already does both,
+  on the far side of a pipe.
+- **Three tmux properties do not come along:** external attach (which TBD ships
+  today), output buffering while the app is gone, and survival of logout. The
+  second is the one most likely to be underestimated — a holder-only supervisor
+  cannot read the pty without reintroducing exactly the wakeups it was built to
+  avoid, so "detached output is lost, and the writer blocks" is intrinsic to the
+  design rather than an implementation gap.
+- **Content and process persist on different clocks.** iTerm2's scrollback is as
+  fresh as the last resign-active save while its processes are current. Any
+  design of this shape inherits that skew and has to decide what it means.
+- **The durable resources needing a named reclaimer** are the supervisor
+  process, the rendezvous socket file, the lock file, and — if the binary is
+  copied anywhere — the copies. iTerm2's answers are: self-exit when childless,
+  lazy `unlink()` before `bind()`, a launch-time filesystem sweep, and
+  `iTermServerDeleter`. Note that it has *no* periodic reconciler, which under
+  TBD's own doctrine would be a gap rather than a precedent to copy.
+- **Identity binding is weaker there than TBD's would be.** iTerm2 matches a
+  restored session to a surviving child by *(socket number, child pid)* carried
+  in a saved arrangement. TBD already has stable worktree and pane identifiers
+  in its database, which is a stronger basis for the same handshake.
+
+## What could not be verified
+
+- **Why the per-session server was replaced by the multi-server.** The
+  originating commits predate this checkout's squashed history. Everything in
+  [The server the multi-server replaced](#the-server-the-multi-server-replaced)
+  is read off the two implementations as they stand today, plus the advanced
+  setting's one-line description.
+- **That output produced while the app is dead is genuinely lost.** Inferred
+  from the server never reading the pty master. Not observed.
+- **That the dead man's pipe's read end leaks in the multi-server path.** No
+  close was found by grep across the client, the MRR category, and the header;
+  an indirect close would falsify this.
+- **Runtime behavior of any kind.** Nothing here was executed, traced, or
+  measured. Every claim is a source reading.

--- a/docs/research/2026-08-30-terminal-session-persistence/measurement-notes.md
+++ b/docs/research/2026-08-30-terminal-session-persistence/measurement-notes.md
@@ -121,6 +121,13 @@ into a headless VT (neither, at the cost of a process in the path).
 
 - `scripts/diag/tmux-vs-rawpty-idle.py` — the raw-pty/tmux comparison above.
 - `scripts/diag/tmux-server-contention.py` — interleaves a busy server against a
-  private one-pane server. Measured 34.1 ms against 36.5 ms p50, which is why
-  pane count per server, and therefore sharding servers more finely, is not a
-  lever here.
+  private one-pane server. Measured 34.1 ms against 36.5 ms p50.
+
+  **Read that pair with its method in mind.** This script forks a `tmux
+  send-keys` client per sample, so both arms carry a fork+exec — the very cost
+  the raw-versus-tmux script above avoids on purpose, and the reason these
+  numbers sit roughly 30× above the 1.1 ms p50 that method measures for quiet
+  tmux. The arms share the method, so a large gap between them would still have
+  shown; but the effective resolution is tens of milliseconds. The honest
+  reading is "pane count per server is not a *large* effect", not "pane count
+  is not an effect", and a few milliseconds could hide here undetected.

--- a/docs/research/2026-08-30-terminal-session-persistence/measurement-notes.md
+++ b/docs/research/2026-08-30-terminal-session-persistence/measurement-notes.md
@@ -1,0 +1,126 @@
+# Measured behaviour of the current tmux path
+
+Companion to the two research records in this directory. Everything here was
+measured on a loaded development machine (48 GB, ~75 concurrent agent
+processes) with the probes in `scripts/diag/`, and is included because the
+design question turns on *where* the latency comes from, not merely that it
+exists.
+
+## Keystroke-to-visible, raw pty against tmux
+
+Both arms are driven identically: write a token into a pty the probe owns, then
+time until it becomes visible coming back out of that same pty. The tmux arm
+attaches a real client through a real pty rather than shelling out per
+keystroke, because spawning a client per key would measure `fork`+`exec` — 5.1 ms
+p50 and 58.9 ms p90 on this machine — instead of tmux.
+
+- **load 20-37** — raw 0.1 ms p50 / 0.3 p90 / 0.4 max; tmux 1.1 ms p50 / 9.3 p90 / 11.6 max
+- **load 62-77** — raw 0.1 ms p50 / 0.9 p90 / 5.0 max; tmux 3.3 ms p50 / 12.7 p90 / 18.2 max
+- **load 72-117** — raw 0.2 ms p50, 5.0 ms max; tmux 139 ms p90 (n=4, directional only)
+
+Two readings matter more than the absolute numbers. **A raw pty never exceeded
+5 ms at any load**, including 117 — it is flat. **tmux's p90 runs 9.3 -> 12.7 ->
+139 ms** across the same range. tmux is not a constant tax that load makes
+visible; it degrades superlinearly against a baseline that does not degrade.
+
+At 1.1 ms p50 on a quiet machine tmux is imperceptible, so the interactive lag
+reported on this machine is a load phenomenon. The scaling difference is the
+durable finding.
+
+## The probe's tmux arm is TBD's live path
+
+Worth stating so these numbers are not discounted as a synthetic analogue. TBD's
+default terminal path is the one described in `docs/tmux-integration.md`: the app
+spawns a `tmux attach` client per viewer against a private single-window session,
+and SwiftTerm reads that client's pty natively rather than parsing a protocol.
+Confirmed on a running system — the `tmux -u -L <server> attach` processes are
+children of the app, not the daemon.
+
+The control-mode path in `Sources/TBDDaemon/Tmux/ControlMode/`, which routes
+`%output` through `PaneFanout` into per-pane pipes vended over the FD sidecar,
+is gated behind `control_mode_enabled`. That flag defaults false
+(`ConfigStore.swift`, `control_mode_enabled ?? false`) and reads `0` in the live
+database.
+
+So the daemon is not a wakeup in the default rendering path, and the probe --
+which attaches a client through a pty it owns and reads the pty directly -- is
+measuring the same arrangement the product ships. The saving available from
+removing tmux is therefore the two server wakeups and the redundant VT parse
+below, and nothing else; there is no intermediary left to delete first.
+
+## The tmux client is not in the keystroke path
+
+An earlier reading of these numbers attributed them to four process hops — app,
+tmux client, tmux server, pane pty. That attribution is wrong, and the error is
+worth recording because it would have justified deleting a component that costs
+nothing.
+
+`tmux attach` dups its stdin/stdout to the server over `SCM_RIGHTS` during
+`client_send_identify`; the server stores them as `c->fd`, registers libevent
+watches on that fd directly, and reads keystrokes off it in `tty_read_callback`.
+GNU screen does the same by way of `SendAttachMsg`. The client process is a
+setup and teardown participant, not a relay.
+
+Measured directly: 2000 keystrokes driven through an attached client's pty,
+sampling both processes' CPU time either side.
+
+- **tmux client — 0 ms** of CPU
+- **tmux server — 80 ms** of CPU, about 40 us per keystroke
+
+So the corrected account of a tmux keystroke is roughly **two server wakeups**
+(one to read the key off the client fd, one to read the echo back off the pane
+pty) plus the reader's own wakeup, against a raw pty's **one**. A wakeup costs
+about 0.4 ms p50 here, and 3 x 0.4 ms lands on the 1.1 ms measured at low load.
+
+The server's actual *work* is 40 us. The latency is almost entirely waiting to be
+scheduled, which is why it tracks system load so closely and why a raw pty —
+whose echo happens in the kernel line discipline inside `write()`, with no
+process wakeup at all — is indifferent to it.
+
+## What this implies for a replacement
+
+The saving available is the two server wakeups and the redundant VT parse, not
+the removal of a client process. Any design in which the persistent process
+*reads* the pty while a viewer is attached reintroduces exactly the cost being
+removed, so an attached viewer must read the pty master itself.
+
+That constraint collides with the detached-output problem described in the two
+companion records, though the window is narrower than it first appears and is
+worth stating precisely.
+
+A supervisor that never reads the pty cannot buffer output produced while
+*nothing at all* is reading, and the writer blocks once the kernel tty buffer
+fills. That window is not "no human is watching" — it is "no reader process
+exists". In iTerm2 the two collapse together because the app is the only reader
+it has: `TaskNotifier` runs a single `select()` loop over every registered task,
+and `wantsRead` consults only `paused` (set solely for an undoable termination)
+and the job manager's `ioAllowed`. Focus and visibility never enter it, so a
+background tab drains exactly like a foreground one, and the stall can only
+happen when the app itself is gone.
+
+TBD's shape differs in a way that helps rather than hurts. iTerm2 has no
+always-on component, so when its app dies nothing can drain and blocking is
+unavoidable. TBD has a daemon that outlives the app, so it can cover exactly the
+window iTerm2 cannot. What it does not automatically cover is its own restart,
+which is the case a minimal holder process — separate from both daemon and app,
+the shape of iTerm2's server — would exist to handle.
+
+So the design needs three roles rather than two: a holder that survives
+everything, a drainer of last resort for whenever no viewer is attached, and the
+attached viewer reading the master directly. The handoff between the last two,
+with an acknowledged edge so exactly one reader owns the fd at a time, is the
+hard part of any such design rather than an implementation detail.
+
+Note also that blocking is backpressure, not loss — a writer stalled on a full
+buffer resumes when a reader returns. The failure modes across prior art differ
+in kind: dtach and abduco read and discard while detached (loss, no stall),
+iTerm2 never reads (stall, no loss), and tmux and its modern equivalents read
+into a headless VT (neither, at the cost of a process in the path).
+
+## Reproducing
+
+- `scripts/diag/tmux-vs-rawpty-idle.py` — the raw-pty/tmux comparison above.
+- `scripts/diag/tmux-server-contention.py` — interleaves a busy server against a
+  private one-pane server. Measured 34.1 ms against 36.5 ms p50, which is why
+  pane count per server, and therefore sharding servers more finely, is not a
+  lever here.

--- a/docs/research/2026-08-30-terminal-session-persistence/prior-art-survey.md
+++ b/docs/research/2026-08-30-terminal-session-persistence/prior-art-survey.md
@@ -1,0 +1,485 @@
+# Prior art: keeping a terminal session alive when the program displaying it dies
+
+*Researched 2026-08-30 from source checkouts, official documentation, and
+maintainer statements in issue and discussion threads. Two claims in this
+document were verified by direct experiment on the development machine and are
+marked as such. Companion document:
+[`iterm2-session-restoration.md`](iterm2-session-restoration.md), which covers
+iTerm2 in depth — this survey defers to it and does not duplicate it.*
+
+TBD keeps agent sessions alive across daemon and app restarts by running them
+under tmux. Field measurement puts a real interactive cost on that choice:
+keystroke-to-visible through a raw pty is 0.1 ms p50 and 0.9 ms p90 and is
+indifferent to system load, while the same keystroke through tmux is 3.3 ms p50
+and 12.7 ms p90, degrading to 139 ms p90 under heavy load. This document
+surveys how other systems have answered the underlying question — can a session
+outlive the program displaying it without putting a process in the
+per-keystroke path — so that the eventual design decision is made against the
+known landscape rather than against two data points.
+
+## Synthesis
+
+**Nobody ships persistence with zero processes in the per-keystroke path, but
+the two halves of the answer both exist in production, in different systems,
+and neither half is speculative.**
+
+The design space turns out to have three occupied regions and one empty one.
+
+- **Own the pty in the GUI process** – Ghostty, kitty, Warp, and every
+  conventional emulator. Zero extra processes per keystroke; the emulator
+  writes the byte to the pty master and the kernel line discipline echoes it
+  inside that same `write()`. Persistence is structurally impossible: the
+  master fd dies with the process and the child gets `SIGHUP`.
+- **Own the pty in a server, relay bytes over a socket** – dtach, abduco,
+  shpool, Zellij, WezTerm's mux domains, zmx, hauntty, VS Code's pty host, and
+  every GUI-app persistence daemon found. Persistence works; a process is in
+  the path on every keystroke.
+- **Own the pty in a server, but hand the *display* fd to the server** – tmux
+  and GNU screen. This is the region most people, including the framing of this
+  research task, get wrong. Both of them pass the attaching client's real
+  terminal fd to the long-lived server over `SCM_RIGHTS`, and the server then
+  does direct `read`/`write`/`tcsetattr` on it. **The tmux and screen client
+  processes are not in the steady-state keystroke path.** They idle on signals.
+  The per-keystroke cost of tmux is the server waking twice and running a full
+  VT parse and grid diff — not a four-hop client relay.
+- **Own the pty in a supervisor, hand the *pty master* fd to the renderer** –
+  empty. This is the region TBD's question points at, and no shipping system
+  occupies it.
+
+The mechanism that region needs is not novel, and every piece of it is in
+production somewhere:
+
+- **Passing a pty master over a socket** is how systemd's `machined` serves
+  `machinectl shell` and `systemd-run --pty`: `OpenPTY`, `OpenLogin`, and
+  `OpenShell` are D-Bus methods whose reply signature is `hs` — a UNIX fd
+  handle plus the pts name — so the caller receives the master and does its own
+  I/O on it ([`machine-dbus.c`](https://github.com/systemd/systemd/blob/main/src/machine/machine-dbus.c)).
+  `machined` closes its own copy, so this buys the handoff and not the
+  persistence.
+- **Keeping a duplicate of the master alive to prevent `SIGHUP`** is how
+  Superset upgrades its terminal daemon without killing shells: the outgoing
+  daemon spawns its successor with the pty masters on inherited fds, and "the
+  kernel's fd refcount keeps master fds alive across the predecessor's
+  exit — shells never see `SIGHUP`"
+  ([PR #3971](https://github.com/superset-sh/superset/pull/3971)).
+- **Moving a live pty master between processes after the fact** is what
+  `reptyr -T` does, attaching to a terminal emulator with `ptrace`, locating the
+  master fd, and pulling it across a UNIX socket with `SCM_RIGHTS`
+  ([nelhage, 2014](https://blog.nelhage.com/2014/08/new-reptyr-feature-tty-stealing/)).
+
+The only place the combination has been written down is the Zed RFC on
+persistent terminal sessions, which proposes a per-session `pty-host` daemon
+and then notes, of the socket-path handshake it settled for, that "file
+descriptor transfer via `SCM_RIGHTS` would be cleaner" — and defers it
+([discussion #50584](https://github.com/zed-industries/zed/discussions/50584)).
+Even there the renderer is not proposed as the direct pty reader; the fd
+transfer is discussed as a tidier way to find the daemon.
+
+Two further conclusions matter as much as the empty region.
+
+**Nothing surveyed resurrects a live process across a reboot, and almost
+nothing does across the death of its own daemon.** What survives is always a
+serialized *description* — a layout file, a grid snapshot, a scrollback
+buffer — used to redraw the screen and relaunch the command. Zellij's session
+resurrection re-runs the pane's command behind a "Press ENTER to run" banner.
+kitty's `--session` restore re-starts the shell and the process inside it. VS
+Code calls its equivalent "process revive". Superset's disk snapshots give a
+"cold restore" the user can look at but cannot resume. The honest framing is
+that persistence across a *client* restart and persistence across a *host*
+restart are different products, and only the first is solved anywhere.
+
+**The minimal supervisors lose output produced while detached** — which is the
+functional gap that matters most for a fleet of agents that keep working with
+nobody watching. This is confirmed in both sources, below.
+
+## The verified mechanism
+
+Two claims underpin any design in the empty region. Both were tested directly
+rather than assumed.
+
+**A pty master handed to another process over `SCM_RIGHTS` works, and the
+receiver's death costs the child nothing so long as a supervisor still holds a
+copy.** A test program created a pty with `forkpty`, passed the master to a
+separate process over a `socketpair` with `SCM_RIGHTS`, had that process do
+direct `read()` and `write()` on the master, then killed it. The shell — which
+had a `trap ... HUP` installed to report the signal — never saw `SIGHUP` and
+exited normally with its own status. This is the whole hypothesis, and on this
+Darwin machine it holds.
+
+**But holding the master is not sufficient; the supervisor must also drain
+it.** The first version of that test had the supervisor hold the master and not
+read it. The shell then wedged permanently in the exiting state (`ps` state
+`?Es`) rather than completing, because its terminal output had nowhere to go.
+Draining the master after the renderer died made the test pass immediately. The
+consequence for a design is concrete: a supervisor that merely parks the fd is
+not enough. It has to take over reading the moment the renderer detaches or
+dies, which means a handoff protocol with an explicit "you read now, I have
+stopped" edge — exactly the pause-and-acknowledge step Superset describes for
+its daemon upgrade, where only one process may actively read a pty at a time.
+And once the supervisor is reading detached output, it needs somewhere to put
+it, which is the whole terminal-state problem that dtach and abduco decline to
+solve.
+
+## The minimal supervisors: dtach and abduco
+
+Both were read end to end from source
+([dtach](https://github.com/crigler/dtach),
+[abduco](https://github.com/martanne/abduco); roughly 1,700 and 1,400 lines
+respectively). They are the closest existing thing to "just hold the pty", and
+they are close to identical in shape.
+
+- **Pty ownership** – a master process created by `forkpty`, which `setsid()`s
+  away from the launching terminal and daemonizes. Nothing external keeps it
+  alive; it is a plain orphan reparented to init, and it exits when its child
+  does.
+- **Keystroke path** – **a process is in the path, and neither passes any file
+  descriptor.** Grepping both trees for `SCM_RIGHTS`, `sendmsg`, and `recvmsg`
+  returns nothing. The attaching client puts its own terminal into raw mode
+  with `ECHO` cleared (`attach.c`), so there is no local kernel echo at all;
+  every byte travels client `read(0)` → `write(socket)` → master
+  `read(socket)` → `write(ptm)` → line-discipline echo → master `read(ptm)` →
+  `write(socket)` → client `read(socket)` → `write(1)`. That is four process
+  wakeups per keystroke, the same topology as a byte-relay multiplexer, with
+  the terminal emulation removed. dtach is smaller than tmux; it is not
+  structurally closer to the kernel.
+- **What survives** – the live process, and nothing else. Neither keeps any
+  terminal state. dtach's answer to a reattached blank screen is a "redraw
+  method": send the application a literal `^L`, or send it `SIGWINCH`, or do
+  nothing (`master.c`, `REDRAW_WINCH` / `REDRAW_CTRL_L`). abduco has no redraw
+  at all; its README recommends running `dvtm` inside it if you want one.
+  Nothing survives a reboot.
+- **Output while detached is discarded.** In abduco, `server.read_pty` is
+  initialised to `(action == 'n')` and set true forever on the first client
+  accept, after which the server keeps reading the pty and, with no clients in
+  its fan-out loop, drops what it reads (`server.c`). dtach's master defers its
+  *first* read until a client attaches — a startup race fix, per the 0.8
+  changelog — and thereafter fans pty output out to whatever clients exist,
+  which when detached is none. For a session a human reattaches to within
+  seconds this is invisible. For an agent that produced twenty minutes of
+  output while nobody was watching, it is total loss.
+- **Reattachment** – by filesystem path. The session *is* a UNIX socket at a
+  path the user names. dtach marks the socket's user-execute bit while clients
+  are attached (`update_socket_modes`) so a lister can tell attached from
+  detached; abduco keeps a directory under `$HOME/.abduco` or `/tmp/abduco/$USER`
+  and its bare invocation prints a session list with attached, terminated, and
+  idle markers.
+- **Orphan reclaim** – an `atexit` handler unlinks the socket in both. That
+  covers a clean exit and nothing else; dtach added stale-socket detection on
+  `-A` in 0.8 precisely because the handler is not reliable. abduco adds a
+  `SIGUSR1` handler to recreate a socket somebody deleted by accident, and
+  documents `pgrep -P 1 abduco` as the way to find a server whose socket is
+  gone — an admission that there is no reconciler and the operator is it.
+- **Relative to tmux, it gives up** – all multiplexing, all scrollback and
+  copy-mode, any machine-readable interface to session state, resize
+  reconciliation across differently-sized clients, and every form of screen
+  restoration. abduco adds read-only clients and a session list over dtach; the
+  gap to tmux is otherwise the same.
+
+## The incumbents: tmux and GNU screen
+
+This is where the common mental model is wrong, and the correction is the most
+decision-relevant fact in this survey.
+
+**GNU screen passes the attaching terminal's fd to the backend.** The attacher
+dups its own controlling tty (`screen.c`, `attach_fd = 0`) and `WriteMessage`
+routes an attach message through `SendAttachMsg` (`socket.c`), which builds a
+`msghdr` with a `SOL_SOCKET`/`SCM_RIGHTS` control message and `sendmsg`s the fd
+over the session socket. The long-lived backend picks it up in `ReceiveMsg`,
+validates it against the pts name, and installs it as `D_userfd` via
+`CreateTempDisplay` → `MakeDisplay`, immediately calling `SetTTY(D_userfd, ...)`
+to put the *user's real terminal* into the mode it wants. From then on the
+backend reads keystrokes from and writes updates to that fd directly. The
+attacher, meanwhile, sits in a loop of `alarm(15); pause();` (`attacher.c`),
+waking only for `SIGWINCH`, detach, suspend, or its liveness alarm. It has no
+per-keystroke role whatsoever.
+
+**tmux does the same thing.** `client_send_identify` dups `STDIN_FILENO` and
+`STDOUT_FILENO` and sends each through `proc_send(..., MSG_IDENTIFY_STDIN, fd, ...)`
+(`client.c`); `proc_send` hands the fd to `imsg_compose`, whose transport is
+`sendmsg` with `SCM_RIGHTS` — and the client's `pledge` promise list includes
+`sendfd` for exactly the window in which this happens. The server stores them as
+`c->fd` and `c->out_fd` (`server-client.c`), then `tty_open` registers its own
+libevent read and write watches directly on `c->fd`, and `tty_start_tty` calls
+`tcsetattr(c->fd, ...)` to put the client's real terminal into raw mode
+(`tty.c`). `tty_read_callback` does `evbuffer_read(tty->in, c->fd, -1)` — the
+server reading raw keystroke bytes off the client's terminal itself. The tmux
+client process, after the identify handshake, handles signals and control
+messages and nothing else.
+
+So for a plain `tmux attach`, the per-keystroke cost is **two wakeups of one
+process** — the server waking on the client's terminal fd, and waking again on
+the pane's pty master once the line discipline echoes — plus a full VT parse of
+the echoed bytes into the grid (`input.c` → `screen-write.c`) and a rendered
+diff written back out to `c->fd`. It is not a four-hop relay, and there is no
+client process to remove. This matters for TBD directly: `TmuxBridge.swift`
+spawns `tmux -u -L <server> attach -t <session>` inside a pty the app owns, so
+the fd the tmux server ends up reading keystrokes from is the slave side of
+TBD's own pty. Whatever the measured 3.3 ms is buying, it is not being spent on
+a client relay that a cleverer design could delete.
+
+Control mode (`-CC`) is a different path — a textual protocol over the imsg
+channel rather than raw tty ownership — and is the one place the byte-relay
+model is the right description of tmux. The identify handshake and fd passing
+happen unconditionally before the control-mode branch, so a control-mode client
+still hands over fds it then does not use for rendering; whether the server
+skips the `tty_open` watch entirely for such clients was not traced and is
+unconfirmed here.
+
+What tmux buys over a bare supervisor is substantial and should not be
+undersold, particularly given that TBD ships an external-attach feature that
+depends on it:
+
+- **Multiplexing** – windows, panes, and layout (`layout.c`, `window.c`), none
+  of which dtach or abduco has in any form.
+- **Attach from any emulator** – the client negotiates terminfo capabilities at
+  identify time (`MSG_IDENTIFY_TERM`, `MSG_IDENTIFY_TERMINFO`), so the server
+  renders correctly for whatever terminal shows up. A bare supervisor passes
+  raw bytes and hopes.
+- **Remote and ssh attach** – falls out of the above: the server is reachable
+  by anything that can run the tmux binary against its socket, including over
+  ssh, from a machine that has never seen TBD.
+- **Shared sessions** – the server holds an array of clients, each with its own
+  tty and its own size, all viewing one session; `resize.c` reconciles them.
+- **A machine interface** – control mode as a protocol, and `capture-pane` for
+  scripted extraction of screen state, which is how a supervisor learns what a
+  session looks like without screen-scraping a rendered display.
+- **Scrollback and copy-mode** – `window-copy.c`, and the grid history behind
+  it, which is also what makes reattachment show you the screen you left rather
+  than a blank one.
+
+On lifecycle, tmux's defaults are worth naming because they are the opposite of
+a reconciler: `exit-empty` defaults on (the server exits with zero sessions) but
+`exit-unattached` defaults off, so a session whose client never returns lives
+forever by design. `destroy-unattached` is the per-session opt-in. The socket
+file is unlinked at bind time by the next server, not at exit by the last one.
+Sessions do not survive a reboot; `tmux-resurrect` and `tmux-continuum` are
+third-party plugins that snapshot layout, working directories, and pane text
+and re-run an operator-configured allowlist of commands — layout restoration,
+not process resumption.
+
+## Latency by prediction: mosh
+
+[mosh](https://mosh.org/) solves a different problem — network round-trip time
+and client roaming, not process death — but it is the canonical answer to the
+*latency* half of TBD's question, and its limits are instructive because they
+are structural rather than incidental.
+
+The `PredictionEngine` in `src/frontend/terminaloverlay.cc` speculatively echoes
+the user's own keystrokes locally, underlined, before the server confirms them,
+and reconciles against the authoritative screen state when the confirmation
+arrives. The USENIX ATC 2012 paper reports that mosh "was able to immediately
+display the effects of 70% of the user keystrokes", cutting median keystroke
+response from 503 ms to under 5 ms on a commercial 3G link, measured over 9,986
+keystrokes from six users across 40 hours
+([Winstein & Balakrishnan](https://www.usenix.org/conference/atc12/technical-sessions/presentation/winstein)).
+
+What it predicts is a narrow set: insertion of a printable single-width
+character, backspace, and left/right arrow. Everything else calls
+`become_tentative()`, which invalidates in-flight predictions until the server
+catches up — any control character, any escape sequence, any CSI dispatch other
+than left or right arrow, any non-single-width character, a prediction landing
+in the last column, and a resize. The man page states the policy plainly: "The
+predictive model must prove itself anew on each row of the terminal and after
+each control character, so mosh avoids echoing passwords or non-echoing editor
+commands."
+
+The limit that matters most for TBD: **prediction only ever speculates about the
+echo of the user's own keystroke. It never touches program output.** Scrolling,
+a full-screen TUI repainting, an agent streaming tokens — none of it is
+predictable, and none of it is helped. The paper concedes the high-output case
+directly, noting that mosh's state-synchronization approach "causes trouble for
+a task like 'cat'-ing a large file to the screen". A full-screen application is
+defeated implicitly, since its escape traffic flips prediction tentative
+continuously.
+
+mosh also does not provide detach and reattach. `mosh-server` exits if no client
+connects within 60 seconds, and after a connection it waits indefinitely for a
+client to reappear unless `MOSH_SERVER_NETWORK_TMOUT` is set. The documented
+answer to persistence is to run tmux or screen under it.
+
+## GUI terminals that own the pty in-process
+
+These are the systems with zero extra processes per keystroke, and they get
+there by not having persistence.
+
+- **Ghostty** – owns the pty in-process (`src/termio/Exec.zig`); no daemon
+  exists, so nothing survives the app. macOS `window-save-state` restores tab
+  and split *layout* with fresh shells and no scrollback. The maintainers'
+  position is a decision, not an omission: a collaborator states flatly in
+  [discussion #4931](https://github.com/ghostty-org/ghostty/discussions/4931)
+  that "Ghostty does not do sessions, and it is currently not planned", and in
+  [#12571](https://github.com/ghostty-org/ghostty/discussions/12571) that the
+  focus is on libghostty as a reusable building block instead. Mitchell
+  Hashimoto's own writing frames libghostty as "a public building block for
+  terminal applications"
+  ([Superlogical](https://mitchellh.com/writing/superlogical)) and the
+  multiplexer he is now building is a separate product built on it, not a
+  Ghostty feature. Read as prior art, this is the strongest argument in the
+  survey for putting persistence in a layer the emulator does not own.
+- **kitty** – calls `openpty()` in `kitty/child.py` and dies with its children.
+  `--session` files restore layout by re-running commands; the documentation is
+  explicit that "the shell **and** the process running inside it are
+  **re-started**". Kovid Goyal's objection to multiplexers is a throughput
+  argument — "every byte has to be parsed twice, once by the middleman and once
+  by the terminal... you get at best a halving of throughput"
+  ([#391](https://github.com/kovidgoyal/kitty/issues/391#issuecomment-638320745)) —
+  and kitty's own benchmarks page carries the measurement. He distinguishes that
+  from persistence, which he has said for years he would implement as a daemon
+  eventually and has not: most recently, "It was never out of scope. Simply
+  something I am not particularly interested in"
+  ([#9318](https://github.com/kovidgoyal/kitty/issues/9318#issuecomment-3688649953)).
+- **Warp** – local sessions run in the app process; quitting kills them, which
+  is why Warp ships a quit warning. Block *text* is persisted to a local SQLite
+  database and window layout is restored, so a restart looks continuous and is
+  not. A tmux-style detach/reattach request is closed as not planned
+  ([#2106](https://github.com/warpdotdev/Warp/issues/2106)). Its remote daemon
+  exists only for ssh sessions, runs on the remote host, and self-terminates on
+  an idle timer.
+
+## GUI applications that added a persistence daemon
+
+This is the group TBD most resembles, and every member of it relays bytes.
+
+- **VS Code** – moved terminal processes out of the renderer into a "pty host"
+  under the shared process. Reloading a window reconnects to the live processes;
+  restarting the application does *not* — that path is "process revive", which
+  restores the terminal's content from disk and relaunches the process with its
+  original environment
+  ([docs](https://code.visualstudio.com/docs/terminal/advanced)). The pty host is
+  monitored and restarted if it dies or stops responding, and
+  `terminal.integrated.persistentSessionScrollback` bounds how much content is
+  kept. The orphan story is a timeout: persistent terminals were originally
+  reclaimed 60 seconds after a disconnect
+  ([#123518](https://github.com/microsoft/vscode/issues/123518)).
+- **Superset** – an Electron terminal whose daemon owns every pty and whose app
+  is "just a *client* of the terminal daemon", with the stated principle that
+  "the default should be persistence, not cleanup". A headless xterm.js instance
+  in the daemon keeps screen state, terminal modes, and cwd, so reattachment
+  restores a real screen rather than a redraw request. Two sockets — one for
+  RPC, one for the output stream — avoid head-of-line blocking. When the daemon
+  dies, sessions are lost; disk snapshots give a cold restore you can read but
+  not resume ([architecture writeup](https://superset.sh/blog/terminal-daemon-deep-dive)).
+  Its fd-inheritance upgrade path is described in the synthesis above.
+- **Zed** – has no shipped implementation; the
+  [RFC](https://github.com/zed-industries/zed/discussions/50584) proposes a
+  standalone per-session `pty-host` binary holding a headless
+  `alacritty_terminal::Term`, serializing the whole grid on reconnect rather
+  than replaying raw bytes ("No replay, no re-parsing"). It rejects tmux
+  integration on double-emulation, nested keybindings, and scrollback grounds.
+  The author reports six months of daily personal use.
+- **WezTerm** – local panes have no server and no IPC hop; only panes in a mux
+  domain do, and there the cost is acknowledged. WezTerm ships
+  `local_echo_threshold_ms`, a predictive-echo feature that exists specifically
+  to hide mux round-trip latency, and a maintainer fix
+  ([`d36ad7c`](https://github.com/wezterm/wezterm/commit/d36ad7ca7f9054a9d2b49ffe8696c3e617623194))
+  addressed the server pushing whole viewports per update and producing roughly
+  half a second of lag per keystroke at large pane sizes. `wezterm-mux-server`
+  daemonizes but is registered with no init system, so reboot survival is the
+  user's problem, and there is no orphan reaper — persistence-until-killed is
+  stated as intentional ([#631](https://github.com/wezterm/wezterm/issues/631)).
+- **Zellij** – server and client split over a UNIX socket, server double-forks
+  and `setsid()`s. Every keystroke is a discrete protobuf `ClientToServerMsg::Key`
+  across the socket. Session resurrection serializes panes, tabs, and each
+  pane's command to a KDL layout file about once a second and, on restore,
+  **re-runs** the command behind a "Press ENTER to run" prompt — the verb is
+  accurate, and REPL or editor state is gone. Reclaim of exited sessions is
+  manual (`delete-session`). Against tmux it adds true multiplayer editing and
+  a browser web client that needs no local binary.
+- **herdr** – a recent agent-oriented multiplexer with the same shape: a
+  persistent server owning all pty sessions, thin clients over UNIX sockets,
+  layout and cwd saved to a JSON file on exit and restored on restart.
+
+## The new state-sharing cohort
+
+A cluster of 2025–2026 tools separates *session persistence* from
+*multiplexing*, keeping the first and discarding the second. Architecturally
+they are all byte relays; what is new is that they carry a real terminal-state
+model, so reattachment restores a screen instead of begging the application for
+a redraw.
+
+- **shpool** – daemon owns named sessions; the client relays. Its README
+  contrasts itself with tmux on rendering rather than on hops: "While `tmux`
+  renders terminal contents remotely and only paints the current view to the
+  screen, `shpool` just directly sends all shell output back to the user's local
+  terminal", so "scrollback and copy-paste will work exactly as they do in your
+  native terminal". It keeps an in-memory render solely to redraw on reattach,
+  including output generated while disconnected. A grep of the tree for
+  `SCM_RIGHTS` returns nothing — the latency claim is about avoiding double
+  rendering, not about removing a process from the path. It is the only system
+  surveyed with a purpose-built reaper: `daemon/ttl_reaper.rs`, a min-heap of
+  session deadlines feeding `--ttl`, with a generation id per session name so a
+  reap cannot clobber a fresh session that reused the name. Its stated
+  philosophy — "managing different terminals is the job of your display or
+  window manager, not your session persistence tool" — is precisely TBD's
+  situation. It allows only one client per session.
+- **zmx** – one daemon *per session* rather than one globally, `forkpty` plus
+  double-fork and `setsid()`. Uses `ghostty-vt` to shadow-consume the pty stream
+  and keep terminal state for restore. Its own framing, "the only thing sitting
+  in-between you and your PTY is a unix socket", describes a byte relay
+  accurately; the tree has no `SCM_RIGHTS`. No panes or tabs, deliberately.
+- **hauntty** – one global daemon, sessions in an in-process map, `ghostty-vt`
+  compiled to WASM for state tracking, snapshots to disk every 30 seconds. Its
+  `restore` path decodes a snapshot for display and then spawns a **new**
+  process — the same re-run-not-reattach limitation as Zellij, at the finer
+  grain of daemon death rather than reboot. Its README is candid that it is an
+  exploratory project.
+
+## Adjacent mechanisms worth knowing
+
+- **The Emacs daemon** takes a third approach to removing the client from the
+  path: `emacsclient` sends the tty *name*, not the fd (`lib-src/emacsclient.c`
+  sends `-tty <ttyname> <termtype>` after `ttyname(STDOUT_FILENO)`; there is no
+  `SCM_RIGHTS` in the file), and the daemon opens that device itself and drives
+  it directly. The client then blocks until the frame closes. Same outcome as
+  screen — the persistent owner talks to the display device, the launcher idles —
+  by a simpler route. It works only because the display is a kernel device a
+  second process can open by name, which is exactly what a SwiftUI view is not.
+- **`reptyr -T`** demonstrates that a live pty master can be moved out of a
+  running emulator after the fact, via `ptrace` plus `SCM_RIGHTS`. It is not a
+  design to copy — it needs root against setuid processes and is inherently
+  fragile — but it is proof the fd is genuinely mobile.
+- **iTerm2** is covered in the companion document and not duplicated here.
+
+## Implications for TBD
+
+Recommendations only; this is a research record, and none of this is a design.
+
+- **The "remove the tmux client from the keystroke path" saving does not
+  exist.** tmux already passes TBD's pty slave fd to its server and reads
+  keystrokes off it directly. Whatever the measured 3.3 ms p50 is, it is one
+  process waking twice and doing a full VT parse and grid diff, not a relay
+  chain. The mechanism attribution behind the current measurement is worth
+  re-deriving before it is used to justify a design, because the obvious saving
+  it implies is not available.
+- **The empty region is reachable, and the first spike is small.** A supervisor
+  that creates the pty, hands the master to the app over `SCM_RIGHTS`, and keeps
+  a copy gives the app direct pty I/O — kernel-line-discipline echo inside
+  `write()`, the 0.1 ms path — while the session survives the app. This was
+  verified working on this machine. Nobody ships it, which is a reason for
+  caution about unknown corners, not evidence that it cannot work.
+- **Draining is the hard half, not the handoff.** A supervisor that parks the fd
+  without reading it wedges the child on exit — observed directly. The design
+  needs an explicit single-reader handoff with an acknowledged edge, and the
+  supervisor needs a terminal-state model to put detached output into, or it
+  reproduces dtach's and abduco's worst property: agents produce output while
+  nobody watches, and it is lost. Every modern tool in this space
+  (shpool, zmx, hauntty, Superset, the Zed RFC) concluded independently that a
+  headless VT model in the persistent process is mandatory, and TBD would be
+  choosing the same thing.
+- **Predictive echo is not the alternative it looks like.** mosh's own numbers
+  are excellent for typing and it does nothing for scrolling or program output,
+  which for a fleet of streaming agents is most of the perceived latency. It is
+  a complement to a fast path, not a substitute.
+- **Whatever replaces tmux has to replace external attach too.** Attaching from
+  any emulator, over ssh, from a machine that has never run TBD, is a real
+  capability that falls out of tmux's terminfo negotiation and socket
+  reachability and out of nothing else in this survey. Every system that dropped
+  multiplexing also dropped some of that, and said so on purpose.
+- **A supervisor is a new kind of durable external resource.** Per-session
+  daemons, their sockets, and their state snapshots all outlive the request that
+  created them, and the survey's evidence on reclaim is discouraging: tmux keeps
+  unattached sessions forever by default, WezTerm has no reaper and calls that
+  intentional, Zellij's is manual, and abduco documents `pgrep -P 1` as the
+  recovery procedure. shpool's TTL reaper — a scheduled heap with a generation
+  id so a reap cannot hit a name-reusing successor — is the one design here
+  worth copying outright.

--- a/docs/research/2026-08-30-terminal-session-persistence/prior-art-survey.md
+++ b/docs/research/2026-08-30-terminal-session-persistence/prior-art-survey.md
@@ -43,8 +43,20 @@ The design space turns out to have three occupied regions and one empty one.
   The per-keystroke cost of tmux is the server waking twice and running a full
   VT parse and grid diff — not a four-hop client relay.
 - **Own the pty in a supervisor, hand the *pty master* fd to the renderer** –
-  empty. This is the region TBD's question points at, and no shipping system
-  occupies it.
+  occupied, but only halfway. **iTerm2 ships exactly this mechanism** and has
+  for years: its session-restoration server owns the master and hands it to
+  the app, which does direct I/O (see the companion iTerm2 record for the
+  source read). So the transport is precedent, not invention, and should not
+  be described as unexplored.
+
+  What is genuinely unoccupied is the *combination*: a supervisor that owns
+  the master, a renderer that reads it directly, **and a always-present
+  daemon that drains the master whenever no renderer is attached**. iTerm2
+  cannot occupy that third corner structurally — it has no process alive
+  while the app is closed, so a detached session's output has nowhere to go
+  and its supervisor simply parks the fd. That gap is the region TBD's
+  question actually points at, and it is a smaller and better-supported claim
+  than "nobody does this".
 
 The mechanism that region needs is not novel, and every piece of it is in
 production somewhere:

--- a/docs/specs/2026-08-30-pty-holder-session-transport-design.md
+++ b/docs/specs/2026-08-30-pty-holder-session-transport-design.md
@@ -171,10 +171,22 @@ child: the kernel's fd refcount keeps the pty alive — the same mechanism
 Superset exploits on purpose for daemon upgrades. The policy is that it kills
 the session anyway, promptly and deliberately. The daemon watches its
 connection to each holder; when a holder dies while its child lives, the
-daemon kills the child by its recorded pid — verifying process identity
-(executable and start time) first, so pid reuse cannot misdirect the kill —
-closes its dups, and marks the session exited with a distinct reason
-(holder lost) rather than a generic exit.
+daemon kills the child's **process group** — the child is the session leader
+of the pty's own session, courtesy of `forkpty`, so the group is the natural
+closure of the job rather than one pid — verifying process identity
+(executable and start time) before signalling, then closes its dups and marks
+the session exited with a distinct reason (holder lost) rather than a generic
+exit.
+
+Two honest limits on that kill, neither new to this design. Identity
+verification narrows the pid-reuse window but does not close it: nothing makes
+"check identity" and "signal" atomic on Darwin, and the residual race is the
+same one every pid-based reclaimer in TBD already runs. And a descendant that
+deliberately leaves the group — `setsid`, a double fork, `nohup`, `disown` —
+is outside the closure and survives, exactly as it survives a tmux pane kill
+today. Reclaiming deliberate escapees is a standing fleet-wide problem that
+belongs to `AgentReaper`, not to the transport; this design neither worsens
+it nor claims to solve it.
 
 The alternative — carrying the session on the daemon's own dup, marked
 degraded — was rejected: it preserves in-flight work only until the next
@@ -202,16 +214,29 @@ have stopped") is an in-process state transition plus one acked fd-vend, not a
 distributed protocol.
 
 - **Attach.** The app requests a session over the existing RPC. The daemon
-  stops reading, renders its headless emulator's screen and retained
-  scrollback into an escape-sequence **snapshot preamble**, and sends the
-  preamble plus the master dup over the FD sidecar. The app feeds the
-  preamble into SwiftTerm first, then goes live on the fd, then jiggles (see
-  below). Reattach therefore paints the last-known screen instantly, as tmux
-  does today.
+  **quiesces** before it snapshots anything: it lets any in-flight `read()`
+  finish and feeds every byte it already holds into its emulator, so no byte
+  is stranded in a buffer the app will never see. Only then does it render its
+  headless emulator's screen and retained scrollback into an escape-sequence
+  **snapshot preamble** and send the preamble plus the master dup over the FD
+  sidecar. The app feeds the preamble into SwiftTerm first, then goes live on
+  the fd, then jiggles (see below). Reattach therefore paints the last-known
+  screen instantly, as tmux does today. Ownership transfers on the app's
+  acknowledgement, not on the send: if the vend or the ack fails, the daemon
+  resumes reading and the session is simply still detached — the invariant is
+  "at most one reader", so the failure direction is always back to the
+  fallback reader.
 - **Detach.** The mirror image, carrying the same ordering discipline in the
   opposite direction: the app stops reading and closes its dup, and **only
-  then** tells the daemon; the daemon resumes reading on receipt and jiggles
-  so a full-screen program repaints into the daemon's emulator. The
+  then** tells the daemon. The detach notice carries a **snapshot preamble of
+  the app's own**, produced by the same serializer attach uses in the other
+  direction; the daemon resets its emulator, replays that preamble, and only
+  then resumes reading. This is what makes the handback symmetric, and it is
+  load-bearing rather than tidy: the jiggle heals only programs that repaint
+  on SIGWINCH, so without the handback a detach from a plain shell would leave
+  the daemon's store frozen at the last attach until new output happened to
+  arrive. One snapshot per detach is not the streaming handback rejected below
+  — it is O(1) per reader change, not per byte. The
   close-before-notify order is what preserves the single-reader invariant — a
   notify-first detach would put the daemon on the fd while the app's last
   `read()` is still outstanding, which is the double-reader corruption in
@@ -316,16 +341,26 @@ every attach, so it cannot rot unnoticed the way failure-edge-only code does.
 ### Two stores, reconciled on demand
 
 While a viewer is attached the daemon reads nothing, so its emulator is
-frozen at the moment of attach. This design accepts that — the **two-store
-model** — rather than having the app stream a copy of everything it reads back
-to the daemon:
+frozen for the duration of that attach — and re-seeded from the app's
+handback snapshot on an orderly detach. This design accepts that — the
+**two-store model** — rather than having the app stream a copy of everything
+it reads back to the daemon:
 
 - The app's SwiftTerm is authoritative while attached; the daemon's emulator
   is authoritative while detached.
 - When the daemon needs an attached session's screen (supervision, `tbd
   terminal read`), it **pulls a snapshot from the app** over the existing
-  RPC; the app serializes its live terminal state on request. Machine reads
-  are therefore always current, from whichever store is live.
+  RPC; the app serializes its live terminal state on request. A machine read
+  therefore reaches whichever store is live, instead of a store that stopped
+  being updated at attach. That is a routing guarantee, not a freshness
+  guarantee: when the pull cannot be answered, the consumer's declared policy
+  below decides, and one of the two policies deliberately returns a stale
+  answer.
+- The handback is the orderly path only. An app that dies attached hands back
+  nothing, so the daemon reverts to an emulator frozen at that attach and
+  heals it with the jiggle alone — which repairs programs that repaint on
+  SIGWINCH and nothing else. Same scoping as the daemon-restart case above,
+  and for the same reason.
 - Pulls are bounded (timeout on an injected clock), and every consumer
   declares a failure policy, because the app can legitimately go quiet (App
   Nap has coalesced this app's work for ~90 s in the field, and app-wedged
@@ -411,11 +446,22 @@ the process table — the same argument as every other resource here.
   and servers to the **holder inventory**: enumerate holder sockets under the
   sessions directory, connect, and handshake (yielding holder pid, child pid,
   child status, and launch parameters). A session row with no live holder is
-  marked exited through the existing handling. A **rejected** connection is
+  marked exited through the existing handling — and specifically as **status
+  unknown**, never a fabricated `0`. This is the durable landing place for the
+  case the holder's Lifetime contract describes: a daemon that was down through
+  the holder's whole report timeout comes back to a vanished holder and an
+  unreported status, and the sweep must record the absence rather than invent
+  a value. A **rejected** connection is
   the opposite of a dead holder — the holder is alive and owned by another
   daemon (a stale daemon from a different checkout is a known hazard on a
-  development machine) — and must never feed the exited path. A live holder with no session
-  row is a half-finished deletion: the daemon kills the child and the holder.
+  development machine) — and must never feed the exited path. **A rejected
+  connection is terminal for this sweep in both directions**: not exited, and
+  not killed either. Killing requires positive proof of ownership — a
+  completed handshake — and a rejection is the absence of that proof, so a
+  holder that will not talk to us is left alone and logged, never reclaimed on
+  the theory that it has no row. Only a holder that handshakes and then turns
+  out to have no session row is a half-finished deletion, and that is the case
+  where the daemon kills the child and the holder.
   **Kill, not adopt** — iTerm2 adopts unclaimed survivors into new tabs
   because its live processes are the only copy of anything; TBD's transcripts
   persist independently, so adoption would buy a mystery-session UI and
@@ -445,11 +491,15 @@ This wholesale-replaces a load-bearing path, so it ships behind a default-off
 flag with a soak and a stated graduation plan.
 
 - **Flag.** `pty_holder_enabled`, a `config` column added by a `.sql`
-  migration with **no SQL `DEFAULT` clause**, so unset stays a third state;
-  the shipped default lives solely in `?? Config.ptyHolderDefault` (`false`)
-  in `ConfigRecord.toModel()`. Tests cover all three states: a pre-migration
-  row reads NULL rather than `0`, NULL follows the constant, and an explicit
-  `0` survives a change to the constant.
+  migration with **no SQL `DEFAULT` clause**, so unset stays a third state.
+  The shipped default is `false`, resolved the way every other nullable gate
+  in `ConfigStore.toModel(...)` resolves one: a `ptyHolderDefault: Bool =
+  Config.ptyHolderDefault` parameter on `toModel`, and `pty_holder_enabled ??
+  ptyHolderDefault` in the body. The injected parameter is not decoration —
+  it is what lets a test change the effective default and prove NULL follows
+  it while an explicit `0` does not. Tests cover all three states: a
+  pre-migration row reads NULL rather than `0`, NULL follows the injected
+  default, and an explicit `0` survives a change to it.
 - **Granularity: spawn time only.** A session records its transport (`tmux`
   or `holder`) in its database row at creation and keeps it for life; the app
   attaches by whichever transport the row names. Flipping the flag never

--- a/docs/specs/2026-08-30-pty-holder-session-transport-design.md
+++ b/docs/specs/2026-08-30-pty-holder-session-transport-design.md
@@ -349,8 +349,11 @@ that never arrives.
 
 Its cost is **two** failure modes, not one, and the second is the easier to
 overlook. A missing ack does not mean the injection was not delivered — the
-app may have written it and had the ack lost or merely delayed, which App Nap
-has been measured doing to this app's work for ~90 s. So the fallback can
+app may have written it and had the ack lost or merely delayed, which macOS
+App Nap can cause by coalescing a backgrounded app's work for far longer than
+any deadline worth waiting on. The policy does not rest on the exact
+magnitude — only on the ack deadline being shorter than an app can plausibly
+stall, which any usable deadline is. So the fallback can
 deliver an injection **twice**, and for a queued prompt acting twice may be
 worse than a sheared keystroke. This is the at-least-once versus at-most-once
 fork, chosen knowingly in favour of at-least-once: a duplicated prompt is
@@ -431,9 +434,10 @@ it reads back to the daemon:
   SIGWINCH and nothing else. Same scoping as the daemon-restart case above,
   and for the same reason.
 - Pulls are bounded (timeout on an injected clock), and every consumer
-  declares a failure policy, because the app can legitimately go quiet (App
-  Nap has coalesced this app's work for ~90 s in the field, and app-wedged
-  correlates with exactly the moments supervision most wants a screen).
+  declares a failure policy, because the app can legitimately go quiet —
+  macOS App Nap coalesces a backgrounded app's work, and an app being wedged
+  or busy correlates with exactly the moments supervision most wants a
+  screen, so "quiet" is not the rare case it looks like.
   Safety-critical consumers fail closed: the hibernation input-veto check
   treats no-answer as unsafe and refuses to hibernate, never risking typed
   input. Best-effort consumers fall back to the daemon's frozen-at-attach
@@ -456,11 +460,16 @@ Rejected alternatives.
 Whenever the reader changes — attach, detach, app death, daemon re-adoption —
 the incoming reader briefly wiggles the tty size (grow one column, restore)
 to force a SIGWINCH, so full-screen programs repaint into the reader's
-emulator. This is iTerm2's `WinSizeController` "jiggle", wired here to every
-handoff edge rather than only orphan adoption (in iTerm2 the plain reattach
-path gets no jiggle, and its resize ioctl is guarded by only-if-changed, so
-the common same-geometry reattach heals nothing — a gap, not a choice; see
-the companion iTerm2 record). The jiggle heals screen *state*; it cannot
+emulator. This is iTerm2's `WinSizeController` jiggle, applied here at every
+handoff edge. iTerm2 reaches it from orphan adoption but **not** from its
+ordinary reattach path, and its size-setting is suppressed at two layers when
+the requested geometry already matches — so a same-geometry reattach there
+issues no ioctl, delivers no SIGWINCH, and heals nothing. Wiring it to every
+edge is therefore a deliberate divergence from a proven mechanism, not an
+invention. (The jiggle in iTerm2 also fires from two paths unrelated to
+attachment — a default-off Clear Buffer setting and a light/dark-change
+workaround — so it is not purely a recovery device. Citations for all of this
+in the companion iTerm2 record's "Forcing a repaint after reattach" section.) The jiggle heals screen *state*; it cannot
 recover missing history and does nothing for scrolled-away output, which is
 why it complements rather than replaces the daemon's emulator.
 
@@ -754,9 +763,10 @@ of which is carried into this design:
 - **`setsid()` in the supervisor is load-bearing**, and SIGHUP/SIGPIPE must
   be ignored, or a crash of the spawning process (or a `sendmsg` into a dead
   peer) takes the supervisor with it.
-- **The jiggle exists and works** — and iTerm2 wires it only to orphan
-  adoption, leaving its common reattach path unhealed behind an
-  only-if-changed resize guard. This design wires it to every reader
+- **The jiggle exists and works** — and iTerm2 reaches it from orphan
+  adoption but not from its ordinary reattach path, leaving that common path
+  unhealed behind two layers of same-size suppression. This design applies it
+  at every reader
   handoff.
 - **Content and process persist on different clocks** unless something keeps
   the detached picture current. iTerm2 saves screen contents only on losing

--- a/docs/specs/2026-08-30-pty-holder-session-transport-design.md
+++ b/docs/specs/2026-08-30-pty-holder-session-transport-design.md
@@ -69,9 +69,9 @@ Three roles, three processes:
 
 - **The holder** — one tiny process per session. It `forkpty()`s the job, owns
   the pty master for the session's whole life, and **never reads it**. It
-  survives daemon restarts, app restarts, and crashes of both. It is the only
-  component whose death kills the session, so it is kept small enough to
-  essentially never change.
+  survives daemon restarts, app restarts, and crashes of both. Holder death
+  is session death — by policy as well as by mechanism, see "Holder death"
+  below — so it is kept small enough to essentially never change.
 - **The daemon** — the arbiter of who reads, and the **default reader**. While
   no viewer is attached it drains the master into a headless terminal
   emulator, so unattended agents never stall and reattachment has a screen to
@@ -102,8 +102,10 @@ bytes the other reader never sees).
 - **Lifetime.** The holder exits when its child exits — but only after
   reporting the child's exit status to the daemon, or timing out trying
   (bounded, injected clock). Exit status is data the session lifecycle wants,
-  and the holder is the only process guaranteed to observe it. On the way out
-  it unlinks its socket.
+  and the holder is the only process guaranteed to observe it. If the report
+  never lands (daemon down through the whole timeout), the session record's
+  status becomes exited, status unknown — implementations must not fabricate
+  one. On the way out the holder unlinks its socket.
 - **Rendezvous and identity.** One Unix socket per holder, at a
   `TBDConstants`-derived path under the TBD home directory (honoring
   `TBD_HOME`), named by the session UUID. Session identity is the UUID TBD
@@ -142,7 +144,39 @@ exit); its socket needs no child multiplexing; and upgrading the holder
 binary — the hardest problem in this space, which Superset solves with a
 successor-spawn fd-inheritance dance — is sidestepped entirely, because new
 sessions simply get the new binary while old ones keep the old. At the design
-point this is ~150 processes, which is trivial on macOS.
+point this is ~150 processes, which is trivial on macOS. The daemon's fd
+budget is likewise a non-issue: it already raises `RLIMIT_NOFILE` at startup
+(`raiseFileDescriptorLimit` in `Sources/TBDDaemon/Daemon.swift`) far beyond
+150 master dups plus 150 holder sockets.
+
+### Holder death
+
+The daemon holds a master dup, so a holder crash does not by itself kill the
+child: the kernel's fd refcount keeps the pty alive — the same mechanism
+Superset exploits on purpose for daemon upgrades. The policy is that it kills
+the session anyway, promptly and deliberately. The daemon watches its
+connection to each holder; when a holder dies while its child lives, the
+daemon kills the child by its recorded pid — verifying process identity
+(executable and start time) first, so pid reuse cannot misdirect the kill —
+closes its dups, and marks the session exited with a distinct reason
+(holder lost) rather than a generic exit.
+
+The alternative — carrying the session on the daemon's own dup, marked
+degraded — was rejected: it preserves in-flight work only until the next
+daemon restart kills the session anyway, at the price of a permanent extra
+session state and an ownership story with an exception in it. Holder crashes
+are expected to be vanishingly rare precisely because the holder is small and
+frozen; predictability is worth more than softening a rare event.
+
+Recovery follows the transcript. For a Claude session the conversation up to
+the last persisted turn survives on disk regardless, and a respawn with
+`claude --resume <session-id>` continues it (any revive affordance must pass
+`--fork-session`; a bare `--resume` reuses the session UUID). The in-flight
+turn and unsubmitted composer input are lost — the same ladder as any process
+death today, and no worse than a tmux server crash is now, with blast radius
+one session rather than a repo's worth. Because the daemon knows why the
+session died, the distinct exit reason enables a natural follow-on, out of
+scope for this design: a UI affordance that revives the session in place.
 
 ## Reader arbitration
 
@@ -162,9 +196,15 @@ distributed protocol.
 - **Detach.** The app tells the daemon and closes its dup; the daemon resumes
   reading and jiggles so a full-screen program repaints into the daemon's
   emulator.
-- **App death.** The daemon observes the sidecar disconnect and reverts every
-  session that app held to daemon-read, with a jiggle. No cooperation from
-  the dead process is needed.
+- **App death.** A sidecar disconnect alone is not death: the sidecar has a
+  designed reconnect path, so a socket-level drop can leave the app alive,
+  holding its dups, still reading — and seizing then is exactly the
+  double-reader corruption this design exists to avoid. On disconnect the
+  daemon first checks whether the app process is alive. Gone: every session
+  it held reverts to daemon-read, with a jiggle, no cooperation from the dead
+  process needed. Alive: the daemon stays off the fds and treats the drop
+  like the startup grace window — await reconnect and re-claim, seize only on
+  confirmed process death.
 - **Daemon death.** Attached sessions are untouched — the app keeps its fds
   and keeps painting through the entire daemon outage. Detached sessions have
   no reader: their writers block on the kernel tty buffer, which is
@@ -176,11 +216,19 @@ distributed protocol.
   sessions the app holds fds for; claimed sessions stay app-owned and
   everything else begins draining. The wait is bounded by a grace window on
   an injected clock; on expiry the daemon re-checks app liveness — app gone,
-  drain everything; app alive but silent, stay off the fds and log loudly.
-  A claim arriving after draining began is handled as an ordinary attach.
-  The database records attach state as an observability hint only; it is
-  never the arbiter, because a persisted row cannot answer a liveness
-  question.
+  drain everything; app alive but silent, stay off the fds, log loudly, and
+  raise a user-visible notification. A claim arriving after draining began is
+  handled as an ordinary attach. The database records attach state as an
+  observability hint only; it is never the arbiter, because a persisted row
+  cannot answer a liveness question.
+
+The alive-but-silent arm is an acknowledged limitation: while an app process
+exists but never (re)connects, no detached session drains — a fleet-wide
+stall of unattended work, visible as the notification above plus writers
+blocked on full tty buffers. The alternative — draining sessions a database
+hint says were detached — trades a visible, recoverable stall for a chance of
+silent corruption, and is rejected; backpressure loses nothing, and the stall
+ends the moment the app reconnects or its process dies.
 
 This arbitration was checked against the restart script's actual sequencing
 (daemon bounces first, then the app): during a full development restart,
@@ -216,10 +264,29 @@ and a `hasPrefix` broke title parsing — the escape-sequence long tail is
 precisely what bites.
 
 The emulator keeps a bounded in-memory scrollback (on the order of 10k lines;
-a plain constant, not a flag) and is **not persisted to disk**. A daemon
-restart starts it empty; the jiggle on re-adoption makes full-screen programs
-repaint into the fresh emulator, and the durable record of an agent's work is
-its transcript, which persists on disk independently of any terminal.
+a plain constant, not a flag) and is **not persisted to disk**. The constant
+is a memory decision as much as a history one: at the design point there are
+~150 emulators resident, and a naive per-cell buffer representation across
+150 sessions can reach into gigabytes, so the limit must be sized against
+SwiftTerm's measured per-line cost at implementation time — and the limit, or
+the representation, gives way first if field memory pressure says so.
+
+A daemon restart starts the emulator empty; the jiggle on re-adoption makes
+full-screen programs repaint into the fresh emulator, and the durable record
+of an agent's work is its transcript, which persists on disk independently of
+any terminal. That heal is scoped honestly: it works for programs that
+repaint on SIGWINCH. A plain shell prompt, or output that has scrolled away,
+repaints nothing — so after a daemon restart such a *detached* session reads,
+and later seeds its viewer, as a blank screen until new output arrives, and a
+shell has no transcript to fall back on. tmux preserves screen and history
+across daemon restarts unconditionally; this design deliberately does not,
+trading that for a daemon that is free to restart under live sessions at all.
+
+Rendering terminal state as bytes is a named deliverable of this design, not
+an assumed primitive: both the attach-time snapshot preamble and the app's
+pull snapshot need a grid-to-escape-stream serializer (screen plus retained
+scrollback, emitted as a stream a fresh emulator ingests). It is exercised on
+every attach, so it cannot rot unnoticed the way failure-edge-only code does.
 
 ### Two stores, reconciled on demand
 
@@ -234,6 +301,14 @@ to the daemon:
   terminal read`), it **pulls a snapshot from the app** over the existing
   RPC; the app serializes its live terminal state on request. Machine reads
   are therefore always current, from whichever store is live.
+- Pulls are bounded (timeout on an injected clock), and every consumer
+  declares a failure policy, because the app can legitimately go quiet (App
+  Nap has coalesced this app's work for ~90 s in the field, and app-wedged
+  correlates with exactly the moments supervision most wants a screen).
+  Safety-critical consumers fail closed: the hibernation input-veto check
+  treats no-answer as unsafe and refuses to hibernate, never risking typed
+  input. Best-effort consumers fall back to the daemon's frozen-at-attach
+  emulator, labeled stale, rather than blocking on an unresponsive app.
 - Terminal scrollback history has a hole across each attached period (minus
   whatever the kernel buffer held at the edges). This is the accepted cost,
   and it is cheap here specifically: the artifact users actually mine history
@@ -268,7 +343,9 @@ Everything TBD does through tmux today, and its replacement:
   better than today, since attached sessions now also survive daemon restarts
   without interruption.
 - **Reattach shows the last screen** — snapshot preamble from the daemon's
-  emulator, plus jiggle.
+  emulator, plus jiggle; scoped by the emulator's lifetime — after a daemon
+  restart, a detached session that does not repaint on SIGWINCH (a plain
+  shell, scrolled-away output) seeds blank until new output arrives.
 - **Input injection** (`tbd terminal send`, queued prompts) — daemon writes to
   its master dup.
 - **Machine reads** (`tbd terminal read`, the interactive-login driver, the
@@ -309,7 +386,10 @@ the process table — the same argument as every other resource here.
   and servers to the **holder inventory**: enumerate holder sockets under the
   sessions directory, connect, and handshake (yielding holder pid, child pid,
   child status, and launch parameters). A session row with no live holder is
-  marked exited through the existing handling. A live holder with no session
+  marked exited through the existing handling. A **rejected** connection is
+  the opposite of a dead holder — the holder is alive and owned by another
+  daemon (a stale daemon from a different checkout is a known hazard on a
+  development machine) — and must never feed the exited path. A live holder with no session
   row is a half-finished deletion: the daemon kills the child and the holder.
   **Kill, not adopt** — iTerm2 adopts unclaimed survivors into new tabs
   because its live processes are the only copy of anything; TBD's transcripts
@@ -322,9 +402,14 @@ the process table — the same argument as every other resource here.
   is mandatory, not hygienic: a SIGKILLed holder cannot unlink its own
   socket, and the tmux precedent on this machine was ~7,100 dead socket
   files, because tmux unlinks lazily on rebind and nothing ever rebound.
-- **`AgentReaper`** keeps its current role unchanged: a child whose holder
-  died is re-parented to launchd and lands in the reaper's existing
-  by-session-identity sweep.
+- **`AgentReaper`** gains a holder-transport leg. Its existing sweep
+  enumerates children of tmux server pids and structurally cannot see a
+  child re-parented to launchd, so for holder-transport sessions it sweeps by
+  each session's **recorded child pid** (captured at spawn and refreshed at
+  adoption), verifying process identity (executable and start time) before
+  killing, and reaps children whose session row is exited or absent. This is
+  the backstop for holder deaths the daemon was down for; the prompt path is
+  the daemon's own holder-connection watch ("Holder death" above).
 
 ## Rollout
 

--- a/docs/specs/2026-08-30-pty-holder-session-transport-design.md
+++ b/docs/specs/2026-08-30-pty-holder-session-transport-design.md
@@ -337,14 +337,33 @@ Three rules close it, in increasing order of how often they apply.
   work: pull from whichever store is live rather than reaching past it.
 - **The app is not allowed to become a single point of failure for
   injection.** If it does not acknowledge within a bounded deadline on an
-  injected clock, the daemon writes directly and accepts the shear risk.
+  injected clock, the daemon writes directly.
 
 That last fallback is deliberately fail-*open*, where the read side's
 safety rail fails closed, and the asymmetry is the point: an unanswered read
 can be resolved by refusing to act on a stale screen, but an unanswered
 injection that is simply dropped leaves an agent waiting forever for a prompt
-that never arrives. A rare sheared keystroke is the smaller harm than a
-queued prompt that silently never lands.
+that never arrives.
+
+Its cost is **two** failure modes, not one, and the second is the easier to
+overlook. A missing ack does not mean the injection was not delivered — the
+app may have written it and had the ack lost or merely delayed, which App Nap
+has been measured doing to this app's work for ~90 s. So the fallback can
+deliver an injection **twice**, and for a queued prompt acting twice may be
+worse than a sheared keystroke. This is the at-least-once versus at-most-once
+fork, chosen knowingly in favour of at-least-once: a duplicated prompt is
+visible and recoverable, while a silently dropped one strands an agent
+indefinitely with nothing to see. **Do not "fix" the duplicate by acking
+before writing** — that trades a visible duplicate for exactly the invisible
+loss this design rejected, and it will look like a cleanup.
+
+Rule 2 also makes a real deferral policy possible, where the daemon could
+never have one. Once the app is the sole writer it is the only process that
+sees both streams, so the serialization point is a single in-process queue —
+and that queue knows its own bracketed-paste state exactly. A daemon-originated
+frame is therefore held while a user paste is open and never lands between its
+markers, which is the strongest form of the guarantee rule 1 approximates.
+That belongs to the attach work, not here.
 
 Resize follows the reader: whichever process currently reads the master owns
 `TIOCSWINSZ` — the app drives it from the view while attached, the daemon

--- a/docs/specs/2026-08-30-pty-holder-session-transport-design.md
+++ b/docs/specs/2026-08-30-pty-holder-session-transport-design.md
@@ -668,6 +668,20 @@ flag with a soak and a stated graduation plan.
   a wakeup in the echo path that the design says it does not, and graduation
   does not proceed on the theory that the absolute number still looks small.
 
+  **The run must exercise a real holder-backed session, not the raw-pty arm
+  standing in for one.** The existing probes measure a raw pty and tmux; the
+  raw arm is *expected* to be the holder's attached echo path exactly, because
+  by construction there is no process between the app and the master once a
+  viewer is attached — the holder never reads, and the daemon has stepped off.
+  But that is the design's central claim, and a graduation gate that assumes it
+  is measuring nothing. So the load arm runs against sessions actually spawned
+  on the holder transport with a viewer attached, and the raw-pty arm stays as
+  the reference the holder path is expected to match: if the two diverge, the
+  gap is a process in the path that should not be there, and finding it is the
+  entire value of the measurement. The detached path is a separate question the
+  flatness bound does not speak to at all — nobody is typing into a detached
+  session — and the reconciler and drain evidence cover it instead.
+
   **"No double-reader violations" is only evidence if something can see one.**
   A double read is silent by construction — each `read()` takes bytes the other
   reader never sees — so an absence of reports is not an absence of the fault,

--- a/docs/specs/2026-08-30-pty-holder-session-transport-design.md
+++ b/docs/specs/2026-08-30-pty-holder-session-transport-design.md
@@ -624,14 +624,13 @@ flag with a soak and a stated graduation plan.
   continuously — the hardest code in the design gets adversarial testing for
   free. Graduation gates on field evidence: no double-reader violations, the
   reconcilers holding (no growth in unclaimed holders or socket litter), and
-  latency flatness re-confirmed under load by re-running the keystroke-echo
-  measurement whose methodology the companion research record documents.
-  That harness is a **deliverable of this work, not an existing tool to lean
-  on**: `scripts/diag/` today holds only a commit-latency report and an
-  RPC-volume report, neither of which measures keystroke echo. A design
-  justified by a latency curve has to ship the committed probe that can
-  re-draw that curve on demand, or graduation is a judgement call rather than
-  a measurement.
+  latency flatness re-confirmed under load by re-running the probes that drew
+  the curve in the first place: `scripts/diag/tmux-vs-rawpty-idle.py` for the
+  raw-versus-tmux echo comparison and `scripts/diag/tmux-server-contention.py`
+  for the pane-count control. Both are committed alongside this design, for
+  the reason that a design justified by a latency curve has to ship the tool
+  that can re-draw it — otherwise graduation is a judgement call wearing a
+  measurement's clothes.
 
   **"No double-reader violations" is only evidence if something can see one.**
   A double read is silent by construction — each `read()` takes bytes the other

--- a/docs/specs/2026-08-30-pty-holder-session-transport-design.md
+++ b/docs/specs/2026-08-30-pty-holder-session-transport-design.md
@@ -1,0 +1,484 @@
+# Migrating terminal sessions off tmux onto per-session pty holders
+
+**Status:** Approved design. Not yet implemented.
+
+**Companion evidence:** the measurement and research records under
+[`docs/research/2026-08-30-terminal-session-persistence/`](../research/2026-08-30-terminal-session-persistence/)
+— field measurements of the tmux path, a full source read of iTerm2's session
+restoration, and a prior-art survey of every shipping system found in this
+space. This spec restates the decision-critical numbers so it stands alone, and
+defers to those records for methodology and file:line citations.
+
+## Summary
+
+TBD today keeps agent sessions alive across daemon and app restarts by running
+them under tmux. This design replaces tmux with a **per-session holder
+process**: a minimal supervisor that `forkpty()`s the job, holds the pty
+master, and hands the master over `SCM_RIGHTS` to whoever should be reading —
+the app while a viewer is attached, the daemon otherwise. The attached path
+becomes a raw pty read in the app with no other process involved, which is the
+arrangement iTerm2 has shipped for years; the daemon's always-on presence
+covers the detached-output window iTerm2 structurally cannot.
+
+The justification is **scaling headroom, not current latency**. At quiet load
+tmux costs 1.1 ms p50 per keystroke and is imperceptible; this design does not
+claim to fix any latency a user feels today. What the measurements show is that
+a raw pty is *flat* under load (never exceeded 5 ms at any load including 117)
+while tmux degrades superlinearly (p90 of 9.3 → 12.7 → 139 ms as load rises),
+because a tmux keystroke costs two extra process wakeups whose latency is
+scheduling delay. tmux is therefore the component that breaks first as the
+fleet grows. The design point is roughly twice the present fleet: **~150
+concurrent sessions at sustained load ≥ 100** on one machine.
+
+## The measured basis
+
+Three findings from the companion records shape everything below.
+
+- **The cost of tmux is process wakeups, and they track load.** A raw pty's
+  echo happens in the kernel line discipline inside `write()`, with no process
+  wakeup at all, which is why it is indifferent to load. A tmux keystroke is
+  two server wakeups (read the key, read the echo) plus the reader's own; the
+  server's actual work is ~40 µs, and the rest is waiting to be scheduled.
+  The tmux *client* is not in the steady-state path — it hands its stdin to
+  the server over `SCM_RIGHTS` at attach — so there is no client relay to
+  delete; the only saving available is the server wakeups and the redundant
+  VT parse.
+- **TBD's live path is already the good arrangement, minus tmux.** The app
+  spawns a `tmux attach` client per viewer and SwiftTerm reads that client's
+  pty natively; the control-mode fanout is gated off by default. There is no
+  intermediary left to remove first.
+- **Holding a pty master elsewhere is proven, and draining is the hard half.**
+  Passing a master over `SCM_RIGHTS` to another process which then does direct
+  I/O works on Darwin, and the shell sees no SIGHUP when the passing process
+  dies. But a supervisor that merely parks the fd wedges its child once the
+  kernel tty buffer fills — observed directly — so exactly one process must be
+  reading at all times that output flows, and the transfer of that role needs
+  an acknowledged edge.
+
+Additionally, tmux imposes a throughput cost this design removes: every byte a
+program prints is parsed twice — once by the tmux server into its grid, then
+re-rendered as a fresh escape stream that SwiftTerm parses again — with tmux's
+output flow control in between. On the new attached path the bytes are read
+once and parsed once, by the app. For the dominant workload (a full-screen
+agent TUI repainting continuously) this is a straight bandwidth win in addition
+to the latency-flatness win.
+
+## Design overview
+
+Three roles, three processes:
+
+- **The holder** — one tiny process per session. It `forkpty()`s the job, owns
+  the pty master for the session's whole life, and **never reads it**. It
+  survives daemon restarts, app restarts, and crashes of both. It is the only
+  component whose death kills the session, so it is kept small enough to
+  essentially never change.
+- **The daemon** — the arbiter of who reads, and the **default reader**. While
+  no viewer is attached it drains the master into a headless terminal
+  emulator, so unattended agents never stall and reattachment has a screen to
+  show. Because the holder owns the master, the daemon is freely restartable:
+  a daemon restart no longer touches any live terminal.
+- **The app (viewer)** — while attached, reads and writes the master directly
+  through a dup received over the existing FD sidecar. Keystroke echo is
+  kernel → app: 0.1 ms, flat under load, identical in mechanism to iTerm2's
+  attached path.
+
+The single-reader invariant, in one sentence: **the daemon reads exactly the
+sessions that no live, connected app has claimed — and when it cannot yet
+know, it errs toward reading nothing**, because not-reading costs recoverable
+backpressure while double-reading is silent corruption (each `read()` steals
+bytes the other reader never sees).
+
+## The holder
+
+### Contract
+
+- **Spawn.** The daemon spawns the holder with fork + `setsid()` + exec.
+  `setsid` detaches it from any process group that could signal it (the
+  iTerm2 lesson: without it, a Ctrl-C aimed at the parent kills the
+  supervisor and strands every session). The holder then `forkpty()`s the
+  job, making it both the master's owner and the child's parent; it reaps the
+  child via SIGCHLD. When the daemon exits, the holder orphans to launchd and
+  carries on. SIGHUP and SIGPIPE are ignored.
+- **Lifetime.** The holder exits when its child exits — but only after
+  reporting the child's exit status to the daemon, or timing out trying
+  (bounded, injected clock). Exit status is data the session lifecycle wants,
+  and the holder is the only process guaranteed to observe it. On the way out
+  it unlinks its socket.
+- **Rendezvous and identity.** One Unix socket per holder, at a
+  `TBDConstants`-derived path under the TBD home directory (honoring
+  `TBD_HOME`), named by the session UUID. Session identity is the UUID TBD
+  already persists — stronger than iTerm2's *(socket number, child pid)*
+  pairing. Socket paths observe `sun_path`-length discipline: the sessions
+  directory stays shallow, and the length is checked before every `bind` and
+  `connect`. The socket is bound with owner-only permissions. One client at a
+  time, enforced holder-side: a second connection is accepted and immediately
+  rejected with a sentinel protocol version.
+- **Protocol.** Minimal and versioned from day one. Verbs: report the child
+  (pid, tty name, launch parameters, alive/exited status) and hand over a
+  master dup; report exit status; forget the child (close the master and stop
+  reporting, so a killed session cannot be resurrected — iTerm2's preemptive
+  wait). The version field is load-bearing: long-lived sessions keep running
+  old holder binaries, so the daemon must interoperate with every holder
+  version that has ever shipped. This is the standing argument for keeping
+  the holder near-featureless forever.
+- **Environment and launch parameters.** The session's environment (including
+  `envOverrides`) is applied at spawn by the daemon and passed through the
+  holder to the child, replacing today's tmux `-e` delivery. The holder
+  retains the launch request and replays it on demand, so a re-adopting
+  daemon can reconstruct what is running without trusting the database.
+- **Binary.** A new small SPM executable target. No copying the binary out of
+  the build tree: a running holder's executable image survives rebuilds and
+  build-directory reclamation (iTerm2 copies its server binary only because
+  its auto-updater deletes the bundle out from under running servers, a
+  hazard TBD does not have). The consequence — old sessions run old holders —
+  is handled by the protocol versioning above.
+
+### Why per-session
+
+The holder is the process whose crash kills its sessions' ptys, so blast
+radius dominates the granularity choice. A per-session holder's bug costs one
+session; its lifecycle is self-reclaiming in the common case (exit on child
+exit); its socket needs no child multiplexing; and upgrading the holder
+binary — the hardest problem in this space, which Superset solves with a
+successor-spawn fd-inheritance dance — is sidestepped entirely, because new
+sessions simply get the new binary while old ones keep the old. At the design
+point this is ~150 processes, which is trivial on macOS.
+
+## Reader arbitration
+
+Each session has exactly one reader at any moment: the app, the daemon, or —
+transiently and safely — nobody. All transitions are arbitrated by the daemon,
+which is also the fallback reader, so the acknowledged edge ("you read now, I
+have stopped") is an in-process state transition plus one acked fd-vend, not a
+distributed protocol.
+
+- **Attach.** The app requests a session over the existing RPC. The daemon
+  stops reading, renders its headless emulator's screen and retained
+  scrollback into an escape-sequence **snapshot preamble**, and sends the
+  preamble plus the master dup over the FD sidecar. The app feeds the
+  preamble into SwiftTerm first, then goes live on the fd, then jiggles (see
+  below). Reattach therefore paints the last-known screen instantly, as tmux
+  does today.
+- **Detach.** The app tells the daemon and closes its dup; the daemon resumes
+  reading and jiggles so a full-screen program repaints into the daemon's
+  emulator.
+- **App death.** The daemon observes the sidecar disconnect and reverts every
+  session that app held to daemon-read, with a jiggle. No cooperation from
+  the dead process is needed.
+- **Daemon death.** Attached sessions are untouched — the app keeps its fds
+  and keeps painting through the entire daemon outage. Detached sessions have
+  no reader: their writers block on the kernel tty buffer, which is
+  backpressure, not loss, and drains when the daemon returns.
+- **Daemon startup (re-adoption).** The new daemon connects to every holder
+  and adopts a master dup, but **reads nothing yet**. If no app process is
+  alive, it becomes reader of everything immediately. If an app process is
+  alive, it waits for that app's sidecar handshake, which carries the list of
+  sessions the app holds fds for; claimed sessions stay app-owned and
+  everything else begins draining. The wait is bounded by a grace window on
+  an injected clock; on expiry the daemon re-checks app liveness — app gone,
+  drain everything; app alive but silent, stay off the fds and log loudly.
+  A claim arriving after draining began is handled as an ordinary attach.
+  The database records attach state as an observability hint only; it is
+  never the arbiter, because a persisted row cannot answer a liveness
+  question.
+
+This arbitration was checked against the restart script's actual sequencing
+(daemon bounces first, then the app): during a full development restart,
+attached sessions keep painting through the daemon swap and go dark only for
+the app's own bounce; detached sessions get a few seconds of harmless
+backpressure. The daemon-only restart path — a live app throughout — is the
+scenario the claim handshake exists for, and ordinary development restarts
+exercise it continuously.
+
+### Input is not arbitrated
+
+Reading the master is exclusive; writing is not. The daemon keeps its master
+dup for the session's whole life and injects input (`tbd terminal send`,
+queued prompts, supervision nudges) by writing to it directly, whether or not
+a viewer is attached. This retires a real bug class: today a daemon keystroke
+is addressed to a tmux pane coordinate resolved at send time and can hit the
+wrong session after pane reuse; a write to an fd bound to the session at
+spawn cannot miss.
+
+Resize follows the reader: whichever process currently reads the master owns
+`TIOCSWINSZ` — the app drives it from the view while attached, the daemon
+holds the last-known size while detached.
+
+## Detached output and the headless emulator
+
+While no viewer is attached, the daemon drains each session's master into a
+headless instance of SwiftTerm's core `Terminal` — the same parser the viewer
+uses, so the detached picture and the attached picture can never disagree on
+interpretation, and every escape-sequence fix benefits both. This repo's own
+history is the argument against a purpose-built minimal parser: the
+`ANSIEscape` component missed `CSI <>=`, `ESC 7/8`, and charset switching,
+and a `hasPrefix` broke title parsing — the escape-sequence long tail is
+precisely what bites.
+
+The emulator keeps a bounded in-memory scrollback (on the order of 10k lines;
+a plain constant, not a flag) and is **not persisted to disk**. A daemon
+restart starts it empty; the jiggle on re-adoption makes full-screen programs
+repaint into the fresh emulator, and the durable record of an agent's work is
+its transcript, which persists on disk independently of any terminal.
+
+### Two stores, reconciled on demand
+
+While a viewer is attached the daemon reads nothing, so its emulator is
+frozen at the moment of attach. This design accepts that — the **two-store
+model** — rather than having the app stream a copy of everything it reads back
+to the daemon:
+
+- The app's SwiftTerm is authoritative while attached; the daemon's emulator
+  is authoritative while detached.
+- When the daemon needs an attached session's screen (supervision, `tbd
+  terminal read`), it **pulls a snapshot from the app** over the existing
+  RPC; the app serializes its live terminal state on request. Machine reads
+  are therefore always current, from whichever store is live.
+- Terminal scrollback history has a hole across each attached period (minus
+  whatever the kernel buffer held at the edges). This is the accepted cost,
+  and it is cheap here specifically: the artifact users actually mine history
+  from is the transcript, and the dominant workload is a full-screen TUI that
+  manages its own display anyway.
+
+The alternative — the app forwarding every chunk it reads to the daemon so
+one unbroken history exists — was rejected because it re-imposes roughly the
+tmux parse-everything CPU bill on the loaded machine this design targets
+(relocated off the paint path, but standing), to buy a property (gapless
+terminal scrollback) that transcripts already provide where it matters. See
+Rejected alternatives.
+
+### The jiggle
+
+Whenever the reader changes — attach, detach, app death, daemon re-adoption —
+the incoming reader briefly wiggles the tty size (grow one column, restore)
+to force a SIGWINCH, so full-screen programs repaint into the reader's
+emulator. This is iTerm2's `WinSizeController` "jiggle", wired here to every
+handoff edge rather than only orphan adoption (in iTerm2 the plain reattach
+path gets no jiggle, and its resize ioctl is guarded by only-if-changed, so
+the common same-geometry reattach heals nothing — a gap, not a choice; see
+the companion iTerm2 record). The jiggle heals screen *state*; it cannot
+recover missing history and does nothing for scrolled-away output, which is
+why it complements rather than replaces the daemon's emulator.
+
+## Feature parity
+
+Everything TBD does through tmux today, and its replacement:
+
+- **Session persistence across app and daemon restarts** — the holder; strictly
+  better than today, since attached sessions now also survive daemon restarts
+  without interruption.
+- **Reattach shows the last screen** — snapshot preamble from the daemon's
+  emulator, plus jiggle.
+- **Input injection** (`tbd terminal send`, queued prompts) — daemon writes to
+  its master dup.
+- **Machine reads** (`tbd terminal read`, the interactive-login driver, the
+  hibernation pending-input rail, the embedded supervision babysitter) — the
+  daemon renders its own emulator when it is the reader and pulls a snapshot
+  from the app when a viewer is attached. This replaces `capture-pane` with a
+  first-party interface, which the no-TUI-scraping rule already pushes
+  toward; the three sanctioned scrapers migrate onto it as part of this work.
+- **Hibernation and revive** — hibernate instructs the holder to terminate its
+  child (the holder reports status and exits); revive spawns a fresh holder.
+  The input-veto and queued-prompt flags keep their semantics, now gating
+  daemon writes to the master instead of tmux `send-keys`.
+- **Scrollback** — bounded emulator history while detached, SwiftTerm's own
+  history while attached, transcripts as the durable record. tmux's 50k-line
+  retention is not matched and deliberately so.
+
+### Out of scope, structurally
+
+- **External attach from another terminal emulator** is not carried forward.
+  It existed only as a diagnostic and is being unshipped independently of
+  this design.
+- **Remote or ssh attach** cannot exist in this design: the interface is a
+  file descriptor, and a file descriptor cannot cross a machine boundary.
+  Every system in the survey that dropped a mux server also dropped this, on
+  purpose. If remote viewing is ever wanted it is a separate streaming
+  feature, not a holder feature. Sessions on remote hosts keep whatever
+  transport they have today; this migration is local-machine only.
+- **Survival of reboot or GUI logout** — not provided, exactly as today.
+
+## Reconciliation
+
+Per the named-reconciler doctrine, the new durable resources are the holder
+processes, their socket files, and (transitively) the agent processes under
+them. Orphans can arise because holder creation is non-transactional against
+the process table — the same argument as every other resource here.
+
+- **`WorktreeLifecycle+Reconcile`** swaps its ground truth from tmux windows
+  and servers to the **holder inventory**: enumerate holder sockets under the
+  sessions directory, connect, and handshake (yielding holder pid, child pid,
+  child status, and launch parameters). A session row with no live holder is
+  marked exited through the existing handling. A live holder with no session
+  row is a half-finished deletion: the daemon kills the child and the holder.
+  **Kill, not adopt** — iTerm2 adopts unclaimed survivors into new tabs
+  because its live processes are the only copy of anything; TBD's transcripts
+  persist independently, so adoption would buy a mystery-session UI and
+  little else, and it cuts against the database-is-intent model the other
+  reconcilers already follow.
+- **`OrphanGC`** (hourly, gated on `gcEnabled` as today) gains two sweeps:
+  unlink socket files with no listening process behind them, and re-run the
+  holder-versus-database check between startup reconciles. The socket sweep
+  is mandatory, not hygienic: a SIGKILLed holder cannot unlink its own
+  socket, and the tmux precedent on this machine was ~7,100 dead socket
+  files, because tmux unlinks lazily on rebind and nothing ever rebound.
+- **`AgentReaper`** keeps its current role unchanged: a child whose holder
+  died is re-parented to launchd and lands in the reaper's existing
+  by-session-identity sweep.
+
+## Rollout
+
+This wholesale-replaces a load-bearing path, so it ships behind a default-off
+flag with a soak and a stated graduation plan.
+
+- **Flag.** `pty_holder_enabled`, a `config` column added by a `.sql`
+  migration with **no SQL `DEFAULT` clause**, so unset stays a third state;
+  the shipped default lives solely in `?? Config.ptyHolderDefault` (`false`)
+  in `ConfigRecord.toModel()`. Tests cover all three states: a pre-migration
+  row reads NULL rather than `0`, NULL follows the constant, and an explicit
+  `0` survives a change to the constant.
+- **Granularity: spawn time only.** A session records its transport (`tmux`
+  or `holder`) in its database row at creation and keeps it for life; the app
+  attaches by whichever transport the row names. Flipping the flag never
+  migrates a running session — the fleet converges as sessions naturally end
+  and respawn. Live migration (extracting a pty from a running tmux server)
+  is rejected; see below.
+
+  The flag therefore gates **spawning, not servicing**: the flag is consulted
+  only when a session is created, and both transports' machinery (attach
+  paths, the daemon's arbitration and drain, each reconciler's ground-truth
+  sweep) runs whenever any session row of that transport exists, regardless
+  of the flag's current value. Toggling in either direction strands nothing:
+  off → on leaves every running tmux session on tmux and routes only new
+  spawns to holders; on → off leaves every running holder session on its
+  holder and routes new spawns back to tmux.
+- **Coexistence cost, stated honestly.** Both paths live until graduation:
+  two attach paths in the app, two reconciliation ground truths, and a
+  doubled test surface. Each gated branch gets tests for flag-on and
+  flag-off behavior.
+- **Soak.** Enable on a development machine running a real fleet at real
+  load. Ordinary development restarts exercise the re-adoption path
+  continuously — the hardest code in the design gets adversarial testing for
+  free. Graduation gates on field evidence: no double-reader incidents, the
+  reconcilers holding (no growth in unclaimed holders or socket litter), and
+  latency flatness confirmed under load by the existing probes in
+  `scripts/diag/`.
+- **Graduation.** Flip `Config.ptyHolderDefault` to `true` — a one-line
+  change that reaches everyone who never chose while preserving every
+  explicit opt-out. Removing the tmux path entirely is separate, later work,
+  undertaken once no `tmux`-transport session rows remain in the wild.
+
+New delays introduced by this design — the re-adoption grace window, the
+holder's exit-report timeout, any handoff ack timeout — take an injected
+clock (`clock: any Clock<Duration> = ContinuousClock()`), per the repo rule.
+
+## Relationship to the build-isolation work
+
+Issue #720 (isolating development builds from the production daemon, tmux
+server, and database) interacts with this design in both directions: it
+reduces how often the production daemon restarts, shrinking one window the
+holder covers, while the holder makes daemon restarts nearly free for live
+sessions, shrinking the pain that motivates it. The two are deliberately
+**independent, with no ordering dependency**: whichever lands first makes the
+other somewhat less urgent, nothing in either design assumes the other, and
+re-scoping #720 is that issue's own decision, not this spec's.
+
+## Learnings from iTerm2
+
+iTerm2 is the shipping precedent for the core of this design, and its source
+is a catalogue of paid-for lessons. **Implementers and reviewers of this work
+should read the companion record
+[`iterm2-session-restoration.md`](../research/2026-08-30-terminal-session-persistence/iterm2-session-restoration.md)
+and consult the iTerm2 source before re-deriving any of the following**, each
+of which is carried into this design:
+
+- **The fd rides on a one-byte `sendmsg`.** `sendmsg` with an `SCM_RIGHTS`
+  control block has been observed failing with `EMSGSIZE` at payload sizes
+  the man page permits, and an empty payload fails too; iTerm2 caps the
+  fd-carrying message at exactly one byte and sends the rest with a plain
+  `write()` — and never re-sends the fd on a short write, or the recipient
+  materializes duplicate descriptors. TBD's existing FD sidecar already
+  navigates fd-number recycling; the holder protocol adopts the one-byte
+  convention as well.
+- **Reads on the fd channel must be serialized by construction** — exactly
+  one method may read after the handshake, or interleaved partial reads
+  corrupt the stream.
+- **Creation races are settled by an advisory lock file** held for the
+  server's whole life; connecting to a busy server is settled separately by
+  accept-then-reject with a sentinel version.
+- **SIGHUP is not enough on user-initiated close.** A supervised child can
+  ignore SIGHUP, leaving the supervisor alive to be adopted later; closing a
+  session must make the holder forget the child (close the master, stop
+  reporting) and then kill, which is why the protocol carries a forget verb.
+- **`sun_path` shapes the feature.** Check the socket path length before
+  every bind and connect; keep the rendezvous directory shallow.
+- **`setsid()` in the supervisor is load-bearing**, and SIGHUP/SIGPIPE must
+  be ignored, or a crash of the spawning process (or a `sendmsg` into a dead
+  peer) takes the supervisor with it.
+- **The jiggle exists and works** — and iTerm2 wires it only to orphan
+  adoption, leaving its common reattach path unhealed behind an
+  only-if-changed resize guard. This design wires it to every reader
+  handoff.
+- **Content and process persist on different clocks** unless something keeps
+  the detached picture current. iTerm2 saves screen contents only on losing
+  focus and at clean quit, so a crash restores a screen as stale as the last
+  click away, with no banner admitting it. The daemon's always-on drain is
+  this design's answer; the residual skew (the attached-period scrollback
+  hole) is accepted and documented above.
+
+## Rejected alternatives
+
+- **Keeping tmux and sharding servers more finely.** Measured: a busy server
+  against a private one-pane server differed by 34.1 vs 36.5 ms p50 under
+  load — pane count per server is not the lever; the wakeups are.
+- **The daemon holds the masters itself (no holder).** A daemon restart is
+  precisely one of the windows persistence exists to cover, and on a
+  development machine the daemon restarts constantly. The holder exists to
+  make the daemon boring to restart.
+- **Per-repo or global holders.** A global holder is a single crash away from
+  SIGHUPing the entire fleet and is the one process that can never be
+  restarted for an upgrade (the successor-spawn fd-inheritance dance is the
+  known workaround, and it is surgery). Per-repo shrinks but keeps both
+  problems and adds child-table multiplexing to the protocol. Per-session
+  makes blast radius one session and upgrade a non-event.
+- **The holder drains its own pty (headless emulator in the holder).** Every
+  minimal-supervisor precedent (shpool, zmx, the Zed proposal) puts the
+  emulator in the persistent process — but each of those has no other
+  persistent process. TBD has an always-on daemon, so putting the emulator
+  there keeps the holder near-featureless and makes the crashiest, most
+  frequently updated code freely restartable and upgradable. The residual
+  window — daemon and app both dead — blocks writers without losing data and
+  is bounded by daemon supervision.
+- **The app streams attached-period output to the daemon for one unbroken
+  history.** Rejected as a standing per-byte tax (roughly tmux's parse bill,
+  relocated) on exactly the loaded machine this design targets, purchasing
+  gapless terminal scrollback that transcripts already provide where it
+  matters. The two-store model with pull-on-demand keeps machine reads
+  current at zero steady-state cost.
+- **State handback at detach** (the app serializes its full terminal state to
+  the daemon when it detaches). Its worst case sits on the worst edge: an
+  app crash is a detach with no handback, leaving both a permanent history
+  gap and a stale emulator resuming mid-stream, and it requires a full
+  SwiftTerm state export/import surface exercised only at failure time.
+- **A purpose-built minimal VT parser.** The `ANSIEscape` scar tissue is the
+  refutation: the escape-sequence long tail is where the bugs live, and a
+  second interpretation of the stream can disagree with the viewer's.
+  Likewise **a third-party headless VT** (e.g. libghostty-vt): well-tested,
+  but a new dependency and a second interpretation; SwiftTerm headless gives
+  one parser for both pictures.
+- **Persisting the daemon's emulator to disk.** Buys a cold-restorable
+  picture across daemon crashes at the cost of a write cadence, a file
+  format, and a new durable resource needing a reclaimer — for a screen the
+  jiggle heals and a history the transcript already holds.
+- **Live-migrating running sessions between transports at flag flip.**
+  Extracting a live pty from a tmux server is ptrace-grade surgery with no
+  payoff; sessions converge to the new transport as they naturally recycle.
+- **Adopting unclaimed holders into the UI** (iTerm2's orphan adoption).
+  TBD's database records intent and its transcripts survive independently; a
+  row-less holder is a half-finished deletion, not a treasure, and adoption
+  UI is real complexity.
+- **Predictive local echo (the mosh approach) instead of removing tmux.**
+  Prediction speculates only about the echo of the user's own printable
+  keystrokes; it does nothing for program output, scrolling, or a
+  full-screen TUI repainting — which is most of what a fleet of streaming
+  agents shows. It is a complement to a fast path, not a substitute.

--- a/docs/specs/2026-08-30-pty-holder-session-transport-design.md
+++ b/docs/specs/2026-08-30-pty-holder-session-transport-design.md
@@ -733,9 +733,20 @@ of which is carried into this design:
 
 ## Rejected alternatives
 
-- **Keeping tmux and sharding servers more finely.** Measured: a busy server
-  against a private one-pane server differed by 34.1 vs 36.5 ms p50 under
-  load — pane count per server is not the lever; the wakeups are.
+- **Keeping tmux and sharding servers more finely.** Rejected on mechanism,
+  not on measurement: the cost of tmux is per-keystroke process wakeups, and
+  every server has those no matter how few panes it holds — so sharding
+  redistributes panes without removing a single wakeup. The supporting
+  measurement (a busy server against a private one-pane server, 34.1 vs
+  36.5 ms p50 under load) is **weaker than it looks and should not be leaned
+  on**: `tmux-server-contention.py` forks a `tmux send-keys` client per
+  sample, so both arms carry a fork+exec that dominates the reading — which is
+  why those numbers sit ~30× above the 1.1 ms p50 the fork-avoiding method
+  measures for quiet tmux. Both arms share the method, so a large difference
+  would still have surfaced; but at that resolution the run cannot rule out a
+  difference of a few milliseconds. It supports "pane count is not a large
+  effect", not "pane count is not an effect", and the argument above does not
+  need the stronger claim.
 - **The daemon holds the masters itself (no holder).** A daemon restart is
   precisely one of the windows persistence exists to cover, and on a
   development machine the daemon restarts constantly. The holder exists to

--- a/docs/specs/2026-08-30-pty-holder-session-transport-design.md
+++ b/docs/specs/2026-08-30-pty-holder-session-transport-design.md
@@ -504,12 +504,24 @@ the process table — the same argument as every other resource here.
   daemon (a stale daemon from a different checkout is a known hazard on a
   development machine) — and must never feed the exited path. **A rejected
   connection is terminal for this sweep in both directions**: not exited, and
-  not killed either. Killing requires positive proof of ownership — a
-  completed handshake — and a rejection is the absence of that proof, so a
-  holder that will not talk to us is left alone and logged, never reclaimed on
-  the theory that it has no row. Only a holder that handshakes and then turns
-  out to have no session row is a half-finished deletion, and that is the case
-  where the daemon kills the child and the holder.
+  not killed either — a holder that will not talk to us is left alone and
+  logged, never reclaimed on the theory that it has no row.
+
+  **A completed handshake is proof of liveness, not of ownership**, and only
+  ownership licenses a kill. Two installations can share a holders directory —
+  the default `TBD_HOME` is shared by every checkout on a machine — so
+  "reachable and absent from *my* database" is exactly the shape a foreign but
+  perfectly healthy session presents. The holder therefore carries an **owner
+  token**, given at spawn and returned by every handshake: a UUID minted once
+  per installation and persisted in the `config` row. It identifies the
+  installation rather than the process, so it survives daemon restarts — a
+  token that did not would strand a daemon from reclaiming the holders it
+  spawned a moment earlier, which is the common case, not the exotic one. The
+  sweep kills only a holder whose token matches its own; a mismatch is left
+  alone and logged, exactly like a rejection. Only a holder that handshakes,
+  proves the same owner, and still has no session row is a half-finished
+  deletion, and that is the case where the daemon kills the child and the
+  holder.
 
   **Row-lessness is only meaningful once creation can no longer be in flight.**
   Reconcile runs on demand from RPC handlers, not only at startup, so it can

--- a/docs/specs/2026-08-30-pty-holder-session-transport-design.md
+++ b/docs/specs/2026-08-30-pty-holder-session-transport-design.md
@@ -233,10 +233,16 @@ distributed protocol.
   sidecar. The app feeds the preamble into SwiftTerm first, then goes live on
   the fd, then jiggles (see below). Reattach therefore paints the last-known
   screen instantly, as tmux does today. Ownership transfers on the app's
-  acknowledgement, not on the send: if the vend or the ack fails, the daemon
-  resumes reading and the session is simply still detached — the invariant is
-  "at most one reader", so the failure direction is always back to the
-  fallback reader.
+  acknowledgement, not on the send. A failed vend or a lost ack does **not**
+  license an unconditional resume, because a lost ack and a lost app are
+  indistinguishable on the wire and the app may already be live on its dup —
+  resuming there would be the double read this whole design exists to prevent.
+  So the daemon applies the same liveness gate as App death below: app
+  confirmed gone, resume reading and the session is detached again; app alive
+  or not yet determined, stay off the fd and await reconnect and re-claim. The
+  invariant is "at most one reader", so the failure direction is always toward
+  reading nothing until liveness says otherwise — accepting a recoverable
+  stall over an unrecoverable corruption.
 - **Detach.** The mirror image, carrying the same ordering discipline in the
   opposite direction: the app stops reading and closes its dup, and **only
   then** tells the daemon. The detach notice carries a **snapshot preamble of
@@ -535,8 +541,14 @@ flag with a soak and a stated graduation plan.
   continuously — the hardest code in the design gets adversarial testing for
   free. Graduation gates on field evidence: no double-reader incidents, the
   reconcilers holding (no growth in unclaimed holders or socket litter), and
-  latency flatness confirmed under load by the existing probes in
-  `scripts/diag/`.
+  latency flatness re-confirmed under load by re-running the keystroke-echo
+  measurement whose methodology the companion research record documents.
+  That harness is a **deliverable of this work, not an existing tool to lean
+  on**: `scripts/diag/` today holds only a commit-latency report and an
+  RPC-volume report, neither of which measures keystroke echo. A design
+  justified by a latency curve has to ship the committed probe that can
+  re-draw that curve on demand, or graduation is a judgement call rather than
+  a measurement.
 - **Graduation.** Flip `Config.ptyHolderDefault` to `true` — a one-line
   change that reaches everyone who never chose while preserving every
   explicit opt-out. Removing the tmux path entirely is separate, later work,

--- a/docs/specs/2026-08-30-pty-holder-session-transport-design.md
+++ b/docs/specs/2026-08-30-pty-holder-session-transport-design.md
@@ -305,15 +305,46 @@ backpressure. The daemon-only restart path — a live app throughout — is the
 scenario the claim handshake exists for, and ordinary development restarts
 exercise it continuously.
 
-### Input is not arbitrated
+### Input is not arbitrated, but it is serialized
 
 Reading the master is exclusive; writing is not. The daemon keeps its master
 dup for the session's whole life and injects input (`tbd terminal send`,
-queued prompts, supervision nudges) by writing to it directly, whether or not
-a viewer is attached. This retires a real bug class: today a daemon keystroke
-is addressed to a tmux pane coordinate resolved at send time and can hit the
-wrong session after pane reuse; a write to an fd bound to the session at
-spawn cannot miss.
+queued prompts, supervision nudges) by writing to it. This retires a real bug
+class: today a daemon keystroke is addressed to a tmux pane coordinate
+resolved at send time and can hit the wrong session after pane reuse; a write
+to an fd bound to the session at spawn cannot miss.
+
+It also introduces one, which the design must answer rather than inherit.
+Today every injection funnels through the single tmux server process, so
+tmux serializes daemon input against user keystrokes for free. Here the app
+and the daemon hold separate fds to the same master, and a `write()` to a tty
+is not atomic — so a daemon injection landing mid-keystroke can shear. The
+sharp case is bracketed paste: user bytes arriving between `ESC[200~` and
+`ESC[201~` are swallowed into the pasted text, and a torn marker leaves the
+TUI's paste state desynchronized. Rare, and recoverable by retyping, but it
+is a regression against today and it is not acceptable to leave implicit.
+
+Three rules close it, in increasing order of how often they apply.
+
+- **Every injection is one message.** The daemon completes partial writes in
+  a loop while holding that session's write lock, so a payload is never
+  interleaved with another *daemon* write. A bracketed paste is one message
+  including both markers — the framing is never split across a decision.
+- **While a viewer is attached, the daemon injects through the app**, over
+  the sidecar frames that already carry input for the control-mode path. The
+  app is then the session's only writer as well as its only reader, and the
+  concurrency simply does not exist. This is the mirror of how reads already
+  work: pull from whichever store is live rather than reaching past it.
+- **The app is not allowed to become a single point of failure for
+  injection.** If it does not acknowledge within a bounded deadline on an
+  injected clock, the daemon writes directly and accepts the shear risk.
+
+That last fallback is deliberately fail-*open*, where the read side's
+safety rail fails closed, and the asymmetry is the point: an unanswered read
+can be resolved by refusing to act on a stale screen, but an unanswered
+injection that is simply dropped leaves an agent waiting forever for a prompt
+that never arrives. A rare sheared keystroke is the smaller harm than a
+queued prompt that silently never lands.
 
 Resize follows the reader: whichever process currently reads the master owns
 `TIOCSWINSZ` — the app drives it from the view while attached, the daemon

--- a/docs/specs/2026-08-30-pty-holder-session-transport-design.md
+++ b/docs/specs/2026-08-30-pty-holder-session-transport-design.md
@@ -115,6 +115,21 @@ bytes the other reader never sees).
   `connect`. The socket is bound with owner-only permissions. One client at a
   time, enforced holder-side: a second connection is accepted and immediately
   rejected with a sentinel protocol version.
+- **Creation is serialized by an advisory lock.** A socket file alone cannot
+  distinguish a live holder from the corpse of a SIGKILLed one, and `bind`
+  refuses a path that already exists — so "unlink the stale socket, then bind"
+  is a race two spawners can both win, leaving one holder bound to a path the
+  other has already unlinked and a session nobody can reach. Beside each
+  socket sits a zero-byte lock file on the same UUID. A spawner takes an
+  exclusive `flock` on it before unlinking or binding anything; the descriptor
+  carrying the lock is passed across exec to the holder (`FD_CLOEXEC`
+  cleared) and the daemon closes its own copy, so the holder alone holds it
+  for its whole life. A spawner that cannot take the lock has learned that a
+  live holder owns that UUID **without connecting to it**, and backs off
+  instead of clearing the path — which is what makes the stale-daemon hazard
+  named under Reconciliation safe rather than merely detectable. The kernel
+  drops the lock when the holder dies, so nothing can leak but an empty file,
+  swept with the socket by `OrphanGC`.
 - **Protocol.** Minimal and versioned from day one. Verbs: report the child
   (pid, tty name, launch parameters, alive/exited status) and hand over a
   master dup; report exit status; forget the child (close the master and stop
@@ -193,14 +208,23 @@ distributed protocol.
   preamble into SwiftTerm first, then goes live on the fd, then jiggles (see
   below). Reattach therefore paints the last-known screen instantly, as tmux
   does today.
-- **Detach.** The app tells the daemon and closes its dup; the daemon resumes
-  reading and jiggles so a full-screen program repaints into the daemon's
-  emulator.
+- **Detach.** The mirror image, carrying the same ordering discipline in the
+  opposite direction: the app stops reading and closes its dup, and **only
+  then** tells the daemon; the daemon resumes reading on receipt and jiggles
+  so a full-screen program repaints into the daemon's emulator. The
+  close-before-notify order is what preserves the single-reader invariant — a
+  notify-first detach would put the daemon on the fd while the app's last
+  `read()` is still outstanding, which is the double-reader corruption in
+  miniature. An app that dies mid-detach needs no special handling: the fd
+  closes with the process and the app-death path below covers it.
 - **App death.** A sidecar disconnect alone is not death: the sidecar has a
   designed reconnect path, so a socket-level drop can leave the app alive,
   holding its dups, still reading — and seizing then is exactly the
   double-reader corruption this design exists to avoid. On disconnect the
-  daemon first checks whether the app process is alive. Gone: every session
+  daemon first checks whether the app process is alive, using the same
+  identity-verified check the holder-death kill uses — recorded pid plus
+  executable and start time — so a reused pid cannot make a dead app look
+  alive and stall the fleet. Gone: every session
   it held reverts to daemon-read, with a jiggle, no cooperation from the dead
   process needed. Alive: the daemon stays off the fds and treats the drop
   like the startup grace window — await reconnect and re-claim, seize only on
@@ -210,9 +234,10 @@ distributed protocol.
   no reader: their writers block on the kernel tty buffer, which is
   backpressure, not loss, and drains when the daemon returns.
 - **Daemon startup (re-adoption).** The new daemon connects to every holder
-  and adopts a master dup, but **reads nothing yet**. If no app process is
-  alive, it becomes reader of everything immediately. If an app process is
-  alive, it waits for that app's sidecar handshake, which carries the list of
+  and adopts a master dup, but **reads nothing yet**. Every app-liveness
+  question below is the identity-verified check described under App death,
+  never a bare `kill(pid, 0)`. If no app process is alive, it becomes reader
+  of everything immediately. If an app process is alive, it waits for that app's sidecar handshake, which carries the list of
   sessions the app holds fds for; claimed sessions stay app-owned and
   everything else begins draining. The wait is bounded by a grace window on
   an injected clock; on expiry the daemon re-checks app liveness — app gone,
@@ -378,8 +403,8 @@ Everything TBD does through tmux today, and its replacement:
 ## Reconciliation
 
 Per the named-reconciler doctrine, the new durable resources are the holder
-processes, their socket files, and (transitively) the agent processes under
-them. Orphans can arise because holder creation is non-transactional against
+processes, their socket and lock files, and (transitively) the agent processes
+under them. Orphans can arise because holder creation is non-transactional against
 the process table — the same argument as every other resource here.
 
 - **`WorktreeLifecycle+Reconcile`** swaps its ground truth from tmux windows
@@ -397,11 +422,14 @@ the process table — the same argument as every other resource here.
   little else, and it cuts against the database-is-intent model the other
   reconcilers already follow.
 - **`OrphanGC`** (hourly, gated on `gcEnabled` as today) gains two sweeps:
-  unlink socket files with no listening process behind them, and re-run the
-  holder-versus-database check between startup reconciles. The socket sweep
-  is mandatory, not hygienic: a SIGKILLed holder cannot unlink its own
-  socket, and the tmux precedent on this machine was ~7,100 dead socket
-  files, because tmux unlinks lazily on rebind and nothing ever rebound.
+  unlink socket files (and their sibling lock files) with no listening
+  process behind them, and re-run the holder-versus-database check between
+  startup reconciles. The socket sweep is mandatory, not hygienic: a
+  SIGKILLed holder cannot unlink its own socket, and the tmux precedent on
+  this machine was ~7,100 dead socket files, because tmux unlinks lazily on
+  rebind and nothing ever rebound. The lock file leaks only as an empty
+  file — the kernel released its lock when the holder died — so it is swept
+  for tidiness on the same pass rather than needing its own reclaimer.
 - **`AgentReaper`** gains a holder-transport leg. Its existing sweep
   enumerates children of tmux server pids and structurally cannot see a
   child re-parented to launchd, so for holder-transport sessions it sweeps by
@@ -489,8 +517,10 @@ of which is carried into this design:
   one method may read after the handshake, or interleaved partial reads
   corrupt the stream.
 - **Creation races are settled by an advisory lock file** held for the
-  server's whole life; connecting to a busy server is settled separately by
-  accept-then-reject with a sentinel version.
+  server's whole life — adopted verbatim, and specified under "Creation is
+  serialized by an advisory lock" above. Connecting to a *busy* server is a
+  separate problem with a separate answer: accept-then-reject with a sentinel
+  version.
 - **SIGHUP is not enough on user-initiated close.** A supervised child can
   ignore SIGHUP, leaving the supervisor alive to be adopted later; closing a
   session must make the holder forget the child (close the master, stop

--- a/docs/specs/2026-08-30-pty-holder-session-transport-design.md
+++ b/docs/specs/2026-08-30-pty-holder-session-transport-design.md
@@ -130,6 +130,17 @@ bytes the other reader never sees).
   named under Reconciliation safe rather than merely detectable. The kernel
   drops the lock when the holder dies, so nothing can leak but an empty file,
   swept with the socket by `OrphanGC`.
+
+  Two rules keep that safe against holder versions. **A socket with no
+  sibling lock is unowned-but-unproven, never unowned**: the spawner must
+  handshake the existing socket before clearing it, and a rejected or
+  timed-out handshake means leave it alone. Absence of a lock is not evidence
+  of absence of a holder. And **the rendezvous layout is frozen at v1** —
+  socket name, lock name, lock semantics — deliberately outside the
+  protocol's version negotiation, because it has to be interpretable *before*
+  a connection exists, which is exactly when no version has been exchanged.
+  A future holder needing a different rendezvous gets a different directory,
+  not a different convention in the same one.
 - **Protocol.** Minimal and versioned from day one. Verbs: report the child
   (pid, tty name, launch parameters, alive/exited status) and hand over a
   master dup; report exit status; forget the child (close the master and stop

--- a/docs/specs/2026-08-30-pty-holder-session-transport-design.md
+++ b/docs/specs/2026-08-30-pty-holder-session-transport-design.md
@@ -587,14 +587,20 @@ flag with a soak and a stated graduation plan.
 
 - **Flag.** `pty_holder_enabled`, a `config` column added by a `.sql`
   migration with **no SQL `DEFAULT` clause**, so unset stays a third state.
-  The shipped default is `false`, resolved the way every other nullable gate
-  in `ConfigRecord.toModel(...)` resolves one: a `ptyHolderDefault: Bool =
-  Config.ptyHolderDefault` parameter on `toModel`, and `pty_holder_enabled ??
-  ptyHolderDefault` in the body. The injected parameter is not decoration —
-  it is what lets a test change the effective default and prove NULL follows
-  it while an explicit `0` does not. Tests cover all three states: a
-  pre-migration row reads NULL rather than `0`, NULL follows the injected
-  default, and an explicit `0` survives a change to it.
+  The shipped default is `false`, resolved in `ConfigRecord.toModel(...)` the
+  way the **graduation-ready** gates there resolve theirs: a
+  `ptyHolderDefault: Bool = Config.ptyHolderDefault` parameter on `toModel`,
+  and `pty_holder_enabled ?? ptyHolderDefault` in the body. That is a minority
+  of the gates in that file, not all of them — roughly seven follow it, while
+  a dozen older ones still hardcode `?? false` or `?? true`. Those older gates
+  are the ones CLAUDE.md describes as not retrofittable, because their columns
+  shipped with a SQL `DEFAULT` that backfilled every existing row and destroyed
+  the distinction between "chose off" and "never chose". The convention here is
+  the one to copy precisely because the file is not uniform. The injected
+  parameter is not decoration — it is what lets a test change the effective
+  default and prove NULL follows it while an explicit `0` does not. Tests cover
+  all three states: a pre-migration row reads NULL rather than `0`, NULL
+  follows the injected default, and an explicit `0` survives a change to it.
 - **Granularity: spawn time only.** A session records its transport (`tmux`
   or `holder`) in its database row at creation and keeps it for life; the app
   attaches by whichever transport the row names. Flipping the flag never

--- a/docs/specs/2026-08-30-pty-holder-session-transport-design.md
+++ b/docs/specs/2026-08-30-pty-holder-session-transport-design.md
@@ -632,6 +632,28 @@ flag with a soak and a stated graduation plan.
   that can re-draw it — otherwise graduation is a judgement call wearing a
   measurement's clothes.
 
+  **Flatness is the claim, so flatness is what the threshold has to test.** An
+  absolute latency bound alone would pass a transport that is merely fast on a
+  quiet machine, which is exactly what tmux already is — its p50 is 1.1 ms and
+  imperceptible. The graduation run is therefore a paired measurement, and all
+  four conditions must hold:
+
+  - **Workload:** the design point — at least 100 concurrent sessions at
+    sustained load on one machine, matched against an idle-machine run of the
+    same probe, interleaved so both arms see the same conditions.
+  - **Sample:** at least 2,000 keystrokes per arm, the size the original
+    measurements used.
+  - **Absolute bound:** p90 keystroke echo at load stays at or under **5 ms**,
+    the ceiling a raw pty was never observed to exceed at any load up to 117.
+  - **Flatness bound:** p90 at load is no more than **2×** p90 at idle. This is
+    the condition that actually discriminates, and it is the one tmux fails —
+    its p90 went 9.3 → 12.7 → 139 ms as load rose, a 15× spread, because a
+    tmux keystroke costs process wakeups whose latency is scheduling delay.
+
+  Any load-dependent growth beyond that flatness bound means the transport has
+  a wakeup in the echo path that the design says it does not, and graduation
+  does not proceed on the theory that the absolute number still looks small.
+
   **"No double-reader violations" is only evidence if something can see one.**
   A double read is silent by construction — each `read()` takes bytes the other
   reader never sees — so an absence of reports is not an absence of the fault,

--- a/docs/specs/2026-08-30-pty-holder-session-transport-design.md
+++ b/docs/specs/2026-08-30-pty-holder-session-transport-design.md
@@ -479,6 +479,20 @@ the process table — the same argument as every other resource here.
   the theory that it has no row. Only a holder that handshakes and then turns
   out to have no session row is a half-finished deletion, and that is the case
   where the daemon kills the child and the holder.
+
+  **Row-lessness is only meaningful once creation can no longer be in flight.**
+  Reconcile runs on demand from RPC handlers, not only at startup, so it can
+  land in the window between a holder becoming connectable and its session row
+  committing — and killing there would destroy a session that was merely being
+  born. Two things close that window, and both are required. Creation **commits
+  the session row before the holder becomes discoverable**: the row is written
+  in a creating state first, and only then is the holder spawned, so a
+  discoverable holder always has a row unless something failed. And the sweep
+  is **keep-biased for young holders** — a holder whose socket is newer than a
+  grace window is left alone regardless of row state, the same guard `OrphanGC`
+  already applies to the same race shape. Ordering alone would be enough if
+  nothing ever crashed between the two steps; the grace window is what makes
+  the guarantee hold when something does.
   **Kill, not adopt** — iTerm2 adopts unclaimed survivors into new tabs
   because its live processes are the only copy of anything; TBD's transcripts
   persist independently, so adoption would buy a mystery-session UI and
@@ -510,7 +524,7 @@ flag with a soak and a stated graduation plan.
 - **Flag.** `pty_holder_enabled`, a `config` column added by a `.sql`
   migration with **no SQL `DEFAULT` clause**, so unset stays a third state.
   The shipped default is `false`, resolved the way every other nullable gate
-  in `ConfigStore.toModel(...)` resolves one: a `ptyHolderDefault: Bool =
+  in `ConfigRecord.toModel(...)` resolves one: a `ptyHolderDefault: Bool =
   Config.ptyHolderDefault` parameter on `toModel`, and `pty_holder_enabled ??
   ptyHolderDefault` in the body. The injected parameter is not decoration —
   it is what lets a test change the effective default and prove NULL follows
@@ -533,13 +547,20 @@ flag with a soak and a stated graduation plan.
   spawns to holders; on → off leaves every running holder session on its
   holder and routes new spawns back to tmux.
 - **Coexistence cost, stated honestly.** Both paths live until graduation:
-  two attach paths in the app, two reconciliation ground truths, and a
-  doubled test surface. Each gated branch gets tests for flag-on and
-  flag-off behavior.
+  two reconciliation ground truths, a doubled test surface, and — counted
+  accurately — a **third** attach path in the app, not a second. The app
+  already carries two: the older one forks a `tmux attach` client per viewer
+  and lets SwiftTerm read that client's pty, and the control-mode one feeds
+  SwiftTerm bytes the daemon relays over the FD sidecar. The holder path joins
+  them. That the count is three is an argument for graduating and deleting
+  promptly, not against the design — and the control-mode path's fd-in,
+  `feed(byteArray:)`-out shape is the closest existing seam to what the holder
+  transport needs, so the third path is cheaper than the second was. Each
+  gated branch gets tests for flag-on and flag-off behavior.
 - **Soak.** Enable on a development machine running a real fleet at real
   load. Ordinary development restarts exercise the re-adoption path
   continuously — the hardest code in the design gets adversarial testing for
-  free. Graduation gates on field evidence: no double-reader incidents, the
+  free. Graduation gates on field evidence: no double-reader violations, the
   reconcilers holding (no growth in unclaimed holders or socket litter), and
   latency flatness re-confirmed under load by re-running the keystroke-echo
   measurement whose methodology the companion research record documents.
@@ -549,6 +570,19 @@ flag with a soak and a stated graduation plan.
   justified by a latency curve has to ship the committed probe that can
   re-draw that curve on demand, or graduation is a judgement call rather than
   a measurement.
+
+  **"No double-reader violations" is only evidence if something can see one.**
+  A double read is silent by construction — each `read()` takes bytes the other
+  reader never sees — so an absence of reports is not an absence of the fault,
+  and gating the design's central safety property on unaided observation would
+  be the weakest step in the argument. Two positive detectors carry that bar
+  instead. An always-on **reader-count assertion**: the daemon holds explicit
+  per-session reader state, and every transition into reading asserts the count
+  was zero, incrementing a violation counter and logging loudly rather than
+  trusting the arbitration to be correct. And a soak-time **continuity
+  canary**: a known sequence written periodically to a session, whose reader
+  checks it arrives unbroken — a gap is byte theft, positively observed rather
+  than inferred. Graduation reads those two numbers.
 - **Graduation.** Flip `Config.ptyHolderDefault` to `true` — a one-line
   change that reaches everyone who never chose while preserving every
   explicit opt-out. Removing the tmux path entirely is separate, later work,

--- a/docs/specs/2026-08-30-pty-holder-session-transport-design.md
+++ b/docs/specs/2026-08-30-pty-holder-session-transport-design.md
@@ -24,9 +24,11 @@ The justification is **scaling headroom, not current latency**. At quiet load
 tmux costs 1.1 ms p50 per keystroke and is imperceptible; this design does not
 claim to fix any latency a user feels today. What the measurements show is that
 a raw pty is *flat* under load (never exceeded 5 ms at any load including 117)
-while tmux degrades superlinearly (p90 of 9.3 → 12.7 → 139 ms as load rises),
-because a tmux keystroke costs two extra process wakeups whose latency is
-scheduling delay. tmux is therefore the component that breaks first as the
+while tmux degrades superlinearly (p90 of 9.3 → 12.7 → 139 ms as load rises —
+the 139 ms bucket is n=4 and directional only, so read it as a direction, not a
+figure; the 9.3 → 12.7 growth is the solid part and is already the whole point,
+since flat means flat), because a tmux keystroke costs two extra process
+wakeups whose latency is scheduling delay. tmux is therefore the component that breaks first as the
 fleet grows. The design point is roughly twice the present fleet: **~150
 concurrent sessions at sustained load ≥ 100** on one machine.
 
@@ -638,17 +640,29 @@ flag with a soak and a stated graduation plan.
   imperceptible. The graduation run is therefore a paired measurement, and all
   four conditions must hold:
 
-  - **Workload:** the design point — at least 100 concurrent sessions at
-    sustained load on one machine, matched against an idle-machine run of the
-    same probe, interleaved so both arms see the same conditions.
-  - **Sample:** at least 2,000 keystrokes per arm, the size the original
-    measurements used.
+  - **Workload:** the design point as stated above — **~150 concurrent sessions
+    at sustained load ≥ 100** on one machine, matched against an idle-machine
+    run of the same probe, interleaved so both arms see the same conditions.
+    Session count and load are two different numbers and both have to be met;
+    validating at 100 sessions would clear a materially lower bar than the
+    design targets.
+  - **Sample:** at least 2,000 keystrokes per arm. This is a bar chosen for
+    graduation, **not** a repeat of the original method: the load-based latency
+    runs behind the headline numbers were small, and their highest-load bucket
+    was explicitly n=4 and directional only. That is precisely why graduation
+    needs a larger sample than the measurements that motivated it — a p90 is
+    the statistic under test, and a p90 from a handful of samples is not one.
   - **Absolute bound:** p90 keystroke echo at load stays at or under **5 ms**,
     the ceiling a raw pty was never observed to exceed at any load up to 117.
-  - **Flatness bound:** p90 at load is no more than **2×** p90 at idle. This is
-    the condition that actually discriminates, and it is the one tmux fails —
-    its p90 went 9.3 → 12.7 → 139 ms as load rose, a 15× spread, because a
-    tmux keystroke costs process wakeups whose latency is scheduling delay.
+  - **Flatness bound:** p90 at load is no more than **2×** p90 at idle. The
+    multiplier is set where it is because it has to sit clear of ordinary
+    scheduling jitter on a loaded machine while still failing anything with a
+    per-keystroke wakeup in the path — and tmux fails it by more than an order
+    of magnitude, so the exact value is not load-bearing. Its p90 went
+    9.3 → 12.7 → 139 ms as load rose; the 139 ms bucket is n=4 and directional
+    only, but even discarding it entirely the 9.3 → 12.7 growth already
+    exceeds nothing-should-grow, and the mechanism is not in doubt: a tmux
+    keystroke costs process wakeups whose latency is scheduling delay.
 
   Any load-dependent growth beyond that flatness bound means the transport has
   a wakeup in the echo path that the design says it does not, and graduation

--- a/scripts/diag/_rtt_stamp.py
+++ b/scripts/diag/_rtt_stamp.py
@@ -1,0 +1,7 @@
+import sys,time
+o=open(sys.argv[1],'a',buffering=1)
+f=sys.stdin.buffer
+while True:
+    b=f.read1(65536)
+    if not b: break
+    o.write(f'{time.time():.6f} {b!r}\n')

--- a/scripts/diag/tmux-server-contention.py
+++ b/scripts/diag/tmux-server-contention.py
@@ -73,7 +73,7 @@ RECLAMATION. Both scratch sessions are durable external resources no sweep
 covers, so this script owns their whole life and kills them on every exit path,
 including Ctrl-C.
 """
-import argparse, os, shutil, subprocess, sys, time
+import argparse, os, shlex, shutil, subprocess, sys, time
 
 SCRATCH = os.environ.get("TMPDIR", "/tmp").rstrip("/")
 STAMPER = os.path.join(os.path.dirname(os.path.abspath(__file__)), "_rtt_stamp.py")
@@ -123,7 +123,11 @@ def arm_up(sock, tag):
                    capture_output=True)
     tmux(sock, "new-session", "-d", "-s", SESSION, "-c", "/tmp", "cat")
     pane = tmux(sock, "list-panes", "-t", f"={SESSION}", "-F", "#{pane_id}")
-    tmux(sock, "pipe-pane", "-o", "-t", pane, f"/usr/bin/python3 {STAMPER} {cap}")
+    # sys.executable, not a hardcoded /usr/bin/python3: if the interpreter is
+    # not at that exact path, pipe-pane fails silently, the capture stays
+    # empty, and the run reports NaN percentiles with nothing pointing at the
+    # cause -- a measurement that lies rather than one that errors.
+    tmux(sock, "pipe-pane", "-o", "-t", pane, f"{shlex.quote(sys.executable)} {shlex.quote(STAMPER)} {shlex.quote(cap)}")
     return pane, cap
 
 

--- a/scripts/diag/tmux-server-contention.py
+++ b/scripts/diag/tmux-server-contention.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Is tmux lag caused by the machine, or by how many panes share one tmux server?
+
+    tmux-server-contention.py [--samples 40] [--interval 0.4]
+
+WHY THIS EXISTS
+
+Typing through tmux is laggy in TBD's panel AND in an external emulator attached
+to the same server, while the same emulator with no tmux in the path is fast.
+That rules out both renderers and leaves the tmux layer. But "the tmux layer" has
+two very different faults inside it, and they call for opposite responses:
+
+  MACHINE   The box is oversubscribed (load 40+, fseventsd and kernel_task eating
+            cores). Every process waits in the run queue on every wakeup. tmux
+            feels worse than a raw pty only because it adds process hops, each
+            paying that wait. No TBD change fixes this.
+
+  SERVER    A tmux server is ONE single-threaded event loop, and TBD gives a whole
+            repo one server -- currently 60 and 78 panes on two of them. Every
+            pane's output is parsed by that one thread, so a keystroke is queued
+            behind however much output the other 77 panes just produced. This is
+            head-of-line blocking, TBD creates it by sharding per repo, and TBD
+            can fix it by sharding finer.
+
+THE DISCRIMINATOR
+
+Run the identical round-trip against two servers, interleaved within the same
+few milliseconds so they see the same system load, differing only in how many
+panes the server thread is juggling:
+
+  arm BUSY  a scratch pane on the live shared server (dozens of panes)
+  arm SOLO  a scratch pane on a private server this script mints (one pane)
+
+  both arms slow, and close together  -> MACHINE. Sharding buys nothing.
+  BUSY slow, SOLO fast                -> SERVER. Pane count per server is the
+                                         cause and sharding is the fix.
+
+Each sample yields two timestamps, which split the path further:
+
+  echo1  the pty line discipline echoes the token in the KERNEL before any
+         process reads it: tmux server -> pty master -> back. Starving a
+         userspace process cannot delay this, so echo1 is the tmux server's own
+         responsiveness.
+  echo2  `cat` then reads the line and writes it back -- echo1's path plus one
+         process wakeup, so (echo2 - echo1) is scheduling latency.
+
+MEASUREMENT HYGIENE. Keystrokes go only to panes this script created. It never
+sends to a live agent session, and the captures hold only its own tokens -- no
+agent output is recorded. Load average rides along on every sample because it
+has dominated every other effect in this investigation.
+
+RECLAMATION. Both scratch sessions are durable external resources no sweep
+covers, so this script owns their whole life and kills them on every exit path,
+including Ctrl-C.
+"""
+import argparse, os, subprocess, sys, time
+
+SCRATCH = os.environ.get("TMPDIR", "/tmp").rstrip("/")
+STAMPER = os.path.join(os.path.dirname(os.path.abspath(__file__)), "_rtt_stamp.py")
+SOLO_LABEL = "tbd-contention-solo"
+SESSION = "tbd-contention"
+
+
+def tmux(sock, *args, check=True):
+    r = subprocess.run(["tmux", "-S", sock, *args], capture_output=True, text=True)
+    if check and r.returncode != 0:
+        raise RuntimeError(f"tmux {' '.join(args)}: {r.stderr.strip()}")
+    return r.stdout.strip()
+
+
+def pane_count(sock):
+    r = subprocess.run(["tmux", "-S", sock, "list-panes", "-a"],
+                       capture_output=True, text=True)
+    return len(r.stdout.splitlines()) if r.returncode == 0 else 0
+
+
+def arm_up(sock, tag):
+    """Mint a scratch pane running `cat` and tee its output through the stamper.
+
+    `cat` needs no rc file, so nothing in the user's shell config can perturb the
+    timing or leak surprise output into the capture.
+    """
+    cap = f"{SCRATCH}/contention-{tag}.txt"
+    open(cap, "w").close()
+    subprocess.run(["tmux", "-S", sock, "kill-session", "-t", f"={SESSION}"],
+                   capture_output=True)
+    tmux(sock, "new-session", "-d", "-s", SESSION, "-c", "/tmp", "cat")
+    pane = tmux(sock, "list-panes", "-t", f"={SESSION}", "-F", "#{pane_id}")
+    tmux(sock, "pipe-pane", "-o", "-t", pane, f"/usr/bin/python3 {STAMPER} {cap}")
+    return pane, cap
+
+
+def arm_down(sock):
+    subprocess.run(["tmux", "-S", sock, "kill-session", "-t", f"={SESSION}"],
+                   capture_output=True)
+
+
+def pct(xs, p):
+    if not xs:
+        return float("nan")
+    s = sorted(xs)
+    return s[min(len(s) - 1, int(len(s) * p / 100))]
+
+
+def parse(cap, sends):
+    """Recover echo1/echo2 for each token from the stamped capture."""
+    hits = {}
+    for ln in open(cap, errors="replace"):
+        ts, _, payload = ln.partition(" ")
+        try:
+            t = float(ts)
+        except ValueError:
+            continue
+        for tok in sends:
+            if tok in payload:
+                hits.setdefault(tok, []).append(t)
+    e1, e2 = [], []
+    for tok, t0 in sends.items():
+        h = sorted(x for x in hits.get(tok, []) if x >= t0)
+        if not h:
+            continue
+        e1.append((h[0] - t0) * 1000)
+        if len(h) > 1:
+            e2.append((h[1] - h[0]) * 1000)
+    return e1, e2
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--busy-socket", default="/tmp/tmux-501/tbd-4c853a38")
+    ap.add_argument("--samples", type=int, default=40)
+    ap.add_argument("--interval", type=float, default=0.4)
+    a = ap.parse_args()
+
+    if not os.path.exists(a.busy_socket):
+        print(f"no such tmux socket: {a.busy_socket}")
+        return 1
+
+    solo_sock = f"{SCRATCH}/{SOLO_LABEL}"
+    busy_panes = pane_count(a.busy_socket)
+    print(f"BUSY {a.busy_socket}  panes={busy_panes}")
+    print(f"SOLO {solo_sock}  panes=1 (minted here)")
+    print(f"{a.samples} interleaved samples, {a.interval}s apart\n")
+
+    busy_pane, busy_cap = arm_up(a.busy_socket, "busy")
+    solo_pane, solo_cap = arm_up(solo_sock, "solo")
+    busy_sends, solo_sends, loads = {}, {}, []
+    try:
+        for i in range(1, a.samples + 1):
+            loads.append(os.getloadavg()[0])
+            for sends, sock, pane, pfx in (
+                (busy_sends, a.busy_socket, busy_pane, "B"),
+                (solo_sends, solo_sock, solo_pane, "S"),
+            ):
+                tok = f"CT{pfx}{i:05d}"
+                t0 = time.time()
+                subprocess.run(["tmux", "-S", sock, "send-keys", "-t", pane, tok, "Enter"],
+                               capture_output=True)
+                sends[tok] = t0
+                time.sleep(a.interval / 2)
+            if i % 10 == 0:
+                print(f"  {i}/{a.samples}  load={loads[-1]:.1f}")
+        time.sleep(1.0)  # let the last echoes land in the captures
+    except KeyboardInterrupt:
+        print("\ninterrupted; reporting what landed")
+    finally:
+        arm_down(a.busy_socket)
+        arm_down(solo_sock)
+        subprocess.run(["tmux", "-S", solo_sock, "kill-server"], capture_output=True)
+
+    print(f"\nload during run: min={min(loads):.1f} max={max(loads):.1f}\n")
+    print(f"{'arm':6} {'n':>4} {'echo1 p50':>10} {'p90':>8} {'max':>9}   "
+          f"{'echo2-1 p50':>12} {'p90':>8} {'max':>9}")
+    res = {}
+    for name, cap, sends in (("BUSY", busy_cap, busy_sends), ("SOLO", solo_cap, solo_sends)):
+        e1, e2 = parse(cap, sends)
+        res[name] = (e1, e2)
+        print(f"{name:6} {len(e1):>4} {pct(e1,50):>9.1f}m {pct(e1,90):>7.1f}m "
+              f"{pct(e1,100):>8.1f}m   {pct(e2,50):>11.1f}m {pct(e2,90):>7.1f}m "
+              f"{pct(e2,100):>8.1f}m")
+
+    b1, s1 = res["BUSY"][0], res["SOLO"][0]
+    if b1 and s1:
+        ratio = pct(b1, 50) / max(pct(s1, 50), 0.001)
+        print(f"\nBUSY/SOLO echo1 p50 ratio: {ratio:.1f}x")
+        if ratio >= 2.0:
+            print("  -> SERVER. Pane count per tmux server is the cause;")
+            print("     sharding servers finer than one-per-repo is the fix.")
+        elif pct(s1, 50) > 25:
+            print("  -> MACHINE. A one-pane server is slow too; the box is")
+            print("     oversubscribed and sharding buys little.")
+        else:
+            print("  -> Both arms healthy right now. Re-run during a stall.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/diag/tmux-server-contention.py
+++ b/scripts/diag/tmux-server-contention.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Is tmux lag caused by the machine, or by how many panes share one tmux server?
 
-    tmux-server-contention.py [--samples 40] [--interval 0.4]
+    tmux-server-contention.py --busy-socket /tmp/tmux-$(id -u)/<name> [--samples 40] [--interval 0.4]
 
 WHY THIS EXISTS
 
@@ -22,11 +22,31 @@ two very different faults inside it, and they call for opposite responses:
             head-of-line blocking, TBD creates it by sharding per repo, and TBD
             can fix it by sharding finer.
 
+METHOD CAVEAT
+
+Every sample here shells out to `tmux send-keys`, so each measurement pays a
+fork+exec of a tmux client on top of whatever tmux itself does. The sibling
+script, tmux-vs-rawpty-idle.py, measured that fork+exec cost in isolation --
+5.1 ms p50 / 58.9 ms p90 on this machine -- and deliberately avoids it by
+driving a real attached client instead of spawning one per keystroke. The
+absolute numbers this script reports are dominated by fork+exec, not tmux,
+and are NOT comparable to the pty-driven numbers from that sibling script.
+
+Both arms pay the identical fork+exec tax, so a LARGE difference between BUSY
+and SOLO still shows through it -- that is what makes this script usable at
+all. But the noise that tax adds is tens of milliseconds wide, so this script
+cannot rule out a difference of a few milliseconds between a busy and a solo
+server; it can only see a difference large enough to clear that floor. A null
+result here means "no difference at this resolution," not "no difference."
+Reach for tmux-vs-rawpty-idle.py's fork-avoiding method when the question is
+whether a small difference exists.
+
 THE DISCRIMINATOR
 
-Run the identical round-trip against two servers, interleaved within the same
-few milliseconds so they see the same system load, differing only in how many
-panes the server thread is juggling:
+Run the identical round-trip against two servers, alternating BUSY and SOLO
+`interval / 2` apart (200 ms by default) so both arms of a pair see the same
+few hundred milliseconds of system load, differing only in how many panes
+the server thread is juggling:
 
   arm BUSY  a scratch pane on the live shared server (dozens of panes)
   arm SOLO  a scratch pane on a private server this script mints (one pane)
@@ -53,7 +73,7 @@ RECLAMATION. Both scratch sessions are durable external resources no sweep
 covers, so this script owns their whole life and kills them on every exit path,
 including Ctrl-C.
 """
-import argparse, os, subprocess, sys, time
+import argparse, os, shutil, subprocess, sys, time
 
 SCRATCH = os.environ.get("TMPDIR", "/tmp").rstrip("/")
 STAMPER = os.path.join(os.path.dirname(os.path.abspath(__file__)), "_rtt_stamp.py")
@@ -61,15 +81,32 @@ SOLO_LABEL = "tbd-contention-solo"
 SESSION = "tbd-contention"
 
 
+def resolve_tmux():
+    """Find the tmux binary: TMUX_BIN env var, then PATH, then the common
+    Homebrew-on-Apple-Silicon path as a last resort. A hardcoded absolute path
+    breaks on Intel Macs, MacPorts, and Linux, so this is the only place that
+    guesses -- everything else uses the result.
+    """
+    for candidate in (os.environ.get("TMUX_BIN"), shutil.which("tmux"),
+                       "/opt/homebrew/bin/tmux"):
+        if candidate and os.path.exists(candidate):
+            return candidate
+    print("no tmux binary found: set TMUX_BIN or install tmux on PATH", file=sys.stderr)
+    sys.exit(1)
+
+
+TMUX_BIN = resolve_tmux()
+
+
 def tmux(sock, *args, check=True):
-    r = subprocess.run(["tmux", "-S", sock, *args], capture_output=True, text=True)
+    r = subprocess.run([TMUX_BIN, "-S", sock, *args], capture_output=True, text=True)
     if check and r.returncode != 0:
         raise RuntimeError(f"tmux {' '.join(args)}: {r.stderr.strip()}")
     return r.stdout.strip()
 
 
 def pane_count(sock):
-    r = subprocess.run(["tmux", "-S", sock, "list-panes", "-a"],
+    r = subprocess.run([TMUX_BIN, "-S", sock, "list-panes", "-a"],
                        capture_output=True, text=True)
     return len(r.stdout.splitlines()) if r.returncode == 0 else 0
 
@@ -82,7 +119,7 @@ def arm_up(sock, tag):
     """
     cap = f"{SCRATCH}/contention-{tag}.txt"
     open(cap, "w").close()
-    subprocess.run(["tmux", "-S", sock, "kill-session", "-t", f"={SESSION}"],
+    subprocess.run([TMUX_BIN, "-S", sock, "kill-session", "-t", f"={SESSION}"],
                    capture_output=True)
     tmux(sock, "new-session", "-d", "-s", SESSION, "-c", "/tmp", "cat")
     pane = tmux(sock, "list-panes", "-t", f"={SESSION}", "-F", "#{pane_id}")
@@ -91,7 +128,7 @@ def arm_up(sock, tag):
 
 
 def arm_down(sock):
-    subprocess.run(["tmux", "-S", sock, "kill-session", "-t", f"={SESSION}"],
+    subprocess.run([TMUX_BIN, "-S", sock, "kill-session", "-t", f"={SESSION}"],
                    capture_output=True)
 
 
@@ -127,7 +164,13 @@ def parse(cap, sends):
 
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument("--busy-socket", default="/tmp/tmux-501/tbd-4c853a38")
+    ap.add_argument("--busy-socket", required=True,
+                    help="path to the live tmux server socket to test, e.g. "
+                         f"/tmp/tmux-{os.getuid()}/<name>. TBD names its "
+                         "per-repo socket from a worktree-derived hash, so "
+                         "there's no portable default -- list "
+                         f"/tmp/tmux-{os.getuid()}/ or check `tmux -L "
+                         "<name> list-sessions` to find the one you want.")
     ap.add_argument("--samples", type=int, default=40)
     ap.add_argument("--interval", type=float, default=0.4)
     a = ap.parse_args()
@@ -142,10 +185,25 @@ def main():
     print(f"SOLO {solo_sock}  panes=1 (minted here)")
     print(f"{a.samples} interleaved samples, {a.interval}s apart\n")
 
-    busy_pane, busy_cap = arm_up(a.busy_socket, "busy")
-    solo_pane, solo_cap = arm_up(solo_sock, "solo")
+    # Every scratch session gets torn down on every exit path, including a
+    # failure partway through setup. Record intent to tear down a socket
+    # *before* arming it, not after arm_up returns -- arm_down/kill-server
+    # against a socket that never got a session is a harmless no-op, but
+    # skipping cleanup because arm_up raised partway through is how the busy
+    # scratch session used to leak onto the live shared server.
+    armed_socks = []
     busy_sends, solo_sends, loads = {}, {}, []
+    # Bound before the try so an interrupt during setup lands in the handler
+    # below with defined names. Ctrl-C is caught, not propagated, so without
+    # this the "report what landed" path would raise NameError instead.
+    busy_cap = solo_cap = None
+
     try:
+        armed_socks.append(a.busy_socket)
+        busy_pane, busy_cap = arm_up(a.busy_socket, "busy")
+        armed_socks.append(solo_sock)
+        solo_pane, solo_cap = arm_up(solo_sock, "solo")
+
         for i in range(1, a.samples + 1):
             loads.append(os.getloadavg()[0])
             for sends, sock, pane, pfx in (
@@ -154,7 +212,7 @@ def main():
             ):
                 tok = f"CT{pfx}{i:05d}"
                 t0 = time.time()
-                subprocess.run(["tmux", "-S", sock, "send-keys", "-t", pane, tok, "Enter"],
+                subprocess.run([TMUX_BIN, "-S", sock, "send-keys", "-t", pane, tok, "Enter"],
                                capture_output=True)
                 sends[tok] = t0
                 time.sleep(a.interval / 2)
@@ -164,9 +222,14 @@ def main():
     except KeyboardInterrupt:
         print("\ninterrupted; reporting what landed")
     finally:
-        arm_down(a.busy_socket)
-        arm_down(solo_sock)
-        subprocess.run(["tmux", "-S", solo_sock, "kill-server"], capture_output=True)
+        for sock in armed_socks:
+            arm_down(sock)
+        if solo_sock in armed_socks:
+            subprocess.run([TMUX_BIN, "-S", solo_sock, "kill-server"], capture_output=True)
+
+    if busy_cap is None or solo_cap is None or not loads:
+        print("\ninterrupted before sampling began; nothing to report")
+        return
 
     print(f"\nload during run: min={min(loads):.1f} max={max(loads):.1f}\n")
     print(f"{'arm':6} {'n':>4} {'echo1 p50':>10} {'p90':>8} {'max':>9}   "

--- a/scripts/diag/tmux-vs-rawpty-idle.py
+++ b/scripts/diag/tmux-vs-rawpty-idle.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Why is a tmux-attached terminal laggy when a raw one on the same box is not?
 
-    tmux-vs-rawpty-idle.py [--reps 4] [--gaps 0.1,1,5,20]
+    tmux-vs-rawpty-idle.py --socket /tmp/tmux-$(id -u)/<name> [--reps 4] [--gaps 0.1,1,5,20]
 
 WHY THIS EXISTS
 
@@ -65,10 +65,26 @@ resources no sweep covers, so this script kills them on every exit path
 including Ctrl-C. Tokens go only to panes it created; no agent session is
 touched and no agent output is recorded.
 """
-import argparse, os, pty, select, signal, struct, subprocess, sys, termios, time, fcntl
+import argparse, os, pty, select, shutil, signal, struct, subprocess, sys, termios, time, fcntl
 
 SESSION = "tbd-idlecost"
-TMUX = "/opt/homebrew/bin/tmux"
+
+
+def resolve_tmux():
+    """Find the tmux binary: TMUX_BIN env var, then PATH, then the common
+    Homebrew-on-Apple-Silicon path as a last resort. A hardcoded absolute path
+    breaks on Intel Macs, MacPorts, and Linux, so this is the only place that
+    guesses -- everything else uses the result.
+    """
+    for candidate in (os.environ.get("TMUX_BIN"), shutil.which("tmux"),
+                       "/opt/homebrew/bin/tmux"):
+        if candidate and os.path.exists(candidate):
+            return candidate
+    print("no tmux binary found: set TMUX_BIN or install tmux on PATH", file=sys.stderr)
+    sys.exit(1)
+
+
+TMUX = resolve_tmux()
 
 
 def set_winsize(fd, rows=50, cols=200):
@@ -133,7 +149,13 @@ def pct(xs, p):
 
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument("--socket", default="/tmp/tmux-501/tbd-4c853a38")
+    ap.add_argument("--socket", required=True,
+                    help="path to the live tmux server socket to test, e.g. "
+                         f"/tmp/tmux-{os.getuid()}/<name>. TBD names its "
+                         "per-repo socket from a worktree-derived hash, so "
+                         "there's no portable default -- list "
+                         f"/tmp/tmux-{os.getuid()}/ or check `tmux -L "
+                         "<name> list-sessions` to find the one you want.")
     ap.add_argument("--reps", type=int, default=4)
     ap.add_argument("--gaps", default="0.1,1,5,20")
     a = ap.parse_args()

--- a/scripts/diag/tmux-vs-rawpty-idle.py
+++ b/scripts/diag/tmux-vs-rawpty-idle.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Why is a tmux-attached terminal laggy when a raw one on the same box is not?
+
+    tmux-vs-rawpty-idle.py [--reps 4] [--gaps 0.1,1,5,20]
+
+WHY THIS EXISTS
+
+The user's own A/B is the sharpest evidence in this investigation: iTerm2 with no
+tmux in the path is fast, iTerm2 attached to tmux is laggy, and TBD's panel is
+laggy in the same way at the same moment. Two unrelated renderers degrading
+together exonerates rendering and points at tmux -- but the obvious tmux stories
+have already been measured and refuted:
+
+  pane count per server   a private one-pane server was exactly as slow as a
+                          60-pane one (34.1 vs 36.5 ms p50), so head-of-line
+                          blocking across panes is not it, and sharding servers
+                          finer would buy nothing.
+  process scheduling      a woken process responded in 0.4 ms p50 at load 60, so
+                          the run queue is not starving anyone.
+
+What those runs could not see is that they sampled every 0.4 s, which keeps every
+process in the path continuously hot. Real typing follows a pause -- reading
+output, thinking -- and this box is memory-exhausted (12.6 of 14.3 GB swap in
+use, 75 agent processes, fseventsd at 3.5 GB). Under that pressure an idle
+process's pages are compressed or evicted, and the next keystroke pays the fault
+to bring them back.
+
+That predicts a difference the earlier probes were blind to, and it is exactly
+the difference the user reports:
+
+  raw pty   one process in the path (the shell), and the emulator is a hot
+            foreground app. Little to reclaim, so latency is flat in idle time.
+  tmux      adds a client AND a server, both background processes, both
+            reclaimable. Latency should grow with how long you were idle.
+
+THE MEASUREMENT
+
+Both arms are driven identically: write a token into a pty we own, then time
+until the token becomes visible coming back out of that same pty. That is
+keystroke-to-visible latency short of the GPU, and it is the quantity the user
+is actually complaining about.
+
+  RAW   our pty -> cat -> our pty
+  TMUX  our pty -> tmux client -> socket -> tmux server -> pane pty -> cat
+        -> server -> client -> our pty
+
+The tmux arm attaches a real client through a real pty rather than shelling out
+to `tmux send-keys`, because spawning a client per keystroke would measure
+fork+exec -- 5.1 ms p50 and 58.9 ms p90 on this box -- instead of tmux. Real
+typing forks nothing.
+
+Each gap is slept before the sample, and the arms are interleaved so both see the
+same system load. Load rides along because it has dominated every other effect
+here.
+
+  both flat across gaps        -> idle reclaim is not the mechanism; look
+                                  downstream at delivery to clients.
+  TMUX grows with gap, RAW flat -> memory pressure evicting the tmux processes.
+                                  The fix is pressure, not tmux.
+  both grow                    -> machine-wide reclaim; tmux only amplifies it
+                                  by having more processes to fault back in.
+
+RECLAMATION. The scratch session and both pty children are durable external
+resources no sweep covers, so this script kills them on every exit path
+including Ctrl-C. Tokens go only to panes it created; no agent session is
+touched and no agent output is recorded.
+"""
+import argparse, os, pty, select, signal, struct, subprocess, sys, termios, time, fcntl
+
+SESSION = "tbd-idlecost"
+TMUX = "/opt/homebrew/bin/tmux"
+
+
+def set_winsize(fd, rows=50, cols=200):
+    fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", rows, cols, 0, 0))
+
+
+def spawn_pty(argv):
+    pid, fd = pty.fork()
+    if pid == 0:
+        try:
+            os.execv(argv[0], argv)
+        finally:
+            os._exit(127)
+    set_winsize(fd)
+    return pid, fd
+
+
+def drain(fd, quiet_for=0.25, limit=3.0):
+    """Read until the fd has been silent for `quiet_for`, so a sample starts clean."""
+    end = time.time() + limit
+    last = time.time()
+    while time.time() < end:
+        r, _, _ = select.select([fd], [], [], 0.05)
+        if r:
+            try:
+                if not os.read(fd, 65536):
+                    return
+            except OSError:
+                return
+            last = time.time()
+        elif time.time() - last >= quiet_for:
+            return
+
+
+def sample(fd, token, timeout=8.0):
+    """Write the token, return ms until it is visible coming back out."""
+    buf = bytearray()
+    t0 = time.time()
+    os.write(fd, token + b"\r")
+    while time.time() - t0 < timeout:
+        r, _, _ = select.select([fd], [], [], timeout - (time.time() - t0))
+        if not r:
+            break
+        try:
+            chunk = os.read(fd, 65536)
+        except OSError:
+            break
+        if not chunk:
+            break
+        buf += chunk
+        if token in buf:
+            return (time.time() - t0) * 1000
+    return None
+
+
+def pct(xs, p):
+    if not xs:
+        return float("nan")
+    s = sorted(xs)
+    return s[min(len(s) - 1, int(len(s) * p / 100))]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--socket", default="/tmp/tmux-501/tbd-4c853a38")
+    ap.add_argument("--reps", type=int, default=4)
+    ap.add_argument("--gaps", default="0.1,1,5,20")
+    a = ap.parse_args()
+    gaps = [float(g) for g in a.gaps.split(",")]
+
+    if not os.path.exists(a.socket):
+        print(f"no such tmux socket: {a.socket}")
+        return 1
+
+    subprocess.run([TMUX, "-S", a.socket, "kill-session", "-t", f"={SESSION}"],
+                   capture_output=True)
+    subprocess.run([TMUX, "-S", a.socket, "new-session", "-d", "-s", SESSION,
+                    "-c", "/tmp", "-x", "200", "-y", "50", "cat"], capture_output=True)
+
+    pids = []
+    try:
+        raw_pid, raw_fd = spawn_pty(["/bin/cat"])
+        pids.append(raw_pid)
+        tmux_pid, tmux_fd = spawn_pty([TMUX, "-S", a.socket, "attach", "-t",
+                                       f"={SESSION}", "-f", "ignore-size"])
+        pids.append(tmux_pid)
+        time.sleep(1.5)  # let the tmux client finish its initial full redraw
+        drain(raw_fd); drain(tmux_fd)
+
+        results = {("RAW", g): [] for g in gaps}
+        results.update({("TMUX", g): [] for g in gaps})
+        loads = []
+        total = len(gaps) * a.reps
+        done = 0
+        for rep in range(a.reps):
+            for g in gaps:
+                for arm, fd in (("RAW", raw_fd), ("TMUX", tmux_fd)):
+                    drain(fd, quiet_for=0.15, limit=1.0)
+                    time.sleep(g)
+                    tok = f"IC{arm[0]}{rep}{int(g*10):04d}".encode()
+                    ms = sample(fd, tok)
+                    if ms is not None:
+                        results[(arm, g)].append(ms)
+                loads.append(os.getloadavg()[0])
+                done += 1
+                print(f"  {done}/{total}  gap={g}s  load={loads[-1]:.0f}", flush=True)
+    finally:
+        for p in pids:
+            try:
+                os.kill(p, signal.SIGKILL)
+                os.waitpid(p, 0)
+            except OSError:
+                pass
+        subprocess.run([TMUX, "-S", a.socket, "kill-session", "-t", f"={SESSION}"],
+                       capture_output=True)
+
+    print(f"\nload during run: min={min(loads):.0f} max={max(loads):.0f}")
+    print(f"\n{'idle gap':>9} | {'RAW p50':>9} {'p90':>8} {'max':>9} | "
+          f"{'TMUX p50':>9} {'p90':>8} {'max':>9} | {'ratio':>6}")
+    print("-" * 78)
+    for g in gaps:
+        r, t = results[("RAW", g)], results[("TMUX", g)]
+        ratio = pct(t, 50) / max(pct(r, 50), 0.001) if r and t else float("nan")
+        print(f"{g:>8}s | {pct(r,50):>8.1f}m {pct(r,90):>7.1f}m {pct(r,100):>8.1f}m | "
+              f"{pct(t,50):>8.1f}m {pct(t,90):>7.1f}m {pct(t,100):>8.1f}m | {ratio:>5.1f}x")
+
+    short, long = gaps[0], gaps[-1]
+    for arm in ("RAW", "TMUX"):
+        s, l = results[(arm, short)], results[(arm, long)]
+        if s and l:
+            print(f"{arm:5} {short}s -> {long}s idle: "
+                  f"{pct(s,50):.1f}ms -> {pct(l,50):.1f}ms "
+                  f"({pct(l,50)/max(pct(s,50),0.001):.1f}x)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Design spec for migrating TBD's terminal sessions off tmux onto per-session pty holders. Field measurement showed a raw pty's keystroke echo never exceeded 5 ms at any system load (it happens in the kernel line discipline, with no process wakeup), while tmux's p90 ran 9.3 → 12.7 → 139 ms as load rose — it degrades superlinearly because each keystroke costs two extra server wakeups whose latency is scheduling delay. The justification is scaling headroom, not current pain: at quiet load tmux is imperceptible, but it is the component that breaks first as the fleet grows. The spec targets ~2× today's fleet (~150 concurrent sessions at sustained load ≥ 100).

## Why this shape

The core precedent is iTerm2's session-restoration server: a supervisor that `forkpty()`s each job and hands the pty master to the app over `SCM_RIGHTS` costs zero process wakeups on the interactive path. The spec adapts that to TBD's advantage — an always-on daemon that can drain output while nothing is attached, covering exactly the window iTerm2 cannot. Key decisions, each with rejected alternatives written out in the spec:

- **Per-session holder** (never reads the pty; tiny, versioned, essentially frozen) over per-repo/global holders or holding masters in the daemon — blast radius one session, and holder upgrades become a non-event.
- **Daemon as arbiter and default reader**, draining detached sessions into a headless SwiftTerm emulator; attach is daemon-brokered over the existing FD sidecar with a snapshot preamble so reattach paints instantly.
- **Two-store model with pull-on-demand** over streaming attached output back to the daemon — machine reads stay current (pull from the app when attached, bounded, hibernation veto fails closed) at zero steady-state cost; the accepted loss is scrollback gaps across attached periods, which transcripts already cover.
- **Single-reader arbitration** that errs toward not reading (backpressure is recoverable; double-reads silently corrupt), checked against the restart script's real daemon-then-app sequencing.
- **Holder death is session death by policy** — prompt, identity-verified kill with a distinct exit reason and a transcript-based recovery ladder.

A fresh-context directional review ran against the committed spec; its findings (sidecar disconnect vs app death, wedged-app fleet stall, reaper blind spot for launchd-reparented children, and others) are folded in as the second commit.

## What this PR does

Adds `docs/specs/2026-08-30-pty-holder-session-transport-design.md`. No implementation, no flag, no migration — the spec itself defines the rollout (`pty_holder_enabled`, default-off, no SQL `DEFAULT`, spawn-time-only gating so both transports coexist through the soak) for the implementation PRs to follow. Reconciler duties are assigned per the named-reconciler doctrine, and a "Learnings from iTerm2" section directs implementers and reviewers to the prior-art evidence before re-deriving its scar tissue.

## Evidence & verification

Docs-only. The evidentiary basis is the measurement and research records under `docs/research/2026-08-30-terminal-session-persistence/` (landing separately from the branch they were produced on); the decision-critical numbers are restated in the spec so it stands alone. Design decisions were answered by a human in a brainstorming session per the repo's spec gate.

https://claude.ai/code/session_01UXqxcPYizvznh99Qb8JKrD
[20260830-boring-panda](https://cheapsteak.github.io/tbd/open/?worktree=A1E9CF50-E608-4F3C-BA8F-377D60BB7478)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an approved design for dedicated per-session terminal persistence.
  * Documented reconnection, reader handoff, snapshots, scrollback, resizing, recovery, rollout, and coexistence with existing persistence.
  * Added research comparing terminal persistence approaches, including reattachment, state retention, failure recovery, and cleanup.
  * Documented performance measurements and requirements for responsive sessions and reliable reattachment.

* **Chores**
  * Added diagnostic tools for measuring terminal latency, round-trip performance, and system contention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->