### PR TITLE
Feat: Add the holder creation lock and the TBDHolder target

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -51,7 +51,7 @@ custom_rules:
     name: "No print() in Sources/"
     # included/excluded HERE take REGEX (not glob), matched against file path.
     included:
-      - "Sources/(TBDShared|TBDDaemon|TBDApp|TBDPeerHelper)/.*\\.swift"
+      - "Sources/(TBDShared|TBDDaemon|TBDApp|TBDPeerHelper|TBDHolder)/.*\\.swift"
     regex: '\b(?:Swift\.|Foundation\.)?print\s*\('
     match_kinds:
       - identifier
@@ -62,7 +62,7 @@ custom_rules:
     name: "No raw Task.sleep in Sources/"
     # included/excluded HERE take REGEX (not glob), matched against file path.
     included:
-      - "Sources/(TBDShared|TBDDaemon|TBDApp|TBDPeerHelper)/.*\\.swift"
+      - "Sources/(TBDShared|TBDDaemon|TBDApp|TBDPeerHelper|TBDHolder)/.*\\.swift"
     regex: 'Task\.sleep\s*\('
     match_kinds:
       - identifier
@@ -73,7 +73,7 @@ custom_rules:
     name: "No account-database home lookup in Sources/"
     # included/excluded HERE take REGEX (not glob), matched against file path.
     included:
-      - "Sources/(TBDShared|TBDDaemon|TBDApp|TBDPeerHelper)/.*\\.swift"
+      - "Sources/(TBDShared|TBDDaemon|TBDApp|TBDPeerHelper|TBDHolder)/.*\\.swift"
     # Every one of these resolves a home directory through the account database
     # and defeats `CFFIXED_USER_HOME` identically. The Swift-shaped ones —
     # `NSHomeDirectoryForUser(_:)` and `FileManager.homeDirectory(forUser:)` —
@@ -91,7 +91,7 @@ custom_rules:
     # custom rule cannot reach files outside it, and pulling all of Tests/ in
     # would drag every default rule onto test code — a separate change.
     included:
-      - "Sources/(TBDShared|TBDDaemon|TBDApp|TBDPeerHelper)/.*\\.swift"
+      - "Sources/(TBDShared|TBDDaemon|TBDApp|TBDPeerHelper|TBDHolder)/.*\\.swift"
       - "Tests/(TBDSharedTests|TBDAppTests)/.*\\.swift"
     # OPTIMIZED FOR THE PRIVACY RATIONALE, deliberately, and that decides both
     # knobs:
@@ -123,7 +123,7 @@ custom_rules:
     name: "No hand-built path into a TBD or agent store"
     # included/excluded HERE take REGEX (not glob), matched against file path.
     included:
-      - "Sources/(TBDShared|TBDDaemon|TBDApp|TBDPeerHelper)/.*\\.swift"
+      - "Sources/(TBDShared|TBDDaemon|TBDApp|TBDPeerHelper|TBDHolder)/.*\\.swift"
     excluded:
       # THE resolvers. `TBDConstants.configDir` and `claudeHostHome` are the
       # single resolution points every other call site is supposed to reach
@@ -172,7 +172,7 @@ custom_rules:
     # `Sources/TBDCLI` from the global list: that would drag every default rule
     # onto the CLI target, which is a separate change.
     included:
-      - "Sources/(TBDShared|TBDDaemon|TBDApp|IconBaker|TBDPeerHelper)/.*\\.swift"
+      - "Sources/(TBDShared|TBDDaemon|TBDApp|IconBaker|TBDPeerHelper|TBDHolder)/.*\\.swift"
     excluded:
       # `GitManager.swift` — its two error types take their conformance from
       # `Git/GitErrorLocalizedDescriptions.swift`, and the rule cannot see an

--- a/Package.swift
+++ b/Package.swift
@@ -160,6 +160,26 @@ let package = Package(
             ],
             path: "Sources/TBDPeerHelper"
         ),
+        // One process per holder-transport session
+        // (docs/specs/2026-08-30-pty-holder-session-transport-design.md). It
+        // `forkpty()`s the job, owns the pty master for the session's life, and
+        // hands a `dup` of it to whoever asks over SCM_RIGHTS — so the session
+        // outlives the daemon that started it.
+        //
+        // A separate executable rather than a thread in the daemon for the
+        // whole point of the design: the pty master must survive a daemon
+        // restart, and a descriptor cannot outlive the process that holds it.
+        //
+        // Deliberately NOT linked against TBDDaemonLib. It needs the rendezvous
+        // paths, the creation lock and the wire protocol, all of which live in
+        // TBDShared, and nothing else.
+        .executableTarget(
+            name: "TBDHolder",
+            dependencies: [
+                "TBDShared",
+            ],
+            path: "Sources/TBDHolder"
+        ),
         .systemLibrary(
             name: "CComrakFFI",
             path: "Sources/CComrakFFI"
@@ -281,6 +301,19 @@ let package = Package(
             name: "TBDPeerHelperTests",
             dependencies: [
                 "TBDPeerHelper",
+                "TBDShared",
+            ]
+        ),
+        // The holder's own suite. Like `TBDPeerHelperTests` above, its
+        // dependency on the EXECUTABLE target is load-bearing rather than
+        // cosmetic: the tests spawn the real `TBDHolder` binary, so the product
+        // has to be built and sit in the same products directory as the test
+        // bundle. `@testable import` reaching the holder's internals is the
+        // lesser half.
+        .testTarget(
+            name: "TBDHolderTests",
+            dependencies: [
+                "TBDHolder",
                 "TBDShared",
             ]
         ),

--- a/Sources/TBDHolder/main.swift
+++ b/Sources/TBDHolder/main.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+// TBDHolder — one process per holder-transport session.
+//
+// PLACEHOLDER. The target exists now so the creation lock, the rendezvous
+// paths and the wire protocol have a product to be built against, and so the
+// daemon's test target can depend on a binary that will exist. The real entry
+// point — adopt the inherited creation-lock fd, bind the rendezvous socket,
+// `forkpty()` the job, serve `handOverPTY`, report exit — lands with the
+// holder itself.
+//
+// It exits nonzero rather than succeeding silently: a spawner that reaches
+// this build by mistake must fail loudly at spawn time, not hand back a
+// session whose pty nobody owns.
+//
+// stderr, not `print()` — `no_print_in_sources` covers this target, and the
+// daemon reads a holder's stderr as its diagnostic channel.
+
+FileHandle.standardError.write(Data("TBDHolder: not implemented yet\n".utf8))
+exit(1)

--- a/Sources/TBDShared/HolderLock.swift
+++ b/Sources/TBDShared/HolderLock.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+/// An exclusive advisory lock serializing holder creation for one session UUID.
+///
+/// A socket file alone cannot distinguish a live holder from the corpse of a
+/// SIGKILLed one, and `bind` refuses a path that already exists — so "unlink
+/// the stale socket, then bind" is a race two spawners can both win. An
+/// exclusive `flock` on a sibling zero-byte file serializes creation instead.
+///
+/// Held for the holder's whole life. A spawner that cannot take it has learned
+/// that a live holder owns this UUID *without connecting*, and must back off
+/// rather than clearing the socket path.
+///
+/// The kernel releases the lock when the holding process dies — by `exit`, by
+/// `SIGKILL`, by anything — so a crash can leak the empty file but never the
+/// lock itself.
+///
+/// Lives in `TBDShared`, not `TBDHolder`, because a SwiftPM library target
+/// cannot import an executable target and the daemon-side spawner takes this
+/// lock before spawning. Same reasoning as `HolderRendezvous`.
+public struct HolderLock {
+    public enum Error: LocalizedError, Equatable {
+        /// A live process already holds the lock for this session.
+        case alreadyHeld(path: String)
+        /// The lock file could not be opened, or `flock` failed for a reason
+        /// other than contention.
+        case cannotOpen(path: String, errno: Int32)
+        /// `FD_CLOEXEC` could not be read or cleared.
+        case cannotSetFlags(errno: Int32)
+
+        public var errorDescription: String? {
+            switch self {
+            case .alreadyHeld(let path):
+                return "a live holder already owns the creation lock at \(path)"
+            case .cannotOpen(let path, let errno):
+                return "could not take the holder creation lock at \(path): "
+                    + "\(String(cString: strerror(errno))) (errno \(errno))"
+            case .cannotSetFlags(let errno):
+                return "could not clear FD_CLOEXEC on the holder creation lock: "
+                    + "\(String(cString: strerror(errno))) (errno \(errno))"
+            }
+        }
+    }
+
+    public let fileDescriptor: Int32
+    /// The lock file this descriptor is open on, kept so a holder or spawner
+    /// can name it in a log line without recomputing the rendezvous path.
+    public let path: String
+
+    public static func acquire(path: String) throws -> HolderLock {
+        let fd = open(path, O_CREAT | O_RDWR | O_CLOEXEC, 0o600)
+        guard fd >= 0 else {
+            throw Error.cannotOpen(path: path, errno: errno)
+        }
+        // LOCK_NB: never block. A spawner that would block is a spawner racing
+        // a live holder, and waiting would only delay the same conclusion.
+        //
+        // EINTR is retried rather than reported: a signal arriving while the
+        // kernel was placing the lock says nothing about whether another
+        // process holds it, and mapping it to `cannotOpen` would turn an
+        // ordinary signal into a spurious spawn failure.
+        while flock(fd, LOCK_EX | LOCK_NB) != 0 {
+            let saved = errno
+            if saved == EINTR { continue }
+            close(fd)
+            if saved == EWOULDBLOCK {
+                throw Error.alreadyHeld(path: path)
+            }
+            throw Error.cannotOpen(path: path, errno: saved)
+        }
+        return HolderLock(fileDescriptor: fd, path: path)
+    }
+
+    /// Clear FD_CLOEXEC so the descriptor — and with it the lock, which lives
+    /// on the open file description — survives into the exec'd holder.
+    public func makeInheritableAcrossExec() throws {
+        let flags = fcntl(fileDescriptor, F_GETFD)
+        guard flags >= 0 else { throw Error.cannotSetFlags(errno: errno) }
+        guard fcntl(fileDescriptor, F_SETFD, flags & ~FD_CLOEXEC) >= 0 else {
+            throw Error.cannotSetFlags(errno: errno)
+        }
+    }
+
+    /// Closing the descriptor drops the lock. The file is left behind
+    /// deliberately: unlinking it would let a racing spawner create and lock a
+    /// *different* file at the same path while we still believe we hold it.
+    /// OrphanGC sweeps the empty file alongside the socket.
+    public func release() {
+        close(fileDescriptor)
+    }
+}

--- a/Tests/TBDHolderTests/HolderBinaryTests.swift
+++ b/Tests/TBDHolderTests/HolderBinaryTests.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Testing
+@testable import TBDHolder
+
+/// The holder's own suite. It is here now to hold the target open for the
+/// holder itself; the one thing worth asserting about a placeholder binary is
+/// the thing that will still matter afterwards — that `TBDHolderTests`'
+/// dependency on the EXECUTABLE target really does build the product into the
+/// same products directory as the test bundle, which is the load-bearing half
+/// of the same dependency `TBDPeerHelperTests` documents.
+///
+/// Without that, the holder's integration tests would look correct and find no
+/// binary to spawn.
+@Suite("Holder binary")
+struct HolderBinaryTests {
+    private final class BundleMarker {}
+
+    /// The built `TBDHolder`, a sibling of the test bundle in the products
+    /// directory — the same sibling lookup `SpawnedPeerHelper` does.
+    private static func locateExecutable() -> URL? {
+        let bundleURL = Bundle(for: BundleMarker.self).bundleURL
+        var candidates = [bundleURL.deletingLastPathComponent(), bundleURL]
+        if let main = Bundle.main.executableURL?.deletingLastPathComponent() {
+            candidates.append(main)
+        }
+        for directory in candidates {
+            let candidate = directory.appendingPathComponent("TBDHolder")
+            if FileManager.default.isExecutableFile(atPath: candidate.path) {
+                return candidate
+            }
+        }
+        return nil
+    }
+
+    @Test func binaryIsBuiltBesideTheTestBundle() throws {
+        #expect(Self.locateExecutable() != nil, "TBDHolder was not built into the products directory")
+    }
+
+    /// The placeholder must fail loudly. A spawner that reaches an
+    /// unimplemented holder has to see a nonzero exit, not a session whose pty
+    /// nobody owns.
+    @Test func placeholderExitsNonzeroWithADiagnostic() throws {
+        let executable = try #require(Self.locateExecutable())
+        let process = Process()
+        process.executableURL = executable
+        let stderrPipe = Pipe()
+        process.standardError = stderrPipe
+        process.standardOutput = Pipe()
+        try process.run()
+        let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        #expect(process.terminationStatus != 0)
+        #expect(String(decoding: stderrData, as: UTF8.self).contains("not implemented"))
+    }
+}

--- a/Tests/TBDSharedTests/HolderLockTests.swift
+++ b/Tests/TBDSharedTests/HolderLockTests.swift
@@ -110,11 +110,41 @@ struct HolderLockTests {
         // process, but the ordering costs nothing and the failure would be
         // baffling.
         try #require(lock.fileDescriptor > 2)
-        posix_spawn_file_actions_adddup2(&actions, lock.fileDescriptor, 9)
-        posix_spawn_file_actions_adddup2(&actions, toChild[0], 0)
-        posix_spawn_file_actions_adddup2(&actions, fromChild[1], 1)
+        // `dup2(fd, fd)` is a no-op that succeeds WITHOUT clearing FD_CLOEXEC,
+        // so if the lock already sits on the target number the descriptor is
+        // closed at exec, `echo K >&9` fails, and the child dies before it can
+        // report — read() then returns EOF and this test fails for a reason
+        // that has nothing to do with locking. Whether the lock lands on 9
+        // depends on how many descriptors sibling tests hold open at the time,
+        // which is why this only reddens when the suite runs together.
+        // `dup` hands back the lowest free number, which cannot be the one
+        // still occupied by the original.
+        var lockSource = lock.fileDescriptor
+        var duplicated: Int32 = -1
+        if lockSource == 9 {
+            duplicated = dup(lockSource)
+            try #require(duplicated >= 0, "could not move the lock off the target descriptor")
+            lockSource = duplicated
+        }
+        defer { if duplicated >= 0 { close(duplicated) } }
+        // File actions run IN ORDER, and the ordering here is load-bearing.
+        //
+        // The closes come first: pipe fds are handed out by number, and under a
+        // parallel suite either unwanted end can land on 9. Closing after the
+        // lock's dup2 would then destroy the descriptor we just placed there —
+        // `echo K >&9` fails, a non-interactive shell exits on a redirection
+        // error, and the parent sees EOF instead of the ready byte. That is a
+        // fd-numbering coincidence, so it reddens only when siblings run
+        // alongside and hold enough descriptors open.
+        //
+        // The stdio dup2s come next, before the lock's, so that if a pipe end
+        // occupies 9 it has already been copied to its final home by the time
+        // the lock overwrites it.
         posix_spawn_file_actions_addclose(&actions, toChild[1])
         posix_spawn_file_actions_addclose(&actions, fromChild[0])
+        posix_spawn_file_actions_adddup2(&actions, toChild[0], 0)
+        posix_spawn_file_actions_adddup2(&actions, fromChild[1], 1)
+        posix_spawn_file_actions_adddup2(&actions, lockSource, 9)
 
         var pid: pid_t = 0
         let arguments = ["sh", "-c", script]

--- a/Tests/TBDSharedTests/HolderLockTests.swift
+++ b/Tests/TBDSharedTests/HolderLockTests.swift
@@ -1,0 +1,175 @@
+import Foundation
+import Testing
+@testable import TBDShared
+
+@Suite("Holder creation lock")
+struct HolderLockTests {
+    private func scratchPath() -> String {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("holder-lock-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.appendingPathComponent("session.lock").path
+    }
+
+    @Test func acquiresAnUncontendedLock() throws {
+        let path = scratchPath()
+        let lock = try HolderLock.acquire(path: path)
+        defer { lock.release() }
+        #expect(lock.fileDescriptor >= 0)
+        #expect(FileManager.default.fileExists(atPath: path))
+    }
+
+    /// The whole point: a second spawner must learn that a live holder owns
+    /// this UUID *without connecting to it*, and back off.
+    @Test func secondAcquisitionFailsWhileFirstIsHeld() throws {
+        let path = scratchPath()
+        let first = try HolderLock.acquire(path: path)
+        defer { first.release() }
+        #expect(throws: HolderLock.Error.alreadyHeld(path: path)) {
+            _ = try HolderLock.acquire(path: path)
+        }
+    }
+
+    @Test func lockIsReacquirableAfterRelease() throws {
+        let path = scratchPath()
+        let first = try HolderLock.acquire(path: path)
+        first.release()
+        let second = try HolderLock.acquire(path: path)
+        defer { second.release() }
+        #expect(second.fileDescriptor >= 0)
+    }
+
+    /// The holder inherits the lock across exec, so FD_CLOEXEC must be clear.
+    @Test func canBeMadeInheritableAcrossExec() throws {
+        let path = scratchPath()
+        let lock = try HolderLock.acquire(path: path)
+        defer { lock.release() }
+        try lock.makeInheritableAcrossExec()
+        let flags = fcntl(lock.fileDescriptor, F_GETFD)
+        #expect(flags >= 0)
+        #expect((flags & FD_CLOEXEC) == 0)
+    }
+
+    /// THE CLAIM THE WHOLE DESIGN RESTS ON, and the only one no in-process test
+    /// can reach: the kernel drops the lock when the holding *process* dies, so
+    /// a holder that crashes or is SIGKILLed leaves behind an empty file and
+    /// nothing else. Every reclaim story in the spec — a spawner retrying a
+    /// session whose holder died, OrphanGC sweeping the file — depends on it,
+    /// and `release()` returning the lock proves only that `close(2)` works.
+    ///
+    /// The child holds the lock by INHERITING the descriptor: the lock lives on
+    /// the open file description, so passing the fd across `exec` passes the
+    /// lock with it. That is also how the real holder gets it, which makes this
+    /// the same mechanism rather than a stand-in for it. `fork()` is
+    /// unavailable to Swift on Darwin ("please use threads or posix_spawn"), so
+    /// the child is a real `posix_spawn`ed `/bin/sh`.
+    ///
+    /// The sequencing is what makes the assertion mean anything:
+    ///
+    ///   1. the child writes a marker THROUGH the inherited fd, so a
+    ///      descriptor that never arrived is caught rather than passing
+    ///      vacuously,
+    ///   2. the parent drops its own fd while the child is still alive, so the
+    ///      child is the sole holder,
+    ///   3. only the child's exit can free the lock.
+    ///
+    /// Deliberately asserts NOTHING about contention: that belongs to
+    /// `secondAcquisitionFailsWhileFirstIsHeld`, and a `LOCK_NB` regression
+    /// should redden that test rather than park this one in a blocking `flock`
+    /// forever.
+    @Test func lockIsReacquirableAfterTheHoldingProcessExits() throws {
+        let path = scratchPath()
+        let lock = try HolderLock.acquire(path: path)
+        var parentStillHoldsLock = true
+        defer { if parentStillHoldsLock { lock.release() } }
+
+        // `echo K >&9` proves the descriptor arrived; `echo R` tells the parent
+        // that write already happened; `read` parks the child until the parent
+        // closes the pipe, so the parent can drop its own fd first.
+        let script = "echo K >&9; echo R; read line"
+        var toChild: [Int32] = [-1, -1]
+        var fromChild: [Int32] = [-1, -1]
+        try #require(pipe(&toChild) == 0)
+        try #require(pipe(&fromChild) == 0)
+
+        var actions: posix_spawn_file_actions_t?
+        posix_spawn_file_actions_init(&actions)
+        defer { posix_spawn_file_actions_destroy(&actions) }
+        // The dup2 file action is what hands the lock over, and deliberately
+        // NOT `makeInheritableAcrossExec()`. `dup2` clears FD_CLOEXEC on the
+        // new descriptor in the child by definition, so the parent's fd keeps
+        // its O_CLOEXEC — whereas clearing it here would expose this lock to
+        // every OTHER `posix_spawn` in the process, and a suite running in
+        // parallel spawns children constantly. A child of an unrelated test
+        // would then inherit this lock and hold it past our own child's exit,
+        // reddening the reacquire below. That is a measured flake, not a
+        // hypothetical.
+        //
+        // The lock's dup2 goes first so a later stdio dup2 cannot land on the
+        // descriptor it is reading from. Every fd here is above 2 in a test
+        // process, but the ordering costs nothing and the failure would be
+        // baffling.
+        try #require(lock.fileDescriptor > 2)
+        posix_spawn_file_actions_adddup2(&actions, lock.fileDescriptor, 9)
+        posix_spawn_file_actions_adddup2(&actions, toChild[0], 0)
+        posix_spawn_file_actions_adddup2(&actions, fromChild[1], 1)
+        posix_spawn_file_actions_addclose(&actions, toChild[1])
+        posix_spawn_file_actions_addclose(&actions, fromChild[0])
+
+        var pid: pid_t = 0
+        let arguments = ["sh", "-c", script]
+        var argv = arguments.map { strdup($0) }
+        argv.append(nil)
+        defer { for arg in argv { free(arg) } }
+        let spawned = posix_spawn(&pid, "/bin/sh", &actions, nil, &argv, nil)
+        close(toChild[0])
+        close(fromChild[1])
+        try #require(spawned == 0, "posix_spawn failed with code \(spawned)")
+        // A child parked in `read` never exits on its own, and an orphan here
+        // compounds across runs. Guarded on `reaped` so a pid this test already
+        // waited on can never be signalled after the number is recycled.
+        var reaped = false
+        defer {
+            if !reaped {
+                kill(pid, SIGKILL)
+                var discarded: Int32 = 0
+                _ = waitpid(pid, &discarded, 0)
+            }
+        }
+
+        var ready = [UInt8](repeating: 0, count: 1)
+        try #require(read(fromChild[0], &ready, 1) == 1, "child never reported that it was up")
+        #expect(ready[0] == UInt8(ascii: "R"))
+
+        // The inherited descriptor is the lock. If fd 9 never reached the
+        // child, this file is empty and everything below would pass vacuously.
+        let marker = try Data(contentsOf: URL(fileURLWithPath: path))
+        #expect(
+            marker == Data("K\n".utf8),
+            "the lock descriptor did not survive exec, so the child never held the lock")
+
+        // From here the child is the sole holder.
+        lock.release()
+        parentStillHoldsLock = false
+        close(toChild[1])
+
+        var status: Int32 = 0
+        for _ in 0..<500 where !reaped {
+            if waitpid(pid, &status, WNOHANG) == pid {
+                reaped = true
+            } else {
+                usleep(10_000)
+            }
+        }
+        close(fromChild[0])
+        try #require(reaped, "child did not exit within 5s of losing its stdin")
+
+        // Nothing in userspace released that lock. If the kernel did not drop
+        // it when the process died, this throws `.alreadyHeld` against a pid
+        // that no longer exists — a session UUID unreclaimable for the life of
+        // the machine.
+        let reacquired = try HolderLock.acquire(path: path)
+        reacquired.release()
+        #expect(reacquired.fileDescriptor >= 0)
+    }
+}


### PR DESCRIPTION
## Summary

Task 4 of the pty-holder transport ([spec](../blob/main/docs/specs/2026-08-30-pty-holder-session-transport-design.md)). The advisory lock that serializes holder creation, plus the empty `TBDHolder` executable target that Task 5 fills in.

**Stacked on #766, which is stacked on #765.** Merge in order.

## Why this shape

A socket file cannot distinguish a live holder from the corpse of a SIGKILLed one, and `bind` refuses a path that already exists — so "unlink the stale socket, then bind" is a race two spawners can both win, leaving one holder bound to a path the other already unlinked. An exclusive `flock` on a sibling file settles creation without anyone having to connect: a spawner that cannot take it has learned a live holder owns that UUID and backs off.

`HolderLock` lives in `TBDShared`, not `TBDHolder`, because a SwiftPM library target cannot import an executable one and the daemon-side spawner needs it.

## What this PR does

- `HolderLock` — non-blocking `flock`, `EINTR` retried rather than reported, `LocalizedError` with real messages.
- `TBDHolder` executable target with a placeholder `main.swift` that exits nonzero on stderr, and `TBDHolderTests`.
- `.swiftlint.yml` — adds `TBDHolder` to all six custom-rule path regexes, so the new target is not silently exempt from `no_print_in_sources` and `no_raw_task_sleep`.

## Evidence & verification

7 tests. The one that matters is `lockIsReacquirableAfterTheHoldingProcessExits`, added because the planned four test everything about the lock *except the claim the design rests on*: that the kernel drops it when the holding process dies. `release()` returning the lock only proves `close(2)` works. It `posix_spawn`s a real child that takes the lock via a dup2 file action, waits for it to exit, and reacquires.

Mutation check: `LOCK_EX` → `LOCK_SH` reddens `secondAcquisitionFailsWhileFirstIsHeld` and only that. (Dropping `LOCK_NB` was deliberately *not* used as the mutation — it makes the contended acquire block forever, so the check would hang rather than report.)

**One bug found by re-running rather than by the first green result**, worth recording because Tasks 5 and 6 do the same dance: the exit test passed alone and failed 3 runs in 4 alongside its siblings. `posix_spawn` file actions run in order, and the lock was duped onto fd 9 *before* the unwanted pipe ends were closed — pipe fds are handed out by number, so under a parallel suite either end can land on 9, and that close destroyed the descriptor just placed there. The child then died on a redirection error before signalling. Fixed by ordering closes first, then stdio dup2s, then the payload dup2; and by `dup()`ing the lock off the target first, since `dup2(fd, fd)` succeeds *without* clearing `FD_CLOEXEC`. Verified 6 consecutive green runs.

`swiftlint --strict`: 0 violations in 900 files. Full suite: 3 failures in `TerminalLockedAccessTests` (AppKit-under-load), unrelated and passing in isolation.

## Assumptions

`makeInheritableAcrossExec()` remains on `HolderLock` and is tested, but Task 6 should prefer the `posix_spawn` dup2 file action at the real call site: clearing `FD_CLOEXEC` on the parent's descriptor exposes it to every *other* concurrent spawn in the process, which in the daemon means an unrelated child inherits a holder's lock and holds that session UUID unreclaimable until it dies. That was measured here as a flake, not theorised.

https://claude.ai/code/session_01UXqxcPYizvznh99Qb8JKrD

[20260830-boring-panda](https://cheapsteak.github.io/tbd/open/?worktree=A1E9CF50-E608-4F3C-BA8F-377D60BB7478)