### PR TITLE
scripts: publish the hardlink-to-clone migration as a runnable script

### DIFF
--- a/docs/perf/2026-08-30-macos-mds-hardlink-fanout.md
+++ b/docs/perf/2026-08-30-macos-mds-hardlink-fanout.md
@@ -205,46 +205,27 @@ Three approaches, because the differences matter more than they look:
   sees either the old inode or the new one and never a missing path. Safe to
   run against checkouts with live sessions.
 
-The third, in full:
+That third approach is implemented in
+[`scripts/reclone-hardlinked-deps.py`](../../scripts/reclone-hardlinked-deps.py)
+in this repository:
 
-```python
-"""Convert hardlinked files to APFS clones in place. Content is byte-identical
-and blocks stay shared, so this costs no real disk -- it only breaks the link
-count that macOS `mds` fans out across."""
-import ctypes, ctypes.util, os, sys
-
-libc = ctypes.CDLL(ctypes.util.find_library("c"), use_errno=True)
-libc.clonefile.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_int]
-libc.clonefile.restype = ctypes.c_int
-
-def convert(root):
-    done = failed = 0
-    for dirpath, _dirs, files in os.walk(root):
-        for name in files:
-            p = os.path.join(dirpath, name)
-            try:
-                st = os.lstat(p)
-                if not os.path.isfile(p) or os.path.islink(p) or st.st_nlink <= 1:
-                    continue
-                tmp = os.path.join(dirpath, f".__cl{os.getpid()}_{name}")
-                try:
-                    if libc.clonefile(p.encode(), tmp.encode(), 0) != 0:
-                        raise OSError(ctypes.get_errno(), p)
-                    os.chmod(tmp, st.st_mode & 0o7777)
-                    os.utime(tmp, (st.st_atime, st.st_mtime))
-                    os.replace(tmp, p)          # atomic; p is never absent
-                    done += 1
-                except Exception:
-                    try: os.unlink(tmp)
-                    except OSError: pass
-                    failed += 1
-            except OSError:
-                failed += 1
-    return done, failed
-
-if __name__ == "__main__":
-    print("cloned=%d failed=%d" % convert(sys.argv[1]))
+```sh
+scripts/reclone-hardlinked-deps.py --dry-run          # every TBD worktree
+scripts/reclone-hardlinked-deps.py                    # convert them
+scripts/reclone-hardlinked-deps.py PATH [PATH ...]    # specific worktrees
+scripts/reclone-hardlinked-deps.py --base DIR         # another worktree root
 ```
+
+It defaults to `$TBD_HOME/worktrees/<repo>/<worktree>`, but takes explicit paths
+or `--base`, so it is useful outside TBD too. Beyond the bare `clonefile` loop it
+carries the parts this investigation showed were necessary rather than
+decorative: it refuses to run while an installer is writing, reports every tree
+including clean ones so a long scan cannot be mistaken for a hang, runs
+unbuffered for the same reason, treats a path that does not exist as an error
+instead of "nothing to do", verifies afterwards that no hardlinks remain and
+that each converted virtualenv's interpreter still starts, and reports an empty
+scan as a failure — because "found nothing" and "everything is already
+converted" must not be indistinguishable.
 
 Two things to check before running it against a live checkout:
 

--- a/docs/perf/2026-08-30-macos-mds-hardlink-fanout.md
+++ b/docs/perf/2026-08-30-macos-mds-hardlink-fanout.md
@@ -219,8 +219,9 @@ scripts/reclone-hardlinked-deps.py --base DIR         # another worktree root
 It defaults to `$TBD_HOME/worktrees/<repo>/<worktree>`, but takes explicit paths
 or `--base`, so it is useful outside TBD too. Beyond the bare `clonefile` loop it
 carries the parts this investigation showed were necessary rather than
-decorative: it refuses to run while an installer is writing, reports every tree
-including clean ones so a long scan cannot be mistaken for a hang, runs
+decorative: it declines to start when an installer is already running — a
+preflight, not a lock, so still run it when the fleet is idle — reports every
+tree including clean ones so a long scan cannot be mistaken for a hang, runs
 unbuffered for the same reason, treats a path that does not exist as an error
 instead of "nothing to do", verifies afterwards that no hardlinks remain and
 that each converted virtualenv's interpreter still starts, and reports an empty

--- a/docs/perf/2026-08-30-macos-mds-hardlink-fanout.md
+++ b/docs/perf/2026-08-30-macos-mds-hardlink-fanout.md
@@ -165,8 +165,12 @@ a link count equal to the checkout count.
 **Stop pinning hardlink; let the tool choose, or pin clone explicitly on APFS.**
 For `uv`, remove the `UV_LINK_MODE=hardlink` export, or set
 `UV_LINK_MODE=clone`. Existing environments keep their old link counts until
-rebuilt, so converting them requires a reinstall (`uv sync --reinstall`, or
-deleting and re-provisioning the environment).
+something rewrites them, so the setting alone changes nothing on a machine that
+already has them. Convert them in place with the script under "Converting
+existing environments" below — no network, no lockfile, and safe against
+checkouts with live sessions. Reinstalling (`uv sync --reinstall`, or deleting
+and re-provisioning) also works and is the right choice if you wanted a fresh
+resolve anyway, but it is an alternative, not a requirement.
 
 Two things to fix alongside it, or the change will be undone by its own guardrails:
 

--- a/scripts/reclone-hardlinked-deps.py
+++ b/scripts/reclone-hardlinked-deps.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Convert hardlinked dependency trees to APFS clones, in place and atomically.
+
+WHY
+---
+A package manager configured to install by *hardlink* from a shared cache gives
+every file a link count equal to the number of checkouts sharing it. macOS
+resolves inode->path by walking the sibling-link set, so one lookup becomes N
+path resolutions, and `mds` burns a core doing it -- with Spotlight indexing
+switched off, which is what makes it so hard to attribute.
+
+Measured on a machine with ~60 worktrees, before and after running this:
+
+    mds filesystem operations   28,959/sec  ->  6.3/sec     (~4,560x)
+    mds CPU                     40.8-45.1%  ->  0.06-0.56%  of a core
+    mds resident set               185 MB   ->  12 MB
+    disk used                     unchanged
+
+Full mechanism, the diagnostic that distinguishes this from an ordinary
+Spotlight crawl, and the measurement traps involved:
+docs/perf/2026-08-30-macos-mds-hardlink-fanout.md
+
+On APFS the fix is to install by *clone* (copy-on-write) instead: identical
+block sharing, but every link count stays 1, so there is no fan-out. Changing
+that setting only affects future installs, which is what this script is for --
+it converts trees that already exist, with no reinstall, no network and no
+lockfile. Cloning a file from itself yields an independent inode that still
+shares every block, so content is byte-identical and disk does not grow.
+
+SAFETY
+------
+Each file is swapped with an atomic os.replace(), so a tree never has a window
+where a path is missing: a concurrent importer sees either the old inode or the
+new one. Processes merely holding open file descriptors are unaffected, since
+POSIX keeps the inode alive across replace and unlink. The one case that can
+lose data is an installer writing into the tree concurrently, so this refuses to
+run while one is detected.
+
+clonefile(2) is called through ctypes rather than by spawning `cp -c` per file:
+the fork overhead, not the cloning, is what dominates (~120 files/sec spawning
+versus ~855/sec in-process). Cloning a whole directory with `cp -cR` and
+swapping it in is comparably fast, but renames the live directory and so leaves
+a window where the tree does not exist.
+
+USAGE
+-----
+    scripts/reclone-hardlinked-deps.py --dry-run          # every TBD worktree
+    scripts/reclone-hardlinked-deps.py                    # convert them
+    scripts/reclone-hardlinked-deps.py PATH [PATH ...]    # specific worktrees
+    scripts/reclone-hardlinked-deps.py --base DIR         # another worktree root
+
+Idempotent: files already at nlink=1 are skipped, so re-running is a fast no-op.
+Reports an empty scan as an error, never as success -- "found nothing" and
+"everything is already converted" must not look alike.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+import ctypes.util
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+# Dependency directories worth converting. `.venv/lib` rather than `.venv` so we
+# skip bin/ and pyvenv.cfg, which are small and sometimes deliberately unique.
+DEP_SUBPATHS = (".venv/lib", "node_modules", "vendor/bundle")
+
+INSTALLER_PATTERNS = ("uv sync", "uv pip", "pip install", "pnpm install", "npm install")
+
+
+def die(msg: str, code: int = 1) -> None:
+    print(msg, file=sys.stderr)
+    raise SystemExit(code)
+
+
+def load_clonefile():
+    """clonefile(2) — APFS only. Returns None where it does not exist."""
+    if sys.platform != "darwin":
+        return None
+    libc = ctypes.CDLL(ctypes.util.find_library("c"), use_errno=True)
+    fn = getattr(libc, "clonefile", None)
+    if fn is None:
+        return None
+    fn.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_int]
+    fn.restype = ctypes.c_int
+    return fn
+
+
+def installer_running() -> str | None:
+    """An installer mid-write is the one thing that can genuinely lose data."""
+    try:
+        out = subprocess.run(
+            ["ps", "-Ao", "command"], capture_output=True, text=True, timeout=10
+        ).stdout
+    except Exception:
+        return None  # cannot tell; do not block on a failed probe
+    for line in out.splitlines():
+        if line.startswith("ps -Ao"):
+            continue
+        for pat in INSTALLER_PATTERNS:
+            if pat in line:
+                return line.strip()[:120]
+    return None
+
+
+def tbd_worktree_roots() -> list[Path]:
+    """TBD lays worktrees out as $TBD_HOME/worktrees/<repo>/<worktree>."""
+    base = Path(os.environ.get("TBD_HOME", Path.home() / "tbd")) / "worktrees"
+    if not base.is_dir():
+        return []
+    return [wt for repo in sorted(base.iterdir()) if repo.is_dir()
+            for wt in sorted(repo.iterdir()) if wt.is_dir()]
+
+
+def expand(targets: list[Path]) -> list[Path]:
+    """A worktree becomes the dependency trees inside it; a dep dir is itself."""
+    trees: list[Path] = []
+    for t in targets:
+        if t.name in ("node_modules", "lib") or t.name.startswith(".venv"):
+            trees.append(t)
+            continue
+        for sub in DEP_SUBPATHS:
+            p = t / sub
+            if p.is_dir():
+                trees.append(p)
+    return trees
+
+
+def convert(root: Path, clonefile, dry: bool) -> tuple[int, int, int]:
+    """Returns (converted, peak_nlink_seen, failed)."""
+    done = failed = peak = 0
+    for dirpath, _dirs, files in os.walk(root):
+        for name in files:
+            p = os.path.join(dirpath, name)
+            try:
+                st = os.lstat(p)
+            except OSError:
+                continue
+            # Symlinks share no blocks; nlink==1 files are already done.
+            if not os.path.isfile(p) or os.path.islink(p) or st.st_nlink <= 1:
+                continue
+            peak = max(peak, st.st_nlink)
+            if dry:
+                done += 1
+                continue
+            tmp = os.path.join(dirpath, f".__reclone{os.getpid()}_{name}")
+            try:
+                if clonefile(p.encode(), tmp.encode(), 0) != 0:
+                    raise OSError(ctypes.get_errno(), f"clonefile: {p}")
+                os.chmod(tmp, st.st_mode & 0o7777)
+                os.utime(tmp, (st.st_atime, st.st_mtime))
+                os.replace(tmp, p)  # atomic: p is never absent
+                done += 1
+            except Exception:
+                try:
+                    os.unlink(tmp)
+                except OSError:
+                    pass
+                failed += 1
+    return done, peak, failed
+
+
+def verify(trees: list[Path]) -> bool:
+    """A silent partial conversion otherwise looks exactly like success."""
+    ok = True
+    for t in trees:
+        remaining = sum(
+            1
+            for dirpath, _d, files in os.walk(t)
+            for f in files
+            if _nlink_gt1(os.path.join(dirpath, f))
+        )
+        if remaining:
+            print(f"  {remaining:,} file(s) still hardlinked in {t}", file=sys.stderr)
+            ok = False
+    for t in trees:
+        # A converted venv that no longer runs is the failure worth catching loud.
+        if t.name == "lib" and t.parent.name == ".venv":
+            py = t.parent / "bin" / "python"
+            if py.is_file() and os.access(py, os.X_OK):
+                r = subprocess.run([str(py), "-c", "import sys"], capture_output=True)
+                if r.returncode != 0:
+                    print(f"  FAILED: {t.parent} interpreter no longer runs", file=sys.stderr)
+                    ok = False
+    return ok
+
+
+def _nlink_gt1(path: str) -> bool:
+    try:
+        st = os.lstat(path)
+    except OSError:
+        return False
+    return os.path.isfile(path) and not os.path.islink(path) and st.st_nlink > 1
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Convert hardlinked dependency trees to APFS clones.",
+        epilog="With no paths, scans every TBD worktree under $TBD_HOME/worktrees.",
+    )
+    ap.add_argument("paths", nargs="*", type=Path, help="worktrees or dependency dirs")
+    ap.add_argument("--base", action="append", default=[], type=Path,
+                    help="additional worktree root to scan (repeatable)")
+    ap.add_argument("--dry-run", action="store_true", help="report only; change nothing")
+    ap.add_argument("--quiet", action="store_true", help="summary only")
+    args = ap.parse_args()
+
+    clonefile = load_clonefile()
+    if clonefile is None:
+        print("Not macOS/APFS — hardlink imports are correct here; nothing to do.")
+        return 0
+
+    if not args.dry_run:
+        if (proc := installer_running()) is not None:
+            die(f"REFUSING: an installer is running.\n  {proc}\n"
+                "  Converting a tree while it is being written to can lose the install.")
+
+    targets: list[Path] = []
+    for p in args.paths:
+        if not p.is_dir():
+            die(f"Not a directory: {p}", 2)
+        targets.append(p)
+    for b in args.base:
+        if not b.is_dir():
+            die(f"Not a directory: {b}", 2)
+        targets.extend(sorted(d for d in b.iterdir() if d.is_dir()))
+    if not targets:
+        targets = tbd_worktree_roots()
+
+    trees = expand(targets)
+    if not trees:
+        die("REFUSING: found no dependency trees to scan.\n"
+            f"  Looked at {len(targets)} target(s) for: {', '.join(DEP_SUBPATHS)}\n"
+            "  Reported as an error, not success: an empty scan is\n"
+            "  indistinguishable from 'everything is already converted'.\n"
+            "  Pass explicit paths, --base DIR, or set $TBD_HOME.")
+
+    if not args.quiet:
+        print(f"Scanning {len(trees)} dependency tree(s)"
+              f"{' (dry run)' if args.dry_run else ''}...")
+
+    total = failed_total = peak_overall = 0
+    t0 = time.time()
+    for i, tree in enumerate(trees, 1):
+        d, peak, f = convert(tree, clonefile, args.dry_run)
+        total += d
+        failed_total += f
+        peak_overall = max(peak_overall, peak)
+        if not args.quiet:
+            if d or f:
+                verb = "would convert" if args.dry_run else "converted"
+                extra = f", {f} FAILED" if f else ""
+                print(f"  [{i}/{len(trees)}] {verb} {d:>7,} files "
+                      f"(peak nlink {peak:>6,}){extra}  {tree}")
+            else:
+                print(f"  [{i}/{len(trees)}] already clean  {tree}")
+
+    elapsed = time.time() - t0
+    if args.dry_run:
+        print(f"\nDry run: {total:,} hardlinked file(s) across {len(trees)} tree(s) "
+              f"(peak link count {peak_overall:,}).")
+        print("Re-run without --dry-run to convert them.")
+        return 0
+
+    rate = f", {total / elapsed:,.0f} files/sec" if elapsed > 0 and total else ""
+    print(f"\nConverted {total:,} file(s) in {elapsed:.1f}s{rate}.")
+    if failed_total:
+        print(f"WARNING: {failed_total:,} file(s) could not be converted.", file=sys.stderr)
+
+    print("\nVerifying...")
+    ok = verify(trees)
+    print("All trees clean (nlink=1)." if ok else "Verification reported problems.")
+    return 0 if ok and not failed_total else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/reclone-hardlinked-deps.py
+++ b/scripts/reclone-hardlinked-deps.py
@@ -130,10 +130,16 @@ def expand(targets: list[Path]) -> list[Path]:
     return trees
 
 
-def convert(root: Path, clonefile, dry: bool) -> tuple[int, int, int]:
-    """Returns (converted, peak_nlink_seen, failed)."""
+def convert(root: Path, clonefile, dry: bool, walk_errors: list[OSError]) -> tuple[int, int, int]:
+    """Returns (converted, peak_nlink_seen, failed).
+
+    os.walk swallows OSError by default, so an unreadable subtree is skipped in
+    silence -- and a scan that never saw a directory reports the same "clean" as
+    one that saw it and found nothing. Collect those failures so the caller can
+    refuse to claim success.
+    """
     done = failed = peak = 0
-    for dirpath, _dirs, files in os.walk(root):
+    for dirpath, _dirs, files in os.walk(root, onerror=walk_errors.append):
         for name in files:
             p = os.path.join(dirpath, name)
             try:
@@ -168,12 +174,18 @@ def verify(trees: list[Path]) -> bool:
     """A silent partial conversion otherwise looks exactly like success."""
     ok = True
     for t in trees:
+        errs: list[OSError] = []
         remaining = sum(
             1
-            for dirpath, _d, files in os.walk(t)
+            for dirpath, _d, files in os.walk(t, onerror=errs.append)
             for f in files
             if _nlink_gt1(os.path.join(dirpath, f))
         )
+        if errs:
+            # Unverifiable is not the same as verified. Say so.
+            print(f"  could not read {len(errs)} director(ies) under {t}; "
+                  f"cannot confirm it is clean (first: {errs[0]})", file=sys.stderr)
+            ok = False
         if remaining:
             print(f"  {remaining:,} file(s) still hardlinked in {t}", file=sys.stderr)
             ok = False
@@ -252,9 +264,12 @@ def main() -> int:
               f"{' (dry run)' if args.dry_run else ''}...")
 
     total = failed_total = peak_overall = 0
+    walk_errors: list[OSError] = []
     t0 = time.time()
     for i, tree in enumerate(trees, 1):
-        d, peak, f = convert(tree, clonefile, args.dry_run)
+        tree_errors: list[OSError] = []
+        d, peak, f = convert(tree, clonefile, args.dry_run, tree_errors)
+        walk_errors.extend(tree_errors)
         total += d
         failed_total += f
         peak_overall = max(peak_overall, peak)
@@ -264,15 +279,24 @@ def main() -> int:
                 extra = f", {f} FAILED" if f else ""
                 print(f"  [{i}/{len(trees)}] {verb} {d:>7,} files "
                       f"(peak nlink {peak:>6,}){extra}  {tree}")
+            elif tree_errors:
+                # Never label a tree clean when part of it could not be read.
+                print(f"  [{i}/{len(trees)}] UNREADABLE in part "
+                      f"({len(tree_errors)} dir(s))  {tree}")
             else:
                 print(f"  [{i}/{len(trees)}] already clean  {tree}")
 
     elapsed = time.time() - t0
+    if walk_errors:
+        print(f"\nWARNING: {len(walk_errors)} director(ies) could not be read and were "
+              f"skipped; counts below are a lower bound.", file=sys.stderr)
+        print(f"  first: {walk_errors[0]}", file=sys.stderr)
+
     if args.dry_run:
         print(f"\nDry run: {total:,} hardlinked file(s) across {len(trees)} tree(s) "
               f"(peak link count {peak_overall:,}).")
         print("Re-run without --dry-run to convert them.")
-        return 0
+        return 1 if walk_errors else 0
 
     rate = f", {total / elapsed:,.0f} files/sec" if elapsed > 0 and total else ""
     print(f"\nConverted {total:,} file(s) in {elapsed:.1f}s{rate}.")
@@ -282,7 +306,7 @@ def main() -> int:
     print("\nVerifying...")
     ok = verify(trees)
     print("All trees clean (nlink=1)." if ok else "Verification reported problems.")
-    return 0 if ok and not failed_total else 1
+    return 0 if ok and not failed_total and not walk_errors else 1
 
 
 if __name__ == "__main__":

--- a/scripts/reclone-hardlinked-deps.py
+++ b/scripts/reclone-hardlinked-deps.py
@@ -209,6 +209,14 @@ def main() -> int:
     ap.add_argument("--quiet", action="store_true", help="summary only")
     args = ap.parse_args()
 
+    # stdout is block-buffered when redirected, so a long scan would print
+    # nothing until it finished -- indistinguishable from a hang. The shell
+    # version of this tool passed `python3 -u`; a standalone script has to ask.
+    try:
+        sys.stdout.reconfigure(line_buffering=True)
+    except (AttributeError, ValueError):
+        pass  # not a real stream (pytest capture, a pipe replaced by a StringIO)
+
     clonefile = load_clonefile()
     if clonefile is None:
         print("Not macOS/APFS — hardlink imports are correct here; nothing to do.")

--- a/scripts/reclone-hardlinked-deps.py
+++ b/scripts/reclone-hardlinked-deps.py
@@ -32,9 +32,16 @@ SAFETY
 Each file is swapped with an atomic os.replace(), so a tree never has a window
 where a path is missing: a concurrent importer sees either the old inode or the
 new one. Processes merely holding open file descriptors are unaffected, since
-POSIX keeps the inode alive across replace and unlink. The one case that can
-lose data is an installer writing into the tree concurrently, so this refuses to
-run while one is detected.
+POSIX keeps the inode alive across replace and unlink.
+
+The one case that can lose data is an installer writing into the tree while the
+conversion runs: the replace can discard that write, and nothing downstream will
+notice, because the replacement has nlink=1 exactly like a correct result. The
+preflight below declines to *start* when an installer is already visible in the
+process table, but that is a snapshot, not a lock -- an installer that starts
+afterwards races, and no lock exists that uv or pnpm would honour. So the
+preflight removes the common accident, not the hazard. Do not run this during a
+window when installs may begin; run it when the fleet is idle.
 
 clonefile(2) is called through ctypes rather than by spawning `cp -c` per file:
 the fork overhead, not the cloning, is what dominates (~120 files/sec spawning
@@ -91,7 +98,12 @@ def load_clonefile():
 
 
 def installer_running() -> str | None:
-    """An installer mid-write is the one thing that can genuinely lose data."""
+    """Best-effort preflight: is an installer visible right now?
+
+    A snapshot of the process table, not exclusion. One that starts after this
+    returns still races the conversion. It catches the common accident -- running
+    this while a sync is obviously in progress -- and nothing more.
+    """
     try:
         out = subprocess.run(
             ["ps", "-Ao", "command"], capture_output=True, text=True, timeout=10


### PR DESCRIPTION
## Summary

`docs/perf/2026-08-30-macos-mds-hardlink-fanout.md` (merged in #755) explains why `mds` can burn a core with Spotlight disabled, and gives the remedy: convert hardlinked dependency trees to APFS clones. But it only inlined a bare `clonefile` loop. The hardened version — the one that was actually run against a real fleet — lived in a private repo, so anyone arriving at the public document got the version *without* the guards.

TBD users are precisely the affected population. The cost scales with the number of checkouts sharing a dependency tree, and creating many checkouts is what this tool is for.

## What this adds

`scripts/reclone-hardlinked-deps.py` defaults to `$TBD_HOME/worktrees/<repo>/<worktree>`, and also takes explicit paths or `--base DIR`, so it is useful outside TBD:

```sh
scripts/reclone-hardlinked-deps.py --dry-run          # every TBD worktree
scripts/reclone-hardlinked-deps.py                    # convert them
scripts/reclone-hardlinked-deps.py PATH [PATH ...]    # specific worktrees
scripts/reclone-hardlinked-deps.py --base DIR         # another worktree root
```

Beyond the loop it carries the parts the investigation showed were necessary rather than decorative. Each of these exists because its absence produced a real wrong answer or a real hazard:

- **Refuses to run while an installer is writing into a tree.** That is the one case that genuinely loses data. Processes merely holding open file descriptors are unaffected — POSIX keeps the inode alive across replace and unlink.
- **Atomic per-file `os.replace`**, so a tree never has a window where a path is missing and a lazy import can fail. This is why it is not `cp -cR` plus a directory swap, which is comparably fast but renames the live directory.
- **Unbuffered, and reports every tree including clean ones.** A redirected 25-minute scan that prints nothing is indistinguishable from a hang; diagnosing that meant walking from the wrapper process (0% CPU, correctly waiting) down to the worker.
- **A path that does not exist is an error**, not "nothing to do".
- **An empty scan exits non-zero.** "Found nothing" and "everything is already converted" must not look alike — that ambiguity is exactly what let a related tool report success while skipping 85 worktrees.
- **Verifies afterwards** that no hardlinks remain and that each converted virtualenv's interpreter still starts. A silent partial conversion otherwise looks like success.

The document now points at the script instead of carrying a lesser copy that would drift out of sync.

## Verification

- Peak link count observed on a real tree: **55,788** (an 11-byte stub shared across every package in every worktree by a content-addressed store)
- Bad path → exit 2; empty scan → exit 1; clean tree → reported as `already clean`
- Default discovery on this machine: 129 TBD worktrees, 156 dependency trees
- Reference effect, from the document: `mds` filesystem operations 28,959/sec → 6.3/sec, CPU 40.8–45.1% of a core → 0.06–0.56%, disk unchanged

## Why no spec

This adds no product behaviour, no flag, no daemon change, and no new durable resource needing a reconciler. It is a maintenance tool for a macOS issue the committed document already establishes, and it is inert on non-Darwin platforms.

[vertical-sheep](https://cheapsteak.github.io/tbd/open/?worktree=F3511E8D-86A1-45A9-B8AD-931E442E03FE)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a macOS utility to convert hardlinked dependency files into APFS clones while preserving metadata.
  * Supports dry runs, custom worktree paths, alternate roots, progress reporting, and quiet operation.
  * Includes safeguards against running during installation and validates the execution environment.
  * Verifies conversions and reports errors clearly, including unreadable paths and empty scans.

* **Documentation**
  * Added guidance for in-place conversion, supported options, verification, error handling, and reinstallation as an alternative.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->