### PR TITLE
Feat: Add holder rendezvous paths and the holder wire protocol

### DIFF
--- a/Sources/TBDShared/Constants.swift
+++ b/Sources/TBDShared/Constants.swift
@@ -55,6 +55,17 @@ public enum TBDConstants {
     /// the app (SCM_RIGHTS). Sibling of `socketPath`.
     public static var vendSocketPath: String { vendSocketPath(environment: ProcessInfo.processInfo.environment) }
 
+    /// Directory holding one socket and one lock file per live pty holder:
+    /// `~/tbd/holders`. Honors TBD_HOME.
+    ///
+    /// Deliberately shallow and directly under the config dir: every holder
+    /// socket path must fit Darwin's ~104-byte `sun_path`, and nesting is the
+    /// thing that breaks that budget first. `HolderRendezvous` composes the
+    /// per-session names inside it and enforces the budget.
+    public static func holdersDir(environment: [String: String] = ProcessInfo.processInfo.environment) -> URL {
+        configDir(environment: environment).appendingPathComponent("holders")
+    }
+
     public static func databasePath(environment: [String: String]) -> String {
         configDir(environment: environment).appendingPathComponent("state.db").path
     }

--- a/Sources/TBDShared/FDChannel.swift
+++ b/Sources/TBDShared/FDChannel.swift
@@ -6,6 +6,7 @@ public enum FDChannelError: LocalizedError, Equatable {
     case sendFailed(Int32)          // errno from sendmsg/write or setup
     case receiveFailed(Int32)       // errno from recvmsg
     case peerClosed                 // clean EOF from the peer
+    case emptyPayload               // sendFDMinimal with nothing to carry the fd
 
     public var errorDescription: String? {
         switch self {
@@ -15,6 +16,8 @@ public enum FDChannelError: LocalizedError, Equatable {
             return "fd channel receive failed: errno \(code) (\(Self.errnoText(code)))"
         case .peerClosed:
             return "fd channel peer closed the connection (clean EOF)"
+        case .emptyPayload:
+            return "fd channel send needs at least one payload byte to carry the descriptor"
         }
     }
 
@@ -131,6 +134,34 @@ public enum FDChannel {
                     try sendData(Data(frame.dropFirst(sent)), over: socket)
                 }
             }
+        }
+    }
+
+    /// Send `fd` over `socket` carrying exactly one byte of `payload`, then
+    /// write the remainder with a plain full-write loop.
+    ///
+    /// Why one byte and not the whole frame: `sendmsg` with an `SCM_RIGHTS`
+    /// control block has been observed failing with `EMSGSIZE` at payload sizes
+    /// the man page permits, and an empty payload fails too. One byte is the
+    /// size known to work, which is why an empty payload is a named error here
+    /// rather than a silent no-op — a caller with nothing to say still needs a
+    /// byte for the descriptor to ride on.
+    ///
+    /// The fd is never re-sent for the remainder: a second `sendmsg` carrying
+    /// the same `SCM_RIGHTS` block would materialize a *duplicate* descriptor
+    /// in the recipient, which then leaks (it is a second reference to the same
+    /// open file, so closing one keeps the pty master alive). `sendFD` already
+    /// handles a short `sendmsg` the same way, by sending only the remaining
+    /// bytes through `sendData`.
+    ///
+    /// Like `sendFD`, `fd` remains the caller's to close on return.
+    public static func sendFDMinimal(_ fd: Int32, over socket: Int32, payload: Data) throws {
+        guard let first = payload.first else {
+            throw FDChannelError.emptyPayload
+        }
+        try sendFD(fd, over: socket, frame: Data([first]))
+        if payload.count > 1 {
+            try sendData(payload.dropFirst(), over: socket)
         }
     }
 

--- a/Sources/TBDShared/HolderProtocol.swift
+++ b/Sources/TBDShared/HolderProtocol.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+public enum HolderProtocolVersion {
+    /// Bumped only for a wire-compatible-breaking change. The daemon must
+    /// interoperate with every version that has ever shipped, because a
+    /// long-lived session keeps running the holder binary it was born with.
+    public static let current = 1
+    /// Returned to a second concurrent client, which is then disconnected.
+    /// A distinct value so "busy" can never be mistaken for a real version.
+    public static let busySentinel = -1
+}
+
+public struct HolderLaunchRequest: Codable, Sendable, Equatable {
+    public var executable: String
+    public var arguments: [String]
+    public var workingDirectory: String
+    public var environment: [String: String]
+    public var columns: UInt16
+    public var rows: UInt16
+
+    public init(
+        executable: String,
+        arguments: [String],
+        workingDirectory: String,
+        environment: [String: String],
+        columns: UInt16,
+        rows: UInt16
+    ) {
+        self.executable = executable
+        self.arguments = arguments
+        self.workingDirectory = workingDirectory
+        self.environment = environment
+        self.columns = columns
+        self.rows = rows
+    }
+}
+
+/// Identifies the TBD *installation* that spawned a holder.
+///
+/// Given at spawn, returned by every handshake, and compared before any
+/// reclamation. A completed handshake proves a holder is alive, not that it is
+/// ours: the default `TBD_HOME` is shared by every checkout on a machine, so
+/// "reachable but absent from my database" is exactly what a foreign, healthy
+/// session looks like.
+///
+/// Minted once per installation and persisted in the `config` row — it must
+/// identify the installation, not the process, or a restarted daemon could not
+/// reclaim the holders it spawned minutes earlier.
+public struct HolderOwnerToken: Codable, Sendable, Equatable, RawRepresentable {
+    public let rawValue: String
+    public init(rawValue: String) { self.rawValue = rawValue }
+}
+
+public enum HolderChildStatus: Codable, Sendable, Equatable {
+    case alive
+    case exited(code: Int32)
+    /// The holder could not observe a status — never fabricate one.
+    case exitedStatusUnknown
+}
+
+public struct HolderChildDescription: Codable, Sendable, Equatable {
+    public var childPID: Int32
+    public var ttyName: String
+    public var status: HolderChildStatus
+    public var launch: HolderLaunchRequest
+    /// Whoever spawned this holder. Reclamation compares this before killing.
+    public var owner: HolderOwnerToken
+
+    public init(
+        childPID: Int32,
+        ttyName: String,
+        status: HolderChildStatus,
+        launch: HolderLaunchRequest,
+        owner: HolderOwnerToken
+    ) {
+        self.childPID = childPID
+        self.ttyName = ttyName
+        self.status = status
+        self.launch = launch
+        self.owner = owner
+    }
+}
+
+/// The verbs are spelled `…PTY` rather than `…Master`: SwiftLint's
+/// `inclusive_language` rule refuses the POSIX word in a *declaration*, and a
+/// suppression on the protocol's central verb is worse than a name whose doc
+/// comment says exactly which end of the pty travels. Prose — here and
+/// throughout the holder code — still says "pty master", because that is what
+/// `forkpty` calls the fd and the rule does not reach comments.
+public enum HolderRequest: Codable, Sendable, Equatable {
+    /// Report the child without transferring anything.
+    case describe
+    /// Report the child and hand over a dup of the pty master via SCM_RIGHTS.
+    case handOverPTY
+    /// Close the pty master and stop reporting, so a killed session cannot be
+    /// resurrected. iTerm2's preemptive wait, adopted for the same reason.
+    case forget
+}
+
+public enum HolderResponse: Codable, Sendable, Equatable {
+    case described(HolderChildDescription)
+    /// Accompanies the `SCM_RIGHTS` transfer of the pty master fd.
+    case handedOverPTY(HolderChildDescription)
+    case forgotten
+    case rejected(version: Int)
+}

--- a/Sources/TBDShared/HolderRendezvous.swift
+++ b/Sources/TBDShared/HolderRendezvous.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// Where a holder listens, and where its creation lock lives.
+///
+/// The layout — socket name, lock name, and the fact that they are siblings —
+/// is frozen at protocol v1 and sits outside version negotiation, because a
+/// spawner must interpret it *before* any connection exists, which is exactly
+/// when no version has been exchanged.
+///
+/// Every path here is derived from `TBDConstants`, never composed from `$HOME`:
+/// a hand-built `"\(home)/tbd/…"` silently ignores `TBD_HOME` and writes into
+/// the developer's real store under `scripts/test.sh`.
+public enum HolderRendezvous {
+    /// Darwin's `sockaddr_un.sun_path` is 104 bytes including the NUL.
+    public static let sunPathLimit = 104
+
+    public enum Error: LocalizedError, Equatable {
+        /// The derived path does not fit `sun_path`. Raised at derivation time
+        /// on purpose: the alternative is a confusing `EINVAL` out of `bind()`
+        /// or `connect()` much later, in a caller that has no idea the path was
+        /// the problem.
+        case socketPathTooLong(path: String, limit: Int)
+
+        public var errorDescription: String? {
+            switch self {
+            case .socketPathTooLong(let path, let limit):
+                return "holder socket path is \(path.utf8.count) bytes, over the "
+                    + "\(limit)-byte sun_path limit: \(path)"
+            }
+        }
+    }
+
+    public static func socketPath(
+        sessionID: UUID,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) throws -> String {
+        try validated(path(sessionID: sessionID, ext: "sock", environment: environment))
+    }
+
+    public static func lockPath(
+        sessionID: UUID,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) throws -> String {
+        // The lock path is validated against the same budget even though it is
+        // never bound, so a lock and its socket can never disagree about
+        // whether this session is representable.
+        try validated(path(sessionID: sessionID, ext: "lock", environment: environment))
+    }
+
+    private static func path(sessionID: UUID, ext: String, environment: [String: String]) -> String {
+        TBDConstants.holdersDir(environment: environment)
+            .appendingPathComponent("\(sessionID.uuidString.lowercased()).\(ext)")
+            .path
+    }
+
+    private static func validated(_ path: String) throws -> String {
+        guard path.utf8.count < sunPathLimit else {
+            throw Error.socketPathTooLong(path: path, limit: sunPathLimit)
+        }
+        return path
+    }
+}

--- a/Tests/TBDSharedTests/HolderProtocolTests.swift
+++ b/Tests/TBDSharedTests/HolderProtocolTests.swift
@@ -1,0 +1,138 @@
+import Darwin
+import Foundation
+import Testing
+@testable import TBDShared
+
+@Suite("Holder protocol")
+struct HolderProtocolTests {
+    private func description(status: HolderChildStatus) -> HolderChildDescription {
+        HolderChildDescription(
+            childPID: 4242,
+            ttyName: "/dev/ttys004",
+            status: status,
+            launch: HolderLaunchRequest(
+                executable: "/bin/zsh",
+                arguments: ["-l"],
+                workingDirectory: "/tmp",
+                environment: ["FOO": "bar"],
+                columns: 80,
+                rows: 24
+            ),
+            owner: HolderOwnerToken(rawValue: "installation-abc")
+        )
+    }
+
+    @Test func requestsRoundTripThroughJSON() throws {
+        let cases: [HolderRequest] = [.describe, .handOverPTY, .forget]
+        for request in cases {
+            let data = try JSONEncoder().encode(request)
+            #expect(try JSONDecoder().decode(HolderRequest.self, from: data) == request)
+        }
+    }
+
+    /// Every status round-trips, including the two that are not `.alive`: a
+    /// holder that could not observe an exit must be able to say so on the wire
+    /// rather than have a code fabricated for it.
+    @Test func responsesRoundTripThroughJSON() throws {
+        let statuses: [HolderChildStatus] = [.alive, .exited(code: 7), .exitedStatusUnknown]
+        for status in statuses {
+            let responses: [HolderResponse] = [
+                .described(description(status: status)),
+                .handedOverPTY(description(status: status)),
+                .forgotten,
+            ]
+            for response in responses {
+                let data = try JSONEncoder().encode(response)
+                #expect(try JSONDecoder().decode(HolderResponse.self, from: data) == response)
+            }
+        }
+    }
+
+    /// The owner token is what reclamation compares before killing a holder, so
+    /// it has to survive the wire — a handshake proves a holder is alive, not
+    /// that it is ours.
+    @Test func ownerTokenSurvivesTheWire() throws {
+        let mine = HolderResponse.described(description(status: .alive))
+        let data = try JSONEncoder().encode(mine)
+        let decoded = try JSONDecoder().decode(HolderResponse.self, from: data)
+        guard case .described(let child) = decoded else {
+            Issue.record("expected .described, got \(decoded)")
+            return
+        }
+        #expect(child.owner == HolderOwnerToken(rawValue: "installation-abc"))
+        #expect(child.owner != HolderOwnerToken(rawValue: "someone-else"))
+    }
+
+    /// A second client must be rejected with a sentinel version rather than
+    /// silently served — two readers on one master is silent byte theft.
+    @Test func rejectionCarriesTheSentinelVersion() throws {
+        let response = HolderResponse.rejected(version: HolderProtocolVersion.busySentinel)
+        let data = try JSONEncoder().encode(response)
+        #expect(try JSONDecoder().decode(HolderResponse.self, from: data) == response)
+        #expect(HolderProtocolVersion.busySentinel != HolderProtocolVersion.current)
+    }
+
+    /// The fd rides one byte and the rest follows by plain `write()`, and the
+    /// fd is NOT re-sent with the remainder — a second `SCM_RIGHTS` block would
+    /// materialize a duplicate descriptor in the recipient, a second reference
+    /// to the same open file that keeps the pty master alive after the first is
+    /// closed.
+    ///
+    /// The *split itself* is not observable from this end: the receiver's first
+    /// `recvmsg` stops at the next ancillary boundary and there isn't one, so
+    /// the trailing plain writes coalesce into the same read and a one-byte
+    /// `sendmsg` looks identical to a whole-frame one. What is observable —
+    /// and what actually matters — is that exactly one descriptor arrives and
+    /// the whole payload does. A re-sent fd is caught precisely because its
+    /// second `SCM_RIGHTS` block *creates* a boundary and forces a second read.
+    @Test func minimalFDSendDeliversFDExactlyOnceAndTheFullPayload() throws {
+        var pair: [Int32] = [0, 0]
+        #expect(socketpair(AF_UNIX, SOCK_STREAM, 0, &pair) == 0)
+        defer { close(pair[0]); close(pair[1]) }
+        // Bound the drain loop: a send that drops the remainder must redden as
+        // a receive error rather than hanging the suite forever.
+        var timeout = timeval(tv_sec: 5, tv_usec: 0)
+        #expect(setsockopt(
+            pair[1], SOL_SOCKET, SO_RCVTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size)) == 0)
+
+        // Any fd will do as the passenger; use a pipe read end.
+        var pipeFDs: [Int32] = [0, 0]
+        #expect(pipe(&pipeFDs) == 0)
+        defer { close(pipeFDs[0]); close(pipeFDs[1]) }
+
+        let payload = Data(("hello-holder-" + String(repeating: "p", count: 512)).utf8)
+        try FDChannel.sendFDMinimal(pipeFDs[0], over: pair[0], payload: payload)
+
+        let received = try FDChannel.receiveMessage(from: pair[1], capacity: 4096)
+        var receivedFDs = received.fds
+        defer { receivedFDs.forEach { close($0) } }
+        #expect(received.fds.count == 1)
+
+        var got = received.data
+        while got.count < payload.count {
+            let more = try FDChannel.receiveMessage(from: pair[1], capacity: 4096)
+            receivedFDs.append(contentsOf: more.fds)
+            #expect(more.fds.isEmpty)
+            got += more.data
+        }
+        #expect(got == payload)
+        #expect(receivedFDs.count == 1)
+    }
+
+    /// An empty payload has no byte for the descriptor to ride on, and an
+    /// empty-payload sendmsg with SCM_RIGHTS is one of the shapes observed to
+    /// fail outright — so it is refused by name instead.
+    @Test func minimalFDSendRefusesAnEmptyPayload() throws {
+        var pair: [Int32] = [0, 0]
+        #expect(socketpair(AF_UNIX, SOCK_STREAM, 0, &pair) == 0)
+        defer { close(pair[0]); close(pair[1]) }
+
+        var pipeFDs: [Int32] = [0, 0]
+        #expect(pipe(&pipeFDs) == 0)
+        defer { close(pipeFDs[0]); close(pipeFDs[1]) }
+
+        #expect(throws: FDChannelError.emptyPayload) {
+            try FDChannel.sendFDMinimal(pipeFDs[0], over: pair[0], payload: Data())
+        }
+    }
+}

--- a/Tests/TBDSharedTests/HolderRendezvousTests.swift
+++ b/Tests/TBDSharedTests/HolderRendezvousTests.swift
@@ -1,0 +1,69 @@
+import Foundation
+import Testing
+@testable import TBDShared
+
+@Suite("Holder rendezvous paths")
+struct HolderRendezvousTests {
+    let session = UUID(uuidString: "00000000-0000-0000-0000-0000000000AB")!
+
+    @Test func socketAndLockAreSiblingsNamedBySession() throws {
+        let env = ["TBD_HOME": "/tmp/tbd-test-home"]
+        let sock = try HolderRendezvous.socketPath(sessionID: session, environment: env)
+        let lock = try HolderRendezvous.lockPath(sessionID: session, environment: env)
+        #expect(sock.hasPrefix("/tmp/tbd-test-home/holders/"))
+        #expect(sock.hasSuffix(".sock"))
+        #expect(lock == sock.replacingOccurrences(of: ".sock", with: ".lock"))
+        #expect(sock.contains(session.uuidString.lowercased()))
+    }
+
+    /// Derived from TBDConstants, never hand-composed from $HOME — a path built
+    /// from $HOME silently ignores TBD_HOME and defeats the test fence.
+    @Test func honorsTBDHome() throws {
+        let a = try HolderRendezvous.socketPath(sessionID: session, environment: ["TBD_HOME": "/tmp/a"])
+        let b = try HolderRendezvous.socketPath(sessionID: session, environment: ["TBD_HOME": "/tmp/b"])
+        #expect(a != b)
+        #expect(a.hasPrefix("/tmp/a/"))
+        #expect(b.hasPrefix("/tmp/b/"))
+    }
+
+    /// sun_path is ~104 bytes on Darwin. Overflow must be a named error at
+    /// derivation time, not a confusing EINVAL from bind() much later.
+    @Test func rejectsPathsThatOverflowSunPath() throws {
+        let deep = "/tmp/" + String(repeating: "d", count: 200)
+        #expect(throws: HolderRendezvous.Error.self) {
+            _ = try HolderRendezvous.socketPath(sessionID: session, environment: ["TBD_HOME": deep])
+        }
+        // The lock shares the budget, so a session that cannot be bound also
+        // cannot be locked — the two must never disagree.
+        #expect(throws: HolderRendezvous.Error.self) {
+            _ = try HolderRendezvous.lockPath(sessionID: session, environment: ["TBD_HOME": deep])
+        }
+    }
+
+    @Test func acceptsAPathAtTheLimit() throws {
+        // A realistic default home must comfortably fit.
+        let sock = try HolderRendezvous.socketPath(sessionID: session, environment: ["TBD_HOME": "/Users/me/tbd"])
+        #expect(sock.utf8.count < HolderRendezvous.sunPathLimit)
+    }
+
+    /// The budget is the NUL-inclusive one, so the longest representable path
+    /// is `sunPathLimit - 1` bytes. Pinned exactly, because an off-by-one here
+    /// is invisible until a `bind()` on a real machine rejects a path the
+    /// derivation just declared fine.
+    @Test func theBoundaryIsExactlyOneByteBelowTheLimit() throws {
+        // "<home>/holders/<36-char uuid>.sock" — 50 bytes past the home.
+        let suffixBytes = "/holders/".utf8.count + session.uuidString.count + ".sock".utf8.count
+        func home(totalBytes: Int) -> String {
+            "/tmp/" + String(repeating: "d", count: totalBytes - suffixBytes - "/tmp/".utf8.count)
+        }
+
+        let longest = try HolderRendezvous.socketPath(
+            sessionID: session, environment: ["TBD_HOME": home(totalBytes: HolderRendezvous.sunPathLimit - 1)])
+        #expect(longest.utf8.count == HolderRendezvous.sunPathLimit - 1)
+
+        #expect(throws: HolderRendezvous.Error.self) {
+            _ = try HolderRendezvous.socketPath(
+                sessionID: session, environment: ["TBD_HOME": home(totalBytes: HolderRendezvous.sunPathLimit)])
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Tasks 2 and 3 of the pty-holder transport ([spec](../blob/main/docs/specs/2026-08-30-pty-holder-session-transport-design.md)). Two more layers of inert plumbing: where a holder listens, and what it says. Nothing constructs a holder yet.

**Stacked on #765** — review that first; this PR targets its branch, not `main`.

## Why this shape

Both types live in `TBDShared` because the holder binary, the daemon, and the tests must agree on them byte for byte. Path math that disagreed across processes would surface as a connect failure with no obvious cause.

`sun_path` is validated at *derivation* time rather than at `bind()`. Darwin's limit is ~104 bytes, and a path that overflows it fails deep inside a syscall with an error that says nothing about path length — so the check is a named error thrown where the path is built.

The protocol is versioned from day one because long-lived sessions keep running the holder binary they were born with, so the daemon must interoperate with every version that ever shipped. `HolderChildDescription` carries an `owner` token for the same reason reclamation needs one: a completed handshake proves a holder is *alive*, not that it is *ours*.

## What this PR does

- `HolderRendezvous` — socket and lock paths per session UUID, derived from `TBDConstants` (so `TBD_HOME` is honored), with `sunPathLimit` validation.
- `TBDConstants.holdersDir(environment:)`.
- `HolderProtocol` — versioned request/response types, `HolderOwnerToken`, `HolderChildStatus` including `exitedStatusUnknown` (the holder must never fabricate an exit status).
- `FDChannel.sendFDMinimal(_:over:payload:)` — sends the descriptor with exactly one byte, then the remainder by plain write, never re-sending the fd on a short write.

## Assumptions

The verb is `handOverPTY`, not `handOverMaster`: SwiftLint's `inclusive_language` rule fires on declarations. Prose still says "pty master" throughout, since the rule does not reach comments.

## Evidence & verification

11 tests, all mutation-checked — each mutation reddened *only* the test that exists to catch it:

- Removing the `sun_path` guard reddens the overflow and boundary tests, nothing else.
- Changing `<` to `<=` reddens **only** `theBoundaryIsExactlyOneByteBelowTheLimit`. That test was added during implementation because the planned `acceptsAPathAtTheLimit` uses a 68-byte path and stays green under an off-by-one — it tested the happy path, not the limit.
- Re-sending the fd with the remainder reddens only the fd test, with `receivedFDs.count == 2`.
- Never sending the remainder reddens only the fd test.

**One measured finding worth recording:** the one-byte split is *not observable from the receiving end*. The trailing plain writes always coalesce into the first `recvmsg`, because a read stops only at the next ancillary boundary and there isn't one — so a whole-frame `sendmsg` and a one-byte one look identical to the peer. The one-byte convention's value is entirely send-side, dodging the `EMSGSIZE` iTerm2 documented. The test therefore pins what is observable and what matters — exactly one descriptor, whole payload — rather than a byte count that would fail against a correct implementation.

`swiftlint --strict` clean across 897 files. Full suite: 4 failures, all in `ReplayLiveIntegrationMatrixTests` and `TerminalLockedAccessTests` (AppKit main-queue and live-tmux suites, unrelated to these types); they pass when run alongside these tests in isolation.

https://claude.ai/code/session_01UXqxcPYizvznh99Qb8JKrD

[20260830-boring-panda](https://cheapsteak.github.io/tbd/open/?worktree=A1E9CF50-E608-4F3C-BA8F-377D60BB7478)