### PR TITLE
Fix: Stop one unbounded wait in a test fixture from wedging the entire test process

### DIFF
--- a/Tests/TBDPeerHelperTests/SpawnedPeerHelper.swift
+++ b/Tests/TBDPeerHelperTests/SpawnedPeerHelper.swift
@@ -166,14 +166,40 @@ final class SpawnedPeerHelper: @unchecked Sendable {
     }
 
     /// Kill whatever is left and remove the scratch root. Idempotent.
+    ///
+    /// **The wait is bounded, like every other wait in this fixture**, and this
+    /// is the one place that used not to be. `Process.waitUntilExit()` blocks
+    /// the calling thread until Foundation *observes* the exit, and it has no
+    /// deadline of its own — a SIGKILL it never observes parks the caller
+    /// forever. `tearDown()` runs from a `defer` inside an async test, so the
+    /// thread it parks is one of Swift Testing's cooperative-pool threads, and
+    /// the whole test process cannot finish while a test is still running on
+    /// one. Measured on a full-suite run: the process sat at 0.0% CPU for 24
+    /// minutes holding the machine-global build lock, with two of these frames
+    /// (`aLineNamingAnotherHandleIsIgnored`, and
+    /// `aLivenessProbeForwardsNothingAndLeavesTheHelperRunning`) the only test
+    /// threads left alive. Polling releases the thread between checks and caps
+    /// the damage at `waitLimit`.
+    ///
+    /// Giving up is deliberately silent here. `tearDown` is a `defer` on every
+    /// exit path including the failing ones, so a diagnostic raised from it
+    /// would attach itself to whatever the test was already reporting; a test
+    /// that cares whether the helper exited asserts on `waitForExit()`, which
+    /// is what that method is for.
     func tearDown() {
         closeStdin()
         if process.isRunning {
             kill(pid, SIGKILL)
-            process.waitUntilExit()
+            let deadline = Date().addingTimeInterval(Self.waitLimit)
+            while process.isRunning, Date() < deadline {
+                usleep(useconds_t(Self.pollIntervalMicroseconds))
+            }
         }
         try? FileManager.default.removeItem(at: root)
     }
+
+    /// `pollInterval` for the synchronous waits, which cannot `await`.
+    private static let pollIntervalMicroseconds = 20_000
 
     // MARK: - Driving it
 


### PR DESCRIPTION
## Summary

`Tests/TBDPeerHelperTests/SpawnedPeerHelper.swift` used a bare `Process.waitUntilExit()` in `tearDown()`. On a loaded machine that parks a Swift Testing cooperative-pool thread forever, and **the whole test process cannot finish** — while holding the machine-global build lock, so every other worktree queues behind it.

Measured on this box: a full-suite run sat at **0.0% CPU for 24 minutes**. It happened three separate times in one day before the cause was found.

One file, 27 lines, no behaviour change outside the fixture.

## Why this happens

`waitUntilExit()` blocks until Foundation *observes* the exit and has no deadline of its own — so a `SIGKILL` it never observes parks the caller indefinitely. Because `tearDown()` runs from a `defer` inside an async test, the thread it parks belongs to Swift Testing's cooperative pool, and the run cannot complete while a test is still occupying one.

Every other wait in this fixture was already a bounded poll against its own `waitLimit`. This was the one place that wasn't.

## What this PR does

Replaces the unbounded wait with a bounded poll on the fixture's existing budget. Polling releases the thread between checks and caps the damage at `waitLimit` instead of forever.

## Evidence & verification

Root cause was sampled, not inferred. The wedged `swiftpm-testing-helper` had exactly two live test threads, both stopped in the same frame:

```
PeerHelperLifecycleTests.aLineNamingAnotherHandleIsIgnored()
  $defer #1 -> SpawnedPeerHelper.tearDown()   SpawnedPeerHelper.swift:173
PeerHelperForwardingTests.aLivenessProbeForwardsNothingAndLeavesTheHelperRunning()
  $defer #1 -> SpawnedPeerHelper.tearDown()   SpawnedPeerHelper.swift:173
```

- **Before:** full-suite run stalled indefinitely; had to be sampled and killed by pid.
- **After:** full suite completes — 9,057 tests in 881 suites in 276 s.
- `PeerHelperTests` alone: 22 tests in 4 suites, 1.9 s.
- No leaked `swift-test`, `swiftpm-testing-helper`, or helper processes afterwards.

## Assumptions

Split out of the pty-holder stack (#765–#773) because it is unrelated to that work and fixes a defect already on `main` that is costing every worktree on this machine. Verified it costs the stack nothing: none of #765–#769 touch this file, and the stack tip carries an identical copy that test-merges against this change with zero conflicts.

https://claude.ai/code/session_01UXqxcPYizvznh99Qb8JKrD

[20260830-boring-panda](https://cheapsteak.github.io/tbd/open/?worktree=A1E9CF50-E608-4F3C-BA8F-377D60BB7478)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test cleanup so forcibly terminated processes no longer cause indefinite hangs.
  * Added a bounded wait during shutdown before temporary files are removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->