### PR TITLE
Feat: Add the pty_holder_enabled gate and per-terminal transport column

### DIFF
--- a/Sources/TBDDaemon/Database/ConfigStore.swift
+++ b/Sources/TBDDaemon/Database/ConfigStore.swift
@@ -87,6 +87,12 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     /// default, so `nil` here means "never chose" rather than "off". Resolve it
     /// through `Config.remotePeerMessagingDefault`, never through `?? false`.
     var remote_peer_messaging_enabled: Bool?
+    /// The pty-holder transport gate. **Genuinely tri-state**, same shape as
+    /// `remote_peer_messaging_enabled`: the
+    /// `20260831055718_config_pty_holder` migration carries no SQL default, so
+    /// `nil` here means "never chose" rather than "off". Resolve it through
+    /// `Config.ptyHolderDefault`, never through `?? false`.
+    var pty_holder_enabled: Bool?
     /// JSON-encoded `[String: String]` remote create-param defaults (machine
     /// scope), keyed by the provider's own field names. Nil/absent means no
     /// opinion at this level — every field falls through to its
@@ -116,6 +122,8 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     /// - Parameter remotePeerMessagingDefault: same shape once more, for
     ///   `remote_peer_messaging_enabled` — the remote peer messaging bridge's
     ///   soak gate.
+    /// - Parameter ptyHolderDefault: same shape once more, for
+    ///   `pty_holder_enabled` — the pty-holder transport's soak gate.
     func toModel(
         queuedPromptDefault: Bool = Config.queuedPromptDefault,
         autoCreateNotesDefault: Bool = Config.autoCreateNotesDefault,
@@ -123,7 +131,8 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         gcProfileDirsDefault: Bool = Config.gcProfileDirsEnabledDefault,
         claudeCloudEnabledDefault: Bool = Config.claudeCloudEnabledDefault,
         gcOrphanProcessesDefault: Bool = Config.gcOrphanProcessesEnabledDefault,
-        remotePeerMessagingDefault: Bool = Config.remotePeerMessagingDefault
+        remotePeerMessagingDefault: Bool = Config.remotePeerMessagingDefault,
+        ptyHolderDefault: Bool = Config.ptyHolderDefault
     ) -> Config {
         Config(
             defaultProfileID: default_profile_id.flatMap(UUID.init(uuidString:)),
@@ -181,6 +190,8 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             // And once more, for the remote peer messaging bridge's gate —
             // NOT `?? false`.
             remotePeerMessagingEnabled: remote_peer_messaging_enabled ?? remotePeerMessagingDefault,
+            // And once more, for the pty-holder transport's gate — NOT `?? false`.
+            ptyHolderEnabled: pty_holder_enabled ?? ptyHolderDefault,
             remoteCreateDefaults: EnvOverridesCoding.decode(remote_create_defaults)
         )
     }
@@ -576,6 +587,21 @@ public struct ConfigStore: Sendable {
         try await writer.write { db in
             try db.execute(
                 sql: "UPDATE config SET remote_peer_messaging_enabled = ? WHERE id = ?",
+                arguments: [enabled, Self.singletonID]
+            )
+        }
+    }
+
+    /// Persist the pty-holder transport gate (default OFF, soaking). It gates
+    /// which transport a session is *spawned* onto; a session records its
+    /// transport at creation and keeps it for life, so flipping this never
+    /// migrates a running session. The column is written on every call, because
+    /// writing either value is the explicit gesture that lifts it out of NULL
+    /// forever after.
+    public func setPtyHolderEnabled(_ enabled: Bool) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE config SET pty_holder_enabled = ? WHERE id = ?",
                 arguments: [enabled, Self.singletonID]
             )
         }

--- a/Sources/TBDDaemon/Database/Migrations/20260831055718_config_pty_holder.sql
+++ b/Sources/TBDDaemon/Database/Migrations/20260831055718_config_pty_holder.sql
@@ -1,0 +1,8 @@
+-- Gate for the per-session pty-holder transport.
+--
+-- No DEFAULT clause, deliberately. ADD COLUMN ... DEFAULT would backfill every
+-- existing row, destroying the distinction between "nobody has chosen" (NULL)
+-- and "chose off" (0) — which is what made auto_hibernate_enabled impossible to
+-- graduate without a forcing UPDATE that also reset deliberate opt-ins.
+-- The shipped default lives in exactly one place: Config.ptyHolderDefault.
+ALTER TABLE config ADD COLUMN pty_holder_enabled INTEGER;

--- a/Sources/TBDDaemon/Database/Migrations/20260831055719_terminal_transport.sql
+++ b/Sources/TBDDaemon/Database/Migrations/20260831055719_terminal_transport.sql
@@ -1,0 +1,11 @@
+-- Which transport carries this terminal's session, recorded at creation and
+-- kept for life. NULL means the row predates the holder transport and is
+-- therefore tmux; Terminal.transport resolves NULL — and any value a future
+-- daemon writes that this one does not recognise — to .tmux.
+ALTER TABLE terminal ADD COLUMN transport TEXT;
+
+-- Holder identity, NULL for tmux-transport rows. tmuxWindowID/tmuxPaneID are
+-- NOT NULL from the v1 schema and cannot be relaxed, so holder rows write the
+-- empty string there and are discriminated by transport, never by those values.
+ALTER TABLE terminal ADD COLUMN holder_pid INTEGER;
+ALTER TABLE terminal ADD COLUMN child_pid INTEGER;

--- a/Sources/TBDDaemon/Database/TerminalStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalStore.swift
@@ -54,6 +54,15 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     /// wait carried no structured reason.
     var awaitingInputReason: String?
     var awaitingInputObservedAt: Date?
+    /// `TerminalTransport` raw value. NULL on every row written before
+    /// `20260831055719_terminal_transport`, which is what `.tmux` means; an
+    /// unrecognized value from a newer daemon degrades the same way rather than
+    /// failing the decode.
+    var transport: String?
+    /// PID of the `TBDHolder` process, for holder-transport rows only.
+    var holder_pid: Int32?
+    /// PID of the job the holder `forkpty()`d, for holder-transport rows only.
+    var child_pid: Int32?
 
     init(from terminal: Terminal) {
         self.id = terminal.id.uuidString
@@ -84,6 +93,9 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         self.activityStateOrderObservedAt = terminal.activityStateOrderObservedAt
         self.awaitingInputReason = FactColumnJSON.encode(terminal.awaitingInputReason)
         self.awaitingInputObservedAt = terminal.awaitingInputObservedAt
+        self.transport = terminal.transport.rawValue
+        self.holder_pid = terminal.holderPID
+        self.child_pid = terminal.childPID
     }
 
     /// Failable decode: skips (returns nil after a logged warning) rather than
@@ -128,7 +140,12 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             activityStateObservedAt: activityStateObservedAt,
             activityStateOrderObservedAt: activityStateOrderObservedAt,
             awaitingInputReason: FactColumnJSON.decode(AwaitingInputReason.self, from: awaitingInputReason),
-            awaitingInputObservedAt: awaitingInputObservedAt
+            awaitingInputObservedAt: awaitingInputObservedAt,
+            // NULL (a row older than the column) and an unrecognized value from
+            // a newer daemon both degrade to tmux rather than throwing.
+            transport: transport.flatMap(TerminalTransport.init(rawValue:)) ?? .tmux,
+            holderPID: holder_pid,
+            childPID: child_pid
         )
     }
 }
@@ -554,6 +571,11 @@ public struct TerminalStore: Sendable {
     /// never held a lease is still a desk. The lease store keeps maintaining
     /// the column afterwards — this is the same mechanism, given a starting
     /// value, not a second one.
+    ///
+    /// `transport` is likewise stamped here and never changed afterwards — the
+    /// `pty_holder_enabled` gate is read at spawn time, so a session created on
+    /// one transport keeps it for life. It defaults to `.tmux` so every existing
+    /// call site keeps creating tmux-backed sessions untouched.
     public func create(
         id: UUID = UUID(),
         worktreeID: UUID,
@@ -563,7 +585,10 @@ public struct TerminalStore: Sendable {
         claudeSessionID: String? = nil,
         profileID: UUID? = nil,
         kind: TerminalKind? = nil,
-        watchDeskRole: WatchDeskRole? = nil
+        watchDeskRole: WatchDeskRole? = nil,
+        transport: TerminalTransport = .tmux,
+        holderPID: Int32? = nil,
+        childPID: Int32? = nil
     ) async throws -> Terminal {
         let terminal = Terminal(
             id: id,
@@ -574,7 +599,10 @@ public struct TerminalStore: Sendable {
             claudeSessionID: claudeSessionID,
             profileID: profileID,
             kind: kind,
-            watchDeskRole: watchDeskRole
+            watchDeskRole: watchDeskRole,
+            transport: transport,
+            holderPID: holderPID,
+            childPID: childPID
         )
         let record = TerminalRecord(from: terminal)
         try await writer.write { db in

--- a/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
@@ -319,4 +319,27 @@ extension RPCRouter {
         subscriptions.broadcast(delta: .modelProfilesChanged)
         return .ok()
     }
+
+    /// Persist the pty-holder transport gate — the default-off soak switch for
+    /// spawning sessions onto a holder process rather than into a tmux window.
+    /// This is how the soak is turned on: the flag is the feature's only opt-in,
+    /// and leaving it reachable only by hand-editing `~/tbd/state.db` would put
+    /// the sole way to enable it behind a database the project's own rules say
+    /// not to go into.
+    ///
+    /// **It applies to sessions created after the call, and to no others.** A
+    /// session records its transport at creation and keeps it for life, so
+    /// flipping this on never moves a running tmux session onto a holder, and
+    /// flipping it off never takes a live holder session away.
+    ///
+    /// The column is written on every call, because writing either value is the
+    /// explicit gesture that lifts it out of NULL forever after.
+    func handleConfigSetPtyHolderEnabled(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(
+            ConfigSetPtyHolderEnabledParams.self, from: paramsData)
+        try await db.config.setPtyHolderEnabled(params.enabled)
+        // Reuse the existing config-change channel so the app reloads Config.
+        subscriptions.broadcast(delta: .modelProfilesChanged)
+        return .ok()
+    }
 }

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -704,6 +704,8 @@ public final class RPCRouter: Sendable {
                 return try await handleConfigSetRemoteBackends(request.paramsData)
             case RPCMethod.configSetRemotePeerMessagingEnabled:
                 return try await handleConfigSetRemotePeerMessagingEnabled(request.paramsData)
+            case RPCMethod.configSetPtyHolderEnabled:
+                return try await handleConfigSetPtyHolderEnabled(request.paramsData)
             case RPCMethod.peerStatus:
                 return try await handlePeerStatus()
             case RPCMethod.gcList:

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -614,6 +614,22 @@ public enum WatchDeskRole: String, Codable, Sendable, Equatable {
     }
 }
 
+/// Which mechanism carries a terminal's session.
+///
+/// Recorded at creation and never changed for the life of the session: the
+/// `pty_holder_enabled` flag gates *spawning*, not servicing, so flipping it
+/// never migrates a running session. Both transports therefore coexist for as
+/// long as any pre-flip session is alive.
+public enum TerminalTransport: String, Codable, Sendable, Equatable {
+    /// The session lives in a tmux window; `tmuxWindowID`/`tmuxPaneID` address it.
+    case tmux
+    /// The session's pty master is owned by a `TBDHolder` process.
+    /// `tmuxWindowID`/`tmuxPaneID` are NOT NULL from the v1 schema and cannot be
+    /// relaxed, so such a row carries empty strings there and must be
+    /// discriminated by this value alone — never by those columns.
+    case holder
+}
+
 public struct Terminal: Codable, Sendable, Identifiable, Equatable {
     public let id: UUID
     public var worktreeID: UUID
@@ -698,6 +714,16 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
     public var awaitingInputReason: AwaitingInputReason?
     /// When `awaitingInputReason` was observed.
     public var awaitingInputObservedAt: Date?
+    /// Which mechanism carries this session. Stamped at creation and never
+    /// changed. Rows and JSON written before the column existed decode as
+    /// `.tmux`, which is what they are.
+    public var transport: TerminalTransport
+    /// PID of the `TBDHolder` process owning the pty master, for
+    /// `transport == .holder` rows. Nil for tmux rows, and nil on a holder row
+    /// only while the holder is being established.
+    public var holderPID: Int32?
+    /// PID of the job the holder `forkpty()`d. Nil for tmux rows.
+    public var childPID: Int32?
 
     /// `activityState` as a fact — value, source, observed-at — or nil.
     ///
@@ -758,7 +784,10 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
                 activityStateObservedAt: Date? = nil,
                 activityStateOrderObservedAt: Date? = nil,
                 awaitingInputReason: AwaitingInputReason? = nil,
-                awaitingInputObservedAt: Date? = nil) {
+                awaitingInputObservedAt: Date? = nil,
+                transport: TerminalTransport = .tmux,
+                holderPID: Int32? = nil,
+                childPID: Int32? = nil) {
         self.id = id
         self.worktreeID = worktreeID
         self.tmuxWindowID = tmuxWindowID
@@ -789,6 +818,9 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
         self.activityStateOrderObservedAt = activityStateOrderObservedAt
         self.awaitingInputReason = awaitingInputReason
         self.awaitingInputObservedAt = awaitingInputObservedAt
+        self.transport = transport
+        self.holderPID = holderPID
+        self.childPID = childPID
     }
 
     enum CodingKeys: String, CodingKey {
@@ -800,6 +832,7 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
         case hibernatedAt, hibernateReason, keepWarm, pendingResumeAt, watchDeskRole
         case activityStateSource, activityStateObservedAt, activityStateOrderObservedAt
         case awaitingInputReason, awaitingInputObservedAt
+        case transport, holderPID, childPID
     }
 
     public init(from decoder: Decoder) throws {
@@ -842,6 +875,17 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
             Date.self, forKey: .activityStateOrderObservedAt)
         awaitingInputReason = try c.decodeIfPresent(AwaitingInputReason.self, forKey: .awaitingInputReason)
         awaitingInputObservedAt = try c.decodeIfPresent(Date.self, forKey: .awaitingInputObservedAt)
+        // Decoded as a raw string rather than as the enum so an unrecognized
+        // transport from a newer daemon degrades to tmux instead of failing the
+        // whole payload — the same rule `TerminalStore` applies to the column.
+        // Absent means the sender predates the holder transport, which is
+        // exactly what `.tmux` says. THIS LINE IS LOAD-BEARING: `init(from:)` is
+        // hand-written, so a defaulted property compiles without it and then
+        // silently reports `.tmux` for every holder row that crosses the wire.
+        transport = try c.decodeIfPresent(String.self, forKey: .transport)
+            .flatMap(TerminalTransport.init(rawValue:)) ?? .tmux
+        holderPID = try c.decodeIfPresent(Int32.self, forKey: .holderPID)
+        childPID = try c.decodeIfPresent(Int32.self, forKey: .childPID)
     }
 }
 
@@ -1418,6 +1462,22 @@ public struct Config: Codable, Sendable, Equatable {
     /// NULL means "never chose" and follows the shipped default wherever it
     /// goes; `0`/`1` is an explicit gesture and is honored forever.
     public var remotePeerMessagingEnabled: Bool
+    /// Whether new sessions spawn onto the per-session pty-holder transport
+    /// instead of tmux. It ships OFF: the holder owns a pty and a child process
+    /// that outlive the daemon, and until the holder reconcilers land nothing
+    /// reclaims one orphaned by a daemon crash.
+    ///
+    /// The gate covers *spawning* only. A session records its transport at
+    /// creation and keeps it for life, so flipping this never migrates a running
+    /// session and both transports coexist while any pre-flip session is alive.
+    ///
+    /// **Resolved, not stored**, like `remotePeerMessagingEnabled`: the backing
+    /// column carries no SQL default and stays NULL until somebody touches the
+    /// toggle, so this property is
+    /// `pty_holder_enabled ?? Config.ptyHolderDefault`. NULL means "never chose"
+    /// and follows the shipped default wherever it goes; `0`/`1` is an explicit
+    /// gesture and is honored forever.
+    public var ptyHolderEnabled: Bool
     /// Machine-wide remote create-param defaults, keyed by the **provider's
     /// own** `create_params` field names — the fall-through level beneath
     /// `Repo.remoteCreateDefaults`. TBD stores and replays these values
@@ -1472,6 +1532,12 @@ public struct Config: Codable, Sendable, Equatable {
     /// constant, with no forcing `UPDATE` migration and every explicit opt-out
     /// left alone.
     public static let remotePeerMessagingDefault = false
+    /// The shipped default for `ptyHolderEnabled`, and the single place it
+    /// lives. The holder transport ships off; graduation — after a soak in which
+    /// no holder or child process outlives the session that owns it — is a
+    /// change to this constant, with no forcing `UPDATE` migration and every
+    /// explicit opt-out left alone.
+    public static let ptyHolderDefault = false
 
     public init(defaultProfileID: UUID? = nil,
                 primaryAgentPreference: PrimaryAgentPreference = .defaultValue,
@@ -1505,6 +1571,7 @@ public struct Config: Codable, Sendable, Equatable {
                 claudeCloudEnabled: Bool = Config.claudeCloudEnabledDefault,
                 gcOrphanProcessesEnabled: Bool = Config.gcOrphanProcessesEnabledDefault,
                 remotePeerMessagingEnabled: Bool = Config.remotePeerMessagingDefault,
+                ptyHolderEnabled: Bool = Config.ptyHolderDefault,
                 remoteCreateDefaults: [String: String] = [:]) {
         self.defaultProfileID = defaultProfileID
         self.primaryAgentPreference = primaryAgentPreference
@@ -1538,6 +1605,7 @@ public struct Config: Codable, Sendable, Equatable {
         self.claudeCloudEnabled = claudeCloudEnabled
         self.gcOrphanProcessesEnabled = gcOrphanProcessesEnabled
         self.remotePeerMessagingEnabled = remotePeerMessagingEnabled
+        self.ptyHolderEnabled = ptyHolderEnabled
         self.remoteCreateDefaults = remoteCreateDefaults
     }
 
@@ -1621,6 +1689,11 @@ public struct Config: Codable, Sendable, Equatable {
         // default rather than hardcoding `false`.
         remotePeerMessagingEnabled = try c.decodeIfPresent(
             Bool.self, forKey: .remotePeerMessagingEnabled) ?? Config.remotePeerMessagingDefault
+        // And once more: absent means the sender knew nothing about the flag,
+        // which is the NULL column's situation — follow the shipped default
+        // rather than hardcoding `false`.
+        ptyHolderEnabled = try c.decodeIfPresent(
+            Bool.self, forKey: .ptyHolderEnabled) ?? Config.ptyHolderDefault
         // Absent means the sender knew nothing about global create defaults —
         // the same state as an empty map: no opinion at this level, so every
         // field falls through to its provider-declared `default`.

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -332,6 +332,10 @@ public enum RPCMethod {
     /// explains.
     public static let configSetRemotePeerMessagingEnabled =
         "config.setRemotePeerMessagingEnabled"
+    /// The pty-holder transport gate (`pty_holder_enabled`) — the feature's only
+    /// opt-in. Reading needs no method of its own: `config.get` already carries
+    /// the resolved value.
+    public static let configSetPtyHolderEnabled = "config.setPtyHolderEnabled"
     /// Everything TBD knows about the peer-messaging bridge, for `tbd peer list`.
     /// Read-only and unaddressed: it takes no params and never actuates.
     public static let peerStatus = "peer.status"
@@ -1605,6 +1609,17 @@ public struct ConfigSetRemoteBackendsParams: Codable, Sendable {
 /// state, so an operator who turns the feature off stays off when the shipped
 /// default graduates.
 public struct ConfigSetPeerMessagingEnabledParams: Codable, Sendable {
+    public let enabled: Bool
+    public init(enabled: Bool) { self.enabled = enabled }
+}
+
+/// Params for `config.setPtyHolderEnabled` — the pty-holder transport gate
+/// (default OFF during soak), which decides whether a *new* session is spawned
+/// onto a holder rather than into a tmux window. Writing either value is the
+/// explicit gesture that lifts the column out of its NULL "never chose" state,
+/// so an operator who turns the feature off stays off when the shipped default
+/// graduates.
+public struct ConfigSetPtyHolderEnabledParams: Codable, Sendable {
     public let enabled: Bool
     public init(enabled: Bool) { self.enabled = enabled }
 }

--- a/Tests/TBDDaemonTests/Config/PtyHolderFlagTests.swift
+++ b/Tests/TBDDaemonTests/Config/PtyHolderFlagTests.swift
@@ -1,0 +1,246 @@
+import Foundation
+import GRDB
+import Testing
+
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Schema and resolution guards for `config.pty_holder_enabled` and for the
+/// `terminal.transport` discriminator that rides with it.
+///
+/// The flag column is added by `20260831055718_config_pty_holder` with **no SQL
+/// default**, so "never chose" (NULL) stays distinguishable from "explicitly
+/// off" (0). If someone adds a `DEFAULT` clause to that migration,
+/// `ptyHolderIsNullBeforeAnyGesture` and
+/// `rowWrittenBeforeTheMigrationStillReadsNull` go red — that is their only job.
+/// The distinction earns its keep here because the holder transport owns a pty
+/// and a child process that outlive the daemon: somebody who turned it off did
+/// so deliberately and must stay opted out through graduation.
+///
+/// `transport` is a second model changing in the same commit, and it has its own
+/// trap: `Terminal` has a hand-written `init(from:)`, so a defaulted property
+/// compiles *without* a decode line and then silently reports `.tmux` for every
+/// holder row that crosses the wire. `terminalTransportRoundTripsHolder` is the
+/// test that discriminates; the default-direction one passes either way.
+@Suite("PtyHolderFlag")
+struct PtyHolderFlagTests {
+
+    /// The last migration identifier that predates the flag's column. Migrating
+    /// only this far reproduces the schema a real pre-flag daemon ran on.
+    private static let lastIdentifierBeforeTheFlag = "20260830022625_shadow_peer_artifacts"
+
+    private func fetchConfigRecord(_ db: TBDDatabase) async throws -> ConfigRecord? {
+        try await db.writerForTests.read { conn in
+            try ConfigRecord.fetchOne(conn, key: ConfigStore.singletonID)
+        }
+    }
+
+    // MARK: - Storage: the column is genuinely NULL until somebody chooses
+
+    /// **The load-bearing test.** The `config` singleton row is inserted by v1,
+    /// so every install — fresh or years old — has a row that predates this
+    /// column. After the migration that row must read NULL, not `0`: a SQL
+    /// default would backfill it and make "never chose" indistinguishable from
+    /// a deliberate opt-out.
+    @Test func ptyHolderIsNullBeforeAnyGesture() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let record = try #require(try await fetchConfigRecord(db))
+        #expect(
+            record.pty_holder_enabled == nil,
+            """
+            config.pty_holder_enabled must be NULL until the toggle is touched \
+            — read back \(String(describing: record.pty_holder_enabled)). A \
+            non-nil value here means 20260831055718_config_pty_holder grew a \
+            DEFAULT clause; remove it.
+            """)
+    }
+
+    /// The same guard against a row written by a real pre-flag daemon: migrate
+    /// only as far as the last identifier that predates the column, write to
+    /// the config row, then finish migrating.
+    @Test func rowWrittenBeforeTheMigrationStillReadsNull() throws {
+        let queue = try DatabaseQueue()
+        let migrator = TBDDatabase.buildMigratorForTests()
+        try migrator.migrate(queue, upTo: Self.lastIdentifierBeforeTheFlag)
+
+        // A pre-flag daemon touching config: the row exists and has been
+        // written to, but knows nothing about the new column.
+        try queue.write { db in
+            try db.execute(
+                sql: "UPDATE config SET auto_create_notes_enabled = 1 WHERE id = ?",
+                arguments: [ConfigStore.singletonID])
+        }
+
+        try migrator.migrate(queue)
+
+        try queue.read { db in
+            let row = try #require(try Row.fetchOne(
+                db, sql: "SELECT * FROM config WHERE id = ?",
+                arguments: [ConfigStore.singletonID]))
+            let raw: DatabaseValue = row["pty_holder_enabled"]
+            #expect(
+                raw.isNull,
+                "a config row written before the migration must read NULL, not \(raw)")
+            // The pre-existing write survived — the migration is purely additive.
+            #expect(row["auto_create_notes_enabled"] == true)
+        }
+    }
+
+    // MARK: - Resolution: the three states are distinguishable
+
+    /// NULL follows `Config.ptyHolderDefault` wherever it goes; an explicit
+    /// `false` does not. That property is what makes graduation a one-line
+    /// constant change with no forcing `UPDATE` migration. Exercised against
+    /// BOTH possible default values, so it fails if the resolution is ever
+    /// wired as `?? false`.
+    @Test func explicitFalseSurvivesADefaultFlipWhileNullFollowsIt() async throws {
+        let db = try TBDDatabase(inMemory: true)
+
+        let untouched = try #require(try await fetchConfigRecord(db))
+        #expect(untouched.pty_holder_enabled == nil)
+        #expect(untouched.toModel(ptyHolderDefault: false).ptyHolderEnabled == false)
+        #expect(
+            untouched.toModel(ptyHolderDefault: true).ptyHolderEnabled == true,
+            "a never-chosen row must pick up a changed shipped default")
+
+        try await db.config.setPtyHolderEnabled(false)
+        let explicitlyOff = try #require(try await fetchConfigRecord(db))
+        #expect(explicitlyOff.pty_holder_enabled == false)
+        #expect(explicitlyOff.toModel(ptyHolderDefault: false).ptyHolderEnabled == false)
+        #expect(
+            explicitlyOff.toModel(ptyHolderDefault: true).ptyHolderEnabled == false,
+            "an explicit opt-out must be honored forever, whatever the shipped default becomes")
+    }
+
+    /// Mirrored for an explicit `true`: an operator who opted into the soak
+    /// stays opted in even if the shipped default never moves.
+    @Test func explicitTrueSticks() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setPtyHolderEnabled(true)
+        let explicitlyOn = try #require(try await fetchConfigRecord(db))
+        #expect(explicitlyOn.pty_holder_enabled == true)
+        #expect(explicitlyOn.toModel(ptyHolderDefault: false).ptyHolderEnabled == true)
+        #expect(explicitlyOn.toModel(ptyHolderDefault: true).ptyHolderEnabled == true)
+    }
+
+    /// Isolates the RESOLUTION guard (`toModel()`'s `?? ptyHolderDefault`) from
+    /// the STORAGE guard (the migration's missing SQL default) by constructing a
+    /// `ConfigRecord` directly — no database, no migration. It catches a
+    /// hardening into `?? false` even if the migration guard were broken at the
+    /// same time.
+    @Test func toModelResolvesNullThroughTheInjectedDefault() {
+        let record = ConfigRecord(id: "unstored", pty_holder_enabled: nil)
+        #expect(record.toModel(ptyHolderDefault: false).ptyHolderEnabled == false)
+        #expect(
+            record.toModel(ptyHolderDefault: true).ptyHolderEnabled == true,
+            "a NULL record must pick up whatever default is injected, not a hardcoded false")
+    }
+
+    // MARK: - The shipped default, and the wire
+
+    /// The shipped default today: OFF. A holder owns a pty and a child process
+    /// that outlive the daemon, and until the holder reconcilers land nothing
+    /// reclaims one orphaned by a daemon crash — so the transport soaks behind
+    /// its own switch. Graduation edits this constant and nothing else.
+    @Test func shippedDefaultIsOff() async throws {
+        #expect(Config.ptyHolderDefault == false)
+        let db = try TBDDatabase(inMemory: true)
+        #expect(try await db.config.get().ptyHolderEnabled == false)
+    }
+
+    @Test func setPtyHolderEnabledRoundtrips() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setPtyHolderEnabled(true)
+        #expect(try await db.config.get().ptyHolderEnabled == true)
+        try await db.config.setPtyHolderEnabled(false)
+        #expect(try await db.config.get().ptyHolderEnabled == false)
+    }
+
+    /// JSON from a daemon that predates the flag still decodes, and the absent
+    /// key means the sender knew nothing about it — the NULL column's
+    /// situation, so it follows the shipped default rather than a hardcoded
+    /// `false`.
+    @Test func configJSONWithoutTheKeyFollowsTheShippedDefault() throws {
+        let json = #"{"primaryAgentPreference":"claude"}"#
+        let config = try JSONDecoder().decode(Config.self, from: Data(json.utf8))
+        #expect(config.ptyHolderEnabled == Config.ptyHolderDefault)
+    }
+
+    /// An explicit `true` on the wire is carried, so the app and the CLI see the
+    /// same state the daemon resolved rather than re-deriving it.
+    @Test func configJSONRoundTripsAnExplicitChoice() throws {
+        var config = Config()
+        config.ptyHolderEnabled = true
+        let decoded = try JSONDecoder().decode(
+            Config.self, from: JSONEncoder().encode(config))
+        #expect(decoded.ptyHolderEnabled == true)
+    }
+
+    // MARK: - Terminal.transport
+
+    /// A `Terminal` payload from a daemon that predates the column decodes as
+    /// `.tmux`, so no existing session is mistaken for a holder session. Every
+    /// required key is present — `Terminal.init(from:)` decodes `createdAt`
+    /// non-optionally, so a payload omitting it would fail against a *correct*
+    /// implementation and prove nothing.
+    @Test func terminalTransportDefaultsToTmux() throws {
+        let json = """
+            {"id":"\(UUID().uuidString)","worktreeID":"\(UUID().uuidString)",\
+            "tmuxWindowID":"@1","tmuxPaneID":"%1","label":"main","createdAt":0}
+            """
+        let decoded = try JSONDecoder().decode(Terminal.self, from: Data(json.utf8))
+        #expect(decoded.transport == .tmux)
+        #expect(decoded.holderPID == nil)
+        #expect(decoded.childPID == nil)
+    }
+
+    /// **The discriminating test.** `Terminal` has a hand-written `init(from:)`,
+    /// so `transport` compiles fine with no decode line at all and then reads
+    /// `.tmux` for every holder row the daemon sends the app or the CLI. Only a
+    /// round trip through the real encoder catches that; the default-direction
+    /// test above passes either way.
+    @Test func terminalTransportRoundTripsHolder() throws {
+        let terminal = Terminal(
+            worktreeID: UUID(),
+            // Holder rows carry empty tmux coordinates: those columns are NOT
+            // NULL from the v1 schema and cannot be relaxed, so `transport` is
+            // the only thing that may discriminate them.
+            tmuxWindowID: "", tmuxPaneID: "",
+            transport: .holder, holderPID: 4242, childPID: 4243)
+        let decoded = try JSONDecoder().decode(
+            Terminal.self, from: JSONEncoder().encode(terminal))
+        #expect(
+            decoded.transport == .holder,
+            "a holder terminal must still be a holder terminal after a wire round trip")
+        #expect(decoded.holderPID == 4242)
+        #expect(decoded.childPID == 4243)
+    }
+
+    /// The column plumbing, end to end through the real store: `create` stamps
+    /// the transport and the two PIDs, and `get` reads them back. Without this
+    /// the eleven tests above all pass against a `TerminalRecord` that never
+    /// writes the column, because they never touch the `terminal` table.
+    @Test func terminalTransportRoundTripsThroughTheStore() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/pty-holder-repo-\(UUID().uuidString)",
+            displayName: "R", defaultBranch: "main")
+        let worktree = try await db.worktrees.create(
+            repoID: repo.id, name: "w", branch: "b",
+            path: "/tmp/pty-holder-wt-\(UUID().uuidString)", tmuxServer: "tbd-pty-holder")
+
+        let tmux = try await db.terminals.create(
+            worktreeID: worktree.id, tmuxWindowID: "@1", tmuxPaneID: "%1")
+        #expect(
+            try await db.terminals.get(id: tmux.id)?.transport == .tmux,
+            "every existing call site must keep creating tmux-backed sessions")
+
+        let holder = try await db.terminals.create(
+            worktreeID: worktree.id, tmuxWindowID: "", tmuxPaneID: "",
+            transport: .holder, holderPID: 4242, childPID: 4243)
+        let reloaded = try #require(try await db.terminals.get(id: holder.id))
+        #expect(reloaded.transport == .holder)
+        #expect(reloaded.holderPID == 4242)
+        #expect(reloaded.childPID == 4243)
+    }
+}

--- a/Tests/TBDDaemonTests/SQLMigrationLoaderTests.swift
+++ b/Tests/TBDDaemonTests/SQLMigrationLoaderTests.swift
@@ -493,6 +493,8 @@ import Testing
             "20260829210843_pending_terminal_incarnation",
             "20260830003851_config_remote_peer_messaging",
             "20260830022625_shadow_peer_artifacts",
+            "20260831055718_config_pty_holder",
+            "20260831055719_terminal_transport",
         ]
         let found = try SQLMigrationLoader.bundled.get()
         #expect(found.files.map(\.identifier) == expected)


### PR DESCRIPTION
## Summary

First implementation step of the pty-holder transport specced in [`docs/specs/2026-08-30-pty-holder-session-transport-design.md`](../blob/main/docs/specs/2026-08-30-pty-holder-session-transport-design.md) (#763). Pure plumbing: it adds the gate and the per-session discriminator that every later step branches on, and changes no behavior at all. Nothing reads the flag yet.

## Why this shape

The flag is **tri-state on purpose**. Its column ships with no SQL `DEFAULT`, so NULL keeps meaning "nobody has chosen" and stays distinguishable from an explicit `0`. The shipped default lives in exactly one place — `Config.ptyHolderDefault` — which makes graduation a one-line change that reaches everyone who never touched the toggle while preserving every deliberate opt-out. This is the convention `queued_prompt_enabled` established after `auto_hibernate_enabled` had to be force-disabled and took real opt-ins with it.

`transport` is recorded per terminal rather than read from the flag at use time, because the flag gates **spawning, not servicing**: a session keeps the transport it was born with, so toggling in either direction strands nothing.

## What this PR does

- Two additive migrations: `pty_holder_enabled` on `config`, and `transport` / `holder_pid` / `child_pid` on `terminal`.
- `TerminalTransport` (`tmux` | `holder`), plumbed through the GRDB record and the `TBDShared` model with defaults so existing rows and JSON still decode.
- `Config.ptyHolderEnabled`, resolved as `pty_holder_enabled ?? ptyHolderDefault` through an injected `toModel` parameter.
- The `configSetPtyHolderEnabled` RPC and its handler.

## Flag & rollout

`pty_holder_enabled`, default **OFF**. Nothing consumes it in this PR. It graduates by flipping `Config.ptyHolderDefault`, with no forcing `UPDATE` migration.

## Assumptions

`terminal.tmuxWindowID`/`tmuxPaneID` are `NOT NULL` from the v1 schema and cannot be relaxed, so holder rows will write empty strings there and be discriminated by `transport` alone — never by those values being empty.

## Evidence & verification

12 tests in `PtyHolderFlagTests`, mirroring `RemotePeerMessagingFlagSchemaTests` so they exercise the real migrator rather than hand-built records. **Mutation-checked**, which is what makes them worth reading:

- Adding `DEFAULT 0` to the migration reddens 3 tests.
- Deleting the `transport` decode line from `Terminal`'s hand-written `init(from:)` reddens exactly one — `terminalTransportRoundTripsHolder`. The default-direction test passes vacuously, which is why both directions are tested.
- A record that stops writing the column reddens only `terminalTransportRoundTripsThroughTheStore`, a test added during implementation after noticing the other eleven never touch the `terminal` table.

`scripts/lint-migrations.py` passes; `swiftlint --strict` clean. Full `scripts/test.sh` has 4 failures, all in `TerminalLockedAccessTests` and `ReplayLiveIntegrationMatrixTests` — AppKit main-queue and live-tmux suites unrelated to a config column. Re-run together with this PR's tests they pass: 25 tests in 3 suites in 1.5 s, versus 157 s of timeouts under full-suite load.

`Terminal.transport` decodes the raw string and maps rather than decoding the enum directly, so an unrecognized value from a newer daemon degrades to `.tmux` instead of throwing — matching the DB-side rule.

https://claude.ai/code/session_01UXqxcPYizvznh99Qb8JKrD

[20260830-boring-panda](https://cheapsteak.github.io/tbd/open/?worktree=A1E9CF50-E608-4F3C-BA8F-377D60BB7478)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable PTY-holder transport option, including persistence and remote configuration support.
  * Terminal sessions now record their transport type and associated holder/child process identifiers.
  * Added support for distinguishing tmux and PTY-holder terminal sessions.

* **Compatibility**
  * Existing terminals and configurations continue to work, defaulting safely to tmux behavior when transport data is missing or unrecognized.
  * Existing configuration data resolves to the shipped PTY-holder default when no explicit value is set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->