### PR TITLE
Decide the shared module cache once, in scripts/swift-safe

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -193,6 +193,7 @@ jobs:
           bash scripts/sweep-preflight-refs.test.sh
           bash scripts/nightly-flake-stress.test.sh
           bash scripts/restart-guard-lib.test.sh
+          bash scripts/restart-build-lib.test.sh
           python3 scripts/diag/daemon-footprint-watch.py --self-test
 
   review-scripts-tests:

--- a/docs/reclaim-build.md
+++ b/docs/reclaim-build.md
@@ -138,6 +138,9 @@ governor.
   machine owner's consent — e.g. `8` on a 12-core laptop. A `-j`/`--jobs` on
   the command line may lower it but not raise it; raise this instead.
 - `TBD_SWIFT_LOCK_TIMEOUT_SECONDS` sets the wait timeout (default `1800`).
+- `TBD_SWIFT_SHARED_MODULE_CACHE=0` restores SwiftPM's per-worktree module
+  cache, and `TBD_SWIFT_MODULE_CACHE_PATH` moves the shared one. See
+  "Shared module cache" below.
 - `TBD_SWIFT_LOCK_PATH` overrides the shared lock path for isolated testing.
 - `TBD_SWIFT_ALLOW_ORPHAN=1` keeps a queued build waiting even after the
   process that requested it exits. A queued wrapper otherwise records its
@@ -158,44 +161,68 @@ unaffected.
 
 ## Shared module cache
 
-`scripts/restart.sh` passes every governed Swift build through a **shared
-clang/Swift module cache** at `$HOME/Library/Caches/tbd/swift-module-cache`:
+`scripts/swift-safe` points every governed compile — `build`, `test` and `run`
+alike — at one **shared clang/Swift module cache** at
+`<home>/Library/Caches/tbd/swift-module-cache`, so all three entry points, and
+every worktree, plan identically:
 
-```sh
-scripts/swift-safe build -Xswiftc -module-cache-path -Xswiftc "$SHARED" -Xcc -fmodules-cache-path="$SHARED"
+```
+-Xswiftc -module-cache-path -Xswiftc <cache> -Xcc -fmodules-cache-path=<cache>
 ```
 
-Without it, every worktree's `.build` accumulates its own ~640 MB
-`ModuleCache` with near-identical contents (precompiled clang modules for
-Foundation, AppKit, SwiftUI, the NIO C shims, …). With it there is **one
-~610–690 MB copy total, regardless of worktree count**, and the per-worktree
-`.build` carries no ModuleCache at all (measured: clean build's `.build`
-drops ~2.1 GB → ~1.4 GB; local `ModuleCache` 707 MB → 0 MB). The `-Xcc
--fmodules-cache-path=` piece is what reaches the C-language dependency shim
-targets (e.g. CNIOAtomics) that `-Xswiftc -module-cache-path` alone misses
-(~70 MB residual otherwise).
+Without it every worktree's `.build` accumulates its own 510–818 MB
+`ModuleCache` of near-identical precompiled clang modules (Foundation, AppKit,
+SwiftUI, the NIO C shims, …). The `-Xcc -fmodules-cache-path=` half is what
+reaches the C-language dependency shim targets (e.g. CNIOAtomics) that
+`-Xswiftc -module-cache-path` alone misses.
+
+The wrapper is the only place that decides this, and that is the point:
+SwiftPM bakes the cache path into every compile command in
+`.build/debug.yaml` at plan time, so **two entry points that disagree about
+the path make every transition between them a full recompile**, in both
+directions. Do not reintroduce the flags in `scripts/restart.sh` or anywhere
+else. Design and evidence:
+[`docs/specs/2026-08-30-shared-module-cache-design.md`](specs/2026-08-30-shared-module-cache-design.md).
 
 Notes:
 
+- **The path is resolved from the passwd database, never `$HOME`.**
+  `scripts/test.sh` deliberately points `HOME` and `CFFIXED_USER_HOME` at a
+  scratch fence it deletes; a `$HOME`-derived path would resolve inside that
+  fence on every test run, minting an empty cache each time so every run paid
+  a full rebuild — silently, looking like nothing worse than slow tests.
+  `pwd.getpwuid(os.getuid()).pw_dir` answers the real home whatever the fence
+  does, so the fence needs no cooperation and `scripts/test.sh` needs no
+  change. Writing into `~/Library/Caches` during a test run is intended: it is
+  a build artifact, not test state, and it is not one of the stores the
+  fence's fingerprint detector brackets.
 - **Concurrency-safe.** clang's module cache is designed for concurrent
-  writers; parallel builds from multiple worktrees against the shared cache
-  were tested with zero lock errors.
-- **Stickiness (expected, not a bug).** SwiftPM bakes the cache path into
-  `.build/debug.yaml` at plan time. A later build after a flagged one silently
-  keeps using the shared cache — and conversely, the first build
-  after a manifest re-plan only picks the shared cache up if it runs with the
-  flags (i.e. via `restart.sh`). Flag alternation does not trigger
-  recompilation; worst case is a ~14 s re-plan.
+  writers, and in practice the wrapper's exclusive lock means at most one
+  build writes to it at a time.
+- **Callers may still choose.** `TBD_SWIFT_MODULE_CACHE_PATH` moves the
+  cache; `TBD_SWIFT_SHARED_MODULE_CACHE=0` restores SwiftPM's per-worktree
+  default. A caller that passes its own `-module-cache-path` is left alone —
+  a second, differently-spelled copy would itself be a third plan variant.
+- **CI opts out.** When `CI` is set the wrapper adds nothing. Runners are
+  ephemeral (one worktree per VM), so a shared cache saves nothing there, and
+  `.github/workflows/test.yml` ends its job with a build that does not route
+  through the wrapper at all — flagging only the steps that do would make CI
+  alternate against its own `actions/cache`d `.build` on every run.
 - **Why not `Package.swift` `swiftSettings`?** Measured dead end:
   `.unsafeFlags(["-module-cache-path", …])` on every root target still left
   a 591 MB local ModuleCache — manifest settings don't apply to dependency
   targets (SwiftNIO, GRDB, SwiftTerm…), which are the bulk of it.
+- **Why not a symlink?** Cached artifacts embed the *spelled* path of the
+  worktree that created them and clang validates that spelling, so a shared
+  directory reached through per-worktree symlinks works for exactly one
+  worktree and wedges every other with `PCH was compiled with module cache
+  path '<A>/…' but the path is currently '<B>/…'`. Sharing by flag works
+  precisely because every worktree spells the identical path.
 - **Not swept by the reaper.** The shared cache sits outside every `.build`,
-  so Tier 1/2 above never touch it. It stays a constant single-copy size and
-  is safe to delete manually at any time — the next build regenerates it.
-- **CI is unchanged.** Runners are ephemeral (one worktree per VM), so a
-  shared cache buys nothing there, and the `actions/cache`d `.build` interacts
-  with plan-time stickiness in non-obvious ways. Deliberately not wired up.
+  so Tier 1/2 above never touch it. clang prunes it itself (a pass every
+  seven days evicting entries unused for thirty-one), which holds it at
+  roughly 1.5 GB, and it is safe to delete by hand at any time — the next
+  build regenerates what it needs.
 
 ## Future
 The ~4.6 GiB of compiled artifacts can only be de-duplicated across worktrees via SwiftPM compilation caching (LLVM CAS + prefix mapping) on the new Swift Build engine — currently an opt-in pitch. Track and pilot when it lands.

--- a/docs/specs/2026-08-30-shared-module-cache-design.md
+++ b/docs/specs/2026-08-30-shared-module-cache-design.md
@@ -94,6 +94,11 @@ Writing into `~/Library/Caches` during a test run is intended and safe: it is a 
 artifact, not test state, and it is not one of the stores the fence's fingerprint
 detector brackets (`~/tbd`, `~/.claude`, `~/.codex`, and the tmux socket directory).
 
+**An unusable cache directory is not a build failure.** If the directory cannot be
+created, the wrapper says so on stderr and adds no flags, leaving SwiftPM's per-worktree
+default in place. A build is the wrong thing to fail over a cache that exists only to be
+regenerated, and the fallback is the behavior every worktree had before this change.
+
 **Callers may still choose.** `TBD_SWIFT_MODULE_CACHE_PATH` overrides the location.
 `TBD_SWIFT_SHARED_MODULE_CACHE=0` disables sharing and restores SwiftPM's per-worktree
 default. If a caller passes its own `-module-cache-path`, the wrapper adds nothing —

--- a/docs/specs/2026-08-30-shared-module-cache-design.md
+++ b/docs/specs/2026-08-30-shared-module-cache-design.md
@@ -94,10 +94,19 @@ Writing into `~/Library/Caches` during a test run is intended and safe: it is a 
 artifact, not test state, and it is not one of the stores the fence's fingerprint
 detector brackets (`~/tbd`, `~/.claude`, `~/.codex`, and the tmux socket directory).
 
-**An unusable cache directory is not a build failure.** If the directory cannot be
-created, the wrapper says so on stderr and adds no flags, leaving SwiftPM's per-worktree
-default in place. A build is the wrong thing to fail over a cache that exists only to be
-regenerated, and the fallback is the behavior every worktree had before this change.
+**An unavailable cache is not a build failure.** Two things can go wrong, and both
+degrade the same way: the wrapper says so on stderr, adds no flags, and leaves SwiftPM's
+per-worktree default in place. A build is the wrong thing to fail over a cache that
+exists only to be regenerated, and the fallback is the behavior every worktree had before
+this change.
+
+The first is a directory that cannot be created. The second is a home directory that
+cannot be resolved at all: `getpwuid` raises for a uid with no passwd entry, which
+minimal containers, sandboxes and arbitrary-UID environments all produce. Because this
+wrapper is the sole mandatory gate for every SwiftPM command in the repo, letting that
+raise would break every build, test and run for such a uid — and the only escape would be
+knowing to set the opt-out beforehand. `TBD_SWIFT_MODULE_CACHE_PATH` is read *before* the
+passwd lookup, so it stays a working escape hatch for exactly that environment.
 
 **Callers may still choose.** `TBD_SWIFT_MODULE_CACHE_PATH` overrides the location.
 `TBD_SWIFT_SHARED_MODULE_CACHE=0` disables sharing and restores SwiftPM's per-worktree

--- a/docs/specs/2026-08-30-shared-module-cache-design.md
+++ b/docs/specs/2026-08-30-shared-module-cache-design.md
@@ -2,12 +2,11 @@
 
 ## Summary
 
-Every TBD worktree keeps its own precompiled-module cache — around 580 MB each,
-roughly 7 GB across the twelve worktrees that currently hold a `.build`. A shared
-cache already exists to collapse those into one copy, but only `scripts/restart.sh`
-passes the flags that select it, so most builds never use it and the machine pays
-for both: about 7 GB of per-worktree caches *plus* 1.5 GB of shared cache, on a data
-volume with 19 GiB free.
+Every TBD worktree keeps its own precompiled-module cache — 510 to 818 MB each, around
+4.7 GB across the worktrees currently holding a `.build`. A shared cache already exists
+to collapse those into one copy, but only `scripts/restart.sh` passes the flags that
+select it, so most builds never use it and the machine pays for both: the per-worktree
+caches *plus* 1.5 GB of shared cache.
 
 Worse, the disagreement itself costs compile time. SwiftPM writes the cache path into
 every compile command in the build plan, so a tree that alternates between
@@ -16,7 +15,7 @@ every compile command in the build plan, so a tree that alternates between
 
 This moves the flags into `scripts/swift-safe`, the wrapper every governed build
 already goes through, so all three entry points plan identically. The disagreement
-disappears, the per-worktree caches stop being regenerated, and roughly 7 GB comes
+disappears, the per-worktree caches stop being regenerated, and roughly 4.7 GB comes
 back.
 
 ## Why the cache path forces a recompile
@@ -111,21 +110,55 @@ branches of this condition are tested.
 
 ## What it costs and what it returns
 
-Twelve worktrees hold a `.build` today; three already carry the shared path and keep
-their plan unchanged, so nine pay a one-time full recompile on their next build. Those
-nine rebuild against an already-warm shared cache, so they skip precompiled-module
-population. The rebuilds are serialized by the wrapper's machine-global lock and are
-spread across whenever each tree next builds, not taken at once.
+**Read every figure here as a snapshot of a moving fleet.** `scripts/reclaim-build.sh`
+reaps idle `.build` trees at 48 hours, so both the number of worktrees holding a cache
+and the total they occupy change hour to hour — the planned-tree count moved from twelve
+to eight inside a day while this was being written. The shape of the trade holds; the
+digits do not.
 
-In return the per-worktree caches stop being regenerated: about 7 GB of local caches
-collapse into the roughly 1.5 GB shared copy that already exists, taking the data
-volume from 19 GiB free to about 26 GiB.
+At the time of writing, nine worktrees hold a local `ModuleCache` totalling 4,765 MB,
+alongside a 1,481 MB shared cache, on a data volume with 27 GiB free at 94% capacity.
+Under this design the local caches stop being regenerated and the shared copy — which
+already exists — absorbs them, so roughly **4.7 GB** comes back. That figure will erode
+somewhat: the shared cache will take on contexts it does not see today, since it will
+serve test plans and every worktree rather than the two that currently reach it.
+
+Keep the scale honest. The `.build` trees those caches sit inside total 28 GB, about six
+times the module caches. **Precompiled modules are not where the disk went**, and this
+is a worthwhile tidy rather than a fix for disk pressure.
+
+**Migration is best measured in build-slot hours, not in recompile counts,** because the
+wrapper's machine-global lock is the scarcest resource on the machine — sampled over 31
+minutes it was held 51% of the time with someone queued behind it 27% of the time, and a
+single holder was observed occupying it for 43 consecutive minutes.
+
+Of the eight worktrees with a plan today, two already carry the shared path and keep it
+unchanged; six pay a one-time full recompile on their next build. A cold full build
+measured 2,441 s — about 41 minutes — so those six cost on the order of **four hours of
+exclusive build slot**, taken whenever each tree next builds rather than at once. Two
+things make that an upper bound: the rebuilds land against an already-warm shared cache
+and so skip precompiled-module population, and the 41-minute figure was measured on a
+heavily loaded machine.
+
+That cost is the honest argument against this design and for the rejected alternative
+below, which converges just as completely for about a third of the slot time.
 
 **This is a disk change, not a speed change.** It removes the alternation tax, but so
-would simply deleting the flags from `scripts/restart.sh`. The only speed it adds
-beyond that is warm precompiled system and dependency modules for a cold worktree's
-first build, which covers Foundation, AppKit, SwiftUI and the NIO shims but not TBD's
-own compilation. That effect has not been measured and should not be claimed.
+would simply deleting the flags from `scripts/restart.sh`. The only speed it adds beyond
+that is warm precompiled system and dependency modules for a cold worktree's first
+build, which covers Foundation, AppKit, SwiftUI and the NIO shims but not TBD's own
+compilation. That effect has not been measured and should not be claimed — and a
+sampled build gives reason to doubt it would show: the thirteen `swift-frontend`
+processes held 49% CPU out of 1200% available, against `kernel_task` at 221%, with every
+frontend runnable rather than blocked on I/O. That build was short of turns, not of
+memory or disk. Returning 4.7 GB adds no RAM and removes no contention.
+
+**A caution for anyone re-measuring.** Timings on this machine swing with fleet load by
+close to an order of magnitude — `git config --get` measured 334 ms under load and 38 ms
+an hour later. Every duration in this document is a loaded-machine number, which makes
+both the alternation tax and the migration cost smaller on an idle machine than stated.
+Interleave the arms rather than measuring them an hour apart; `Tests/CLAUDE.md` records a
+prior comparison invalidated by exactly this drift.
 
 ## Cache growth
 
@@ -181,11 +214,18 @@ lost.
 ## Rejected alternatives
 
 **Delete the flags from `scripts/restart.sh` instead.** Converges the entry points just
-as completely and costs three recompiles rather than nine, with no new mechanism. It was
-the right answer while the field evidence for the alternation cost was in doubt. It
-forfeits the roughly 7 GB, which on a volume at 96% capacity is the reason to prefer
-sharing, and it discards a warm 1.5 GB cache that would have to be rebuilt if sharing
-were adopted later.
+as completely, with no new mechanism, and inverts the migration: the two trees on the
+shared path revert instead of the six on the default path, costing roughly a third of
+the build-slot hours. It removes the alternation tax exactly as well — that tax argues
+for convergence, not for sharing, and this is the cheaper convergence.
+
+It forfeits the roughly 4.7 GB and discards a warm 1.5 GB cache that would have to be
+rebuilt if sharing were adopted later. The case for paying the extra slot time is that
+the saving is permanent and recurring, while the migration is paid once; the case
+against is that 4.7 GB is 17% of the 28 GB the `.build` trees occupy, so it does not by
+itself resolve disk pressure, and build-slot time is the resource in shortest supply.
+This is the live trade-off between the two designs, and it is close enough that it
+turned on a judgement call rather than on evidence.
 
 **Change nothing and correct the documentation.** Leaves the flags in `restart.sh` as a
 trap for the next reader and keeps paying 1.5 GB for a benefit no worktree receives.

--- a/docs/specs/2026-08-30-shared-module-cache-design.md
+++ b/docs/specs/2026-08-30-shared-module-cache-design.md
@@ -1,0 +1,198 @@
+# Shared Swift/clang module cache, applied at the admission wrapper
+
+## Summary
+
+Every TBD worktree keeps its own precompiled-module cache — around 580 MB each,
+roughly 7 GB across the twelve worktrees that currently hold a `.build`. A shared
+cache already exists to collapse those into one copy, but only `scripts/restart.sh`
+passes the flags that select it, so most builds never use it and the machine pays
+for both: about 7 GB of per-worktree caches *plus* 1.5 GB of shared cache, on a data
+volume with 19 GiB free.
+
+Worse, the disagreement itself costs compile time. SwiftPM writes the cache path into
+every compile command in the build plan, so a tree that alternates between
+`scripts/restart.sh` (shared path) and `scripts/swift-safe` or `scripts/test.sh`
+(default path) re-plans and fully recompiles on every transition, in both directions.
+
+This moves the flags into `scripts/swift-safe`, the wrapper every governed build
+already goes through, so all three entry points plan identically. The disagreement
+disappears, the per-worktree caches stop being regenerated, and roughly 7 GB comes
+back.
+
+## Why the cache path forces a recompile
+
+SwiftPM always emits a `-module-cache-path` (Swift) and `-fmodules-cache-path`
+(clang) pair into each target's compile command in `.build/debug.yaml`. With no flags
+they name the worktree's own `.build/arm64-apple-macosx/debug/ModuleCache`; with the
+flags they name the shared directory. The flags therefore do not *add* an argument —
+they change the value of one that is always present.
+
+Any change to that value changes the command line, which invalidates the llbuild node
+and swift-driver's argument hash, so every module recompiles. Measured on a
+three-target package (two Swift, one C) under Swift 6.2.4: building twice with the
+same flags rewrites no artifacts, while switching the flags rewrites every module.
+Switching *back* to an already-warm default cache also rewrites every module, which
+rules out cache warmth as the cause and leaves the changed argument as the only
+explanation. The effect is independent of package size and so applies in full to a
+TBD build.
+
+This is why no environment variable can select the cache instead: an explicit flag is
+always on the command line, and it wins. It is also why a `--toolset` JSON is not an
+escape hatch — its options land in the build plan verbatim, making it this same design
+with a different spelling.
+
+## Why not a symlink
+
+Pointing each worktree's `ModuleCache` at one shared directory would need no flags at
+all and so would cost no re-plan. It does not work.
+
+Cached artifacts embed the *spelled*, unresolved path of the worktree that created
+them, and clang validates that spelling rather than the inode. A second worktree
+symlinked to a directory a first has populated fails outright:
+
+```
+error: PCH was compiled with module cache path '<A>/.build/.../ModuleCache/SJHDC727RGOA',
+       but the path is currently '<B>/.build/.../ModuleCache/SJHDC727RGOA'
+error: missing required module 'SwiftShims'
+```
+
+It does not self-heal on retry. The symlink works for exactly one worktree and wedges
+every other one, so single-copy disk by symlink is impossible with this toolchain. The
+same embedded-path bytes defeat APFS cloning for the same reason: two worktrees' `.pcm`
+files differ, so their contents cannot deduplicate.
+
+Sharing by flag avoids this precisely because every worktree spells the *identical*
+path. Verified: a second package built against a cache a first had warmed added zero
+new entries and hit no path error.
+
+## Design
+
+`scripts/swift-safe` appends the module-cache flags to every compile subcommand
+(`build`, `test`, `run`), making it the single place that decides where precompiled
+modules live. `scripts/restart.sh` stops passing them.
+
+**The wrapper is the right home.** It is already the one mandatory path to SwiftPM —
+the repository guardrail rejects raw `swift build`/`test`/`run`, and `scripts/test.sh`
+routes through it too. Anything that decides a build-wide compile setting belongs
+where every build already passes, not duplicated across callers where copies drift
+apart. That drift is the present bug.
+
+**One spelling, resolved from the passwd database.** The path stays
+`<home>/Library/Caches/tbd/swift-module-cache`, the directory that already holds a
+warm 1.5 GB cache. It is resolved with `pwd.getpwuid(os.getuid()).pw_dir`, **not**
+`$HOME`.
+
+That distinction is load-bearing. `scripts/test.sh` deliberately points `HOME` and
+`CFFIXED_USER_HOME` at a scratch directory, and relocates SwiftPM's own caches into it.
+A `$HOME`-derived path would therefore resolve *inside the fence* on every test run,
+minting an empty cache each time — so every test run would pay a full rebuild and
+regrow the cache it was meant to eliminate. That is the failure mode CLAUDE.md already
+records as "a path hand-built from `$HOME`", and it fails silently. `getpwuid` returns
+the real home regardless of the fence, so the wrapper needs no cooperation from its
+callers and `scripts/test.sh` needs no change.
+
+Writing into `~/Library/Caches` during a test run is intended and safe: it is a build
+artifact, not test state, and it is not one of the stores the fence's fingerprint
+detector brackets (`~/tbd`, `~/.claude`, `~/.codex`, and the tmux socket directory).
+
+**Callers may still choose.** `TBD_SWIFT_MODULE_CACHE_PATH` overrides the location.
+`TBD_SWIFT_SHARED_MODULE_CACHE=0` disables sharing and restores SwiftPM's per-worktree
+default. If a caller passes its own `-module-cache-path`, the wrapper adds nothing —
+a second, differently-spelled copy would itself be a third plan variant and reintroduce
+the alternation this removes.
+
+**Continuous integration keeps today's behavior.** When `CI` is set the wrapper adds
+no flags. Runners are ephemeral — one worktree per VM — so a shared cache saves nothing
+there, and `.github/workflows/test.yml` ends its job with a bare `swift build` that
+does not route through the wrapper. Applying the flags only to the `scripts/test.sh`
+steps in that job would make CI alternate against itself on every run, and the
+`actions/cache`d `.build` would carry whichever plan ran last into the next job. Both
+branches of this condition are tested.
+
+## What it costs and what it returns
+
+Twelve worktrees hold a `.build` today; three already carry the shared path and keep
+their plan unchanged, so nine pay a one-time full recompile on their next build. Those
+nine rebuild against an already-warm shared cache, so they skip precompiled-module
+population. The rebuilds are serialized by the wrapper's machine-global lock and are
+spread across whenever each tree next builds, not taken at once.
+
+In return the per-worktree caches stop being regenerated: about 7 GB of local caches
+collapse into the roughly 1.5 GB shared copy that already exists, taking the data
+volume from 19 GiB free to about 26 GiB.
+
+**This is a disk change, not a speed change.** It removes the alternation tax, but so
+would simply deleting the flags from `scripts/restart.sh`. The only speed it adds
+beyond that is warm precompiled system and dependency modules for a cold worktree's
+first build, which covers Foundation, AppKit, SwiftUI and the NIO shims but not TBD's
+own compilation. That effect has not been measured and should not be claimed.
+
+## Cache growth
+
+The shared cache holds about 1.5 GB across 146 top-level entries — roughly two dozen
+clang hash-context directories of 60–115 MB each, plus per-module entries at about two
+hash variants per module name. Each distinct compiler-invocation context mints its own
+directory, so contexts accumulate rather than overwrite.
+
+Growth is bounded by clang's own pruning, which is active: `modules.timestamp` is
+present, and the defaults run a prune pass every seven days evicting entries unused for
+thirty-one. The steady state is therefore "every context touched in the last month",
+which is about 1.5 GB — not the 650 MB an earlier estimate assumed. The directory sits
+outside every `.build`, so `scripts/reclaim-build.sh` never sweeps it, and it can be
+deleted by hand at any time; the next build regenerates what it needs.
+
+## On shipping this enabled
+
+CLAUDE.md requires large or risky new behavior to ship behind a default-off flag that
+soaks before graduating. That rule's mechanics — a `config` column added by migration,
+or a UserDefaults key — describe daemon and app behavior and have no counterpart in a
+shell and Python build wrapper, and its motivating cases are autonomous action and
+destroyed state, neither of which applies here.
+
+The substance of the rule is served differently. A default-off flag would deliver
+nothing until flipped, and the flip is the entire change. Instead the change is
+reversible at the cost of one recompile per tree, carries an opt-out for anyone who
+wants the old behavior immediately, and touches no persisted state — nothing it does
+outlives a `.build` directory and a cache that is safe to delete. The blast radius is
+nine worktrees on one developer machine, and the failure is a slow build rather than a
+lost artifact.
+
+The genuine risk it does carry is shared fate: one corrupt cache would affect every
+worktree instead of one. That is accepted because the cache is disposable and
+regenerates, and because clang's cache is designed for concurrent access — and in
+practice the wrapper's exclusive lock means at most one build writes to it at a time.
+
+## Testing
+
+`scripts/test-swift-safe.py` covers the wrapper and gains cases for: flags appended to
+each compile subcommand by default; no flags when `CI` is set; no flags under
+`TBD_SWIFT_SHARED_MODULE_CACHE=0`; `TBD_SWIFT_MODULE_CACHE_PATH` honored; nothing added
+when the caller already passes `-module-cache-path`; and the resolved path unaffected by
+a fenced `HOME`, which is the regression that would otherwise reappear silently.
+
+Each of these gates behavior, so both branches are asserted — the flags present when
+the condition is absent, and absent when it is present.
+
+`scripts/reclaim-build.test.sh` currently asserts that `scripts/restart.sh` contains the
+flags. That invariant moves rather than disappears: it now asserts the wrapper supplies
+them and that `restart.sh` does not, so the assertion still fails if the behavior is
+lost.
+
+## Rejected alternatives
+
+**Delete the flags from `scripts/restart.sh` instead.** Converges the entry points just
+as completely and costs three recompiles rather than nine, with no new mechanism. It was
+the right answer while the field evidence for the alternation cost was in doubt. It
+forfeits the roughly 7 GB, which on a volume at 96% capacity is the reason to prefer
+sharing, and it discards a warm 1.5 GB cache that would have to be rebuilt if sharing
+were adopted later.
+
+**Change nothing and correct the documentation.** Leaves the flags in `restart.sh` as a
+trap for the next reader and keeps paying 1.5 GB for a benefit no worktree receives.
+Defensible only if the three flagged trees never alternate again, which the standard
+workflow — `scripts/test.sh` while iterating, `scripts/restart.sh` to verify live —
+contradicts.
+
+**Set the cache through `Package.swift` `swiftSettings`.** Measured dead end: manifest
+settings do not reach dependency targets such as SwiftNIO, GRDB and SwiftTerm, which are
+the bulk of the cache, leaving most of it local.

--- a/docs/specs/2026-08-30-shared-module-cache-design.md
+++ b/docs/specs/2026-08-30-shared-module-cache-design.md
@@ -68,7 +68,9 @@ new entries and hit no path error.
 
 `scripts/swift-safe` appends the module-cache flags to every compile subcommand
 (`build`, `test`, `run`), making it the single place that decides where precompiled
-modules live. `scripts/restart.sh` stops passing them.
+modules live. Its callers stop passing them: `scripts/restart.sh`, and
+`scripts/update.sh`, which builds the same products through the same wrapper from
+the update clone.
 
 **The wrapper is the right home.** It is already the one mandatory path to SwiftPM —
 the repository guardrail rejects raw `swift build`/`test`/`run`, and `scripts/test.sh`
@@ -222,8 +224,8 @@ the condition is absent, and absent when it is present.
 
 `scripts/reclaim-build.test.sh` currently asserts that `scripts/restart.sh` contains the
 flags. That invariant moves rather than disappears: it now asserts the wrapper supplies
-them and that `restart.sh` does not, so the assertion still fails if the behavior is
-lost.
+them and that neither caller — `restart.sh` nor `update.sh` — spells a cache of its own,
+so the assertion still fails if the behavior is lost or a third decider appears.
 
 ## Rejected alternatives
 

--- a/scripts/reclaim-build.test.sh
+++ b/scripts/reclaim-build.test.sh
@@ -396,7 +396,7 @@ test_restart_sh_launches_reclaim_async_and_silent() {
   # shellcheck disable=SC2016
   nohup_ln="$(grep -nF 'nohup "$RECLAIM_SCRIPT"' "$restart" | head -1 | cut -d: -f1)"
   # shellcheck disable=SC2016
-  build_ln="$(grep -nF '(cd "$REPO_ROOT" && scripts/swift-safe build' "$restart" | head -1 | cut -d: -f1)"
+  build_ln="$(grep -nF 'run_governed_build "$REPO_ROOT"' "$restart" | head -1 | cut -d: -f1)"
   local order="unknown"
   if [[ -n "$nohup_ln" && -n "$build_ln" ]] && (( nohup_ln < build_ln )); then order="before"; fi
   assert_eq "reclaim launch (line ${nohup_ln:-?}) precedes swift build (line ${build_ln:-?})" "before" "$order"
@@ -416,13 +416,18 @@ test_restart_sh_uses_shared_module_cache() {
   assert_contains "flags include the Swift frontend module-cache-path" "$body" '-Xswiftc -module-cache-path'
   assert_contains "flags include the clang modules cache path" "$body" '-Xcc -fmodules-cache-path='
 
-  # The build line itself must carry the flags.
+  # The build itself runs through scripts/restart-build-lib.sh (which captures
+  # swift-safe's real exit status instead of piping it away), so the flags are
+  # asserted on the call restart.sh makes, and the admission wrapper on the lib
+  # that call lands in.
   local build_line
   # shellcheck disable=SC2016
-  build_line="$(grep -F '(cd "$REPO_ROOT" && scripts/swift-safe build' "$restart")"
+  build_line="$(grep -F 'run_governed_build "$REPO_ROOT"' "$restart")"
   # shellcheck disable=SC2016
-  assert_contains "build line uses admission wrapper" "$build_line" 'scripts/swift-safe build'
-  assert_contains "build line passes the module-cache flags" "$build_line" 'build "${MODULE_CACHE_FLAGS[@]}"'
+  assert_contains "build line passes the module-cache flags" "$build_line" '"${MODULE_CACHE_FLAGS[@]}"'
+  # shellcheck disable=SC2016
+  assert_contains "the governed build still uses the admission wrapper" \
+    "$(cat "$HERE/restart-build-lib.sh")" 'scripts/swift-safe build'
 
   # mkdir must precede the build so the first flagged build never races a
   # missing parent directory.
@@ -430,7 +435,7 @@ test_restart_sh_uses_shared_module_cache() {
   # shellcheck disable=SC2016
   mkdir_ln="$(grep -nF 'mkdir -p "$SHARED_MODULE_CACHE"' "$restart" | head -1 | cut -d: -f1)"
   # shellcheck disable=SC2016
-  build_ln="$(grep -nF '(cd "$REPO_ROOT" && scripts/swift-safe build' "$restart" | head -1 | cut -d: -f1)"
+  build_ln="$(grep -nF 'run_governed_build "$REPO_ROOT"' "$restart" | head -1 | cut -d: -f1)"
   local order="unknown"
   if [[ -n "$mkdir_ln" && -n "$build_ln" ]] && (( mkdir_ln < build_ln )); then order="before"; fi
   assert_eq "shared cache mkdir (line ${mkdir_ln:-?}) precedes swift build (line ${build_ln:-?})" "before" "$order"

--- a/scripts/reclaim-build.test.sh
+++ b/scripts/reclaim-build.test.sh
@@ -402,43 +402,49 @@ test_restart_sh_launches_reclaim_async_and_silent() {
   assert_eq "reclaim launch (line ${nohup_ln:-?}) precedes swift build (line ${build_ln:-?})" "before" "$order"
 }
 
-# Static check: restart.sh's swift build must route the clang/Swift module
-# cache to the shared per-user directory (single ~610 MB copy for ALL
-# worktrees instead of ~640 MB inside each .build) — both the Swift frontend
-# flag and the clang flag (which reaches C-shim dependency targets like
-# CNIOAtomics), and the cache dir must be created before the build runs.
-test_restart_sh_uses_shared_module_cache() {
+# Static check: the shared clang/Swift module cache must be selected in exactly
+# ONE place — scripts/swift-safe, the wrapper every governed compile goes
+# through — so that `build`, `test` and `run` plan identically. Two entry points
+# that disagree about the path make every transition between them a full
+# recompile, because SwiftPM bakes the path into .build/debug.yaml at plan time.
+# The invariant is therefore two-sided: the wrapper supplies both flags, and
+# restart.sh supplies neither.
+# See docs/specs/2026-08-30-shared-module-cache-design.md.
+test_the_shared_module_cache_is_selected_only_by_the_wrapper() {
   local restart="$HERE/restart.sh"
-  local body; body="$(cat "$restart")"
-  assert_contains "restart.sh points at the shared per-user module cache" "$body" 'Library/Caches/tbd/swift-module-cache'
-  # shellcheck disable=SC2016 # literal, unexpanded strings searched in restart.sh
-  assert_contains "restart.sh creates the shared cache dir" "$body" 'mkdir -p "$SHARED_MODULE_CACHE"'
-  assert_contains "flags include the Swift frontend module-cache-path" "$body" '-Xswiftc -module-cache-path'
-  assert_contains "flags include the clang modules cache path" "$body" '-Xcc -fmodules-cache-path='
+  local wrapper; wrapper="$(cat "$HERE/swift-safe")"
 
-  # The build itself runs through scripts/restart-build-lib.sh (which captures
-  # swift-safe's real exit status instead of piping it away), so the flags are
-  # asserted on the call restart.sh makes, and the admission wrapper on the lib
-  # that call lands in.
-  local build_line
+  assert_contains "the wrapper points at the shared per-user module cache" "$wrapper" 'Library/Caches/tbd/swift-module-cache'
+  assert_contains "the wrapper supplies the Swift frontend module-cache-path" "$wrapper" '"-module-cache-path"'
+  assert_contains "the wrapper supplies the clang modules cache path" "$wrapper" 'f"-fmodules-cache-path={path}"'
+  # The path must come from the passwd database: scripts/test.sh points HOME at
+  # a scratch fence it deletes, so a $HOME-derived cache would be minted empty
+  # inside the fence on every test run and every run would pay a full rebuild.
+  assert_contains "the wrapper resolves the path from the passwd database" "$wrapper" 'pwd.getpwuid(os.getuid()).pw_dir'
+  assert_missing "the wrapper never derives the cache from \$HOME" "$wrapper" 'os.environ["HOME"]'
+  # The wrapper creates it, so no build races a missing parent directory.
+  assert_contains "the wrapper creates the shared cache dir" "$wrapper" 'path.mkdir(parents=True, exist_ok=True)'
+
+  # restart.sh must not select it a second time, in any spelling.
+  local body; body="$(cat "$restart")"
+  local restart_flags
+  restart_flags="$(grep -nE '^[^#]*(-module-cache-path|-fmodules-cache-path|MODULE_CACHE_FLAGS)' "$restart" || true)"
+  assert_eq "restart.sh selects no module cache of its own" "" "$restart_flags"
+
+  # The build still runs through scripts/restart-build-lib.sh, which captures
+  # swift-safe's real exit status instead of piping it away, and that lib is
+  # where the admission wrapper is actually invoked. restart.sh passes it only
+  # the build configuration and the product to build — no cache flags.
+  local call
+  # shellcheck disable=SC2016 # literal, unexpanded strings searched in restart.sh
+  call="$(sed -n '/run_governed_build "\$REPO_ROOT"/,/build_status=\$?/p' "$restart")"
+  assert_contains "restart.sh runs the governed build" "$body" 'run_governed_build "$REPO_ROOT"'
   # shellcheck disable=SC2016
-  build_line="$(grep -F 'run_governed_build "$REPO_ROOT"' "$restart")"
-  # shellcheck disable=SC2016
-  assert_contains "build line passes the module-cache flags" "$build_line" '"${MODULE_CACHE_FLAGS[@]}"'
+  assert_contains "the governed build passes only the config and the product" "$call" \
+    '-c "$build_config" --product "$product" || build_status=$?'
   # shellcheck disable=SC2016
   assert_contains "the governed build still uses the admission wrapper" \
     "$(cat "$HERE/restart-build-lib.sh")" 'scripts/swift-safe build'
-
-  # mkdir must precede the build so the first flagged build never races a
-  # missing parent directory.
-  local mkdir_ln build_ln
-  # shellcheck disable=SC2016
-  mkdir_ln="$(grep -nF 'mkdir -p "$SHARED_MODULE_CACHE"' "$restart" | head -1 | cut -d: -f1)"
-  # shellcheck disable=SC2016
-  build_ln="$(grep -nF 'run_governed_build "$REPO_ROOT"' "$restart" | head -1 | cut -d: -f1)"
-  local order="unknown"
-  if [[ -n "$mkdir_ln" && -n "$build_ln" ]] && (( mkdir_ln < build_ln )); then order="before"; fi
-  assert_eq "shared cache mkdir (line ${mkdir_ln:-?}) precedes swift build (line ${build_ln:-?})" "before" "$order"
 }
 
 # --- install-reaping + gate helpers ------------------------------------------

--- a/scripts/reclaim-build.test.sh
+++ b/scripts/reclaim-build.test.sh
@@ -407,8 +407,8 @@ test_restart_sh_launches_reclaim_async_and_silent() {
 # through — so that `build`, `test` and `run` plan identically. Two entry points
 # that disagree about the path make every transition between them a full
 # recompile, because SwiftPM bakes the path into .build/debug.yaml at plan time.
-# The invariant is therefore two-sided: the wrapper supplies both flags, and
-# restart.sh supplies neither.
+# The invariant is therefore two-sided: the wrapper supplies both flags, and no
+# caller of it — restart.sh, update.sh — supplies any.
 # See docs/specs/2026-08-30-shared-module-cache-design.md.
 test_the_shared_module_cache_is_selected_only_by_the_wrapper() {
   local restart="$HERE/restart.sh"
@@ -425,11 +425,15 @@ test_the_shared_module_cache_is_selected_only_by_the_wrapper() {
   # The wrapper creates it, so no build races a missing parent directory.
   assert_contains "the wrapper creates the shared cache dir" "$wrapper" 'path.mkdir(parents=True, exist_ok=True)'
 
-  # restart.sh must not select it a second time, in any spelling.
+  # No caller of the wrapper may select it a second time, in any spelling.
+  # update.sh matters as much as restart.sh: it builds the same products
+  # through the same wrapper, from the update clone.
   local body; body="$(cat "$restart")"
-  local restart_flags
-  restart_flags="$(grep -nE '^[^#]*(-module-cache-path|-fmodules-cache-path|MODULE_CACHE_FLAGS)' "$restart" || true)"
-  assert_eq "restart.sh selects no module cache of its own" "" "$restart_flags"
+  local caller caller_flags
+  for caller in restart.sh update.sh; do
+    caller_flags="$(grep -nEi '^[^#]*(-module-cache-path|-fmodules-cache-path|module_cache_flags|shared_module_cache)' "$HERE/$caller" || true)"
+    assert_eq "$caller selects no module cache of its own" "" "$caller_flags"
+  done
 
   # The build still runs through scripts/restart-build-lib.sh, which captures
   # swift-safe's real exit status instead of piping it away, and that lib is

--- a/scripts/restart-build-lib.sh
+++ b/scripts/restart-build-lib.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Governed-build helpers for restart.sh. Safe to source: defines functions
+# only, launches nothing, installs nothing.
+#
+# restart.sh's job after the build is destructive and machine-wide — it
+# assembles a bundle, copies it over /Applications/TBD.app, and restarts the
+# shared daemon. Everything it ships comes out of .build/debug, so it may only
+# run when the build it just asked for actually produced those binaries. That
+# makes "did the build succeed?" a load-bearing decision rather than a
+# formality, which is why it lives here as a pure function with its own
+# harness (scripts/restart-build-lib.test.sh).
+#
+# Exit statuses come from scripts/swift-safe; its EXIT_MEANINGS dict is the
+# authoritative list. Two of them mean the machine-wide build lock was never
+# obtained, so *nothing was compiled* — those are retryable, and reporting
+# them as a compile failure would send a reader hunting for a compiler error
+# that does not exist.
+
+# Statuses that mean scripts/swift-safe never got the shared build slot: 75
+# (EX_TEMPFAIL — the wait timed out or the requester went away) and 76 (the
+# wait yielded its place in the queue). Both compiled nothing at all.
+SWIFT_SAFE_SLOT_NOT_OBTAINED_STATUSES=(75 76)
+
+# May restart.sh ship what is in .build/debug, given the status of the build
+# it just ran? Only a clean zero says yes. Deliberately not "is it one of the
+# statuses I recognize" — an unrecognized non-zero is still a build that did
+# not finish, and a whitelist of known-good is the only shape that stays safe
+# when scripts/swift-safe grows a status this file has never heard of.
+build_status_permits_ship() {
+    [ "${1-}" = "0" ]
+}
+
+# True when the status means the shared build slot was never obtained.
+build_status_is_slot_not_obtained() {
+    local status="${1-}"
+    local candidate
+    for candidate in "${SWIFT_SAFE_SLOT_NOT_OBTAINED_STATUSES[@]}"; do
+        [ "$status" = "$candidate" ] && return 0
+    done
+    return 1
+}
+
+# Explain a non-zero build status on stdout, in scripts/swift-safe's own
+# vocabulary. Callers redirect this to stderr.
+describe_build_failure() {
+    local status="${1-}"
+    if build_status_is_slot_not_obtained "$status"; then
+        printf 'ERROR: nothing was compiled — scripts/swift-safe exited %s.\n' "$status"
+        if [ "$status" = "75" ]; then
+            printf '  75 = EX_TEMPFAIL: the shared build slot was not obtained.\n'
+        else
+            printf '  76 = the wait yielded its place in the queue.\n'
+        fi
+        printf '  The machine-wide build lock was never acquired, so no compiler ran.\n'
+        printf '  This is retryable: re-run scripts/restart.sh once the machine is quieter.\n'
+    else
+        printf 'ERROR: the build FAILED — scripts/swift-safe exited %s.\n' "$status"
+        printf '  See the build output printed above for the compiler error.\n'
+    fi
+    # The reassuring half, and the reason there is no automatic retry: a
+    # 30-minute silent re-queue is worse than a clear failure, because the
+    # human cannot tell it from a hang. Let them decide.
+    printf '  Nothing was shipped: no bundle assembled, no install, and the\n'
+    printf '  running app and daemon were left exactly as they were.\n'
+    printf '  Not retried automatically — a silent 30-minute re-queue would be\n'
+    printf '  indistinguishable from a hang. Re-run when you want it.\n'
+}
+
+# Run the governed build for the worktree at $1, passing the remaining
+# arguments through to `scripts/swift-safe build`. Prints the last few lines
+# of the build output and returns scripts/swift-safe's real exit status.
+#
+# The build output goes to a temp file rather than through `| tail -3`
+# because the pipeline is exactly the bug this function exists to prevent:
+# a pipeline's exit status is the LAST command's, so `swift-safe … | tail -3`
+# always reports 0, `set -e` never fires, and restart.sh happily ships
+# whatever stale binaries were already in .build/debug. That is not
+# hypothetical — a 1800s lock timeout (exit 75, nothing compiled) was read as
+# a successful build and the app and daemon were relaunched machine-wide.
+# scripts/swift-safe prints its numeric status on a final stderr line
+# precisely so it survives a pipe; capture the real status anyway and do not
+# "simplify" this back into a pipeline.
+#
+# The trimming itself is deliberate and must stay: full compiler output is
+# thousands of lines and restart.sh is nearly always run by an agent, whose
+# context window it would otherwise flood. swift-safe's final "exit status N"
+# line is the last thing it writes, so the tail keeps it.
+run_governed_build() {
+    local repo_root="$1"
+    shift
+    local build_log status
+    build_log="$(mktemp "${TMPDIR:-/tmp}/tbd-restart-build.XXXXXX")" || return 1
+
+    status=0
+    (cd "$repo_root" && scripts/swift-safe build "$@") > "$build_log" 2>&1 || status=$?
+
+    tail -3 "$build_log"
+    rm -f "$build_log"
+
+    if ! build_status_permits_ship "$status"; then
+        describe_build_failure "$status" >&2
+        return "$status"
+    fi
+    return 0
+}

--- a/scripts/restart-build-lib.sh
+++ b/scripts/restart-build-lib.sh
@@ -4,7 +4,7 @@
 #
 # restart.sh's job after the build is destructive and machine-wide — it
 # assembles a bundle, copies it over /Applications/TBD.app, and restarts the
-# shared daemon. Everything it ships comes out of .build/debug, so it may only
+# shared daemon. Everything it ships comes out of .build/<config>, so it may only
 # run when the build it just asked for actually produced those binaries. That
 # makes "did the build succeed?" a load-bearing decision rather than a
 # formality, which is why it lives here as a pure function with its own
@@ -21,7 +21,7 @@
 # wait yielded its place in the queue). Both compiled nothing at all.
 SWIFT_SAFE_SLOT_NOT_OBTAINED_STATUSES=(75 76)
 
-# May restart.sh ship what is in .build/debug, given the status of the build
+# May restart.sh ship what is in .build/<config>, given the status of the build
 # it just ran? Only a clean zero says yes. Deliberately not "is it one of the
 # statuses I recognize" — an unrecognized non-zero is still a build that did
 # not finish, and a whitelist of known-good is the only shape that stays safe
@@ -74,7 +74,7 @@ describe_build_failure() {
 # because the pipeline is exactly the bug this function exists to prevent:
 # a pipeline's exit status is the LAST command's, so `swift-safe … | tail -3`
 # always reports 0, `set -e` never fires, and restart.sh happily ships
-# whatever stale binaries were already in .build/debug. That is not
+# whatever stale binaries were already in .build/<config>. That is not
 # hypothetical — a 1800s lock timeout (exit 75, nothing compiled) was read as
 # a successful build and the app and daemon were relaunched machine-wide.
 # scripts/swift-safe prints its numeric status on a final stderr line

--- a/scripts/restart-build-lib.test.sh
+++ b/scripts/restart-build-lib.test.sh
@@ -188,13 +188,21 @@ test_output_is_trimmed_to_three_lines() {
     rm -rf "$d"
 }
 
+# restart.sh passes no extra arguments today, but the lib's contract is that
+# whatever it is given reaches the wrapper unmangled — flags and their values
+# alike. (The module cache is deliberately NOT among them: scripts/swift-safe
+# decides that for every governed build. See
+# docs/specs/2026-08-30-shared-module-cache-design.md.)
 test_arguments_pass_through_to_swift_safe() {
     local d; d="$(mkfakeworktree 0)"
-    run_under_restart_shell "$d" -Xswiftc -module-cache-path -Xswiftc /tmp/cache >/dev/null 2>&1
+    run_under_restart_shell "$d" --product TBDApp -Xswiftc -DEXAMPLE >/dev/null 2>&1
     local args; args="$(cat "$d/args.txt")"
     assert_contains "the subcommand is build" "$args" "build"
-    assert_contains "module-cache flags reach swift-safe" "$args" "-module-cache-path"
-    assert_contains "flag values reach swift-safe" "$args" "/tmp/cache"
+    # The stub records one argument per line, so each is asserted on its own.
+    assert_contains "flags reach swift-safe" "$args" "-Xswiftc"
+    assert_contains "flag values reach swift-safe" "$args" "-DEXAMPLE"
+    assert_contains "options reach swift-safe" "$args" "--product"
+    assert_contains "option values reach swift-safe" "$args" "TBDApp"
     rm -rf "$d"
 }
 
@@ -227,8 +235,6 @@ test_restart_sh_routes_the_build_through_the_guard() {
     local call
     # shellcheck disable=SC2016
     call="$(sed -n '/run_governed_build "\$REPO_ROOT"/,/build_status=\$?/p' "$HERE/restart.sh")"
-    # shellcheck disable=SC2016
-    assert_contains "the governed build still passes the module-cache flags" "$call" '"${MODULE_CACHE_FLAGS[@]}"'
     # shellcheck disable=SC2016
     assert_contains "a non-zero build status is kept, not discarded" "$call" '|| build_status=$?'
     # ...and stops restart.sh with that same status, before anything ships.

--- a/scripts/restart-build-lib.test.sh
+++ b/scripts/restart-build-lib.test.sh
@@ -1,0 +1,267 @@
+#!/usr/bin/env bash
+# Tests for scripts/restart-build-lib.sh — run: bash scripts/restart-build-lib.test.sh
+#
+# The invariant under test: restart.sh may only ship .build/debug when the
+# build it just ran actually succeeded. The failure this guards against is a
+# pipeline swallowing the status — `scripts/swift-safe build … | tail -3`
+# exits with tail's status (0) even when swift-safe exited 75 having compiled
+# nothing, and restart.sh then relaunched the app and daemon machine-wide from
+# whatever stale binaries happened to be lying around.
+#
+# shellcheck disable=SC2329 # test_* helpers are dispatched dynamically via `declare -F`/"$t" below
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=/dev/null
+source "$HERE/restart-build-lib.sh"   # pure function defs, no side effects
+
+FAIL=0
+pass() { echo "ok   - $1"; }
+fail() { echo "FAIL - $1"; FAIL=1; }
+
+assert_ok()   { local d="$1"; shift; if "$@" >/dev/null 2>&1; then pass "$d"; else fail "$d: expected success"; fi; }
+assert_fail() { local d="$1"; shift; if "$@" >/dev/null 2>&1; then fail "$d: expected failure"; else pass "$d"; fi; }
+assert_eq()   { if [[ "$2" == "$3" ]]; then pass "$1"; else fail "$1: expected [$2] got [$3]"; fi; }
+assert_contains() {
+    if [[ "$2" == *"$3"* ]]; then pass "$1"; else fail "$1: [$3] not found in [$2]"; fi
+}
+assert_missing() {
+    if [[ "$2" != *"$3"* ]]; then pass "$1"; else fail "$1: [$3] unexpectedly present"; fi
+}
+
+# Build a throwaway "worktree" whose scripts/swift-safe is a stub that exits
+# with $1 after writing $2 lines to stdout and one line to stderr (the shape
+# of the real wrapper's final "exit status N" line). Every invocation appends
+# its arguments to $d/args.txt so pass-through can be asserted. Echoes $d.
+mkfakeworktree() {
+    local status="$1" stdout_lines="${2:-1}"
+    local d; d="$(mktemp -d "${TMPDIR:-/tmp}/restart-build-test.XXXXXX")"
+    mkdir -p "$d/scripts"
+    cat > "$d/scripts/swift-safe" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$@" >> "$d/args.txt"
+for i in \$(seq 1 $stdout_lines); do echo "compiler output line \$i"; done
+echo "swift-safe: exit status $status" >&2
+exit $status
+EOF
+    chmod +x "$d/scripts/swift-safe"
+    echo "$d"
+}
+
+# Run run_governed_build under RESTART.SH's shell options, not this harness's.
+# This file sets `pipefail`; restart.sh sets only `set -e`, and without
+# pipefail a pipeline reports its LAST command's status — the entire bug. A
+# test that called the function directly would inherit this harness's pipefail
+# and pass even against the piped implementation, which is worthless. So the
+# call goes through a subshell configured exactly like restart.sh, and the
+# subshell's own exit status is the answer.
+run_under_restart_shell() {
+    local repo="$1"; shift
+    bash -c '
+        set -e
+        # shellcheck source=/dev/null
+        source "$0/restart-build-lib.sh"
+        repo="$1"; shift
+        run_governed_build "$repo" "$@"
+    ' "$HERE" "$repo" "$@"
+}
+
+# --- the ship/no-ship decision ------------------------------------------------
+
+test_only_zero_permits_shipping() {
+    assert_ok   "status 0 permits shipping" build_status_permits_ship 0
+    assert_fail "status 1 does not permit shipping" build_status_permits_ship 1
+    assert_fail "status 75 does not permit shipping" build_status_permits_ship 75
+    assert_fail "status 76 does not permit shipping" build_status_permits_ship 76
+    # An unrecognized status is still a build that did not finish: the
+    # decision is a whitelist of known-good, never a blacklist of known-bad.
+    assert_fail "unknown status 42 does not permit shipping" build_status_permits_ship 42
+    assert_fail "empty status does not permit shipping" build_status_permits_ship ""
+}
+
+test_slot_not_obtained_statuses() {
+    assert_ok   "75 is slot-not-obtained" build_status_is_slot_not_obtained 75
+    assert_ok   "76 is slot-not-obtained" build_status_is_slot_not_obtained 76
+    assert_fail "0 is not slot-not-obtained" build_status_is_slot_not_obtained 0
+    assert_fail "1 is not slot-not-obtained" build_status_is_slot_not_obtained 1
+    assert_fail "69 is not slot-not-obtained" build_status_is_slot_not_obtained 69
+}
+
+# --- the failure message ------------------------------------------------------
+
+test_message_for_lock_timeout_says_nothing_compiled() {
+    local msg; msg="$(describe_build_failure 75)"
+    assert_contains "75 names its status" "$msg" "exited 75"
+    assert_contains "75 uses swift-safe's EX_TEMPFAIL vocabulary" "$msg" "EX_TEMPFAIL"
+    assert_contains "75 says nothing was compiled" "$msg" "nothing was compiled"
+    assert_contains "75 says it is retryable" "$msg" "retryable"
+    assert_contains "75 says nothing was shipped" "$msg" "Nothing was shipped"
+    assert_contains "75 says the running processes were untouched" "$msg" "running app and daemon were left"
+    # A lock that was never obtained is NOT a compile failure; saying so would
+    # send the reader hunting for a compiler error that does not exist.
+    assert_missing "75 does not claim the build failed" "$msg" "the build FAILED"
+}
+
+test_message_for_queue_yield_says_nothing_compiled() {
+    local msg; msg="$(describe_build_failure 76)"
+    assert_contains "76 names its status" "$msg" "exited 76"
+    assert_contains "76 uses swift-safe's yield vocabulary" "$msg" "yielded its place in the queue"
+    assert_contains "76 says nothing was compiled" "$msg" "nothing was compiled"
+    assert_missing "76 does not claim the build failed" "$msg" "the build FAILED"
+}
+
+test_message_for_compile_failure_points_at_output() {
+    local msg; msg="$(describe_build_failure 1)"
+    assert_contains "compile failure says the build failed" "$msg" "the build FAILED"
+    assert_contains "compile failure names its status" "$msg" "exited 1"
+    assert_contains "compile failure points at the printed output" "$msg" "output printed above"
+    assert_missing "compile failure does not claim a lock timeout" "$msg" "EX_TEMPFAIL"
+    assert_contains "compile failure still says nothing was shipped" "$msg" "Nothing was shipped"
+}
+
+test_no_automatic_retry_is_stated() {
+    local msg; msg="$(describe_build_failure 75)"
+    assert_contains "message explains why there is no auto-retry" "$msg" "Not retried automatically"
+}
+
+# --- running the governed build ----------------------------------------------
+
+# THE REGRESSION: swift-safe timed out waiting for the machine-wide build lock
+# and exited 75 having compiled nothing. Piped into `tail -3`, that surfaced as
+# status 0 and restart.sh shipped stale binaries. The real status must survive.
+test_lock_timeout_status_survives() {
+    local d; d="$(mkfakeworktree 75)"
+    local out status=0
+    out="$(run_under_restart_shell "$d" -Xswiftc -foo 2>/dev/null)" || status=$?
+    assert_eq "run_governed_build returns swift-safe's 75, not tail's 0" "75" "$status"
+    rm -rf "$d"
+}
+
+test_queue_yield_status_survives() {
+    local d; d="$(mkfakeworktree 76)"
+    local status=0
+    run_under_restart_shell "$d" >/dev/null 2>&1 || status=$?
+    assert_eq "run_governed_build returns 76" "76" "$status"
+    rm -rf "$d"
+}
+
+test_compile_failure_status_survives() {
+    local d; d="$(mkfakeworktree 1)"
+    local status=0
+    run_under_restart_shell "$d" >/dev/null 2>&1 || status=$?
+    assert_eq "run_governed_build returns 1 on a compile failure" "1" "$status"
+    rm -rf "$d"
+}
+
+test_successful_build_returns_zero() {
+    local d; d="$(mkfakeworktree 0)"
+    local status=0
+    run_under_restart_shell "$d" >/dev/null 2>&1 || status=$?
+    assert_eq "run_governed_build returns 0 on success" "0" "$status"
+    rm -rf "$d"
+}
+
+test_failure_explanation_reaches_stderr() {
+    local d; d="$(mkfakeworktree 75)"
+    local err; err="$(run_under_restart_shell "$d" 2>&1 >/dev/null)" || true
+    assert_contains "explanation goes to stderr" "$err" "EX_TEMPFAIL"
+    rm -rf "$d"
+}
+
+# swift-safe's own final stderr line — the one it prints so the number
+# survives a pipe — must still reach the human through the trimmed output.
+test_swift_safe_status_line_reaches_the_human() {
+    local d; d="$(mkfakeworktree 75)"
+    local out; out="$(run_under_restart_shell "$d" 2>/dev/null)" || true
+    assert_contains "swift-safe's exit-status line survives the trim" "$out" "swift-safe: exit status 75"
+    rm -rf "$d"
+}
+
+# The trimming is the whole reason the old pipeline existed: restart.sh is
+# nearly always run by an agent, and full compiler output floods its context.
+test_output_is_trimmed_to_three_lines() {
+    local d; d="$(mkfakeworktree 0 200)"
+    local out; out="$(run_under_restart_shell "$d" 2>/dev/null)"
+    assert_eq "only the last 3 lines are printed" "3" "$(printf '%s\n' "$out" | wc -l | tr -d ' ')"
+    assert_contains "the trimmed output is the TAIL" "$out" "compiler output line 200"
+    assert_missing "the head of the output is dropped" "$out" "compiler output line 1 "
+    rm -rf "$d"
+}
+
+test_arguments_pass_through_to_swift_safe() {
+    local d; d="$(mkfakeworktree 0)"
+    run_under_restart_shell "$d" -Xswiftc -module-cache-path -Xswiftc /tmp/cache >/dev/null 2>&1
+    local args; args="$(cat "$d/args.txt")"
+    assert_contains "the subcommand is build" "$args" "build"
+    assert_contains "module-cache flags reach swift-safe" "$args" "-module-cache-path"
+    assert_contains "flag values reach swift-safe" "$args" "/tmp/cache"
+    rm -rf "$d"
+}
+
+# The output file is an implementation detail of not-piping; it must not
+# accumulate in TMPDIR on either the success or the failure path.
+test_temp_output_file_is_cleaned_up() {
+    local scratch; scratch="$(mktemp -d "${TMPDIR:-/tmp}/restart-build-tmpdir.XXXXXX")"
+    local d0 d75
+    d0="$(mkfakeworktree 0)"; d75="$(mkfakeworktree 75)"
+    ( TMPDIR="$scratch"; run_under_restart_shell "$d0" >/dev/null 2>&1 ) || true
+    ( TMPDIR="$scratch"; run_under_restart_shell "$d75" >/dev/null 2>&1 ) || true
+    local leftovers; leftovers="$(find "$scratch" -name 'tbd-restart-build.*' | wc -l | tr -d ' ')"
+    assert_eq "no build-output temp files left behind" "0" "$leftovers"
+    rm -rf "$scratch" "$d0" "$d75"
+}
+
+# --- restart.sh wiring --------------------------------------------------------
+#
+# Static checks: the guard is worth nothing if restart.sh stops calling it, and
+# the pipeline is an easy "simplification" for a future editor to reintroduce.
+
+test_restart_sh_routes_the_build_through_the_guard() {
+    local body; body="$(cat "$HERE/restart.sh")"
+    assert_contains "restart.sh sources the build lib" "$body" 'scripts/restart-build-lib.sh'
+    # shellcheck disable=SC2016 # literal, unexpanded strings searched in restart.sh
+    assert_contains "restart.sh runs the governed build" "$body" 'run_governed_build "$REPO_ROOT"'
+    # restart.sh builds one runtime product per invocation, so the invocation
+    # spans several lines. Read the whole call — from the function name to the
+    # line that keeps its status — rather than pinning one spelling of it.
+    local call
+    # shellcheck disable=SC2016
+    call="$(sed -n '/run_governed_build "\$REPO_ROOT"/,/build_status=\$?/p' "$HERE/restart.sh")"
+    # shellcheck disable=SC2016
+    assert_contains "the governed build still passes the module-cache flags" "$call" '"${MODULE_CACHE_FLAGS[@]}"'
+    # shellcheck disable=SC2016
+    assert_contains "a non-zero build status is kept, not discarded" "$call" '|| build_status=$?'
+    # ...and stops restart.sh with that same status, before anything ships.
+    # shellcheck disable=SC2016
+    assert_contains "a non-zero build status exits restart.sh" "$body" '[ "$build_status" -eq 0 ] || exit "$build_status"'
+}
+
+test_restart_sh_never_pipes_the_build_status_away() {
+    local piped
+    piped="$(grep -nE 'swift-safe build.*\|' "$HERE/restart.sh" || true)"
+    assert_eq "no swift-safe build invocation is piped in restart.sh" "" "$piped"
+}
+
+# --skip-build (--quick) must keep shipping the existing binaries: no build was
+# attempted, so there is no status to gate on. The guarded call must therefore
+# sit inside the skip_build branch, not before it.
+test_guard_applies_only_when_a_build_is_attempted() {
+    local restart="$HERE/restart.sh"
+    local skip_ln guard_ln bundle_ln
+    # shellcheck disable=SC2016 # literal, unexpanded strings searched in restart.sh
+    skip_ln="$(grep -nF 'if [ "$skip_build" = false ]; then' "$restart" | head -1 | cut -d: -f1)"
+    # shellcheck disable=SC2016
+    guard_ln="$(grep -nF 'run_governed_build "$REPO_ROOT"' "$restart" | head -1 | cut -d: -f1)"
+    bundle_ln="$(grep -nF '# MARK: - Assemble TBD.app bundle' "$restart" | head -1 | cut -d: -f1)"
+    local order="unknown"
+    if [[ -n "$skip_ln" && -n "$guard_ln" && -n "$bundle_ln" ]] \
+        && (( skip_ln < guard_ln )) && (( guard_ln < bundle_ln )); then
+        order="inside-skip-build-branch"
+    fi
+    assert_eq "guarded build (line ${guard_ln:-?}) sits inside the skip_build branch (line ${skip_ln:-?}) and before the bundle (line ${bundle_ln:-?})" \
+        "inside-skip-build-branch" "$order"
+}
+
+for t in $(declare -F | awk '{print $3}' | grep '^test_'); do "$t"; done
+if [ "$FAIL" -ne 0 ]; then echo "SOME TESTS FAILED"; exit 1; fi
+echo "ALL RESTART-BUILD-LIB TESTS PASSED"

--- a/scripts/restart-build-lib.test.sh
+++ b/scripts/restart-build-lib.test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Tests for scripts/restart-build-lib.sh — run: bash scripts/restart-build-lib.test.sh
 #
-# The invariant under test: restart.sh may only ship .build/debug when the
+# The invariant under test: restart.sh may only ship .build/<config> when the
 # build it just ran actually succeeded. The failure this guards against is a
 # pipeline swallowing the status — `scripts/swift-safe build … | tail -3`
 # exits with tail's status (0) even when swift-safe exited 75 having compiled

--- a/scripts/restart-build-lib.test.sh
+++ b/scripts/restart-build-lib.test.sh
@@ -242,10 +242,19 @@ test_restart_sh_routes_the_build_through_the_guard() {
     assert_contains "a non-zero build status exits restart.sh" "$body" '[ "$build_status" -eq 0 ] || exit "$build_status"'
 }
 
-test_restart_sh_never_pipes_the_build_status_away() {
-    local piped
-    piped="$(grep -nE 'swift-safe build.*\|' "$HERE/restart.sh" || true)"
-    assert_eq "no swift-safe build invocation is piped in restart.sh" "" "$piped"
+# The `swift-safe build` invocation lives in restart-build-lib.sh, so that is the
+# file this grep has to read; pointed at restart.sh it can never match and the
+# assertion passes unconditionally. Both files are scanned so the mistake cannot
+# be reintroduced at the call's old home either.
+test_the_build_invocation_never_pipes_the_status_away() {
+    local f piped
+    for f in restart-build-lib.sh restart.sh; do
+        # `||` is not a pipe. Mask it before looking for a real one, or the
+        # `|| status=$?` that KEEPS the build's status reads as the very bug
+        # this guard exists to catch.
+        piped="$(grep -nE 'swift-safe build' "$HERE/$f" | sed 's/||/OR/g' | grep -E '\|' || true)"
+        assert_eq "no swift-safe build invocation is piped in $f" "" "$piped"
+    done
 }
 
 # --skip-build (--quick) must keep shipping the existing binaries: no build was

--- a/scripts/restart-guard-lib.sh
+++ b/scripts/restart-guard-lib.sh
@@ -12,9 +12,11 @@
 # The set of paths that can affect the installed product: swift build compiles
 # Sources/ per Package.swift/Package.resolved; the bundle assembly copies
 # Resources/TBDApp.Info.plist and Resources/AppIcon.icns into the bundle; and
-# restart.sh together with the three libraries it sources determines what lands
-# in /Applications. Nothing else (Tests/, docs/, other scripts, stray root
-# files) can change the installed product.
+# restart.sh together with every library it sources determines what lands in
+# /Applications. Nothing else (Tests/, docs/, other scripts, stray root files)
+# can change the installed product. Adding a library to restart.sh means adding
+# it here too — restart-guard-lib.test.sh derives the expected set from
+# restart.sh's own `source` lines and fails if one is missing.
 INSTALL_PATHSPECS=(
     Sources
     Resources
@@ -22,6 +24,7 @@ INSTALL_PATHSPECS=(
     Package.resolved
     scripts/restart.sh
     scripts/restart-guard-lib.sh
+    scripts/restart-build-lib.sh
     scripts/restart-bundle-lib.sh
     scripts/restart-environment-lib.sh
 )

--- a/scripts/restart-guard-lib.test.sh
+++ b/scripts/restart-guard-lib.test.sh
@@ -122,6 +122,40 @@ test_no_main_ref_not_install_ready() {
     rm -rf "$d"
 }
 
+# Membership guard for INSTALL_PATHSPECS itself. Every library restart.sh sources
+# helps decide what lands in /Applications, so an uncommitted edit to any of them
+# must make the tree dirty; one missing from the array is a hole the guard cannot
+# see through. The expected set is DERIVED from restart.sh's own `source` lines
+# rather than hard-coded, so a library added later fails here loudly instead of
+# silently widening the hole.
+pathspec_listed() {
+    local needle="$1" p
+    for p in "${INSTALL_PATHSPECS[@]}"; do
+        [ "$p" = "$needle" ] && return 0
+    done
+    return 1
+}
+
+test_install_pathspecs_cover_every_library_restart_sh_sources() {
+    local restart="$HERE/restart.sh"
+    local libs
+    libs="$(grep -E '^[[:space:]]*(source|\.)[[:space:]]' "$restart" \
+        | grep -oE 'restart-[A-Za-z0-9_-]+-lib\.sh' | sort -u)"
+
+    # A derivation that matched nothing would make every assertion below vacuous
+    # and this whole test a no-op, so assert the shape of what was derived first.
+    local derived; derived="$(printf '%s\n' "$libs" | grep -c . || true)"
+    local enough="no (derived $derived)"
+    [ "${derived:-0}" -ge 4 ] && enough="yes"
+    assert_eq "restart.sh sources at least 4 libraries (derivation is not vacuous)" "yes" "$enough"
+
+    assert_ok "INSTALL_PATHSPECS lists scripts/restart.sh itself" pathspec_listed "scripts/restart.sh"
+    while IFS= read -r lib; do
+        [ -n "$lib" ] || continue
+        assert_ok "INSTALL_PATHSPECS lists scripts/$lib" pathspec_listed "scripts/$lib"
+    done <<< "$libs"
+}
+
 for t in $(declare -F | awk '{print $3}' | grep '^test_'); do "$t"; done
 if [ "$FAIL" -ne 0 ]; then echo "SOME TESTS FAILED"; exit 1; fi
 echo "ALL GUARD-LIB TESTS PASSED"

--- a/scripts/restart.sh
+++ b/scripts/restart.sh
@@ -160,6 +160,22 @@ MODULE_CACHE_FLAGS=(
     -Xcc -fmodules-cache-path="$SHARED_MODULE_CACHE"
 )
 
+# Everything below this point ships what is in .build/<config> — it assembles
+# the bundle, copies it over /Applications/TBD.app, and restarts the shared
+# daemon. So a build that did not succeed must stop the script here, before
+# any of that. The status of the governed build is CAPTURED, never read
+# through a pipe: `scripts/swift-safe … | tail -3` reports tail's status
+# (always 0), so `set -e` never fires and a build that compiled nothing is
+# indistinguishable from one that succeeded — which is how an 1800s lock
+# timeout (exit 75) once relaunched the app and daemon machine-wide from
+# stale binaries. run_governed_build keeps the output trimming and returns
+# the real status; see scripts/restart-build-lib.sh (harness:
+# scripts/restart-build-lib.test.sh). `--quick`/`--skip-build` is unaffected:
+# shipping the existing binaries is the point there, and no build was
+# attempted to have a status.
+# shellcheck source=/dev/null
+source "$REPO_ROOT/scripts/restart-build-lib.sh"
+
 # Stamp the build identity BEFORE the compiler runs, so the sidecar beside a
 # binary always names the tree that binary came from. A build that skips this
 # (a tree with no git HEAD) leaves no sidecar, and the loader falls back to the
@@ -188,22 +204,22 @@ if [ "$skip_build" = false ]; then
     # looks for beside its own binary (see the list for what each one does
     # when it is missing). The test targets are scripts/test.sh's job, not
     # the restart path's.
-    build_ok=true
+    # run_governed_build captures scripts/swift-safe's real status, trims the
+    # output to its last few lines, and explains a non-zero status in
+    # swift-safe's own vocabulary. Piping the build straight into `tail` would
+    # make the pipeline's status `tail`'s (always 0) — the very
+    # status-discarding bug the lib exists to prevent. The status is kept
+    # rather than flattened to 1, so a caller can still tell "nothing was
+    # compiled, retry later" (75/76) from "the compiler said no".
+    build_status=0
     for product in "${RUNTIME_PRODUCTS[@]}"; do
-        # Capture the status, THEN print. Piping the build straight into
-        # `tail` would make the pipeline's status `tail`'s (always 0) — the
-        # very status-discarding bug this block exists to fix.
-        if ! build_out=$( (cd "$REPO_ROOT" && scripts/swift-safe build \
-                -c "$build_config" --product "$product" \
-                "${MODULE_CACHE_FLAGS[@]}") 2>&1 ); then
-            build_ok=false
-            # The rest would build behind the same machine-global lock and
-            # scroll the failure off the screen, and the restart below is
-            # abandoned either way.
-            printf '%s\n' "$build_out" | tail -3
-            break
-        fi
-        printf '%s\n' "$build_out" | tail -3
+        run_governed_build "$REPO_ROOT" \
+            -c "$build_config" --product "$product" \
+            "${MODULE_CACHE_FLAGS[@]}" || build_status=$?
+        # The rest would build behind the same machine-global lock and scroll
+        # the failure off the screen, and the restart below is abandoned
+        # either way.
+        [ "$build_status" -eq 0 ] || break
     done
     echo "  Build: $((SECONDS - t0))s"
 
@@ -211,10 +227,9 @@ if [ "$skip_build" = false ]; then
     # `tail`, discarding its status, so a broken build fell through to the
     # bundle assembly and daemon restart and silently relaunched the STALE
     # binary — a failed build that looked like a successful restart.
-    if [ "$build_ok" = false ]; then
-        echo "ERROR: build failed — not restarting. The running daemon/app are unchanged." >&2
-        exit 1
-    fi
+    # run_governed_build has already said what went wrong and that nothing was
+    # shipped, so this only has to stop.
+    [ "$build_status" -eq 0 ] || exit "$build_status"
 fi
 
 # MARK: - Assemble TBD.app bundle

--- a/scripts/restart.sh
+++ b/scripts/restart.sh
@@ -141,24 +141,13 @@ fi
 
 # MARK: - Build
 #
-# Shared clang/Swift module cache across ALL TBD worktrees. By default every
-# worktree's `.build` accumulates its own ~640 MB ModuleCache with near-
-# identical contents; pointing both the Swift frontend (-module-cache-path)
-# and clang (-fmodules-cache-path, reaches the C-shim dependency targets like
-# CNIOAtomics) at one $HOME-level directory keeps a single ~610 MB copy total,
-# concurrency-safe across parallel builds. Verified empirically (Swift 6.2.4):
-# local ModuleCache drops to ~0 MB with this flag combo.
-#
-# Stickiness note: SwiftPM bakes the cache path into .build/debug.yaml at plan
-# time, so a later build in this worktree silently keeps using
-# the shared cache until a manifest re-plan — expected, not a bug. See
-# docs/reclaim-build.md ("Shared module cache").
-SHARED_MODULE_CACHE="$HOME/Library/Caches/tbd/swift-module-cache"
-mkdir -p "$SHARED_MODULE_CACHE"
-MODULE_CACHE_FLAGS=(
-    -Xswiftc -module-cache-path -Xswiftc "$SHARED_MODULE_CACHE"
-    -Xcc -fmodules-cache-path="$SHARED_MODULE_CACHE"
-)
+# The shared clang/Swift module cache is NOT selected here. scripts/swift-safe
+# points every governed compile at it, so `build`, `test` and `run` all plan
+# identically. Passing the flags from here as well is how that agreement was
+# lost before: SwiftPM bakes the cache path into .build/debug.yaml at plan
+# time, so a tree that alternated between this script and the wrapper fully
+# recompiled on every transition, in both directions. See
+# docs/specs/2026-08-30-shared-module-cache-design.md.
 
 # Everything below this point ships what is in .build/<config> — it assembles
 # the bundle, copies it over /Applications/TBD.app, and restarts the shared
@@ -204,6 +193,7 @@ if [ "$skip_build" = false ]; then
     # looks for beside its own binary (see the list for what each one does
     # when it is missing). The test targets are scripts/test.sh's job, not
     # the restart path's.
+    #
     # run_governed_build captures scripts/swift-safe's real status, trims the
     # output to its last few lines, and explains a non-zero status in
     # swift-safe's own vocabulary. Piping the build straight into `tail` would
@@ -214,8 +204,7 @@ if [ "$skip_build" = false ]; then
     build_status=0
     for product in "${RUNTIME_PRODUCTS[@]}"; do
         run_governed_build "$REPO_ROOT" \
-            -c "$build_config" --product "$product" \
-            "${MODULE_CACHE_FLAGS[@]}" || build_status=$?
+            -c "$build_config" --product "$product" || build_status=$?
         # The rest would build behind the same machine-global lock and scroll
         # the failure off the screen, and the restart below is abandoned
         # either way.

--- a/scripts/swift-safe
+++ b/scripts/swift-safe
@@ -20,6 +20,20 @@ set nothing and could not silence it.  A ``-j``/``--jobs`` on the command line
 may lower it but not raise it — an agent that wants more parallelism is asking
 to overrule the machine owner, and should raise ``TBD_SWIFT_JOBS`` instead.
 
+Compile commands are also pointed at one shared precompiled-module cache
+under the user's real home, so every TBD worktree plans identically instead of
+each growing its own several-hundred-megabyte copy.  SwiftPM writes that path
+into every compile command in ``.build/debug.yaml``, so two entry points that
+disagree about it make each tree fully recompile on every transition between
+them — which is why the decision lives here, on the one path every governed
+build already takes, rather than in each caller.  The location is resolved from
+the passwd database and never from ``$HOME``: ``scripts/test.sh`` points ``HOME``
+at a scratch fence, and a ``$HOME``-derived cache would be minted empty inside
+it on every test run.  ``TBD_SWIFT_MODULE_CACHE_PATH`` moves it,
+``TBD_SWIFT_SHARED_MODULE_CACHE=0`` restores SwiftPM's per-worktree default, a
+caller that passes its own ``-module-cache-path`` is left alone, and ``CI`` is
+left alone too — runners are ephemeral, so a shared cache saves nothing there.
+
 Waiting is reported on stderr, never stdout, so a caller parsing SwiftPM's
 output sees nothing from this wrapper.  The holder writes ``pid``/``cwd``/
 ``command`` into the lock file after acquiring, and a waiter reads it back to
@@ -86,6 +100,7 @@ import fcntl
 import math
 import os
 from pathlib import Path
+import pwd
 import shutil
 import subprocess
 import sys
@@ -103,6 +118,11 @@ DEFAULT_HEARTBEAT_SECONDS = 60.0
 HOLDER_FIELDS = ("pid", "cwd", "command")
 MAX_REPORTED_COMMAND_CHARACTERS = 120
 COMPILE_SUBCOMMANDS = {"build", "run", "test"}
+# Where the shared precompiled-module cache lives, under the user's real home.
+SHARED_MODULE_CACHE_SUBPATH = "Library/Caches/tbd/swift-module-cache"
+# A caller that already spelled one of these has chosen; see
+# `_shares_the_module_cache`.
+MODULE_CACHE_OPTIONS = {"-module-cache-path", "-fmodules-cache-path"}
 SUPPORTED_SUBCOMMANDS = COMPILE_SUBCOMMANDS
 # Every status this wrapper produces itself, and what it means.  SwiftPM's own
 # status is deliberately absent and cannot be added: by then this process has
@@ -249,6 +269,101 @@ def _requested_jobs(arguments: list[str]) -> int | None:
     return None
 
 
+def _shared_module_cache_path() -> Path:
+    """Where precompiled modules go, spelled identically in every worktree.
+
+    Resolved from the passwd database, NEVER from ``$HOME`` and never through
+    ``Path.home()``, which reads ``$HOME`` first.  ``scripts/test.sh`` points
+    ``HOME`` and ``CFFIXED_USER_HOME`` at a scratch fence it deletes, so a
+    ``$HOME``-derived path would resolve inside that fence on every test run:
+    an empty cache minted per run, a full rebuild paid for it, and the local
+    caches this exists to retire regrown — all of it silent, looking like
+    nothing worse than slow tests.  `getpwuid` answers the real home whatever
+    the fence does, so the fence needs no cooperation from this wrapper and
+    this wrapper needs none from it.
+
+    Sharing depends on every worktree spelling the SAME path: the cached
+    artifacts embed the spelling, so a symlink per worktree would wedge every
+    worktree but the first.
+    """
+    explicit = os.environ.get("TBD_SWIFT_MODULE_CACHE_PATH")
+    if explicit:
+        return Path(explicit).expanduser()
+    return Path(pwd.getpwuid(os.getuid()).pw_dir) / SHARED_MODULE_CACHE_SUBPATH
+
+
+def _requests_a_module_cache(arguments: list[str]) -> bool:
+    """Whether the caller already named a module cache, in either spelling.
+
+    Covers the passthrough forms SwiftPM takes (``-Xswiftc
+    -module-cache-path <path>``, ``-Xcc -fmodules-cache-path=<path>``) by
+    looking for the flag itself wherever it appears in SwiftPM's own
+    arguments, with or without an ``=`` value attached.
+    """
+    return any(
+        argument.split("=", 1)[0] in MODULE_CACHE_OPTIONS for argument in arguments
+    )
+
+
+def _shares_the_module_cache(subcommand: str, swiftpm_arguments: list[str]) -> bool:
+    """Whether this invocation should be pointed at the shared cache.
+
+    Four ways to decline, each for its own reason:
+
+    * a subcommand that compiles nothing has no build plan to place;
+    * under ``CI`` the runners are ephemeral — one worktree per VM — so a
+      shared cache saves nothing, and ``.github/workflows/test.yml`` ends its
+      job with a build that does not come through here at all, so flagging
+      only the steps that do would make CI alternate against its own
+      ``actions/cache``d ``.build`` on every run;
+    * ``TBD_SWIFT_SHARED_MODULE_CACHE=0`` is the opt-out back to SwiftPM's
+      per-worktree default;
+    * a caller that passed its own path has chosen, and a second
+      differently-spelled copy would be a third plan variant — reintroducing
+      exactly the alternation that moving this decision here removes.
+    """
+    if subcommand not in COMPILE_SUBCOMMANDS:
+        return False
+    if os.environ.get("CI"):
+        return False
+    if os.environ.get("TBD_SWIFT_SHARED_MODULE_CACHE") == "0":
+        return False
+    return not _requests_a_module_cache(swiftpm_arguments)
+
+
+def _module_cache_arguments(subcommand: str, swiftpm_arguments: list[str]) -> list[str]:
+    """The flags to append, or nothing at all, creating the directory if used.
+
+    Both halves are needed: ``-Xswiftc -module-cache-path`` covers the Swift
+    frontend, and ``-Xcc -fmodules-cache-path=`` reaches the C-language
+    dependency shim targets (CNIOAtomics and friends) that the Swift flag
+    alone misses.
+
+    A directory that cannot be created costs a slower build, never a failed
+    one — SwiftPM's per-worktree default still works — so this says so once
+    and adds nothing, rather than failing a build over a cache.
+    """
+    if not _shares_the_module_cache(subcommand, swiftpm_arguments):
+        return []
+    path = _shared_module_cache_path()
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+    except OSError as error:
+        _report(
+            f"swift-safe: could not create the shared module cache at {path} "
+            f"({error}); building with SwiftPM's per-worktree cache instead"
+        )
+        return []
+    return [
+        "-Xswiftc",
+        "-module-cache-path",
+        "-Xswiftc",
+        str(path),
+        "-Xcc",
+        f"-fmodules-cache-path={path}",
+    ]
+
+
 def _run_swiftpm_arguments(arguments: list[str]) -> list[str]:
     """Return only `swift run` options before the executable and app args."""
     prefix: list[str] = []
@@ -277,24 +392,33 @@ def _bounded_arguments(subcommand: str, arguments: list[str]) -> list[str]:
         return result
 
     limit = _job_limit()
-    job_arguments = (
+    # `run` takes the program's own arguments after the executable name, and
+    # they are not SwiftPM's to read: both the job count and the module-cache
+    # flags are decided from the prefix alone, and inserted inside it.
+    swiftpm_arguments = (
         _run_swiftpm_arguments(arguments) if subcommand == "run" else arguments
     )
-    requested = _requested_jobs(job_arguments)
+    requested = _requested_jobs(swiftpm_arguments)
     if requested is None:
         _report_jobs_past_the_core_count(limit)
-        if subcommand == "run":
-            return [subcommand, "--jobs", str(limit), *arguments]
-        return [*result, "--jobs", str(limit)]
-    if requested <= 0:
-        raise SystemExit("SwiftPM --jobs must be positive")
-    if requested > limit:
-        raise SystemExit(
-            f"requested SwiftPM --jobs {requested} exceeds TBD_SWIFT_JOBS={limit}; "
-            "lower the command, or raise TBD_SWIFT_JOBS if you own this machine"
-        )
-    _report_jobs_past_the_core_count(requested)
-    return result
+        added = ["--jobs", str(limit)]
+    else:
+        if requested <= 0:
+            raise SystemExit("SwiftPM --jobs must be positive")
+        if requested > limit:
+            raise SystemExit(
+                f"requested SwiftPM --jobs {requested} exceeds TBD_SWIFT_JOBS={limit}; "
+                "lower the command, or raise TBD_SWIFT_JOBS if you own this machine"
+            )
+        _report_jobs_past_the_core_count(requested)
+        added = []
+
+    added += _module_cache_arguments(subcommand, swiftpm_arguments)
+    if not added:
+        return result
+    if subcommand == "run":
+        return [subcommand, *added, *arguments]
+    return [*result, *added]
 
 
 def _lock_path() -> Path:

--- a/scripts/swift-safe
+++ b/scripts/swift-safe
@@ -269,8 +269,11 @@ def _requested_jobs(arguments: list[str]) -> int | None:
     return None
 
 
-def _shared_module_cache_path() -> Path:
+def _shared_module_cache_path() -> Path | None:
     """Where precompiled modules go, spelled identically in every worktree.
+
+    ``None`` when the home directory cannot be resolved at all, which is not a
+    build failure — see the `KeyError` note below.
 
     Resolved from the passwd database, NEVER from ``$HOME`` and never through
     ``Path.home()``, which reads ``$HOME`` first.  ``scripts/test.sh`` points
@@ -289,7 +292,19 @@ def _shared_module_cache_path() -> Path:
     explicit = os.environ.get("TBD_SWIFT_MODULE_CACHE_PATH")
     if explicit:
         return Path(explicit).expanduser()
-    return Path(pwd.getpwuid(os.getuid()).pw_dir) / SHARED_MODULE_CACHE_SUBPATH
+    try:
+        home = pwd.getpwuid(os.getuid()).pw_dir
+    except KeyError:
+        # A uid with no passwd entry — minimal containers, sandboxes and
+        # arbitrary-UID environments all produce one. Unguarded this raises
+        # through `main` and aborts the invocation with a traceback, and since
+        # this wrapper is the sole mandatory gate for every SwiftPM command in
+        # the repo, that would break every build, test and run for such a uid
+        # with no way out short of already knowing to set the opt-out. The
+        # cache is an optimisation; losing it costs a slower build, so this
+        # degrades exactly as an uncreatable directory does.
+        return None
+    return Path(home) / SHARED_MODULE_CACHE_SUBPATH
 
 
 def _requests_a_module_cache(arguments: list[str]) -> bool:
@@ -346,6 +361,13 @@ def _module_cache_arguments(subcommand: str, swiftpm_arguments: list[str]) -> li
     if not _shares_the_module_cache(subcommand, swiftpm_arguments):
         return []
     path = _shared_module_cache_path()
+    if path is None:
+        _report(
+            "swift-safe: could not resolve this uid's home directory, so there "
+            "is nowhere to put a shared module cache; building with SwiftPM's "
+            "per-worktree cache instead"
+        )
+        return []
     try:
         path.mkdir(parents=True, exist_ok=True)
     except OSError as error:

--- a/scripts/swift-safe
+++ b/scripts/swift-safe
@@ -354,9 +354,13 @@ def _module_cache_arguments(subcommand: str, swiftpm_arguments: list[str]) -> li
     dependency shim targets (CNIOAtomics and friends) that the Swift flag
     alone misses.
 
-    A directory that cannot be created costs a slower build, never a failed
-    one — SwiftPM's per-worktree default still works — so this says so once
-    and adds nothing, rather than failing a build over a cache.
+    A directory that cannot be used costs a slower build, never a failed one —
+    SwiftPM's per-worktree default still works — so this says so once and adds
+    nothing, rather than failing a build over a cache.  "Cannot be used" covers
+    one it cannot create AND one that is already there but not writable:
+    `mkdir(exist_ok=True)` succeeds on the latter, and naming a cache the
+    compiler cannot write into would turn a disposable optimisation into a
+    failed build, which is the one outcome this must never cause.
     """
     if not _shares_the_module_cache(subcommand, swiftpm_arguments):
         return []
@@ -374,6 +378,14 @@ def _module_cache_arguments(subcommand: str, swiftpm_arguments: list[str]) -> li
         _report(
             f"swift-safe: could not create the shared module cache at {path} "
             f"({error}); building with SwiftPM's per-worktree cache instead"
+        )
+        return []
+    # An existing directory satisfies `exist_ok=True` whatever its mode, so
+    # creation succeeding is not yet evidence the compiler can write there.
+    if not os.access(path, os.W_OK | os.X_OK):
+        _report(
+            f"swift-safe: the shared module cache at {path} is not writable; "
+            "building with SwiftPM's per-worktree cache instead"
         )
         return []
     return [

--- a/scripts/test-swift-safe.py
+++ b/scripts/test-swift-safe.py
@@ -829,6 +829,33 @@ class SharedModuleCacheTests(RunnerFixture):
         self.assertEqual(result.stdout.strip(), "build --jobs 2")
         self.assertIn("shared module cache", result.stderr)
 
+    def test_a_uid_with_no_passwd_entry_falls_back_rather_than_crashing(self):
+        """The same promise, one step earlier: home resolution can fail too.
+
+        `pwd.getpwuid` raises `KeyError` for a uid with no passwd entry —
+        minimal containers, sandboxes and arbitrary-UID environments all make
+        one. This wrapper is the sole mandatory gate for every SwiftPM command
+        in the repo, so an unhandled raise here would abort every build, test
+        and run for such a uid, with no way out short of already knowing to set
+        the opt-out. Degrade like an uncreatable directory instead.
+        """
+        with self.in_process_environment():
+            with mock.patch.object(
+                swift_safe.pwd, "getpwuid", side_effect=KeyError("uid not found")
+            ):
+                self.assertIsNone(swift_safe._shared_module_cache_path())
+                self.assertEqual(swift_safe._module_cache_arguments("build", []), [])
+
+    def test_an_explicit_path_still_works_without_a_passwd_entry(self):
+        """The override is read before the passwd lookup, so it remains the
+        escape hatch for exactly the environment that has no home to find."""
+        target = Path(self.temp.name) / "explicit"
+        with self.in_process_environment(TBD_SWIFT_MODULE_CACHE_PATH=str(target)):
+            with mock.patch.object(
+                swift_safe.pwd, "getpwuid", side_effect=KeyError("uid not found")
+            ):
+                self.assertEqual(swift_safe._shared_module_cache_path(), target)
+
 
 class WaitReportingTests(unittest.TestCase):
     """Drive `_acquire` against a real contended flock with a fake clock."""

--- a/scripts/test-swift-safe.py
+++ b/scripts/test-swift-safe.py
@@ -13,6 +13,7 @@ import importlib.machinery
 import importlib.util
 import os
 from pathlib import Path
+import pwd
 import shlex
 import signal
 import subprocess
@@ -132,7 +133,13 @@ def _dead_pid() -> int:
     return finished.pid
 
 
-class SwiftSafeTests(unittest.TestCase):
+class RunnerFixture(unittest.TestCase):
+    """A temp `TBD_HOME` and a fake `swift` that echoes the argv it was given.
+
+    Shared by the job-governor cases and the module-cache cases, which need
+    the same fixture but disagree about one knob (see `runner_env`).
+    """
+
     def setUp(self):
         self.temp = tempfile.TemporaryDirectory()
         root = Path(self.temp.name)
@@ -159,30 +166,58 @@ class SwiftSafeTests(unittest.TestCase):
         wrapper invites exactly that — must not decide what these cases
         observe, or the default cases assert their job count instead of the
         shipped one.  Each case states the settings it depends on itself.
+
+        `CI` is cleared for the same reason and matters more than it looks:
+        this harness runs inside GitHub Actions, where `CI=true` is exported,
+        and the wrapper reads it.  Inherited, it would silently switch every
+        case here onto the no-flags branch — green locally, vacuous in CI.
+
+        The shared module cache is turned OFF here, so that the cases below
+        keep asserting SwiftPM's argv exactly and stay about the job
+        governor.  `sharing_env` is the same environment with that opt-out
+        removed, which is what a real caller gets.
         """
         env = {
             name: value
             for name, value in os.environ.items()
             if not name.startswith("TBD_SWIFT_")
         }
+        env.pop("CI", None)
         env.update(
             {
                 "TBD_HOME": str(self.tbd_home),
                 "TBD_SWIFT_BIN": str(self.fake_swift),
+                "TBD_SWIFT_SHARED_MODULE_CACHE": "0",
                 **extra_env,
             }
         )
         return env
 
-    def run_runner(self, *arguments, **extra_env):
+    def sharing_env(self, **extra_env) -> dict[str, str]:
+        """`runner_env` without the module-cache opt-out: the shipped default."""
+        env = self.runner_env(**extra_env)
+        if "TBD_SWIFT_SHARED_MODULE_CACHE" not in extra_env:
+            env.pop("TBD_SWIFT_SHARED_MODULE_CACHE", None)
+        return env
+
+    def _run(self, env: dict[str, str], arguments):
         return subprocess.run(
             [str(RUNNER), *arguments],
             text=True,
             capture_output=True,
-            env=self.runner_env(**extra_env),
+            env=env,
             check=False,
         )
 
+    def run_runner(self, *arguments, **extra_env):
+        return self._run(self.runner_env(**extra_env), arguments)
+
+    def run_sharing(self, *arguments, **extra_env):
+        """Run with the module cache left at its shipped (shared) default."""
+        return self._run(self.sharing_env(**extra_env), arguments)
+
+
+class SwiftSafeTests(RunnerFixture):
     def test_compile_commands_default_to_two_jobs(self):
         result = self.run_runner("test", "--filter", "Foo")
         self.assertEqual(result.returncode, 0, result.stderr)
@@ -581,6 +616,185 @@ class SwiftSafeTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertNotIn(self.EXIT_STATUS_PREFIX, result.stderr)
         self.assertNotIn(self.EXIT_STATUS_PREFIX, result.stdout)
+
+
+class SharedModuleCacheTests(RunnerFixture):
+    """Where precompiled modules land, decided here for every governed build.
+
+    Each case asserts both directions of the condition it names: the flags
+    present when the condition is absent, and absent when it holds.  A case
+    that only ever asserts absence would pass against a wrapper that never
+    added the flags at all.
+    """
+
+    def flags_for(self, path) -> str:
+        """The flags as the fake `swift` prints them: argv joined by spaces."""
+        return (
+            f"-Xswiftc -module-cache-path -Xswiftc {path} "
+            f"-Xcc -fmodules-cache-path={path}"
+        )
+
+    @property
+    def shipped_path(self) -> Path:
+        """The location the wrapper resolves with nothing configured."""
+        return Path(pwd.getpwuid(os.getuid()).pw_dir) / (
+            "Library/Caches/tbd/swift-module-cache"
+        )
+
+    # ---- the resolved path ------------------------------------------------
+
+    def test_the_path_comes_from_the_passwd_database_not_from_home(self):
+        """THE regression this whole change turns on, asserted directly.
+
+        `scripts/test.sh` points `HOME` and `CFFIXED_USER_HOME` at a scratch
+        fence.  A `$HOME`-derived cache would resolve inside that fence on
+        every test run, minting an empty cache each time — so every run would
+        pay a full rebuild while looking like nothing worse than slow tests.
+        `Path.home()` reads `$HOME` first and is the same bug spelled shorter.
+        """
+        with tempfile.TemporaryDirectory() as fence:
+            with mock.patch.dict(
+                os.environ, {"HOME": fence, "CFFIXED_USER_HOME": fence}
+            ):
+                resolved = swift_safe._shared_module_cache_path()
+        self.assertEqual(resolved, self.shipped_path)
+        self.assertNotIn(fence, str(resolved))
+
+    def test_a_fenced_home_does_not_move_the_flags_end_to_end(self):
+        """The same fact through the real script, where the fence really is set."""
+        with tempfile.TemporaryDirectory() as fence:
+            result = self.run_sharing("build", HOME=fence, CFFIXED_USER_HOME=fence)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn(self.flags_for(self.shipped_path), result.stdout)
+        self.assertNotIn(fence, result.stdout)
+
+    def test_an_explicit_path_overrides_the_shipped_one(self):
+        override = Path(self.temp.name) / "elsewhere"
+        result = self.run_sharing("build", TBD_SWIFT_MODULE_CACHE_PATH=str(override))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn(self.flags_for(override), result.stdout)
+        self.assertNotIn(str(self.shipped_path), result.stdout)
+
+    # ---- which subcommands get them ---------------------------------------
+
+    def test_every_compile_subcommand_gets_the_flags(self):
+        for subcommand in ("build", "test"):
+            with self.subTest(subcommand=subcommand):
+                result = self.run_sharing(subcommand)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertIn(self.flags_for(self.shipped_path), result.stdout)
+
+    def test_run_places_the_flags_before_the_executable(self):
+        """Past the executable name SwiftPM stops reading its own arguments."""
+        result = self.run_sharing("run", "TBDApp", "--jobs", "99")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            result.stdout.strip(),
+            "run --jobs 2 "
+            + self.flags_for(self.shipped_path)
+            + " TBDApp --jobs 99",
+        )
+
+    def test_a_non_compiling_subcommand_is_never_flagged(self):
+        """`package resolve` plans nothing, so it has no cache to place."""
+        self.assertFalse(swift_safe._shares_the_module_cache("package", []))
+        self.assertTrue(swift_safe._shares_the_module_cache("build", []))
+
+    # ---- continuous integration -------------------------------------------
+
+    def test_ci_keeps_swiftpms_own_per_worktree_cache(self):
+        """Ephemeral runners share nothing, and `test.yml` also builds
+        without this wrapper — flagging only some of its steps would make CI
+        alternate against its own cached `.build` on every run."""
+        flagged = self.run_sharing("build")
+        self.assertIn(self.flags_for(self.shipped_path), flagged.stdout)
+
+        for value in ("1", "true"):
+            with self.subTest(value=value):
+                result = self.run_sharing("build", CI=value)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertNotIn("-module-cache-path", result.stdout)
+                self.assertNotIn("-fmodules-cache-path", result.stdout)
+
+    def test_an_empty_ci_variable_does_not_count_as_ci(self):
+        """`CI=` is how a shell unsets-in-place; it is not a CI runner."""
+        result = self.run_sharing("build", CI="")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn(self.flags_for(self.shipped_path), result.stdout)
+
+    # ---- the opt-out -------------------------------------------------------
+
+    def test_the_opt_out_restores_the_per_worktree_default(self):
+        off = self.run_sharing("build", TBD_SWIFT_SHARED_MODULE_CACHE="0")
+        self.assertEqual(off.returncode, 0, off.stderr)
+        self.assertNotIn("-module-cache-path", off.stdout)
+        self.assertNotIn("-fmodules-cache-path", off.stdout)
+
+        for value in ("1", ""):
+            with self.subTest(value=value):
+                on = self.run_sharing("build", TBD_SWIFT_SHARED_MODULE_CACHE=value)
+                self.assertEqual(on.returncode, 0, on.stderr)
+                self.assertIn(self.flags_for(self.shipped_path), on.stdout)
+
+    # ---- a caller that already chose --------------------------------------
+
+    def test_a_caller_supplied_cache_path_is_left_alone(self):
+        """A second, differently-spelled copy would be a third plan variant —
+        exactly the alternation this change exists to remove."""
+        chosen = Path(self.temp.name) / "callers-cache"
+        spellings = (
+            ("-Xswiftc", "-module-cache-path", "-Xswiftc", str(chosen)),
+            ("-Xcc", f"-fmodules-cache-path={chosen}"),
+        )
+        for arguments in spellings:
+            with self.subTest(arguments=arguments):
+                result = self.run_sharing("build", *arguments)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertNotIn(str(self.shipped_path), result.stdout)
+                self.assertEqual(
+                    result.stdout.strip(),
+                    "build " + " ".join(arguments) + " --jobs 2",
+                )
+
+        # The other direction: the same command without that flag is flagged.
+        result = self.run_sharing("build")
+        self.assertIn(self.flags_for(self.shipped_path), result.stdout)
+
+    def test_a_cache_flag_meant_for_the_program_does_not_disarm_a_run(self):
+        """Mutation guard: `run` scans only SwiftPM's own prefix, as `--jobs`
+        does — an argument past the executable name belongs to the program."""
+        result = self.run_sharing(
+            "run", "TBDApp", "-Xcc", "-fmodules-cache-path=/tmp/not-swiftpms"
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn(self.flags_for(self.shipped_path), result.stdout)
+
+    # ---- the directory itself ----------------------------------------------
+
+    def test_the_cache_directory_is_created_only_when_it_will_be_used(self):
+        created = Path(self.temp.name) / "made-here"
+        result = self.run_sharing("build", TBD_SWIFT_MODULE_CACHE_PATH=str(created))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue(created.is_dir(), "the shared cache directory was not created")
+
+        skipped = Path(self.temp.name) / "not-made-here"
+        off = self.run_sharing(
+            "build",
+            TBD_SWIFT_MODULE_CACHE_PATH=str(skipped),
+            TBD_SWIFT_SHARED_MODULE_CACHE="0",
+        )
+        self.assertEqual(off.returncode, 0, off.stderr)
+        self.assertFalse(skipped.exists(), "a directory was created for an unused path")
+
+    def test_an_uncreatable_cache_directory_falls_back_rather_than_failing(self):
+        """A cache we cannot make is a slower build, never a failed one — the
+        default per-worktree cache still works, and the wrapper says so."""
+        blocked = Path(self.temp.name) / "a-file" / "cache"
+        blocked.parent.write_text("not a directory", encoding="utf-8")
+        result = self.run_sharing("build", TBD_SWIFT_MODULE_CACHE_PATH=str(blocked))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "build --jobs 2")
+        self.assertIn("shared module cache", result.stderr)
 
 
 class WaitReportingTests(unittest.TestCase):

--- a/scripts/test-swift-safe.py
+++ b/scripts/test-swift-safe.py
@@ -216,6 +216,27 @@ class RunnerFixture(unittest.TestCase):
         """Run with the module cache left at its shipped (shared) default."""
         return self._run(self.sharing_env(**extra_env), arguments)
 
+    @contextlib.contextmanager
+    def in_process_environment(self, **overrides):
+        """`sharing_env`'s twin for helpers called in-process, not as a subprocess.
+
+        `_shares_the_module_cache` reads `os.environ` directly, so calling it
+        from a test inherits the *real* environment — and this harness runs
+        inside GitHub Actions, where `CI=true` is exported.  Left alone, every
+        in-process assertion silently evaluates the no-flags branch: the
+        `assertFalse` legs then pass for entirely the wrong reason, and only an
+        `assertTrue` control leg reveals it.  One did, in CI, after the
+        subprocess half had already been sanitised here — which is the whole
+        argument for routing both halves through a named helper rather than
+        remembering the environment at each call site.
+        """
+        env = dict(os.environ)
+        env.pop("CI", None)
+        env.pop("TBD_SWIFT_SHARED_MODULE_CACHE", None)
+        env.update(overrides)
+        with mock.patch.dict(os.environ, env, clear=True):
+            yield
+
 
 class SwiftSafeTests(RunnerFixture):
     def test_compile_commands_default_to_two_jobs(self):
@@ -697,8 +718,20 @@ class SharedModuleCacheTests(RunnerFixture):
 
     def test_a_non_compiling_subcommand_is_never_flagged(self):
         """`package resolve` plans nothing, so it has no cache to place."""
-        self.assertFalse(swift_safe._shares_the_module_cache("package", []))
-        self.assertTrue(swift_safe._shares_the_module_cache("build", []))
+        with self.in_process_environment():
+            self.assertFalse(swift_safe._shares_the_module_cache("package", []))
+            self.assertTrue(swift_safe._shares_the_module_cache("build", []))
+
+    def test_the_in_process_control_leg_survives_a_ci_runner(self):
+        """The regression that reached CI: `CI=true` disarmed the control leg.
+
+        Pins the helper rather than the predicate.  Without the environment
+        scrubbing, this is exactly the assertion that failed on a runner while
+        passing on every developer machine.
+        """
+        with mock.patch.dict(os.environ, {"CI": "true"}):
+            with self.in_process_environment():
+                self.assertTrue(swift_safe._shares_the_module_cache("build", []))
 
     # ---- continuous integration -------------------------------------------
 

--- a/scripts/test-swift-safe.py
+++ b/scripts/test-swift-safe.py
@@ -230,9 +230,12 @@ class RunnerFixture(unittest.TestCase):
         argument for routing both halves through a named helper rather than
         remembering the environment at each call site.
         """
-        env = dict(os.environ)
+        env = {
+            name: value
+            for name, value in os.environ.items()
+            if not name.startswith("TBD_SWIFT_")
+        }
         env.pop("CI", None)
-        env.pop("TBD_SWIFT_SHARED_MODULE_CACHE", None)
         env.update(overrides)
         with mock.patch.dict(os.environ, env, clear=True):
             yield
@@ -674,9 +677,7 @@ class SharedModuleCacheTests(RunnerFixture):
         `Path.home()` reads `$HOME` first and is the same bug spelled shorter.
         """
         with tempfile.TemporaryDirectory() as fence:
-            with mock.patch.dict(
-                os.environ, {"HOME": fence, "CFFIXED_USER_HOME": fence}
-            ):
+            with self.in_process_environment(HOME=fence, CFFIXED_USER_HOME=fence):
                 resolved = swift_safe._shared_module_cache_path()
         self.assertEqual(resolved, self.shipped_path)
         self.assertNotIn(fence, str(resolved))
@@ -828,6 +829,30 @@ class SharedModuleCacheTests(RunnerFixture):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(result.stdout.strip(), "build --jobs 2")
         self.assertIn("shared module cache", result.stderr)
+
+    def test_an_unwritable_cache_directory_falls_back_rather_than_failing(self):
+        """`mkdir(exist_ok=True)` is happy with a directory it cannot write to.
+
+        Creation succeeding therefore says nothing about whether the compiler
+        can put a module there, and naming a cache it cannot write into would
+        fail the build — the one outcome the fallback exists to prevent.
+        Both directions: writable gets the flags, unwritable gets none.
+        """
+        blocked = Path(self.temp.name) / "read-only-cache"
+        blocked.mkdir()
+
+        warm = self.run_sharing("build", TBD_SWIFT_MODULE_CACHE_PATH=str(blocked))
+        self.assertEqual(warm.returncode, 0, warm.stderr)
+        self.assertIn(self.flags_for(blocked), warm.stdout)
+
+        blocked.chmod(0o500)
+        try:
+            result = self.run_sharing("build", TBD_SWIFT_MODULE_CACHE_PATH=str(blocked))
+        finally:
+            blocked.chmod(0o700)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "build --jobs 2")
+        self.assertIn("not writable", result.stderr)
 
     def test_a_uid_with_no_passwd_entry_falls_back_rather_than_crashing(self):
         """The same promise, one step earlier: home resolution can fail too.

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -488,16 +488,15 @@ maybe_reexec() {
 
 build_products() {
     local repo_root="${1-}"
-    local shared_module_cache="$HOME/Library/Caches/tbd/swift-module-cache"
-    local module_cache_flags product build_out
+    local product build_out
 
-    mkdir -p "$shared_module_cache"
-    # The same shared clang/Swift module cache restart.sh uses: without it
-    # every tree accumulates its own ~640 MB of near-identical modules.
-    module_cache_flags=(
-        -Xswiftc -module-cache-path -Xswiftc "$shared_module_cache"
-        -Xcc "-fmodules-cache-path=$shared_module_cache"
-    )
+    # The shared clang/Swift module cache is NOT selected here.
+    # scripts/swift-safe points every governed compile at it, so this script,
+    # scripts/restart.sh and scripts/test.sh all plan identically. Naming it a
+    # second time is how that agreement gets lost: SwiftPM bakes the path into
+    # the build plan, so two callers that spell it differently make every
+    # transition between them a full recompile. See
+    # docs/specs/2026-08-30-shared-module-cache-design.md.
 
     # SwiftPM honors only the last --product, so these are separate
     # invocations. The list is RUNTIME_PRODUCTS in restart-bundle-lib.sh, shared
@@ -509,8 +508,7 @@ build_products() {
         # Capture the status, THEN print. Piping the build into `tail` would
         # make the pipeline's status tail's, which is always zero.
         if ! build_out="$( (cd "$repo_root" && scripts/swift-safe build \
-                -c "$BUILD_CONFIG" --product "$product" \
-                "${module_cache_flags[@]}") 2>&1 )"; then
+                -c "$BUILD_CONFIG" --product "$product") 2>&1 )"; then
             printf '%s\n' "$build_out" | tail -20 >&2
             log_error "build of $product failed — the running installation is untouched"
             return 1


### PR DESCRIPTION
## Summary

Every TBD worktree keeps its own precompiled-module cache — 510 to 818 MB each, around
4.7 GB across the worktrees currently holding a `.build`. A shared cache already existed
to collapse those into one copy, but only `scripts/restart.sh` selected it, so most
builds never used it and the machine paid for both: the per-worktree caches *plus* 1.5 GB
of shared cache.

The disagreement also cost compile time. SwiftPM writes the module-cache path into every
compile command in the build plan, so a worktree that alternates between `restart.sh`
(shared path) and `scripts/swift-safe` or `scripts/test.sh` (default path) re-plans and
**fully recompiles on every transition, in both directions**. That is the normal
iteration loop — tests while working, restart to verify live — so the trees most actively
worked on paid it most often.

This moves the decision into `scripts/swift-safe`, the one wrapper every governed build
already passes through, so all three entry points plan identically. The per-worktree
caches stop being regenerated and about 4.7 GB comes back.

A second, unrelated bug fix rides along because it was found while investigating this
one; it is described separately below and is safe to review independently.

## Why this shape

Spec: [`docs/specs/2026-08-30-shared-module-cache-design.md`](docs/specs/2026-08-30-shared-module-cache-design.md).

The wrapper is the right home because it is already the mandatory path to SwiftPM — the
repo guardrail rejects raw SwiftPM invocations, and `scripts/test.sh` routes through it
too. A build-wide compile setting duplicated across callers drifts apart, and that drift
was the bug.

Three findings shaped it, all recorded in the spec with evidence:

- **The path is always in the plan.** SwiftPM emits a module-cache path into every compile
  command even with no flags, naming the worktree's own directory. The flags don't *add*
  an argument, they change the *value* of one that is always present — which is why the
  recompile is symmetric, and why no environment variable can select the cache instead.
- **A symlink cannot work.** Cached artifacts embed the *spelled* path of the worktree
  that created them and clang validates that spelling, not the inode. A second worktree
  sharing a directory this way fails outright with a PCH path mismatch and does not
  self-heal. The same embedded bytes defeat APFS cloning.
- **The path must come from the passwd database, not `$HOME`.** `scripts/test.sh` fences
  `HOME` and `CFFIXED_USER_HOME` to a scratch directory. A `$HOME`-derived path would
  resolve *inside the fence* on every test run, minting an empty cache each time — so
  every test run would pay a full rebuild and regrow the caches this removes, failing
  silently as nothing worse than slow tests. This is the bug class CLAUDE.md records as
  "a path hand-built from `$HOME`".

**Rejected:** deleting the flags from `restart.sh` instead. It converges just as
completely and costs about a third of the build-slot time, and it was the right answer
while the evidence was in doubt. It forfeits the 4.7 GB and discards a warm shared cache.
The spec keeps this as a genuinely close call rather than presenting the chosen design as
obvious.

**Honest scoping:** this is a disk change, not a speed change. It removes the alternation
tax, but so would the rejected alternative. Any cold-build speedup from warm system
modules is unmeasured and is not claimed. For scale, the `.build` trees these caches sit
inside total 28 GB — six times the module caches — so this is a tidy, not a fix for disk
pressure.

## What this PR does

**Shared module cache (`165d7c83`)**

- `scripts/swift-safe` gains the module-cache flags for `build`, `test` and `run`,
  resolving the directory from `pwd.getpwuid(os.getuid()).pw_dir` — never `$HOME`, never
  `Path.home()`.
- Skipped entirely when: the subcommand does not compile; `CI` is set; the caller passes
  `TBD_SWIFT_SHARED_MODULE_CACHE=0`; or the caller already supplies a module-cache flag
  (a second, differently-spelled copy would itself become a third plan variant and
  reintroduce the alternation). `TBD_SWIFT_MODULE_CACHE_PATH` overrides the location.
- A cache that cannot be had reports on stderr and adds no flags rather than failing the
  build — covering both a directory that cannot be created and a home directory that
  cannot be resolved (`getpwuid` raises for a uid with no passwd entry, as minimal
  containers and arbitrary-UID environments produce). The explicit-path override is read
  *before* the passwd lookup, so it remains a working escape hatch there.
- `scripts/restart.sh` and `scripts/update.sh` stop passing the flags. Both build the
  same runtime products through the same wrapper, so either one naming a cache of its
  own is the disagreement this removes; the invariant test sweeps every caller rather
  than `restart.sh` alone, so a third decider fails the harness.
- `docs/reclaim-build.md` rewritten. It previously claimed flag alternation was free and
  that the path was benignly sticky; both are false, and the measurements are in the spec.

**Unrelated bug fix (`4a59fb16`) — restart.sh shipped binaries it had not built**

`scripts/restart.sh` sets `set -e` but piped the build to `tail -3` without `pipefail`, so
the pipeline's status was `tail`'s and the real one was discarded. When the wrapper timed
out waiting for the machine-global build slot and exited 75 — *nothing was compiled* —
`restart.sh` read success, assembled the bundle, and relaunched the daemon and app from
whatever stale binaries were already present, reporting `RESTART_EXIT=0`. That is this
repo's documented "stale daemon reverts the fleet" failure, machine-wide, silently.

The build now runs through `scripts/restart-build-lib.sh`, which captures the real status,
keeps the output trimming, and refuses to assemble or relaunch anything when the build did
not run. 75 and 76 are reported as "the slot was not obtained, nothing was compiled,
nothing was shipped, retryable"; other non-zero statuses as a build failure. No automatic
retry — a silent 30-minute retry is worse than a clear failure. `--skip-build` semantics
are unchanged.

## CI

`swift-safe` adds no flags when `CI` is set, so CI keeps exactly today's behavior. Runners
are ephemeral, so a shared cache buys nothing there, and `test.yml` ends its job with a
bare SwiftPM build that does not route through the wrapper — flagging only the wrapped
steps would make every CI job alternate against itself and poison the cached `.build`.
Both branches of that condition are tested.

## Rebased onto `main` (2026-09-07)

The branch was 84 commits behind and `CONFLICTING`. Two files conflicted, both resolved
by keeping `main`'s newer structure and re-applying this branch's intent on top:

- **`scripts/restart.sh`.** `main` rewrote the build block since the merge base: it now
  builds each product in `RUNTIME_PRODUCTS` separately (#811), takes `-c "$build_config"`
  for `--release` (#621), stamps the build identity before compiling and delegates bundle
  assembly to `restart-bundle-lib.sh` (#805). All of that is preserved. `main` had also
  fixed the status-through-a-pipe bug independently and inline; the loop now calls
  `run_governed_build` instead, which keeps `main`'s per-product structure while restoring
  this branch's 75/76-versus-compile-failure vocabulary. It propagates the wrapper's real
  status rather than flattening it to 1, so "nothing was compiled, retry later" stays
  distinguishable from "the compiler said no".
- **`.github/workflows/test.yml`.** A line-adjacent conflict in the ubuntu
  guardrail-and-harness job only. Both sides kept; the macOS test job — its fast parallel
  passes, count floors and `--skip` regexes (#817) — is untouched by this PR.

The static assertions in `restart-build-lib.test.sh` and `reclaim-build.test.sh` that
pinned the old one-line invocation were rewritten against the new multi-line call and
mutation-checked: each one goes red when the thing it guards is removed.

`scripts/update.sh` did not exist at the merge base and had duplicated the cache decision
— from `$HOME`, not the passwd database. It is converged here for the same reason
`restart.sh` is.

Harnesses re-run on the rebased head, all green: `test-swift-safe.py`,
`restart-build-lib.test.sh`, `reclaim-build.test.sh`, `restart-bundle-lib.test.sh`,
`restart-guard-lib.test.sh`, `update.test.sh`, `test.test.sh`. shellcheck reports one
pre-existing warning, unchanged.

## Assumptions

- Assumes `pwd.getpwuid(os.getuid()).pw_dir` is the real home even when `HOME` is fenced.
  If a future harness fences the passwd database too, the cache silently relocates and
  every build becomes a full rebuild — `test_the_shared_module_cache_is_selected_only_by_the_wrapper`
  guards the code path but cannot see the environment.
- Assumes clang's own pruning keeps the shared cache bounded. `modules.timestamp` is
  present and the defaults prune weekly, evicting entries unused for 31 days; steady state
  is about 1.5 GB. If pruning stops, it grows without a reclaimer — it sits outside every
  `.build`, so `reclaim-build.sh` never sweeps it.

## Rollout

Converging costs a one-time full recompile in each worktree not already on the shared
path — six of the eight with a plan at time of writing; two already carry it and keep
their plan. Those rebuilds land against an already-warm cache and are spread across
whenever each tree next builds. Not gated behind a flag: a default-off flag would deliver
nothing since the flip is the entire change, and the shipped opt-out plus the one-line
revert cover the same ground. The spec argues this explicitly rather than skipping the
convention.

## Evidence & verification

**A test per branch**, red-then-green verified by reverting each production change
individually and confirming the named test goes red — path from `$HOME`, `CI` check
deleted, `CI` tested by presence rather than value, opt-out deleted, dedup always-true,
dedup scanning a program's own args, non-compile exclusion deleted, explicit-path override
ignored, `mkdir` deleted, `mkdir` failure made fatal, `run` appending after the executable
name, and flags never appended. `scripts/test-swift-safe.py`: **90 tests, exit 0** (was 77).

One fixture change is load-bearing: the harness now clears `CI`, because it runs inside
GitHub Actions where `CI=true` is exported — which would have silently switched every new
case onto the no-flags branch and passed green while testing nothing.

**The real build plan**, verified on a throwaway 3-target package (2 Swift, 1 C) built
through the modified wrapper under a private lock, so no machine-global build slot was
taken. A cold build with `.build` deleted produced **no local `ModuleCache` at all**, and
the shared cache did not grow — pure reuse of warm modules. The `-Xcc` half provably
reaches the C target: the shared path appears on the C node's compile command. With `CI=1`
and with the opt-out set, the plan reverts to the per-worktree path.

Every build log was checked for the queue-wait line before being trusted: a build that sat
in the queue reports zero errors having compiled nothing, which is the same shape as the
`restart.sh` bug above. One intermediate verification here *was* a false positive for
exactly that reason — a 0.23 s "Build complete" that compiled nothing — and was redone as
a genuine cold build.

`scripts/reclaim-build.test.sh` 120 ok / 0 fail; `scripts/restart-build-lib.test.sh` all
passed, including the assertion that a non-zero build status exits `restart.sh`.
shellcheck reports only two findings, both pre-existing and identical on `HEAD`.

**Not verified:** nothing was compiled at TBD scale. Local resources are constrained and
the machine-global slot was deliberately not taken, so the compile verdict for this repo
comes from this PR's CI run rather than from a local build.

[20260826-foreign-fish](https://cheapsteak.github.io/tbd/open/?worktree=DF792900-B763-4F2D-8A4E-7596563700DF)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added shared Swift and C module caching for supported build, test, and run commands, with configuration overrides and safe fallbacks.
  - Improved build status handling so failed builds stop packaging and installation while providing clearer diagnostics.
  - Preserved quick and skip-build workflows.

- **Bug Fixes**
  - Improved behavior in environments without a resolvable user home directory.

- **Documentation**
  - Added detailed guidance and design documentation for shared module caching.

- **Tests**
  - Expanded coverage for cache selection, build failures, status propagation, and restart integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
