### PR TITLE
Fix: Stop the tmux reconciler deleting holder-backed sessions on every restart

### DIFF
--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -590,10 +590,19 @@ extension WorktreeLifecycle {
                 // have been created. `windowExists` can therefore only ever
                 // answer "gone" for them, and both outcomes below — the park
                 // and the delete — would then destroy a live session on the
-                // very daemon restart the transport exists to survive. Their
-                // ground truth is the holder inventory, which is a separate
-                // sweep. This loop is about tmux, and has to say so before it
-                // reaches either arm of the fork.
+                // very daemon restart the transport exists to survive. This
+                // loop is about tmux, and has to say so before it reaches
+                // either arm of the fork.
+                //
+                // **Nothing reconciles holder rows yet.** Their ground truth
+                // is the holder inventory, and the sweep that would consult it
+                // is Milestone B's work — see `HolderSpawner`'s doc comment and
+                // the spec's Reconciliation section. So this guard is not
+                // "handled elsewhere"; it is "not handled at all, and wrongly
+                // destroying them is worse than leaving them alone". That gap
+                // is what keeps `pty_holder_enabled` off outside a development
+                // machine, and it should stay visible here until a real sweep
+                // closes it.
                 guard terminal.transport == .tmux else { continue }
 
                 var windowAlive = false

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -585,6 +585,17 @@ extension WorktreeLifecycle {
             // is expected, and the row is already exactly what this pass would
             // produce.
             for terminal in terminals where !terminal.isParked {
+                // Holder-backed sessions carry no tmux coordinate: their
+                // `tmuxWindowID` is "" and the repo's tmux server may never
+                // have been created. `windowExists` can therefore only ever
+                // answer "gone" for them, and both outcomes below — the park
+                // and the delete — would then destroy a live session on the
+                // very daemon restart the transport exists to survive. Their
+                // ground truth is the holder inventory, which is a separate
+                // sweep. This loop is about tmux, and has to say so before it
+                // reaches either arm of the fork.
+                guard terminal.transport == .tmux else { continue }
+
                 var windowAlive = false
                 if serverAlive {
                     windowAlive = await tmux.windowExists(

--- a/Tests/TBDDaemonTests/Holder/HolderReconcileExemptionTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HolderReconcileExemptionTests.swift
@@ -1,0 +1,121 @@
+import Foundation
+import TestSupport
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// The tmux liveness sweep, and the rows it must not judge.
+///
+/// `reconcileTerminalsWhileLocked` probes `windowExists` for every unparked
+/// terminal row and then parks the resumable Claude ones and deletes the rest.
+/// A holder-backed session has no tmux coordinate at all — its `tmuxWindowID`
+/// is `""`, and the repo's tmux server may never have been started — so that
+/// probe can only ever answer "gone". Without an exemption the sweep destroys a
+/// live holder session on the next daemon start, which is precisely the event
+/// the holder transport exists to survive.
+///
+/// The fork the exemption has to sit ahead of is park-versus-delete: a
+/// resumable Claude row is parked and everything else is deleted outright. Both
+/// suites here carry one row of each kind, so an exemption placed inside either
+/// arm fails the first test, and an exemption that swallowed the whole loop
+/// fails the second.
+///
+/// Both entry points into that loop — the per-repo `reconcile` and
+/// `reconcileScratchTerminals` — funnel through the same function, so the
+/// behaviour is asserted once, at the loop.
+@Suite("Holder rows and the tmux reconcile")
+struct HolderReconcileExemptionTests {
+
+    private func makeLifecycle(db: TBDDatabase, tmux: TmuxManager) -> WorktreeLifecycle {
+        WorktreeLifecycle(db: db, git: GitManager(), tmux: tmux, hooks: HookResolver())
+    }
+
+    /// Dry-run tmux with every window reported dead.
+    ///
+    /// That is the same state a holder row produces against a real server:
+    /// `windowExists("")` cannot succeed, and a server that was never created
+    /// answers the same way. Reaching it through the hook rather than through a
+    /// missing server keeps the fixture from depending on a live tmux.
+    private func deadWindowTmux() -> TmuxManager {
+        TmuxManager(dryRun: true, dryRunWindowIsDead: { _ in true })
+    }
+
+    /// A real git repo plus its main worktree row — the shape the sweep accepts
+    /// as live, so nothing but the terminal rows is under test.
+    private func seedRepo(db: TBDDatabase, at repoPath: String) async throws -> (Repo, Worktree) {
+        let repo = try await db.repos.create(
+            path: repoPath, displayName: "acme", defaultBranch: "main")
+        let main = try await db.worktrees.createMain(
+            repoID: repo.id, name: "main", branch: "main", path: repoPath,
+            tmuxServer: TmuxManager.serverName(forRepoPath: repoPath))
+        return (repo, main)
+    }
+
+    @Test("a holder-backed row survives the sweep, unparked")
+    func holderRowSurvivesTmuxReconcile() async throws {
+        let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(db: db, tmux: deadWindowTmux())
+        let (repo, main) = try await seedRepo(db: db, at: repoDir.path)
+
+        // Empty tmux coordinates are not a degenerate fixture: they are what
+        // `HolderSpawner`'s create path writes, because there is no window.
+        let claude = try await db.terminals.create(
+            worktreeID: main.id, tmuxWindowID: "", tmuxPaneID: "",
+            label: TerminalLabel.claudeCode, claudeSessionID: "sess-holder",
+            kind: .claude, transport: .holder, holderPID: 4242, childPID: 4243)
+        let shell = try await db.terminals.create(
+            worktreeID: main.id, tmuxWindowID: "", tmuxPaneID: "",
+            kind: .shell, transport: .holder, holderPID: 4244, childPID: 4245)
+
+        try await lifecycle.reconcile(
+            repoID: repo.id,
+            actuationLog: makeTestActuationLog(),
+            reapSharedScratchTmuxResources: true)
+
+        let survivingClaude = try #require(
+            try await db.terminals.get(id: claude.id),
+            "the sweep deleted a holder-backed Claude row")
+        #expect(
+            survivingClaude.hibernatedAt == nil,
+            "the sweep parked a holder-backed Claude row whose session is still running")
+        #expect(survivingClaude.transport == .holder)
+        #expect(
+            try await db.terminals.get(id: shell.id) != nil,
+            "the sweep deleted a holder-backed shell row")
+    }
+
+    @Test("a tmux-backed row whose window is gone is still parked or deleted")
+    func tmuxRowStillReconciledNormally() async throws {
+        let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(db: db, tmux: deadWindowTmux())
+        let (repo, main) = try await seedRepo(db: db, at: repoDir.path)
+
+        let claude = try await db.terminals.create(
+            worktreeID: main.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: TerminalLabel.claudeCode, claudeSessionID: "sess-tmux", kind: .claude)
+        let shell = try await db.terminals.create(
+            worktreeID: main.id, tmuxWindowID: "@2", tmuxPaneID: "%2", kind: .shell)
+
+        try await lifecycle.reconcile(
+            repoID: repo.id,
+            actuationLog: makeTestActuationLog(),
+            reapSharedScratchTmuxResources: true)
+
+        let parked = try #require(
+            try await db.terminals.get(id: claude.id),
+            "the sweep deleted a resumable Claude row instead of parking it")
+        #expect(
+            parked.hibernatedAt != nil,
+            "the exemption disabled reconciliation for the transport that still needs it")
+        #expect(parked.hibernateReason == .recovery)
+        #expect(
+            try await db.terminals.get(id: shell.id) == nil,
+            "the exemption disabled reconciliation for the transport that still needs it")
+    }
+}


### PR DESCRIPTION
## Summary

Task 8 of the pty-holder transport ([spec](../blob/main/docs/specs/2026-08-30-pty-holder-session-transport-design.md)). One guard, two tests.

**Stacked on #773 → #769 → #768 → #767 → #766 → #765.** Merge in order.

## What's broken

`WorktreeLifecycle+Reconcile.swift`'s per-terminal liveness loop probes `windowExists(server:windowID: terminal.tmuxWindowID)` for every non-parked terminal, then **parks** the row (Claude sessions with a session ID) or **deletes** it outright.

A holder-transport row carries `tmuxWindowID: ""` on a worktree whose tmux server may never have been created. It therefore evaluates as gone — and is destroyed **on the very daemon restart the milestone exists to survive**. The reconciler runs at every startup, so without this the transport would demolish its own acceptance test.

## Why it happens

The loop's ground truth is tmux, and it was written when tmux was the only transport. A row with no tmux coordinate is not a dead session; it is a session whose liveness lives somewhere this loop cannot see.

**And nothing reconciles holder rows yet.** `WorktreeLifecycle+Reconcile` has no holder-inventory pass, `OrphanGC` has no holder socket or lock sweep, and `AgentReaper` has no holder-transport leg — all of that is Milestone B, as `HolderSpawner`'s doc comment and the spec's Reconciliation section both state. So this guard is not "handled elsewhere"; it is **"not handled at all, and wrongly destroying them is worse than leaving them alone."** That gap is precisely what keeps `pty_holder_enabled` off outside a development machine, and the comment at the guard says so, so it stays visible until a real sweep closes it.

## What this PR does

`guard terminal.transport == .tmux else { continue }`, at the top of the loop, ahead of the park-vs-delete fork.

## Evidence & verification

The pre-fix run reproduced the failure exactly as predicted: the holder-backed Claude row came back with `hibernatedAt` set, and the holder-backed shell row was gone entirely.

Both tests carry **one row of each transport**, which pins the guard's placement from both sides — an exemption written inside either arm fails `holderRowSurvivesTmuxReconcile`, and one that swallowed the whole loop fails `tmuxRowStillReconciledNormally`, which asserts the `.tmux` Claude row is still parked with `hibernateReason == .recovery` and the `.tmux` shell row still deleted.

174 tests green across five runs by the implementer and four more independently (`--filter 'Holder|Reconcile'`); `swiftlint --strict` clean; no leaked processes.

## Assumptions

`TmuxManager(dryRun: true)` reports `serverExists == true` unconditionally, so "a worktree with no tmux server" is unreachable in dry run. The tests reach the identical downstream state via `dryRunWindowIsDead`, which is honest for the same reason — `windowExists("")` cannot succeed against a real server either. Noted in the fixture.

## Follow-up, not fixed here

`reconcileTmuxResources` inserts a holder row's empty `tmuxWindowID` into its `trackedWindowIDs` set. Harmless today, since no real tmux window is named `""`, but it is a second place holder rows leak into tmux bookkeeping and belongs with Milestone B's reconciler work.

https://claude.ai/code/session_01UXqxcPYizvznh99Qb8JKrD

[20260830-boring-panda](https://cheapsteak.github.io/tbd/open/?worktree=A1E9CF50-E608-4F3C-BA8F-377D60BB7478)