### PR TITLE
Feat: Add the daemon-side holder client and spawner

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -240,6 +240,12 @@ let package = Package(
                 "TBDDaemonLib",
                 "TBDShared",
                 "TestSupport",
+                // Load-bearing for the same reason `TBDPeerHelperTests` depends
+                // on `TBDPeerHelper` below: `Holder/HolderClientTests` spawns
+                // the real `TBDHolder` binary through the real `HolderSpawner`,
+                // so the product has to be built and sit in the same products
+                // directory as the test bundle. Nothing here imports it.
+                "TBDHolder",
                 .product(name: "GRDB", package: "GRDB.swift"),
                 .product(name: "Clocks", package: "swift-clocks"),
             ]

--- a/Sources/TBDDaemon/Holder/HolderClient.swift
+++ b/Sources/TBDDaemon/Holder/HolderClient.swift
@@ -70,17 +70,34 @@ actor HolderClient {
     private var inbox = Data()
     /// Frames decoded but not yet returned to a caller.
     ///
-    /// **This queue is the point.** One `recvmsg` routinely carries a response
-    /// and the holder's unsolicited exit push together — the holder answers a
-    /// request and reports a status microseconds apart, and the kernel
-    /// coalesces them. A client that returned the first frame and dropped the
-    /// tail would then read EOF on its next call, because the holder closes
-    /// right after reporting an exit, and would report a closed peer for a
-    /// message that did arrive. That was a real load-dependent flake in the
-    /// holder's own harness, not a hypothetical.
+    /// **The queue exists because one `recvmsg` routinely carries two frames.**
+    /// The holder answers a request and reports a status microseconds apart,
+    /// and the kernel coalesces them; a client that decoded the first and threw
+    /// the rest of the buffer away would lose a message that did arrive, then
+    /// read EOF looking for it, because the holder closes right after reporting
+    /// an exit. That was a real load-dependent flake in the holder's own
+    /// harness, not a hypothetical.
+    ///
+    /// What the queue must never do is hand one request's tail to the *next*
+    /// request as its answer. Whatever is in it when a request goes out
+    /// therefore arrived before that request existed and is retired as an
+    /// unsolicited push rather than served — see `raiseBarrier`.
     private var pending: [HolderResponse] = []
     /// Descriptors received but not yet handed to the frame they rode with.
     private var carriedFDs: [Int32] = []
+    /// The most recent description the holder sent **without being asked**.
+    ///
+    /// The holder pushes a `.described` frame carrying the terminal status when
+    /// the child exits while a client is connected, and the kernel routinely
+    /// delivers that push in the same read as the answer it trails. Such a
+    /// frame answers nobody's request, so it is retired from the queue rather
+    /// than handed to whoever asks next — and kept here, because it is the one
+    /// place a child's exit status arrives unsolicited and throwing it away
+    /// silently would lose the fact entirely.
+    ///
+    /// Deliberately survives `close()`: it is an observation about the child,
+    /// not connection state.
+    private(set) var lastPushedDescription: HolderChildDescription?
 
     init(socketPath: String, receiveTimeout: Duration = HolderClient.defaultReceiveTimeout) {
         self.socketPath = socketPath
@@ -101,7 +118,7 @@ actor HolderClient {
     func describe() async throws -> HolderChildDescription {
         try connectIfNeeded()
         try send(.describe)
-        let (response, fds) = try receive()
+        let (response, fds) = try receive(answering: .describe)
         closeAll(fds)
         switch response {
         case .described(let description), .handedOverPTY(let description):
@@ -109,7 +126,7 @@ actor HolderClient {
         case .rejected(let version):
             throw Error.rejected(version: version)
         case .forgotten:
-            throw Error.unexpectedResponse("forgotten")
+            throw unexpected(response)
         }
     }
 
@@ -118,7 +135,7 @@ actor HolderClient {
     func handOverPTY() async throws -> (HolderChildDescription, Int32) {
         try connectIfNeeded()
         try send(.handOverPTY)
-        let (response, fds) = try receive()
+        let (response, fds) = try receive(answering: .handOverPTY)
         switch response {
         case .handedOverPTY(let description):
             guard let descriptor = fds.first else { throw Error.noDescriptor }
@@ -143,7 +160,7 @@ actor HolderClient {
             throw Error.rejected(version: version)
         case .forgotten:
             closeAll(fds)
-            throw Error.unexpectedResponse("forgotten")
+            throw unexpected(response)
         }
     }
 
@@ -152,7 +169,7 @@ actor HolderClient {
     func forget() async throws {
         try connectIfNeeded()
         try send(.forget)
-        let (response, fds) = try receive()
+        let (response, fds) = try receive(answering: .forget)
         closeAll(fds)
         switch response {
         case .forgotten:
@@ -160,7 +177,7 @@ actor HolderClient {
         case .rejected(let version):
             throw Error.rejected(version: version)
         case .described, .handedOverPTY:
-            throw Error.unexpectedResponse(String(describing: response))
+            throw unexpected(response)
         }
     }
 
@@ -171,9 +188,10 @@ actor HolderClient {
         if fd >= 0 { Darwin.close(fd) }
         fd = -1
         inbox = Data()
-        pending = []
-        closeAll(carriedFDs)
-        carriedFDs = []
+        // Anything still queued at close is by definition nobody's answer, so
+        // it is retired the same way a send retires it: the status it may carry
+        // is remembered, and its descriptors are closed rather than leaked.
+        retireQueuedFrames()
     }
 
     // MARK: - Transport
@@ -221,6 +239,7 @@ actor HolderClient {
 
     private func send(_ request: HolderRequest) throws {
         guard fd >= 0 else { throw Error.notConnected }
+        try raiseBarrier()
         do {
             try FDChannel.sendData(HolderFraming.frame(request), over: fd)
         } catch {
@@ -228,42 +247,175 @@ actor HolderClient {
         }
     }
 
-    /// Returns the next decoded frame, reading only when the queue is empty.
-    private func receive() throws -> (HolderResponse, [Int32]) {
+    /// Separates everything the holder has already said from the answer to the
+    /// request about to be written.
+    ///
+    /// **This is the request/response correlation**, and the wire carries no
+    /// identifier that could provide one: the holder's frames are anonymous, so
+    /// "which request does this answer" can only be decided by *when* it
+    /// arrived. Drawing the line at send time makes the next frame this
+    /// request's answer by construction.
+    ///
+    /// It has to reach the socket, not just the decoded queue. A coalesced
+    /// exit push lands in the queue, but a push written a moment after the
+    /// answer it followed is still sitting in the kernel's receive buffer —
+    /// unread and indistinguishable, later, from an answer. Both are taken here.
+    ///
+    /// Without it a `handOverPTY` that leaves a `.described(exited)` behind
+    /// makes the next `forget` fail with `unexpectedResponse` for a verb the
+    /// holder performed correctly, and leaves that verb's real answer to be
+    /// misattributed to the one after it — a desync that never heals.
+    private func raiseBarrier() throws {
+        guard fd >= 0 else { return }
+        while hasBufferedInput() {
+            try readMoreFrames()
+        }
+        // A frame still arriving when the barrier ran was written before the
+        // request, so it is read to completion rather than left to finish
+        // arriving behind the answer and be mistaken for it. Bounded by
+        // `SO_RCVTIMEO` like every other read here.
+        while !inbox.isEmpty {
+            try readMoreFrames()
+        }
+        retireQueuedFrames()
+    }
+
+    /// Whether the socket has something to deliver right now.
+    private func hasBufferedInput() -> Bool {
+        guard fd >= 0 else { return false }
+        var watched = pollfd(fd: fd, events: Int16(POLLIN), revents: 0)
+        while true {
+            let ready = poll(&watched, 1, 0)
+            if ready < 0 {
+                if errno == EINTR { continue }
+                return false
+            }
+            return ready > 0 && watched.revents & Int16(POLLIN) != 0
+        }
+    }
+
+    /// Retires everything decoded but unclaimed.
+    ///
+    /// In practice these are the holder's unsolicited exit pushes, which
+    /// **trail** the answer they were coalesced with: the holder pushes only
+    /// from its reaping branch, only at a client that is already connected, and
+    /// only after that client's previous request was answered in an earlier
+    /// pass of its loop.
+    private func retireQueuedFrames() {
+        for response in pending {
+            switch response {
+            case .described(let description), .handedOverPTY(let description):
+                lastPushedDescription = description
+                Self.logger.debug(
+                    """
+                    holder at \(self.socketPath, privacy: .public) pushed an unsolicited status for \
+                    child \(description.childPID, privacy: .public): \
+                    \(String(describing: description.status), privacy: .public)
+                    """)
+            case .forgotten, .rejected:
+                Self.logger.debug(
+                    """
+                    discarding an unsolicited \(String(describing: response), privacy: .public) frame \
+                    from the holder at \(self.socketPath, privacy: .public)
+                    """)
+            }
+        }
+        pending = []
+        // A descriptor still carried here rode with a frame nobody is waiting
+        // for. Nothing will ever come to collect it, so it is closed rather
+        // than attached to an unrelated later hand-over.
+        closeAll(carriedFDs)
+        carriedFDs = []
+    }
+
+    /// Returns the frame that answers `request`, reading only when the queue is
+    /// empty.
+    ///
+    /// The barrier `send` raised is what makes the first frame here this
+    /// request's answer. The shape check is the backstop: a frame that could
+    /// not answer what was just asked means the stream is no longer understood,
+    /// so the connection is dropped and the desync cannot outlive the call —
+    /// the next verb reconnects and starts from a known state.
+    private func receive(answering request: HolderRequest) throws -> (HolderResponse, [Int32]) {
         while true {
             if !pending.isEmpty {
                 let response = pending.removeFirst()
                 // Only a hand-over carries a descriptor, so anything queued now
                 // belongs to this frame if it is one and stays queued if not.
+                var fds: [Int32] = []
                 if case .handedOverPTY = response, !carriedFDs.isEmpty {
-                    let fds = carriedFDs
+                    fds = carriedFDs
                     carriedFDs = []
-                    return (response, fds)
                 }
-                return (response, [])
+                guard Self.response(response, answers: request) else {
+                    closeAll(fds)
+                    throw unexpected(response)
+                }
+                return (response, fds)
             }
 
-            guard fd >= 0 else { throw Error.notConnected }
-            let message: (data: Data, fds: [Int32])
-            do {
-                message = try FDChannel.receiveMessage(from: fd, capacity: Self.readChunkSize)
-            } catch FDChannelError.peerClosed {
-                throw Error.peerClosed
-            } catch {
-                throw Error.transportFailed(error.localizedDescription)
-            }
-            carriedFDs.append(contentsOf: message.fds)
-            inbox.append(message.data)
-            do {
-                pending = try HolderFraming.drainResponses(from: &inbox)
-            } catch {
-                throw Error.transportFailed(error.localizedDescription)
-            }
+            try readMoreFrames()
+        }
+    }
+
+    /// One bounded `recvmsg`, decoded into the queue.
+    private func readMoreFrames() throws {
+        guard fd >= 0 else { throw Error.notConnected }
+        let message: (data: Data, fds: [Int32])
+        do {
+            message = try FDChannel.receiveMessage(from: fd, capacity: Self.readChunkSize)
+        } catch FDChannelError.peerClosed {
+            throw Error.peerClosed
+        } catch {
+            throw Error.transportFailed(error.localizedDescription)
+        }
+        carriedFDs.append(contentsOf: message.fds)
+        inbox.append(message.data)
+        do {
+            // Appended, never assigned: a read that completes a frame while
+            // others are already queued must not drop the ones in front of it.
+            pending.append(contentsOf: try HolderFraming.drainResponses(from: &inbox))
+        } catch {
+            throw Error.transportFailed(error.localizedDescription)
         }
     }
 
     private func closeAll(_ fds: [Int32]) {
         for descriptor in fds { Darwin.close(descriptor) }
+    }
+
+    /// Whether `response` is a shape the holder can legitimately answer
+    /// `request` with.
+    ///
+    /// `.rejected` answers everything — a busy holder refuses the connection
+    /// itself, whatever was asked. `.described` answers `handOverPTY` because
+    /// that is how a forgotten holder, or one whose `dup` failed, says it has
+    /// nothing to transfer.
+    private static func response(_ response: HolderResponse, answers request: HolderRequest) -> Bool {
+        if case .rejected = response { return true }
+        switch request {
+        case .describe, .handOverPTY:
+            if case .forgotten = response { return false }
+            return true
+        case .forget:
+            if case .forgotten = response { return true }
+            return false
+        }
+    }
+
+    /// Drops the connection and reports the frame that did not belong.
+    ///
+    /// Closing is the point: a client that keeps a stream it has stopped
+    /// understanding attributes every later answer to the wrong request
+    /// forever, so the one recoverable move is to start over.
+    private func unexpected(_ response: HolderResponse) -> Error {
+        Self.logger.error(
+            """
+            holder at \(self.socketPath, privacy: .public) answered with an unexpected \
+            \(String(describing: response), privacy: .public); dropping the connection
+            """)
+        close()
+        return Error.unexpectedResponse(String(describing: response))
     }
 
     private static func timeval(from duration: Duration) -> timeval {

--- a/Sources/TBDDaemon/Holder/HolderClient.swift
+++ b/Sources/TBDDaemon/Holder/HolderClient.swift
@@ -1,0 +1,277 @@
+import Darwin
+import Foundation
+import TBDShared
+import os
+
+/// The daemon's end of one holder's Unix socket.
+///
+/// An `actor` because the holder enforces **one client at a time** and the
+/// stream underneath is a single reader's to drain: two tasks interleaving
+/// `recvmsg` on the same descriptor would split frames between them and, worse,
+/// let an `SCM_RIGHTS` descriptor land on whichever one happened to read first.
+/// Making the socket actor-isolated means the single-reader discipline is a
+/// property of the type rather than of every call site's good manners.
+///
+/// The I/O here is deliberately blocking, bounded by `SO_RCVTIMEO`. Every verb
+/// is a short request/response round trip against a process that is either
+/// alive and answering in microseconds or wedged — and a wedged holder must
+/// surface as a thrown error attributed to the caller, never as a task parked
+/// forever. Draining the pty stream, which is unbounded and must not block
+/// anything, is a different job and belongs to the reader, not here.
+actor HolderClient {
+    private static let logger = Logger(subsystem: "com.tbd.daemon", category: "holder")
+
+    /// How long a single request may wait for its answer before the holder is
+    /// declared unresponsive.
+    static let defaultReceiveTimeout: Duration = .seconds(10)
+
+    enum Error: LocalizedError, Equatable {
+        case socketPathTooLong(path: String, limit: Int)
+        case cannotConnect(path: String, errno: Int32)
+        case notConnected
+        case peerClosed
+        /// The holder answered with the busy sentinel: somebody else is already
+        /// its one client.
+        case rejected(version: Int)
+        case unexpectedResponse(String)
+        /// A `handedOverPTY` frame arrived with no descriptor attached.
+        case noDescriptor
+        case transportFailed(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .socketPathTooLong(let path, let limit):
+                return "holder socket path is \(path.utf8.count) bytes, over the "
+                    + "\(limit)-byte sun_path limit: \(path)"
+            case .cannotConnect(let path, let code):
+                return "could not connect to the holder socket at \(path): "
+                    + "\(String(cString: strerror(code))) (errno \(code))"
+            case .notConnected:
+                return "the holder client has already been closed"
+            case .peerClosed:
+                return "the holder closed the connection without answering"
+            case .rejected(let version):
+                return "the holder rejected this connection (protocol version \(version)); "
+                    + "another client is already attached"
+            case .unexpectedResponse(let response):
+                return "the holder answered with an unexpected response: \(response)"
+            case .noDescriptor:
+                return "the holder reported handing over the pty but sent no descriptor"
+            case .transportFailed(let detail):
+                return "holder socket transport failed: \(detail)"
+            }
+        }
+    }
+
+    let socketPath: String
+    private let receiveTimeout: Duration
+    private var fd: Int32 = -1
+    /// Bytes read but not yet parsed into a whole frame.
+    private var inbox = Data()
+    /// Frames decoded but not yet returned to a caller.
+    ///
+    /// **This queue is the point.** One `recvmsg` routinely carries a response
+    /// and the holder's unsolicited exit push together — the holder answers a
+    /// request and reports a status microseconds apart, and the kernel
+    /// coalesces them. A client that returned the first frame and dropped the
+    /// tail would then read EOF on its next call, because the holder closes
+    /// right after reporting an exit, and would report a closed peer for a
+    /// message that did arrive. That was a real load-dependent flake in the
+    /// holder's own harness, not a hypothetical.
+    private var pending: [HolderResponse] = []
+    /// Descriptors received but not yet handed to the frame they rode with.
+    private var carriedFDs: [Int32] = []
+
+    init(socketPath: String, receiveTimeout: Duration = HolderClient.defaultReceiveTimeout) {
+        self.socketPath = socketPath
+        self.receiveTimeout = receiveTimeout
+    }
+
+    deinit {
+        if fd >= 0 { Darwin.close(fd) }
+        for descriptor in carriedFDs { Darwin.close(descriptor) }
+    }
+
+    // MARK: - Verbs
+
+    /// Report the child without transferring anything. Doubles as the
+    /// handshake: a holder that answers this is alive, speaking the protocol,
+    /// and naming the installation that spawned it.
+    @discardableResult
+    func describe() async throws -> HolderChildDescription {
+        try connectIfNeeded()
+        try send(.describe)
+        let (response, fds) = try receive()
+        closeAll(fds)
+        switch response {
+        case .described(let description), .handedOverPTY(let description):
+            return description
+        case .rejected(let version):
+            throw Error.rejected(version: version)
+        case .forgotten:
+            throw Error.unexpectedResponse("forgotten")
+        }
+    }
+
+    /// Ask for a `dup` of the pty master. The returned descriptor is the
+    /// caller's to close; nobody else will.
+    func handOverPTY() async throws -> (HolderChildDescription, Int32) {
+        try connectIfNeeded()
+        try send(.handOverPTY)
+        let (response, fds) = try receive()
+        switch response {
+        case .handedOverPTY(let description):
+            guard let descriptor = fds.first else { throw Error.noDescriptor }
+            // A second descriptor would be a duplicate reference to the same
+            // open file and would keep the pty alive after the caller closed
+            // the one it was given, so extras are closed rather than kept.
+            closeAll(Array(fds.dropFirst()))
+            return (description, descriptor)
+        case .described(let description):
+            // The holder answers with a plain description when it has nothing
+            // to hand over — it was forgotten, or its `dup` failed. Saying so
+            // is better than pretending a transfer happened.
+            closeAll(fds)
+            Self.logger.error(
+                """
+                holder at \(self.socketPath, privacy: .public) has no pty to hand over for \
+                child \(description.childPID, privacy: .public)
+                """)
+            throw Error.noDescriptor
+        case .rejected(let version):
+            closeAll(fds)
+            throw Error.rejected(version: version)
+        case .forgotten:
+            closeAll(fds)
+            throw Error.unexpectedResponse("forgotten")
+        }
+    }
+
+    /// Tell the holder to close the pty master and stop reporting, so a session
+    /// TBD has deliberately killed cannot be resurrected by a later attach.
+    func forget() async throws {
+        try connectIfNeeded()
+        try send(.forget)
+        let (response, fds) = try receive()
+        closeAll(fds)
+        switch response {
+        case .forgotten:
+            return
+        case .rejected(let version):
+            throw Error.rejected(version: version)
+        case .described, .handedOverPTY:
+            throw Error.unexpectedResponse(String(describing: response))
+        }
+    }
+
+    /// Drops the connection. Idempotent; the client reconnects on the next
+    /// verb, which is what makes a `HolderClient` reusable across a holder's
+    /// life without pinning its single client slot between requests.
+    func close() {
+        if fd >= 0 { Darwin.close(fd) }
+        fd = -1
+        inbox = Data()
+        pending = []
+        closeAll(carriedFDs)
+        carriedFDs = []
+    }
+
+    // MARK: - Transport
+
+    private func connectIfNeeded() throws {
+        guard fd < 0 else { return }
+        guard socketPath.utf8.count < HolderRendezvous.sunPathLimit else {
+            throw Error.socketPathTooLong(path: socketPath, limit: HolderRendezvous.sunPathLimit)
+        }
+
+        let socketFD = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard socketFD >= 0 else { throw Error.cannotConnect(path: socketPath, errno: errno) }
+
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let sunPathSize = MemoryLayout.size(ofValue: address.sun_path)
+        socketPath.withCString { source in
+            withUnsafeMutablePointer(to: &address.sun_path) { destination in
+                destination.withMemoryRebound(to: CChar.self, capacity: sunPathSize) { chars in
+                    _ = strlcpy(chars, source, sunPathSize)
+                }
+            }
+        }
+        let connected = withUnsafePointer(to: &address) { addressPtr in
+            addressPtr.withMemoryRebound(to: sockaddr.self, capacity: 1) { generic in
+                Darwin.connect(socketFD, generic, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard connected == 0 else {
+            let saved = errno
+            Darwin.close(socketFD)
+            throw Error.cannotConnect(path: socketPath, errno: saved)
+        }
+
+        var timeout = Self.timeval(from: receiveTimeout)
+        _ = setsockopt(socketFD, SOL_SOCKET, SO_RCVTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))
+        // A holder that has already reported an exit closes as soon as it has,
+        // so a write can legitimately land on a socket whose peer is gone.
+        // Without this that write raises SIGPIPE, whose default disposition
+        // would take the whole daemon down over one dead holder.
+        var on: Int32 = 1
+        _ = setsockopt(socketFD, SOL_SOCKET, SO_NOSIGPIPE, &on, socklen_t(MemoryLayout<Int32>.size))
+        fd = socketFD
+    }
+
+    private func send(_ request: HolderRequest) throws {
+        guard fd >= 0 else { throw Error.notConnected }
+        do {
+            try FDChannel.sendData(HolderFraming.frame(request), over: fd)
+        } catch {
+            throw Error.transportFailed(error.localizedDescription)
+        }
+    }
+
+    /// Returns the next decoded frame, reading only when the queue is empty.
+    private func receive() throws -> (HolderResponse, [Int32]) {
+        while true {
+            if !pending.isEmpty {
+                let response = pending.removeFirst()
+                // Only a hand-over carries a descriptor, so anything queued now
+                // belongs to this frame if it is one and stays queued if not.
+                if case .handedOverPTY = response, !carriedFDs.isEmpty {
+                    let fds = carriedFDs
+                    carriedFDs = []
+                    return (response, fds)
+                }
+                return (response, [])
+            }
+
+            guard fd >= 0 else { throw Error.notConnected }
+            let message: (data: Data, fds: [Int32])
+            do {
+                message = try FDChannel.receiveMessage(from: fd, capacity: Self.readChunkSize)
+            } catch FDChannelError.peerClosed {
+                throw Error.peerClosed
+            } catch {
+                throw Error.transportFailed(error.localizedDescription)
+            }
+            carriedFDs.append(contentsOf: message.fds)
+            inbox.append(message.data)
+            do {
+                pending = try HolderFraming.drainResponses(from: &inbox)
+            } catch {
+                throw Error.transportFailed(error.localizedDescription)
+            }
+        }
+    }
+
+    private func closeAll(_ fds: [Int32]) {
+        for descriptor in fds { Darwin.close(descriptor) }
+    }
+
+    private static func timeval(from duration: Duration) -> timeval {
+        let components = duration.components
+        return Darwin.timeval(
+            tv_sec: Int(components.seconds),
+            tv_usec: suseconds_t(components.attoseconds / 1_000_000_000_000))
+    }
+
+    private static let readChunkSize = 4096
+}

--- a/Sources/TBDDaemon/Holder/HolderSpawner.swift
+++ b/Sources/TBDDaemon/Holder/HolderSpawner.swift
@@ -34,6 +34,10 @@ struct HolderHandle: Sendable, Equatable {
 ///      and the kernel drops it when the holder dies.
 ///   7. The socket is polled for reachability on the injected clock, then
 ///      handshaken.
+///   8. A holder that never answers is judged by whether its socket exists,
+///      never by the handshake alone: no socket means it never bound and so
+///      never forked, which is the only state where killing it can orphan
+///      nothing. See `resolveUnreachableHolder`.
 ///
 /// **Who reclaims a holder is not answered here.** The holder is spawned as a
 /// direct child of the daemon, so a daemon that outlives it must reap its exit
@@ -58,15 +62,28 @@ struct HolderSpawner {
     /// the spawn rather than wedge the caller.
     static let defaultBindTimeout: Duration = .seconds(10)
     static let defaultBindPollInterval: Duration = .milliseconds(20)
+    /// How long one handshake attempt against a socket that already exists may
+    /// wait. Separate from `bindTimeout`, which bounds the whole wait: a
+    /// connect that succeeds and then goes quiet must not spend the entire
+    /// startup budget on a single attempt.
+    static let defaultHandshakeTimeout: Duration = .seconds(2)
 
     enum Error: LocalizedError, Equatable {
         /// Another live holder owns this session UUID. Nothing was created and,
         /// crucially, nothing was cleared.
         case lockHeldByLiveHolder(sessionID: UUID, lockPath: String)
-        /// The holder never became reachable within the budget. Carries
-        /// whatever it wrote to stderr, which is the only channel for anything
-        /// that went wrong before the socket existed.
-        case holderDidNotBind(socketPath: String, diagnostics: String)
+        /// The holder never created its socket within the budget, and was
+        /// therefore killed. Carries whatever it wrote to stderr, which is the
+        /// only channel for anything that went wrong before the socket existed.
+        case holderDidNotBind(holderPID: Int32, socketPath: String, diagnostics: String)
+        /// The holder created its socket but never answered the handshake.
+        ///
+        /// **It is deliberately left running.** Binding happens before
+        /// `forkpty`, so a holder that got this far may already be supervising
+        /// a live job — one recorded in no database, which nothing would ever
+        /// find again if the holder were killed here. The pid and the socket
+        /// path are carried so a human, or a later reconciler, can.
+        case holderBoundButUnresponsive(holderPID: Int32, socketPath: String, diagnostics: String)
         /// The holder answered the handshake with the busy sentinel.
         case rejected(version: Int)
         case rendezvousDirectoryUnavailable(path: String, detail: String)
@@ -78,9 +95,14 @@ struct HolderSpawner {
             case .lockHeldByLiveHolder(let sessionID, let lockPath):
                 return "a live holder already owns session \(sessionID.uuidString) "
                     + "(creation lock at \(lockPath)); refusing to clear its socket"
-            case .holderDidNotBind(let socketPath, let diagnostics):
-                return "the holder never bound \(socketPath) within the budget. "
+            case .holderDidNotBind(let holderPID, let socketPath, let diagnostics):
+                return "the holder never created \(socketPath) within the budget, so pid "
+                    + "\(holderPID) was killed before it could fork a job. "
                     + "Holder output: \(diagnostics)"
+            case .holderBoundButUnresponsive(let holderPID, let socketPath, let diagnostics):
+                return "the holder bound \(socketPath) but never answered the handshake. "
+                    + "Pid \(holderPID) was left running because it may already own a live "
+                    + "job; kill it by hand once you have checked. Holder output: \(diagnostics)"
             case .rejected(let version):
                 return "the freshly spawned holder rejected the handshake "
                     + "(protocol version \(version))"
@@ -98,17 +120,20 @@ struct HolderSpawner {
     let executableURL: URL
     let bindTimeout: Duration
     let bindPollInterval: Duration
+    let handshakeTimeout: Duration
     private let clock: any Clock<Duration>
 
     init(
         executableURL: URL,
         bindTimeout: Duration = HolderSpawner.defaultBindTimeout,
         bindPollInterval: Duration = HolderSpawner.defaultBindPollInterval,
+        handshakeTimeout: Duration = HolderSpawner.defaultHandshakeTimeout,
         clock: any Clock<Duration> = ContinuousClock()
     ) {
         self.executableURL = executableURL
         self.bindTimeout = bindTimeout
         self.bindPollInterval = bindPollInterval
+        self.handshakeTimeout = handshakeTimeout
         self.clock = clock
     }
 
@@ -182,24 +207,14 @@ struct HolderSpawner {
 
         let description: HolderChildDescription
         do {
-            description = try await awaitBinding(socketPath: socketPath, stderrPath: stderrPath)
+            description = try await awaitBinding(socketPath: socketPath)
         } catch {
-            // A holder that never answered must not be left running: it holds
-            // the creation lock, and while it does this session UUID cannot be
-            // respawned or reclaimed by anything. Killing it is safe precisely
-            // here — the holder binds *before* it `forkpty`s, so one that never
-            // bound has no job to orphan — and reaping keeps a corpse from
-            // accumulating in the daemon's process table.
-            Self.logger.error(
-                """
-                holder pid \(holderPID, privacy: .public) for session \
-                \(sessionID.uuidString, privacy: .public) never answered; killing it: \
-                \(error.localizedDescription, privacy: .public)
-                """)
-            kill(holderPID, SIGKILL)
-            var ignored: Int32 = 0
-            _ = waitpid(holderPID, &ignored, 0)
-            throw error
+            throw resolveUnreachableHolder(
+                holderPID: holderPID,
+                sessionID: sessionID,
+                socketPath: socketPath,
+                stderrPath: stderrPath,
+                cause: error)
         }
 
         Self.logger.info(
@@ -210,6 +225,78 @@ struct HolderSpawner {
             """)
         return HolderHandle(
             holderPID: holderPID, childPID: description.childPID, socketPath: socketPath)
+    }
+
+    // MARK: - A holder that was spawned but never answered
+
+    /// Decides what to do with a spawned holder that never completed a
+    /// handshake, and returns the error the spawn fails with.
+    ///
+    /// **The kill is gated on evidence that no job can exist, not on the
+    /// handshake having failed.** `Holder.run()` binds and listens *before* it
+    /// `forkpty`s, and it only ever `accept`s from inside `serve()`, which runs
+    /// after the fork. So a socket that was never created is proof the holder
+    /// never reached bind and therefore never forked a job: nothing can be
+    /// orphaned by killing it, and leaving it alive would strand the creation
+    /// lock it holds. That, and only that, licenses SIGKILL.
+    ///
+    /// A socket that *does* exist says the opposite — the holder got at least
+    /// as far as bind, and the very case the generous budget exists for (a
+    /// loaded machine, a cold `execve`) is the case where it has since forked a
+    /// job that is recorded in no database. Milestone A has no holder
+    /// reconciler, so killing the holder there would orphan that job
+    /// permanently and destroy the only evidence of it. It is left running and
+    /// named instead: the spawn still fails, this session UUID stays locked
+    /// until somebody deals with the pid, and that is a visible, recoverable
+    /// state rather than a silent leak.
+    ///
+    /// The residual window is the microseconds between the holder's bind and
+    /// its fork, and the check is read at the moment of the decision — a holder
+    /// that creates its socket after this stat has already missed the whole
+    /// budget.
+    private func resolveUnreachableHolder(
+        holderPID: Int32,
+        sessionID: UUID,
+        socketPath: String,
+        stderrPath: String,
+        cause: Swift.Error
+    ) -> Swift.Error {
+        let socketExists = FileManager.default.fileExists(atPath: socketPath)
+        let diagnostics = (try? String(contentsOfFile: stderrPath, encoding: .utf8))
+            .flatMap { $0.isEmpty ? nil : $0 } ?? "<no holder output>"
+
+        guard !socketExists else {
+            Self.logger.error(
+                """
+                holder pid \(holderPID, privacy: .public) for session \
+                \(sessionID.uuidString, privacy: .public) bound \(socketPath, privacy: .public) but \
+                never answered; leaving it alive because it may already own a job: \
+                \(cause.localizedDescription, privacy: .public)
+                """)
+            // A busy holder answered — with the sentinel, but it answered — so
+            // that failure keeps its own name rather than being reported as
+            // silence.
+            if let spawnerError = cause as? Error, case .rejected = spawnerError {
+                return spawnerError
+            }
+            return Error.holderBoundButUnresponsive(
+                holderPID: holderPID, socketPath: socketPath, diagnostics: diagnostics)
+        }
+
+        Self.logger.error(
+            """
+            holder pid \(holderPID, privacy: .public) for session \
+            \(sessionID.uuidString, privacy: .public) never created \
+            \(socketPath, privacy: .public), so it never forked a job; killing it: \
+            \(cause.localizedDescription, privacy: .public)
+            """)
+        kill(holderPID, SIGKILL)
+        // Reaped because the holder is the daemon's own child: without this the
+        // corpse accumulates in its process table.
+        var ignored: Int32 = 0
+        _ = waitpid(holderPID, &ignored, 0)
+        return Error.holderDidNotBind(
+            holderPID: holderPID, socketPath: socketPath, diagnostics: diagnostics)
     }
 
     // MARK: - Probing an existing socket
@@ -354,13 +441,10 @@ struct HolderSpawner {
     /// `Instant`: instant arithmetic does not typecheck through the
     /// existential, and a limit expressed as "how much waiting has been spent"
     /// is what a fake clock can drive.
-    private func awaitBinding(
-        socketPath: String,
-        stderrPath: String
-    ) async throws -> HolderChildDescription {
+    private func awaitBinding(socketPath: String) async throws -> HolderChildDescription {
         var waited: Duration = .zero
         while true {
-            let client = HolderClient(socketPath: socketPath, receiveTimeout: .seconds(2))
+            let client = HolderClient(socketPath: socketPath, receiveTimeout: handshakeTimeout)
             do {
                 let description = try await client.describe()
                 await client.close()
@@ -377,8 +461,20 @@ struct HolderSpawner {
             waited += bindPollInterval
         }
 
-        let diagnostics = (try? String(contentsOfFile: stderrPath, encoding: .utf8))
-            .flatMap { $0.isEmpty ? nil : $0 } ?? "<no holder output>"
-        throw Error.holderDidNotBind(socketPath: socketPath, diagnostics: diagnostics)
+        throw BindBudgetExhausted(budget: bindTimeout)
+    }
+
+    /// The budget ran out with no answer. Never escapes `spawn`: what a caller
+    /// sees is whichever error `resolveUnreachableHolder` chooses once it knows
+    /// whether the holder ever created its socket — the two outcomes differ in
+    /// whether a job can exist, which this type deliberately cannot know. It
+    /// still carries a real description, because it is logged as the cause of
+    /// whichever of those two the spawn fails with.
+    private struct BindBudgetExhausted: LocalizedError {
+        let budget: Duration
+
+        var errorDescription: String? {
+            "no answer within the \(budget) bind budget"
+        }
     }
 }

--- a/Sources/TBDDaemon/Holder/HolderSpawner.swift
+++ b/Sources/TBDDaemon/Holder/HolderSpawner.swift
@@ -1,0 +1,384 @@
+import Darwin
+import Foundation
+import TBDShared
+import os
+
+/// A live holder, and everything the daemon needs to find it again.
+///
+/// `holderPID` is the supervisor; `childPID` is the job it `forkpty`'d. They
+/// are deliberately separate facts: holder death is **not** child death, and
+/// treating one pid as a proxy for the other is how a reclaimer ends up killing
+/// the wrong process or believing a session ended when only its supervisor did.
+struct HolderHandle: Sendable, Equatable {
+    var holderPID: Int32
+    var childPID: Int32
+    var socketPath: String
+}
+
+/// Spawns one holder process per session and waits for it to become reachable.
+///
+/// The ordering in `spawn` is the contract rather than a preference, and each
+/// step closes a hazard the previous one cannot:
+///
+///   1. The rendezvous directory must exist before anything is created in it.
+///   2. The creation lock is taken **before** the socket path is examined. A
+///      spawner that cannot take it has learned a live holder owns this UUID
+///      without connecting, and must back off rather than clear the path.
+///   3. A socket with no sibling lock file is *unowned-but-unproven*, never
+///      unowned: it is probed, and only a connect that fails outright licenses
+///      unlinking it.
+///   4. The lock travels to the holder as a **descriptor number**, placed by a
+///      `posix_spawn` `dup2` file action.
+///   5. The holder's stdio is detached, with stderr somewhere retrievable.
+///   6. The daemon drops its own copy of the lock, so the holder alone holds it
+///      and the kernel drops it when the holder dies.
+///   7. The socket is polled for reachability on the injected clock, then
+///      handshaken.
+///
+/// **Who reclaims a holder is not answered here.** The holder is spawned as a
+/// direct child of the daemon, so a daemon that outlives it must reap its exit
+/// status, and a holder orphaned by a daemon crash is reclaimed by nothing
+/// today. Both belong to the reconcilers Milestone B adds (the
+/// `WorktreeLifecycle+Reconcile` holder inventory, the `OrphanGC` socket and
+/// lock sweep, and the `AgentReaper` holder-transport leg); until they land the
+/// flag stays off outside a development machine.
+struct HolderSpawner {
+    private static let logger = Logger(subsystem: "com.tbd.daemon", category: "holder")
+
+    /// The descriptor number the creation lock is placed on in the holder.
+    ///
+    /// Any number above stdio works — `forkpty` dup2s the pty slave onto 0/1/2
+    /// in the job, so a lock parked there would be silently overwritten — and
+    /// the holder validates that it landed above 2.
+    static let lockDescriptorNumber: Int32 = 9
+
+    /// How long to wait for a freshly spawned holder to bind and answer.
+    /// Generous because it covers a cold `execve` of a debug binary under a
+    /// loaded machine, and bounded because a holder that never binds must fail
+    /// the spawn rather than wedge the caller.
+    static let defaultBindTimeout: Duration = .seconds(10)
+    static let defaultBindPollInterval: Duration = .milliseconds(20)
+
+    enum Error: LocalizedError, Equatable {
+        /// Another live holder owns this session UUID. Nothing was created and,
+        /// crucially, nothing was cleared.
+        case lockHeldByLiveHolder(sessionID: UUID, lockPath: String)
+        /// The holder never became reachable within the budget. Carries
+        /// whatever it wrote to stderr, which is the only channel for anything
+        /// that went wrong before the socket existed.
+        case holderDidNotBind(socketPath: String, diagnostics: String)
+        /// The holder answered the handshake with the busy sentinel.
+        case rejected(version: Int)
+        case rendezvousDirectoryUnavailable(path: String, detail: String)
+        case lockUnavailable(path: String, detail: String)
+        case spawnFailed(executable: String, errno: Int32)
+
+        var errorDescription: String? {
+            switch self {
+            case .lockHeldByLiveHolder(let sessionID, let lockPath):
+                return "a live holder already owns session \(sessionID.uuidString) "
+                    + "(creation lock at \(lockPath)); refusing to clear its socket"
+            case .holderDidNotBind(let socketPath, let diagnostics):
+                return "the holder never bound \(socketPath) within the budget. "
+                    + "Holder output: \(diagnostics)"
+            case .rejected(let version):
+                return "the freshly spawned holder rejected the handshake "
+                    + "(protocol version \(version))"
+            case .rendezvousDirectoryUnavailable(let path, let detail):
+                return "could not create the holder rendezvous directory \(path): \(detail)"
+            case .lockUnavailable(let path, let detail):
+                return "could not take the holder creation lock at \(path): \(detail)"
+            case .spawnFailed(let executable, let code):
+                return "could not spawn \(executable): "
+                    + "\(String(cString: strerror(code))) (errno \(code))"
+            }
+        }
+    }
+
+    let executableURL: URL
+    let bindTimeout: Duration
+    let bindPollInterval: Duration
+    private let clock: any Clock<Duration>
+
+    init(
+        executableURL: URL,
+        bindTimeout: Duration = HolderSpawner.defaultBindTimeout,
+        bindPollInterval: Duration = HolderSpawner.defaultBindPollInterval,
+        clock: any Clock<Duration> = ContinuousClock()
+    ) {
+        self.executableURL = executableURL
+        self.bindTimeout = bindTimeout
+        self.bindPollInterval = bindPollInterval
+        self.clock = clock
+    }
+
+    // MARK: - Spawn
+
+    func spawn(
+        sessionID: UUID,
+        launch: HolderLaunchRequest,
+        owner: HolderOwnerToken,
+        environment: [String: String]
+    ) async throws -> HolderHandle {
+        let socketPath = try HolderRendezvous.socketPath(sessionID: sessionID, environment: environment)
+        let lockPath = try HolderRendezvous.lockPath(sessionID: sessionID, environment: environment)
+        let holdersDir = TBDConstants.holdersDir(environment: environment)
+
+        do {
+            try FileManager.default.createDirectory(
+                at: holdersDir,
+                withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o700])
+        } catch {
+            throw Error.rendezvousDirectoryUnavailable(
+                path: holdersDir.path, detail: error.localizedDescription)
+        }
+
+        // Read BEFORE acquiring: `HolderLock.acquire` creates the file, so
+        // asking afterwards can only ever answer "yes" and the
+        // socket-without-a-lock case would become unreachable.
+        let lockFileExisted = FileManager.default.fileExists(atPath: lockPath)
+
+        let lock: HolderLock
+        do {
+            lock = try HolderLock.acquire(path: lockPath)
+        } catch HolderLock.Error.alreadyHeld {
+            // Deliberately nothing else: not a probe, not an unlink, not a
+            // stat. The lock is the proof, and a spawner that goes on to touch
+            // the socket here is the exact hazard the lock exists to prevent.
+            throw Error.lockHeldByLiveHolder(sessionID: sessionID, lockPath: lockPath)
+        } catch {
+            throw Error.lockUnavailable(path: lockPath, detail: error.localizedDescription)
+        }
+        var lockReleased = false
+        defer { if !lockReleased { lock.release() } }
+
+        if !lockFileExisted, FileManager.default.fileExists(atPath: socketPath) {
+            // Absence of a lock is not evidence of absence of a holder — the
+            // file could have been swept, or written by a layout we do not
+            // recognise. Ask the socket itself.
+            if await someoneIsListening(at: socketPath) {
+                throw Error.lockHeldByLiveHolder(sessionID: sessionID, lockPath: lockPath)
+            }
+            unlink(socketPath)
+        }
+
+        let stderrPath = holdersDir.appendingPathComponent(
+            "\(sessionID.uuidString.lowercased()).log").path
+        let holderPID = try launchHolder(
+            sessionID: sessionID,
+            socketPath: socketPath,
+            stderrPath: stderrPath,
+            launch: launch,
+            owner: owner,
+            environment: environment,
+            lock: lock)
+
+        // The holder now owns the lock through its own copy of the open file
+        // description. Dropping ours makes it the sole owner, which is what
+        // makes the kernel release the lock exactly when the holder dies.
+        lock.release()
+        lockReleased = true
+
+        let description: HolderChildDescription
+        do {
+            description = try await awaitBinding(socketPath: socketPath, stderrPath: stderrPath)
+        } catch {
+            // A holder that never answered must not be left running: it holds
+            // the creation lock, and while it does this session UUID cannot be
+            // respawned or reclaimed by anything. Killing it is safe precisely
+            // here — the holder binds *before* it `forkpty`s, so one that never
+            // bound has no job to orphan — and reaping keeps a corpse from
+            // accumulating in the daemon's process table.
+            Self.logger.error(
+                """
+                holder pid \(holderPID, privacy: .public) for session \
+                \(sessionID.uuidString, privacy: .public) never answered; killing it: \
+                \(error.localizedDescription, privacy: .public)
+                """)
+            kill(holderPID, SIGKILL)
+            var ignored: Int32 = 0
+            _ = waitpid(holderPID, &ignored, 0)
+            throw error
+        }
+
+        Self.logger.info(
+            """
+            spawned holder pid \(holderPID, privacy: .public) for session \
+            \(sessionID.uuidString, privacy: .public): child \
+            \(description.childPID, privacy: .public) on \(description.ttyName, privacy: .public)
+            """)
+        return HolderHandle(
+            holderPID: holderPID, childPID: description.childPID, socketPath: socketPath)
+    }
+
+    // MARK: - Probing an existing socket
+
+    /// Whether something answers at `socketPath`.
+    ///
+    /// A successful handshake and a rejection both mean "back off": one is a
+    /// live holder serving somebody, the other is a live holder that is busy.
+    /// So does a connect that fails for any reason other than "nothing is
+    /// listening" — an unreadable socket is not a dead one. Only
+    /// `ECONNREFUSED` (a bound path whose server is gone) and `ENOENT` (the
+    /// path vanished under us) license unlinking.
+    private func someoneIsListening(at socketPath: String) async -> Bool {
+        let client = HolderClient(socketPath: socketPath, receiveTimeout: Self.probeTimeout)
+        let answer: Bool
+        do {
+            _ = try await client.describe()
+            answer = true
+        } catch HolderClient.Error.rejected {
+            answer = true
+        } catch HolderClient.Error.cannotConnect(_, let code) {
+            answer = !(code == ECONNREFUSED || code == ENOENT)
+        } catch {
+            // Connected but did not answer, or answered nonsense. Something has
+            // that path open; leave it alone.
+            answer = true
+        }
+        await client.close()
+        return answer
+    }
+
+    /// Bound separately from `bindTimeout`: probing an unknown socket is not
+    /// waiting for our own holder to start, and a stranger that connects but
+    /// never answers must not stretch a spawn by the full startup budget.
+    private static let probeTimeout: Duration = .seconds(2)
+
+    // MARK: - Launching
+
+    private func launchHolder(
+        sessionID: UUID,
+        socketPath: String,
+        stderrPath: String,
+        launch: HolderLaunchRequest,
+        owner: HolderOwnerToken,
+        environment: [String: String],
+        lock: HolderLock
+    ) throws -> Int32 {
+        let payload = try JSONEncoder().encode(launch).base64EncodedString()
+        let arguments = [
+            executableURL.path,
+            "--session", sessionID.uuidString,
+            "--socket", socketPath,
+            "--lock-fd", String(Self.lockDescriptorNumber),
+            "--launch", payload,
+            "--owner", owner.rawValue,
+        ]
+
+        // `</dev/null` and a real file for stdout/stderr, never inherited
+        // descriptors. A holder that inherits the daemon's stdout holds that
+        // pipe open for the whole session's life, so whatever reads it never
+        // sees EOF — measured while driving the binary by hand, where it looked
+        // exactly like a protocol hang. stderr must still go somewhere
+        // retrievable: it is the daemon's only channel for anything that went
+        // wrong before the socket existed.
+        let nullFD = open("/dev/null", O_RDONLY | O_CLOEXEC)
+        let logFD = open(stderrPath, O_WRONLY | O_CREAT | O_APPEND | O_CLOEXEC, 0o600)
+        defer {
+            if nullFD >= 0 { close(nullFD) }
+            if logFD >= 0 { close(logFD) }
+        }
+        guard nullFD >= 0, logFD >= 0 else {
+            throw Error.spawnFailed(executable: executableURL.path, errno: errno)
+        }
+
+        // The lock is relocated above the target number rather than passed
+        // where it sits, because `dup2(fd, fd)` succeeds WITHOUT clearing
+        // `FD_CLOEXEC`: a lock that already occupied the target would be closed
+        // at exec and the holder would refuse to start. `F_DUPFD_CLOEXEC`
+        // guarantees a number above the target in one call, and keeps the
+        // duplicate close-on-exec in *this* process — which is the whole reason
+        // this uses a dup2 file action rather than
+        // `HolderLock.makeInheritableAcrossExec()`. Clearing `FD_CLOEXEC` on
+        // the daemon's own descriptor would expose the lock to every other
+        // concurrent `posix_spawn` in the daemon, and an unrelated child that
+        // inherited it would hold this session UUID unreclaimable until it
+        // died.
+        let lockSource = fcntl(lock.fileDescriptor, F_DUPFD_CLOEXEC, Self.lockDescriptorNumber + 1)
+        guard lockSource >= 0 else {
+            throw Error.spawnFailed(executable: executableURL.path, errno: errno)
+        }
+        defer { close(lockSource) }
+
+        var actions: posix_spawn_file_actions_t?
+        posix_spawn_file_actions_init(&actions)
+        defer { posix_spawn_file_actions_destroy(&actions) }
+        // File actions run IN ORDER, and fd numbers collide. The stdio dup2s
+        // come first and the lock's dup2 last, so that if the log or /dev/null
+        // descriptor happens to land on the target number it has already been
+        // copied to its final home by the time the lock overwrites it. There
+        // are deliberately NO trailing closes: a close scheduled after the
+        // lock's dup2 would destroy the descriptor it just placed.
+        posix_spawn_file_actions_adddup2(&actions, nullFD, 0)
+        posix_spawn_file_actions_adddup2(&actions, logFD, 1)
+        posix_spawn_file_actions_adddup2(&actions, logFD, 2)
+        posix_spawn_file_actions_adddup2(&actions, lockSource, Self.lockDescriptorNumber)
+
+        // Everything the daemon happens to have open without FD_CLOEXEC would
+        // otherwise arrive in a process that outlives it. The four descriptors
+        // above are named in file actions and survive; nothing else does.
+        var attributes: posix_spawnattr_t?
+        posix_spawnattr_init(&attributes)
+        defer { posix_spawnattr_destroy(&attributes) }
+        posix_spawnattr_setflags(&attributes, Int16(POSIX_SPAWN_CLOEXEC_DEFAULT))
+
+        var argv = arguments.map { strdup($0) }
+        argv.append(nil)
+        // Sorted purely so a holder's environment is reproducible in a log or a
+        // crash report; the holder cannot observe the order.
+        let envStrings: [String] = environment.map { "\($0.key)=\($0.value)" }.sorted()
+        var envp = envStrings.map { strdup($0) }
+        envp.append(nil)
+        defer {
+            for entry in argv { free(entry) }
+            for entry in envp { free(entry) }
+        }
+
+        var pid: pid_t = 0
+        let status = posix_spawn(&pid, executableURL.path, &actions, &attributes, &argv, &envp)
+        guard status == 0 else {
+            throw Error.spawnFailed(executable: executableURL.path, errno: status)
+        }
+        return pid
+    }
+
+    // MARK: - Waiting for the rendezvous
+
+    /// Polls until the socket answers a handshake, bounded on the **injected**
+    /// clock.
+    ///
+    /// Elapsed time is accumulated from the poll interval rather than measured
+    /// against a deadline because `any Clock<Duration>` pins `Duration` but not
+    /// `Instant`: instant arithmetic does not typecheck through the
+    /// existential, and a limit expressed as "how much waiting has been spent"
+    /// is what a fake clock can drive.
+    private func awaitBinding(
+        socketPath: String,
+        stderrPath: String
+    ) async throws -> HolderChildDescription {
+        var waited: Duration = .zero
+        while true {
+            let client = HolderClient(socketPath: socketPath, receiveTimeout: .seconds(2))
+            do {
+                let description = try await client.describe()
+                await client.close()
+                return description
+            } catch HolderClient.Error.rejected(let version) {
+                await client.close()
+                throw Error.rejected(version: version)
+            } catch {
+                await client.close()
+            }
+
+            guard waited < bindTimeout else { break }
+            try? await clock.sleep(for: bindPollInterval)
+            waited += bindPollInterval
+        }
+
+        let diagnostics = (try? String(contentsOfFile: stderrPath, encoding: .utf8))
+            .flatMap { $0.isEmpty ? nil : $0 } ?? "<no holder output>"
+        throw Error.holderDidNotBind(socketPath: socketPath, diagnostics: diagnostics)
+    }
+}

--- a/Sources/TBDHolder/Holder.swift
+++ b/Sources/TBDHolder/Holder.swift
@@ -697,7 +697,6 @@ enum HolderStartupError: LocalizedError, Equatable {
     case cannotBind(path: String, errno: Int32)
     case cannotListen(path: String, errno: Int32)
     case forkFailed(errno: Int32)
-    case oversizedFrame(bytes: Int, limit: Int)
 
     /// The process exit code this failure ends the holder with.
     ///
@@ -711,12 +710,6 @@ enum HolderStartupError: LocalizedError, Equatable {
             return HolderExitCode.badInvocation
         case .socketDirectoryUnavailable, .cannotBind, .cannotListen, .forkFailed:
             return HolderExitCode.environmentFailure
-        case .oversizedFrame:
-            // A peer sent a length word larger than the holder will allocate
-            // for. That is neither a bad command line nor a sick machine — it
-            // is a client speaking badly, and the spawner learns nothing
-            // actionable from retrying or from editing its arguments.
-            return HolderExitCode.unexpected
         }
     }
 
@@ -751,8 +744,6 @@ enum HolderStartupError: LocalizedError, Equatable {
                 + "\(String(cString: strerror(errno))) (errno \(errno))"
         case .forkFailed(let errno):
             return "forkpty failed: \(String(cString: strerror(errno))) (errno \(errno))"
-        case .oversizedFrame(let bytes, let limit):
-            return "holder frame claims \(bytes) bytes, over the \(limit)-byte limit"
         }
     }
 }
@@ -786,55 +777,5 @@ struct ExitReportWindow {
     mutating func charging(_ work: () -> Void) {
         let slice = clock.measure(work)
         if isArmed { elapsed += slice }
-    }
-}
-
-// MARK: - Wire framing
-
-/// `[UInt32 little-endian byte count][JSON]`, both directions.
-///
-/// It lives in the holder rather than in `TBDShared` for now because the
-/// holder is the only thing that speaks it; the daemon-side client hoists it
-/// when it lands.
-enum HolderFraming {
-    /// Refuses anything larger than this rather than trusting a length word
-    /// from the wire — a peer that desyncs would otherwise make the holder
-    /// allocate gigabytes on its behalf.
-    static let maximumFrameSize = 1 << 20
-
-    static func frame(_ response: HolderResponse) throws -> Data { try encode(response) }
-    static func frame(_ request: HolderRequest) throws -> Data { try encode(request) }
-
-    private static func encode<Message: Encodable>(_ message: Message) throws -> Data {
-        let payload = try JSONEncoder().encode(message)
-        var length = UInt32(payload.count).littleEndian
-        var framed = Data(bytes: &length, count: MemoryLayout<UInt32>.size)
-        framed.append(payload)
-        return framed
-    }
-
-    /// Pulls every complete frame out of `buffer`, leaving any partial tail
-    /// behind for the next read.
-    static func drain<Message: Decodable>(_ type: Message.Type, from buffer: inout Data) throws -> [Message] {
-        var messages: [Message] = []
-        while true {
-            guard buffer.count >= MemoryLayout<UInt32>.size else { return messages }
-            let header = buffer.prefix(MemoryLayout<UInt32>.size)
-            let length = Int(header.withUnsafeBytes { raw in
-                UInt32(littleEndian: raw.loadUnaligned(as: UInt32.self))
-            })
-            guard length <= maximumFrameSize else {
-                throw HolderStartupError.oversizedFrame(bytes: length, limit: maximumFrameSize)
-            }
-            let total = MemoryLayout<UInt32>.size + length
-            guard buffer.count >= total else { return messages }
-            let payload = buffer.dropFirst(MemoryLayout<UInt32>.size).prefix(length)
-            messages.append(try JSONDecoder().decode(Message.self, from: Data(payload)))
-            buffer = Data(buffer.dropFirst(total))
-        }
-    }
-
-    static func drainRequests(from buffer: inout Data) throws -> [HolderRequest] {
-        try drain(HolderRequest.self, from: &buffer)
     }
 }

--- a/Sources/TBDShared/HolderFraming.swift
+++ b/Sources/TBDShared/HolderFraming.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+public enum HolderFramingError: LocalizedError, Equatable {
+    /// A length word from the wire claimed more bytes than any real frame can
+    /// carry. Refused rather than trusted: a desynced peer would otherwise make
+    /// the reader allocate gigabytes on its behalf.
+    case oversizedFrame(bytes: Int, limit: Int)
+
+    public var errorDescription: String? {
+        switch self {
+        case .oversizedFrame(let bytes, let limit):
+            return "holder frame claims \(bytes) bytes, over the \(limit)-byte limit"
+        }
+    }
+}
+
+/// The holder wire framing: `[UInt32 little-endian byte count][JSON]`, both
+/// directions.
+///
+/// It lives in `TBDShared` because both ends speak it — the holder binary
+/// serving requests and the daemon-side `HolderClient` issuing them. A second
+/// implementation on the daemon side would be two chances to get the length
+/// word's endianness, the size cap, or the partial-frame carry wrong, and a
+/// framing disagreement between two processes shows up as a desync rather than
+/// as an error anybody can read.
+public enum HolderFraming {
+    /// The largest frame either side will decode. Holder descriptions are a few
+    /// hundred bytes; a megabyte is slack for a launch request with a large
+    /// environment, and far below "allocate whatever the peer said".
+    public static let maximumFrameSize = 1 << 20
+
+    public static func frame(_ response: HolderResponse) throws -> Data { try encode(response) }
+    public static func frame(_ request: HolderRequest) throws -> Data { try encode(request) }
+
+    private static func encode<Message: Encodable>(_ message: Message) throws -> Data {
+        let payload = try JSONEncoder().encode(message)
+        var length = UInt32(payload.count).littleEndian
+        var framed = Data(bytes: &length, count: MemoryLayout<UInt32>.size)
+        framed.append(payload)
+        return framed
+    }
+
+    /// Pulls every complete frame out of `buffer`, leaving any partial tail
+    /// behind for the next read.
+    ///
+    /// Returning *every* decoded frame rather than the first is the contract,
+    /// and callers must queue what they do not use immediately: one `recvmsg`
+    /// routinely carries a response and an unsolicited push together, and a
+    /// reader that returns the head and discards the tail then hits EOF on its
+    /// next read and reports a closed peer for a message that did arrive.
+    public static func drain<Message: Decodable>(_ type: Message.Type, from buffer: inout Data) throws -> [Message] {
+        var messages: [Message] = []
+        while true {
+            guard buffer.count >= MemoryLayout<UInt32>.size else { return messages }
+            let header = buffer.prefix(MemoryLayout<UInt32>.size)
+            let length = Int(header.withUnsafeBytes { raw in
+                UInt32(littleEndian: raw.loadUnaligned(as: UInt32.self))
+            })
+            guard length <= maximumFrameSize else {
+                throw HolderFramingError.oversizedFrame(bytes: length, limit: maximumFrameSize)
+            }
+            let total = MemoryLayout<UInt32>.size + length
+            guard buffer.count >= total else { return messages }
+            let payload = buffer.dropFirst(MemoryLayout<UInt32>.size).prefix(length)
+            messages.append(try JSONDecoder().decode(Message.self, from: Data(payload)))
+            buffer = Data(buffer.dropFirst(total))
+        }
+    }
+
+    public static func drainRequests(from buffer: inout Data) throws -> [HolderRequest] {
+        try drain(HolderRequest.self, from: &buffer)
+    }
+
+    public static func drainResponses(from buffer: inout Data) throws -> [HolderResponse] {
+        try drain(HolderResponse.self, from: &buffer)
+    }
+}

--- a/Tests/TBDDaemonTests/Holder/HolderClientTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HolderClientTests.swift
@@ -550,6 +550,80 @@ struct HolderClientTests {
         #expect(pushed?.status == .exited(code: 7))
         await client.close()
     }
+
+    /// The same misattribution, from a push that never reached the queue.
+    ///
+    /// The coalesced case above is only half the hazard, and the easier half: a
+    /// push that shared a read with the answer it trailed is already decoded,
+    /// so draining the queue at send time is enough to retire it. The holder
+    /// does not owe anyone that coincidence. It reaps its child on its own
+    /// schedule, so the push can be written a moment *after* the client read
+    /// its answer — and then it is sitting unread in the socket's receive
+    /// buffer, where the queue cannot see it and where it is indistinguishable,
+    /// on the next read, from that request's answer. Only a barrier that reaches
+    /// the socket catches it.
+    ///
+    /// The ordering is arranged rather than raced, and in both directions,
+    /// because a test that merely *hoped* the writes landed in separate reads
+    /// would be the coalesced test again on a good day: the peer holds the push
+    /// until `handOverPTY` has returned, and the test holds `forget` until the
+    /// push has been written. Nothing reads that socket between those two
+    /// points — `HolderClient` reads only from inside a verb — so the push is
+    /// provably buffered and undecoded when the barrier runs.
+    @Test func drainsAnExitPushStillBufferedInTheSocketBeforeTheNextRequest() async throws {
+        let home = SpawnedHolderFixture.scratchHome()
+        defer { try? FileManager.default.removeItem(atPath: home) }
+        try FileManager.default.createDirectory(atPath: home, withIntermediateDirectories: true)
+        let socketPath = home + "/stub.sock"
+
+        let alive = SpawnedHolderFixture.description(childPID: 4242, home: home)
+        var exited = alive
+        exited.status = .exited(code: 7)
+
+        // Stands in for the pty master, as in the coalesced case: what is under
+        // test is frame attribution, not what the descriptor points at.
+        let carried = open("/dev/null", O_RDWR)
+        try #require(carried >= 0, "could not open a descriptor to hand over")
+        defer { Darwin.close(carried) }
+
+        let gate = ScriptedStubPeer.TrailerGate()
+        let peer = try ScriptedStubPeer(
+            socketPath: socketPath,
+            answers: [
+                ScriptedStubPeer.Answer(
+                    descriptor: carried,
+                    payload: try HolderFraming.frame(HolderResponse.handedOverPTY(alive)),
+                    trailer: try HolderFraming.frame(HolderResponse.described(exited)),
+                    trailerGate: gate),
+                ScriptedStubPeer.Answer(payload: try HolderFraming.frame(HolderResponse.forgotten)),
+            ])
+        defer { peer.tearDown() }
+
+        let client = HolderClient(socketPath: socketPath, receiveTimeout: .seconds(2))
+        let (description, ptyFD) = try await client.handOverPTY()
+        defer { Darwin.close(ptyFD) }
+        #expect(description.status == .alive)
+        #expect(ptyFD >= 0)
+
+        // Nothing has been pushed yet, and that is what separates this test from
+        // the coalesced one: the exit has not been written, so it cannot be in
+        // the queue, and everything observed after this point came off the wire.
+        let beforeTheGate = await client.lastPushedDescription
+        #expect(beforeTheGate == nil, "the stub pushed the exit before the test released it")
+
+        gate.release()
+        try #require(gate.waitUntilWritten(), "the stub peer never wrote its trailing push")
+
+        // The push is now in the kernel's receive buffer, unread. `forget`'s
+        // barrier has to poll the socket to find it; a barrier that only drained
+        // the decoded queue would take this frame as the answer to `forget`.
+        try await client.forget()
+
+        let pushed = await client.lastPushedDescription
+        #expect(pushed?.status == .exited(code: 7))
+        #expect(pushed?.childPID == 4242)
+        await client.close()
+    }
 }
 
 // MARK: - Support
@@ -844,10 +918,59 @@ private final class ScriptedStubPeer: @unchecked Sendable {
     /// between, so the two arrive in the client's single read — the arranged
     /// version of the holder answering and then reporting an exit microseconds
     /// later.
+    ///
+    /// A `trailerGate` inverts that: the peer holds the trailer back until the
+    /// test says the client has finished reading `payload`, so the two frames
+    /// arrive in *different* reads. See `TrailerGate`.
     struct Answer {
         var descriptor: Int32 = -1
         var payload: Data
         var trailer: Data = Data()
+        var trailerGate: TrailerGate?
+    }
+
+    /// A rendezvous between the test and the stub peer's thread, for the case
+    /// where the trailing push must be written **after** the client has already
+    /// read the answer it follows.
+    ///
+    /// Both directions are needed, and a sleep would give neither. `release()`
+    /// tells the peer the client is done reading, so the push cannot be
+    /// coalesced into that read; `waitUntilWritten` tells the test the push has
+    /// reached the socket, so the next verb is guaranteed to find it buffered
+    /// rather than still in flight. Every wait is bounded, and the peer's also
+    /// gives up when the stub is torn down, so a test that fails before
+    /// releasing cannot strand the thread.
+    final class TrailerGate: Sendable {
+        private let released = DispatchSemaphore(value: 0)
+        private let written = DispatchSemaphore(value: 0)
+
+        /// Lets the peer write the trailer.
+        func release() { released.signal() }
+
+        /// Blocks the peer until `release()`, until the stub is torn down, or
+        /// until the budget runs out. Returns whether the trailer may be written.
+        fileprivate func waitForRelease(timeout: TimeInterval, stopped: () -> Bool) -> Bool {
+            let deadline = Date().addingTimeInterval(timeout)
+            while Date() < deadline {
+                if released.wait(timeout: .now() + 0.02) == .success { return true }
+                if stopped() { return false }
+            }
+            return false
+        }
+
+        fileprivate func markWritten() { written.signal() }
+
+        /// Blocks the test until the trailer has been written, or fails.
+        func waitUntilWritten(
+            timeout: TimeInterval = 10.0,
+            sourceLocation: SourceLocation = #_sourceLocation
+        ) -> Bool {
+            if written.wait(timeout: .now() + timeout) == .success { return true }
+            Issue.record(
+                "timed out after \(timeout)s waiting for the stub peer to write its trailing push",
+                sourceLocation: sourceLocation)
+            return false
+        }
     }
 
     private let listenFD: Int32
@@ -880,7 +1003,14 @@ private final class ScriptedStubPeer: @unchecked Sendable {
                     try? FDChannel.sendData(answer.payload, over: incoming)
                 }
                 if !answer.trailer.isEmpty {
-                    try? FDChannel.sendData(answer.trailer, over: incoming)
+                    if let gate = answer.trailerGate {
+                        guard gate.waitForRelease(timeout: 10.0, stopped: { self.isStopped })
+                        else { break }
+                        try? FDChannel.sendData(answer.trailer, over: incoming)
+                        gate.markWritten()
+                    } else {
+                        try? FDChannel.sendData(answer.trailer, over: incoming)
+                    }
                 }
             }
             // Park with the connection open. Closing here would let the client

--- a/Tests/TBDDaemonTests/Holder/HolderClientTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HolderClientTests.swift
@@ -120,6 +120,138 @@ struct HolderClientTests {
         #expect(survivor == Data("not really a socket".utf8))
     }
 
+    /// The other half of the lock's contract, and the branch the held-lock test
+    /// above never reaches: a socket with **no** lock file beside it.
+    ///
+    /// Absence of a lock is not evidence of absence of a holder — `flock` lives
+    /// on the open file description, so a holder whose lock file was swept out
+    /// from under it keeps the lock while the path is free for anyone to
+    /// recreate. A spawner that read "no lock file" as "no holder" would unlink
+    /// a live session's rendezvous. The probe is what stops it.
+    @Test func refusesToClearASocketAnAliveHolderStillAnswers() async throws {
+        let fixture = try await SpawnedHolderFixture.start(command: "sleep 30")
+        defer { fixture.tearDown() }
+        let environment = SpawnedHolderFixture.environment(home: fixture.home)
+        let lockPath = try HolderRendezvous.lockPath(
+            sessionID: fixture.sessionID, environment: environment)
+
+        // Sweep the lock file. The live holder keeps its lock; the path is now
+        // free, so the next spawner takes a *different* one and learns nothing
+        // from having got it.
+        try FileManager.default.removeItem(atPath: lockPath)
+
+        let spawner = try SpawnedHolderFixture.makeSpawner()
+        var thrown: Swift.Error?
+        do {
+            _ = try await spawner.spawn(
+                sessionID: fixture.sessionID,
+                launch: SpawnedHolderFixture.launch(command: "sleep 30", home: fixture.home),
+                owner: fixture.owner,
+                environment: environment)
+        } catch {
+            thrown = error
+        }
+
+        guard case .lockHeldByLiveHolder? = thrown as? HolderSpawner.Error else {
+            Issue.record("expected .lockHeldByLiveHolder, got \(String(describing: thrown))")
+            return
+        }
+        #expect(FileManager.default.fileExists(atPath: fixture.handle.socketPath))
+        #expect(processIsAlive(fixture.handle.holderPID))
+
+        // The assertion that matters: the session the probe protected is still
+        // usable, not merely still on disk.
+        let client = HolderClient(socketPath: fixture.handle.socketPath, receiveTimeout: .seconds(5))
+        let description = try await client.describe()
+        await client.close()
+        #expect(description.childPID == fixture.handle.childPID)
+        #expect(description.status == .alive)
+    }
+
+    /// The branch that *does* license clearing: a bound path whose server is
+    /// gone answers `ECONNREFUSED`, and nothing is left to protect.
+    ///
+    /// The holder that gets launched here never binds, so the spawn fails — and
+    /// that is what makes the assertion direct. A real holder unlinks the path
+    /// itself before binding, which would leave "the socket is gone" true no
+    /// matter what the spawner decided.
+    @Test func clearsASocketWhoseListenerIsGone() async throws {
+        let home = SpawnedHolderFixture.scratchHome()
+        defer { try? FileManager.default.removeItem(atPath: home) }
+        let environment = SpawnedHolderFixture.environment(home: home)
+        try FileManager.default.createDirectory(
+            atPath: TBDConstants.holdersDir(environment: environment).path,
+            withIntermediateDirectories: true)
+
+        let session = UUID()
+        let socketPath = try HolderRendezvous.socketPath(sessionID: session, environment: environment)
+        // Bind, listen, close: the socket file survives its server, which is
+        // exactly what a SIGKILLed holder leaves behind.
+        Darwin.close(try bindUnixListener(at: socketPath, backlog: 4))
+        try #require(FileManager.default.fileExists(atPath: socketPath))
+
+        let spawner = HolderSpawner(
+            executableURL: try SpawnedHolderFixture.writeNeverBindingHolder(into: home),
+            bindTimeout: .milliseconds(200),
+            bindPollInterval: .milliseconds(20),
+            handshakeTimeout: .milliseconds(50))
+        var thrown: Swift.Error?
+        do {
+            _ = try await spawner.spawn(
+                sessionID: session,
+                launch: SpawnedHolderFixture.launch(command: "sleep 30", home: home),
+                owner: HolderOwnerToken(rawValue: "acme-installation"),
+                environment: environment)
+        } catch {
+            thrown = error
+        }
+
+        guard case .holderDidNotBind? = thrown as? HolderSpawner.Error else {
+            Issue.record("expected .holderDidNotBind, got \(String(describing: thrown))")
+            return
+        }
+        #expect(!FileManager.default.fileExists(atPath: socketPath))
+    }
+
+    /// Every other errno must NOT license clearing: an unreadable socket is not
+    /// a dead one.
+    ///
+    /// A regular file at the rendezvous path answers `connect` with `ENOTSOCK`,
+    /// which is neither of the two answers that mean "nothing is listening". A
+    /// spawner that treated any failed connect as permission to unlink would
+    /// destroy whatever that path really is.
+    @Test func refusesToClearAPathThatIsNotASocket() async throws {
+        let home = SpawnedHolderFixture.scratchHome()
+        defer { try? FileManager.default.removeItem(atPath: home) }
+        let environment = SpawnedHolderFixture.environment(home: home)
+        try FileManager.default.createDirectory(
+            atPath: TBDConstants.holdersDir(environment: environment).path,
+            withIntermediateDirectories: true)
+
+        let session = UUID()
+        let socketPath = try HolderRendezvous.socketPath(sessionID: session, environment: environment)
+        let contents = Data("not really a socket".utf8)
+        try contents.write(to: URL(fileURLWithPath: socketPath))
+
+        let spawner = try SpawnedHolderFixture.makeSpawner()
+        var thrown: Swift.Error?
+        do {
+            _ = try await spawner.spawn(
+                sessionID: session,
+                launch: SpawnedHolderFixture.launch(command: "sleep 30", home: home),
+                owner: HolderOwnerToken(rawValue: "acme-installation"),
+                environment: environment)
+        } catch {
+            thrown = error
+        }
+
+        guard case .lockHeldByLiveHolder? = thrown as? HolderSpawner.Error else {
+            Issue.record("expected .lockHeldByLiveHolder, got \(String(describing: thrown))")
+            return
+        }
+        #expect((try? Data(contentsOf: URL(fileURLWithPath: socketPath))) == contents)
+    }
+
     // MARK: - Forget
 
     @Test func forgetStopsReporting() async throws {
@@ -204,6 +336,114 @@ struct HolderClientTests {
         }
     }
 
+    /// A holder that never created its socket is killed, and that is the *only*
+    /// state in which killing is licensed.
+    ///
+    /// `Holder.run()` binds and listens before it `forkpty`s and only ever
+    /// `accept`s from inside `serve()`, after the fork — so an absent socket is
+    /// proof no job exists to orphan. Leaving such a holder alive would be the
+    /// real hazard: it holds the creation lock, and this session UUID could
+    /// then never be spawned or reclaimed again.
+    ///
+    /// The fake holder stays alive on purpose. A stand-in that exited by itself
+    /// would leave the same "process is gone" observation whether the spawner
+    /// killed it or not.
+    @Test func killsAHolderThatNeverCreatedItsSocket() async throws {
+        let home = SpawnedHolderFixture.scratchHome()
+        defer { try? FileManager.default.removeItem(atPath: home) }
+        let environment = SpawnedHolderFixture.environment(home: home)
+
+        let spawner = HolderSpawner(
+            executableURL: try SpawnedHolderFixture.writeNeverBindingHolder(into: home),
+            bindTimeout: .milliseconds(200),
+            bindPollInterval: .milliseconds(20),
+            handshakeTimeout: .milliseconds(50))
+        var thrown: Swift.Error?
+        do {
+            _ = try await spawner.spawn(
+                sessionID: UUID(),
+                launch: SpawnedHolderFixture.launch(command: "sleep 30", home: home),
+                owner: HolderOwnerToken(rawValue: "acme-installation"),
+                environment: environment)
+        } catch {
+            thrown = error
+        }
+
+        guard case .holderDidNotBind(let holderPID, _, _)? = thrown as? HolderSpawner.Error else {
+            Issue.record("expected .holderDidNotBind, got \(String(describing: thrown))")
+            return
+        }
+        // Reaped as well as killed, so nothing is signallable: the holder is
+        // the spawner's own child, and an unreaped corpse answers `kill(pid, 0)`
+        // exactly like a live process.
+        defer { reapIfAlive(holderPID) }
+        #expect(holderPID > 0)
+        #expect(!processIsAlive(holderPID))
+    }
+
+    /// A holder that DID create its socket must survive the failed spawn.
+    ///
+    /// Binding happens before `forkpty`, so a holder that got this far may
+    /// already be supervising a job — and the loaded machine that made it miss
+    /// the budget is exactly when that is most likely. Milestone A has no
+    /// holder reconciler, so a blind kill here orphans that job permanently and
+    /// erases the only evidence of it. The spawn still fails; what it must
+    /// carry is enough to find what it left behind.
+    ///
+    /// The state is built the way it really occurs rather than by racing a real
+    /// holder into wedging: a listener that accepts and never answers, and a
+    /// stand-in process that stays alive. The unheld lock file is what steers
+    /// `spawn` past the probe-and-unlink branch so the listener is still there
+    /// when the holder is launched.
+    @Test func leavesAHolderThatBoundButNeverAnsweredAlive() async throws {
+        let home = SpawnedHolderFixture.scratchHome()
+        defer { try? FileManager.default.removeItem(atPath: home) }
+        let environment = SpawnedHolderFixture.environment(home: home)
+        try FileManager.default.createDirectory(
+            atPath: TBDConstants.holdersDir(environment: environment).path,
+            withIntermediateDirectories: true)
+
+        let session = UUID()
+        let socketPath = try HolderRendezvous.socketPath(sessionID: session, environment: environment)
+        let lockPath = try HolderRendezvous.lockPath(sessionID: session, environment: environment)
+        try HolderLock.acquire(path: lockPath).release()
+
+        // Bound and listening, never accepting: connects succeed from the
+        // backlog and no request is ever answered.
+        let listener = try bindUnixListener(at: socketPath, backlog: 64)
+        defer {
+            Darwin.close(listener)
+            unlink(socketPath)
+        }
+
+        let spawner = HolderSpawner(
+            executableURL: try SpawnedHolderFixture.writeNeverBindingHolder(into: home),
+            bindTimeout: .milliseconds(200),
+            bindPollInterval: .milliseconds(20),
+            handshakeTimeout: .milliseconds(50))
+        var thrown: Swift.Error?
+        do {
+            _ = try await spawner.spawn(
+                sessionID: session,
+                launch: SpawnedHolderFixture.launch(command: "sleep 30", home: home),
+                owner: HolderOwnerToken(rawValue: "acme-installation"),
+                environment: environment)
+        } catch {
+            thrown = error
+        }
+
+        guard case .holderBoundButUnresponsive(let holderPID, let reportedSocket, _)?
+            = thrown as? HolderSpawner.Error else {
+            Issue.record("expected .holderBoundButUnresponsive, got \(String(describing: thrown))")
+            return
+        }
+        // This test owns the process now — nothing in the daemon reaps it.
+        defer { reapIfAlive(holderPID) }
+        #expect(holderPID > 0)
+        #expect(reportedSocket == socketPath)
+        #expect(processIsAlive(holderPID), "the spawner killed a holder that may have owned a job")
+    }
+
     // MARK: - The pending-message queue
 
     /// One `recvmsg` routinely carries a response and the holder's unsolicited
@@ -218,21 +458,17 @@ struct HolderClientTests {
     ///
     /// The peer here is a stub rather than a real holder precisely so the
     /// coalescing is *arranged* instead of raced: it writes both frames in a
-    /// single `write` and then answers nothing else ever. With the queue the
-    /// second read is served from memory; without it, it waits for a reply that
-    /// will never come and dies on the receive timeout.
-    @Test func queuesAResponseAndAnExitPushDeliveredInOneRead() async throws {
+    /// single `write` and then answers nothing else ever. The push is nobody's
+    /// answer — it is retired and surfaced as `lastPushedDescription` — but a
+    /// client that decoded only the first frame and discarded the rest of the
+    /// read would have lost the exit entirely.
+    @Test func keepsAnExitPushCoalescedWithAnAnswerInsteadOfLosingIt() async throws {
         let home = SpawnedHolderFixture.scratchHome()
         defer { try? FileManager.default.removeItem(atPath: home) }
         try FileManager.default.createDirectory(atPath: home, withIntermediateDirectories: true)
         let socketPath = home + "/stub.sock"
 
-        let alive = HolderChildDescription(
-            childPID: 4242,
-            ttyName: "/dev/ttys004",
-            status: .alive,
-            launch: SpawnedHolderFixture.launch(command: "sleep 30", home: home),
-            owner: HolderOwnerToken(rawValue: "acme-installation"))
+        let alive = SpawnedHolderFixture.description(childPID: 4242, home: home)
         var exited = alive
         exited.status = .exited(code: 7)
 
@@ -240,18 +476,78 @@ struct HolderClientTests {
         coalesced += try HolderFraming.frame(HolderResponse.described(alive))
         coalesced += try HolderFraming.frame(HolderResponse.described(exited))
 
-        let peer = try CoalescingStubPeer(socketPath: socketPath, singleWrite: coalesced)
+        let peer = try ScriptedStubPeer(
+            socketPath: socketPath,
+            answers: [ScriptedStubPeer.Answer(payload: coalesced)])
         defer { peer.tearDown() }
 
         let client = HolderClient(socketPath: socketPath, receiveTimeout: .seconds(2))
         let first = try await client.describe()
         #expect(first.status == .alive)
+        #expect(first.childPID == 4242)
 
-        // The discriminating half. The stub has stopped writing, so this can
-        // only be answered from the queue.
-        let second = try await client.describe()
-        #expect(second.status == .exited(code: 7))
-        #expect(second.childPID == 4242)
+        // The discriminating half: the second frame arrived in the same read
+        // and the stub has stopped writing, so anything known about the exit
+        // now can only have come from that read.
+        await client.close()
+        let pushed = await client.lastPushedDescription
+        #expect(pushed?.status == .exited(code: 7))
+        #expect(pushed?.childPID == 4242)
+    }
+
+    /// The coalesced push must not become the **next** verb's answer.
+    ///
+    /// Mixing verbs across the push is what makes this visible: two `describe`s
+    /// cannot, because `describe` accepts either frame shape and a stale
+    /// `.described` therefore looks exactly like a correct reply. A hand-over
+    /// followed by a `forget` cannot hide it — a queue served first-in-first-out
+    /// answers the `forget` with the hand-over's trailing exit push, so the call
+    /// throws `unexpectedResponse` for a verb the holder performed correctly,
+    /// the real `.forgotten` is left on the wire for whatever asks next, and the
+    /// connection never resynchronises.
+    @Test func doesNotAnswerForgetWithTheHandOversCoalescedExitPush() async throws {
+        let home = SpawnedHolderFixture.scratchHome()
+        defer { try? FileManager.default.removeItem(atPath: home) }
+        try FileManager.default.createDirectory(atPath: home, withIntermediateDirectories: true)
+        let socketPath = home + "/stub.sock"
+
+        let alive = SpawnedHolderFixture.description(childPID: 4242, home: home)
+        var exited = alive
+        exited.status = .exited(code: 7)
+
+        // Stands in for the pty master. Any descriptor will do: what is under
+        // test is which frame the client attributes to which request, not what
+        // the transferred fd points at.
+        let carried = open("/dev/null", O_RDWR)
+        try #require(carried >= 0, "could not open a descriptor to hand over")
+        defer { Darwin.close(carried) }
+
+        let peer = try ScriptedStubPeer(
+            socketPath: socketPath,
+            answers: [
+                // The hand-over's answer, with the exit push written straight
+                // after it so both land in one read.
+                ScriptedStubPeer.Answer(
+                    descriptor: carried,
+                    payload: try HolderFraming.frame(HolderResponse.handedOverPTY(alive)),
+                    trailer: try HolderFraming.frame(HolderResponse.described(exited))),
+                ScriptedStubPeer.Answer(payload: try HolderFraming.frame(HolderResponse.forgotten)),
+            ])
+        defer { peer.tearDown() }
+
+        let client = HolderClient(socketPath: socketPath, receiveTimeout: .seconds(2))
+        let (description, ptyFD) = try await client.handOverPTY()
+        defer { Darwin.close(ptyFD) }
+        #expect(description.status == .alive)
+        #expect(ptyFD >= 0)
+
+        // The assertion: `forget` is answered by the holder's `.forgotten`, not
+        // by the exit push the hand-over left behind.
+        try await client.forget()
+
+        // And the push is not simply thrown away to achieve that.
+        let pushed = await client.lastPushedDescription
+        #expect(pushed?.status == .exited(code: 7))
         await client.close()
     }
 }
@@ -307,6 +603,61 @@ private func processIsAlive(_ pid: Int32) -> Bool {
     pid > 0 && kill(pid, 0) == 0
 }
 
+/// Kills and reaps a spawned holder a test is finished with.
+///
+/// Safe to call on one the spawner already reaped: `waitpid` simply reports
+/// there is no such child. A test that leaves a holder running leaks a `sleep`
+/// with it, because holder death is not child death.
+private func reapIfAlive(_ pid: Int32) {
+    guard pid > 0 else { return }
+    kill(pid, SIGKILL)
+    var ignored: Int32 = 0
+    _ = waitpid(pid, &ignored, 0)
+}
+
+/// Binds and listens on a Unix socket at `socketPath`, returning the listening
+/// descriptor. Nothing accepts on it: a connect lands in the backlog and is
+/// never answered, which is what a holder that reached `bind` and then wedged
+/// looks like from the outside.
+private func bindUnixListener(
+    at socketPath: String,
+    backlog: Int32,
+    sourceLocation: SourceLocation = #_sourceLocation
+) throws -> Int32 {
+    let listenFD = socket(AF_UNIX, SOCK_STREAM, 0)
+    try #require(listenFD >= 0, "could not create a listening socket", sourceLocation: sourceLocation)
+
+    var address = sockaddr_un()
+    address.sun_family = sa_family_t(AF_UNIX)
+    let sunPathSize = MemoryLayout.size(ofValue: address.sun_path)
+    socketPath.withCString { source in
+        withUnsafeMutablePointer(to: &address.sun_path) { destination in
+            destination.withMemoryRebound(to: CChar.self, capacity: sunPathSize) { chars in
+                _ = strlcpy(chars, source, sunPathSize)
+            }
+        }
+    }
+    unlink(socketPath)
+    let bound = withUnsafePointer(to: &address) { addressPtr in
+        addressPtr.withMemoryRebound(to: sockaddr.self, capacity: 1) { generic in
+            Darwin.bind(listenFD, generic, socklen_t(MemoryLayout<sockaddr_un>.size))
+        }
+    }
+    guard bound == 0, listen(listenFD, backlog) == 0 else {
+        let saved = errno
+        Darwin.close(listenFD)
+        Issue.record(
+            "could not listen at \(socketPath) (errno \(saved))", sourceLocation: sourceLocation)
+        throw HolderTestSetupFailure()
+    }
+    return listenFD
+}
+
+/// Thrown when a test's own scaffolding could not be built. Never an assertion
+/// about the code under test — the `Issue` was already recorded where it was
+/// discovered.
+private struct HolderTestSetupFailure: Swift.Error {}
+
 /// Takes whatever is queued on a handed-over pty master, without blocking.
 ///
 /// **A test that holds the master must drain it, or the job cannot finish
@@ -358,6 +709,32 @@ private final class SpawnedHolderFixture {
             environment: ["PATH": "/usr/bin:/bin", "TERM": "xterm-256color"],
             columns: 80,
             rows: 24)
+    }
+
+    /// A description shaped like one a holder would send, for tests that drive
+    /// the client against a stub instead of a real holder.
+    static func description(childPID: Int32, home: String) -> HolderChildDescription {
+        HolderChildDescription(
+            childPID: childPID,
+            ttyName: "/dev/ttys004",
+            status: .alive,
+            launch: launch(command: "sleep 30", home: home),
+            owner: HolderOwnerToken(rawValue: "acme-installation"))
+    }
+
+    /// An executable that stands in for a holder which never reaches `bind`.
+    ///
+    /// It ignores the arguments the spawner passes — a real holder's flags mean
+    /// nothing to it — and stays alive until something kills it, so "the
+    /// process is gone" can only be the spawner's doing. `exec` rather than a
+    /// plain command so the pid the spawner holds is the pid that sleeps.
+    static func writeNeverBindingHolder(into home: String) throws -> URL {
+        try FileManager.default.createDirectory(atPath: home, withIntermediateDirectories: true)
+        let url = URL(fileURLWithPath: home + "/never-binding-holder")
+        try "#!/bin/sh\nexec sleep 30\n".write(to: url, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755], ofItemAtPath: url.path)
+        return url
     }
 
     static func locateExecutable() -> URL? {
@@ -453,43 +830,35 @@ private final class SpawnedHolderFixture {
     }
 }
 
-/// A stub peer that writes a prepared byte string in exactly one `write` on its
-/// first read, and then answers nothing ever again.
+/// A stub peer that answers each request the client sends from a fixed script,
+/// and then answers nothing ever again.
 ///
-/// Deliberately not a holder: the property under test is what the *client* does
-/// when two frames land in one read, and racing a real holder into coalescing
-/// them would make the test load-dependent — which is precisely the failure
-/// mode being closed.
-private final class CoalescingStubPeer: @unchecked Sendable {
+/// Deliberately not a holder: what is under test is which frame the *client*
+/// attributes to which request when two of them land in one read, and racing a
+/// real holder into coalescing them would make the test load-dependent — which
+/// is precisely the failure mode being closed.
+private final class ScriptedStubPeer: @unchecked Sendable {
+    /// One scripted reply, sent when a request arrives.
+    ///
+    /// `trailer` is written immediately after `payload` and with no request in
+    /// between, so the two arrive in the client's single read — the arranged
+    /// version of the holder answering and then reporting an exit microseconds
+    /// later.
+    struct Answer {
+        var descriptor: Int32 = -1
+        var payload: Data
+        var trailer: Data = Data()
+    }
+
     private let listenFD: Int32
     private let socketPath: String
     private let lock = NSLock()
     private var connectionFD: Int32 = -1
     private var stopped = false
 
-    init(socketPath: String, singleWrite: Data) throws {
+    init(socketPath: String, answers: [Answer]) throws {
         self.socketPath = socketPath
-        listenFD = socket(AF_UNIX, SOCK_STREAM, 0)
-        try #require(listenFD >= 0, "could not create the stub peer's socket")
-
-        var address = sockaddr_un()
-        address.sun_family = sa_family_t(AF_UNIX)
-        let sunPathSize = MemoryLayout.size(ofValue: address.sun_path)
-        socketPath.withCString { source in
-            withUnsafeMutablePointer(to: &address.sun_path) { destination in
-                destination.withMemoryRebound(to: CChar.self, capacity: sunPathSize) { chars in
-                    _ = strlcpy(chars, source, sunPathSize)
-                }
-            }
-        }
-        unlink(socketPath)
-        let bound = withUnsafePointer(to: &address) { addressPtr in
-            addressPtr.withMemoryRebound(to: sockaddr.self, capacity: 1) { generic in
-                Darwin.bind(listenFD, generic, socklen_t(MemoryLayout<sockaddr_un>.size))
-            }
-        }
-        try #require(bound == 0, "could not bind the stub peer at \(socketPath) (errno \(errno))")
-        try #require(listen(listenFD, 4) == 0, "could not listen on the stub peer's socket")
+        listenFD = try bindUnixListener(at: socketPath, backlog: 4)
 
         let listener = listenFD
         let thread = Thread { [weak self] in
@@ -500,11 +869,19 @@ private final class CoalescingStubPeer: @unchecked Sendable {
             }
             self.adopt(incoming)
             var scratch = [UInt8](repeating: 0, count: 256)
-            // Wait for the client's first request, so the two frames are a
-            // reply rather than an unsolicited greeting.
-            _ = read(incoming, &scratch, scratch.count)
-            _ = singleWrite.withUnsafeBytes { raw in
-                Darwin.write(incoming, raw.baseAddress, raw.count)
+            for answer in answers {
+                // Wait for the request this answers, so every frame written is
+                // a reply rather than an unsolicited greeting.
+                guard read(incoming, &scratch, scratch.count) > 0 else { break }
+                if answer.descriptor >= 0 {
+                    try? FDChannel.sendFDMinimal(
+                        answer.descriptor, over: incoming, payload: answer.payload)
+                } else {
+                    try? FDChannel.sendData(answer.payload, over: incoming)
+                }
+                if !answer.trailer.isEmpty {
+                    try? FDChannel.sendData(answer.trailer, over: incoming)
+                }
             }
             // Park with the connection open. Closing here would let the client
             // reach EOF, which is the very thing the queue is meant to make

--- a/Tests/TBDDaemonTests/Holder/HolderClientTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HolderClientTests.swift
@@ -1,0 +1,540 @@
+import Clocks
+import Darwin
+import Foundation
+import TestSupport
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// The daemon-side half of the holder rendezvous, driven against real holder
+/// processes spawned through the real `HolderSpawner`.
+///
+/// Four rules shape the suite, each one a bug it would otherwise ship:
+///
+///   1. **Every wait is a bounded poll.** A holder that wedges must fail a test
+///      with a named diagnostic, not hang the suite with no output.
+///   2. **Every bootstrap is rc-free.** `/bin/sh` with an explicit environment,
+///      never a login shell — a developer's profile must not decide whether a
+///      test passes.
+///   3. **Every test kills its holder AND its job.** Holder death is
+///      deliberately not child death, so a test that terminates a holder
+///      orphans a `sleep` that no reconciler covers yet.
+///   4. **No `setenv`.** The rendezvous paths come from an explicit environment
+///      dictionary handed to `spawn`, so nothing here can reach the developer's
+///      real `~/tbd` even for an instant.
+@Suite(.serialized)
+struct HolderClientTests {
+
+    // MARK: - Spawning
+
+    @Test func spawnsAHolderAndDescribesItsChild() async throws {
+        let fixture = try await SpawnedHolderFixture.start(command: "sleep 30")
+        defer { fixture.tearDown() }
+
+        #expect(fixture.handle.childPID > 0)
+        #expect(fixture.handle.holderPID > 0)
+        #expect(processIsAlive(fixture.handle.childPID))
+        #expect(processIsAlive(fixture.handle.holderPID))
+
+        // The spawner closes its handshake connection, so the holder's single
+        // client slot is free for a fresh one — which is what every later
+        // daemon-side consumer relies on.
+        let client = HolderClient(socketPath: fixture.handle.socketPath, receiveTimeout: .seconds(5))
+        let description = try await client.describe()
+        await client.close()
+        #expect(description.childPID == fixture.handle.childPID)
+        #expect(description.status == .alive)
+        #expect(description.ttyName.hasPrefix("/dev/"))
+        // `--owner` is passed through as given: it names the installation, not
+        // the process, so a restarted daemon still recognises its own holders.
+        #expect(description.owner == fixture.owner)
+    }
+
+    @Test func handsOverAReadablePTY() async throws {
+        let fixture = try await SpawnedHolderFixture.start(command: "printf HOLDER-OK; sleep 30")
+        defer { fixture.tearDown() }
+
+        let client = HolderClient(socketPath: fixture.handle.socketPath, receiveTimeout: .seconds(5))
+        let (description, ptyFD) = try await client.handOverPTY()
+        defer { Darwin.close(ptyFD) }
+        await client.close()
+        #expect(description.childPID == fixture.handle.childPID)
+        #expect(ptyFD >= 0)
+
+        var seen = Data()
+        let sawMarker = waitUntilTrue("the job's output on the handed-over pty") {
+            drainPTYInto(ptyFD, &seen)
+            return String(decoding: seen, as: UTF8.self).contains("HOLDER-OK")
+        }
+        #expect(sawMarker, "read \(seen.count) bytes: \(String(decoding: seen, as: UTF8.self).debugDescription)")
+    }
+
+    // MARK: - The creation lock
+
+    /// The regression test for the exact hazard the lock exists to prevent.
+    ///
+    /// A socket file cannot distinguish a live holder from the corpse of a
+    /// SIGKILLed one, so "unlink the stale socket, then bind" is a race two
+    /// spawners can both win. A spawner that cannot take the lock has already
+    /// learned a live holder owns this UUID and must touch nothing.
+    @Test func refusesToClearASocketWhoseLockIsHeld() async throws {
+        let home = SpawnedHolderFixture.scratchHome()
+        defer { try? FileManager.default.removeItem(atPath: home) }
+        let environment = SpawnedHolderFixture.environment(home: home)
+        try FileManager.default.createDirectory(
+            atPath: TBDConstants.holdersDir(environment: environment).path,
+            withIntermediateDirectories: true)
+
+        let session = UUID()
+        let socketPath = try HolderRendezvous.socketPath(sessionID: session, environment: environment)
+        let lockPath = try HolderRendezvous.lockPath(sessionID: session, environment: environment)
+
+        // Stand in for a live holder's bound socket. What matters to the
+        // assertion is only that *something* occupies the path.
+        try Data("not really a socket".utf8).write(to: URL(fileURLWithPath: socketPath))
+
+        let lock = try HolderLock.acquire(path: lockPath)
+        defer { lock.release() }
+
+        let spawner = try SpawnedHolderFixture.makeSpawner()
+        var thrown: Swift.Error?
+        do {
+            _ = try await spawner.spawn(
+                sessionID: session,
+                launch: SpawnedHolderFixture.launch(command: "sleep 30", home: home),
+                owner: HolderOwnerToken(rawValue: "acme-installation"),
+                environment: environment)
+        } catch {
+            thrown = error
+        }
+
+        guard case .lockHeldByLiveHolder(let reported, _)? = thrown as? HolderSpawner.Error else {
+            Issue.record("expected .lockHeldByLiveHolder, got \(String(describing: thrown))")
+            return
+        }
+        #expect(reported == session)
+        // The other half of the assertion, and the one that actually guards the
+        // hazard: the pre-existing socket is still there, byte for byte.
+        #expect(FileManager.default.fileExists(atPath: socketPath))
+        let survivor = try? Data(contentsOf: URL(fileURLWithPath: socketPath))
+        #expect(survivor == Data("not really a socket".utf8))
+    }
+
+    // MARK: - Forget
+
+    @Test func forgetStopsReporting() async throws {
+        let fixture = try await SpawnedHolderFixture.start(command: "sleep 30")
+        defer { fixture.tearDown() }
+        let childPID = fixture.handle.childPID
+
+        let client = HolderClient(socketPath: fixture.handle.socketPath, receiveTimeout: .seconds(5))
+        try await client.forget()
+        await client.close()
+
+        // A forgotten holder has nothing left to say, so it drops its pty and
+        // exits, unlinking the socket on the way out.
+        //
+        // Exit is observed by reaping rather than by `kill(pid, 0)`: the holder
+        // is this process's own child, so until somebody waits on it, it is a
+        // zombie — and a zombie answers signal-zero exactly like a live process.
+        #expect(fixture.reapHolder(), "the forgotten holder never exited")
+        #expect(waitUntilTrue("the holder socket to be unlinked") {
+            !FileManager.default.fileExists(atPath: fixture.handle.socketPath)
+        })
+
+        let reconnect = HolderClient(socketPath: fixture.handle.socketPath, receiveTimeout: .seconds(1))
+        await #expect(throws: HolderClient.Error.self) {
+            _ = try await reconnect.describe()
+        }
+        await reconnect.close()
+
+        // And the job can be killed without anything resurrecting it — the
+        // whole point of `forget` (iTerm2's preemptive wait, adopted for the
+        // same reason).
+        kill(childPID, SIGKILL)
+        #expect(waitUntilTrue("the forgotten job to die") { !processIsAlive(childPID) })
+    }
+
+    // MARK: - The bind budget
+
+    /// Proves the budget runs on the **injected** clock: the fake executable
+    /// exits before it could bind anything, and the spawn only gives up once
+    /// virtual time is advanced past `bindTimeout`. On wall time this test
+    /// would take 200 ms of real waiting; on a `TestClock` it takes none, and a
+    /// spawner that consulted `ContinuousClock` instead could not pass inside
+    /// the helper's own real-time guard.
+    @Test func spawnTimesOutIfTheHolderNeverBinds() async throws {
+        let home = SpawnedHolderFixture.scratchHome()
+        defer { try? FileManager.default.removeItem(atPath: home) }
+        let environment = SpawnedHolderFixture.environment(home: home)
+
+        let clock = TestClock<Duration>()
+        let spawner = HolderSpawner(
+            // Exits immediately and binds nothing. `/usr/bin/true` rather than a
+            // written script so nothing about the fixture's own file creation
+            // can be what the test measures.
+            executableURL: URL(fileURLWithPath: "/usr/bin/true"),
+            bindTimeout: .milliseconds(200),
+            bindPollInterval: .milliseconds(20),
+            clock: clock)
+
+        let outcome = ResultBox()
+        let task = Task {
+            do {
+                _ = try await spawner.spawn(
+                    sessionID: UUID(),
+                    launch: SpawnedHolderFixture.launch(command: "sleep 30", home: home),
+                    owner: HolderOwnerToken(rawValue: "acme-installation"),
+                    environment: environment)
+                outcome.finish(nil)
+            } catch {
+                outcome.finish(error)
+            }
+        }
+
+        let ranOut = await clock.advanceUntil("the bind budget to run out", by: .milliseconds(20)) {
+            outcome.isFinished
+        }
+        #expect(ranOut)
+        await task.value
+
+        guard case .holderDidNotBind? = outcome.error as? HolderSpawner.Error else {
+            Issue.record("expected .holderDidNotBind, got \(String(describing: outcome.error))")
+            return
+        }
+    }
+
+    // MARK: - The pending-message queue
+
+    /// One `recvmsg` routinely carries a response and the holder's unsolicited
+    /// exit push together — the holder answers a request and reports a status
+    /// microseconds apart, and the kernel coalesces them.
+    ///
+    /// A client that returned the first frame and dropped the tail would then
+    /// have to read again for a message it had already been handed, and since a
+    /// holder closes right after reporting an exit that read is an EOF: the
+    /// caller gets "the peer closed" for a report that did arrive. That was a
+    /// real load-dependent flake in the holder's own harness.
+    ///
+    /// The peer here is a stub rather than a real holder precisely so the
+    /// coalescing is *arranged* instead of raced: it writes both frames in a
+    /// single `write` and then answers nothing else ever. With the queue the
+    /// second read is served from memory; without it, it waits for a reply that
+    /// will never come and dies on the receive timeout.
+    @Test func queuesAResponseAndAnExitPushDeliveredInOneRead() async throws {
+        let home = SpawnedHolderFixture.scratchHome()
+        defer { try? FileManager.default.removeItem(atPath: home) }
+        try FileManager.default.createDirectory(atPath: home, withIntermediateDirectories: true)
+        let socketPath = home + "/stub.sock"
+
+        let alive = HolderChildDescription(
+            childPID: 4242,
+            ttyName: "/dev/ttys004",
+            status: .alive,
+            launch: SpawnedHolderFixture.launch(command: "sleep 30", home: home),
+            owner: HolderOwnerToken(rawValue: "acme-installation"))
+        var exited = alive
+        exited.status = .exited(code: 7)
+
+        var coalesced = Data()
+        coalesced += try HolderFraming.frame(HolderResponse.described(alive))
+        coalesced += try HolderFraming.frame(HolderResponse.described(exited))
+
+        let peer = try CoalescingStubPeer(socketPath: socketPath, singleWrite: coalesced)
+        defer { peer.tearDown() }
+
+        let client = HolderClient(socketPath: socketPath, receiveTimeout: .seconds(2))
+        let first = try await client.describe()
+        #expect(first.status == .alive)
+
+        // The discriminating half. The stub has stopped writing, so this can
+        // only be answered from the queue.
+        let second = try await client.describe()
+        #expect(second.status == .exited(code: 7))
+        #expect(second.childPID == 4242)
+        await client.close()
+    }
+}
+
+// MARK: - Support
+
+/// Collects an async task's outcome for a test that has to drive a clock while
+/// the task runs. A class with a lock rather than an actor so the clock-driving
+/// loop can check it without awaiting a possibly-blocked actor.
+private final class ResultBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var finished = false
+    private var thrown: Swift.Error?
+
+    func finish(_ error: Swift.Error?) {
+        lock.lock()
+        defer { lock.unlock() }
+        finished = true
+        thrown = error
+    }
+
+    var isFinished: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return finished
+    }
+
+    var error: Swift.Error? {
+        lock.lock()
+        defer { lock.unlock() }
+        return thrown
+    }
+}
+
+/// Poll until `condition` holds or the deadline passes.
+@discardableResult
+private func waitUntilTrue(
+    _ description: String,
+    timeout: TimeInterval = 10.0,
+    sourceLocation: SourceLocation = #_sourceLocation,
+    _ condition: () throws -> Bool
+) rethrows -> Bool {
+    let deadline = Date().addingTimeInterval(timeout)
+    while Date() < deadline {
+        if try condition() { return true }
+        usleep(20_000)
+    }
+    Issue.record("timed out after \(timeout)s waiting for \(description)", sourceLocation: sourceLocation)
+    return false
+}
+
+private func processIsAlive(_ pid: Int32) -> Bool {
+    pid > 0 && kill(pid, 0) == 0
+}
+
+/// Takes whatever is queued on a handed-over pty master, without blocking.
+///
+/// **A test that holds the master must drain it, or the job cannot finish
+/// exiting.** The job is the pty's session leader, and XNU's `proc_exit` calls
+/// `ttywait` on the controlling terminal before revoking it, so the process
+/// stays in `P_WEXIT` until the tty's output queue is empty. Only a reader on
+/// the master empties it, and the holder can never be that reader.
+private func drainPTYInto(_ ptyFD: Int32, _ sink: inout Data) {
+    _ = fcntl(ptyFD, F_SETFL, fcntl(ptyFD, F_GETFL) | O_NONBLOCK)
+    var buffer = [UInt8](repeating: 0, count: 4096)
+    while true {
+        let count = read(ptyFD, &buffer, buffer.count)
+        guard count > 0 else { return }
+        sink.append(contentsOf: buffer[0..<count])
+    }
+}
+
+/// A holder started the way the daemon starts one — through the real
+/// `HolderSpawner`, with a real `posix_spawn` — plus everything needed to take
+/// it back down.
+private final class SpawnedHolderFixture {
+    let home: String
+    let sessionID: UUID
+    let owner: HolderOwnerToken
+    let handle: HolderHandle
+    private var torndown = false
+
+    private final class BundleMarker {}
+
+    /// A short scratch root. Short on purpose: the rendezvous socket lives
+    /// under it and `sun_path` is 104 bytes, so a deep `TMPDIR` would fail the
+    /// bind rather than the assertion.
+    static func scratchHome() -> String {
+        "/tmp/tbdh6-\(UUID().uuidString.prefix(8).lowercased())"
+    }
+
+    /// The environment the rendezvous paths are derived from *and* the holder
+    /// process runs under. Explicit and rc-free: nothing here comes from the
+    /// developer's shell, and `TBD_HOME` never leaves this dictionary.
+    static func environment(home: String) -> [String: String] {
+        ["TBD_HOME": home, "PATH": "/usr/bin:/bin"]
+    }
+
+    static func launch(command: String, home: String) -> HolderLaunchRequest {
+        HolderLaunchRequest(
+            executable: "/bin/sh",
+            arguments: ["-c", command],
+            workingDirectory: "/tmp",
+            environment: ["PATH": "/usr/bin:/bin", "TERM": "xterm-256color"],
+            columns: 80,
+            rows: 24)
+    }
+
+    static func locateExecutable() -> URL? {
+        let bundleURL = Bundle(for: BundleMarker.self).bundleURL
+        var candidates = [bundleURL.deletingLastPathComponent(), bundleURL]
+        if let main = Bundle.main.executableURL?.deletingLastPathComponent() {
+            candidates.append(main)
+        }
+        for directory in candidates {
+            let candidate = directory.appendingPathComponent("TBDHolder")
+            if FileManager.default.isExecutableFile(atPath: candidate.path) {
+                return candidate
+            }
+        }
+        return nil
+    }
+
+    static func makeSpawner(clock: any Clock<Duration> = ContinuousClock()) throws -> HolderSpawner {
+        let executable = try #require(
+            locateExecutable(), "TBDHolder must be built beside the test bundle")
+        return HolderSpawner(executableURL: executable, clock: clock)
+    }
+
+    static func start(
+        command: String,
+        owner: String = "acme-installation",
+        session: UUID = UUID()
+    ) async throws -> SpawnedHolderFixture {
+        let home = scratchHome()
+        let token = HolderOwnerToken(rawValue: owner)
+        let spawner = try makeSpawner()
+        let handle = try await spawner.spawn(
+            sessionID: session,
+            launch: launch(command: command, home: home),
+            owner: token,
+            environment: environment(home: home))
+        return SpawnedHolderFixture(
+            home: home, sessionID: session, owner: token, handle: handle)
+    }
+
+    private init(home: String, sessionID: UUID, owner: HolderOwnerToken, handle: HolderHandle) {
+        self.home = home
+        self.sessionID = sessionID
+        self.owner = owner
+        self.handle = handle
+    }
+
+    private var reaped = false
+
+    /// Polls for the holder to exit on its own and reaps it.
+    ///
+    /// `kill(pid, 0)` cannot answer this question: the holder is this process's
+    /// child, so between its exit and somebody waiting on it, it is a zombie —
+    /// and a zombie is signallable. Reaping is therefore the only observation
+    /// that distinguishes "exited" from "still running".
+    @discardableResult
+    func reapHolder(timeout: TimeInterval = 10.0) -> Bool {
+        if reaped { return true }
+        var status: Int32 = 0
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if waitpid(handle.holderPID, &status, WNOHANG) == handle.holderPID {
+                reaped = true
+                return true
+            }
+            usleep(20_000)
+        }
+        return false
+    }
+
+    /// Kills the holder AND the job, in that order, then removes the scratch
+    /// root. Holder death is not child death, so both need naming. The holder
+    /// is this process's own child — the spawner `posix_spawn`s it directly —
+    /// so it must also be reaped, or the corpse outlives the suite.
+    func tearDown() {
+        guard !torndown else { return }
+        torndown = true
+
+        if !reaped {
+            kill(handle.holderPID, SIGKILL)
+            var ignored: Int32 = 0
+            _ = waitpid(handle.holderPID, &ignored, 0)
+            reaped = true
+        }
+        if processIsAlive(handle.childPID) { kill(handle.childPID, SIGKILL) }
+        // The job is the holder's child, not ours, so nothing here can reap it;
+        // the kernel reparents and reaps. Confirm it is gone so a leak fails the
+        // test that caused it rather than the next run.
+        waitUntilTrue("the holder's job to disappear", timeout: 5.0) {
+            !processIsAlive(handle.childPID)
+        }
+        try? FileManager.default.removeItem(atPath: home)
+    }
+}
+
+/// A stub peer that writes a prepared byte string in exactly one `write` on its
+/// first read, and then answers nothing ever again.
+///
+/// Deliberately not a holder: the property under test is what the *client* does
+/// when two frames land in one read, and racing a real holder into coalescing
+/// them would make the test load-dependent — which is precisely the failure
+/// mode being closed.
+private final class CoalescingStubPeer: @unchecked Sendable {
+    private let listenFD: Int32
+    private let socketPath: String
+    private let lock = NSLock()
+    private var connectionFD: Int32 = -1
+    private var stopped = false
+
+    init(socketPath: String, singleWrite: Data) throws {
+        self.socketPath = socketPath
+        listenFD = socket(AF_UNIX, SOCK_STREAM, 0)
+        try #require(listenFD >= 0, "could not create the stub peer's socket")
+
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let sunPathSize = MemoryLayout.size(ofValue: address.sun_path)
+        socketPath.withCString { source in
+            withUnsafeMutablePointer(to: &address.sun_path) { destination in
+                destination.withMemoryRebound(to: CChar.self, capacity: sunPathSize) { chars in
+                    _ = strlcpy(chars, source, sunPathSize)
+                }
+            }
+        }
+        unlink(socketPath)
+        let bound = withUnsafePointer(to: &address) { addressPtr in
+            addressPtr.withMemoryRebound(to: sockaddr.self, capacity: 1) { generic in
+                Darwin.bind(listenFD, generic, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        try #require(bound == 0, "could not bind the stub peer at \(socketPath) (errno \(errno))")
+        try #require(listen(listenFD, 4) == 0, "could not listen on the stub peer's socket")
+
+        let listener = listenFD
+        let thread = Thread { [weak self] in
+            let incoming = accept(listener, nil, nil)
+            guard incoming >= 0, let self else {
+                if incoming >= 0 { Darwin.close(incoming) }
+                return
+            }
+            self.adopt(incoming)
+            var scratch = [UInt8](repeating: 0, count: 256)
+            // Wait for the client's first request, so the two frames are a
+            // reply rather than an unsolicited greeting.
+            _ = read(incoming, &scratch, scratch.count)
+            _ = singleWrite.withUnsafeBytes { raw in
+                Darwin.write(incoming, raw.baseAddress, raw.count)
+            }
+            // Park with the connection open. Closing here would let the client
+            // reach EOF, which is the very thing the queue is meant to make
+            // unnecessary — an EOF would mask a missing queue as a pass.
+            while !self.isStopped { usleep(20_000) }
+        }
+        thread.name = "holder-stub-peer"
+        thread.start()
+    }
+
+    private func adopt(_ fd: Int32) {
+        lock.lock()
+        defer { lock.unlock() }
+        connectionFD = fd
+    }
+
+    private var isStopped: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return stopped
+    }
+
+    func tearDown() {
+        lock.lock()
+        stopped = true
+        let connection = connectionFD
+        connectionFD = -1
+        lock.unlock()
+        if connection >= 0 { Darwin.close(connection) }
+        Darwin.close(listenFD)
+        unlink(socketPath)
+    }
+}

--- a/Tests/TBDHolderTests/HolderInvocationTests.swift
+++ b/Tests/TBDHolderTests/HolderInvocationTests.swift
@@ -125,7 +125,7 @@ struct HolderInvocationTests {
         var buffer = Data()
         var length = UInt32(HolderFraming.maximumFrameSize + 1).littleEndian
         buffer.append(Data(bytes: &length, count: MemoryLayout<UInt32>.size))
-        #expect(throws: HolderStartupError.self) {
+        #expect(throws: HolderFramingError.self) {
             _ = try HolderFraming.drainRequests(from: &buffer)
         }
     }

--- a/Tests/TBDSharedTests/HolderLockTests.swift
+++ b/Tests/TBDSharedTests/HolderLockTests.swift
@@ -117,12 +117,24 @@ struct HolderLockTests {
         // that has nothing to do with locking. Whether the lock lands on 9
         // depends on how many descriptors sibling tests hold open at the time,
         // which is why this only reddens when the suite runs together.
-        // `dup` hands back the lowest free number, which cannot be the one
-        // still occupied by the original.
+        //
+        // `F_DUPFD_CLOEXEC` hands back the lowest free number at or above its
+        // argument, which is past the target, and keeps the duplicate
+        // close-on-exec — a plain `dup` would clear FD_CLOEXEC and expose this
+        // lock to every other concurrent `posix_spawn` in the process.
+        //
+        // **The duplicate must be closed before the reacquire below, not by a
+        // trailing `defer`.** `flock` lives on the open file description, and a
+        // `dup` shares one: while this descriptor is open, the parent still
+        // holds the child's lock, so the reacquire throws `.alreadyHeld`
+        // against a claim userspace never dropped. That is a measured flake,
+        // and its trigger is that `lock.fileDescriptor` happened to land on 9 —
+        // which depends on how many descriptors sibling suites hold open, so it
+        // fires only when the suite runs alongside others.
         var lockSource = lock.fileDescriptor
         var duplicated: Int32 = -1
         if lockSource == 9 {
-            duplicated = dup(lockSource)
+            duplicated = fcntl(lockSource, F_DUPFD_CLOEXEC, 10)
             try #require(duplicated >= 0, "could not move the lock off the target descriptor")
             lockSource = duplicated
         }
@@ -178,9 +190,15 @@ struct HolderLockTests {
             marker == Data("K\n".utf8),
             "the lock descriptor did not survive exec, so the child never held the lock")
 
-        // From here the child is the sole holder.
+        // From here the child is the sole holder — which means dropping EVERY
+        // descriptor this process has on that open file description, not just
+        // the one `release()` knows about.
         lock.release()
         parentStillHoldsLock = false
+        if duplicated >= 0 {
+            close(duplicated)
+            duplicated = -1
+        }
         close(toChild[1])
 
         var status: Int32 = 0


### PR DESCRIPTION
## Summary

Task 6 of the pty-holder transport ([spec](../blob/main/docs/specs/2026-08-30-pty-holder-session-transport-design.md)). The daemon's half of the holder protocol: a client that speaks it, and a spawner that brings holders into existence safely.

**Stacked on #768 → #767 → #766 → #765.** Merge in order.

## Why this shape

`HolderClient` is an `actor` so the single-reader discipline on the socket is enforced by the type system rather than by convention.

**It keeps a pending-message queue**, which is not incidental: one `recvmsg` can carry a response *and* the holder's unsolicited exit push together. Returning the first and dropping the tail makes the next read hit EOF and report a closed peer for a message that actually arrived. That was a real load-dependent flake in the holder's own harness before it was understood.

The spawn order is the contract. The lock is taken first; a socket present with **no** lock file is handshaked before anything is unlinked, because absence of a lock is not evidence of absence of a holder. Only a connect failing `ECONNREFUSED`/`ENOENT` licenses clearing the path.

## What this PR does

- `HolderClient` — `describe`, `handOverPTY`, `forget`, with the pending queue.
- `HolderSpawner` / `HolderHandle` — the seven-step spawn, bounded on an injected clock.
- `HolderFraming` hoisted from `TBDHolder` into `TBDShared` so both sides share one implementation rather than two that can drift.
- `Package.swift`: `TBDDaemonTests` gains its `TBDHolder` dependency, which no earlier task had actually added.

## Assumptions

Three decisions taken beyond the plan, each recorded in the code:

- **`POSIX_SPAWN_CLOEXEC_DEFAULT`**, and the lock relocated with `fcntl(F_DUPFD_CLOEXEC, 10)` rather than `makeInheritableAcrossExec()`. Clearing `FD_CLOEXEC` on the daemon's own descriptor would expose it to every other concurrent spawn in the daemon, leaving a session UUID unreclaimable until an unrelated child dies. This also sidesteps the `dup2(fd, fd)` trap unconditionally.
- **A holder that fails to bind is killed and reaped.** An unbound-but-live holder holds the creation lock forever. Safe because the holder binds *before* it `forkpty`s, so there is no job to orphan.
- **`describe()` is the handshake** — the holder does no version exchange on connect, and `.rejected(version: busySentinel)` is how a second client learns it is second.

## Known gap, deliberately not closed here

**Nothing reaps a holder that exits while the daemon lives.** The daemon `posix_spawn`s it directly, so it becomes a zombie; only the never-bound path reaps today. The general case belongs to Milestone B's `AgentReaper` leg, and it is documented in `HolderSpawner`'s doc comment rather than left to be discovered.

## Evidence & verification

38 tests across 6 suites, green on five consecutive runs (independently re-run four more times before opening this). Mutation-checked:

- `unlink(socketPath)` before throwing `.lockHeldByLiveHolder` → only `refusesToClearASocketWhoseLockIsHeld` reddens, on both legs (file gone, bytes nil).
- Truncating the client's pending queue to one message → only `queuesAResponseAndAnExitPushDeliveredInOneRead` reddens, with a receive timeout — it went back to the wire for a message it had already been handed.

Full suite: 4 failures, all pre-existing. Proved rather than assumed by holding out the new test file — the same run gives the identical four failures (`TerminalLockedAccessTests` ×3 time-limits, one replay test whose own message reads "harness/load, not production"). `swiftlint --strict` clean.

## Also fixes a Task 4 flake

`HolderLockTests.lockIsReacquirableAfterTheHoldingProcessExits` (#767) closed its duplicated lock descriptor in a *trailing* `defer` — after the reacquire. `flock` lives on the open file description and a `dup` shares one, so the parent still held the child's lock and the reacquire threw `.alreadyHeld` against a claim userspace never dropped. It only fires when the lock lands on fd 9, which depends on how many descriptors sibling suites hold open — and this PR's new tests changed that landscape enough to expose it. The duplicate is now closed at the point the child becomes sole holder, and `dup` became `fcntl(F_DUPFD_CLOEXEC, 10)`.

https://claude.ai/code/session_01UXqxcPYizvznh99Qb8JKrD

[20260830-boring-panda](https://cheapsteak.github.io/tbd/open/?worktree=A1E9CF50-E608-4F3C-BA8F-377D60BB7478)