### PR TITLE
Feat: Drain holder masters into a headless emulator in the daemon

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -113,6 +113,16 @@ let package = Package(
                 .product(name: "NIO", package: "swift-nio"),
                 .product(name: "NIOPosix", package: "swift-nio"),
                 .product(name: "NIOHTTP1", package: "swift-nio"),
+                // The daemon is the default reader for a holder-backed session:
+                // it drains that session's pty master into a headless SwiftTerm
+                // `Terminal` so an unattended job never wedges behind a full tty
+                // queue (Sources/TBDDaemon/Holder/HolderReader.swift).
+                //
+                // This pulls an AppKit-importing target into the daemon binary.
+                // SwiftTerm ships one target with no core/views split, so there
+                // is no headless-only product to depend on instead; the daemon
+                // simply never touches the view types.
+                .product(name: "SwiftTerm", package: "SwiftTerm"),
             ],
             path: "Sources/TBDDaemon",
             exclude: ["main.swift"],

--- a/Sources/TBDDaemon/Holder/HolderClient.swift
+++ b/Sources/TBDDaemon/Holder/HolderClient.swift
@@ -64,7 +64,11 @@ actor HolderClient {
     }
 
     let socketPath: String
-    private let receiveTimeout: Duration
+    /// Mutable because a connection can outlive the budget it was made under:
+    /// `HolderSpawner` handshakes on a short handshake timeout and then hands
+    /// the same connection on as a session's long-lived one. See
+    /// `adoptReceiveTimeout`.
+    private var receiveTimeout: Duration
     private var fd: Int32 = -1
     /// Bytes read but not yet parsed into a whole frame.
     private var inbox = Data()
@@ -98,6 +102,21 @@ actor HolderClient {
     /// Deliberately survives `close()`: it is an observation about the child,
     /// not connection state.
     private(set) var lastPushedDescription: HolderChildDescription?
+    /// The busy sentinel this connection was refused with, if it has arrived.
+    ///
+    /// **`.rejected` is the other frame the holder writes without being asked**,
+    /// and unlike an exit push it is not noise: the holder writes it the moment
+    /// it accepts a connection it cannot serve, and then hangs up. So it
+    /// routinely lands *before* the first request is even written, where the
+    /// barrier finds it — and a barrier that discarded it left the following
+    /// write to fail with `EPIPE`, reporting a perfectly ordinary busy holder
+    /// as `transportFailed("Broken pipe")`. Which of the two a caller saw was
+    /// decided by microseconds.
+    ///
+    /// Kept, so the verb that was about to go out fails with the refusal the
+    /// holder actually gave. Cleared by `close()`: it is a fact about one
+    /// connection, and the next one gets its own answer.
+    private var refusal: Int?
 
     init(socketPath: String, receiveTimeout: Duration = HolderClient.defaultReceiveTimeout) {
         self.socketPath = socketPath
@@ -181,6 +200,21 @@ actor HolderClient {
         }
     }
 
+    /// Re-times an already-open connection, and every later one.
+    ///
+    /// Exists because `HolderSpawner` connects under a deliberately short
+    /// handshake budget — a holder that connects and then goes quiet must not
+    /// spend the whole startup budget on one attempt — and then hands that same
+    /// connection to the daemon to keep for the session's life. Leaving the
+    /// handshake budget on it would silently apply a startup-shaped deadline to
+    /// every later verb.
+    func adoptReceiveTimeout(_ timeout: Duration) {
+        receiveTimeout = timeout
+        guard fd >= 0 else { return }
+        var value = Self.timeval(from: timeout)
+        _ = setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &value, socklen_t(MemoryLayout<timeval>.size))
+    }
+
     /// Drops the connection. Idempotent; the client reconnects on the next
     /// verb, which is what makes a `HolderClient` reusable across a holder's
     /// life without pinning its single client slot between requests.
@@ -192,6 +226,10 @@ actor HolderClient {
         // it is retired the same way a send retires it: the status it may carry
         // is remembered, and its descriptors are closed rather than leaked.
         retireQueuedFrames()
+        // A refusal belongs to the connection that was refused, not to the
+        // client. Carrying one across a reconnect would fail the next verb with
+        // an answer a holder gave about a socket that no longer exists.
+        refusal = nil
     }
 
     // MARK: - Transport
@@ -237,14 +275,46 @@ actor HolderClient {
         fd = socketFD
     }
 
+    /// **A refusal outranks whatever else went wrong on the way to noticing
+    /// it**, which is why every failure path here consults it first.
+    ///
+    /// A holder refuses and hangs up in one breath, so the refusal is always
+    /// chased by an EOF and, if the write lost the race, an `EPIPE`. Those are
+    /// the same event seen from further away: reporting `peerClosed` or
+    /// `transportFailed("Broken pipe")` would name the symptom and lose the
+    /// reason, and which of the three a caller saw was decided by microseconds.
+    /// Reporting `.rejected` in all of them is what makes "somebody else is
+    /// already attached" a fact a caller can act on rather than a coin toss.
     private func send(_ request: HolderRequest) throws {
         guard fd >= 0 else { throw Error.notConnected }
-        try raiseBarrier()
+        do {
+            try raiseBarrier()
+        } catch {
+            throw refusalError() ?? error
+        }
+        if let refused = refusalError() { throw refused }
         do {
             try FDChannel.sendData(HolderFraming.frame(request), over: fd)
         } catch {
-            throw Error.transportFailed(error.localizedDescription)
+            // The refusal can still be sitting unread in the receive buffer
+            // when the write fails. The barrier's own throw says nothing this
+            // does not already know — the refusal, if there was one, is
+            // recorded on its way out.
+            try? raiseBarrier()
+            throw refusalError() ?? Error.transportFailed(error.localizedDescription)
         }
+    }
+
+    /// Consumes a recorded refusal, dropping the connection it belongs to.
+    ///
+    /// Dropping is what makes the client reusable: the holder closes every
+    /// connection it refuses, so the socket is already dead, and a caller that
+    /// backs off and retries reconnects on its next verb rather than writing
+    /// into a corpse.
+    private func refusalError() -> Error? {
+        guard let version = refusal else { return nil }
+        close()
+        return .rejected(version: version)
     }
 
     /// Separates everything the holder has already said from the answer to the
@@ -267,6 +337,17 @@ actor HolderClient {
     /// misattributed to the one after it — a desync that never heals.
     private func raiseBarrier() throws {
         guard fd >= 0 else { return }
+        // Retired on the way out **however the barrier ends**, because the
+        // commonest shape of a pushed exit is a push immediately followed by
+        // the holder's own shutdown: the first read decodes the push, the next
+        // one is the EOF behind it, and a barrier that only retired on the
+        // success path threw that EOF with the exit still sitting undelivered
+        // in the queue. `lastPushedDescription` then stayed nil until somebody
+        // called `close()`, so a poller doing `describe()` and reading the
+        // pushed status never saw how the child ended. Everything queued when
+        // the barrier ran arrived before this request existed and is nobody's
+        // answer, which is exactly as true when the read after it fails.
+        defer { retireQueuedFrames() }
         while hasBufferedInput() {
             try readMoreFrames()
         }
@@ -277,7 +358,6 @@ actor HolderClient {
         while !inbox.isEmpty {
             try readMoreFrames()
         }
-        retireQueuedFrames()
     }
 
     /// Whether the socket has something to deliver right now.
@@ -312,7 +392,14 @@ actor HolderClient {
                     child \(description.childPID, privacy: .public): \
                     \(String(describing: description.status), privacy: .public)
                     """)
-            case .forgotten, .rejected:
+            case .rejected(let version):
+                refusal = version
+                Self.logger.debug(
+                    """
+                    the holder at \(self.socketPath, privacy: .public) refused this connection \
+                    before it was asked anything (protocol version \(version, privacy: .public))
+                    """)
+            case .forgotten:
                 Self.logger.debug(
                     """
                     discarding an unsolicited \(String(describing: response), privacy: .public) frame \

--- a/Sources/TBDDaemon/Holder/HolderReader.swift
+++ b/Sources/TBDDaemon/Holder/HolderReader.swift
@@ -98,6 +98,8 @@ actor HolderReader {
     ///   `ptyFD` rather than the POSIX word because SwiftLint's
     ///   `inclusive_language` rule refuses that word in a *declaration*; prose
     ///   throughout still says "pty master", which is what `forkpty` calls it.
+    /// - Parameter readFault: a test seam. Production passes nothing; see
+    ///   `HolderReadFault` for why the branch it reaches has no other way in.
     init(
         sessionID: UUID,
         ptyFD: Int32,
@@ -105,12 +107,13 @@ actor HolderReader {
         rows: Int,
         scrollbackLines: Int = HolderReader.scrollbackLines,
         stopTimeout: Duration = HolderReader.defaultStopTimeout,
+        readFault: HolderReadFault? = nil,
         clock: any Clock<Duration> = ContinuousClock()
     ) {
         self.sessionID = sessionID
         self.stopTimeout = stopTimeout
         self.clock = clock
-        let descriptor = PTYDescriptor(fd: ptyFD)
+        let descriptor = PTYDescriptor(fd: ptyFD, readFault: readFault)
         self.descriptor = descriptor
         // The emulator's replies go straight back down the same descriptor.
         // A device-status or cursor-position report that never reaches the
@@ -306,6 +309,30 @@ private final class DrainLoop: @unchecked Sendable {
     /// into spinning.
     private static let pollSliceMilliseconds: Int32 = 250
 
+    /// The first pause after a read failed with an unclassified errno, doubling
+    /// per consecutive failure up to the ceiling.
+    private static let readBackoffBaseMilliseconds: Int32 = 10
+    /// The slowest the loop will retry a failing descriptor. Four attempts a
+    /// second costs nothing and keeps the promise that the queue will be
+    /// emptied the moment the descriptor can be read again.
+    private static let readBackoffCeilingMilliseconds: Int32 = 250
+    /// The streak length at which a failure stops being plausibly transient and
+    /// earns a second, louder log line. It changes what is *said*, never what is
+    /// done: the loop keeps retrying past it.
+    private static let implausibleReadFailureStreak = 8
+
+    /// What one pass of `drainEverythingReadable` decided about the descriptor.
+    private enum DrainOutcome {
+        /// The descriptor was emptied and may yield again.
+        case readable
+        /// The descriptor will never yield anything again — end of file, or an
+        /// errno that no amount of waiting can change.
+        case exhausted
+        /// A read failed with an errno that is *not* classified as permanent.
+        /// The descriptor stays in the loop's care and is retried after a pause.
+        case retryable(errno: Int32)
+    }
+
     private let sessionID: UUID
     private let descriptor: PTYDescriptor
     private let emulator: HolderEmulator
@@ -343,14 +370,23 @@ private final class DrainLoop: @unchecked Sendable {
         var buffer = [UInt8](repeating: 0, count: Self.readBufferSize)
         var ptyCanYieldBytes = ptyFD >= 0
         var consecutivePollFailures = 0
+        var consecutiveReadFailures = 0
+        // While positive, the loop is pausing before it retries a descriptor
+        // whose last read failed. The pause is spent in `poll` on the wake pipe
+        // alone rather than in a sleep, so `stop()` is answered immediately and
+        // the pty is simply not looked at for that long.
+        var readBackoffMilliseconds: Int32 = 0
 
         while true {
+            let backingOff = readBackoffMilliseconds > 0
+            let watchingPTY = ptyCanYieldBytes && !backingOff
             var watched = [pollfd(fd: wakeReadFD, events: Int16(POLLIN), revents: 0)]
-            if ptyCanYieldBytes {
+            if watchingPTY {
                 watched.append(pollfd(fd: ptyFD, events: Int16(POLLIN), revents: 0))
             }
 
-            let ready = poll(&watched, nfds_t(watched.count), Self.pollSliceMilliseconds)
+            let slice = backingOff ? readBackoffMilliseconds : Self.pollSliceMilliseconds
+            let ready = poll(&watched, nfds_t(watched.count), slice)
             if ready < 0 {
                 if errno == EINTR { continue }
                 // **Never a reason to stop draining.** A poll that fails leaves
@@ -368,7 +404,11 @@ private final class DrainLoop: @unchecked Sendable {
                         """)
                 }
                 if ptyCanYieldBytes {
-                    ptyCanYieldBytes = drainEverythingReadable(into: &buffer)
+                    apply(
+                        drainEverythingReadable(into: &buffer),
+                        canYield: &ptyCanYieldBytes,
+                        failures: &consecutiveReadFailures,
+                        backoff: &readBackoffMilliseconds)
                 }
                 usleep(20_000)
                 continue
@@ -378,27 +418,116 @@ private final class DrainLoop: @unchecked Sendable {
             // Checked before the pty: a stop must win a tie, or a session
             // flooding its terminal could keep the loop fed forever.
             if watched[0].revents != 0 { return }
-            guard ready > 0, ptyCanYieldBytes, watched.count > 1, watched[1].revents != 0 else {
+
+            if backingOff {
+                // The pause is over — the descriptor was deliberately not in
+                // the poll set, so nothing here says whether it is readable.
+                // Ask it directly; that is what the pause was for.
+                readBackoffMilliseconds = 0
+                if ptyCanYieldBytes {
+                    apply(
+                        drainEverythingReadable(into: &buffer),
+                        canYield: &ptyCanYieldBytes,
+                        failures: &consecutiveReadFailures,
+                        backoff: &readBackoffMilliseconds)
+                }
                 continue
             }
-            ptyCanYieldBytes = drainEverythingReadable(into: &buffer)
+
+            guard ready > 0, watchingPTY, watched.count > 1, watched[1].revents != 0 else {
+                continue
+            }
+            apply(
+                drainEverythingReadable(into: &buffer),
+                canYield: &ptyCanYieldBytes,
+                failures: &consecutiveReadFailures,
+                backoff: &readBackoffMilliseconds)
         }
     }
 
+    /// Folds one drain pass into the loop's state.
+    ///
+    /// The `.retryable` arm is the whole point of the enum. Draining is a
+    /// liveness requirement — a job cannot finish exiting while its output sits
+    /// unread — so a failure the loop cannot *prove* is permanent must never
+    /// end the loop's interest in the descriptor. It backs off instead, and
+    /// keeps backing off at a floor of four attempts a second for as long as
+    /// the session lives.
+    private func apply(
+        _ outcome: DrainOutcome,
+        canYield: inout Bool,
+        failures: inout Int,
+        backoff: inout Int32
+    ) {
+        switch outcome {
+        case .readable:
+            failures = 0
+            backoff = 0
+        case .exhausted:
+            canYield = false
+            failures = 0
+            backoff = 0
+        case .retryable(let code):
+            failures += 1
+            backoff = Self.backoffMilliseconds(forAttempt: failures)
+            if failures == 1 {
+                Self.logger.error(
+                    """
+                    read failed on the pty for session \
+                    \(self.sessionID.uuidString, privacy: .public) \
+                    (errno \(code, privacy: .public)); retrying — this errno is not one the \
+                    drain loop treats as permanent
+                    """)
+            } else if failures == Self.implausibleReadFailureStreak {
+                // Copied out: an os_log interpolation is an escaping
+                // autoclosure and cannot capture an `inout` parameter.
+                let streak = failures
+                Self.logger.error(
+                    """
+                    read on the pty for session \(self.sessionID.uuidString, privacy: .public) \
+                    has failed \(streak, privacy: .public) times running \
+                    (errno \(code, privacy: .public)); still retrying at the floor cadence, so \
+                    the job stays drainable if the descriptor recovers
+                    """)
+            }
+        }
+    }
+
+    /// Doubling backoff, capped. Attempt 1 pauses 10 ms; by attempt 6 the pause
+    /// has reached the 250 ms floor cadence and stays there.
+    private static func backoffMilliseconds(forAttempt attempt: Int) -> Int32 {
+        let doublings = Int32(min(max(attempt - 1, 0), 16))
+        let scaled = readBackoffBaseMilliseconds << doublings
+        return min(scaled, readBackoffCeilingMilliseconds)
+    }
+
+    /// The errnos a read on a pty master can report that no amount of waiting
+    /// will change.
+    ///
+    /// Deliberately a short, explicit list rather than a catch-all. `EBADF`
+    /// means the number is not an open descriptor and `ENXIO` means the device
+    /// behind it is gone; neither can become readable again. Everything else —
+    /// `ENOMEM` under memory pressure being the obvious case — is retried,
+    /// because assuming an unclassified errno is permanent is exactly how a
+    /// drain loop abandons a live job and wedges it in `ttywait`.
+    private static func isPermanentReadFailure(_ code: Int32) -> Bool {
+        code == EBADF || code == ENXIO
+    }
+
     /// Reads until the descriptor would block, feeding everything to the
-    /// emulator. Returns whether the descriptor can still yield bytes.
+    /// emulator, and says what the caller should do with the descriptor next.
     ///
     /// The inner loop matters: one `poll` wake means *at least* one read is
     /// ready, and a loop that took one bufferful per wake would fall behind a
     /// job writing faster than the scheduler round-trips.
-    private func drainEverythingReadable(into buffer: inout [UInt8]) -> Bool {
+    private func drainEverythingReadable(into buffer: inout [UInt8]) -> DrainOutcome {
         while true {
             switch descriptor.read(into: &buffer) {
             case .bytes(let count):
                 // Never logged, at any level: these are session contents.
                 emulator.feed(buffer[0..<count])
             case .wouldBlock, .interrupted:
-                return true
+                return .readable
             case .childGone:
                 // `0` or `EIO` on a pty master means the last slave closed —
                 // the ordinary end of a session, not an error. The loop stays
@@ -408,26 +537,53 @@ private final class DrainLoop: @unchecked Sendable {
                     pty for session \(self.sessionID.uuidString, privacy: .public) reached end of \
                     file; the job's terminal has no slave left
                     """)
-                return false
+                return .exhausted
             case .failed(let code):
-                // Unrecoverable rather than transient: EAGAIN and EINTR are
-                // handled above, so what is left is a descriptor that will
-                // never yield anything again. Continuing to read it would spin.
+                // EAGAIN, EINTR and EIO are classified above, so what arrives
+                // here is an errno nobody has ruled on. Only the explicitly
+                // permanent ones end the drain; the rest are handed back for a
+                // paced retry, because a descriptor that fails once is not
+                // evidence of a job that has stopped producing output — and a
+                // job whose output goes unread cannot finish exiting.
+                guard Self.isPermanentReadFailure(code) else {
+                    return .retryable(errno: code)
+                }
                 Self.logger.error(
                     """
                     read failed on the pty for session \
                     \(self.sessionID.uuidString, privacy: .public) \
-                    (errno \(code, privacy: .public)); stopped draining it
+                    (errno \(code, privacy: .public)); that descriptor can never be read again, \
+                    so draining it stopped
                     """)
-                return false
+                return .exhausted
             case .closed:
-                return false
+                return .exhausted
             }
         }
     }
 }
 
 // MARK: - The descriptor
+
+/// A test seam that substitutes a synthetic errno for one `read` on the pty.
+///
+/// It exists because the branch it reaches cannot otherwise be entered. The
+/// drain loop's retry path fires on errnos like `ENOMEM` — a machine under
+/// genuine memory pressure — which a test cannot provoke on demand and must not
+/// try to. Production never constructs one: every real call site takes the
+/// defaulted `nil`, so the check costs an optional test per read and nothing
+/// else.
+struct HolderReadFault: Sendable {
+    /// Consulted immediately before each `read`. Return an errno to report in
+    /// place of issuing the syscall, or `nil` to let the real read happen. The
+    /// returned errno runs through the same classification as a real one, so a
+    /// fault can exercise any outcome the descriptor can produce.
+    let nextErrno: @Sendable () -> Int32?
+
+    init(nextErrno: @escaping @Sendable () -> Int32?) {
+        self.nextErrno = nextErrno
+    }
+}
 
 /// Owns the handed-over pty master and serializes every operation on it.
 ///
@@ -444,6 +600,9 @@ private final class PTYDescriptor: @unchecked Sendable {
         case interrupted
         /// End of file, or `EIO`: on a pty master, the last slave has closed.
         case childGone
+        /// An errno this type does not rule on. Whether it ends the drain is the
+        /// drain loop's decision, not the descriptor's — see
+        /// `DrainLoop.isPermanentReadFailure`.
         case failed(errno: Int32)
         case closed
     }
@@ -458,9 +617,11 @@ private final class PTYDescriptor: @unchecked Sendable {
 
     private let lock = NSLock()
     private var fd: Int32
+    private let readFault: HolderReadFault?
 
-    init(fd: Int32) {
+    init(fd: Int32, readFault: HolderReadFault? = nil) {
         self.fd = fd
+        self.readFault = readFault
         // Non-blocking from the outset, for both directions. Reads are
         // poll-guarded anyway; what this really buys is that no `write` — not
         // the actor's, and above all not a terminal reply issued from inside a
@@ -486,16 +647,24 @@ private final class PTYDescriptor: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         guard fd >= 0 else { return .closed }
+        // The injected errno takes the same classification path a real one
+        // does, so a fault cannot accidentally test a shape production never
+        // produces.
+        if let injected = readFault?.nextErrno() { return Self.classify(errno: injected) }
         let count = buffer.withUnsafeMutableBytes { raw -> Int in
             Darwin.read(fd, raw.baseAddress, raw.count)
         }
         if count > 0 { return .bytes(count) }
         if count == 0 { return .childGone }
-        switch errno {
+        return Self.classify(errno: errno)
+    }
+
+    private static func classify(errno code: Int32) -> ReadOutcome {
+        switch code {
         case EAGAIN: return .wouldBlock
         case EINTR: return .interrupted
         case EIO: return .childGone
-        default: return .failed(errno: errno)
+        default: return .failed(errno: code)
         }
     }
 

--- a/Sources/TBDDaemon/Holder/HolderReader.swift
+++ b/Sources/TBDDaemon/Holder/HolderReader.swift
@@ -1,0 +1,679 @@
+import Darwin
+import Foundation
+import SwiftTerm
+import os
+
+/// The daemon's drain loop and headless emulator for one holder-backed session.
+///
+/// **Draining is a liveness requirement, not a convenience.** The job is its
+/// pty's session leader, and XNU's `proc_exit` calls `ttywait` on the
+/// controlling terminal before revoking it: a job that exits with anything at
+/// all still queued on the terminal stops half-exited in `P_WEXIT`, and the
+/// holder's `waitpid` correctly reports nothing, because nothing has happened
+/// yet. A few bytes of ordinary echo are enough. So whoever holds the master
+/// **must read it unconditionally** — not lazily, not only while somebody wants
+/// a screen, not only while a session is idle. A reader that stops reading is
+/// not falling behind; it is holding jobs open.
+///
+/// Two consequences shape everything below. The drain loop never exits on a
+/// transient error, and it is never gated on anyone wanting the output: the
+/// emulator is where the bytes go, but emptying the queue is why the loop runs.
+///
+/// An `actor` for the ordinary reason — its callers are async and the state
+/// machine (`idle → draining → stopped`) must not be raced — but note what is
+/// *not* actor-isolated: `Terminal` is not `Sendable`, so the emulator and the
+/// descriptor live in two lock-guarded boxes shared with the drain thread. The
+/// actor holds the state machine; the boxes hold everything the thread touches.
+actor HolderReader {
+    private static let logger = Logger(subsystem: "com.tbd.daemon", category: "holder")
+
+    /// Lines of detached history the emulator keeps behind the viewport.
+    ///
+    /// Named rather than inherited: SwiftTerm's default is 500 lines, which is
+    /// an accident of its own defaults, not a decision about how much of an
+    /// unattended agent's session a daemon should be able to show. Each line
+    /// costs a `BufferLine` of `cols` cells, so this is memory per live
+    /// session — generous enough to answer "what did it print before it went
+    /// quiet", bounded enough that a thousand-session fleet is not a leak.
+    static let scrollbackLines = 5_000
+
+    /// How long `stop()` waits for the drain thread to acknowledge the wake and
+    /// close the descriptor. Bounded because a `stop` that never returns is
+    /// worse than one that gives up and says so.
+    static let defaultStopTimeout: Duration = .seconds(5)
+    /// The granularity of that wait. Small: the thread is woken by a self-pipe
+    /// write, so it is already on its way out.
+    static let stopPollInterval: Duration = .milliseconds(5)
+
+    enum Error: LocalizedError, Equatable {
+        /// The reader has been stopped; its descriptor is gone or going.
+        case stopped
+        /// The self-pipe `start()` needs could not be created, so there would be
+        /// no way to wake a blocked `poll` — and a drain thread that cannot be
+        /// woken cannot be stopped without closing an fd under it.
+        case cannotCreateWakePipe(errno: Int32)
+        case writeFailed(errno: Int32)
+        /// The child never made room for the rest of the write inside the
+        /// budget. Carries what is left so a caller can decide, rather than
+        /// pretending a partial write succeeded.
+        case writeTimedOut(unwritten: Int)
+
+        var errorDescription: String? {
+            switch self {
+            case .stopped:
+                return "the holder reader has been stopped"
+            case .cannotCreateWakePipe(let code):
+                return "could not create the drain loop's wake pipe: "
+                    + "\(String(cString: strerror(code))) (errno \(code))"
+            case .writeFailed(let code):
+                return "could not write to the session's pty: "
+                    + "\(String(cString: strerror(code))) (errno \(code))"
+            case .writeTimedOut(let unwritten):
+                return "the session's pty did not accept \(unwritten) more bytes within the budget"
+            }
+        }
+    }
+
+    private enum State {
+        case idle
+        case draining
+        case stopped
+    }
+
+    let sessionID: UUID
+    private let descriptor: PTYDescriptor
+    private let emulator: HolderEmulator
+    private let stopTimeout: Duration
+    private let clock: any Clock<Duration>
+
+    private var state: State = .idle
+    /// The write end of the self-pipe that wakes a blocked `poll`. Held by the
+    /// actor, written by `stop()`; the read end belongs to the drain thread.
+    private var wakeWriteFD: Int32 = -1
+    private var drain: DrainLoop?
+
+    /// - Parameter ptyFD: a `dup` of the session's pty master, handed over by
+    ///   the holder. The reader owns it from here: it closes it on the drain
+    ///   thread when the loop ends, and nowhere else. The parameter is spelled
+    ///   `ptyFD` rather than the POSIX word because SwiftLint's
+    ///   `inclusive_language` rule refuses that word in a *declaration*; prose
+    ///   throughout still says "pty master", which is what `forkpty` calls it.
+    init(
+        sessionID: UUID,
+        ptyFD: Int32,
+        columns: Int,
+        rows: Int,
+        scrollbackLines: Int = HolderReader.scrollbackLines,
+        stopTimeout: Duration = HolderReader.defaultStopTimeout,
+        clock: any Clock<Duration> = ContinuousClock()
+    ) {
+        self.sessionID = sessionID
+        self.stopTimeout = stopTimeout
+        self.clock = clock
+        let descriptor = PTYDescriptor(fd: ptyFD)
+        self.descriptor = descriptor
+        // The emulator's replies go straight back down the same descriptor.
+        // A device-status or cursor-position report that never reaches the
+        // child is a hang in that child, not a cosmetic loss — the program
+        // asked the terminal a question and is waiting for the answer.
+        self.emulator = HolderEmulator(
+            columns: columns,
+            rows: rows,
+            scrollback: scrollbackLines,
+            reply: { [descriptor] bytes in descriptor.replyBestEffort(bytes) })
+    }
+
+    deinit {
+        // Every stored property is read into a local first: a `deinit` may
+        // touch isolated state only until something copies `self`, and a log
+        // interpolation counts as a copy.
+        let finalState = state
+        let wake = wakeWriteFD
+        let identifier = sessionID.uuidString
+        let pty = descriptor
+
+        // A reader dropped without `stop()` leaks its drain thread, because the
+        // thread's only exit is the wake pipe and nothing is left to write it.
+        // The descriptor is not closed here: the thread may be inside a read on
+        // it, and closing an fd under a live reader is the use-after-close race
+        // this whole design exists to avoid. Only the never-started case is
+        // safe to clean up.
+        if wake >= 0 { Darwin.close(wake) }
+        switch finalState {
+        case .idle:
+            pty.close()
+        case .draining:
+            Self.logger.error(
+                """
+                holder reader for session \(identifier, privacy: .public) was deallocated while \
+                still draining; its thread and pty descriptor are leaked
+                """)
+        case .stopped:
+            break
+        }
+    }
+
+    /// Whether the drain loop is running. Test-facing, and the honest answer:
+    /// it reads the thread's own flag rather than the actor's intent.
+    var isDraining: Bool {
+        guard let drain else { return false }
+        return !drain.isFinished
+    }
+
+    // MARK: - Lifecycle
+
+    /// Starts draining. Idempotent; a stopped reader stays stopped.
+    func start() throws {
+        switch state {
+        case .draining: return
+        case .stopped: throw Error.stopped
+        case .idle: break
+        }
+
+        var pipeFDs: [Int32] = [-1, -1]
+        guard pipe(&pipeFDs) == 0 else {
+            throw Error.cannotCreateWakePipe(errno: errno)
+        }
+        wakeWriteFD = pipeFDs[1]
+
+        let loop = DrainLoop(
+            sessionID: sessionID,
+            descriptor: descriptor,
+            emulator: emulator,
+            wakeReadFD: pipeFDs[0])
+        drain = loop
+        state = .draining
+
+        let thread = Thread { loop.run() }
+        thread.name = "tbd-holder-drain"
+        // Bigger than the 512 KB Foundation hands a bare Thread: the drain
+        // buffer alone is 64 KB of stack-adjacent scratch and the parser
+        // recurses on escape sequences.
+        thread.stackSize = 1 << 20
+        thread.start()
+    }
+
+    /// Stops draining and closes the descriptor — **on the drain thread**.
+    ///
+    /// The ordering is the whole point. Closing the fd here, from the actor,
+    /// while the thread sits in `read` or `poll` on it, is a use-after-close the
+    /// moment the kernel hands that number to something else: the thread would
+    /// then be watching an unrelated descriptor. So `stop` writes a byte to the
+    /// self-pipe the loop also polls, and the thread — which alone knows it has
+    /// left the descriptor — closes it. This call then waits, bounded on the
+    /// injected clock, for that to have happened.
+    func stop() async {
+        guard state == .draining else {
+            // A reader that never started has no thread to hand the close to,
+            // and nothing can be mid-read on the descriptor, so this is the one
+            // place the actor may close it itself. Stopping such a reader must
+            // still release the pty: it is a `dup` the holder handed over, and
+            // leaking it keeps a reference to that terminal alive for the life
+            // of the daemon.
+            if state == .idle { descriptor.close() }
+            state = .stopped
+            return
+        }
+        state = .stopped
+
+        if wakeWriteFD >= 0 {
+            var byte: UInt8 = 1
+            // One byte, and the result is deliberately ignored: a full pipe
+            // means a wake is already queued, which is exactly the outcome
+            // wanted. SIGPIPE cannot arrive — the read end is closed only by
+            // the thread on its way out, after which the wait below ends.
+            _ = Darwin.write(wakeWriteFD, &byte, 1)
+            Darwin.close(wakeWriteFD)
+            wakeWriteFD = -1
+        }
+
+        await awaitDrainExit()
+    }
+
+    /// Polls for the drain thread to finish, accumulating elapsed time from the
+    /// interval rather than measuring against a deadline: `any Clock<Duration>`
+    /// pins `Duration` but not `Instant`, so instant arithmetic does not
+    /// typecheck through the existential — and "how much waiting has been
+    /// spent" is what a fake clock can drive. Same idiom as `HolderSpawner`.
+    private func awaitDrainExit() async {
+        guard let drain else { return }
+        var waited: Duration = .zero
+        while !drain.isFinished, waited < stopTimeout {
+            try? await clock.sleep(for: Self.stopPollInterval)
+            waited += Self.stopPollInterval
+        }
+        if !drain.isFinished {
+            Self.logger.error(
+                """
+                drain thread for session \(self.sessionID.uuidString, privacy: .public) did not \
+                stop within the budget; its pty descriptor stays open
+                """)
+        }
+    }
+
+    // MARK: - The session's screen
+
+    /// The viewport as text, one line per row, trailing blank rows dropped.
+    func renderScreen() -> String {
+        emulator.renderScreen()
+    }
+
+    /// The tail of the scrollback plus the viewport, at most `maxLines` lines.
+    func renderScreenWithScrollback(maxLines: Int) -> String {
+        emulator.renderScreenWithScrollback(maxLines: maxLines)
+    }
+
+    // MARK: - Input and size
+
+    /// Writes input to the child. Bounded: a child that has stopped reading its
+    /// terminal must fail the write rather than park the caller forever.
+    func write(_ data: Data) throws {
+        guard state != .stopped else { throw Error.stopped }
+        try descriptor.write(data)
+    }
+
+    /// Resizes both halves of the illusion: the emulator's grid, so rendering
+    /// matches, and the pty itself, so the child gets `SIGWINCH` and can lay
+    /// itself out. Doing only the first leaves a child drawing at the old size
+    /// into a differently-shaped grid.
+    func resize(columns: Int, rows: Int) {
+        let cols = max(1, columns)
+        let lines = max(1, rows)
+        emulator.resize(columns: cols, rows: lines)
+        descriptor.setWindowSize(columns: cols, rows: lines)
+    }
+}
+
+// MARK: - The drain loop
+
+/// The body of the dedicated reader thread.
+///
+/// A `Thread` rather than a `DispatchSource` on a shared queue, deliberately: a
+/// feed is a full escape-sequence parse of up to a bufferful, and a session
+/// flooding its terminal would otherwise occupy a concurrent-queue worker for
+/// as long as it kept flooding. One thread per holder-backed session costs a
+/// stack; a stalled queue costs unrelated daemon work.
+private final class DrainLoop: @unchecked Sendable {
+    private static let logger = Logger(subsystem: "com.tbd.daemon", category: "holder")
+
+    /// Sized to take a whole tty output queue in one read on any plausible
+    /// setting, so a flooding job costs one syscall per burst rather than one
+    /// per kilobyte.
+    private static let readBufferSize = 64 * 1024
+    /// The poll slice. Finite rather than infinite so a loop that somehow
+    /// missed a wake still notices its descriptor is gone, and so a poll that
+    /// fails for a reason nobody predicted degrades into polling rather than
+    /// into spinning.
+    private static let pollSliceMilliseconds: Int32 = 250
+
+    private let sessionID: UUID
+    private let descriptor: PTYDescriptor
+    private let emulator: HolderEmulator
+    private let wakeReadFD: Int32
+    private let stateLock = NSLock()
+    private var finished = false
+
+    init(sessionID: UUID, descriptor: PTYDescriptor, emulator: HolderEmulator, wakeReadFD: Int32) {
+        self.sessionID = sessionID
+        self.descriptor = descriptor
+        self.emulator = emulator
+        self.wakeReadFD = wakeReadFD
+    }
+
+    var isFinished: Bool {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return finished
+    }
+
+    func run() {
+        defer {
+            // The descriptor is closed here and nowhere else: this thread is
+            // the only one that can know it has left the fd alone.
+            descriptor.close()
+            Darwin.close(wakeReadFD)
+            stateLock.lock()
+            finished = true
+            stateLock.unlock()
+        }
+
+        // Stable for the loop's life: nothing else closes this descriptor, so
+        // the number cannot be reused under the poll set.
+        let ptyFD = descriptor.rawDescriptor
+        var buffer = [UInt8](repeating: 0, count: Self.readBufferSize)
+        var ptyCanYieldBytes = ptyFD >= 0
+        var consecutivePollFailures = 0
+
+        while true {
+            var watched = [pollfd(fd: wakeReadFD, events: Int16(POLLIN), revents: 0)]
+            if ptyCanYieldBytes {
+                watched.append(pollfd(fd: ptyFD, events: Int16(POLLIN), revents: 0))
+            }
+
+            let ready = poll(&watched, nfds_t(watched.count), Self.pollSliceMilliseconds)
+            if ready < 0 {
+                if errno == EINTR { continue }
+                // **Never a reason to stop draining.** A poll that fails leaves
+                // the queue exactly as full as it was, and a job blocked in
+                // `ttywait` behind it. So the loop reads anyway — the read is
+                // non-blocking and answers the same question poll was asked —
+                // and slows itself down only enough not to spin.
+                consecutivePollFailures += 1
+                if consecutivePollFailures == 1 {
+                    Self.logger.error(
+                        """
+                        poll failed while draining session \
+                        \(self.sessionID.uuidString, privacy: .public) \
+                        (errno \(errno, privacy: .public)); continuing to drain
+                        """)
+                }
+                if ptyCanYieldBytes {
+                    ptyCanYieldBytes = drainEverythingReadable(into: &buffer)
+                }
+                usleep(20_000)
+                continue
+            }
+            consecutivePollFailures = 0
+
+            // Checked before the pty: a stop must win a tie, or a session
+            // flooding its terminal could keep the loop fed forever.
+            if watched[0].revents != 0 { return }
+            guard ready > 0, ptyCanYieldBytes, watched.count > 1, watched[1].revents != 0 else {
+                continue
+            }
+            ptyCanYieldBytes = drainEverythingReadable(into: &buffer)
+        }
+    }
+
+    /// Reads until the descriptor would block, feeding everything to the
+    /// emulator. Returns whether the descriptor can still yield bytes.
+    ///
+    /// The inner loop matters: one `poll` wake means *at least* one read is
+    /// ready, and a loop that took one bufferful per wake would fall behind a
+    /// job writing faster than the scheduler round-trips.
+    private func drainEverythingReadable(into buffer: inout [UInt8]) -> Bool {
+        while true {
+            switch descriptor.read(into: &buffer) {
+            case .bytes(let count):
+                // Never logged, at any level: these are session contents.
+                emulator.feed(buffer[0..<count])
+            case .wouldBlock, .interrupted:
+                return true
+            case .childGone:
+                // `0` or `EIO` on a pty master means the last slave closed —
+                // the ordinary end of a session, not an error. The loop stays
+                // alive on the wake pipe so `stop()` still owns the close.
+                Self.logger.debug(
+                    """
+                    pty for session \(self.sessionID.uuidString, privacy: .public) reached end of \
+                    file; the job's terminal has no slave left
+                    """)
+                return false
+            case .failed(let code):
+                // Unrecoverable rather than transient: EAGAIN and EINTR are
+                // handled above, so what is left is a descriptor that will
+                // never yield anything again. Continuing to read it would spin.
+                Self.logger.error(
+                    """
+                    read failed on the pty for session \
+                    \(self.sessionID.uuidString, privacy: .public) \
+                    (errno \(code, privacy: .public)); stopped draining it
+                    """)
+                return false
+            case .closed:
+                return false
+            }
+        }
+    }
+}
+
+// MARK: - The descriptor
+
+/// Owns the handed-over pty master and serializes every operation on it.
+///
+/// The lock is not about throughput — the descriptor is non-blocking, so no
+/// operation under it waits on the child — it is about the fd *number*. Reads
+/// happen on the drain thread, writes arrive from the actor, and the close
+/// happens exactly once; funnelling all three through one lock and one `fd`
+/// field is what makes "closed" a state a writer can observe instead of a race
+/// it can lose.
+private final class PTYDescriptor: @unchecked Sendable {
+    enum ReadOutcome {
+        case bytes(Int)
+        case wouldBlock
+        case interrupted
+        /// End of file, or `EIO`: on a pty master, the last slave has closed.
+        case childGone
+        case failed(errno: Int32)
+        case closed
+    }
+
+    /// How long a `write` may wait for a child that is not currently reading
+    /// its terminal. Short: the caller is an actor, and a paste that cannot
+    /// land must be reported rather than absorbed into an unbounded wait.
+    private static let writeBudgetMilliseconds: Int32 = 250
+    /// The same budget for the emulator's own replies, which are written from
+    /// inside a feed and must not hold the terminal lock for long.
+    private static let replyBudgetMilliseconds: Int32 = 50
+
+    private let lock = NSLock()
+    private var fd: Int32
+
+    init(fd: Int32) {
+        self.fd = fd
+        // Non-blocking from the outset, for both directions. Reads are
+        // poll-guarded anyway; what this really buys is that no `write` — not
+        // the actor's, and above all not a terminal reply issued from inside a
+        // feed — can park a thread on a child that has stopped reading.
+        //
+        // The flag lives on the open file description, which this descriptor
+        // shares with the holder's own copy. That is harmless precisely because
+        // of the holder's central invariant: it never reads the master.
+        if fd >= 0 {
+            _ = fcntl(fd, F_SETFL, fcntl(fd, F_GETFL) | O_NONBLOCK)
+        }
+    }
+
+    /// The raw number, for a poll set. Valid only while the owner has not
+    /// closed it — which, by construction, only the drain thread does.
+    var rawDescriptor: Int32 {
+        lock.lock()
+        defer { lock.unlock() }
+        return fd
+    }
+
+    func read(into buffer: inout [UInt8]) -> ReadOutcome {
+        lock.lock()
+        defer { lock.unlock() }
+        guard fd >= 0 else { return .closed }
+        let count = buffer.withUnsafeMutableBytes { raw -> Int in
+            Darwin.read(fd, raw.baseAddress, raw.count)
+        }
+        if count > 0 { return .bytes(count) }
+        if count == 0 { return .childGone }
+        switch errno {
+        case EAGAIN: return .wouldBlock
+        case EINTR: return .interrupted
+        case EIO: return .childGone
+        default: return .failed(errno: errno)
+        }
+    }
+
+    func write(_ data: Data) throws {
+        guard !data.isEmpty else { return }
+        try data.withUnsafeBytes { raw in
+            try writeAll(raw, budgetMilliseconds: Self.writeBudgetMilliseconds)
+        }
+    }
+
+    /// A terminal reply, written best-effort.
+    ///
+    /// Best-effort because the alternative is worse: this runs inside a feed,
+    /// under the terminal lock, and there is no caller to hand an error to. A
+    /// reply that cannot land within a small budget is dropped and logged —
+    /// never the bytes, only the fact.
+    func replyBestEffort(_ bytes: ArraySlice<UInt8>) {
+        guard !bytes.isEmpty else { return }
+        do {
+            try bytes.withUnsafeBufferPointer { pointer in
+                try writeAll(UnsafeRawBufferPointer(pointer), budgetMilliseconds: Self.replyBudgetMilliseconds)
+            }
+        } catch {
+            Logger(subsystem: "com.tbd.daemon", category: "holder").error(
+                "could not deliver a terminal reply to the child: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    private func writeAll(_ bytes: UnsafeRawBufferPointer, budgetMilliseconds: Int32) throws {
+        lock.lock()
+        defer { lock.unlock() }
+        guard fd >= 0 else { throw HolderReader.Error.stopped }
+
+        var offset = 0
+        var remainingBudget = budgetMilliseconds
+        while offset < bytes.count {
+            let written = Darwin.write(fd, bytes.baseAddress!.advanced(by: offset), bytes.count - offset)
+            if written > 0 {
+                offset += written
+                continue
+            }
+            if written < 0, errno == EINTR { continue }
+            guard written < 0, errno == EAGAIN else {
+                throw HolderReader.Error.writeFailed(errno: errno)
+            }
+            guard remainingBudget > 0 else {
+                throw HolderReader.Error.writeTimedOut(unwritten: bytes.count - offset)
+            }
+            let slice = min(remainingBudget, 20)
+            var watched = pollfd(fd: fd, events: Int16(POLLOUT), revents: 0)
+            let ready = poll(&watched, 1, slice)
+            if ready < 0, errno != EINTR {
+                throw HolderReader.Error.writeFailed(errno: errno)
+            }
+            remainingBudget -= slice
+        }
+    }
+
+    func setWindowSize(columns: Int, rows: Int) {
+        lock.lock()
+        defer { lock.unlock() }
+        guard fd >= 0 else { return }
+        var size = winsize(
+            ws_row: UInt16(clamping: rows),
+            ws_col: UInt16(clamping: columns),
+            ws_xpixel: 0,
+            ws_ypixel: 0)
+        if ioctl(fd, TIOCSWINSZ, &size) != 0 {
+            Logger(subsystem: "com.tbd.daemon", category: "holder").error(
+                "TIOCSWINSZ failed (errno \(errno, privacy: .public))")
+        }
+    }
+
+    /// Closes the descriptor once. Every later operation observes "closed"
+    /// rather than acting on a number the kernel may have handed to somebody
+    /// else in the meantime.
+    func close() {
+        lock.lock()
+        defer { lock.unlock() }
+        if fd >= 0 { Darwin.close(fd) }
+        fd = -1
+    }
+}
+
+// MARK: - The emulator
+
+/// The headless terminal, and the lock discipline it demands.
+///
+/// `Terminal` is not `Sendable`, carries no `@MainActor`, and does not lock
+/// itself: it publishes `terminalLock` and expects every feed and every read of
+/// its state to hold it. The drain thread and a rendering caller are genuinely
+/// concurrent, so this box exists to make that impossible to get wrong — no
+/// path reaches the `Terminal` except through a method here, and every method
+/// here takes the lock. Getting it wrong garbles output rather than crashing,
+/// which is why it must be structural instead of remembered.
+private final class HolderEmulator: @unchecked Sendable {
+    private let terminal: Terminal
+    /// Held strongly: `Terminal.tdel` is `weak`, so a delegate nobody else
+    /// retains is deallocated and the child's terminal queries go unanswered.
+    private let delegate: ReplyForwardingDelegate
+
+    init(columns: Int, rows: Int, scrollback: Int, reply: @escaping @Sendable (ArraySlice<UInt8>) -> Void) {
+        let delegate = ReplyForwardingDelegate(reply: reply)
+        self.delegate = delegate
+        self.terminal = Terminal(
+            delegate: delegate,
+            options: TerminalOptions(
+                cols: max(1, columns),
+                rows: max(1, rows),
+                scrollback: max(0, scrollback)))
+    }
+
+    func feed(_ bytes: ArraySlice<UInt8>) {
+        terminal.terminalLock.withLock {
+            terminal.feed(buffer: bytes)
+        }
+    }
+
+    func renderScreen() -> String {
+        terminal.terminalLock.withLock {
+            var lines: [String] = []
+            lines.reserveCapacity(terminal.rows)
+            for row in 0..<terminal.rows {
+                lines.append(terminal.getLine(row: row)?.translateToString(trimRight: true) ?? "")
+            }
+            return Self.joined(lines)
+        }
+    }
+
+    /// The tail of the whole buffer — scrollback and viewport together.
+    ///
+    /// Enumeration starts at `totalLinesTrimmed`, the absolute index of the
+    /// oldest line still held, and runs until `getScrollInvariantLine` returns
+    /// nil: there is no public line count, and `Buffer.lines` is internal.
+    func renderScreenWithScrollback(maxLines: Int) -> String {
+        guard maxLines > 0 else { return "" }
+        return terminal.terminalLock.withLock {
+            var lines: [String] = []
+            var row = terminal.buffer.totalLinesTrimmed
+            while let line = terminal.getScrollInvariantLine(row: row) {
+                lines.append(line.translateToString(trimRight: true))
+                row += 1
+            }
+            if lines.count > maxLines {
+                lines.removeFirst(lines.count - maxLines)
+            }
+            return Self.joined(lines)
+        }
+    }
+
+    func resize(columns: Int, rows: Int) {
+        terminal.terminalLock.withLock {
+            terminal.resize(cols: columns, rows: rows)
+        }
+    }
+
+    /// Trailing blank lines are dropped — a screen is 24 rows whether or not
+    /// the job filled them, and rendering 20 empty ones helps nobody.
+    private static func joined(_ lines: [String]) -> String {
+        var lines = lines
+        while let last = lines.last, last.isEmpty { lines.removeLast() }
+        return lines.joined(separator: "\n")
+    }
+}
+
+/// The emulator's only required delegate hook: bytes the terminal itself wants
+/// to send back — device-status replies, cursor-position reports, the answers
+/// to `DECRQM`. `TerminalDelegate` declares 31 methods and a public extension
+/// defaults 30 of them; this is the one that has no default, and routing it
+/// anywhere but the child would turn every terminal query into a hang.
+private final class ReplyForwardingDelegate: TerminalDelegate {
+    private let reply: @Sendable (ArraySlice<UInt8>) -> Void
+
+    init(reply: @escaping @Sendable (ArraySlice<UInt8>) -> Void) {
+        self.reply = reply
+    }
+
+    func send(source: Terminal, data: ArraySlice<UInt8>) {
+        reply(data)
+    }
+}

--- a/Sources/TBDDaemon/Holder/HolderSpawner.swift
+++ b/Sources/TBDDaemon/Holder/HolderSpawner.swift
@@ -15,6 +15,28 @@ struct HolderHandle: Sendable, Equatable {
     var socketPath: String
 }
 
+/// A spawned holder, together with **the connection its handshake ran on**.
+///
+/// The connection is returned rather than closed because the holder serves one
+/// client at a time and learns the previous one has gone only when its `poll`
+/// loop next reads EOF on that socket. A spawner that closed its handshake
+/// connection and returned would leave every caller to reconnect into that
+/// window, where the holder legitimately answers the busy sentinel for a slot
+/// that is already free. Handing the live connection on removes the reconnect,
+/// so the window cannot be entered: the caller attaches over the connection the
+/// handshake already proved good, and pays one fewer connect per session.
+///
+/// **Ownership is the client's, and it is released by letting go.** `client` is
+/// an actor whose `deinit` closes the socket, so a caller that never uses it
+/// frees the holder's client slot by dropping the result; a caller that wants
+/// the slot free sooner calls `close()`, and the client reconnects on its next
+/// verb like any other. Nothing is returned on a failed spawn — every
+/// connection the spawner opened on the way to one is closed before it throws.
+struct HolderSpawnResult: Sendable {
+    var handle: HolderHandle
+    var client: HolderClient
+}
+
 /// Spawns one holder process per session and waits for it to become reachable.
 ///
 /// The ordering in `spawn` is the contract rather than a preference, and each
@@ -33,7 +55,10 @@ struct HolderHandle: Sendable, Equatable {
 ///   6. The daemon drops its own copy of the lock, so the holder alone holds it
 ///      and the kernel drops it when the holder dies.
 ///   7. The socket is polled for reachability on the injected clock, then
-///      handshaken.
+///      handshaken — and the connection that answered is **returned, not
+///      closed**, because a caller made to reconnect would race the holder's
+///      notice that the handshake connection went away. See
+///      `HolderSpawnResult`.
 ///   8. A holder that never answers is judged by whether its socket exists,
 ///      never by the handshake alone: no socket means it never bound and so
 ///      never forked, which is the only state where killing it can orphan
@@ -144,7 +169,7 @@ struct HolderSpawner {
         launch: HolderLaunchRequest,
         owner: HolderOwnerToken,
         environment: [String: String]
-    ) async throws -> HolderHandle {
+    ) async throws -> HolderSpawnResult {
         let socketPath = try HolderRendezvous.socketPath(sessionID: sessionID, environment: environment)
         let lockPath = try HolderRendezvous.lockPath(sessionID: sessionID, environment: environment)
         let holdersDir = TBDConstants.holdersDir(environment: environment)
@@ -205,9 +230,9 @@ struct HolderSpawner {
         lock.release()
         lockReleased = true
 
-        let description: HolderChildDescription
+        let attached: (description: HolderChildDescription, client: HolderClient)
         do {
-            description = try await awaitBinding(socketPath: socketPath)
+            attached = try await awaitBinding(socketPath: socketPath)
         } catch {
             throw resolveUnreachableHolder(
                 holderPID: holderPID,
@@ -217,14 +242,17 @@ struct HolderSpawner {
                 cause: error)
         }
 
+        let description = attached.description
         Self.logger.info(
             """
             spawned holder pid \(holderPID, privacy: .public) for session \
             \(sessionID.uuidString, privacy: .public): child \
             \(description.childPID, privacy: .public) on \(description.ttyName, privacy: .public)
             """)
-        return HolderHandle(
-            holderPID: holderPID, childPID: description.childPID, socketPath: socketPath)
+        return HolderSpawnResult(
+            handle: HolderHandle(
+                holderPID: holderPID, childPID: description.childPID, socketPath: socketPath),
+            client: attached.client)
     }
 
     // MARK: - A holder that was spawned but never answered
@@ -434,21 +462,31 @@ struct HolderSpawner {
     // MARK: - Waiting for the rendezvous
 
     /// Polls until the socket answers a handshake, bounded on the **injected**
-    /// clock.
+    /// clock, and returns the connection that answered.
+    ///
+    /// **The winning connection is kept open**, which is what makes the spawn
+    /// hand-off raceless — see `HolderSpawnResult`. Every connection that did
+    /// *not* answer is closed here, on both the retry and the rejection paths,
+    /// so a failed spawn leaves nothing attached to the holder's one client
+    /// slot.
     ///
     /// Elapsed time is accumulated from the poll interval rather than measured
     /// against a deadline because `any Clock<Duration>` pins `Duration` but not
     /// `Instant`: instant arithmetic does not typecheck through the
     /// existential, and a limit expressed as "how much waiting has been spent"
     /// is what a fake clock can drive.
-    private func awaitBinding(socketPath: String) async throws -> HolderChildDescription {
+    private func awaitBinding(
+        socketPath: String
+    ) async throws -> (description: HolderChildDescription, client: HolderClient) {
         var waited: Duration = .zero
         while true {
             let client = HolderClient(socketPath: socketPath, receiveTimeout: handshakeTimeout)
             do {
                 let description = try await client.describe()
-                await client.close()
-                return description
+                // The handshake budget is a startup deadline, not a session
+                // one, and this connection is about to become a session's.
+                await client.adoptReceiveTimeout(HolderClient.defaultReceiveTimeout)
+                return (description, client)
             } catch HolderClient.Error.rejected(let version) {
                 await client.close()
                 throw Error.rejected(version: version)

--- a/Tests/TBDDaemonTests/Holder/HolderClientTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HolderClientTests.swift
@@ -36,12 +36,10 @@ struct HolderClientTests {
         #expect(processIsAlive(fixture.handle.childPID))
         #expect(processIsAlive(fixture.handle.holderPID))
 
-        // The spawner closes its handshake connection, so the holder's single
-        // client slot is free for a fresh one — which is what every later
-        // daemon-side consumer relies on.
-        let client = HolderClient(socketPath: fixture.handle.socketPath, receiveTimeout: .seconds(5))
-        let description = try await client.describe()
-        await client.close()
+        // The spawner hands its handshake connection on, so the holder is
+        // already attached and answering before the caller asks anything —
+        // which is what every later daemon-side consumer relies on.
+        let description = try await fixture.client.describe()
         #expect(description.childPID == fixture.handle.childPID)
         #expect(description.status == .alive)
         #expect(description.ttyName.hasPrefix("/dev/"))
@@ -54,10 +52,13 @@ struct HolderClientTests {
         let fixture = try await SpawnedHolderFixture.start(command: "printf HOLDER-OK; sleep 30")
         defer { fixture.tearDown() }
 
-        let client = HolderClient(socketPath: fixture.handle.socketPath, receiveTimeout: .seconds(5))
-        let (description, ptyFD) = try await client.handOverPTY()
+        // Straight onto the spawner's own connection, with no reconnect in
+        // between. This used to dial the socket again and fail about one run in
+        // five with the busy sentinel, because the holder had not yet read EOF
+        // on the connection the spawner closed a moment earlier.
+        let (description, ptyFD) = try await fixture.client.handOverPTY()
         defer { Darwin.close(ptyFD) }
-        await client.close()
+        await fixture.client.close()
         #expect(description.childPID == fixture.handle.childPID)
         #expect(ptyFD >= 0)
 
@@ -67,6 +68,45 @@ struct HolderClientTests {
             return String(decoding: seen, as: UTF8.self).contains("HOLDER-OK")
         }
         #expect(sawMarker, "read \(seen.count) bytes: \(String(decoding: seen, as: UTF8.self).debugDescription)")
+    }
+
+    /// Handing the handshake connection on must not soften the busy sentinel.
+    ///
+    /// The sentinel is the only thing standing between one pty master and two
+    /// readers, and "two readers" is silent byte theft rather than an error
+    /// anyone would notice. So the fix for the spawn race is checked against
+    /// its opposite: while the spawner's connection is genuinely attached, a
+    /// second client is refused — and once that connection is let go, the slot
+    /// really does become free, which is what makes the refusal a statement
+    /// about occupancy rather than a permanent lockout.
+    @Test func refusesASecondClientWhileTheSpawnersConnectionIsHeld() async throws {
+        let fixture = try await SpawnedHolderFixture.start(command: "sleep 30")
+        defer { fixture.tearDown() }
+
+        // Not merely constructed: a round trip proves the spawner's connection
+        // is the live one occupying the holder's single slot.
+        let held = try await fixture.client.describe()
+        #expect(held.status == .alive)
+
+        let second = HolderClient(socketPath: fixture.handle.socketPath, receiveTimeout: .seconds(5))
+        await #expect(throws: HolderClient.Error.rejected(version: HolderProtocolVersion.busySentinel)) {
+            _ = try await second.describe()
+        }
+        await second.close()
+
+        // The other half: the refusal tracks occupancy. Polled rather than
+        // asserted once, because the holder learns the slot is free only when
+        // its poll loop next reads EOF — the very latency that made a
+        // reconnecting caller flaky, here waited out on purpose.
+        await fixture.client.close()
+        let socketPath = fixture.handle.socketPath
+        let reattached = await pollUntil("the holder to free its client slot") {
+            let probe = HolderClient(socketPath: socketPath, receiveTimeout: .seconds(5))
+            let answered = (try? await probe.describe()) != nil
+            await probe.close()
+            return answered
+        }
+        #expect(reattached, "the holder never freed its client slot")
     }
 
     // MARK: - The creation lock
@@ -161,9 +201,7 @@ struct HolderClientTests {
 
         // The assertion that matters: the session the probe protected is still
         // usable, not merely still on disk.
-        let client = HolderClient(socketPath: fixture.handle.socketPath, receiveTimeout: .seconds(5))
-        let description = try await client.describe()
-        await client.close()
+        let description = try await fixture.client.describe()
         #expect(description.childPID == fixture.handle.childPID)
         #expect(description.status == .alive)
     }
@@ -259,9 +297,8 @@ struct HolderClientTests {
         defer { fixture.tearDown() }
         let childPID = fixture.handle.childPID
 
-        let client = HolderClient(socketPath: fixture.handle.socketPath, receiveTimeout: .seconds(5))
-        try await client.forget()
-        await client.close()
+        try await fixture.client.forget()
+        await fixture.client.close()
 
         // A forgotten holder has nothing left to say, so it drops its pty and
         // exits, unlinking the socket on the way out.
@@ -624,6 +661,68 @@ struct HolderClientTests {
         #expect(pushed?.childPID == 4242)
         await client.close()
     }
+
+    /// A pushed exit must be observable **without** anybody calling `close()`.
+    ///
+    /// This is the shape a real holder produces: it pushes the terminal status
+    /// at its connected client and then winds itself down, so the push and the
+    /// EOF behind it are both waiting when the next verb runs. The barrier
+    /// decodes the push, the read after it fails on the EOF, and the verb
+    /// rightly throws — but the exit it just decoded is a fact about the child,
+    /// not about the connection, and it has to survive the throw. A poller that
+    /// calls `describe()` and reads `lastPushedDescription` is the whole reason:
+    /// it never closes, so a status only retired at `close()` reaches it never.
+    ///
+    /// `close()` is deliberately not called before the assertion — calling it
+    /// would retire the queue by the other path and turn the test green with
+    /// the fix reverted.
+    @Test func surfacesAPushedExitWithoutWaitingForClose() async throws {
+        let home = SpawnedHolderFixture.scratchHome()
+        defer { try? FileManager.default.removeItem(atPath: home) }
+        try FileManager.default.createDirectory(atPath: home, withIntermediateDirectories: true)
+        let socketPath = home + "/stub.sock"
+
+        let alive = SpawnedHolderFixture.description(childPID: 4242, home: home)
+        var exited = alive
+        exited.status = .exited(code: 7)
+
+        // Gated so the push lands in its own read rather than coalesced with
+        // the answer, and the peer then hangs up — the holder's own sequence.
+        let gate = ScriptedStubPeer.TrailerGate()
+        let peer = try ScriptedStubPeer(
+            socketPath: socketPath,
+            answers: [
+                ScriptedStubPeer.Answer(
+                    payload: try HolderFraming.frame(HolderResponse.described(alive)),
+                    trailer: try HolderFraming.frame(HolderResponse.described(exited)),
+                    trailerGate: gate),
+            ],
+            closesAfterScript: true)
+        defer { peer.tearDown() }
+
+        let client = HolderClient(socketPath: socketPath, receiveTimeout: .seconds(2))
+        let first = try await client.describe()
+        #expect(first.status == .alive)
+        let beforeTheGate = await client.lastPushedDescription
+        #expect(beforeTheGate == nil, "the stub pushed the exit before the test released it")
+
+        gate.release()
+        try #require(gate.waitUntilWritten(), "the stub peer never wrote its trailing push")
+        // Waiting for the hang-up, not just the write, is what makes the
+        // interleaving deterministic: both the push and the EOF are queued
+        // before the next verb runs, so the barrier is guaranteed to decode one
+        // and then fail on the other.
+        try #require(peer.waitUntilClosed(), "the stub peer never closed the connection")
+
+        await #expect(throws: HolderClient.Error.peerClosed) {
+            _ = try await client.describe()
+        }
+
+        let pushed = await client.lastPushedDescription
+        #expect(pushed?.status == .exited(code: 7))
+        #expect(pushed?.childPID == 4242)
+        await client.close()
+    }
 }
 
 // MARK: - Support
@@ -757,6 +856,11 @@ private final class SpawnedHolderFixture {
     let sessionID: UUID
     let owner: HolderOwnerToken
     let handle: HolderHandle
+    /// The connection the spawner's handshake ran on, handed straight over.
+    /// Tests use this rather than dialling the socket again: a fresh connect
+    /// would race the holder's notice that the handshake connection had gone,
+    /// which is the race this fixture exists to stop reintroducing.
+    let client: HolderClient
     private var torndown = false
 
     private final class BundleMarker {}
@@ -840,20 +944,31 @@ private final class SpawnedHolderFixture {
         let home = scratchHome()
         let token = HolderOwnerToken(rawValue: owner)
         let spawner = try makeSpawner()
-        let handle = try await spawner.spawn(
+        let spawned = try await spawner.spawn(
             sessionID: session,
             launch: launch(command: command, home: home),
             owner: token,
             environment: environment(home: home))
         return SpawnedHolderFixture(
-            home: home, sessionID: session, owner: token, handle: handle)
+            home: home,
+            sessionID: session,
+            owner: token,
+            handle: spawned.handle,
+            client: spawned.client)
     }
 
-    private init(home: String, sessionID: UUID, owner: HolderOwnerToken, handle: HolderHandle) {
+    private init(
+        home: String,
+        sessionID: UUID,
+        owner: HolderOwnerToken,
+        handle: HolderHandle,
+        client: HolderClient
+    ) {
         self.home = home
         self.sessionID = sessionID
         self.owner = owner
         self.handle = handle
+        self.client = client
     }
 
     private var reaped = false
@@ -978,8 +1093,16 @@ private final class ScriptedStubPeer: @unchecked Sendable {
     private let lock = NSLock()
     private var connectionFD: Int32 = -1
     private var stopped = false
+    /// Signalled once the peer has hung up, for `closesAfterScript`.
+    private let closedConnection = DispatchSemaphore(value: 0)
 
-    init(socketPath: String, answers: [Answer]) throws {
+    /// `closesAfterScript` makes the peer hang up when its script runs out
+    /// instead of parking with the connection open. Parking is the default
+    /// because an EOF the client did not expect can mask a missing queue as a
+    /// pass; a test about what happens *at* the EOF needs the opposite, and
+    /// waits for `waitUntilClosed()` so the hang-up is ordered rather than
+    /// raced.
+    init(socketPath: String, answers: [Answer], closesAfterScript: Bool = false) throws {
         self.socketPath = socketPath
         listenFD = try bindUnixListener(at: socketPath, backlog: 4)
 
@@ -1015,7 +1138,12 @@ private final class ScriptedStubPeer: @unchecked Sendable {
             }
             // Park with the connection open. Closing here would let the client
             // reach EOF, which is the very thing the queue is meant to make
-            // unnecessary — an EOF would mask a missing queue as a pass.
+            // unnecessary — an EOF would mask a missing queue as a pass. A test
+            // whose subject IS the EOF opts out with `closesAfterScript`.
+            if closesAfterScript {
+                self.hangUp()
+                self.closedConnection.signal()
+            }
             while !self.isStopped { usleep(20_000) }
         }
         thread.name = "holder-stub-peer"
@@ -1034,13 +1162,34 @@ private final class ScriptedStubPeer: @unchecked Sendable {
         return stopped
     }
 
-    func tearDown() {
+    /// Closes the accepted connection, once. Safe to race `tearDown`: whichever
+    /// runs first takes the descriptor and leaves -1 behind.
+    private func hangUp() {
         lock.lock()
-        stopped = true
         let connection = connectionFD
         connectionFD = -1
         lock.unlock()
         if connection >= 0 { Darwin.close(connection) }
+    }
+
+    /// Blocks the test until a `closesAfterScript` peer has hung up.
+    @discardableResult
+    func waitUntilClosed(
+        timeout: TimeInterval = 10.0,
+        sourceLocation: SourceLocation = #_sourceLocation
+    ) -> Bool {
+        if closedConnection.wait(timeout: .now() + timeout) == .success { return true }
+        Issue.record(
+            "timed out after \(timeout)s waiting for the stub peer to close the connection",
+            sourceLocation: sourceLocation)
+        return false
+    }
+
+    func tearDown() {
+        lock.lock()
+        stopped = true
+        lock.unlock()
+        hangUp()
         Darwin.close(listenFD)
         unlink(socketPath)
     }

--- a/Tests/TBDDaemonTests/Holder/HolderReaderTestSupport.swift
+++ b/Tests/TBDDaemonTests/Holder/HolderReaderTestSupport.swift
@@ -1,0 +1,153 @@
+import Darwin
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// A holder started the way the daemon starts one — through the real
+/// `HolderSpawner`, with a real `posix_spawn` — plus everything needed to take
+/// it and its job back down.
+///
+/// Four rules, each one a bug the suite would otherwise ship:
+///
+///   1. **Every wait is a bounded poll.** A wedged holder must fail a test with
+///      a named diagnostic, not hang the suite with no output.
+///   2. **Every bootstrap is rc-free.** `/bin/sh` with an explicit environment,
+///      never a login shell — a developer's profile must not decide whether a
+///      test passes.
+///   3. **Every test kills its holder AND its job.** Holder death is
+///      deliberately not child death, so a test that terminates a holder
+///      orphans whatever it was supervising.
+///   4. **No `setenv`.** The rendezvous paths come from an explicit environment
+///      dictionary handed to `spawn`, so nothing here can reach the developer's
+///      real `~/tbd` even for an instant.
+///
+/// It deliberately duplicates the fixture in `HolderClientTests` rather than
+/// sharing it: that file belongs to a separate change still under review, and a
+/// shared extraction is worth doing once both have landed.
+final class HolderProcessFixture {
+    let home: String
+    let sessionID: UUID
+    let owner: HolderOwnerToken
+    let handle: HolderHandle
+    private var torndown = false
+    private var reaped = false
+
+    private final class BundleMarker {}
+
+    /// A short scratch root. Short on purpose: the rendezvous socket lives
+    /// under it and `sun_path` is 104 bytes, so a deep `TMPDIR` would fail the
+    /// bind rather than the assertion.
+    static func scratchHome() -> String {
+        "/tmp/tbdh7-\(UUID().uuidString.prefix(8).lowercased())"
+    }
+
+    /// The environment the rendezvous paths are derived from *and* the holder
+    /// process runs under. Explicit and rc-free: nothing here comes from the
+    /// developer's shell, and `TBD_HOME` never leaves this dictionary.
+    static func environment(home: String) -> [String: String] {
+        ["TBD_HOME": home, "PATH": "/usr/bin:/bin"]
+    }
+
+    static func launch(command: String) -> HolderLaunchRequest {
+        HolderLaunchRequest(
+            executable: "/bin/sh",
+            arguments: ["-c", command],
+            workingDirectory: "/tmp",
+            environment: ["PATH": "/usr/bin:/bin", "TERM": "xterm-256color"],
+            columns: 80,
+            rows: 24)
+    }
+
+    static func locateExecutable() -> URL? {
+        let bundleURL = Bundle(for: BundleMarker.self).bundleURL
+        var candidates = [bundleURL.deletingLastPathComponent(), bundleURL]
+        if let main = Bundle.main.executableURL?.deletingLastPathComponent() {
+            candidates.append(main)
+        }
+        for directory in candidates {
+            let candidate = directory.appendingPathComponent("TBDHolder")
+            if FileManager.default.isExecutableFile(atPath: candidate.path) {
+                return candidate
+            }
+        }
+        return nil
+    }
+
+    static func start(
+        command: String,
+        owner: String = "acme-installation",
+        session: UUID = UUID()
+    ) async throws -> HolderProcessFixture {
+        let home = scratchHome()
+        let token = HolderOwnerToken(rawValue: owner)
+        let executable = try #require(
+            locateExecutable(), "TBDHolder must be built beside the test bundle")
+        let spawner = HolderSpawner(executableURL: executable)
+        let handle = try await spawner.spawn(
+            sessionID: session,
+            launch: launch(command: command),
+            owner: token,
+            environment: environment(home: home))
+        return HolderProcessFixture(home: home, sessionID: session, owner: token, handle: handle)
+    }
+
+    private init(home: String, sessionID: UUID, owner: HolderOwnerToken, handle: HolderHandle) {
+        self.home = home
+        self.sessionID = sessionID
+        self.owner = owner
+        self.handle = handle
+    }
+
+    /// Kills the holder AND the job, in that order, then removes the scratch
+    /// root. Holder death is not child death, so both need naming. The holder
+    /// is this process's own child — the spawner `posix_spawn`s it directly —
+    /// so it must also be reaped, or the corpse outlives the suite.
+    func tearDown() {
+        guard !torndown else { return }
+        torndown = true
+
+        if !reaped {
+            kill(handle.holderPID, SIGKILL)
+            var ignored: Int32 = 0
+            _ = waitpid(handle.holderPID, &ignored, 0)
+            reaped = true
+        }
+        if holderProcessIsAlive(handle.childPID) { kill(handle.childPID, SIGKILL) }
+        // The job is the holder's child, not ours, so nothing here can reap it;
+        // the kernel reparents and reaps. Confirm it is gone so a leak fails the
+        // test that caused it rather than the next run.
+        let deadline = Date().addingTimeInterval(5.0)
+        while Date() < deadline, holderProcessIsAlive(handle.childPID) {
+            usleep(20_000)
+        }
+        try? FileManager.default.removeItem(atPath: home)
+    }
+}
+
+/// Whether a pid can still be signalled.
+///
+/// Both a running job and one wedged in `ttywait` — past its last instruction,
+/// but blocked inside `proc_exit` behind an undrained terminal — answer yes,
+/// and both mean the same thing to these tests: the exit has not completed.
+/// Only a job whose exit finished and whose holder reaped it is gone.
+func holderProcessIsAlive(_ pid: Int32) -> Bool {
+    pid > 0 && kill(pid, 0) == 0
+}
+
+/// Polls an async condition until it holds or the budget runs out.
+@discardableResult
+func pollUntil(
+    _ description: String,
+    timeout: TimeInterval = 20.0,
+    sourceLocation: SourceLocation = #_sourceLocation,
+    _ condition: () async throws -> Bool
+) async rethrows -> Bool {
+    let deadline = Date().addingTimeInterval(timeout)
+    while Date() < deadline {
+        if try await condition() { return true }
+        try? await Task.sleep(for: .milliseconds(20))
+    }
+    Issue.record("timed out after \(timeout)s waiting for \(description)", sourceLocation: sourceLocation)
+    return false
+}

--- a/Tests/TBDDaemonTests/Holder/HolderReaderTestSupport.swift
+++ b/Tests/TBDDaemonTests/Holder/HolderReaderTestSupport.swift
@@ -30,6 +30,11 @@ final class HolderProcessFixture {
     let sessionID: UUID
     let owner: HolderOwnerToken
     let handle: HolderHandle
+    /// The connection the spawner's handshake ran on, handed straight over.
+    /// Reconnecting instead would race the holder's notice that the handshake
+    /// connection had gone, and be answered with the busy sentinel for a slot
+    /// that is already free.
+    let client: HolderClient
     private var torndown = false
     private var reaped = false
 
@@ -84,19 +89,31 @@ final class HolderProcessFixture {
         let executable = try #require(
             locateExecutable(), "TBDHolder must be built beside the test bundle")
         let spawner = HolderSpawner(executableURL: executable)
-        let handle = try await spawner.spawn(
+        let spawned = try await spawner.spawn(
             sessionID: session,
             launch: launch(command: command),
             owner: token,
             environment: environment(home: home))
-        return HolderProcessFixture(home: home, sessionID: session, owner: token, handle: handle)
+        return HolderProcessFixture(
+            home: home,
+            sessionID: session,
+            owner: token,
+            handle: spawned.handle,
+            client: spawned.client)
     }
 
-    private init(home: String, sessionID: UUID, owner: HolderOwnerToken, handle: HolderHandle) {
+    private init(
+        home: String,
+        sessionID: UUID,
+        owner: HolderOwnerToken,
+        handle: HolderHandle,
+        client: HolderClient
+    ) {
         self.home = home
         self.sessionID = sessionID
         self.owner = owner
         self.handle = handle
+        self.client = client
     }
 
     /// Kills the holder AND the job, in that order, then removes the scratch

--- a/Tests/TBDDaemonTests/Holder/HolderReaderTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HolderReaderTests.swift
@@ -91,6 +91,113 @@ struct HolderReaderTests {
         #expect(sawBoth)
     }
 
+    // MARK: - Read failures
+
+    /// A read that fails with an errno nobody has classified must not end the
+    /// drain — the loop backs off and tries again, and picks the session up
+    /// where it left off.
+    ///
+    /// `ENOMEM` is the case this defends: a machine under memory pressure can
+    /// fail a `read` on a perfectly live pty, and a loop that took that as
+    /// final would stop draining a job that is still producing output — which
+    /// is the `ttywait` wedge this whole task exists to close, arrived at by a
+    /// different road.
+    ///
+    /// The marker written *after* the failures is what discriminates. A drain
+    /// that gave up would still have `ALPHA` nowhere and `BRAVO` nowhere, but a
+    /// drain that merely swallowed the error and read once more would show
+    /// `ALPHA` alone.
+    @Test func retriesATransientReadFailureAndKeepsDraining() async throws {
+        let fault = ScriptedReadFault(errno: ENOMEM, times: 3)
+        let fixture = try await HolderProcessFixture.start(
+            command: "printf 'ALPHA\\n'; sleep 0.6; printf 'BRAVO\\n'; sleep 30")
+        defer { fixture.tearDown() }
+
+        let client = fixture.client
+        let (_, ptyFD) = try await client.handOverPTY()
+        await client.close()
+        let reader = HolderReader(
+            sessionID: fixture.sessionID, ptyFD: ptyFD, columns: 80, rows: 24,
+            readFault: fault.seam())
+        try await reader.start()
+        defer { stopInBackground(reader) }
+
+        let sawBoth = await pollUntil("both markers, across the injected read failures") {
+            let screen = await reader.renderScreen()
+            return screen.contains("ALPHA") && screen.contains("BRAVO")
+        }
+        let screen = await reader.renderScreen()
+        #expect(sawBoth, "screen was: \(screen.debugDescription)")
+        #expect(
+            fault.injectedCount == 3,
+            "the fault fired \(fault.injectedCount) times, so this proved nothing about retrying")
+    }
+
+    /// The bound on retrying is the *cadence*, not a count.
+    ///
+    /// A scheme that gave up after N attempts would put the descriptor back
+    /// where the old code left it — permanently unread, with the job unable to
+    /// finish exiting — just later. So a failure that keeps failing keeps being
+    /// retried, forever, at a floor of a few attempts a second. Both halves are
+    /// asserted: attempts continue well past any plausible give-up point, and
+    /// they are paced rather than spun.
+    @Test func keepsRetryingAnUnclassifiedReadFailureRatherThanGivingUp() async throws {
+        let fault = ScriptedReadFault(errno: ENOMEM, times: nil)
+        let fixture = try await HolderProcessFixture.start(
+            command: "printf 'ECHO\\n'; sleep 30")
+        defer { fixture.tearDown() }
+
+        let client = fixture.client
+        let (_, ptyFD) = try await client.handOverPTY()
+        await client.close()
+        let reader = HolderReader(
+            sessionID: fixture.sessionID, ptyFD: ptyFD, columns: 80, rows: 24,
+            readFault: fault.seam())
+        try await reader.start()
+        defer { stopInBackground(reader) }
+
+        let keptTrying = await pollUntil("read attempts to continue past a give-up point") {
+            fault.injectedCount > 12
+        }
+        #expect(keptTrying, "the drain loop stopped retrying after \(fault.injectedCount) attempts")
+        // Paced, not spun. The backoff floor is four attempts a second; a loop
+        // retrying without one would be four orders of magnitude above this.
+        #expect(
+            fault.injectedCount < 400,
+            "the retry path is spinning: \(fault.injectedCount) attempts")
+    }
+
+    /// The other branch: an errno that genuinely cannot recover ends the drain
+    /// immediately, with no retries at all.
+    ///
+    /// `EBADF` means the number is not an open descriptor, so retrying it is
+    /// pure waste. The assertion is that exactly one read was ever attempted,
+    /// even though the job keeps writing for the whole window — which is what
+    /// separates "classified as permanent" from "retried and still failing".
+    @Test func stopsDrainingOnAPermanentReadFailure() async throws {
+        let fault = ScriptedReadFault(errno: EBADF, times: nil)
+        let fixture = try await HolderProcessFixture.start(
+            command: "while true; do printf 'TICK\\n'; sleep 0.05; done")
+        defer { fixture.tearDown() }
+
+        let client = fixture.client
+        let (_, ptyFD) = try await client.handOverPTY()
+        await client.close()
+        let reader = HolderReader(
+            sessionID: fixture.sessionID, ptyFD: ptyFD, columns: 80, rows: 24,
+            readFault: fault.seam())
+        try await reader.start()
+        defer { stopInBackground(reader) }
+
+        let attempted = await pollUntil("the first read attempt") { fault.injectedCount >= 1 }
+        #expect(attempted)
+
+        try await Task.sleep(for: .milliseconds(600))
+        #expect(
+            fault.injectedCount == 1,
+            "a permanent errno was retried \(fault.injectedCount) times")
+    }
+
     // MARK: - The emulator
 
     @Test func drainsChildOutputIntoTheEmulator() async throws {
@@ -230,6 +337,45 @@ struct HolderReaderTests {
 }
 
 // MARK: - Support
+
+/// A programmable `read` failure for the drain loop.
+///
+/// The failures it stands in for — `ENOMEM` above all — cannot be provoked on a
+/// healthy machine, and a test that tried to would be measuring the machine
+/// rather than the loop. It counts what it injects, because "the fault fired"
+/// is the difference between a test that proves retrying happens and one that
+/// passes because nothing ever went wrong.
+///
+/// Consulted on the drain thread while the test reads its counter, so every
+/// field is under the lock.
+private final class ScriptedReadFault: @unchecked Sendable {
+    private let lock = NSLock()
+    private let code: Int32
+    /// How many reads to fail. `nil` means every read, forever.
+    private let budget: Int?
+    private var injected = 0
+
+    init(errno code: Int32, times: Int?) {
+        self.code = code
+        self.budget = times
+    }
+
+    var injectedCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return injected
+    }
+
+    func seam() -> HolderReadFault {
+        HolderReadFault { [self] in
+            lock.lock()
+            defer { lock.unlock() }
+            if let budget, injected >= budget { return nil }
+            injected += 1
+            return code
+        }
+    }
+}
 
 /// Waits for a job to finish exiting, and returns the status the holder
 /// collected for it.

--- a/Tests/TBDDaemonTests/Holder/HolderReaderTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HolderReaderTests.swift
@@ -38,8 +38,8 @@ struct HolderReaderTests {
             command: "for i in $(seq 1 5000); do echo line-$i; done")
         defer { fixture.tearDown() }
 
-        let client = HolderClient(socketPath: fixture.handle.socketPath, receiveTimeout: .seconds(5))
-        let (_, ptyFD) = try await adoptPTY(via: client)
+        let client = fixture.client
+        let (_, ptyFD) = try await client.handOverPTY()
         await client.close()
         let reader = HolderReader(
             sessionID: fixture.sessionID, ptyFD: ptyFD, columns: 80, rows: 24)
@@ -73,8 +73,8 @@ struct HolderReaderTests {
             command: "printf 'BRAVO\\n'; sleep 0.4; printf 'CHARLIE\\n'")
         defer { fixture.tearDown() }
 
-        let client = HolderClient(socketPath: fixture.handle.socketPath, receiveTimeout: .seconds(5))
-        let (_, ptyFD) = try await adoptPTY(via: client)
+        let client = fixture.client
+        let (_, ptyFD) = try await client.handOverPTY()
         await client.close()
         let reader = HolderReader(
             sessionID: fixture.sessionID, ptyFD: ptyFD, columns: 80, rows: 24)
@@ -98,8 +98,8 @@ struct HolderReaderTests {
             command: "printf 'ALPHA\\n'; sleep 30")
         defer { fixture.tearDown() }
 
-        let client = HolderClient(socketPath: fixture.handle.socketPath, receiveTimeout: .seconds(5))
-        let (_, ptyFD) = try await adoptPTY(via: client)
+        let client = fixture.client
+        let (_, ptyFD) = try await client.handOverPTY()
         await client.close()
         let reader = HolderReader(
             sessionID: fixture.sessionID, ptyFD: ptyFD, columns: 80, rows: 24)
@@ -125,8 +125,8 @@ struct HolderReaderTests {
             command: "while IFS= read -r line; do printf 'GOT:%s\\n' \"$line\"; done")
         defer { fixture.tearDown() }
 
-        let client = HolderClient(socketPath: fixture.handle.socketPath, receiveTimeout: .seconds(5))
-        let (_, ptyFD) = try await adoptPTY(via: client)
+        let client = fixture.client
+        let (_, ptyFD) = try await client.handOverPTY()
         await client.close()
         let reader = HolderReader(
             sessionID: fixture.sessionID, ptyFD: ptyFD, columns: 80, rows: 24)
@@ -157,8 +157,8 @@ struct HolderReaderTests {
             command: "printf 'DELTA\\n'; sleep 30")
         defer { fixture.tearDown() }
 
-        let client = HolderClient(socketPath: fixture.handle.socketPath, receiveTimeout: .seconds(5))
-        let (_, ptyFD) = try await adoptPTY(via: client)
+        let client = fixture.client
+        let (_, ptyFD) = try await client.handOverPTY()
         let reader = HolderReader(
             sessionID: fixture.sessionID, ptyFD: ptyFD, columns: 80, rows: 24)
         try await reader.start()
@@ -257,34 +257,6 @@ private func awaitJobExit(
     }
     guard reaped else { return nil }
     return try? await client.describe().status
-}
-
-/// Takes the pty master from a freshly spawned holder, retrying a refusal.
-///
-/// The holder serves **one client at a time**, and it learns that the previous
-/// one has gone only when its poll loop next reads EOF on that socket. The
-/// spawner closes its handshake connection and returns immediately, so a
-/// hand-over issued in the next microsecond can legitimately be answered with
-/// the busy sentinel — the slot is free, the holder has not noticed yet. It is
-/// a race the wire cannot avoid and the caller must absorb, so every consumer
-/// of a just-spawned holder needs this retry; here it is bounded, and a
-/// refusal that outlives the budget is rethrown rather than swallowed.
-private func adoptPTY(
-    via client: HolderClient,
-    timeout: TimeInterval = 5.0
-) async throws -> (HolderChildDescription, Int32) {
-    let deadline = Date().addingTimeInterval(timeout)
-    while true {
-        do {
-            return try await client.handOverPTY()
-        } catch HolderClient.Error.rejected(let version) {
-            guard Date() < deadline else { throw HolderClient.Error.rejected(version: version) }
-            // The holder drops a rejected connection, so the next attempt has
-            // to start a new one.
-            await client.close()
-            try? await Task.sleep(for: .milliseconds(25))
-        }
-    }
 }
 
 /// Stops a reader from a `defer`, which cannot `await`.

--- a/Tests/TBDDaemonTests/Holder/HolderReaderTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HolderReaderTests.swift
@@ -1,0 +1,298 @@
+import Darwin
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// The daemon as default reader, driven against real holders and real jobs.
+///
+/// The suite exists for one measured fact: **a job cannot finish exiting while
+/// anything it wrote is still queued on its terminal.** The job is the pty's
+/// session leader, and XNU's `proc_exit` calls `ttywait` before revoking the
+/// terminal, so a job that exits with a few bytes unread stops half-exited and
+/// the holder's `waitpid` correctly reports nothing. Draining is therefore a
+/// liveness requirement, and two tests here — `keepsDrainingPastOneBufferful`
+/// and `completesTheExitOfAJobThatWroteUnreadOutput` — are the regression tests
+/// for it.
+///
+/// An exit is observed as the job's pid **disappearing**, which happens only
+/// once the holder's `waitpid` has collected it. A wedged job is still there:
+/// it has run its last instruction, but it is stuck inside `proc_exit` and
+/// nothing has reaped it. That is exactly the distinction these tests need, and
+/// the reason a screenful of expected output is never enough on its own.
+@Suite(.serialized)
+struct HolderReaderTests {
+
+    // MARK: - The drain is what lets jobs die
+
+    /// The regression test for the measured wedge, and the reason this task
+    /// exists.
+    ///
+    /// The job writes far more than any kernel tty buffer can hold, so a reader
+    /// that stops reading — or never starts — leaves it blocked mid-write and
+    /// then blocked in `ttywait` forever. The assertion is not that the output
+    /// is pretty: it is that the job **exits**, which it can only do if
+    /// somebody drained every byte of it.
+    @Test func keepsDrainingPastOneBufferful() async throws {
+        let fixture = try await HolderProcessFixture.start(
+            command: "for i in $(seq 1 5000); do echo line-$i; done")
+        defer { fixture.tearDown() }
+
+        let client = HolderClient(socketPath: fixture.handle.socketPath, receiveTimeout: .seconds(5))
+        let (_, ptyFD) = try await adoptPTY(via: client)
+        await client.close()
+        let reader = HolderReader(
+            sessionID: fixture.sessionID, ptyFD: ptyFD, columns: 80, rows: 24)
+        try await reader.start()
+        defer { stopInBackground(reader) }
+
+        let status = await awaitJobExit(childPID: fixture.handle.childPID, reportedBy: client)
+        #expect(status == .exited(code: 0), "the job never finished exiting: \(String(describing: status))")
+
+        // And the emulator holds the tail — draining is not the same as
+        // discarding, and a reader that read the bytes without feeding them
+        // would satisfy the exit assertion alone.
+        let sawTail = await pollUntil("the last line on the emulator's screen") {
+            await reader.renderScreen().contains("line-5000")
+        }
+        #expect(sawTail)
+        let history = await reader.renderScreenWithScrollback(maxLines: 500)
+        #expect(history.contains("line-4900"), "the scrollback did not keep the recent history")
+    }
+
+    /// The `ttywait` case stated directly: a job that exits with output nobody
+    /// has read still completes its exit, because a reader is attached.
+    ///
+    /// The second write is what makes this discriminate. A drain that stopped
+    /// after its first read would have emptied the queue before the job wrote
+    /// `CHARLIE`, and the job would then die on a clean terminal no matter how
+    /// broken the loop was — so the job writes, pauses long enough for that
+    /// first read to happen, and writes again immediately before exiting.
+    @Test func completesTheExitOfAJobThatWroteUnreadOutput() async throws {
+        let fixture = try await HolderProcessFixture.start(
+            command: "printf 'BRAVO\\n'; sleep 0.4; printf 'CHARLIE\\n'")
+        defer { fixture.tearDown() }
+
+        let client = HolderClient(socketPath: fixture.handle.socketPath, receiveTimeout: .seconds(5))
+        let (_, ptyFD) = try await adoptPTY(via: client)
+        await client.close()
+        let reader = HolderReader(
+            sessionID: fixture.sessionID, ptyFD: ptyFD, columns: 80, rows: 24)
+        try await reader.start()
+        defer { stopInBackground(reader) }
+
+        let status = await awaitJobExit(childPID: fixture.handle.childPID, reportedBy: client)
+        #expect(status == .exited(code: 0), "the job never finished exiting: \(String(describing: status))")
+
+        let sawBoth = await pollUntil("both markers on the emulator's screen") {
+            let screen = await reader.renderScreen()
+            return screen.contains("BRAVO") && screen.contains("CHARLIE")
+        }
+        #expect(sawBoth)
+    }
+
+    // MARK: - The emulator
+
+    @Test func drainsChildOutputIntoTheEmulator() async throws {
+        let fixture = try await HolderProcessFixture.start(
+            command: "printf 'ALPHA\\n'; sleep 30")
+        defer { fixture.tearDown() }
+
+        let client = HolderClient(socketPath: fixture.handle.socketPath, receiveTimeout: .seconds(5))
+        let (_, ptyFD) = try await adoptPTY(via: client)
+        await client.close()
+        let reader = HolderReader(
+            sessionID: fixture.sessionID, ptyFD: ptyFD, columns: 80, rows: 24)
+        try await reader.start()
+        defer { stopInBackground(reader) }
+
+        let sawMarker = await pollUntil("the job's output on the emulator's screen") {
+            await reader.renderScreen().contains("ALPHA")
+        }
+        let screen = await reader.renderScreen()
+        #expect(sawMarker, "screen was: \(screen.debugDescription)")
+    }
+
+    /// Input written to the reader reaches the job.
+    ///
+    /// The assertion is on the job's *transformation* of the input rather than
+    /// on the input itself: a pty in canonical mode echoes what is written to
+    /// it, so a screen containing `MARKER` would prove only that the terminal
+    /// echoed, not that anything read it. `GOT:MARKER` can only have been
+    /// produced by the job.
+    @Test func writeReachesTheChild() async throws {
+        let fixture = try await HolderProcessFixture.start(
+            command: "while IFS= read -r line; do printf 'GOT:%s\\n' \"$line\"; done")
+        defer { fixture.tearDown() }
+
+        let client = HolderClient(socketPath: fixture.handle.socketPath, receiveTimeout: .seconds(5))
+        let (_, ptyFD) = try await adoptPTY(via: client)
+        await client.close()
+        let reader = HolderReader(
+            sessionID: fixture.sessionID, ptyFD: ptyFD, columns: 80, rows: 24)
+        try await reader.start()
+        defer { stopInBackground(reader) }
+
+        try await reader.write(Data("MARKER\n".utf8))
+
+        let sawResponse = await pollUntil("the job's answer to the written line") {
+            await reader.renderScreen().contains("GOT:MARKER")
+        }
+        let screen = await reader.renderScreen()
+        #expect(sawResponse, "screen was: \(screen.debugDescription)")
+    }
+
+    // MARK: - Stopping
+
+    /// `stop()` ends the drain and closes the descriptor without touching the
+    /// job. That is what makes a later hand-off to an attached viewer possible:
+    /// the daemon is the *default* reader, not the owner.
+    ///
+    /// The close is the delicate half. It happens on the drain thread, woken by
+    /// a self-pipe, precisely so no descriptor is ever closed under a blocked
+    /// `read` — and `isDraining` reads the thread's own flag, so this asserts
+    /// the thread really left rather than that the actor intended it to.
+    @Test func stopEndsTheDrainWithoutKillingTheChild() async throws {
+        let fixture = try await HolderProcessFixture.start(
+            command: "printf 'DELTA\\n'; sleep 30")
+        defer { fixture.tearDown() }
+
+        let client = HolderClient(socketPath: fixture.handle.socketPath, receiveTimeout: .seconds(5))
+        let (_, ptyFD) = try await adoptPTY(via: client)
+        let reader = HolderReader(
+            sessionID: fixture.sessionID, ptyFD: ptyFD, columns: 80, rows: 24)
+        try await reader.start()
+        defer { stopInBackground(reader) }
+
+        let sawMarker = await pollUntil("the job's output before stopping") {
+            await reader.renderScreen().contains("DELTA")
+        }
+        #expect(sawMarker)
+
+        await reader.stop()
+        let stillDraining = await reader.isDraining
+        #expect(stillDraining == false, "the drain thread outlived stop()")
+
+        // The job is untouched: the holder still owns its own copy of the pty
+        // master, so closing the reader's dup destroys nothing.
+        let description = try await client.describe()
+        #expect(description.status == .alive)
+        #expect(description.childPID == fixture.handle.childPID)
+        #expect(holderProcessIsAlive(fixture.handle.holderPID))
+
+        // Idempotent, and still not fatal to anything.
+        await reader.stop()
+        #expect(holderProcessIsAlive(fixture.handle.childPID))
+    }
+
+    /// The other branch of `stop()`: a reader that was never started still owns
+    /// a `dup` the holder handed over, and stopping it must release that
+    /// descriptor. There is no drain thread to hand the close to, so the actor
+    /// does it — the one case where that is safe, because nothing can be
+    /// mid-read on a descriptor no thread has ever touched.
+    ///
+    /// The proof is the far end of a pipe reaching end of file, which happens
+    /// only when the last writer is gone. Two details of that are load-bearing
+    /// and were both learned the hard way:
+    ///
+    ///   - The ends are made close-on-exec **immediately**. Every test target
+    ///     compiles into one process and its suites run concurrently, so a
+    ///     neighbouring test that spawns a long-lived child would otherwise
+    ///     hand it an inherited copy of the write end, and the pipe would never
+    ///     report EOF however correctly the reader behaved. That is not a
+    ///     hypothetical: it reddened this test on its third run.
+    ///   - The assertion is not `F_GETFD` on the descriptor number. The kernel
+    ///     hands out the lowest free number, so a just-closed one is a *likely*
+    ///     pick for the next `open` on any of those concurrent threads — an
+    ///     assertion about the number would fail exactly when the code was
+    ///     right.
+    @Test func stoppingAReaderThatNeverStartedReleasesThePTY() async throws {
+        var ends: [Int32] = [-1, -1]
+        try #require(pipe(&ends) == 0, "could not create a pipe")
+        for end in ends { _ = fcntl(end, F_SETFD, FD_CLOEXEC) }
+        let readEnd = ends[0]
+        defer { Darwin.close(readEnd) }
+        // Non-blocking, so a reader that failed to release the write end fails
+        // the assertion instead of parking the suite in `read`.
+        _ = fcntl(readEnd, F_SETFL, fcntl(readEnd, F_GETFL) | O_NONBLOCK)
+
+        let reader = HolderReader(
+            sessionID: UUID(), ptyFD: ends[1], columns: 80, rows: 24)
+        let neverDrained = await reader.isDraining
+        #expect(neverDrained == false)
+
+        await reader.stop()
+
+        var scratch: UInt8 = 0
+        let outcome = Darwin.read(readEnd, &scratch, 1)
+        #expect(outcome == 0, "the reader kept the descriptor open (read returned \(outcome))")
+    }
+}
+
+// MARK: - Support
+
+/// Waits for a job to finish exiting, and returns the status the holder
+/// collected for it.
+///
+/// The wait itself is on the **pid disappearing**, not on a status. That is
+/// what discriminates: a job wedged in `ttywait` has run its last instruction
+/// and still answers `kill(pid, 0)` exactly like a healthy one, because it is
+/// stuck inside `proc_exit` and has not been reaped. The pid only goes away
+/// once the holder's `waitpid` has collected it, which cannot happen until the
+/// exit completes — which cannot happen until somebody drained the terminal.
+///
+/// Nothing stays connected to the holder while this waits, deliberately. The
+/// holder *pushes* a status at a client that happens to be connected when its
+/// job exits, and then winds itself down; a poller that raced that push would
+/// sometimes collect the status and sometimes find the holder already gone.
+/// With no client attached the holder arms its exit-report window instead and
+/// waits to be asked, which is the same path a restarted daemon takes.
+private func awaitJobExit(
+    childPID: Int32,
+    reportedBy client: HolderClient,
+    timeout: TimeInterval = 25.0
+) async -> HolderChildStatus? {
+    let reaped = await pollUntil("the job to finish exiting", timeout: timeout) {
+        !holderProcessIsAlive(childPID)
+    }
+    guard reaped else { return nil }
+    return try? await client.describe().status
+}
+
+/// Takes the pty master from a freshly spawned holder, retrying a refusal.
+///
+/// The holder serves **one client at a time**, and it learns that the previous
+/// one has gone only when its poll loop next reads EOF on that socket. The
+/// spawner closes its handshake connection and returns immediately, so a
+/// hand-over issued in the next microsecond can legitimately be answered with
+/// the busy sentinel — the slot is free, the holder has not noticed yet. It is
+/// a race the wire cannot avoid and the caller must absorb, so every consumer
+/// of a just-spawned holder needs this retry; here it is bounded, and a
+/// refusal that outlives the budget is rethrown rather than swallowed.
+private func adoptPTY(
+    via client: HolderClient,
+    timeout: TimeInterval = 5.0
+) async throws -> (HolderChildDescription, Int32) {
+    let deadline = Date().addingTimeInterval(timeout)
+    while true {
+        do {
+            return try await client.handOverPTY()
+        } catch HolderClient.Error.rejected(let version) {
+            guard Date() < deadline else { throw HolderClient.Error.rejected(version: version) }
+            // The holder drops a rejected connection, so the next attempt has
+            // to start a new one.
+            await client.close()
+            try? await Task.sleep(for: .milliseconds(25))
+        }
+    }
+}
+
+/// Stops a reader from a `defer`, which cannot `await`.
+///
+/// Every test needs this on every exit path — a reader left running leaks a
+/// thread and a pty descriptor for the rest of the suite — and a detached task
+/// is the only way to reach an actor method from a non-async context. The stop
+/// is idempotent, so a test that already stopped its reader loses nothing.
+private func stopInBackground(_ reader: HolderReader) {
+    Task.detached { await reader.stop() }
+}

--- a/Tests/TBDPeerHelperTests/SpawnedPeerHelper.swift
+++ b/Tests/TBDPeerHelperTests/SpawnedPeerHelper.swift
@@ -166,14 +166,40 @@ final class SpawnedPeerHelper: @unchecked Sendable {
     }
 
     /// Kill whatever is left and remove the scratch root. Idempotent.
+    ///
+    /// **The wait is bounded, like every other wait in this fixture**, and this
+    /// is the one place that used not to be. `Process.waitUntilExit()` blocks
+    /// the calling thread until Foundation *observes* the exit, and it has no
+    /// deadline of its own — a SIGKILL it never observes parks the caller
+    /// forever. `tearDown()` runs from a `defer` inside an async test, so the
+    /// thread it parks is one of Swift Testing's cooperative-pool threads, and
+    /// the whole test process cannot finish while a test is still running on
+    /// one. Measured on a full-suite run: the process sat at 0.0% CPU for 24
+    /// minutes holding the machine-global build lock, with two of these frames
+    /// (`aLineNamingAnotherHandleIsIgnored`, and
+    /// `aLivenessProbeForwardsNothingAndLeavesTheHelperRunning`) the only test
+    /// threads left alive. Polling releases the thread between checks and caps
+    /// the damage at `waitLimit`.
+    ///
+    /// Giving up is deliberately silent here. `tearDown` is a `defer` on every
+    /// exit path including the failing ones, so a diagnostic raised from it
+    /// would attach itself to whatever the test was already reporting; a test
+    /// that cares whether the helper exited asserts on `waitForExit()`, which
+    /// is what that method is for.
     func tearDown() {
         closeStdin()
         if process.isRunning {
             kill(pid, SIGKILL)
-            process.waitUntilExit()
+            let deadline = Date().addingTimeInterval(Self.waitLimit)
+            while process.isRunning, Date() < deadline {
+                usleep(useconds_t(Self.pollIntervalMicroseconds))
+            }
         }
         try? FileManager.default.removeItem(at: root)
     }
+
+    /// `pollInterval` for the synchronous waits, which cannot `await`.
+    private static let pollIntervalMicroseconds = 20_000
 
     // MARK: - Driving it
 


### PR DESCRIPTION
## Summary

Task 7 of the pty-holder transport ([spec](../blob/main/docs/specs/2026-08-30-pty-holder-session-transport-design.md)). The daemon's `HolderReader`: a headless SwiftTerm `Terminal` fed by a dedicated drain thread, so unattended sessions never stall. Plus two transport fixes and one repo-wide test fix found while building it.

**Stacked on #769 → #768 → #767 → #766 → #765.** Merge in order.

## Why this shape

**Draining is a liveness requirement, not a convenience** — and that reframing came from measurement, not theory. A job is its pty's session leader, and the kernel's process teardown waits on the terminal's output queue before revoking it, so a job that exits with anything unread stops half-exited and `waitpid` correctly reports nothing. A few bytes of ordinary echo are enough. Since the holder must never be the drainer, a reader that stops reading is not falling behind — it is holding jobs open. The drain loop therefore does not exit early on transient errors and is never gated on anyone wanting the output.

`Terminal` is not `Sendable` and carries no `@MainActor`, so every `feed` and every grid read holds `terminalLock`. Getting that wrong garbles output rather than crashing, which means it fails late and gets misdiagnosed as an escape-sequence bug.

## What this PR does

- `HolderReader` — drain thread, headless emulator, `renderScreen`, scrollback, `write`, `resize` (which also drives `TIOCSWINSZ`, so the child actually gets `SIGWINCH`).
- **The post-spawn `.rejected` race, fixed at the spawner.** `spawn` now returns the connection its handshake ran on, still open, so no reconnect exists and the busy window cannot be entered. The alternative — a bounded retry in the client — was rejected because it makes every caller pay for a condition transient in one window, and erodes `.rejected`, which is the genuine "somebody else is attached" signal protecting against two readers on one pty. A new test asserts a real second client is still refused.
- **A pushed exit is observable without `close()`.** `raiseBarrier` decoded the push, then threw `peerClosed` on the EOF behind it before retiring — so a poller doing `describe()` + `lastPushedDescription` never saw the status. Retire is now a `defer`.
- **A busy holder no longer reports as a broken pipe.** `.rejected` is written unsolicited on accept-then-hang-up, so it routinely landed *before* the first request, where the barrier discarded it as noise; which of three errors you saw was decided by microseconds. The refusal is now recorded and outranks whatever else went wrong.
- `Package.swift`: `TBDDaemonLib` links SwiftTerm. This pulls an AppKit-importing target into the daemon binary — SwiftTerm is a single target with no core/views split, so there is no headless-only product. The daemon never touches the view types.

## The repo-wide fix, which is not about holders at all

`Tests/TBDPeerHelperTests/SpawnedPeerHelper.swift` used a bare `Process.waitUntilExit()` in `tearDown()`. It blocks until Foundation *observes* the exit and has no deadline, so a SIGKILL it never observes parks the caller forever — and because `tearDown()` runs from a `defer` in an async test, the parked thread is one of Swift Testing's cooperative-pool threads, so **the entire test process cannot finish**.

Measured: a full-suite run sat at **0.0% CPU for 24 minutes holding the machine-global build lock**, with two of these frames the only live test threads. This wedged this machine three separate times today and blocked every other worktree behind it. The file is byte-identical on `main` and this branch touches no other peer-helper file — it is pre-existing, and every other wait in that fixture was already bounded.

Now a bounded poll against the fixture's own `waitLimit`. Before: stalled, sampled, killed. After: 9,057 tests in 881 suites in 276 s.

## Evidence & verification

84 tests green across eight consecutive runs by the implementer plus four more independently; peer-helper suite 22/22; `swiftlint --strict` clean; zero leaked holder, `swift-test`, or helper processes.

Mutation checks, all run:
- Revert the spawn hand-off → 4 of 16 runs red with `rejected(version: -1)` across five different tests.
- Revert the barrier `defer` → `surfacesAPushedExitWithoutWaitingForClose` red 3/3.
- Re-discard the refusal → `refusesASecondClientWhileTheSpawnersConnectionIsHeld` red 3/3 with the broken-pipe error.
- Treat a short read as EOF in the drain loop → exactly the two wedge tests red, nothing else.

## Known gaps, deliberately not closed here

- `HolderClient.connectIfNeeded` uses a **bare blocking `Darwin.connect`** — the same class of defect as the wedge above. Pre-existing and untouched, but it should be bounded before Task 10 puts it on the session-creation path.
- After EOF the drain thread parks on its wake pipe rather than exiting, keeping the fd close exclusively on the stop path so `write()` cannot race a reused descriptor. The cost is one parked thread per finished session until someone calls `stop()`; Task 10 and Milestone B own that call.

https://claude.ai/code/session_01UXqxcPYizvznh99Qb8JKrD

[20260830-boring-panda](https://cheapsteak.github.io/tbd/open/?worktree=A1E9CF50-E608-4F3C-BA8F-377D60BB7478)