### PR TITLE
Feat: Add the pty holder binary

### DIFF
--- a/Sources/TBDHolder/Holder.swift
+++ b/Sources/TBDHolder/Holder.swift
@@ -1,0 +1,736 @@
+import Darwin
+import Foundation
+import TBDShared
+import os
+
+/// One holder process owns one session's pty master for that session's whole
+/// life, and hands `dup`s of it out over a Unix socket.
+///
+/// The single invariant everything else rests on: **the holder never `read()`s
+/// the master.** The only operations it performs on that descriptor are `dup`
+/// (hand-over), `ioctl` (size), `write` (input) and `close` (forget). A byte
+/// the holder consumed is a byte no reader can ever see again, and there is no
+/// way to put it back.
+///
+/// The holder is deliberately single-threaded. `forkpty` is a `fork`, and a
+/// `fork` in a multithreaded process gives the child one thread plus whatever
+/// locks the others happened to hold — which is how a child deadlocks inside
+/// `malloc` before it ever reaches `execve`. Reaping is therefore a `WNOHANG`
+/// `waitpid` inside the same `poll` loop that serves clients, not a thread
+/// blocked in `waitpid`: no thread means no window in which one could exist.
+final class Holder {
+    private static let logger = Logger(subsystem: "com.tbd.daemon", category: "holder")
+
+    /// How long a holder whose child has exited keeps its socket bound waiting
+    /// for somebody to come and collect the status. Long enough for a daemon
+    /// that is restarting to reconnect, short enough that nothing lingers.
+    static let defaultExitReportTimeout: Duration = .seconds(10)
+
+    private let arguments: HolderArguments
+    private let exitReportTimeout: Duration
+    private let clock: any Clock<Duration>
+
+    init(
+        arguments: HolderArguments,
+        exitReportTimeout: Duration = Holder.defaultExitReportTimeout,
+        clock: any Clock<Duration> = ContinuousClock()
+    ) {
+        self.arguments = arguments
+        self.exitReportTimeout = exitReportTimeout
+        self.clock = clock
+    }
+
+    /// Runs the holder to completion and returns the process exit code.
+    ///
+    /// Ordering here is the contract, not a preference:
+    ///
+    ///   1. `setsid()` first, so a Ctrl-C aimed at whatever spawned us cannot
+    ///      reach the holder and strand every session on the machine.
+    ///   2. `SIGHUP`/`SIGPIPE` to `SIG_IGN`, so the spawner's death — or a
+    ///      `sendmsg` into a peer that just went away — is not ours.
+    ///   3. adopt the inherited creation-lock descriptor. We never *take* the
+    ///      lock: the spawner already holds it and passed it by number.
+    ///   4. bind and listen.
+    ///   5. `forkpty`, before any thread could exist.
+    ///   6. serve.
+    func run() throws -> Int32 {
+        // Detaching the session is what makes a holder survive its spawner's
+        // terminal. `setsid` fails with EPERM when we are already a process
+        // group leader, which is a fine state to be in — it is only worth a
+        // debug line, never a failure.
+        if setsid() == -1 {
+            Self.logger.debug("setsid failed (errno \(errno, privacy: .public)); already a session leader")
+        }
+        signal(SIGHUP, SIG_IGN)
+        signal(SIGPIPE, SIG_IGN)
+
+        // The lock arrives as a descriptor number the spawner dup2'd into
+        // place. It must be above stdio: `forkpty` dup2s the pty slave onto
+        // 0/1/2 in the child, so a lock parked on one of those would be
+        // silently overwritten and the lock's whole contract would be a lie.
+        guard arguments.lockFD > 2, fcntl(arguments.lockFD, F_GETFD) >= 0 else {
+            throw HolderStartupError.invalidLockDescriptor(arguments.lockFD)
+        }
+
+        let listenFD = try bindListener(at: arguments.socketPath)
+        var socketIsBound = true
+        defer {
+            if socketIsBound {
+                close(listenFD)
+                unlink(arguments.socketPath)
+            }
+        }
+
+        let child = try spawnChild(listenFD: listenFD)
+        Self.logger.info(
+            """
+            holder up: session \(self.arguments.sessionID.uuidString, privacy: .public) \
+            pid \(child.pid, privacy: .public) tty \(child.ttyName, privacy: .public)
+            """)
+
+        let code = serve(listenFD: listenFD, child: child)
+        socketIsBound = false
+        close(listenFD)
+        unlink(arguments.socketPath)
+        return code
+    }
+
+    // MARK: - Rendezvous
+
+    private func bindListener(at path: String) throws -> Int32 {
+        let directory = (path as NSString).deletingLastPathComponent
+        do {
+            try FileManager.default.createDirectory(
+                atPath: directory,
+                withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o700])
+        } catch {
+            throw HolderStartupError.socketDirectoryUnavailable(path: directory, errno: errno)
+        }
+
+        guard path.utf8.count < HolderRendezvous.sunPathLimit else {
+            throw HolderStartupError.socketPathTooLong(path: path, limit: HolderRendezvous.sunPathLimit)
+        }
+
+        // Unlinking a socket path is only ever safe for the process that holds
+        // the creation lock for it, and we do — the spawner took it and handed
+        // us the descriptor. `bind` refuses an existing path, and the corpse of
+        // a SIGKILLed holder looks exactly like a live one from the filesystem.
+        unlink(path)
+
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else { throw HolderStartupError.cannotBind(path: path, errno: errno) }
+
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let sunPathSize = MemoryLayout.size(ofValue: address.sun_path)
+        path.withCString { source in
+            withUnsafeMutablePointer(to: &address.sun_path) { destination in
+                destination.withMemoryRebound(to: CChar.self, capacity: sunPathSize) { chars in
+                    _ = strlcpy(chars, source, sunPathSize)
+                }
+            }
+        }
+        let bound = withUnsafePointer(to: &address) { addressPtr in
+            addressPtr.withMemoryRebound(to: sockaddr.self, capacity: 1) { generic in
+                Darwin.bind(fd, generic, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard bound == 0 else {
+            let saved = errno
+            close(fd)
+            throw HolderStartupError.cannotBind(path: path, errno: saved)
+        }
+        guard listen(fd, 8) == 0 else {
+            let saved = errno
+            close(fd)
+            unlink(path)
+            throw HolderStartupError.cannotListen(path: path, errno: saved)
+        }
+        return fd
+    }
+
+    // MARK: - The job
+
+    /// `ptyFD` is the pty **master**. Declarations spell it `ptyFD` for the
+    /// same reason the wire verbs are `handOverPTY`/`handedOverPTY`: SwiftLint's
+    /// `inclusive_language` rule refuses the POSIX word in a declaration, and a
+    /// suppression on the central noun of this design is worse than a name
+    /// whose doc comment says exactly which end of the pty it is. Prose keeps
+    /// saying "pty master", because that is what `forkpty` calls it.
+    private struct SpawnedChild {
+        var pid: pid_t
+        var ptyFD: Int32
+        var ttyName: String
+    }
+
+    private func spawnChild(listenFD: Int32) throws -> SpawnedChild {
+        let launch = arguments.launch
+
+        // EVERY allocation happens here, before the fork. Between `forkpty`
+        // and `execve` only async-signal-safe calls are legal, and `strdup`,
+        // `malloc` and every Swift string operation are not.
+        let executablePath = strdup(launch.executable)
+        let workingDirectory = strdup(launch.workingDirectory)
+        let argv = Self.makeCArray([launch.executable] + launch.arguments)
+        // Sorted purely so a holder's environment is reproducible in a log or
+        // a crash report; the child cannot observe the order.
+        let envp = Self.makeCArray(launch.environment.map { "\($0.key)=\($0.value)" }.sorted())
+        let nameBuffer = UnsafeMutablePointer<CChar>.allocate(capacity: Self.ttyNameCapacity)
+        nameBuffer.initialize(repeating: 0, count: Self.ttyNameCapacity)
+        defer {
+            free(executablePath)
+            free(workingDirectory)
+            Self.freeCArray(argv)
+            Self.freeCArray(envp)
+            nameBuffer.deallocate()
+        }
+
+        // Passed to `forkpty` AND re-applied below. `forkpty` sizes the pty
+        // before the child exists, which closes the window where a job reads
+        // 0x0 and lays itself out for a zero-column terminal; the explicit
+        // `ioctl` is what the rest of the system uses to resize, so going
+        // through it once here keeps one code path for "the size is now this".
+        var size = winsize(
+            ws_row: launch.rows, ws_col: launch.columns, ws_xpixel: 0, ws_ypixel: 0)
+        var primaryFD: Int32 = -1
+        // Read into locals BEFORE the fork, for the same reason the C strings
+        // are built here: a Swift `static let` is a lazy global behind
+        // `swift_once`, and touching one for the first time in a forked child
+        // can deadlock on a lock another thread held at fork time.
+        let lockFD = arguments.lockFD
+        let chdirFailure = Self.chdirFailureExitCode
+        let execFailure = Self.execFailureExitCode
+        let descriptorCeiling = Self.descriptorCeiling()
+
+        let pid = forkpty(&primaryFD, nameBuffer, nil, &size)
+        if pid == 0 {
+            // ---- CHILD. Async-signal-safe calls only, and no `defer`: the
+            // `_exit`s below deliberately skip Swift cleanup.
+
+            // `SIG_IGN` is inherited across fork AND exec, so without this the
+            // job would start life with SIGPIPE ignored — `yes | head` spins
+            // instead of dying, and nothing hangs up on a lost terminal.
+            // `signal(2)` is async-signal-safe, so it is legal in this window.
+            signal(SIGHUP, SIG_DFL)
+            signal(SIGPIPE, SIG_DFL)
+
+            // **A job gets a terminal and nothing else.** Everything above
+            // stdio is closed, and two of those descriptors are the reason the
+            // sweep exists rather than a pair of named closes:
+            //
+            //   - `lockFD`, the creation lock. `flock` lives on the open file
+            //     description, so a job that inherits the descriptor holds the
+            //     lock — and keeps holding it after the holder is SIGKILLed.
+            //     Both halves of the lock's contract break at once: the kernel
+            //     no longer drops it when the holder dies, and a respawn sees
+            //     `.alreadyHeld` forever with no holder alive to explain it.
+            //   - `listenFD`, the rendezvous socket, which a job would
+            //     otherwise keep alive past the holder's exit.
+            //
+            // Naming only those two is not enough, because the holder does not
+            // know what its spawner leaked into it: anything the spawner had
+            // open without `FD_CLOEXEC` arrives here unannounced and would then
+            // outlive the whole chain in a job nobody associates with it. That
+            // is not hypothetical — this repo's own build wrapper holds a
+            // machine-global `flock`, and a `sleep` job that inherited it went
+            // on blocking every other worktree's build after its holder, its
+            // test process and its harness were all gone.
+            //
+            // `close(2)` is async-signal-safe, and the ceiling was read before
+            // the fork because `getrlimit` is not.
+            close(lockFD)
+            close(listenFD)
+            var descriptor: Int32 = 3
+            while descriptor < descriptorCeiling {
+                close(descriptor)
+                descriptor += 1
+            }
+
+            if chdir(workingDirectory) != 0 { _exit(chdirFailure) }
+            execve(executablePath, argv, envp)
+            _exit(execFailure)
+        }
+        guard pid > 0 else { throw HolderStartupError.forkFailed(errno: errno) }
+
+        var applied = size
+        if ioctl(primaryFD, TIOCSWINSZ, &applied) != 0 {
+            Self.logger.error("TIOCSWINSZ failed (errno \(errno, privacy: .public))")
+        }
+        return SpawnedChild(pid: pid, ptyFD: primaryFD, ttyName: String(cString: nameBuffer))
+    }
+
+    // MARK: - Serving
+
+    // swiftlint:disable:next function_body_length - one poll loop; splitting it
+    // would scatter the state machine across helpers that each need all of it.
+    private func serve(listenFD: Int32, child: SpawnedChild) -> Int32 {
+        var ptyFD = child.ptyFD
+        var status: HolderChildStatus = .alive
+        var clientFD: Int32 = -1
+        var inbox = Data()
+        var forgotten = false
+        var exitReported = false
+        var window = ExitReportWindow(limit: exitReportTimeout, clock: clock)
+
+        func describe() -> HolderChildDescription {
+            HolderChildDescription(
+                childPID: child.pid,
+                ttyName: child.ttyName,
+                status: status,
+                launch: arguments.launch,
+                owner: arguments.owner)
+        }
+
+        func dropClient() {
+            if clientFD >= 0 { close(clientFD) }
+            clientFD = -1
+            inbox = Data()
+        }
+
+        /// Push the terminal status at whoever is connected. There is no
+        /// separate "exited" verb on the wire: the description already carries
+        /// the status, and an unsolicited `.described` frame is what a reader
+        /// blocked on the pty needs to see to stop waiting.
+        ///
+        /// The `status != .alive` guard is load-bearing, not defensive. Without
+        /// it this fires on every accept and greets each client with an
+        /// unsolicited frame it did not ask for — which then answers the
+        /// client's FIRST request, so `handOverPTY` comes back as a plain
+        /// `.described` with no descriptor and the whole hand-over silently
+        /// stops working.
+        func reportExitIfPossible() {
+            guard status != .alive, clientFD >= 0, !exitReported else { return }
+            guard let frame = try? HolderFraming.frame(.described(describe())) else { return }
+            do {
+                try FDChannel.sendData(frame, over: clientFD)
+                exitReported = true
+            } catch {
+                Self.logger.error(
+                    "could not report exit to the connected client: \(error.localizedDescription, privacy: .public)")
+                dropClient()
+            }
+        }
+
+        while true {
+            if case .alive = status {
+                var raw: Int32 = 0
+                let reaped = waitpid(child.pid, &raw, WNOHANG)
+                if reaped == child.pid {
+                    status = Self.status(fromWaitpidStatus: raw)
+                    window.arm()
+                    Self.logger.info(
+                        "child \(child.pid, privacy: .public) exited: \(String(describing: status), privacy: .public)")
+                    reportExitIfPossible()
+                } else if reaped < 0 && errno != EINTR {
+                    // We can no longer observe the child at all. Say exactly
+                    // that — a fabricated exit code would be indistinguishable
+                    // from a real one to everything downstream.
+                    status = .exitedStatusUnknown
+                    window.arm()
+                    Self.logger.error("waitpid failed (errno \(errno, privacy: .public))")
+                    reportExitIfPossible()
+                }
+            }
+
+            if forgotten { break }
+            if window.isArmed && (exitReported || window.isExpired) { break }
+
+            var watched = [pollfd(fd: listenFD, events: Int16(POLLIN), revents: 0)]
+            if clientFD >= 0 {
+                watched.append(pollfd(fd: clientFD, events: Int16(POLLIN), revents: 0))
+            }
+            var ready: Int32 = 0
+            // The window only charges while it is armed, so the ordinary
+            // serving loop runs untimed and a holder whose child has exited
+            // starts burning its grace period from that moment.
+            window.charging {
+                ready = poll(&watched, nfds_t(watched.count), Self.pollSliceMilliseconds)
+            }
+            if ready < 0 && errno != EINTR {
+                Self.logger.error("poll failed (errno \(errno, privacy: .public))")
+            }
+            guard ready > 0 else { continue }
+
+            if clientFD >= 0, watched.count > 1, watched[1].revents & Int16(POLLIN | POLLHUP | POLLERR) != 0 {
+                switch readRequests(from: clientFD, into: &inbox) {
+                case .closed:
+                    dropClient()
+                case .requests(let requests):
+                    for request in requests {
+                        switch request {
+                        case .describe:
+                            if !send(.described(describe()), to: clientFD) { dropClient() }
+                        case .handOverPTY:
+                            // A forgotten holder has no master left to hand
+                            // over; it answers with the description instead of
+                            // pretending the transfer happened.
+                            let delivered = ptyFD >= 0
+                                ? handOver(ptyFD, description: describe(), to: clientFD)
+                                : send(.described(describe()), to: clientFD)
+                            if !delivered { dropClient() }
+                        case .forget:
+                            _ = send(.forgotten, to: clientFD)
+                            if ptyFD >= 0 { close(ptyFD) }
+                            ptyFD = -1
+                            forgotten = true
+                            Self.logger.info(
+                                "forgot session \(self.arguments.sessionID.uuidString, privacy: .public)")
+                        }
+                        if forgotten || clientFD < 0 { break }
+                    }
+                }
+            }
+
+            if watched[0].revents & Int16(POLLIN) != 0 {
+                let incoming = accept(listenFD, nil, nil)
+                if incoming >= 0 {
+                    if clientFD >= 0 {
+                        // Two readers on one pty master is silent byte theft:
+                        // whichever `read` lands first wins the bytes and the
+                        // other reader never learns they existed. So a second
+                        // client is answered — with a version that can never
+                        // be mistaken for a real one — and disconnected.
+                        _ = send(.rejected(version: HolderProtocolVersion.busySentinel), to: incoming)
+                        close(incoming)
+                    } else {
+                        clientFD = incoming
+                        reportExitIfPossible()
+                    }
+                }
+            }
+
+            if forgotten { break }
+        }
+
+        dropClient()
+        if ptyFD >= 0 { close(ptyFD) }
+        return 0
+    }
+
+    private enum ReadOutcome {
+        case closed
+        case requests([HolderRequest])
+    }
+
+    private func readRequests(from fd: Int32, into inbox: inout Data) -> ReadOutcome {
+        var buffer = [UInt8](repeating: 0, count: Self.readChunkSize)
+        let count = read(fd, &buffer, buffer.count)
+        if count == 0 { return .closed }
+        if count < 0 {
+            if errno == EINTR || errno == EAGAIN { return .requests([]) }
+            return .closed
+        }
+        inbox.append(contentsOf: buffer[0..<count])
+        do {
+            return .requests(try HolderFraming.drainRequests(from: &inbox))
+        } catch {
+            Self.logger.error(
+                "unparseable request frame, dropping the client: \(error.localizedDescription, privacy: .public)")
+            return .closed
+        }
+    }
+
+    /// Returns `false` when the client is gone, so call sites can read as
+    /// `send(…) || dropClient()`.
+    @discardableResult
+    private func send(_ response: HolderResponse, to fd: Int32) -> Bool {
+        do {
+            try FDChannel.sendData(try HolderFraming.frame(response), over: fd)
+            return true
+        } catch {
+            Self.logger.error("send failed: \(error.localizedDescription, privacy: .public)")
+            return false
+        }
+    }
+
+    @discardableResult
+    private func handOver(_ ptyFD: Int32, description: HolderChildDescription, to fd: Int32) -> Bool {
+        // A `dup`, never the original: the caller closes what it receives, and
+        // the holder's own reference to the pty master has to outlive every
+        // reader that ever attaches.
+        let duplicate = dup(ptyFD)
+        guard duplicate >= 0 else {
+            Self.logger.error("dup of the pty master failed (errno \(errno, privacy: .public))")
+            return send(.described(description), to: fd)
+        }
+        defer { close(duplicate) }
+        do {
+            let frame = try HolderFraming.frame(.handedOverPTY(description))
+            try FDChannel.sendFDMinimal(duplicate, over: fd, payload: frame)
+            return true
+        } catch {
+            Self.logger.error("hand-over failed: \(error.localizedDescription, privacy: .public)")
+            return false
+        }
+    }
+
+    // MARK: - Small helpers
+
+    /// `<sys/wait.h>`'s `WIFEXITED`/`WEXITSTATUS` are function-like macros,
+    /// which Swift does not import — this is their definition, spelled out.
+    static func status(fromWaitpidStatus raw: Int32) -> HolderChildStatus {
+        let terminatingSignal = raw & 0x7f
+        guard terminatingSignal == 0 else {
+            // Killed by a signal: there IS no exit code, so do not invent one.
+            return .exitedStatusUnknown
+        }
+        return .exited(code: (raw >> 8) & 0xff)
+    }
+
+    /// One past the highest descriptor the child sweeps closed.
+    ///
+    /// Read in the parent because `getrlimit` is not async-signal-safe. Clamped
+    /// because `RLIMIT_NOFILE` can be `RLIM_INFINITY`, and floored at 3 so a
+    /// pathological limit cannot make the sweep touch stdio.
+    private static func descriptorCeiling() -> Int32 {
+        var limits = rlimit()
+        guard getrlimit(RLIMIT_NOFILE, &limits) == 0 else { return descriptorSweepCap }
+        // The `<` also catches `RLIM_INFINITY`, whose Swift name the SDK does
+        // not export ("macro unavailable: structure not supported") — it is
+        // 2^63-1, so an unlimited soft limit clamps like any oversized one.
+        let soft = limits.rlim_cur
+        guard soft < rlim_t(descriptorSweepCap) else { return descriptorSweepCap }
+        return max(3, Int32(soft))
+    }
+
+    /// 64Ki close() syscalls is a fraction of a millisecond, and no sane soft
+    /// limit reaches it — this only bounds the pathological case.
+    private static let descriptorSweepCap: Int32 = 65_536
+    private static let ttyNameCapacity = 1024
+    private static let readChunkSize = 4096
+    private static let pollSliceMilliseconds: Int32 = 50
+    private static let chdirFailureExitCode: Int32 = 126
+    private static let execFailureExitCode: Int32 = 127
+
+    private static func makeCArray(_ strings: [String]) -> UnsafeMutablePointer<UnsafeMutablePointer<CChar>?> {
+        let buffer = UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>.allocate(capacity: strings.count + 1)
+        for (index, value) in strings.enumerated() {
+            buffer[index] = strdup(value)
+        }
+        buffer[strings.count] = nil
+        return buffer
+    }
+
+    private static func freeCArray(_ array: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>) {
+        var index = 0
+        while let entry = array[index] {
+            free(entry)
+            index += 1
+        }
+        array.deallocate()
+    }
+}
+
+// MARK: - Invocation
+
+/// The parsed command line.
+///
+/// The lock arrives as a **descriptor number**, not a path. The spawner has
+/// already taken the lock and `dup2`d it into the child; the holder adopts
+/// that descriptor and holds it for life. A holder that only knew the path
+/// could not name the inherited descriptor, and therefore could not keep it
+/// out of the job — which is the one thing about the lock that must not
+/// happen. The holder never calls `HolderLock.acquire` itself.
+struct HolderArguments: Equatable {
+    var sessionID: UUID
+    var socketPath: String
+    var lockFD: Int32
+    var launch: HolderLaunchRequest
+    /// Which TBD installation spawned us. Echoed in every description so
+    /// reclamation can tell one of ours from a healthy stranger's. Optional on
+    /// the command line so a holder launched by hand for diagnosis still runs.
+    var owner: HolderOwnerToken
+
+    static let usage = """
+        usage: TBDHolder --session <uuid> --socket <path> --lock-fd <n> \
+        --launch <base64-json> [--owner <token>]
+        """
+
+    /// `arguments` excludes argv[0].
+    ///
+    /// Unrecognised `--flags` are collected and ignored rather than refused, on
+    /// purpose: a long-lived session keeps running the holder binary it was
+    /// born with, so a newer daemon will one day pass a flag an older holder
+    /// has never heard of. Refusing would turn "this holder predates the flag"
+    /// into "this session cannot start". A bare word with no leading `--` is
+    /// still an error, because that is a quoting mistake rather than a version
+    /// skew.
+    static func parse(_ arguments: [String]) throws -> HolderArguments {
+        var values: [String: String] = [:]
+        var index = 0
+        while index < arguments.count {
+            let flag = arguments[index]
+            guard flag.hasPrefix("--") else {
+                throw HolderStartupError.unknownArgument(flag)
+            }
+            guard index + 1 < arguments.count else {
+                throw HolderStartupError.missingValue(flag)
+            }
+            values[String(flag.dropFirst(2))] = arguments[index + 1]
+            index += 2
+        }
+
+        func required(_ name: String) throws -> String {
+            guard let value = values[name], !value.isEmpty else {
+                throw HolderStartupError.missingArgument(name)
+            }
+            return value
+        }
+
+        let sessionText = try required("session")
+        guard let sessionID = UUID(uuidString: sessionText) else {
+            throw HolderStartupError.invalidSessionID(sessionText)
+        }
+        let lockText = try required("lock-fd")
+        guard let lockFD = Int32(lockText) else {
+            throw HolderStartupError.invalidLockDescriptorArgument(lockText)
+        }
+        let launchText = try required("launch")
+        guard let launchData = Data(base64Encoded: launchText),
+              let launch = try? JSONDecoder().decode(HolderLaunchRequest.self, from: launchData) else {
+            throw HolderStartupError.invalidLaunchPayload
+        }
+
+        return HolderArguments(
+            sessionID: sessionID,
+            socketPath: try required("socket"),
+            lockFD: lockFD,
+            launch: launch,
+            owner: HolderOwnerToken(rawValue: values["owner"] ?? ""))
+    }
+}
+
+enum HolderStartupError: LocalizedError, Equatable {
+    case unknownArgument(String)
+    case missingValue(String)
+    case missingArgument(String)
+    case invalidSessionID(String)
+    case invalidLaunchPayload
+    case invalidLockDescriptorArgument(String)
+    case invalidLockDescriptor(Int32)
+    case socketPathTooLong(path: String, limit: Int)
+    case socketDirectoryUnavailable(path: String, errno: Int32)
+    case cannotBind(path: String, errno: Int32)
+    case cannotListen(path: String, errno: Int32)
+    case forkFailed(errno: Int32)
+    case oversizedFrame(bytes: Int, limit: Int)
+
+    var errorDescription: String? {
+        switch self {
+        case .unknownArgument(let argument):
+            return "unexpected argument \"\(argument)\"\n\(HolderArguments.usage)"
+        case .missingValue(let flag):
+            return "\(flag) needs a value\n\(HolderArguments.usage)"
+        case .missingArgument(let name):
+            return "--\(name) is required\n\(HolderArguments.usage)"
+        case .invalidSessionID(let text):
+            return "--session must be a UUID, got \"\(text)\""
+        case .invalidLaunchPayload:
+            return "--launch must be base64-encoded JSON for a HolderLaunchRequest"
+        case .invalidLockDescriptorArgument(let text):
+            return "--lock-fd must be a descriptor number, got \"\(text)\""
+        case .invalidLockDescriptor(let fd):
+            return "--lock-fd \(fd) is not an open descriptor above stdio; the "
+                + "spawner must dup2 the held creation lock into place"
+        case .socketPathTooLong(let path, let limit):
+            return "holder socket path is \(path.utf8.count) bytes, over the "
+                + "\(limit)-byte sun_path limit: \(path)"
+        case .socketDirectoryUnavailable(let path, let errno):
+            return "could not create the holder rendezvous directory \(path): "
+                + "\(String(cString: strerror(errno))) (errno \(errno))"
+        case .cannotBind(let path, let errno):
+            return "could not bind the holder socket at \(path): "
+                + "\(String(cString: strerror(errno))) (errno \(errno))"
+        case .cannotListen(let path, let errno):
+            return "could not listen on the holder socket at \(path): "
+                + "\(String(cString: strerror(errno))) (errno \(errno))"
+        case .forkFailed(let errno):
+            return "forkpty failed: \(String(cString: strerror(errno))) (errno \(errno))"
+        case .oversizedFrame(let bytes, let limit):
+            return "holder frame claims \(bytes) bytes, over the \(limit)-byte limit"
+        }
+    }
+}
+
+// MARK: - The bounded wait for somebody to collect the exit status
+
+/// The holder's one delay, and therefore the one thing that takes the clock.
+///
+/// It is duration-shaped rather than deadline-shaped on purpose: `any
+/// Clock<Duration>` pins `Duration` but not `Instant`, so instant arithmetic
+/// does not typecheck through the existential — and a limit expressed as
+/// "how much time has been spent" is what a fake clock can drive.
+struct ExitReportWindow {
+    private let limit: Duration
+    private let clock: any Clock<Duration>
+    private var elapsed: Duration = .zero
+    private(set) var isArmed = false
+
+    init(limit: Duration, clock: any Clock<Duration>) {
+        self.limit = limit
+        self.clock = clock
+    }
+
+    var isExpired: Bool { isArmed && elapsed >= limit }
+
+    /// Starts the clock. Before this the window never expires, so an ordinary
+    /// holder serving a live child is untimed.
+    mutating func arm() { isArmed = true }
+
+    /// Runs `work`, charging its wall time against the limit once armed.
+    mutating func charging(_ work: () -> Void) {
+        let slice = clock.measure(work)
+        if isArmed { elapsed += slice }
+    }
+}
+
+// MARK: - Wire framing
+
+/// `[UInt32 little-endian byte count][JSON]`, both directions.
+///
+/// It lives in the holder rather than in `TBDShared` for now because the
+/// holder is the only thing that speaks it; the daemon-side client hoists it
+/// when it lands.
+enum HolderFraming {
+    /// Refuses anything larger than this rather than trusting a length word
+    /// from the wire — a peer that desyncs would otherwise make the holder
+    /// allocate gigabytes on its behalf.
+    static let maximumFrameSize = 1 << 20
+
+    static func frame(_ response: HolderResponse) throws -> Data { try encode(response) }
+    static func frame(_ request: HolderRequest) throws -> Data { try encode(request) }
+
+    private static func encode<Message: Encodable>(_ message: Message) throws -> Data {
+        let payload = try JSONEncoder().encode(message)
+        var length = UInt32(payload.count).littleEndian
+        var framed = Data(bytes: &length, count: MemoryLayout<UInt32>.size)
+        framed.append(payload)
+        return framed
+    }
+
+    /// Pulls every complete frame out of `buffer`, leaving any partial tail
+    /// behind for the next read.
+    static func drain<Message: Decodable>(_ type: Message.Type, from buffer: inout Data) throws -> [Message] {
+        var messages: [Message] = []
+        while true {
+            guard buffer.count >= MemoryLayout<UInt32>.size else { return messages }
+            let header = buffer.prefix(MemoryLayout<UInt32>.size)
+            let length = Int(header.withUnsafeBytes { raw in
+                UInt32(littleEndian: raw.loadUnaligned(as: UInt32.self))
+            })
+            guard length <= maximumFrameSize else {
+                throw HolderStartupError.oversizedFrame(bytes: length, limit: maximumFrameSize)
+            }
+            let total = MemoryLayout<UInt32>.size + length
+            guard buffer.count >= total else { return messages }
+            let payload = buffer.dropFirst(MemoryLayout<UInt32>.size).prefix(length)
+            messages.append(try JSONDecoder().decode(Message.self, from: Data(payload)))
+            buffer = Data(buffer.dropFirst(total))
+        }
+    }
+
+    static func drainRequests(from buffer: inout Data) throws -> [HolderRequest] {
+        try drain(HolderRequest.self, from: &buffer)
+    }
+}

--- a/Sources/TBDHolder/Holder.swift
+++ b/Sources/TBDHolder/Holder.swift
@@ -22,8 +22,25 @@ final class Holder {
     private static let logger = Logger(subsystem: "com.tbd.daemon", category: "holder")
 
     /// How long a holder whose child has exited keeps its socket bound waiting
-    /// for somebody to come and collect the status. Long enough for a daemon
-    /// that is restarting to reconnect, short enough that nothing lingers.
+    /// for somebody to come and collect the status.
+    ///
+    /// The trade-off it encodes, in both directions:
+    ///
+    ///   - **Long enough** that a daemon which was restarting when the job
+    ///     finished can come back, connect, and be told what happened. Ten
+    ///     seconds comfortably covers a daemon relaunch, which is the case this
+    ///     window exists for.
+    ///   - **Short enough** that nothing lingers. A holder past this point has
+    ///     no job, no reader and nothing left to say; every extra second is a
+    ///     process and a bound socket that some reconciler would otherwise have
+    ///     to reclaim.
+    ///
+    /// What is lost when it expires is bounded and honest: the holder unlinks
+    /// its rendezvous and goes, so whoever asks later learns the session is
+    /// gone but not how it ended — the status reads `exitedStatusUnknown`
+    /// rather than a fabricated code. An invented exit code would be
+    /// indistinguishable downstream from one the job really returned, which is
+    /// strictly worse than admitting the status was never collected.
     static let defaultExitReportTimeout: Duration = .seconds(10)
 
     private let arguments: HolderArguments
@@ -270,7 +287,13 @@ final class Holder {
         var clientFD: Int32 = -1
         var inbox = Data()
         var forgotten = false
-        var exitReported = false
+        /// The terminal status has actually **reached** a client — either
+        /// pushed at one that was already connected when the child exited, or
+        /// carried back as the answer to that client's own request. It is what
+        /// ends the holder's life, so it is set only after a successful send: a
+        /// send that failed collected nothing, and the window must stay open
+        /// for whoever connects next.
+        var exitCollected = false
         var window = ExitReportWindow(limit: exitReportTimeout, clock: clock)
 
         func describe() -> HolderChildDescription {
@@ -288,28 +311,41 @@ final class Holder {
             inbox = Data()
         }
 
-        /// Push the terminal status at whoever is connected. There is no
-        /// separate "exited" verb on the wire: the description already carries
-        /// the status, and an unsolicited `.described` frame is what a reader
-        /// blocked on the pty needs to see to stop waiting.
+        /// Push the terminal status at a client that was **already connected**
+        /// when the child exited. There is no separate "exited" verb on the
+        /// wire: the description already carries the status, and an unsolicited
+        /// `.described` frame is what a reader blocked on the pty needs to see
+        /// to stop waiting.
         ///
-        /// The `status != .alive` guard is load-bearing, not defensive. Without
-        /// it this fires on every accept and greets each client with an
-        /// unsolicited frame it did not ask for — which then answers the
-        /// client's FIRST request, so `handOverPTY` comes back as a plain
-        /// `.described` with no descriptor and the whole hand-over silently
-        /// stops working.
-        func reportExitIfPossible() {
-            guard status != .alive, clientFD >= 0, !exitReported else { return }
+        /// It is called from the reaping branch alone, and that restriction is
+        /// the whole contract: **the holder never speaks first to a client that
+        /// arrives after the child is gone.** Greeting one at accept time put a
+        /// frame nobody asked for where that client's first response belongs —
+        /// its `handOverPTY` came back as a bare `.described` with no
+        /// descriptor — and the collection that frame recorded then tore the
+        /// connection down before the request was ever read. That is exactly
+        /// the shape of a daemon reconnecting after a restart to collect a
+        /// finished job's status, so it silently broke the primary
+        /// re-adoption path. Such a client is served instead; see the request
+        /// loop below.
+        func pushExitToConnectedClient() {
+            guard status != .alive, clientFD >= 0, !exitCollected else { return }
             guard let frame = try? HolderFraming.frame(.described(describe())) else { return }
             do {
                 try FDChannel.sendData(frame, over: clientFD)
-                exitReported = true
+                exitCollected = true
             } catch {
                 Self.logger.error(
                     "could not report exit to the connected client: \(error.localizedDescription, privacy: .public)")
                 dropClient()
             }
+        }
+
+        /// Records that an answer we just sent carried the terminal status, so
+        /// the loop can wind the holder down. A response about a live child
+        /// collects nothing and leaves the holder serving.
+        func noteAnswerCarriedTheStatus() {
+            if status != .alive { exitCollected = true }
         }
 
         while true {
@@ -321,7 +357,7 @@ final class Holder {
                     window.arm()
                     Self.logger.info(
                         "child \(child.pid, privacy: .public) exited: \(String(describing: status), privacy: .public)")
-                    reportExitIfPossible()
+                    pushExitToConnectedClient()
                 } else if reaped < 0 && errno != EINTR {
                     // We can no longer observe the child at all. Say exactly
                     // that — a fabricated exit code would be indistinguishable
@@ -329,12 +365,17 @@ final class Holder {
                     status = .exitedStatusUnknown
                     window.arm()
                     Self.logger.error("waitpid failed (errno \(errno, privacy: .public))")
-                    reportExitIfPossible()
+                    pushExitToConnectedClient()
                 }
             }
 
             if forgotten { break }
-            if window.isArmed && (exitReported || window.isExpired) { break }
+            // Once the status has reached somebody the holder has nothing left
+            // to do, and the armed window bounds the wait for anyone at all.
+            // Both halves must read `exitCollected` as "a client has actually
+            // been answered": a flag set by an unsolicited greeting would break
+            // here before that client's own request was ever read.
+            if window.isArmed && (exitCollected || window.isExpired) { break }
 
             var watched = [pollfd(fd: listenFD, events: Int16(POLLIN), revents: 0)]
             if clientFD >= 0 {
@@ -360,15 +401,33 @@ final class Holder {
                     for request in requests {
                         switch request {
                         case .describe:
-                            if !send(.described(describe()), to: clientFD) { dropClient() }
+                            if send(.described(describe()), to: clientFD) {
+                                noteAnswerCarriedTheStatus()
+                            } else {
+                                dropClient()
+                            }
                         case .handOverPTY:
                             // A forgotten holder has no master left to hand
                             // over; it answers with the description instead of
                             // pretending the transfer happened.
+                            //
+                            // A holder whose child has **exited** still hands
+                            // the master over, deliberately. The holder never
+                            // read it, so everything the job wrote and nobody
+                            // collected is still queued there and dies with the
+                            // holder — and the description riding the same
+                            // frame carries the terminal status, so no reader
+                            // can mistake the child for alive. Answering
+                            // `.described` instead would be a coherent reply
+                            // too, but it would throw those bytes away.
                             let delivered = ptyFD >= 0
                                 ? handOver(ptyFD, description: describe(), to: clientFD)
                                 : send(.described(describe()), to: clientFD)
-                            if !delivered { dropClient() }
+                            if delivered {
+                                noteAnswerCarriedTheStatus()
+                            } else {
+                                dropClient()
+                            }
                         case .forget:
                             _ = send(.forgotten, to: clientFD)
                             if ptyFD >= 0 { close(ptyFD) }
@@ -394,8 +453,10 @@ final class Holder {
                         _ = send(.rejected(version: HolderProtocolVersion.busySentinel), to: incoming)
                         close(incoming)
                     } else {
+                        // Nothing is sent here, even when the child is already
+                        // gone. This client has asked nothing yet, and the next
+                        // frame down this socket belongs to its first request.
                         clientFD = incoming
-                        reportExitIfPossible()
                     }
                 }
             }
@@ -601,6 +662,28 @@ struct HolderArguments: Equatable {
     }
 }
 
+/// What a holder that died before it ever served anything exits with.
+///
+/// The split is the point. A spawner reading a holder's exit code has exactly
+/// one decision to make — could retrying ever help? — and a single code for
+/// every startup failure answers it wrongly half the time: it reads a full
+/// disk or a rendezvous directory that momentarily did not exist as a mistake
+/// in its own command line, and gives up on a session that a second attempt
+/// would have started.
+enum HolderExitCode {
+    /// The invocation was wrong: a missing or malformed flag, a lock
+    /// descriptor the spawner never placed, a socket path that cannot fit in
+    /// `sun_path`. The same command line will fail the same way forever, so
+    /// the spawner must fix its arguments or give up. Retrying is pointless.
+    static let badInvocation: Int32 = 2
+    /// The machine refused: no rendezvous directory, a socket that would not
+    /// bind or listen, a `forkpty` that failed. Nothing about the invocation
+    /// is wrong, so a later attempt on a healthier machine can succeed.
+    static let environmentFailure: Int32 = 3
+    /// Something that is neither — an error `run()` did not classify.
+    static let unexpected: Int32 = 1
+}
+
 enum HolderStartupError: LocalizedError, Equatable {
     case unknownArgument(String)
     case missingValue(String)
@@ -615,6 +698,27 @@ enum HolderStartupError: LocalizedError, Equatable {
     case cannotListen(path: String, errno: Int32)
     case forkFailed(errno: Int32)
     case oversizedFrame(bytes: Int, limit: Int)
+
+    /// The process exit code this failure ends the holder with.
+    ///
+    /// Switched exhaustively with no `default`, so a new case cannot be added
+    /// without deciding which side of the retry question it falls on.
+    var exitCode: Int32 {
+        switch self {
+        case .unknownArgument, .missingValue, .missingArgument, .invalidSessionID,
+             .invalidLaunchPayload, .invalidLockDescriptorArgument, .invalidLockDescriptor,
+             .socketPathTooLong:
+            return HolderExitCode.badInvocation
+        case .socketDirectoryUnavailable, .cannotBind, .cannotListen, .forkFailed:
+            return HolderExitCode.environmentFailure
+        case .oversizedFrame:
+            // A peer sent a length word larger than the holder will allocate
+            // for. That is neither a bad command line nor a sick machine — it
+            // is a client speaking badly, and the spawner learns nothing
+            // actionable from retrying or from editing its arguments.
+            return HolderExitCode.unexpected
+        }
+    }
 
     var errorDescription: String? {
         switch self {

--- a/Sources/TBDHolder/main.swift
+++ b/Sources/TBDHolder/main.swift
@@ -2,19 +2,31 @@ import Foundation
 
 // TBDHolder — one process per holder-transport session.
 //
-// PLACEHOLDER. The target exists now so the creation lock, the rendezvous
-// paths and the wire protocol have a product to be built against, and so the
-// daemon's test target can depend on a binary that will exist. The real entry
-// point — adopt the inherited creation-lock fd, bind the rendezvous socket,
-// `forkpty()` the job, serve `handOverPTY`, report exit — lands with the
-// holder itself.
+// Invoked as:
 //
-// It exits nonzero rather than succeeding silently: a spawner that reaches
-// this build by mistake must fail loudly at spawn time, not hand back a
-// session whose pty nobody owns.
+//   TBDHolder --session <uuid> --socket <path> --lock-fd <n> \
+//             --launch <base64-json HolderLaunchRequest> [--owner <token>]
 //
-// stderr, not `print()` — `no_print_in_sources` covers this target, and the
-// daemon reads a holder's stderr as its diagnostic channel.
+// Argument parsing and exactly one call into `Holder`. Every decision the
+// holder makes lives in `Holder.swift`, so it can be exercised without
+// spawning a process.
+//
+// Diagnostics go to stderr rather than `print()` — `no_print_in_sources`
+// covers this target, and the daemon reads a holder's stderr as its channel
+// for anything that went wrong before the socket existed.
 
-FileHandle.standardError.write(Data("TBDHolder: not implemented yet\n".utf8))
-exit(1)
+func fail(_ message: String, code: Int32) -> Never {
+    FileHandle.standardError.write(Data("TBDHolder: \(message)\n".utf8))
+    exit(code)
+}
+
+do {
+    let arguments = try HolderArguments.parse(Array(CommandLine.arguments.dropFirst()))
+    exit(try Holder(arguments: arguments).run())
+} catch let error as HolderStartupError {
+    // 2 is "the invocation was wrong", distinct from a holder that started and
+    // then failed, so a spawner can tell a bad command line from a bad machine.
+    fail(error.localizedDescription, code: 2)
+} catch {
+    fail(error.localizedDescription, code: 1)
+}

--- a/Sources/TBDHolder/main.swift
+++ b/Sources/TBDHolder/main.swift
@@ -24,9 +24,11 @@ do {
     let arguments = try HolderArguments.parse(Array(CommandLine.arguments.dropFirst()))
     exit(try Holder(arguments: arguments).run())
 } catch let error as HolderStartupError {
-    // 2 is "the invocation was wrong", distinct from a holder that started and
-    // then failed, so a spawner can tell a bad command line from a bad machine.
-    fail(error.localizedDescription, code: 2)
+    // The code carries the one thing a spawner needs from a dead holder: could
+    // retrying help? 2 says no — the command line is wrong and will stay wrong.
+    // 3 says the machine refused, so a later attempt can succeed. See
+    // `HolderExitCode` for which failure sits on which side.
+    fail(error.localizedDescription, code: error.exitCode)
 } catch {
-    fail(error.localizedDescription, code: 1)
+    fail(error.localizedDescription, code: HolderExitCode.unexpected)
 }

--- a/Tests/TBDHolderTests/HolderBinaryTests.swift
+++ b/Tests/TBDHolderTests/HolderBinaryTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 @testable import TBDHolder
+@testable import TBDShared
 
 /// The holder's own suite. It is here now to hold the target open for the
 /// holder itself; the one thing worth asserting about a placeholder binary is
@@ -36,10 +37,11 @@ struct HolderBinaryTests {
         #expect(Self.locateExecutable() != nil, "TBDHolder was not built into the products directory")
     }
 
-    /// A bad invocation must fail loudly, and distinguishably. Exit 2 is "the
-    /// command line was wrong", separate from a holder that started and then
-    /// failed, so a spawner can tell a mistake of its own from a bad machine —
-    /// and either way it must never get back a session whose pty nobody owns.
+    /// A bad invocation must fail loudly, and distinguishably. Exit 2 means the
+    /// command line was wrong: the same arguments will fail the same way
+    /// forever, so a spawner that sees it must fix them or give up rather than
+    /// retry — and either way it must never get back a session whose pty nobody
+    /// owns.
     @Test func aBadInvocationExitsTwoWithAUsageDiagnostic() throws {
         let executable = try #require(Self.locateExecutable())
         let process = Process()
@@ -54,5 +56,58 @@ struct HolderBinaryTests {
         let diagnostic = String(decoding: stderrData, as: UTF8.self)
         #expect(diagnostic.contains("--session is required"))
         #expect(diagnostic.contains("--lock-fd"), "the usage line must name the descriptor flag")
+    }
+
+    /// The other side of that distinction, which is only real if the codes
+    /// actually differ. A perfectly-formed invocation whose rendezvous
+    /// directory cannot exist is the machine refusing, not a spawner mistake:
+    /// it must exit 3, so a retry stays on the table.
+    ///
+    /// The socket is asked for under `/dev/null`, which exists and is not a
+    /// directory — `mkdir` there fails with `ENOTDIR` on any machine, needing
+    /// no permissions games and leaving nothing behind. A bootstrap `sh` opens
+    /// the lock descriptor the holder demands and then `exec`s, so the status
+    /// observed here is the holder's own.
+    @Test func anEnvironmentFailureExitsThreeRatherThanTwo() throws {
+        let executable = try #require(Self.locateExecutable())
+        let launch = HolderLaunchRequest(
+            executable: "/bin/sh",
+            arguments: ["-c", "sleep 1"],
+            workingDirectory: "/tmp",
+            environment: ["PATH": "/usr/bin:/bin"],
+            columns: 80,
+            rows: 24)
+        let payload = try JSONEncoder().encode(launch).base64EncodedString()
+        let command = [
+            "exec 9</dev/null;",
+            "exec", Self.shellQuoted(executable.path),
+            "--session", UUID().uuidString,
+            "--socket", "/dev/null/holders/session.sock",
+            "--lock-fd", "9",
+            "--launch", Self.shellQuoted(payload),
+        ].joined(separator: " ")
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = ["-c", command]
+        // Explicit and rc-free: nothing here may come from the developer's
+        // shell, and the holder must not find a real TBD home to write into.
+        process.environment = ["PATH": "/usr/bin:/bin"]
+        let stderrPipe = Pipe()
+        process.standardError = stderrPipe
+        process.standardOutput = Pipe()
+        try process.run()
+        let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+
+        #expect(
+            process.terminationStatus == 3,
+            "an environment failure must not be reported as a bad command line")
+        let diagnostic = String(decoding: stderrData, as: UTF8.self)
+        #expect(diagnostic.contains("could not create the holder rendezvous directory"))
+    }
+
+    private static func shellQuoted(_ value: String) -> String {
+        "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
     }
 }

--- a/Tests/TBDHolderTests/HolderBinaryTests.swift
+++ b/Tests/TBDHolderTests/HolderBinaryTests.swift
@@ -36,10 +36,11 @@ struct HolderBinaryTests {
         #expect(Self.locateExecutable() != nil, "TBDHolder was not built into the products directory")
     }
 
-    /// The placeholder must fail loudly. A spawner that reaches an
-    /// unimplemented holder has to see a nonzero exit, not a session whose pty
-    /// nobody owns.
-    @Test func placeholderExitsNonzeroWithADiagnostic() throws {
+    /// A bad invocation must fail loudly, and distinguishably. Exit 2 is "the
+    /// command line was wrong", separate from a holder that started and then
+    /// failed, so a spawner can tell a mistake of its own from a bad machine —
+    /// and either way it must never get back a session whose pty nobody owns.
+    @Test func aBadInvocationExitsTwoWithAUsageDiagnostic() throws {
         let executable = try #require(Self.locateExecutable())
         let process = Process()
         process.executableURL = executable
@@ -49,7 +50,9 @@ struct HolderBinaryTests {
         try process.run()
         let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
         process.waitUntilExit()
-        #expect(process.terminationStatus != 0)
-        #expect(String(decoding: stderrData, as: UTF8.self).contains("not implemented"))
+        #expect(process.terminationStatus == 2)
+        let diagnostic = String(decoding: stderrData, as: UTF8.self)
+        #expect(diagnostic.contains("--session is required"))
+        #expect(diagnostic.contains("--lock-fd"), "the usage line must name the descriptor flag")
     }
 }

--- a/Tests/TBDHolderTests/HolderInvocationTests.swift
+++ b/Tests/TBDHolderTests/HolderInvocationTests.swift
@@ -141,6 +141,46 @@ struct HolderInvocationTests {
         #expect(Holder.status(fromWaitpidStatus: SIGKILL) == .exitedStatusUnknown)
     }
 
+    // MARK: - Exit codes
+
+    /// A spawner reading a dead holder's exit code has exactly one decision to
+    /// make — could retrying help? — so the codes must split on that line and
+    /// nothing else. A single code for every startup failure answers it wrongly
+    /// half the time: it reads a rendezvous directory that momentarily could not
+    /// be created as a mistake in the spawner's own command line, and abandons a
+    /// session a second attempt would have started.
+    @Test func startupErrorsSeparateABadInvocationFromABadMachine() {
+        #expect(HolderExitCode.badInvocation != HolderExitCode.environmentFailure)
+
+        let badInvocations: [HolderStartupError] = [
+            .unknownArgument("stray"),
+            .missingValue("--socket"),
+            .missingArgument("session"),
+            .invalidSessionID("not-a-uuid"),
+            .invalidLaunchPayload,
+            .invalidLockDescriptorArgument("/tmp/holders/session.lock"),
+            .invalidLockDescriptor(1),
+            .socketPathTooLong(path: "/tmp/holders/session.sock", limit: 104),
+        ]
+        for error in badInvocations {
+            #expect(
+                error.exitCode == HolderExitCode.badInvocation,
+                "\(error) is the command line being wrong; retrying it changes nothing")
+        }
+
+        let badMachines: [HolderStartupError] = [
+            .socketDirectoryUnavailable(path: "/tmp/holders", errno: ENOTDIR),
+            .cannotBind(path: "/tmp/holders/session.sock", errno: EADDRINUSE),
+            .cannotListen(path: "/tmp/holders/session.sock", errno: EINVAL),
+            .forkFailed(errno: EAGAIN),
+        ]
+        for error in badMachines {
+            #expect(
+                error.exitCode == HolderExitCode.environmentFailure,
+                "\(error) is the machine refusing, and a later attempt can succeed")
+        }
+    }
+
     // MARK: - The clock seam
 
     /// A clock whose every `now` read advances by a fixed step, so elapsed time

--- a/Tests/TBDHolderTests/HolderInvocationTests.swift
+++ b/Tests/TBDHolderTests/HolderInvocationTests.swift
@@ -1,0 +1,185 @@
+import Foundation
+import Testing
+@testable import TBDHolder
+@testable import TBDShared
+
+/// The parts of the holder that need no process: the command line, the wire
+/// framing, the exit-status decode, and the one delay that carries the clock
+/// seam.
+@Suite("Holder invocation")
+struct HolderInvocationTests {
+    private static let launch = HolderLaunchRequest(
+        executable: "/bin/zsh",
+        arguments: ["-l"],
+        workingDirectory: "/tmp",
+        environment: ["TERM": "xterm-256color"],
+        columns: 120,
+        rows: 40)
+
+    private static func commandLine(
+        session: UUID,
+        lockFD: String = "9",
+        owner: String? = "installation-abc"
+    ) throws -> [String] {
+        var arguments = [
+            "--session", session.uuidString,
+            "--socket", "/tmp/holders/session.sock",
+            "--lock-fd", lockFD,
+            "--launch", try JSONEncoder().encode(launch).base64EncodedString(),
+        ]
+        if let owner { arguments += ["--owner", owner] }
+        return arguments
+    }
+
+    @Test func parsesAFullInvocation() throws {
+        let session = UUID()
+        let parsed = try HolderArguments.parse(try Self.commandLine(session: session))
+        #expect(parsed.sessionID == session)
+        #expect(parsed.socketPath == "/tmp/holders/session.sock")
+        #expect(parsed.lockFD == 9)
+        #expect(parsed.launch == Self.launch)
+        #expect(parsed.owner == HolderOwnerToken(rawValue: "installation-abc"))
+    }
+
+    /// The lock is a DESCRIPTOR NUMBER, never a path. A holder that took a path
+    /// could not name the descriptor it inherited, and therefore could not keep
+    /// it out of the job — the one thing about the lock that must not happen.
+    @Test func refusesALockPathWhereADescriptorBelongs() throws {
+        let arguments = try Self.commandLine(session: UUID(), lockFD: "/tmp/holders/session.lock")
+        #expect(throws: HolderStartupError.invalidLockDescriptorArgument("/tmp/holders/session.lock")) {
+            _ = try HolderArguments.parse(arguments)
+        }
+    }
+
+    /// A holder started by hand for diagnosis has no installation behind it.
+    @Test func ownerIsOptional() throws {
+        let parsed = try HolderArguments.parse(try Self.commandLine(session: UUID(), owner: nil))
+        #expect(parsed.owner == HolderOwnerToken(rawValue: ""))
+    }
+
+    /// A long-lived session keeps running the holder binary it was born with,
+    /// so a newer daemon will eventually pass a flag an older holder never
+    /// heard of. That must not be the difference between a session starting and
+    /// not; a bare word with no leading `--` still is, because that is a
+    /// quoting mistake rather than version skew.
+    @Test func toleratesAnUnrecognisedFlagButNotABareWord() throws {
+        let session = UUID()
+        var arguments = try Self.commandLine(session: session)
+        arguments += ["--future-flag", "whatever"]
+        #expect(try HolderArguments.parse(arguments).sessionID == session)
+
+        #expect(throws: HolderStartupError.unknownArgument("stray")) {
+            _ = try HolderArguments.parse(try Self.commandLine(session: session) + ["stray"])
+        }
+    }
+
+    @Test func refusesAnIncompleteInvocation() throws {
+        #expect(throws: HolderStartupError.missingArgument("session")) {
+            _ = try HolderArguments.parse(["--socket", "/tmp/x.sock"])
+        }
+        #expect(throws: HolderStartupError.missingValue("--socket")) {
+            _ = try HolderArguments.parse(["--socket"])
+        }
+        #expect(throws: HolderStartupError.invalidLaunchPayload) {
+            _ = try HolderArguments.parse([
+                "--session", UUID().uuidString,
+                "--socket", "/tmp/x.sock",
+                "--lock-fd", "9",
+                "--launch", "not-base64-json",
+            ])
+        }
+    }
+
+    // MARK: - Framing
+
+    @Test func framesSurviveArbitraryChunking() throws {
+        let responses: [HolderResponse] = [
+            .described(HolderChildDescription(
+                childPID: 4242,
+                ttyName: "/dev/ttys004",
+                status: .alive,
+                launch: Self.launch,
+                owner: HolderOwnerToken(rawValue: "installation-abc"))),
+            .forgotten,
+            .rejected(version: HolderProtocolVersion.busySentinel),
+        ]
+        var stream = Data()
+        for response in responses { stream += try HolderFraming.frame(response) }
+
+        // Feed the scanner one byte at a time: a stream socket may split a
+        // frame anywhere, and a scanner that assumes a whole frame per read
+        // desyncs the moment it does.
+        var buffer = Data()
+        var decoded: [HolderResponse] = []
+        for byte in stream {
+            buffer.append(byte)
+            decoded += try HolderFraming.drain(HolderResponse.self, from: &buffer)
+        }
+        #expect(decoded == responses)
+        #expect(buffer.isEmpty)
+    }
+
+    /// A desynced peer must not be able to make the holder allocate on its
+    /// behalf just by claiming a large length.
+    @Test func refusesAnOversizedLengthWord() throws {
+        var buffer = Data()
+        var length = UInt32(HolderFraming.maximumFrameSize + 1).littleEndian
+        buffer.append(Data(bytes: &length, count: MemoryLayout<UInt32>.size))
+        #expect(throws: HolderStartupError.self) {
+            _ = try HolderFraming.drainRequests(from: &buffer)
+        }
+    }
+
+    // MARK: - Exit status
+
+    /// A child killed by a signal has no exit code, so the holder says it could
+    /// not observe one rather than inventing a number downstream cannot tell
+    /// apart from a real exit.
+    @Test func signalledChildrenReportAnUnknownStatus() {
+        #expect(Holder.status(fromWaitpidStatus: 42 << 8) == .exited(code: 42))
+        #expect(Holder.status(fromWaitpidStatus: 0) == .exited(code: 0))
+        #expect(Holder.status(fromWaitpidStatus: SIGKILL) == .exitedStatusUnknown)
+    }
+
+    // MARK: - The clock seam
+
+    /// A clock whose every `now` read advances by a fixed step, so elapsed time
+    /// is exactly countable instead of being whatever the machine was doing.
+    private final class SteppingClock: Clock, @unchecked Sendable {
+        typealias Instant = ContinuousClock.Instant
+
+        private let step: Duration
+        private var current = ContinuousClock.Instant.now
+
+        init(step: Duration) { self.step = step }
+
+        var now: ContinuousClock.Instant {
+            defer { current = current.advanced(by: step) }
+            return current
+        }
+        var minimumResolution: Duration { .nanoseconds(1) }
+        func sleep(until deadline: ContinuousClock.Instant, tolerance: Duration?) async throws {}
+    }
+
+    @Test func theExitReportWindowIsUntimedUntilArmed() {
+        // Each `charging` reads `now` twice, so it charges two steps.
+        var window = ExitReportWindow(limit: .seconds(1), clock: SteppingClock(step: .seconds(10)))
+        for _ in 0..<20 { window.charging {} }
+        #expect(!window.isArmed)
+        #expect(!window.isExpired, "a holder serving a live child must never time itself out")
+    }
+
+    @Test func theExitReportWindowExpiresOnceArmed() {
+        // Each `charging` reads `now` twice, one step apart, so it charges one
+        // step against the limit.
+        var window = ExitReportWindow(limit: .seconds(1), clock: SteppingClock(step: .milliseconds(400)))
+        window.arm()
+        #expect(window.isArmed)
+        window.charging {}
+        #expect(!window.isExpired, "0.4s of a 1s window")
+        window.charging {}
+        #expect(!window.isExpired, "0.8s of a 1s window")
+        window.charging {}
+        #expect(window.isExpired, "1.2s of a 1s window")
+    }
+}

--- a/Tests/TBDHolderTests/HolderLifecycleTests.swift
+++ b/Tests/TBDHolderTests/HolderLifecycleTests.swift
@@ -412,4 +412,124 @@ struct HolderLifecycleTests {
         let final = try client.awaitTerminalStatus()
         #expect(final.status == .exitedStatusUnknown)
     }
+
+    // MARK: 11 — the client that arrives after the child is already gone
+
+    /// A job that publishes its own pid, waits to be released, and exits with
+    /// `code`.
+    ///
+    /// It writes nothing to its terminal, which is what makes these tests
+    /// possible at all: a job that had written would block in `ttywait` until
+    /// somebody drained the master, so it could never reach a reaped state
+    /// *before* a client connected. See `drainPTY`. Bounded so a job that
+    /// somehow escapes teardown reaps itself.
+    private static func jobThatExitsOnCue(home: String, code: Int32) -> HolderLaunchRequest {
+        let script = [
+            "echo $$ > '\(home)/job.pid'",
+            "i=0",
+            "while [ ! -e '\(home)/go' ] && [ $i -lt 600 ]; do sleep 0.1; i=$((i+1)); done",
+            "exit \(code)",
+        ].joined(separator: "; ")
+        return HolderLaunchRequest(
+            executable: "/bin/sh",
+            arguments: ["-c", script],
+            workingDirectory: "/tmp",
+            environment: rcFreeEnvironment,
+            columns: 80,
+            rows: 24)
+    }
+
+    /// Brings up a holder, releases its job, and returns once the holder has
+    /// **reaped** it — with no client having ever connected.
+    ///
+    /// The pid disappearing is precisely "reaped": a zombie still answers
+    /// `kill(pid, 0)` until its parent collects it, so `!processIsAlive` cannot
+    /// become true until the holder's `waitpid` has run and the exit window is
+    /// armed. Everything after this point is the state a daemon finds when it
+    /// restarts and comes back for a job that finished while it was away.
+    private static func holderWithAnAlreadyExitedChild(
+        code: Int32
+    ) throws -> (fixture: HolderFixture, jobPID: Int32) {
+        let home = HolderFixture.scratchHome()
+        let fixture = try HolderFixture.start(launch: jobThatExitsOnCue(home: home, code: code), home: home)
+        fixture.waitForSocket()
+
+        var jobPID: Int32 = 0
+        waitUntil("the job to report its pid\n\(fixture.diagnostics())") {
+            guard let text = try? String(contentsOfFile: home + "/job.pid", encoding: .utf8) else { return false }
+            jobPID = Int32(text.trimmingCharacters(in: .whitespacesAndNewlines)) ?? 0
+            return jobPID > 0
+        }
+        fixture.trackChild(jobPID)
+
+        FileManager.default.createFile(atPath: home + "/go", contents: nil)
+        waitUntil("the holder to reap its exited job") { !processIsAlive(jobPID) }
+        return (fixture, jobPID)
+    }
+
+    /// **The primary re-adoption path.** A daemon that was restarting when the
+    /// job finished comes back, connects, and asks for the pty.
+    ///
+    /// The holder used to greet such a client with an unsolicited `.described`
+    /// frame at accept time: it landed where this request's answer belonged, so
+    /// the hand-over came back with no descriptor, and the collection that
+    /// frame recorded then ended the serve loop before the request was ever
+    /// read. Every existing hand-over test connects while the child is alive,
+    /// which is why it shipped.
+    @Test func handsOverThePTYToAClientThatArrivesAfterTheChildExited() throws {
+        let (fixture, jobPID) = try Self.holderWithAnAlreadyExitedChild(code: 7)
+        defer { fixture.tearDown() }
+
+        let client = try fixture.connect()
+        defer { client.close() }
+        let (response, fds) = try client.requestWithFDs(.handOverPTY)
+        defer { fds.forEach { close($0) } }
+
+        guard case .handedOverPTY(let description) = response else {
+            Issue.record("expected .handedOverPTY, got \(response)\n\(fixture.diagnostics())")
+            return
+        }
+        #expect(fds.count == 1, "the master must still ride the hand-over after the child has gone")
+        #expect(description.status == .exited(code: 7))
+        #expect(description.childPID == jobPID)
+    }
+
+    /// The same client, asking the cheaper question. Two claims, and the first
+    /// is what the second rests on: the holder says **nothing** to a client
+    /// that has asked for nothing, and then answers what it is asked.
+    @Test func describesAnAlreadyExitedChildOnlyWhenAsked() throws {
+        let (fixture, jobPID) = try Self.holderWithAnAlreadyExitedChild(code: 3)
+        defer { fixture.tearDown() }
+
+        let client = try fixture.connect(receiveTimeout: 1.0)
+        defer { client.close() }
+        #expect(
+            try client.frameArrivingUnsolicited() == nil,
+            "the holder greeted a client that had asked for nothing")
+
+        guard case .described(let description) = try client.request(.describe) else {
+            Issue.record("expected .described\n\(fixture.diagnostics())")
+            return
+        }
+        #expect(description.status == .exited(code: 3))
+        #expect(description.childPID == jobPID)
+    }
+
+    /// `forget` must work on this path too, and it is the request the old
+    /// behaviour could never answer: the connection was already torn down.
+    @Test func forgetsForAClientThatArrivesAfterTheChildExited() throws {
+        let (fixture, _) = try Self.holderWithAnAlreadyExitedChild(code: 0)
+        defer { fixture.tearDown() }
+
+        let client = try fixture.connect()
+        #expect(try client.request(.forget) == .forgotten)
+        client.close()
+
+        waitUntil("the holder to unlink its socket and exit") {
+            !FileManager.default.fileExists(atPath: fixture.socketPath)
+                && !processIsAlive(fixture.holderPID)
+        }
+        #expect(!processIsAlive(fixture.holderPID))
+        #expect(!FileManager.default.fileExists(atPath: fixture.socketPath))
+    }
 }

--- a/Tests/TBDHolderTests/HolderLifecycleTests.swift
+++ b/Tests/TBDHolderTests/HolderLifecycleTests.swift
@@ -1,0 +1,415 @@
+import Darwin
+import Foundation
+import Testing
+@testable import TBDHolder
+@testable import TBDShared
+
+/// Live-process tests for the holder.
+///
+/// Serialized because each one spawns real processes and a pty, and the point
+/// of several of them is a claim about process death — running them alongside
+/// each other would make a failure ambiguous about whose child died.
+@Suite("Holder lifecycle", .serialized)
+struct HolderLifecycleTests {
+    private static let rcFreeEnvironment = ["PATH": "/usr/bin:/bin", "TERM": "dumb"]
+
+    /// A job that does nothing but stay alive. Bounded so a fixture that
+    /// somehow escapes teardown still reaps itself.
+    private static func idleJob(marker: String = "") -> HolderLaunchRequest {
+        HolderLaunchRequest(
+            executable: "/bin/sh",
+            arguments: ["-c", marker.isEmpty ? "sleep 60" : "printf '\(marker)\\n'; sleep 60"],
+            workingDirectory: "/tmp",
+            environment: rcFreeEnvironment,
+            columns: 100,
+            rows: 30)
+    }
+
+    // MARK: 1 — it binds and describes
+
+    @Test func holderBindsItsSocketAndDescribesItsChild() throws {
+        let fixture = try HolderFixture.start(launch: Self.idleJob())
+        defer { fixture.tearDown() }
+        fixture.waitForSocket()
+
+        let client = try fixture.connect()
+        defer { client.close() }
+        guard case .described(let description) = try client.request(.describe) else {
+            Issue.record("expected .described\n\(fixture.diagnostics())")
+            return
+        }
+        fixture.trackChild(description.childPID)
+
+        #expect(description.childPID > 0)
+        #expect(description.status == .alive)
+        #expect(description.launch.executable == "/bin/sh")
+        // The size travels from the launch request into the pty, so a job that
+        // asks its terminal how wide it is gets the answer the caller chose.
+        #expect(description.launch.columns == 100)
+        #expect(description.ttyName.hasPrefix("/dev/tty"))
+        #expect(description.owner == HolderOwnerToken(rawValue: "test-installation"))
+        #expect(processIsAlive(description.childPID))
+    }
+
+    // MARK: 2 — the central claim
+
+    /// The design's whole point: the job outlives the process that spawned the
+    /// holder, because the pty master lives in the holder rather than in
+    /// whoever asked for the session.
+    ///
+    /// The fixture always launches through a bootstrap `/bin/sh` that
+    /// backgrounds the holder and exits, so by the time any test body runs the
+    /// spawner is already gone. This one asserts that instead of assuming it.
+    @Test func childSurvivesTheSpawningProcessExiting() throws {
+        let fixture = try HolderFixture.start(launch: Self.idleJob())
+        defer { fixture.tearDown() }
+        fixture.waitForSocket()
+
+        #expect(fixture.spawnerExitStatus == 0, "the bootstrap shell should have exited cleanly")
+
+        let client = try fixture.connect()
+        defer { client.close() }
+        guard case .described(let description) = try client.request(.describe) else {
+            Issue.record("expected .described\n\(fixture.diagnostics())")
+            return
+        }
+        fixture.trackChild(description.childPID)
+
+        #expect(description.status == .alive)
+        #expect(processIsAlive(description.childPID), "the job died with its spawner")
+        #expect(processIsAlive(fixture.holderPID), "the holder died with its spawner")
+    }
+
+    // MARK: 3 — one client at a time
+
+    /// Two readers on one pty master is silent byte theft: whichever `read`
+    /// lands first wins the bytes and the other reader never learns they
+    /// existed. So the second connection is accepted, answered with a version
+    /// that cannot be mistaken for a real one, and closed.
+    @Test func secondConcurrentClientIsRejected() throws {
+        let fixture = try HolderFixture.start(launch: Self.idleJob())
+        defer { fixture.tearDown() }
+        fixture.waitForSocket()
+
+        let first = try fixture.connect()
+        defer { first.close() }
+        guard case .described(let description) = try first.request(.describe) else {
+            Issue.record("expected .described\n\(fixture.diagnostics())")
+            return
+        }
+        fixture.trackChild(description.childPID)
+
+        let second = try fixture.connect()
+        defer { second.close() }
+        #expect(try second.receive() == .rejected(version: HolderProtocolVersion.busySentinel))
+
+        // The rejection must not have cost the first client its session.
+        guard case .described = try first.request(.describe) else {
+            Issue.record("the incumbent client stopped being served after a rejection")
+            return
+        }
+    }
+
+    // MARK: 4 — hand-over
+
+    /// The holder never reads the master, so everything the job has written
+    /// since it started is still queued when a reader finally arrives.
+    @Test func handsOverAPTYThatCarriesChildOutput() throws {
+        let fixture = try HolderFixture.start(launch: Self.idleJob(marker: "HOLDER-OK"))
+        defer { fixture.tearDown() }
+        fixture.waitForSocket()
+
+        let client = try fixture.connect()
+        defer { client.close() }
+        let (response, fds) = try client.requestWithFDs(.handOverPTY)
+        defer { fds.forEach { close($0) } }
+
+        guard case .handedOverPTY(let description) = response else {
+            Issue.record("expected .handedOverPTY, got \(response)\n\(fixture.diagnostics())")
+            return
+        }
+        fixture.trackChild(description.childPID)
+        #expect(fds.count == 1, "exactly one descriptor should ride the hand-over")
+
+        let pty = try #require(fds.first)
+        var seen = Data()
+        waitUntil("the job's output on the handed-over pty") {
+            drainPTY(pty, into: &seen)
+            return String(decoding: seen, as: UTF8.self).contains("HOLDER-OK")
+        }
+        #expect(String(decoding: seen, as: UTF8.self).contains("HOLDER-OK"))
+    }
+
+    // MARK: 5 — forget
+
+    /// `forget` is the preemptive close: a session the user killed must not be
+    /// resurrectable by anything that reconnects afterwards. The holder answers
+    /// once, drops the pty master, unlinks its rendezvous and exits — and the
+    /// job it was holding is left for its caller to reap, because holder death
+    /// is deliberately not child death.
+    @Test func forgetStopsReportingAndDoesNotResurrectTheChild() throws {
+        let fixture = try HolderFixture.start(launch: Self.idleJob())
+        defer { fixture.tearDown() }
+        fixture.waitForSocket()
+
+        let client = try fixture.connect()
+        guard case .described(let description) = try client.request(.describe) else {
+            Issue.record("expected .described\n\(fixture.diagnostics())")
+            return
+        }
+        fixture.trackChild(description.childPID)
+
+        #expect(try client.request(.forget) == .forgotten)
+        client.close()
+
+        waitUntil("the holder to unlink its socket and exit") {
+            !FileManager.default.fileExists(atPath: fixture.socketPath)
+                && !processIsAlive(fixture.holderPID)
+        }
+        #expect(!processIsAlive(fixture.holderPID))
+        // Nothing may report the child any more, and nothing may bring a new
+        // holder up in its place on its own.
+        #expect(throws: TestHolderError.self) { _ = try fixture.connect(receiveTimeout: 1.0) }
+        #expect(!FileManager.default.fileExists(atPath: fixture.socketPath))
+    }
+
+    // MARK: 6 — the lock stays with the holder
+
+    /// **The job must not inherit the creation lock.** `flock` lives on the
+    /// open file description, so a job that inherits the descriptor holds the
+    /// lock — and keeps holding it after the holder is SIGKILLed. Both halves
+    /// of the lock's contract break at once: the kernel stops dropping it when
+    /// the holder dies, and every later spawn for this session sees
+    /// `.alreadyHeld` forever with no holder alive to explain it.
+    ///
+    /// The sequencing is what gives the assertion meaning: the holder is killed
+    /// while the job is still alive, so if the reacquire succeeds it can only
+    /// be because the job never had the lock.
+    @Test func theJobDoesNotInheritTheCreationLock() throws {
+        let fixture = try HolderFixture.start(launch: Self.idleJob())
+        defer { fixture.tearDown() }
+        fixture.waitForSocket()
+
+        let childPID: Int32
+        do {
+            let client = try fixture.connect()
+            defer { client.close() }
+            guard case .described(let description) = try client.request(.describe) else {
+                Issue.record("expected .described\n\(fixture.diagnostics())")
+                return
+            }
+            childPID = description.childPID
+            fixture.trackChild(childPID)
+        }
+
+        kill(fixture.holderPID, SIGKILL)
+        waitUntil("the holder to die") { !processIsAlive(fixture.holderPID) }
+        // Without a live job this test would pass vacuously — the lock would be
+        // free because nothing at all was left holding it.
+        try #require(processIsAlive(childPID), "the job must outlive the holder for this to mean anything")
+
+        let reacquired = try HolderLock.acquire(path: fixture.lockPath)
+        reacquired.release()
+        #expect(reacquired.fileDescriptor >= 0)
+    }
+
+    // MARK: 7 — a job gets a terminal and nothing else
+
+    /// The named closes cover the two descriptors the holder knows it holds.
+    /// They cannot cover the ones it does not: anything its spawner had open
+    /// without `FD_CLOEXEC` arrives unannounced and, without the sweep, ends up
+    /// in a job that outlives every process anybody would think to look at.
+    ///
+    /// Measured, not hypothetical — this repo's build wrapper holds a
+    /// machine-global `flock`, and before the sweep a `sleep` job that had
+    /// inherited it went on blocking every other worktree's build after its
+    /// holder, its test process and its harness were all gone.
+    ///
+    /// The probe writes THROUGH the descriptor rather than asking whether
+    /// something is open at that number: `[ -e /dev/fd/N ]` answers the weaker
+    /// question, and the shell's own machinery can transiently park a
+    /// descriptor on N. A write can only reach the probe file if the probe file
+    /// is still what N refers to. The `ran` marker is the positive control —
+    /// without it, an empty probe file would also be what "the job never
+    /// started" looks like.
+    ///
+    /// Nothing here depends on the holder observing or reporting an exit, so
+    /// machine load cannot turn the assertion into a timeout.
+    @Test func theJobDoesNotInheritStrayDescriptors() throws {
+        let home = HolderFixture.scratchHome()
+        let probe = HolderFixture.strayDescriptorNumber
+        let script = [
+            "echo LEAKED >&\(probe) 2>/dev/null",
+            "echo RAN > '\(home)/ran.marker'",
+            "sleep 120",
+        ].joined(separator: "; ")
+        let launch = HolderLaunchRequest(
+            executable: "/bin/sh",
+            arguments: ["-c", script],
+            workingDirectory: "/tmp",
+            environment: Self.rcFreeEnvironment,
+            columns: 80,
+            rows: 24)
+        let fixture = try HolderFixture.start(launch: launch, strayDescriptorProbe: true, home: home)
+        defer { fixture.tearDown() }
+        fixture.waitForSocket()
+
+        let client = try fixture.connect()
+        defer { client.close() }
+        guard case .described(let description) = try client.request(.describe) else {
+            Issue.record("expected .described\n\(fixture.diagnostics())")
+            return
+        }
+        fixture.trackChild(description.childPID)
+
+        waitUntil("the job to run past its probe") {
+            FileManager.default.fileExists(atPath: home + "/ran.marker")
+        }
+        let leaked = (try? String(contentsOfFile: home + "/stray.probe", encoding: .utf8)) ?? ""
+        #expect(
+            leaked.isEmpty,
+            "a descriptor the holder never asked for reached the job through fd \(probe)")
+    }
+
+    // MARK: 8 — the job's signal dispositions are its own
+
+    /// **The job must not start with SIGPIPE ignored.** The holder ignores
+    /// SIGHUP and SIGPIPE so its spawner's death is not its own, but `SIG_IGN`
+    /// is inherited across fork AND exec — so without an explicit reset between
+    /// the two, every job would run with SIGPIPE ignored and `yes | head` would
+    /// spin forever instead of terminating.
+    ///
+    /// The probe is the shell's own rule that a signal ignored on entry cannot
+    /// be trapped or reset. A job whose SIGPIPE was reset to `SIG_DFL` installs
+    /// the trap, takes the signal it sends itself, and writes the marker; a job
+    /// that inherited `SIG_IGN` could not install the trap, never sees the
+    /// signal, and leaves the marker absent. The `ran` marker is the positive
+    /// control, so "no marker" cannot be satisfied by a job that never started.
+    @Test func theJobDoesNotStartWithSIGPIPEIgnored() throws {
+        let home = HolderFixture.scratchHome()
+        let script = [
+            "trap 'echo TRAPPED > \"\(home)/sigpipe.marker\"; exit 42' PIPE",
+            "echo RAN > '\(home)/ran.marker'",
+            "kill -PIPE $$",
+            "sleep 120",
+        ].joined(separator: "; ")
+        let launch = HolderLaunchRequest(
+            executable: "/bin/sh",
+            arguments: ["-c", script],
+            workingDirectory: "/tmp",
+            environment: Self.rcFreeEnvironment,
+            columns: 80,
+            rows: 24)
+        let fixture = try HolderFixture.start(launch: launch, home: home)
+        defer { fixture.tearDown() }
+        fixture.waitForSocket()
+
+        let client = try fixture.connect()
+        defer { client.close() }
+        guard case .described(let description) = try client.request(.describe) else {
+            Issue.record("expected .described\n\(fixture.diagnostics())")
+            return
+        }
+        fixture.trackChild(description.childPID)
+
+        waitUntil("the job to run past its trap") {
+            FileManager.default.fileExists(atPath: home + "/ran.marker")
+        }
+        waitUntil("the job to take its SIGPIPE trap") {
+            FileManager.default.fileExists(atPath: home + "/sigpipe.marker")
+        }
+        #expect(
+            FileManager.default.fileExists(atPath: home + "/sigpipe.marker"),
+            "the job could not install a SIGPIPE trap, so SIGPIPE was still ignored at exec")
+    }
+
+    // MARK: 9 — reporting the exit
+
+    /// The holder exits when its job does, but only after telling a connected
+    /// client what happened. The exit is triggered from here — through the
+    /// handed-over pty, so the client is connected the whole time and the report
+    /// cannot race a fresh connection. Driving it through the master also makes
+    /// this the one test that proves *input* survives the hand-over; test 4
+    /// only proves output does.
+    ///
+    /// **The reader has to keep draining while it waits.** The job is the pty's
+    /// session leader, so its exit blocks in `ttywait` until the tty's output
+    /// queue is empty, and the four bytes of canonical echo for `"go\n"` are
+    /// enough to wedge it forever — the holder must never drain them itself.
+    /// See `drainPTY`.
+    @Test func reportsTheJobsExitCodeToAConnectedClient() throws {
+        // Every path this job touches lives under the fixture's own scratch
+        // root. A fixed `/tmp/…` name is shared by every concurrent run of this
+        // suite on the machine — several worktrees test here at once — so one
+        // run could satisfy or clobber another's marker.
+        let home = HolderFixture.scratchHome()
+        let launch = HolderLaunchRequest(
+            executable: "/bin/sh",
+            arguments: ["-c", "read line; echo DONE > '\(home)/read.marker'; exit 7"],
+            workingDirectory: "/tmp",
+            environment: Self.rcFreeEnvironment,
+            columns: 80,
+            rows: 24)
+        let fixture = try HolderFixture.start(launch: launch, home: home)
+        defer { fixture.tearDown() }
+        fixture.waitForSocket()
+
+        let client = try fixture.connect(receiveTimeout: 15.0)
+        defer { client.close() }
+        let (response, fds) = try client.requestWithFDs(.handOverPTY)
+        defer { fds.forEach { close($0) } }
+        guard case .handedOverPTY(let description) = response else {
+            Issue.record("expected .handedOverPTY, got \(response)\n\(fixture.diagnostics())")
+            return
+        }
+        fixture.trackChild(description.childPID)
+
+        // `forkpty` leaves the line discipline canonical, so a newline is what
+        // completes the job's `read`.
+        let pty = try #require(fds.first)
+        let line = Array("go\n".utf8)
+        #expect(write(pty, line, line.count) == line.count)
+        var echoed = Data()
+        waitUntil("the job to finish its read and exit") {
+            drainPTY(pty, into: &echoed)
+            return !processIsAlive(description.childPID)
+        }
+        // The positive control: without it, a job that never received the line
+        // and was killed by teardown would look the same as one that ran.
+        #expect(
+            FileManager.default.fileExists(atPath: home + "/read.marker"),
+            "the job never completed its read, so nothing written to the master reached it")
+
+        let final = try client.awaitTerminalStatus()
+        #expect(final.status == .exited(code: 7))
+        #expect(final.childPID == description.childPID)
+
+        // Having reported, the holder is done: it unlinks its rendezvous and
+        // goes, rather than sitting on a socket nothing can use.
+        waitUntil("the holder to unlink its socket and exit") {
+            !FileManager.default.fileExists(atPath: fixture.socketPath)
+                && !processIsAlive(fixture.holderPID)
+        }
+    }
+
+    /// A job killed by a signal has no exit code. The holder must say it could
+    /// not observe one rather than reporting a number that downstream cannot
+    /// tell apart from a real exit.
+    @Test func reportsAnUnknownStatusForASignalledJob() throws {
+        let fixture = try HolderFixture.start(launch: Self.idleJob())
+        defer { fixture.tearDown() }
+        fixture.waitForSocket()
+
+        let client = try fixture.connect(receiveTimeout: 15.0)
+        defer { client.close() }
+        guard case .described(let description) = try client.request(.describe) else {
+            Issue.record("expected .described\n\(fixture.diagnostics())")
+            return
+        }
+        fixture.trackChild(description.childPID)
+
+        kill(description.childPID, SIGKILL)
+        let final = try client.awaitTerminalStatus()
+        #expect(final.status == .exitedStatusUnknown)
+    }
+}

--- a/Tests/TBDHolderTests/TestHolderSupport.swift
+++ b/Tests/TBDHolderTests/TestHolderSupport.swift
@@ -439,6 +439,22 @@ final class TestHolderClient {
         try FDChannel.sendData(HolderFraming.frame(request), over: fd)
     }
 
+    /// Waits out the connection's receive timeout and reports whatever the
+    /// holder said without being asked — `nil` for the silence a client that
+    /// has issued no request is owed.
+    ///
+    /// Silence and a closed connection stay distinct on purpose. A holder that
+    /// greeted this client and hung up would satisfy "nothing more arrives"
+    /// while being exactly the failure the probe exists to catch, so the EOF
+    /// throws rather than reading as quiet.
+    func frameArrivingUnsolicited() throws -> HolderResponse? {
+        do {
+            return try receive()
+        } catch FDChannelError.receiveFailed(let code) where code == EAGAIN {
+            return nil
+        }
+    }
+
     /// Reads the next framed response, along with any descriptors that rode
     /// with it.
     /// One `recvmsg` can carry several frames — the holder answers a request

--- a/Tests/TBDHolderTests/TestHolderSupport.swift
+++ b/Tests/TBDHolderTests/TestHolderSupport.swift
@@ -1,0 +1,485 @@
+import Darwin
+import Foundation
+import Testing
+@testable import TBDHolder
+@testable import TBDShared
+
+// Scaffolding for the holder's live-process tests.
+//
+// Three rules shape all of it, and each one is a bug this suite would
+// otherwise have shipped:
+//
+//   1. **Every wait is a bounded poll.** A holder that wedges must fail a test,
+//      not hang the whole suite with no output and no named failure.
+//   2. **Every bootstrap is rc-free.** `/bin/sh` with an explicit environment,
+//      never a login shell — a developer's profile must not be able to change
+//      whether a test passes.
+//   3. **Every test kills its holder AND its job.** Holder death is
+//      deliberately not child death, so a test that terminates a holder
+//      orphans a `sleep` that no reconciler covers yet. Bounded at the sleep's
+//      own duration, but it compounds across runs.
+
+enum TestHolderError: LocalizedError {
+    case executableNotFound
+    case spawnFailed(Int32)
+    case holderNeverReportedItsPID(diagnostics: String)
+    case connectFailed(path: String, errno: Int32)
+    case noResponse
+
+    var errorDescription: String? {
+        switch self {
+        case .executableNotFound:
+            return "TBDHolder was not built into the products directory"
+        case .spawnFailed(let code):
+            return "posix_spawn of the holder bootstrap failed with code \(code)"
+        case .holderNeverReportedItsPID(let diagnostics):
+            return "the bootstrap shell never wrote a holder pid.\n\(diagnostics)"
+        case .connectFailed(let path, let code):
+            return "could not connect to \(path): \(String(cString: strerror(code))) (errno \(code))"
+        case .noResponse:
+            return "the holder closed the connection without answering"
+        }
+    }
+}
+
+/// Poll until `condition` holds or the deadline passes.
+@discardableResult
+func waitUntil(
+    _ description: String,
+    timeout: TimeInterval = 10.0,
+    _ condition: () throws -> Bool
+) rethrows -> Bool {
+    let deadline = Date().addingTimeInterval(timeout)
+    while Date() < deadline {
+        if try condition() { return true }
+        usleep(20_000)
+    }
+    Issue.record("timed out after \(timeout)s waiting for \(description)")
+    return false
+}
+
+func processIsAlive(_ pid: Int32) -> Bool {
+    pid > 0 && kill(pid, 0) == 0
+}
+
+/// Takes whatever is queued on a handed-over pty master, without blocking.
+///
+/// **A test that holds the master must drain it, or the job cannot finish
+/// exiting.** The job is the pty's session leader, and XNU's `proc_exit` calls
+/// `ttywait` on the controlling terminal before revoking it: the process stays
+/// in `P_WEXIT` — `ps` shows state `?Es` and parenthesises the command — until
+/// the tty's output queue is empty. Only a reader on the master empties it.
+///
+/// The holder cannot be that reader; never reading the master is its central
+/// invariant, because a byte it consumed is a byte no reader can ever see
+/// again. So an undrained master wedges the job's exit, `waitpid(…, WNOHANG)`
+/// correctly keeps reporting 0, and the holder never observes a status to
+/// report. Four bytes of canonical-mode echo are enough — that is exactly what
+/// wedged `reportsTheJobsExitCodeToAConnectedClient`.
+///
+/// Made non-blocking on the caller's behalf, since a master with nothing queued
+/// would otherwise block the very poll that is trying to make progress.
+func drainPTY(_ ptyFD: Int32, into sink: inout Data) {
+    _ = fcntl(ptyFD, F_SETFL, fcntl(ptyFD, F_GETFL) | O_NONBLOCK)
+    var buffer = [UInt8](repeating: 0, count: 4096)
+    while true {
+        let count = read(ptyFD, &buffer, buffer.count)
+        guard count > 0 else { return }
+        sink.append(contentsOf: buffer[0..<count])
+    }
+}
+
+/// A holder started the way the daemon will start one, plus everything needed
+/// to take it back down.
+///
+/// The holder is deliberately **not** a child of the test process. A short
+/// bootstrap `/bin/sh` is spawned, backgrounds the holder, and exits; the test
+/// reaps the shell. Every fixture therefore already satisfies the design's
+/// central claim — the process that spawned the holder is gone — and
+/// `childSurvivesTheSpawningProcessExiting` asserts it rather than arranging
+/// it.
+final class HolderFixture {
+    let home: String
+    let sessionID: UUID
+    let socketPath: String
+    let lockPath: String
+    let stderrPath: String
+    let holderPID: Int32
+    /// The bootstrap shell's exit status, or nil if it never exited.
+    let spawnerExitStatus: Int32?
+
+    private var trackedChildPID: Int32 = 0
+    private var torndown = false
+
+    private final class BundleMarker {}
+
+    static func locateExecutable() -> URL? {
+        let bundleURL = Bundle(for: BundleMarker.self).bundleURL
+        var candidates = [bundleURL.deletingLastPathComponent(), bundleURL]
+        if let main = Bundle.main.executableURL?.deletingLastPathComponent() {
+            candidates.append(main)
+        }
+        for directory in candidates {
+            let candidate = directory.appendingPathComponent("TBDHolder")
+            if FileManager.default.isExecutableFile(atPath: candidate.path) {
+                return candidate
+            }
+        }
+        return nil
+    }
+
+    /// A short scratch root. Short on purpose: the rendezvous socket lives
+    /// under it and `sun_path` is 104 bytes, so a deep `TMPDIR` would push the
+    /// path over the limit and fail the bind rather than the assertion.
+    ///
+    /// Exposed so a test can name paths inside it — a marker file the job
+    /// writes — while building the launch request, before the fixture exists.
+    static func scratchHome() -> String {
+        "/tmp/tbdh-\(UUID().uuidString.prefix(8).lowercased())"
+    }
+
+    /// The descriptor number `strayDescriptorProbe` plants a leaked fd on.
+    /// Above the lock's 9 so the two file actions cannot collide.
+    static let strayDescriptorNumber: Int32 = 11
+
+    // swiftlint:disable:next function_body_length
+    static func start(
+        launch: HolderLaunchRequest,
+        owner: String = "test-installation",
+        session: UUID = UUID(),
+        /// When true, an ordinary file descriptor is planted at
+        /// `strayDescriptorNumber` in the bootstrap shell and inherited by the
+        /// holder, standing in for whatever a real spawner happens to have open
+        /// without `FD_CLOEXEC`. The job must not receive it.
+        strayDescriptorProbe: Bool = false,
+        /// Must match the root any marker paths inside `launch` were built
+        /// from; defaults to a fresh one.
+        home: String = HolderFixture.scratchHome()
+    ) throws -> HolderFixture {
+        let executable = try #require(locateExecutable(), "TBDHolder must be built beside the test bundle")
+        let environment = ["TBD_HOME": home]
+        try FileManager.default.createDirectory(
+            atPath: TBDConstants.holdersDir(environment: environment).path,
+            withIntermediateDirectories: true)
+
+        let socketPath = try HolderRendezvous.socketPath(sessionID: session, environment: environment)
+        let lockPath = try HolderRendezvous.lockPath(sessionID: session, environment: environment)
+        let stderrPath = home + "/holder.log"
+        let pidPath = home + "/holder.pid"
+
+        // The spawner takes the lock and hands the DESCRIPTOR down; the holder
+        // never acquires it itself. This is the production sequence, not a
+        // stand-in for it.
+        let lock = try HolderLock.acquire(path: lockPath)
+        var lockReleased = false
+        defer { if !lockReleased { lock.release() } }
+
+        let payload = try JSONEncoder().encode(launch).base64EncodedString()
+        let command = [
+            shellQuoted(executable.path),
+            "--session", shellQuoted(session.uuidString),
+            "--socket", shellQuoted(socketPath),
+            "--lock-fd", "9",
+            "--launch", shellQuoted(payload),
+            "--owner", shellQuoted(owner),
+            "&",
+            "echo $! >", shellQuoted(pidPath),
+        ].joined(separator: " ")
+
+        // O_CLOEXEC on both: they are dup2'd onto the child's stdio, and the
+        // originals must then vanish at exec rather than leaking down into the
+        // job. Setting FD_CLOEXEC is the safe direction — CLEARING it on a
+        // parent descriptor would expose it to every other concurrent
+        // posix_spawn in this process.
+        let logFD = open(stderrPath, O_WRONLY | O_CREAT | O_APPEND | O_CLOEXEC, 0o600)
+        let nullFD = open("/dev/null", O_RDONLY | O_CLOEXEC)
+        defer {
+            if logFD >= 0 { close(logFD) }
+            if nullFD >= 0 { close(nullFD) }
+        }
+
+        // `dup2(fd, fd)` succeeds WITHOUT clearing FD_CLOEXEC, so a lock that
+        // already sits on the target number would be closed at exec and the
+        // holder would refuse to start. `dup` hands back the lowest free
+        // number, which cannot be the one still occupied by the original.
+        var lockSource = lock.fileDescriptor
+        var relocated: Int32 = -1
+        if lockSource == 9 {
+            relocated = dup(lockSource)
+            try #require(relocated >= 0, "could not move the lock off the target descriptor")
+            lockSource = relocated
+        }
+        defer { if relocated >= 0 { close(relocated) } }
+
+        var actions: posix_spawn_file_actions_t?
+        posix_spawn_file_actions_init(&actions)
+        defer { posix_spawn_file_actions_destroy(&actions) }
+        // File actions run IN ORDER. The stdio dup2s come first and the lock's
+        // dup2 last, so that if the log or /dev/null descriptor happens to land
+        // on 9 it has already been copied to its final home by the time the
+        // lock overwrites it. There are deliberately NO trailing closes: a
+        // close scheduled after the lock's dup2 would destroy the descriptor it
+        // just placed, and O_CLOEXEC already retires the originals at exec.
+        posix_spawn_file_actions_adddup2(&actions, nullFD, 0)
+        posix_spawn_file_actions_adddup2(&actions, logFD, 1)
+        posix_spawn_file_actions_adddup2(&actions, logFD, 2)
+        posix_spawn_file_actions_adddup2(&actions, lockSource, 9)
+
+        var strayFD: Int32 = -1
+        var strayRelocated: Int32 = -1
+        defer {
+            if strayRelocated >= 0 { close(strayRelocated) }
+            if strayFD >= 0 { close(strayFD) }
+        }
+        if strayDescriptorProbe {
+            strayFD = open(home + "/stray.probe", O_WRONLY | O_CREAT | O_CLOEXEC, 0o600)
+            try #require(strayFD >= 0, "could not open the stray-descriptor probe")
+            // Same `dup2(fd, fd)` hazard as the lock, same remedy.
+            var straySource = strayFD
+            if straySource == strayDescriptorNumber {
+                strayRelocated = dup(straySource)
+                try #require(strayRelocated >= 0, "could not move the probe off the target descriptor")
+                straySource = strayRelocated
+            }
+            posix_spawn_file_actions_adddup2(&actions, straySource, strayDescriptorNumber)
+        }
+
+        var shellPID: pid_t = 0
+        let argvStrings = ["sh", "-c", command]
+        var argv = argvStrings.map { strdup($0) }
+        argv.append(nil)
+        // An explicit, rc-free environment: `sh -c` reads no profile, and
+        // nothing here comes from the developer's shell.
+        let envpStrings = ["PATH=/usr/bin:/bin", "TBD_HOME=\(home)"]
+        var envp = envpStrings.map { strdup($0) }
+        envp.append(nil)
+        defer {
+            for entry in argv { free(entry) }
+            for entry in envp { free(entry) }
+        }
+        let spawned = posix_spawn(&shellPID, "/bin/sh", &actions, nil, &argv, &envp)
+        guard spawned == 0 else { throw TestHolderError.spawnFailed(spawned) }
+
+        // The holder now owns the lock through its own copy of the open file
+        // description. Dropping ours makes it the sole holder, which is what
+        // `theJobDoesNotInheritTheCreationLock` goes on to assert.
+        lock.release()
+        lockReleased = true
+
+        var raw: Int32 = 0
+        var reaped = false
+        waitUntil("the bootstrap shell to exit", timeout: 10.0) {
+            if waitpid(shellPID, &raw, WNOHANG) == shellPID { reaped = true }
+            return reaped
+        }
+        if !reaped {
+            kill(shellPID, SIGKILL)
+            _ = waitpid(shellPID, &raw, 0)
+        }
+        let exitStatus: Int32? = reaped ? ((raw >> 8) & 0xff) : nil
+
+        var holderPID: Int32 = 0
+        let reported = waitUntil("the bootstrap shell to report a holder pid", timeout: 10.0) {
+            guard let text = try? String(contentsOfFile: pidPath, encoding: .utf8) else { return false }
+            holderPID = Int32(text.trimmingCharacters(in: .whitespacesAndNewlines)) ?? 0
+            return holderPID > 0
+        }
+        guard reported else {
+            let log = (try? String(contentsOfFile: stderrPath, encoding: .utf8)) ?? "<no holder output>"
+            throw TestHolderError.holderNeverReportedItsPID(diagnostics: log)
+        }
+
+        return HolderFixture(
+            home: home,
+            sessionID: session,
+            socketPath: socketPath,
+            lockPath: lockPath,
+            stderrPath: stderrPath,
+            holderPID: holderPID,
+            spawnerExitStatus: exitStatus)
+    }
+
+    private init(
+        home: String,
+        sessionID: UUID,
+        socketPath: String,
+        lockPath: String,
+        stderrPath: String,
+        holderPID: Int32,
+        spawnerExitStatus: Int32?
+    ) {
+        self.home = home
+        self.sessionID = sessionID
+        self.socketPath = socketPath
+        self.lockPath = lockPath
+        self.stderrPath = stderrPath
+        self.holderPID = holderPID
+        self.spawnerExitStatus = spawnerExitStatus
+    }
+
+    func waitForSocket(timeout: TimeInterval = 10.0) {
+        waitUntil("the holder socket at \(socketPath)\n\(diagnostics())", timeout: timeout) {
+            FileManager.default.fileExists(atPath: socketPath)
+        }
+    }
+
+    func connect(receiveTimeout: TimeInterval = 5.0) throws -> TestHolderClient {
+        try TestHolderClient(socketPath: socketPath, receiveTimeout: receiveTimeout)
+    }
+
+    /// Remember a job pid so teardown can reclaim it. Holder death is not child
+    /// death, so anything a test learns about the job has to be recorded here.
+    func trackChild(_ pid: Int32) {
+        if pid > 0 { trackedChildPID = pid }
+    }
+
+    func diagnostics() -> String {
+        (try? String(contentsOfFile: stderrPath, encoding: .utf8)) ?? "<no holder output>"
+    }
+
+    /// Kills the holder AND the job, in that order, then removes the scratch
+    /// root. Idempotent, so a test may terminate the holder mid-body and still
+    /// call this from its `defer`.
+    func tearDown() {
+        guard !torndown else { return }
+        torndown = true
+
+        // Last chance to learn the job pid: a test that never described the
+        // child would otherwise leave a `sleep` behind.
+        if trackedChildPID == 0, processIsAlive(holderPID),
+           let client = try? connect(receiveTimeout: 1.0) {
+            if case .described(let description)? = try? client.request(.describe) {
+                trackedChildPID = description.childPID
+            }
+            client.close()
+        }
+
+        if processIsAlive(holderPID) { kill(holderPID, SIGKILL) }
+        if processIsAlive(trackedChildPID) { kill(trackedChildPID, SIGKILL) }
+        // Neither is our child, so nothing here can `waitpid`; the kernel
+        // reparents and reaps them. Confirm they are gone so a leak fails the
+        // test that caused it rather than the next run.
+        waitUntil("the holder and its job to disappear", timeout: 5.0) {
+            !processIsAlive(holderPID) && !processIsAlive(trackedChildPID)
+        }
+        try? FileManager.default.removeItem(atPath: home)
+    }
+
+    private static func shellQuoted(_ value: String) -> String {
+        "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+}
+
+/// A minimal client for the holder's `[UInt32 LE length][JSON]` protocol.
+///
+/// `SO_RCVTIMEO` is what keeps a wedged holder from hanging the suite: a
+/// receive that times out surfaces as a thrown error attributed to the test.
+final class TestHolderClient {
+    private var fd: Int32
+    private var inbox = Data()
+    private var pending: [HolderResponse] = []
+
+    init(socketPath: String, receiveTimeout: TimeInterval = 5.0) throws {
+        fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else { throw TestHolderError.connectFailed(path: socketPath, errno: errno) }
+
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let sunPathSize = MemoryLayout.size(ofValue: address.sun_path)
+        socketPath.withCString { source in
+            withUnsafeMutablePointer(to: &address.sun_path) { destination in
+                destination.withMemoryRebound(to: CChar.self, capacity: sunPathSize) { chars in
+                    _ = strlcpy(chars, source, sunPathSize)
+                }
+            }
+        }
+        let connected = withUnsafePointer(to: &address) { addressPtr in
+            addressPtr.withMemoryRebound(to: sockaddr.self, capacity: 1) { generic in
+                Darwin.connect(fd, generic, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard connected == 0 else {
+            let saved = errno
+            Darwin.close(fd)
+            fd = -1
+            throw TestHolderError.connectFailed(path: socketPath, errno: saved)
+        }
+
+        let whole = Int(receiveTimeout)
+        var timeout = timeval(
+            tv_sec: whole,
+            tv_usec: suseconds_t((receiveTimeout - TimeInterval(whole)) * 1_000_000))
+        _ = setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))
+        // A holder that has already reported an exit closes as soon as it has,
+        // so a write can legitimately land on a socket whose peer is gone.
+        // Without this that write raises SIGPIPE, whose default disposition
+        // would kill the TEST RUNNER — every suite in the process, with no
+        // failure attributed to anything.
+        var on: Int32 = 1
+        _ = setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &on, socklen_t(MemoryLayout<Int32>.size))
+    }
+
+    /// Sends one `describe` and then reads until the holder reports a status
+    /// that is not `.alive`.
+    ///
+    /// Tolerates both orderings, which is not cosmetic: a job that exits
+    /// promptly may already be reaped by the time this client connects, in
+    /// which case the holder pushes the terminal status at accept time and
+    /// never reads the request. Bounded by `SO_RCVTIMEO` — a status that never
+    /// arrives throws rather than hanging.
+    func awaitTerminalStatus() throws -> HolderChildDescription {
+        try? send(.describe)
+        while true {
+            guard case .described(let description) = try receive() else { continue }
+            if description.status != .alive { return description }
+        }
+    }
+
+    func send(_ request: HolderRequest) throws {
+        try FDChannel.sendData(HolderFraming.frame(request), over: fd)
+    }
+
+    /// Reads the next framed response, along with any descriptors that rode
+    /// with it.
+    /// One `recvmsg` can carry several frames — the holder answers a request
+    /// and pushes an exit report microseconds apart — so decoded-but-unreturned
+    /// frames are QUEUED, never dropped. Returning `drain(…).first` and
+    /// discarding the rest loses the second frame, and since the holder closes
+    /// right after reporting an exit, the next read then sees EOF: the caller
+    /// gets `peerClosed` for a report that did arrive. That was a real,
+    /// load-dependent flake in this suite, not a hypothetical.
+    func receiveWithFDs() throws -> (HolderResponse, [Int32]) {
+        var fds: [Int32] = []
+        while true {
+            if !pending.isEmpty {
+                return (pending.removeFirst(), fds)
+            }
+            pending = try HolderFraming.drain(HolderResponse.self, from: &inbox)
+            if !pending.isEmpty { continue }
+            let message = try FDChannel.receiveMessage(from: fd, capacity: 4096)
+            fds.append(contentsOf: message.fds)
+            inbox.append(message.data)
+        }
+    }
+
+    func receive() throws -> HolderResponse {
+        let (response, fds) = try receiveWithFDs()
+        for descriptor in fds { Darwin.close(descriptor) }
+        return response
+    }
+
+    func request(_ request: HolderRequest) throws -> HolderResponse {
+        try send(request)
+        return try receive()
+    }
+
+    func requestWithFDs(_ request: HolderRequest) throws -> (HolderResponse, [Int32]) {
+        try send(request)
+        return try receiveWithFDs()
+    }
+
+    func close() {
+        if fd >= 0 { Darwin.close(fd) }
+        fd = -1
+    }
+}


### PR DESCRIPTION
## Summary

Task 5 of the pty-holder transport ([spec](../blob/main/docs/specs/2026-08-30-pty-holder-session-transport-design.md)). The supervisor process itself: it `forkpty()`s the job, owns the pty master for the session's life, and hands it to whoever should be reading.

**Stacked on #767 → #766 → #765.** Merge in order.

## Why this shape

**The holder never `read()`s the master.** A byte the holder consumed is a byte no reader can ever see again, and there is no way to put it back. The only operations it performs on that descriptor are `dup` (hand-over), `ioctl` (size), `write` (input) and `close` (forget).

**It is deliberately single-threaded.** `forkpty` is a `fork`, and a `fork` in a multithreaded process gives the child one thread plus whatever locks the others happened to hold — which is how a child deadlocks inside `malloc` before reaching `execve`. Reaping is a `WNOHANG` `waitpid` inside the same `poll` loop that serves clients: no thread means no window in which one could exist.

## What this PR does

Startup order, each step load-bearing: `setsid` → ignore SIGHUP/SIGPIPE → adopt the inherited lock descriptor (passed by number, never acquired here) → bind and listen → `forkpty` → serve. In the child, between fork and exec: reset SIGHUP/SIGPIPE to `SIG_DFL`, then close every descriptor above stdio.

## Evidence & verification

22 tests. Mutation-checked, each mutation reddening only its own test:

- Delete the child-side fd-closing block → `theJobDoesNotInheritTheCreationLock` and `theJobDoesNotInheritStrayDescriptors`.
- Delete only the sweep → `theJobDoesNotInheritStrayDescriptors`.
- Delete the two `SIG_DFL` resets → `theJobDoesNotStartWithSIGPIPEIgnored`.

Eight consecutive green runs of all three holder suites; `swiftlint --strict` clean across 901 files; zero leaked holder processes and no `/tmp/tbdh-*` residue after runs.

## Three findings that constrain later tasks

**1. A job's exit blocks on an undrained pty.** The job is the pty's session leader, and XNU's `proc_exit` calls `ttywait` before revoking the terminal, so it sits in `P_WEXIT` until the tty output queue is empty — four bytes of canonical echo are enough. `waitpid(WNOHANG)` correctly reports nothing, so the holder never sees a status. Since the holder must never be the drainer, **the daemon-side reader's drain is a liveness requirement, not a convenience**: if it stops draining, jobs cannot finish dying. This was measured by driving the built binary by hand, not inferred.

**2. A frame reader must queue what it decodes.** One `recvmsg` can carry a response and the unsolicited exit push together; returning the first and dropping the rest makes the next read hit EOF and report `peerClosed` for a report that did arrive. Task 6's `HolderClient` needs the same pending queue.

**3. Anything a spawner leaks reaches the job.** Measured: before the fd sweep existed, a `sleep` job inherited `scripts/swift-safe`'s machine-global `flock` and blocked every other worktree's build after its holder, its test process, and its harness were all gone. That is why the child closes everything above stdio rather than the two descriptors it knows about.

## Assumptions

`--owner <token>` was added: the documented flags carried no source for `HolderChildDescription.owner`. It defaults to an empty token so a hand-run holder still starts; Task 6 must pass it.

The unsolicited exit push reuses `.described` and is guarded on `status != .alive`. Without that guard it fires on every accept, and the stray frame answers the client's first request — so `handOverPTY` silently returns a plain `.described` with no descriptor. That bug was live until the hand-over test caught it.

https://claude.ai/code/session_01UXqxcPYizvznh99Qb8JKrD

[20260830-boring-panda](https://cheapsteak.github.io/tbd/open/?worktree=A1E9CF50-E608-4F3C-BA8F-377D60BB7478)