### PR TITLE
Feat: Re-adopt holder sessions after a daemon restart

### DIFF
--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -1091,7 +1091,7 @@ public final class Daemon: Sendable {
         // opted in.
         if mockMode == nil {
             let holderRegistry = HolderRegistry(
-                owner: HolderRegistry.installationOwner(),
+                owner: await HolderRegistry.installationOwner(config: database.config),
                 listTerminals: { [database] in try await database.terminals.list() })
             self.holderRegistry = holderRegistry
             await holderRegistry.adoptAll()

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -196,6 +196,14 @@ public final class Daemon: Sendable {
     /// it the same way they reach `rpcRouter.hibernationCoordinator`. `nil`
     /// in mock mode (never constructed).
     public nonisolated(unsafe) var orphanGC: OrphanGC?
+    /// The daemon's single owner of every live `HolderReader` — one per
+    /// holder-backed session, re-adopted at startup (step 8e). Owned here
+    /// because a reader's lifetime is the daemon's: the holder and its job
+    /// outlive us, the reader must not. `nil` in mock mode.
+    ///
+    /// Internal rather than public because the holder types are: nothing
+    /// outside `TBDDaemonLib` has any business holding a pty master.
+    nonisolated(unsafe) var holderRegistry: HolderRegistry?
     /// The registry a live `ShadowPeerManager` registers itself with, so
     /// `ShadowPeerReconciler` can tell a live shadow from an orphan. Owned here
     /// because the two have opposite lifetimes: the reconciler runs for the
@@ -1069,6 +1077,26 @@ public final class Daemon: Sendable {
             mockMode: mockMode, database: database, git: git, lifecycle: lifecycle,
             actuationLog: actuationLog)
 
+        // 8e. Re-adopt holder-backed sessions. A `HolderReader` lives only in
+        // the memory of the daemon that made it, so after a restart every live
+        // holder session has nobody draining its pty master — and an undrained
+        // master does not merely cost a screen: a job cannot finish exiting
+        // while anything it wrote is still queued on its terminal, so those
+        // sessions pile up half-exited. This must therefore run before the
+        // listeners serve, both because `terminal.output` needs the readers and
+        // because the liveness debt starts accruing the moment the daemon is up.
+        //
+        // With `pty_holder_enabled` off there are no such rows and this is a
+        // single query — it cannot delay the socket bind for anyone who has not
+        // opted in.
+        if mockMode == nil {
+            let holderRegistry = HolderRegistry(
+                owner: HolderRegistry.installationOwner(),
+                listTerminals: { [database] in try await database.terminals.list() })
+            self.holderRegistry = holderRegistry
+            await holderRegistry.adoptAll()
+        }
+
         // 9. Start socket server
         let sock = SocketServer(router: rpcRouter)
         self.socketServer = sock
@@ -1527,6 +1555,13 @@ public final class Daemon: Sendable {
         if let resumeScheduler = limitResumeScheduler {
             await resumeScheduler.stop()
         }
+
+        // Stop every holder drain loop. The holders and their jobs are
+        // deliberately untouched — a session outliving its daemon is the point
+        // of the transport — but a reader that is merely dropped leaks its drain
+        // thread and the pty descriptor it owns, because after end of file that
+        // thread parks on its wake pipe rather than exiting.
+        await holderRegistry?.releaseAll()
 
         if let questionSweep = pendingQuestionExpirySweep {
             await questionSweep.stop()

--- a/Sources/TBDDaemon/Database/ConfigStore.swift
+++ b/Sources/TBDDaemon/Database/ConfigStore.swift
@@ -93,6 +93,13 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     /// `nil` here means "never chose" rather than "off". Resolve it through
     /// `Config.ptyHolderDefault`, never through `?? false`.
     var pty_holder_enabled: Bool?
+    /// This installation's holder owner token, minted once by the first daemon
+    /// that needs one and read forever after. **Not a flag**: NULL means "not
+    /// yet minted", and the mint is the conditional UPDATE in
+    /// `ensureHolderOwnerToken` rather than a resolved default — there is no
+    /// value the shipped code could default this to that would not make every
+    /// checkout on a machine claim every other checkout's holders.
+    var holder_owner_token: String?
     /// JSON-encoded `[String: String]` remote create-param defaults (machine
     /// scope), keyed by the provider's own field names. Nil/absent means no
     /// opinion at this level — every field falls through to its
@@ -192,8 +199,25 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             remotePeerMessagingEnabled: remote_peer_messaging_enabled ?? remotePeerMessagingDefault,
             // And once more, for the pty-holder transport's gate — NOT `?? false`.
             ptyHolderEnabled: pty_holder_enabled ?? ptyHolderDefault,
-            remoteCreateDefaults: EnvOverridesCoding.decode(remote_create_defaults)
+            remoteCreateDefaults: EnvOverridesCoding.decode(remote_create_defaults),
+            // Passed straight through, NULL included: "not yet minted" is a
+            // real state and has no default to resolve to.
+            holderOwnerToken: holder_owner_token
         )
+    }
+}
+
+/// Failures the singleton `config` row can produce that GRDB has no error for.
+public enum ConfigStoreError: LocalizedError, Equatable {
+    /// The conditional mint ran and the row still holds no usable token — the
+    /// singleton row is missing, or something wrote an empty value over it.
+    case holderOwnerTokenUnavailable
+
+    public var errorDescription: String? {
+        switch self {
+        case .holderOwnerTokenUnavailable:
+            return "the config row holds no holder owner token and one could not be minted"
+        }
     }
 }
 
@@ -604,6 +628,46 @@ public struct ConfigStore: Sendable {
                 sql: "UPDATE config SET pty_holder_enabled = ? WHERE id = ?",
                 arguments: [enabled, Self.singletonID]
             )
+        }
+    }
+
+    /// Return this installation's holder owner token, minting `candidate` only
+    /// if none has been minted yet.
+    ///
+    /// **The conditional write is the whole point.** Two daemons starting at
+    /// once on one `TBD_HOME` must agree on one token or each would disown the
+    /// other's holders, so the decision is made by SQLite rather than by the
+    /// caller: `WHERE holder_owner_token IS NULL` means the second writer's
+    /// UPDATE matches no row, and the read-back inside the same transaction
+    /// returns whichever token actually landed. This is the SQL equivalent of
+    /// the `O_EXCL` open the file-backed store used before the token moved into
+    /// the `config` row.
+    ///
+    /// The empty string is treated as unminted: a hand-edited row or a
+    /// half-written value must not become an identity every holder is compared
+    /// against.
+    ///
+    /// - Returns: the token now stored, which may not be `candidate`.
+    /// - Throws: if the row cannot be written or read — including the case
+    ///   where no singleton row exists at all, which no migrated database has.
+    public func ensureHolderOwnerToken(minting candidate: String) async throws -> String {
+        try await writer.write { db in
+            try db.execute(
+                sql: """
+                    UPDATE config SET holder_owner_token = ?
+                     WHERE id = ? AND (holder_owner_token IS NULL OR holder_owner_token = '')
+                    """,
+                arguments: [candidate, Self.singletonID]
+            )
+            let stored = try String.fetchOne(
+                db,
+                sql: "SELECT holder_owner_token FROM config WHERE id = ?",
+                arguments: [Self.singletonID]
+            )
+            guard let stored, !stored.isEmpty else {
+                throw ConfigStoreError.holderOwnerTokenUnavailable
+            }
+            return stored
         }
     }
 

--- a/Sources/TBDDaemon/Database/Migrations/20260831200151_config_holder_owner_token.sql
+++ b/Sources/TBDDaemon/Database/Migrations/20260831200151_config_holder_owner_token.sql
@@ -1,0 +1,12 @@
+-- This installation's holder owner token.
+--
+-- It identifies the INSTALLATION, not the process: a token minted per daemon
+-- would make every holder that daemon spawned look foreign to its own
+-- successor, and re-adoption -- the entire point of the pty-holder transport --
+-- would never adopt anything.
+--
+-- No DEFAULT clause, deliberately, and for a different reason than the feature
+-- flags: NULL here means "not yet minted", which is the state the conditional
+-- mint tests for. A DEFAULT would hand every install the same literal token and
+-- make every checkout on a machine claim every other checkout's holders.
+ALTER TABLE config ADD COLUMN holder_owner_token TEXT;

--- a/Sources/TBDDaemon/Holder/HolderRegistry.swift
+++ b/Sources/TBDDaemon/Holder/HolderRegistry.swift
@@ -39,6 +39,11 @@ actor HolderRegistry {
         /// It is left strictly alone: reachable-but-absent-from-my-database is
         /// exactly what another checkout's healthy session looks like.
         case foreignOwner(terminalID: UUID, holderOwner: String)
+        /// A concurrent `release` (or a later adoption) took the slot while this
+        /// adoption was still in flight, so its result was discarded rather than
+        /// published. Everything it obtained — the reader, and with it the pty
+        /// dup — was released before this was thrown.
+        case superseded(terminalID: UUID)
 
         var errorDescription: String? {
             switch self {
@@ -47,6 +52,9 @@ actor HolderRegistry {
             case .foreignOwner(let terminalID, let holderOwner):
                 return "the holder for terminal \(terminalID.uuidString) belongs to installation "
                     + "\(holderOwner); leaving it alone"
+            case .superseded(let terminalID):
+                return "the adoption of terminal \(terminalID.uuidString) was superseded while it "
+                    + "was in flight; its reader was stopped rather than published"
             }
         }
     }
@@ -95,16 +103,32 @@ actor HolderRegistry {
     /// an unreachable holder is recorded as `exitedStatusUnknown` — never as a
     /// fabricated code, which downstream could not tell from a real one.
     private var statuses: [UUID: HolderChildStatus] = [:]
-    /// How many drain loops this registry has ever started.
+    /// How many drain loops this registry has ever taken ownership of — that
+    /// is, how many adoptions it has published.
     ///
     /// Test-facing, and the honest instrument for the invariant above: object
     /// identity alone cannot tell a registry that reused a reader from one that
     /// built a second and threw it away, and only the count sees the second
     /// drain loop that would have been stealing bytes.
+    ///
+    /// A superseded adoption is deliberately **not** counted. Its loop did
+    /// start, and was stopped again before this call returned; counting it would
+    /// make the number say "loops that ever ran" when what every assertion here
+    /// asks is "loops this registry is on the hook for".
     private(set) var drainLoopsStarted = 0
 
     private let busyRetryBudget: Duration
     private let clock: any Clock<Duration>
+
+    /// Awaited inside `adopt` between the attach settling and the slot being
+    /// published — the exact window a concurrent `release` interleaves in.
+    ///
+    /// A seam rather than a sleep: the interleaving this guards against is a
+    /// continuation-ordering accident, and a test that reproduced it by timing
+    /// would pass by luck and stop reproducing it the day the scheduler
+    /// changed. Nil in production, where the cost is one nil check per
+    /// adoption.
+    private var publishBarrier: (@Sendable () async -> Void)?
 
     init(
         owner: HolderOwnerToken,
@@ -118,6 +142,12 @@ actor HolderRegistry {
         self.listTerminals = listTerminals
         self.busyRetryBudget = busyRetryBudget
         self.clock = clock
+    }
+
+    /// Installs the publish barrier described above. Test-facing; production
+    /// never calls it.
+    func setPublishBarrier(_ barrier: (@Sendable () async -> Void)?) {
+        publishBarrier = barrier
     }
 
     // MARK: - Reading
@@ -172,15 +202,47 @@ actor HolderRegistry {
         }
         slots[terminalID] = .adopting(task)
 
+        let settled = await task.result
+        // The one suspension a test can steer. In production `publishBarrier` is
+        // nil and this is a nil check.
+        await publishBarrier?()
+
         let adoption: Adoption
         do {
-            adoption = try await task.value
+            adoption = try settled.get()
         } catch {
             // Nothing was started, so nothing is owed a `stop()`. Clearing the
             // slot is what lets a later pass retry a holder that was merely
-            // slow to answer.
-            slots[terminalID] = nil
+            // slow to answer — but only while the slot is still this call's to
+            // clear. Past a supersession it belongs to whoever took it, and
+            // clearing it would discard a live adoption's task and let the next
+            // caller open a *second* attach on the same pty.
+            if slotStillHolds(task, for: terminalID) {
+                slots[terminalID] = nil
+            }
             throw error
+        }
+        // The publish decision and the publish itself, with no `await` between
+        // them. An actor's methods are not atomic across suspension: while this
+        // call was parked awaiting the attach, a `release` could have cleared
+        // the slot and stopped this very reader, or a later `adopt` could have put
+        // its own task there. Writing unconditionally would then either
+        // resurrect a stopped reader or orphan a live one — two drain loops on
+        // one pty master, which is the byte theft this type exists to prevent.
+        guard slotStillHolds(task, for: terminalID) else {
+            // Superseded. Whatever took the slot is the current truth, so
+            // nothing from this adoption is published — not the reader, and not
+            // the description's status either, which would otherwise overwrite
+            // a fresher observation with a staler one. The reader is a resource,
+            // so it is released: `stop()` is what closes the pty dup and joins
+            // the drain thread, and a reader dropped without one leaks both.
+            await adoption.reader.stop()
+            Self.logger.info(
+                """
+                discarded a superseded adoption of session \
+                \(terminalID.uuidString, privacy: .public); its reader was stopped
+                """)
+            throw Error.superseded(terminalID: terminalID)
         }
         slots[terminalID] = .adopted(adoption.reader)
         statuses[terminalID] = adoption.description.status
@@ -192,6 +254,20 @@ actor HolderRegistry {
             \(String(describing: adoption.description.status), privacy: .public)
             """)
         return adoption.reader
+    }
+
+    /// Whether `terminalID`'s slot still holds the in-flight task that `adopt`
+    /// started, rather than a later adoption's task, a published reader, or
+    /// nothing at all.
+    ///
+    /// Synchronous on purpose, and every caller must use its answer with no
+    /// `await` in between: the answer is only true of the instant it was read,
+    /// and an actor's methods are not atomic across suspension.
+    private func slotStillHolds(
+        _ task: Task<Adoption, Swift.Error>, for terminalID: UUID
+    ) -> Bool {
+        guard case .adopting(let current) = slots[terminalID] else { return false }
+        return current == task
     }
 
     /// Adopts every holder-backed row, once, at startup.
@@ -384,47 +460,45 @@ extension HolderRegistry {
     /// It must identify the **installation**, not the process: a token minted
     /// per daemon would make every holder that daemon spawned look foreign to
     /// its own successor, and re-adoption — the entire point of the transport —
-    /// would never adopt anything. So it is persisted beside the other
-    /// installation-scoped files under `TBD_HOME` (`tbdd.pid`, `port`), and like
-    /// them it is a fixed name that is rewritten rather than accumulated: no
-    /// sweep is owed one.
+    /// would never adopt anything. So it lives in the singleton `config` row,
+    /// with the rest of the daemon's structured installation-scoped settings.
     ///
-    /// Minting is `O_EXCL`, so two daemons racing on a fresh `TBD_HOME` agree on
-    /// whichever won rather than each keeping its own.
+    /// **The mint is a conditional UPDATE, not a read-then-write.** Two daemons
+    /// starting at once on one `TBD_HOME` must agree on one token, so the
+    /// decision is SQLite's: the second writer's UPDATE matches no row and the
+    /// read-back in the same transaction hands it the token the first one
+    /// wrote. That is the same guarantee the file-backed store got from an
+    /// `O_EXCL` open, which is what this replaced.
     static func installationOwner(
+        config: ConfigStore,
         environment: [String: String] = ProcessInfo.processInfo.environment
-    ) -> HolderOwnerToken {
-        let path = TBDConstants.holderOwnerTokenPath(environment: environment)
-        if let existing = readOwnerToken(at: path) { return existing }
-
-        let minted = UUID().uuidString.lowercased()
-        try? FileManager.default.createDirectory(
-            at: TBDConstants.configDir(environment: environment),
-            withIntermediateDirectories: true)
-        let fd = open(path, O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC, 0o600)
-        if fd >= 0 {
-            var bytes = Array(minted.utf8)
-            _ = Darwin.write(fd, &bytes, bytes.count)
-            Darwin.close(fd)
-            return HolderOwnerToken(rawValue: minted)
+    ) async -> HolderOwnerToken {
+        do {
+            let stored = try await config.ensureHolderOwnerToken(
+                minting: UUID().uuidString.lowercased())
+            return HolderOwnerToken(rawValue: stored)
+        } catch {
+            // The database is unwritable. A path-derived token is the least-bad
+            // answer — it is at least stable for as long as the outage lasts,
+            // where an ephemeral one would disown this daemon's own holders on
+            // its very next boot.
+            //
+            // What it costs, plainly: a daemon that cannot persist its token is
+            // running on an identity nothing else agrees to. Holders it spawns
+            // during the outage are stamped with the path-derived token, so the
+            // moment the database becomes writable again a real token is minted
+            // and every one of those holders reads as `foreignOwner` — left
+            // running, adopted by nobody, and reclaimed by nothing until the
+            // holder reconciler lands.
+            Self.logger.error(
+                """
+                could not mint or read the holder owner token from the config row \
+                (\(error.localizedDescription, privacy: .public)); falling back to a \
+                path-derived token, under which holders spawned now will read as foreign \
+                once the database is writable again
+                """)
+            return HolderOwnerToken(
+                rawValue: "tbd-home:\(TBDConstants.configDir(environment: environment).path)")
         }
-        // Lost the race, or could not write at all. A token read back is the
-        // right answer; a store we cannot write to gets a value derived from the
-        // store's own path, which is at least stable across restarts — an
-        // ephemeral one would quietly disown every holder on the next boot.
-        if let existing = readOwnerToken(at: path) { return existing }
-        Self.logger.error(
-            """
-            could not persist the holder owner token at \(path, privacy: .public) \
-            (errno \(errno, privacy: .public)); falling back to a path-derived token
-            """)
-        return HolderOwnerToken(
-            rawValue: "tbd-home:\(TBDConstants.configDir(environment: environment).path)")
-    }
-
-    private static func readOwnerToken(at path: String) -> HolderOwnerToken? {
-        guard let contents = try? String(contentsOfFile: path, encoding: .utf8) else { return nil }
-        let trimmed = contents.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.isEmpty ? nil : HolderOwnerToken(rawValue: trimmed)
     }
 }

--- a/Sources/TBDDaemon/Holder/HolderRegistry.swift
+++ b/Sources/TBDDaemon/Holder/HolderRegistry.swift
@@ -1,0 +1,430 @@
+import Darwin
+import Foundation
+import TBDShared
+import os
+
+/// The daemon's single owner of every live `HolderReader`.
+///
+/// **A reader lives only in the memory of the daemon that made one**, and the
+/// session it drains does not. That asymmetry is the whole reason this type
+/// exists: a restarted daemon inherits holders and jobs that are still running
+/// and has no reader for any of them, so nothing drains their pty masters —
+/// which is not merely "no screen to show". A job cannot finish exiting while
+/// anything it wrote is still queued on its terminal (XNU's `proc_exit` calls
+/// `ttywait` before revoking it), so an undrained session silently piles up
+/// half-exited jobs. Re-adoption is therefore a liveness obligation of startup,
+/// not a convenience for rendering.
+///
+/// Two invariants shape the API:
+///
+///   - **One reader per session, ever.** Two drain loops on one pty master is
+///     silent byte theft — each `read` takes bytes the other will never see,
+///     and nothing anywhere reports it. Adoption is therefore idempotent
+///     through the actor's own state: a second call for a session already being
+///     adopted *awaits the first* rather than racing it.
+///   - **Whoever owns a reader stops it.** After end of file a drain thread
+///     parks on its wake pipe instead of exiting, deliberately — that is what
+///     keeps the descriptor's close on the stop path, where no `write` can race
+///     a reused fd number. So a reader that is dropped without `stop()` leaks a
+///     thread and a descriptor, and this registry is the owner that must not do
+///     that. See `release(terminalID:)`.
+actor HolderRegistry {
+    private static let logger = Logger(subsystem: "com.tbd.daemon", category: "holder")
+
+    enum Error: LocalizedError, Equatable {
+        /// The row does not carry a holder-backed session, so there is nothing
+        /// at a rendezvous path to adopt.
+        case notAHolderSession(terminalID: UUID)
+        /// The holder answered, and named an installation that is not ours.
+        /// It is left strictly alone: reachable-but-absent-from-my-database is
+        /// exactly what another checkout's healthy session looks like.
+        case foreignOwner(terminalID: UUID, holderOwner: String)
+
+        var errorDescription: String? {
+            switch self {
+            case .notAHolderSession(let terminalID):
+                return "terminal \(terminalID.uuidString) is not a holder-backed session"
+            case .foreignOwner(let terminalID, let holderOwner):
+                return "the holder for terminal \(terminalID.uuidString) belongs to installation "
+                    + "\(holderOwner); leaving it alone"
+            }
+        }
+    }
+
+    /// A reader and the description the hand-over rode with.
+    ///
+    /// The description is not decoration: it is the one place a job that
+    /// finished while no daemon was listening reports how it ended.
+    private struct Adoption: Sendable {
+        let reader: HolderReader
+        let description: HolderChildDescription
+    }
+
+    /// What the registry knows about one session.
+    ///
+    /// `adopting` is the idempotence guard. It holds the *task*, not a flag, so
+    /// a second caller has something to await rather than a state to poll —
+    /// which is what makes "two concurrent adoptions produce one reader" a
+    /// property of the type instead of a timing accident.
+    private enum Slot {
+        case adopting(Task<Adoption, Swift.Error>)
+        case adopted(HolderReader)
+    }
+
+    /// How long an adoption keeps retrying a holder that answers the busy
+    /// sentinel. Comfortably longer than the holder's own poll slice, which is
+    /// how long it can take to notice a dead daemon's connection has gone; short
+    /// enough that a holder somebody really is attached to is reported as such
+    /// rather than waited on.
+    static let defaultBusyRetryBudget: Duration = .seconds(1)
+    static let busyRetryInterval: Duration = .milliseconds(50)
+
+    /// This installation's token, compared against every holder's before it is
+    /// adopted.
+    let owner: HolderOwnerToken
+    /// The environment the rendezvous paths are derived from. Explicit rather
+    /// than ambient so tests never reach the developer's real `~/tbd`.
+    private let environment: [String: String]
+    private let listTerminals: @Sendable () async throws -> [Terminal]
+
+    private var slots: [UUID: Slot] = [:]
+    /// The last status a holder reported for a session, and the only home it
+    /// has: no `terminal` column records an exit status, and the row's fate
+    /// belongs to the holder reconciler Milestone B adds. Recorded here so a
+    /// job that ended during an outage is *reported* rather than lost, and so
+    /// an unreachable holder is recorded as `exitedStatusUnknown` — never as a
+    /// fabricated code, which downstream could not tell from a real one.
+    private var statuses: [UUID: HolderChildStatus] = [:]
+    /// How many drain loops this registry has ever started.
+    ///
+    /// Test-facing, and the honest instrument for the invariant above: object
+    /// identity alone cannot tell a registry that reused a reader from one that
+    /// built a second and threw it away, and only the count sees the second
+    /// drain loop that would have been stealing bytes.
+    private(set) var drainLoopsStarted = 0
+
+    private let busyRetryBudget: Duration
+    private let clock: any Clock<Duration>
+
+    init(
+        owner: HolderOwnerToken,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        listTerminals: @escaping @Sendable () async throws -> [Terminal],
+        busyRetryBudget: Duration = HolderRegistry.defaultBusyRetryBudget,
+        clock: any Clock<Duration> = ContinuousClock()
+    ) {
+        self.owner = owner
+        self.environment = environment
+        self.listTerminals = listTerminals
+        self.busyRetryBudget = busyRetryBudget
+        self.clock = clock
+    }
+
+    // MARK: - Reading
+
+    /// The live reader for a session, or nil if none has been adopted.
+    /// A session still being adopted answers nil: there is no drain loop yet.
+    func reader(for terminalID: UUID) -> HolderReader? {
+        guard case .adopted(let reader) = slots[terminalID] else { return nil }
+        return reader
+    }
+
+    /// The last status a holder reported for a session, if one ever has.
+    func lastKnownStatus(for terminalID: UUID) -> HolderChildStatus? {
+        statuses[terminalID]
+    }
+
+    // MARK: - Adoption
+
+    /// Connects to the session's holder, takes a `dup` of its pty master, and
+    /// starts draining it.
+    ///
+    /// Idempotent, and that is load-bearing rather than tidy — see the type's
+    /// note on byte theft. A call for a session already adopted returns the same
+    /// reader; a call for one mid-adoption awaits that adoption's own task.
+    @discardableResult
+    func adopt(terminal: Terminal) async throws -> HolderReader {
+        guard terminal.transport == .holder else {
+            throw Error.notAHolderSession(terminalID: terminal.id)
+        }
+        switch slots[terminal.id] {
+        case .adopted(let reader):
+            return reader
+        case .adopting(let task):
+            return try await task.value.reader
+        case nil:
+            break
+        }
+
+        let terminalID = terminal.id
+        let socketPath = try HolderRendezvous.socketPath(
+            sessionID: terminalID, environment: environment)
+        let expected = owner
+        let budget = busyRetryBudget
+        let clock = self.clock
+        let task = Task<Adoption, Swift.Error> {
+            try await Self.attach(
+                terminalID: terminalID,
+                socketPath: socketPath,
+                expecting: expected,
+                busyRetryBudget: budget,
+                clock: clock)
+        }
+        slots[terminalID] = .adopting(task)
+
+        let adoption: Adoption
+        do {
+            adoption = try await task.value
+        } catch {
+            // Nothing was started, so nothing is owed a `stop()`. Clearing the
+            // slot is what lets a later pass retry a holder that was merely
+            // slow to answer.
+            slots[terminalID] = nil
+            throw error
+        }
+        slots[terminalID] = .adopted(adoption.reader)
+        statuses[terminalID] = adoption.description.status
+        drainLoopsStarted += 1
+        Self.logger.info(
+            """
+            adopted the holder for session \(terminalID.uuidString, privacy: .public): child \
+            \(adoption.description.childPID, privacy: .public) is \
+            \(String(describing: adoption.description.status), privacy: .public)
+            """)
+        return adoption.reader
+    }
+
+    /// Adopts every holder-backed row, once, at startup.
+    ///
+    /// Failures are per-session and never propagate: one unreachable holder
+    /// must not stop the daemon adopting the rest, and a startup that threw
+    /// here would leave every *other* live session undrained.
+    func adoptAll() async {
+        let terminals: [Terminal]
+        do {
+            terminals = try await listTerminals()
+        } catch {
+            Self.logger.error(
+                """
+                could not list terminals to re-adopt holder sessions: \
+                \(error.localizedDescription, privacy: .public)
+                """)
+            return
+        }
+
+        for terminal in terminals where terminal.transport == .holder {
+            do {
+                _ = try await adopt(terminal: terminal)
+            } catch let error as Error {
+                // A holder that named another installation answered correctly;
+                // it is simply not ours. Left running, and not recorded as
+                // exited — it is somebody else's live session.
+                Self.logger.info(
+                    """
+                    skipping session \(terminal.id.uuidString, privacy: .public): \
+                    \(error.localizedDescription, privacy: .public)
+                    """)
+            } catch HolderClient.Error.rejected {
+                // Somebody else holds the holder's one client slot. That is a
+                // legitimate answer from a live holder — "not ours to adopt
+                // right now" — not a failure to retry into the ground, and
+                // certainly not evidence the job ended.
+                Self.logger.info(
+                    """
+                    the holder for session \(terminal.id.uuidString, privacy: .public) already has a \
+                    client; leaving it alone
+                    """)
+            } catch {
+                // Nothing answered at the rendezvous. The session is over, and
+                // the only honest thing to say about how it ended is that
+                // nobody collected the status.
+                statuses[terminal.id] = .exitedStatusUnknown
+                Self.logger.info(
+                    """
+                    no holder answered for session \(terminal.id.uuidString, privacy: .public), so \
+                    its job ended with an unknown status: \
+                    \(error.localizedDescription, privacy: .public)
+                    """)
+            }
+        }
+    }
+
+    /// The one round trip that re-adoption is made of.
+    ///
+    /// **The owner check happens on the hand-over's own answer, not on a
+    /// `describe` before it, and that ordering is deliberate.** A holder whose
+    /// job has already exited winds itself down the moment an answer carrying
+    /// the terminal status reaches a client — so a separate `describe` would
+    /// collect that status, end the holder, and take everything the job wrote
+    /// and nobody read down with it. `handOverPTY` answers the same question
+    /// *and* rescues the queued output, which is exactly why the holder keeps
+    /// handing the master over after its child is gone.
+    ///
+    /// The cost is that a foreign holder briefly hands over a descriptor before
+    /// being told no. That descriptor is closed here and never read, so nothing
+    /// is stolen from it — see the byte-theft note on the type — and the holder
+    /// and its job are left running.
+    ///
+    /// **A refusal is retried, briefly.** The holder serves one client at a time
+    /// and learns the previous one has gone only when its poll loop next reads
+    /// EOF, so for up to one poll slice after a daemon dies its holder still
+    /// believes that dead daemon is attached and answers the busy sentinel.
+    /// `HolderSpawner` never meets that window because it keeps the connection
+    /// its handshake ran on; an adopter has no such connection and must instead
+    /// outlast the window. The budget is small and finite on purpose: past it,
+    /// a refusal means somebody really is attached, and the honest answer is
+    /// "not ours to adopt right now" rather than a retry loop that never ends.
+    private static func attach(
+        terminalID: UUID,
+        socketPath: String,
+        expecting owner: HolderOwnerToken,
+        busyRetryBudget: Duration,
+        clock: any Clock<Duration>
+    ) async throws -> Adoption {
+        var waited: Duration = .zero
+        while true {
+            do {
+                return try await attemptAttach(
+                    terminalID: terminalID, socketPath: socketPath, expecting: owner)
+            } catch HolderClient.Error.rejected(let version) {
+                guard waited < busyRetryBudget else {
+                    throw HolderClient.Error.rejected(version: version)
+                }
+                // Elapsed time is accumulated from the interval rather than
+                // measured against a deadline: `any Clock<Duration>` pins
+                // `Duration` but not `Instant`, so instant arithmetic does not
+                // typecheck through the existential. Same idiom as
+                // `HolderSpawner.awaitBinding`.
+                try? await clock.sleep(for: Self.busyRetryInterval)
+                waited += Self.busyRetryInterval
+            }
+        }
+    }
+
+    /// One connect-and-take. Every exit path closes the connection: the holder
+    /// serves one client at a time, so a connection kept past the hand-over
+    /// would refuse every later verb — a `forget` on the deletion path above all.
+    private static func attemptAttach(
+        terminalID: UUID,
+        socketPath: String,
+        expecting owner: HolderOwnerToken
+    ) async throws -> Adoption {
+        let client = HolderClient(socketPath: socketPath)
+        let description: HolderChildDescription
+        let ptyFD: Int32
+        do {
+            (description, ptyFD) = try await client.handOverPTY()
+        } catch {
+            await client.close()
+            throw error
+        }
+        await client.close()
+
+        guard description.owner == owner else {
+            Darwin.close(ptyFD)
+            throw Error.foreignOwner(
+                terminalID: terminalID, holderOwner: description.owner.rawValue)
+        }
+
+        let reader = HolderReader(
+            sessionID: terminalID,
+            ptyFD: ptyFD,
+            columns: Int(description.launch.columns),
+            rows: Int(description.launch.rows))
+        do {
+            try await reader.start()
+        } catch {
+            // `stop()` on a reader that never drained closes the descriptor
+            // from the actor, which is safe precisely because no thread has
+            // ever touched it.
+            await reader.stop()
+            throw error
+        }
+        return Adoption(reader: reader, description: description)
+    }
+
+    // MARK: - Release
+
+    /// Stops a session's reader and forgets it.
+    ///
+    /// The `stop()` is the point: a reader dropped without one leaks its drain
+    /// thread and the pty descriptor it owns, because after end of file that
+    /// thread parks on its wake pipe rather than exiting.
+    func release(terminalID: UUID) async {
+        guard let slot = slots.removeValue(forKey: terminalID) else { return }
+        switch slot {
+        case .adopted(let reader):
+            await reader.stop()
+        case .adopting(let task):
+            // The attach performs no cancellation checks, so this waits for it
+            // to finish rather than interrupting it — which is what we want: a
+            // reader that was started while we were releasing would otherwise
+            // be exactly the leak this method exists to prevent.
+            task.cancel()
+            if let adoption = try? await task.value {
+                await adoption.reader.stop()
+            }
+        }
+    }
+
+    /// Releases every reader. The holders and their jobs are untouched — that
+    /// is the whole design: a session outlives the daemon that was reading it.
+    func releaseAll() async {
+        for terminalID in slots.keys {
+            await release(terminalID: terminalID)
+        }
+    }
+}
+
+// MARK: - Installation identity
+
+extension HolderRegistry {
+    /// This installation's owner token, minted once and read forever after.
+    ///
+    /// It must identify the **installation**, not the process: a token minted
+    /// per daemon would make every holder that daemon spawned look foreign to
+    /// its own successor, and re-adoption — the entire point of the transport —
+    /// would never adopt anything. So it is persisted beside the other
+    /// installation-scoped files under `TBD_HOME` (`tbdd.pid`, `port`), and like
+    /// them it is a fixed name that is rewritten rather than accumulated: no
+    /// sweep is owed one.
+    ///
+    /// Minting is `O_EXCL`, so two daemons racing on a fresh `TBD_HOME` agree on
+    /// whichever won rather than each keeping its own.
+    static func installationOwner(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> HolderOwnerToken {
+        let path = TBDConstants.holderOwnerTokenPath(environment: environment)
+        if let existing = readOwnerToken(at: path) { return existing }
+
+        let minted = UUID().uuidString.lowercased()
+        try? FileManager.default.createDirectory(
+            at: TBDConstants.configDir(environment: environment),
+            withIntermediateDirectories: true)
+        let fd = open(path, O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC, 0o600)
+        if fd >= 0 {
+            var bytes = Array(minted.utf8)
+            _ = Darwin.write(fd, &bytes, bytes.count)
+            Darwin.close(fd)
+            return HolderOwnerToken(rawValue: minted)
+        }
+        // Lost the race, or could not write at all. A token read back is the
+        // right answer; a store we cannot write to gets a value derived from the
+        // store's own path, which is at least stable across restarts — an
+        // ephemeral one would quietly disown every holder on the next boot.
+        if let existing = readOwnerToken(at: path) { return existing }
+        Self.logger.error(
+            """
+            could not persist the holder owner token at \(path, privacy: .public) \
+            (errno \(errno, privacy: .public)); falling back to a path-derived token
+            """)
+        return HolderOwnerToken(
+            rawValue: "tbd-home:\(TBDConstants.configDir(environment: environment).path)")
+    }
+
+    private static func readOwnerToken(at path: String) -> HolderOwnerToken? {
+        guard let contents = try? String(contentsOfFile: path, encoding: .utf8) else { return nil }
+        let trimmed = contents.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : HolderOwnerToken(rawValue: trimmed)
+    }
+}

--- a/Sources/TBDDaemon/Holder/HolderRegistry.swift
+++ b/Sources/TBDDaemon/Holder/HolderRegistry.swift
@@ -70,13 +70,28 @@ actor HolderRegistry {
 
     /// What the registry knows about one session.
     ///
-    /// `adopting` is the idempotence guard. It holds the *task*, not a flag, so
-    /// a second caller has something to await rather than a state to poll —
-    /// which is what makes "two concurrent adoptions produce one reader" a
-    /// property of the type instead of a timing accident.
+    /// **A slot is occupied for as long as a reader for that session exists —
+    /// from before the pty dup is asked for until after the drain thread has
+    /// actually gone.** That is the invariant, and every case here is one leg of
+    /// it. There is deliberately no state that means "empty, but a reader is
+    /// still draining": that state is what a fresh `adopt` would read as "nobody
+    /// is on this pty", and it is how two drain loops end up on one master.
+    ///
+    /// Each occupied case holds the *task* that will vacate it, not a flag, so a
+    /// caller who finds the slot busy has something to await rather than a state
+    /// to poll — which is what makes "two concurrent adoptions produce one
+    /// reader" a property of the type instead of a timing accident.
+    ///
+    ///   - `adopting` — an attach is in flight. A second `adopt` awaits it; a
+    ///     `release` supersedes it.
+    ///   - `adopted` — a reader is published and draining.
+    ///   - `releasing` — a reader is being stopped. Its descriptor may still be
+    ///     open and its thread still in `read`, so an `adopt` arriving here
+    ///     *waits* rather than opening a second hand-over against it.
     private enum Slot {
         case adopting(Task<Adoption, Swift.Error>)
         case adopted(HolderReader)
+        case releasing(Task<Void, Never>)
     }
 
     /// How long an adoption keeps retrying a holder that answers the busy
@@ -116,6 +131,38 @@ actor HolderRegistry {
     /// make the number say "loops that ever ran" when what every assertion here
     /// asks is "loops this registry is on the hook for".
     private(set) var drainLoopsStarted = 0
+    /// How many published drain loops are live right now.
+    ///
+    /// The decrement happens inside the releasing task, before anything awaiting
+    /// that task resumes, so an adoption queued behind a release can never see
+    /// its own publish overlap the reader it waited for.
+    private var liveDrainLoops = 0
+    /// The most drain loops that have ever been live at one time.
+    ///
+    /// Test-facing, and the direct instrument for "one reader per session,
+    /// ever": `drainLoopsStarted` counts adoptions over all time and so cannot
+    /// tell a registry that stopped one reader before starting the next from one
+    /// that ran both at once. A peak above one is the byte theft itself, seen
+    /// after the fact.
+    private(set) var peakLiveDrainLoops = 0
+    /// How many calls to `adopt` have got as far as consulting the slot.
+    ///
+    /// Test-facing, and the one instrument every interleaving reaches: it is
+    /// incremented before the slot decision, so watching it go up proves a
+    /// concurrent adoption has already run its whole synchronous prefix —
+    /// whichever branch that prefix took. Tests use it to pin the instant at
+    /// which the *other* counters are meaningful, without waiting on a wall
+    /// clock.
+    private(set) var adoptionCallsEntered = 0
+    /// How many hand-over round trips this registry has opened against a
+    /// holder — that is, how many times it has committed to taking a fresh
+    /// `dup` of a pty master.
+    ///
+    /// Test-facing. Counted at the moment the attach task is created, because
+    /// that is the commitment: everything after it is that task's own business,
+    /// and a second one opened while a reader is still draining is the failure
+    /// this registry exists to prevent, whether or not it is ever published.
+    private(set) var attachRoundTripsStarted = 0
 
     private let busyRetryBudget: Duration
     private let clock: any Clock<Duration>
@@ -129,6 +176,15 @@ actor HolderRegistry {
     /// changed. Nil in production, where the cost is one nil check per
     /// adoption.
     private var publishBarrier: (@Sendable () async -> Void)?
+
+    /// Awaited inside a release, immediately before the reader is stopped — the
+    /// exact window a concurrent `adopt` interleaves in, and the one in which
+    /// the released reader is still draining the pty.
+    ///
+    /// A seam for the same reason `publishBarrier` is one: the interleaving is a
+    /// continuation-ordering accident, and a test that reproduced it by timing
+    /// would pass by luck. Nil in production.
+    private var releaseBarrier: (@Sendable () async -> Void)?
 
     init(
         owner: HolderOwnerToken,
@@ -150,10 +206,19 @@ actor HolderRegistry {
         publishBarrier = barrier
     }
 
+    /// Installs the release barrier described above. Test-facing; production
+    /// never calls it.
+    func setReleaseBarrier(_ barrier: (@Sendable () async -> Void)?) {
+        releaseBarrier = barrier
+    }
+
     // MARK: - Reading
 
     /// The live reader for a session, or nil if none has been adopted.
+    ///
     /// A session still being adopted answers nil: there is no drain loop yet.
+    /// So does one being released — its reader may still be draining, but it is
+    /// on its way out and nothing new should be routed to it.
     func reader(for terminalID: UUID) -> HolderReader? {
         guard case .adopted(let reader) = slots[terminalID] else { return nil }
         return reader
@@ -171,22 +236,75 @@ actor HolderRegistry {
     ///
     /// Idempotent, and that is load-bearing rather than tidy — see the type's
     /// note on byte theft. A call for a session already adopted returns the same
-    /// reader; a call for one mid-adoption awaits that adoption's own task.
+    /// reader; a call for one mid-adoption awaits that adoption's own task; a
+    /// call for one mid-*release* waits for the outgoing reader to have actually
+    /// stopped before it opens a hand-over of its own.
+    ///
+    /// The loop is the shape the slot protocol demands. Every occupied state is
+    /// vacated by awaiting a task, and an actor's methods are not atomic across
+    /// suspension, so the slot is re-read after every await instead of being
+    /// remembered across one.
     @discardableResult
     func adopt(terminal: Terminal) async throws -> HolderReader {
         guard terminal.transport == .holder else {
             throw Error.notAHolderSession(terminalID: terminal.id)
         }
-        switch slots[terminal.id] {
-        case .adopted(let reader):
-            return reader
-        case .adopting(let task):
-            return try await task.value.reader
-        case nil:
-            break
-        }
-
         let terminalID = terminal.id
+        adoptionCallsEntered += 1
+
+        while true {
+            switch slots[terminalID] {
+            case .adopted(let reader):
+                return reader
+            case .adopting(let task):
+                return try await joinInFlightAdoption(task, for: terminalID)
+            case .releasing(let task):
+                // A reader for this pty is still draining. Waiting for its stop
+                // — rather than treating the release's suspension as an empty
+                // slot — is what keeps "one reader per session, ever" true
+                // across the whole of a release instead of only up to its first
+                // await. Clearing the slot here rather than leaving it to the
+                // releaser is what guarantees this loop makes progress.
+                await task.value
+                clearIfStillReleasing(task, for: terminalID)
+                continue
+            case nil:
+                return try await beginAdoption(of: terminalID)
+            }
+        }
+    }
+
+    /// Waits for an adoption another caller already has in flight, and hands
+    /// back its reader only if the registry is really standing behind it.
+    ///
+    /// The re-check is the point. The awaited task settles at the *attach*, one
+    /// suspension before the publish decision, so a `release` arriving in
+    /// between supersedes that adoption and stops its reader. Returning it
+    /// anyway would hand this caller a reader whose drain thread has exited and
+    /// whose pty dup is closed — a screen that never updates again, and writes
+    /// that fail.
+    private func joinInFlightAdoption(
+        _ task: Task<Adoption, Swift.Error>, for terminalID: UUID
+    ) async throws -> HolderReader {
+        let adoption = try await task.value
+        // Read and decide with no await in between, as everywhere else here.
+        switch slots[terminalID] {
+        case .adopted(let published) where published === adoption.reader:
+            return published
+        case .adopting(let current) where current == task:
+            // Not published yet, but still this adoption's slot: nothing has
+            // superseded it, and its reader is the one that will be published.
+            return adoption.reader
+        default:
+            throw Error.superseded(terminalID: terminalID)
+        }
+    }
+
+    /// The empty-slot path: opens a hand-over, publishes what it obtains.
+    ///
+    /// Reached only with the slot genuinely vacant — no reader adopted, none
+    /// being adopted, and none still draining its way out of a release.
+    private func beginAdoption(of terminalID: UUID) async throws -> HolderReader {
         let socketPath = try HolderRendezvous.socketPath(
             sessionID: terminalID, environment: environment)
         let expected = owner
@@ -200,6 +318,7 @@ actor HolderRegistry {
                 busyRetryBudget: budget,
                 clock: clock)
         }
+        attachRoundTripsStarted += 1
         slots[terminalID] = .adopting(task)
 
         let settled = await task.result
@@ -247,6 +366,8 @@ actor HolderRegistry {
         slots[terminalID] = .adopted(adoption.reader)
         statuses[terminalID] = adoption.description.status
         drainLoopsStarted += 1
+        liveDrainLoops += 1
+        peakLiveDrainLoops = max(peakLiveDrainLoops, liveDrainLoops)
         Self.logger.info(
             """
             adopted the holder for session \(terminalID.uuidString, privacy: .public): child \
@@ -426,21 +547,71 @@ actor HolderRegistry {
     /// The `stop()` is the point: a reader dropped without one leaks its drain
     /// thread and the pty descriptor it owns, because after end of file that
     /// thread parks on its wake pipe rather than exiting.
+    ///
+    /// **The slot is not vacated until the stop has happened.** It is handed to
+    /// a `releasing` task first, so that the suspension inside `stop()` — which
+    /// is where this call spends nearly all its time, with the outgoing reader
+    /// still on the pty — is a state a concurrent `adopt` can see and wait for,
+    /// rather than an absence it would read as "nobody is on this master".
     func release(terminalID: UUID) async {
-        guard let slot = slots.removeValue(forKey: terminalID) else { return }
-        switch slot {
+        switch slots[terminalID] {
+        case nil:
+            return
+        case .releasing(let task):
+            // Somebody is already stopping this reader; waiting for their stop
+            // *is* this method's whole contract, so there is nothing to add.
+            await task.value
+            clearIfStillReleasing(task, for: terminalID)
         case .adopted(let reader):
-            await reader.stop()
-        case .adopting(let task):
-            // The attach performs no cancellation checks, so this waits for it
-            // to finish rather than interrupting it — which is what we want: a
-            // reader that was started while we were releasing would otherwise
-            // be exactly the leak this method exists to prevent.
-            task.cancel()
-            if let adoption = try? await task.value {
-                await adoption.reader.stop()
-            }
+            let task = Task<Void, Never> { await self.stopPublished(reader) }
+            slots[terminalID] = .releasing(task)
+            await task.value
+            clearIfStillReleasing(task, for: terminalID)
+        case .adopting(let attach):
+            let task = Task<Void, Never> { await self.stopInFlight(attach) }
+            slots[terminalID] = .releasing(task)
+            await task.value
+            clearIfStillReleasing(task, for: terminalID)
         }
+    }
+
+    /// Stops a reader this registry published, and drops it from the live count
+    /// **before** anything awaiting the release resumes — which is what lets an
+    /// adoption queued behind a release publish without ever overlapping the
+    /// reader it waited for.
+    private func stopPublished(_ reader: HolderReader) async {
+        await releaseBarrier?()
+        await reader.stop()
+        liveDrainLoops -= 1
+    }
+
+    /// Stops whatever an in-flight adoption managed to obtain.
+    ///
+    /// Nothing is decremented: an adoption that never published was never
+    /// counted, and the adoption itself will find its slot taken and discard the
+    /// reader too. Both stops are harmless — `HolderReader.stop()` is
+    /// idempotent — and neither may be skipped, because which of them runs first
+    /// is exactly the ordering nobody here controls.
+    private func stopInFlight(_ attach: Task<Adoption, Swift.Error>) async {
+        // The attach performs no cancellation checks, so this waits for it to
+        // finish rather than interrupting it — which is what we want: a reader
+        // that was started while we were releasing would otherwise be exactly
+        // the leak this method exists to prevent.
+        attach.cancel()
+        if let adoption = try? await attach.value {
+            await adoption.reader.stop()
+        }
+    }
+
+    /// Vacates a slot, but only while it still holds the release that finished.
+    ///
+    /// Both the releaser and every adoption that waited on it call this, and
+    /// whichever arrives first wins; the losers find a slot that is no longer
+    /// theirs and leave it alone. Synchronous, like `slotStillHolds`, and for
+    /// the same reason.
+    private func clearIfStillReleasing(_ task: Task<Void, Never>, for terminalID: UUID) {
+        guard case .releasing(let current) = slots[terminalID], current == task else { return }
+        slots[terminalID] = nil
     }
 
     /// Releases every reader. The holders and their jobs are untouched — that

--- a/Sources/TBDShared/Constants.swift
+++ b/Sources/TBDShared/Constants.swift
@@ -66,6 +66,20 @@ public enum TBDConstants {
         configDir(environment: environment).appendingPathComponent("holders")
     }
 
+    /// File holding this installation's holder owner token: `~/tbd/holder-owner`.
+    /// Honors TBD_HOME.
+    ///
+    /// The token identifies the **installation**, not the process, which is why
+    /// it is persisted at all: a daemon that minted a fresh one on every boot
+    /// would find every holder it had spawned minutes earlier unrecognisable and
+    /// adopt none of them. A fixed name that is rewritten rather than
+    /// accumulated, exactly like `tbdd.pid` and `port` beside it.
+    public static func holderOwnerTokenPath(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> String {
+        configDir(environment: environment).appendingPathComponent("holder-owner").path
+    }
+
     public static func databasePath(environment: [String: String]) -> String {
         configDir(environment: environment).appendingPathComponent("state.db").path
     }

--- a/Sources/TBDShared/Constants.swift
+++ b/Sources/TBDShared/Constants.swift
@@ -66,20 +66,6 @@ public enum TBDConstants {
         configDir(environment: environment).appendingPathComponent("holders")
     }
 
-    /// File holding this installation's holder owner token: `~/tbd/holder-owner`.
-    /// Honors TBD_HOME.
-    ///
-    /// The token identifies the **installation**, not the process, which is why
-    /// it is persisted at all: a daemon that minted a fresh one on every boot
-    /// would find every holder it had spawned minutes earlier unrecognisable and
-    /// adopt none of them. A fixed name that is rewritten rather than
-    /// accumulated, exactly like `tbdd.pid` and `port` beside it.
-    public static func holderOwnerTokenPath(
-        environment: [String: String] = ProcessInfo.processInfo.environment
-    ) -> String {
-        configDir(environment: environment).appendingPathComponent("holder-owner").path
-    }
-
     public static func databasePath(environment: [String: String]) -> String {
         configDir(environment: environment).appendingPathComponent("state.db").path
     }

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -1484,6 +1484,16 @@ public struct Config: Codable, Sendable, Equatable {
     /// without interpreting them; see `Repo.remoteCreateDefaults` for why the
     /// map is keyed generically rather than given a column per concept.
     public var remoteCreateDefaults: [String: String]
+    /// This installation's holder owner token, or nil if none has been minted.
+    ///
+    /// **Identity, not a preference**, which is why it is the one field here
+    /// with no shipped default: nil genuinely means "not yet minted", and any
+    /// literal the code could fall back to would be shared by every checkout on
+    /// the machine — making each of them claim all the others' holder sessions.
+    /// It is minted by `ConfigStore.ensureHolderOwnerToken(minting:)`, whose
+    /// conditional UPDATE is what keeps two daemons starting at once from
+    /// minting two.
+    public var holderOwnerToken: String?
 
     /// Default idle-timeout for auto-hibernation, in minutes.
     public static let defaultHibernateIdleMinutes = 30
@@ -1572,7 +1582,8 @@ public struct Config: Codable, Sendable, Equatable {
                 gcOrphanProcessesEnabled: Bool = Config.gcOrphanProcessesEnabledDefault,
                 remotePeerMessagingEnabled: Bool = Config.remotePeerMessagingDefault,
                 ptyHolderEnabled: Bool = Config.ptyHolderDefault,
-                remoteCreateDefaults: [String: String] = [:]) {
+                remoteCreateDefaults: [String: String] = [:],
+                holderOwnerToken: String? = nil) {
         self.defaultProfileID = defaultProfileID
         self.primaryAgentPreference = primaryAgentPreference
         self.envSettingOverrides = envSettingOverrides
@@ -1607,6 +1618,7 @@ public struct Config: Codable, Sendable, Equatable {
         self.remotePeerMessagingEnabled = remotePeerMessagingEnabled
         self.ptyHolderEnabled = ptyHolderEnabled
         self.remoteCreateDefaults = remoteCreateDefaults
+        self.holderOwnerToken = holderOwnerToken
     }
 
     public init(from decoder: Decoder) throws {
@@ -1699,6 +1711,10 @@ public struct Config: Codable, Sendable, Equatable {
         // field falls through to its provider-declared `default`.
         remoteCreateDefaults = try c.decodeIfPresent(
             [String: String].self, forKey: .remoteCreateDefaults) ?? [:]
+        // Absent means the sender knew nothing about the token — the same state
+        // as an unminted column. Unlike every flag above there is no shipped
+        // default to fall through to; see the property's note.
+        holderOwnerToken = try c.decodeIfPresent(String.self, forKey: .holderOwnerToken)
     }
 }
 

--- a/Tests/TBDDaemonTests/Holder/HolderAdoptionTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HolderAdoptionTests.swift
@@ -119,7 +119,7 @@ struct HolderAdoptionTests {
     /// updates again and a job that can no longer finish exiting, because
     /// nothing is draining its terminal.
     ///
-    /// The interleaving is **forced, not waited for.** `PublishBarrier` parks
+    /// The interleaving is **forced, not waited for.** `ReentryBarrier` parks
     /// the adoption at exactly the suspension point that matters, so the
     /// ordering is a property of the test rather than of the scheduler.
     @Test func aReleaseIsNotUndoneByTheAdoptionItRaced() async throws {
@@ -130,7 +130,7 @@ struct HolderAdoptionTests {
 
         let registry = makeRegistry(owner: fixture.owner, home: fixture.home)
         defer { releaseInBackground(registry) }
-        let barrier = PublishBarrier()
+        let barrier = ReentryBarrier()
         await registry.setPublishBarrier(barrier.hook())
         let terminal = holderTerminal(id: fixture.sessionID)
 
@@ -186,7 +186,7 @@ struct HolderAdoptionTests {
 
         let registry = makeRegistry(owner: fixture.owner, home: fixture.home)
         defer { releaseInBackground(registry) }
-        let barrier = PublishBarrier()
+        let barrier = ReentryBarrier()
         await registry.setPublishBarrier(barrier.hook())
         let terminal = holderTerminal(id: fixture.sessionID)
 
@@ -218,6 +218,99 @@ struct HolderAdoptionTests {
             await live.renderScreen().contains("GOT:AFTER")
         }
         let screen = await live.renderScreen()
+        #expect(sawAfter, "screen was: \(screen.debugDescription)")
+    }
+
+    /// The third member of the family, and the one a targeted guard would have
+    /// missed: a **fresh** adoption arriving while a published reader is being
+    /// stopped.
+    ///
+    /// `release` spends nearly all of its time suspended inside `reader.stop()`,
+    /// waiting for the drain thread to acknowledge its wake and close the pty
+    /// dup. If the slot is vacated before that suspension, an `adopt` landing in
+    /// the window reads "nobody is on this master", opens its own `handOverPTY`
+    /// round trip, and takes a second `dup` of a pty a live drain loop is still
+    /// reading. That is the byte theft this registry exists to prevent — each
+    /// `read` takes bytes the other will never see, and nothing reports it.
+    ///
+    /// **The interleaving is forced, not waited for**, in both directions:
+    ///
+    ///   - `ReentryBarrier` parks the release at exactly the stop step, so the
+    ///     window is open for as long as the test wants it.
+    ///   - `adoptionCallsEntered` pins the instant to assert at. An actor runs
+    ///     one job at a time, so observing that counter go to two proves the
+    ///     racing `adopt` has already run its entire synchronous prefix — up to
+    ///     and including whichever slot decision it made. Whether it opened a
+    ///     round trip is therefore decided, not pending, and reading
+    ///     `attachRoundTripsStarted` next is reading a settled fact rather than
+    ///     racing one.
+    @Test func aFreshAdoptionWaitsForAReaderThatIsStillDraining() async throws {
+        let fixture = try await HolderProcessFixture.start(
+            command: "while IFS= read -r line; do printf 'GOT:%s\\n' \"$line\"; done")
+        defer { fixture.tearDown() }
+        await fixture.client.close()
+
+        let registry = makeRegistry(owner: fixture.owner, home: fixture.home)
+        defer { releaseInBackground(registry) }
+        let terminal = holderTerminal(id: fixture.sessionID)
+
+        let first = try await registry.adopt(terminal: terminal)
+        let adopted = await registry.drainLoopsStarted
+        #expect(adopted == 1)
+
+        let barrier = ReentryBarrier()
+        await registry.setReleaseBarrier(barrier.hook())
+        // Hoisted: capturing `fixture` itself in a `Task` would send a
+        // non-Sendable class across an isolation boundary.
+        let sessionID = fixture.sessionID
+        let releasing = Task { await registry.release(terminalID: sessionID) }
+        let parked = await pollUntil("the release to reach its stop step") {
+            await barrier.hasParked
+        }
+        #expect(parked)
+        let stillDraining = await first.isDraining
+        #expect(
+            stillDraining,
+            "the released reader had already stopped, so the window this test forces never existed")
+
+        // The whole point: a fresh adoption, arriving with the outgoing reader
+        // still on the pty.
+        let racing = Task { try await registry.adopt(terminal: terminal) }
+        let entered = await pollUntil("the racing adoption to consult the slot") {
+            await registry.adoptionCallsEntered == 2
+        }
+        #expect(entered)
+
+        let roundTrips = await registry.attachRoundTripsStarted
+        #expect(
+            roundTrips == 1,
+            """
+            a fresh adoption opened a second handOverPTY round trip against a reader that was \
+            still draining: \(roundTrips) round trips for one session
+            """)
+        let overlapped = await first.isDraining
+        #expect(overlapped, "the release finished on its own, so nothing was raced")
+
+        await barrier.release()
+        let fresh = try await racing.value
+        await releasing.value
+
+        let peak = await registry.peakLiveDrainLoops
+        #expect(peak == 1, "\(peak) drain loops were live at once on one pty master")
+        let stopped = await first.isDraining
+        #expect(!stopped, "the released reader was still draining after its release returned")
+        let stored = await registry.reader(for: fixture.sessionID)
+        #expect(stored === fresh, "the registry did not keep the reader that waited its turn")
+        let loops = await registry.drainLoopsStarted
+        #expect(loops == 2, "the re-adoption did not start a drain loop of its own")
+
+        // And it is genuinely draining, not merely published: only a live loop
+        // can show output the job produced after the re-adoption.
+        try await fresh.write(Data("AFTER\n".utf8))
+        let sawAfter = await pollUntil("output the job produced after the re-adoption") {
+            await fresh.renderScreen().contains("GOT:AFTER")
+        }
+        let screen = await fresh.renderScreen()
         #expect(sawAfter, "screen was: \(screen.debugDescription)")
     }
 
@@ -495,29 +588,30 @@ private func releaseInBackground(_ registry: HolderRegistry) {
     Task.detached { await registry.releaseAll() }
 }
 
-/// Holds the **first** adoption that reaches its publish step, and waves through
-/// every one after it.
+/// Holds the **first** caller that reaches the seam it is installed on, and
+/// waves through every one after it.
 ///
-/// It exists so the release/adopt race is a property of the test rather than of
-/// the scheduler. That race is a continuation-ordering accident inside an actor:
-/// reproducing it by timing would pass by luck, stop reproducing the day the
-/// scheduler changed, and prove nothing on the day it went green. Installed on
-/// the registry with `setPublishBarrier`, this parks the adoption at exactly the
-/// suspension point in question, so the interleaving is forced.
+/// It exists so these races are properties of the tests rather than of the
+/// scheduler. Each of them is a continuation-ordering accident inside an actor:
+/// reproducing one by timing would pass by luck, stop reproducing the day the
+/// scheduler changed, and prove nothing on the day it went green. Installed with
+/// `setPublishBarrier` it parks an adoption between its attach and its publish;
+/// installed with `setReleaseBarrier` it parks a release with the outgoing
+/// reader still draining. Either way the interleaving is forced.
 ///
 /// Nothing here sleeps to *create* the interleaving. The polling is only how
 /// each side observes a state the other has definitely reached, and it is
 /// bounded through `pollUntil`, so a barrier nobody releases fails its test with
 /// a named diagnostic instead of hanging the suite.
-private actor PublishBarrier {
+private actor ReentryBarrier {
     private var parked = false
     private var released = false
 
-    /// Whether an adoption is being held. The test waits for this before doing
+    /// Whether a caller is being held. The test waits for this before doing
     /// whatever must interleave.
     var hasParked: Bool { parked }
 
-    /// Lets the parked adoption finish.
+    /// Lets the parked caller finish.
     func release() { released = true }
 
     private var isReleased: Bool { released }

--- a/Tests/TBDDaemonTests/Holder/HolderAdoptionTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HolderAdoptionTests.swift
@@ -1,5 +1,6 @@
 import Darwin
 import Foundation
+import GRDB
 import Testing
 @testable import TBDDaemonLib
 @testable import TBDShared
@@ -102,6 +103,122 @@ struct HolderAdoptionTests {
 
         let loops = await registry.drainLoopsStarted
         #expect(loops == 1, "the registry started \(loops) drain loops on one pty")
+    }
+
+    // MARK: - A release that races the adoption it is releasing
+
+    /// A `release` that runs while an adoption is between its attach and its
+    /// publish must not be undone by that adoption.
+    ///
+    /// The registry is an actor, and an actor's methods are **not** atomic
+    /// across `await`. `release` clears the slot and then suspends inside
+    /// `reader.stop()`; the adoption it just cancelled can resume in that window
+    /// and — before this fix — wrote its result into the slot regardless. The
+    /// registry was then holding a reader whose drain thread had already exited
+    /// and whose pty descriptor was closed: a session with a screen that never
+    /// updates again and a job that can no longer finish exiting, because
+    /// nothing is draining its terminal.
+    ///
+    /// The interleaving is **forced, not waited for.** `PublishBarrier` parks
+    /// the adoption at exactly the suspension point that matters, so the
+    /// ordering is a property of the test rather than of the scheduler.
+    @Test func aReleaseIsNotUndoneByTheAdoptionItRaced() async throws {
+        let fixture = try await HolderProcessFixture.start(
+            command: "while IFS= read -r line; do printf 'GOT:%s\\n' \"$line\"; done")
+        defer { fixture.tearDown() }
+        await fixture.client.close()
+
+        let registry = makeRegistry(owner: fixture.owner, home: fixture.home)
+        defer { releaseInBackground(registry) }
+        let barrier = PublishBarrier()
+        await registry.setPublishBarrier(barrier.hook())
+        let terminal = holderTerminal(id: fixture.sessionID)
+
+        let racing = Task { try await registry.adopt(terminal: terminal) }
+        let parked = await pollUntil("the adoption to reach its publish step") {
+            await barrier.hasParked
+        }
+        #expect(parked)
+
+        // Runs to completion — slot cleared, reader stopped — while the
+        // adoption sits parked between its attach and its publish.
+        await registry.release(terminalID: fixture.sessionID)
+        await barrier.release()
+
+        await #expect(throws: HolderRegistry.Error.superseded(terminalID: fixture.sessionID)) {
+            try await racing.value
+        }
+        let stored = await registry.reader(for: fixture.sessionID)
+        #expect(stored == nil, "the registry kept a reader the release had already stopped")
+        let loopsAfterTheRace = await registry.drainLoopsStarted
+        #expect(loopsAfterTheRace == 0, "a superseded adoption was published as a live reader")
+
+        // And the session is still adoptable, which is the whole point: the
+        // discarded reader neither survived in the slot nor left a drain loop
+        // behind to take bytes from this one. Asserting on output the job
+        // produced *after* this adoption is what distinguishes a reader that is
+        // really draining from one that merely exists.
+        let reader = try await registry.adopt(terminal: terminal)
+        try await reader.write(Data("AFTER\n".utf8))
+        let sawAfter = await pollUntil("output the job produced after the re-adoption") {
+            await reader.renderScreen().contains("GOT:AFTER")
+        }
+        let screen = await reader.renderScreen()
+        #expect(sawAfter, "screen was: \(screen.debugDescription)")
+        let loops = await registry.drainLoopsStarted
+        #expect(loops == 1, "the registry started \(loops) drain loops on one pty")
+    }
+
+    /// The other half of the same race: a *later* adoption takes the slot while
+    /// an earlier one is parked, and the earlier one must not clobber it.
+    ///
+    /// This is the escalation, and it is worse than the case above. Before the
+    /// fix the parked adoption overwrote the slot with its own stopped reader,
+    /// which both resurrected a dead reader **and** orphaned the live one — a
+    /// reader nothing owns any more, still draining the pty master, still owed a
+    /// `stop()` nobody will ever call. Two drain loops on one master is silent
+    /// byte theft: each `read` takes bytes the other will never see.
+    @Test func aLaterAdoptionIsNotClobberedByTheOneItSuperseded() async throws {
+        let fixture = try await HolderProcessFixture.start(
+            command: "while IFS= read -r line; do printf 'GOT:%s\\n' \"$line\"; done")
+        defer { fixture.tearDown() }
+        await fixture.client.close()
+
+        let registry = makeRegistry(owner: fixture.owner, home: fixture.home)
+        defer { releaseInBackground(registry) }
+        let barrier = PublishBarrier()
+        await registry.setPublishBarrier(barrier.hook())
+        let terminal = holderTerminal(id: fixture.sessionID)
+
+        let superseded = Task { try await registry.adopt(terminal: terminal) }
+        let parked = await pollUntil("the first adoption to reach its publish step") {
+            await barrier.hasParked
+        }
+        #expect(parked)
+
+        // The slot is freed and then claimed by a second adoption, which runs
+        // to completion — the barrier holds only the first arrival.
+        await registry.release(terminalID: fixture.sessionID)
+        let live = try await registry.adopt(terminal: terminal)
+        await barrier.release()
+
+        await #expect(throws: HolderRegistry.Error.superseded(terminalID: fixture.sessionID)) {
+            try await superseded.value
+        }
+        let stored = await registry.reader(for: fixture.sessionID)
+        #expect(
+            stored === live,
+            "the superseded adoption overwrote the live one, orphaning its drain loop")
+        let loops = await registry.drainLoopsStarted
+        #expect(loops == 1, "the registry published \(loops) readers for one pty")
+
+        // Still the session's only reader, and still genuinely draining.
+        try await live.write(Data("AFTER\n".utf8))
+        let sawAfter = await pollUntil("output the surviving reader drained after the race") {
+            await live.renderScreen().contains("GOT:AFTER")
+        }
+        let screen = await live.renderScreen()
+        #expect(sawAfter, "screen was: \(screen.debugDescription)")
     }
 
     // MARK: - Somebody else's session
@@ -256,25 +373,94 @@ struct HolderAdoptionTests {
     /// own successor, and `adoptAll` would walk away from every live session it
     /// was written to rescue — while still passing a test that only checked two
     /// different installations disagree.
-    @Test func theInstallationOwnerTokenSurvivesARestart() throws {
-        let home = HolderProcessFixture.scratchHome()
-        defer { try? FileManager.default.removeItem(atPath: home) }
-        let elsewhere = HolderProcessFixture.scratchHome()
-        defer { try? FileManager.default.removeItem(atPath: elsewhere) }
+    ///
+    /// A second `TBDDatabase` is a second installation, which is what makes the
+    /// last assertion mean anything: the token has to be per-`TBD_HOME`, not a
+    /// constant every checkout on the machine would share.
+    @Test func theInstallationOwnerTokenSurvivesARestart() async throws {
+        let database = try TBDDatabase(inMemory: true)
+        let elsewhere = try TBDDatabase(inMemory: true)
 
-        let minted = HolderRegistry.installationOwner(
-            environment: HolderProcessFixture.environment(home: home))
+        let minted = await HolderRegistry.installationOwner(config: database.config)
         #expect(!minted.rawValue.isEmpty)
+        #expect(!minted.rawValue.hasPrefix("tbd-home:"), "the mint fell back instead of persisting")
 
-        let reread = HolderRegistry.installationOwner(
-            environment: HolderProcessFixture.environment(home: home))
+        // The restart: a second daemon, reading the row the first one wrote.
+        let reread = await HolderRegistry.installationOwner(config: database.config)
         #expect(
             reread == minted,
             "the token was re-minted, so a restarted daemon would disown its own holders")
 
-        let other = HolderRegistry.installationOwner(
-            environment: HolderProcessFixture.environment(home: elsewhere))
+        let other = await HolderRegistry.installationOwner(config: elsewhere.config)
         #expect(other != minted, "two installations share one token")
+    }
+
+    /// The column is genuinely NULL until somebody mints, and the mint is what
+    /// fills it.
+    ///
+    /// If the migration ever grows a `DEFAULT` clause this goes red, which is
+    /// its only job — and the failure it prevents is not a lost preference but a
+    /// shared identity: every checkout on the machine would carry the same
+    /// literal token and claim every other checkout's holder sessions.
+    @Test func theOwnerTokenColumnIsNullUntilItIsMinted() async throws {
+        let database = try TBDDatabase(inMemory: true)
+
+        let before = try await database.config.get().holderOwnerToken
+        #expect(
+            before == nil,
+            """
+            config.holder_owner_token must be NULL until a daemon mints one — read back \
+            \(String(describing: before)). A non-nil value here means \
+            20260831200151_config_holder_owner_token grew a DEFAULT clause; remove it.
+            """)
+
+        let minted = await HolderRegistry.installationOwner(config: database.config)
+        let after = try await database.config.get().holderOwnerToken
+        #expect(after == minted.rawValue, "the minted token did not reach the config row")
+    }
+
+    /// Two daemons starting at once mint one token between them.
+    ///
+    /// This is the property the file-backed store got from `O_EXCL` and the
+    /// `config` row gets from a conditional UPDATE: whoever loses the race reads
+    /// back the winner's value instead of keeping its own. Two tokens here would
+    /// mean two daemons that each disown the other's holders — and, because a
+    /// foreign holder is deliberately left strictly alone, sessions neither of
+    /// them ever drains.
+    @Test func concurrentMintsAgreeOnOneToken() async throws {
+        let database = try TBDDatabase(inMemory: true)
+
+        async let first = HolderRegistry.installationOwner(config: database.config)
+        async let second = HolderRegistry.installationOwner(config: database.config)
+        async let third = HolderRegistry.installationOwner(config: database.config)
+        let tokens = await [first, second, third].map(\.rawValue)
+
+        #expect(
+            Set(tokens).count == 1,
+            "concurrent mints produced \(Set(tokens).count) tokens: \(tokens)")
+        let stored = try await database.config.get().holderOwnerToken
+        #expect(stored == tokens[0], "the row holds a token nobody was handed")
+    }
+
+    /// A daemon whose database cannot be written still starts, and says what
+    /// that costs.
+    ///
+    /// The fallback is path-derived rather than random on purpose: it is stable
+    /// for as long as the outage lasts, where an ephemeral token would disown
+    /// this daemon's own holders on its very next boot. What it still costs is
+    /// real, and is the reason the log line exists — holders stamped with it
+    /// read as foreign the moment a real token is minted.
+    @Test func anUnwritableStoreFallsBackToAStableToken() async throws {
+        // A database with no `config` table at all: every write against it
+        // throws, which is the shape of an unwritable store.
+        let store = ConfigStore(writer: try DatabaseQueue())
+        let home = HolderProcessFixture.scratchHome()
+        let environment = HolderProcessFixture.environment(home: home)
+
+        let first = await HolderRegistry.installationOwner(config: store, environment: environment)
+        #expect(!first.rawValue.isEmpty, "a daemon that cannot persist a token must still start")
+        let second = await HolderRegistry.installationOwner(config: store, environment: environment)
+        #expect(first == second, "the fallback token changed between two calls in one outage")
     }
 
     // MARK: - Support
@@ -307,4 +493,46 @@ struct HolderAdoptionTests {
 /// idempotent.
 private func releaseInBackground(_ registry: HolderRegistry) {
     Task.detached { await registry.releaseAll() }
+}
+
+/// Holds the **first** adoption that reaches its publish step, and waves through
+/// every one after it.
+///
+/// It exists so the release/adopt race is a property of the test rather than of
+/// the scheduler. That race is a continuation-ordering accident inside an actor:
+/// reproducing it by timing would pass by luck, stop reproducing the day the
+/// scheduler changed, and prove nothing on the day it went green. Installed on
+/// the registry with `setPublishBarrier`, this parks the adoption at exactly the
+/// suspension point in question, so the interleaving is forced.
+///
+/// Nothing here sleeps to *create* the interleaving. The polling is only how
+/// each side observes a state the other has definitely reached, and it is
+/// bounded through `pollUntil`, so a barrier nobody releases fails its test with
+/// a named diagnostic instead of hanging the suite.
+private actor PublishBarrier {
+    private var parked = false
+    private var released = false
+
+    /// Whether an adoption is being held. The test waits for this before doing
+    /// whatever must interleave.
+    var hasParked: Bool { parked }
+
+    /// Lets the parked adoption finish.
+    func release() { released = true }
+
+    private var isReleased: Bool { released }
+
+    /// True for the first caller only; every later one is waved through.
+    private func claimPark() -> Bool {
+        guard !parked else { return false }
+        parked = true
+        return true
+    }
+
+    nonisolated func hook() -> @Sendable () async -> Void {
+        { [self] in
+            guard await claimPark() else { return }
+            await pollUntil("the test to release the parked adoption") { await self.isReleased }
+        }
+    }
 }

--- a/Tests/TBDDaemonTests/Holder/HolderAdoptionTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HolderAdoptionTests.swift
@@ -1,0 +1,310 @@
+import Darwin
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Re-adopting live holders after the daemon that spawned them has gone.
+///
+/// The suite simulates the only interesting failure the transport exists to
+/// survive: the daemon dies, its readers die with it, and the holder and its job
+/// carry on. Nothing here kills a holder or a job to set that up — a test that
+/// did would be testing respawn, not adoption.
+///
+/// Two of these are load-bearing rather than hygiene:
+///
+///   - `adoptsALiveHolderAndResumesDraining` asserts on output the job produced
+///     **after** the adoption. A reader that was constructed but never started
+///     would satisfy any assertion about earlier output, and would leave the
+///     session exactly as wedged as no reader at all.
+///   - `adoptionIsIdempotent` asserts the **count** of drain loops. Two loops on
+///     one pty master is silent byte theft: each `read` takes bytes the other
+///     never sees, and object identity alone cannot see the second loop.
+@Suite(.serialized)
+struct HolderAdoptionTests {
+
+    // MARK: - Adoption resumes the drain
+
+    /// The daemon dies, its reader dies with it, and the session does not.
+    ///
+    /// The job only speaks when spoken to, deliberately: a job writing on its
+    /// own during the outage would wedge in `ttywait` behind its own undrained
+    /// output and the test would be measuring that instead. Here the outage is
+    /// quiet, and the marker written after the adoption can only reach the
+    /// screen if the new reader is genuinely draining.
+    @Test func adoptsALiveHolderAndResumesDraining() async throws {
+        let fixture = try await HolderProcessFixture.start(
+            command: "while IFS= read -r line; do printf 'GOT:%s\\n' \"$line\"; done")
+        defer { fixture.tearDown() }
+
+        // The daemon that spawned this session had a reader. Stopping it is
+        // what a daemon's death looks like from the holder's side: the dup goes
+        // away, and the holder, the pty and the job are all untouched.
+        let (_, ptyFD) = try await fixture.client.handOverPTY()
+        let previous = HolderReader(
+            sessionID: fixture.sessionID, ptyFD: ptyFD, columns: 80, rows: 24)
+        try await previous.start()
+        try await previous.write(Data("BEFORE\n".utf8))
+        let sawBefore = await pollUntil("the job's answer before the outage") {
+            await previous.renderScreen().contains("GOT:BEFORE")
+        }
+        #expect(sawBefore)
+        await previous.stop()
+        // And the client slot goes with it, or the restarted daemon's own
+        // connection would be answered with the busy sentinel.
+        await fixture.client.close()
+
+        let registry = makeRegistry(owner: fixture.owner, home: fixture.home)
+        defer { releaseInBackground(registry) }
+
+        let reader = try await registry.adopt(
+            terminal: holderTerminal(id: fixture.sessionID))
+        try await reader.write(Data("AFTER\n".utf8))
+
+        let sawAfter = await pollUntil("output the job produced after the adoption") {
+            await reader.renderScreen().contains("GOT:AFTER")
+        }
+        let screen = await reader.renderScreen()
+        #expect(sawAfter, "screen was: \(screen.debugDescription)")
+
+        let stored = await registry.reader(for: fixture.sessionID)
+        #expect(stored === reader, "the registry did not keep the reader it adopted")
+        #expect(holderProcessIsAlive(fixture.handle.childPID))
+    }
+
+    // MARK: - One reader, ever
+
+    /// Two adoptions of one session yield one reader and one drain loop.
+    ///
+    /// The two calls are concurrent on purpose: the guard has to be the actor's
+    /// own state, so that a second call arriving mid-adoption *awaits* the first
+    /// rather than opening its own connection and taking its own dup. The count
+    /// is the assertion that matters — a registry that built a second reader and
+    /// then returned the first would pass an identity check while a second drain
+    /// loop quietly stole half the session's bytes.
+    @Test func adoptionIsIdempotent() async throws {
+        let fixture = try await HolderProcessFixture.start(
+            command: "printf 'DELTA\\n'; sleep 30")
+        defer { fixture.tearDown() }
+        await fixture.client.close()
+
+        let registry = makeRegistry(owner: fixture.owner, home: fixture.home)
+        defer { releaseInBackground(registry) }
+        let terminal = holderTerminal(id: fixture.sessionID)
+
+        async let first = registry.adopt(terminal: terminal)
+        async let second = registry.adopt(terminal: terminal)
+        let readers = try await (first, second)
+        #expect(readers.0 === readers.1, "concurrent adoptions produced two readers")
+
+        let third = try await registry.adopt(terminal: terminal)
+        #expect(third === readers.0, "a later adoption produced a second reader")
+
+        let loops = await registry.drainLoopsStarted
+        #expect(loops == 1, "the registry started \(loops) drain loops on one pty")
+    }
+
+    // MARK: - Somebody else's session
+
+    /// A holder that names another installation is left strictly alone.
+    ///
+    /// `TBD_HOME` is shared by every checkout on a machine, so "reachable and
+    /// absent from my database" is exactly what a healthy foreign session looks
+    /// like. The assertions are therefore not only that we did not adopt it, but
+    /// that it is still *serving* afterwards — alive is not the same as
+    /// unharmed.
+    @Test func adoptionSkipsForeignOwners() async throws {
+        let fixture = try await HolderProcessFixture.start(
+            command: "printf 'FOREIGN\\n'; sleep 30",
+            owner: "another-installation")
+        defer { fixture.tearDown() }
+        await fixture.client.close()
+
+        let registry = makeRegistry(
+            owner: HolderOwnerToken(rawValue: "acme-installation"), home: fixture.home)
+        defer { releaseInBackground(registry) }
+
+        await #expect(
+            throws: HolderRegistry.Error.foreignOwner(
+                terminalID: fixture.sessionID, holderOwner: "another-installation")
+        ) {
+            try await registry.adopt(terminal: holderTerminal(id: fixture.sessionID))
+        }
+
+        let stored = await registry.reader(for: fixture.sessionID)
+        #expect(stored == nil, "a foreign session was adopted")
+        let loops = await registry.drainLoopsStarted
+        #expect(loops == 0)
+        #expect(holderProcessIsAlive(fixture.handle.holderPID))
+        #expect(holderProcessIsAlive(fixture.handle.childPID))
+
+        // Still serving, not merely still running.
+        let description = try await fixture.client.describe()
+        #expect(description.status == .alive)
+        #expect(description.owner == HolderOwnerToken(rawValue: "another-installation"))
+    }
+
+    /// The other end of the busy-sentinel retry: a holder somebody really is
+    /// attached to is reported as refused, not waited on forever.
+    ///
+    /// The retry exists only to outlast the window in which a holder has not yet
+    /// noticed a dead daemon's connection go away. Here the connection is
+    /// genuinely alive, so no amount of waiting would help — and a zero budget
+    /// says exactly that without spending a second proving it.
+    @Test func aBusyHolderIsReportedRatherThanAdopted() async throws {
+        let fixture = try await HolderProcessFixture.start(command: "sleep 30")
+        defer { fixture.tearDown() }
+        // Deliberately left attached: the spawner's handshake connection is the
+        // holder's one client slot, and it still holds it.
+        _ = try await fixture.client.describe()
+
+        let registry = HolderRegistry(
+            owner: fixture.owner,
+            environment: HolderProcessFixture.environment(home: fixture.home),
+            listTerminals: { [] },
+            busyRetryBudget: .zero)
+        defer { releaseInBackground(registry) }
+
+        await #expect(
+            throws: HolderClient.Error.rejected(version: HolderProtocolVersion.busySentinel)
+        ) {
+            try await registry.adopt(terminal: holderTerminal(id: fixture.sessionID))
+        }
+        let stored = await registry.reader(for: fixture.sessionID)
+        #expect(stored == nil)
+        let loops = await registry.drainLoopsStarted
+        #expect(loops == 0)
+    }
+
+    // MARK: - The startup sweep
+
+    /// `adoptAll` walks holder rows and nothing else.
+    ///
+    /// Both branches, because the exemption must not become an excuse: a tmux
+    /// row is never probed at all — it has no rendezvous to probe — while a
+    /// holder row whose holder has gone is recorded as having ended with an
+    /// **unknown** status. Never a fabricated code: downstream could not tell
+    /// one of those from a status the job really returned.
+    @Test func adoptAllSkipsTmuxRows() async throws {
+        let home = HolderProcessFixture.scratchHome()
+        defer { try? FileManager.default.removeItem(atPath: home) }
+
+        let tmuxRow = Terminal(
+            worktreeID: UUID(), tmuxWindowID: "@7", tmuxPaneID: "%7", transport: .tmux)
+        let holderRow = holderTerminal(id: UUID())
+        let registry = HolderRegistry(
+            owner: HolderOwnerToken(rawValue: "acme-installation"),
+            environment: HolderProcessFixture.environment(home: home),
+            listTerminals: { [tmuxRow, holderRow] })
+        defer { releaseInBackground(registry) }
+
+        await registry.adoptAll()
+
+        let tmuxReader = await registry.reader(for: tmuxRow.id)
+        #expect(tmuxReader == nil)
+        let tmuxStatus = await registry.lastKnownStatus(for: tmuxRow.id)
+        #expect(tmuxStatus == nil, "a tmux row was probed as though it had a holder")
+
+        let holderStatus = await registry.lastKnownStatus(for: holderRow.id)
+        #expect(
+            holderStatus == .exitedStatusUnknown,
+            "an unreachable holder was reported as \(String(describing: holderStatus))")
+        let loops = await registry.drainLoopsStarted
+        #expect(loops == 0)
+    }
+
+    // MARK: - A job that ended while nobody was listening
+
+    /// The status of a job that finished during the outage reaches the daemon.
+    ///
+    /// This is the case the holder's exit-report window exists for: it reaps the
+    /// child, finds no client, keeps its rendezvous bound, and waits to be
+    /// asked. A restarted daemon asks by adopting, and the description riding
+    /// the hand-over carries the status — so the job's exit is *reported* rather
+    /// than lost with the process that observed it.
+    ///
+    /// The job sleeps first so the exit lands after the spawner's own connection
+    /// is gone. With a client still attached the holder pushes the status at it
+    /// and winds down, which is a different path — and one no restarted daemon
+    /// can take, because its predecessor's connection died with it.
+    @Test func reportsAJobThatFinishedDuringTheOutage() async throws {
+        let fixture = try await HolderProcessFixture.start(command: "sleep 1; exit 7")
+        defer { fixture.tearDown() }
+        await fixture.client.close()
+
+        let ended = await pollUntil("the job to finish exiting") {
+            !holderProcessIsAlive(fixture.handle.childPID)
+        }
+        #expect(ended)
+
+        let registry = makeRegistry(owner: fixture.owner, home: fixture.home)
+        defer { releaseInBackground(registry) }
+
+        _ = try await registry.adopt(terminal: holderTerminal(id: fixture.sessionID))
+        let status = await registry.lastKnownStatus(for: fixture.sessionID)
+        #expect(
+            status == .exited(code: 7),
+            "the exit status was lost: \(String(describing: status))")
+    }
+
+    // MARK: - Installation identity
+
+    /// The owner token identifies the installation, and must survive a restart.
+    ///
+    /// This is the property the whole comparison rests on: a token minted per
+    /// process would make every holder a daemon spawned unrecognisable to its
+    /// own successor, and `adoptAll` would walk away from every live session it
+    /// was written to rescue — while still passing a test that only checked two
+    /// different installations disagree.
+    @Test func theInstallationOwnerTokenSurvivesARestart() throws {
+        let home = HolderProcessFixture.scratchHome()
+        defer { try? FileManager.default.removeItem(atPath: home) }
+        let elsewhere = HolderProcessFixture.scratchHome()
+        defer { try? FileManager.default.removeItem(atPath: elsewhere) }
+
+        let minted = HolderRegistry.installationOwner(
+            environment: HolderProcessFixture.environment(home: home))
+        #expect(!minted.rawValue.isEmpty)
+
+        let reread = HolderRegistry.installationOwner(
+            environment: HolderProcessFixture.environment(home: home))
+        #expect(
+            reread == minted,
+            "the token was re-minted, so a restarted daemon would disown its own holders")
+
+        let other = HolderRegistry.installationOwner(
+            environment: HolderProcessFixture.environment(home: elsewhere))
+        #expect(other != minted, "two installations share one token")
+    }
+
+    // MARK: - Support
+
+    /// A holder-transport row. `tmuxWindowID`/`tmuxPaneID` are empty because
+    /// those columns are NOT NULL from the v1 schema and a holder row has no
+    /// tmux coordinate to put in them — it is discriminated by `transport`
+    /// alone, never by those values.
+    private func holderTerminal(id: UUID) -> Terminal {
+        Terminal(
+            id: id, worktreeID: UUID(), tmuxWindowID: "", tmuxPaneID: "", transport: .holder)
+    }
+
+    /// A registry whose rendezvous paths come from an explicit environment, so
+    /// nothing here can reach the developer's real `~/tbd` even for an instant.
+    /// `listTerminals` is unused by `adopt` and returns nothing.
+    private func makeRegistry(owner: HolderOwnerToken, home: String) -> HolderRegistry {
+        HolderRegistry(
+            owner: owner,
+            environment: HolderProcessFixture.environment(home: home),
+            listTerminals: { [] })
+    }
+}
+
+/// Releases a registry's readers from a `defer`, which cannot `await`.
+///
+/// Every test needs it on every exit path: a reader left running leaks its drain
+/// thread and a pty descriptor for the rest of the suite, because after end of
+/// file the thread parks on its wake pipe rather than exiting. Releasing is
+/// idempotent.
+private func releaseInBackground(_ registry: HolderRegistry) {
+    Task.detached { await registry.releaseAll() }
+}

--- a/Tests/TBDDaemonTests/SQLMigrationLoaderTests.swift
+++ b/Tests/TBDDaemonTests/SQLMigrationLoaderTests.swift
@@ -495,6 +495,7 @@ import Testing
             "20260830022625_shadow_peer_artifacts",
             "20260831055718_config_pty_holder",
             "20260831055719_terminal_transport",
+            "20260831200151_config_holder_owner_token",
         ]
         let found = try SQLMigrationLoader.bundled.get()
         #expect(found.files.map(\.identifier) == expected)


### PR DESCRIPTION
## Summary

Task 9 of the pty-holder transport ([spec](../blob/main/docs/specs/2026-08-30-pty-holder-session-transport-design.md)). `HolderRegistry`, the daemon's single owner of live readers, plus `adoptAll()` at startup.

**Stacked on #775 → #773 → #769 → #768 → #767 → #766 → #765.** Merge in order.

## Why this task exists

A `HolderReader` lives only in the memory of the daemon that made it. Without adoption, a restarted daemon has no reader — so nothing drains, `tbd terminal output` has nothing to render, and **jobs that finish cannot complete their exit**, because the kernel's teardown waits on the pty's output queue. Sessions would silently pile up half-exited. This is the task that makes "a session outlives the daemon" true rather than aspirational.

## Why this shape

**Adoption is a single `handOverPTY` round trip, and the owner check rides its answer.** Doing `describe` first would break re-adoption outright: the holder winds down the moment a status-carrying answer reaches a client, so a pre-check on an exited job would collect its status, end the holder, and take the job's still-queued output with it. `Holder.serve()` hands the master over *after* the child exits precisely for this path. The cost is that a foreign holder briefly hands over a descriptor before being told no — it is closed unread, so nothing is stolen and both holder and job keep running.

**A refusal is retried on an injected clock.** Found by running, not reasoning: a holder learns its previous client is gone only when its poll loop next reads EOF, so it answers the busy sentinel for a window after a daemon dies. `HolderSpawner` never meets that window because it keeps its handshake connection; an adopter has none. Past the budget, `.rejected` propagates as "not ours to adopt".

**The owner token lives in `config.holder_owner_token`** — settled, not open. An earlier revision of this branch used a file (`~/tbd/holder-owner`); it was moved into the DB column to match both the spec and the repo's "DB columns for small structured settings" convention, and the file-backed store is deleted. Migration `20260831200151_config_holder_owner_token`, with all four touchpoints in one commit per the migrations rule. Minting is race-safe without `O_EXCL`: a conditional `UPDATE ... WHERE holder_owner_token IS NULL` with a read-back inside the same write transaction, so two daemons starting at once agree on one token.

## The slot protocol, and why it is a state machine rather than three guards

Two readers draining one pty master is the silent byte theft this registry exists to prevent: each `read` takes bytes the other will never see, and nothing anywhere reports it. Getting there needed three attempts, and the third is the one worth reading.

An actor's methods are not atomic across `await`, and this actor produced the same defect in four places:

- `adopt()` published into `slots` unconditionally after `await task.value`, so a concurrent `release()` could be overwritten by the parked adoption.
- The same shape in `adopt()`'s `catch` branch.
- `release()`'s `.adopted` branch removed the slot **synchronously** and only then awaited `reader.stop()` — so an `adopt()` landing in that window read an empty slot and opened its own `handOverPTY` against a reader still on the pty.
- `release()`'s `.adopting` branch had the identical window one state over, previously unreported.

The first two were closed with site-local identity guards. That the third and fourth then appeared is the argument against a fourth guard: the defect is not in any one call site, it is that **the slot type could express "empty while a reader is still draining"**. So `Slot` gains a `releasing(Task<Void, Never>)` case and the invariant becomes *a slot is occupied for as long as a reader for that session exists* — from before the pty dup is requested until after the drain thread is gone. `adopt` re-reads the slot after every await instead of remembering it across one, and on `.releasing` waits for the stop and retries. Both release branches install `.releasing` synchronously before their first suspension. No caller signature changed; the blast radius is one file.

A fourth member fell out while tracing: `adopt`'s `.adopting` branch returned `task.value.reader` unconditionally, but that task settles at the *attach*, one suspension before the publish decision — so a release arriving in between handed the joining caller a reader that had already been stopped. It now re-checks the slot and throws `.superseded`.

## Evidence & verification

592 tests green (591 + the new race test). `swiftlint --strict` clean; `scripts/lint-migrations.py` OK; no leaked processes.

Mutations, each reddening only its own tests:
- Publish made unconditional again → only `aReleaseIsNotUndoneByTheAdoptionItRaced` and `aLaterAdoptionIsNotClobberedByTheOneItSuperseded`.
- `WHERE ... IS NULL` dropped from the mint → only `theInstallationOwnerTokenSurvivesARestart` (two different UUIDs) and `concurrentMintsAgreeOnOneToken` (`Set(tokens).count → 3`).
- Removing `reader.start()` → `adoptsALiveHolderAndResumesDraining` **and** the two race tests, since all three share that call site and assert on drained output. (An earlier revision of this description claimed only the first; that was overstated.)
- `release`'s `.adopted` branch reverted to clearing the slot before the stop → exactly one test, `aFreshAdoptionWaitsForAReaderThatIsStillDraining`, on both of its discriminating assertions (`roundTrips → 2` and `peak → 2`). The two older race tests were unaffected, which is correct: the mutation reopens only the `.adopted` window and they exercise the `.adopting` one.

Determinism comes from two injected seams and no sleeps. A barrier parks the release *inside* `stopPublished`, immediately before `reader.stop()`, holding the window open as long as the test wants. `adoptionCallsEntered` says when to assert: an actor runs one job at a time, so watching that counter reach 2 proves the racing adoption has finished its entire synchronous prefix including its slot decision — so reading the round-trip counter is settled rather than itself a race. The test also asserts the window it forces actually existed (`first.isDraining` before and after), so it cannot pass vacuously, and finishes by writing to the *new* reader and waiting for the job's echo — proving the re-adopted reader is genuinely draining, not merely published.

## Known gaps, stated rather than hidden

- **"Marked exited with status unknown" has no persisted home.** No `terminal` column records an exit status, and Task 8 deliberately left holder rows unreconciled. The registry records it in memory via `lastKnownStatus(for:)` and does not park, delete, or mutate the row. Persisting belongs with Milestone B's holder reconciler.
- **One member of the race family remains open, by choice.** `joinInFlightAdoption` can still return a reader that a release stops immediately *after* its slot re-check. That is a race the release genuinely wins by arriving later, and no second drain loop results — but a caller can briefly hold a stopped reader. Closing it means the slot must carry the whole adopt operation's task rather than the attach task, so a joiner awaits the publish decision itself; that restructures the publish path and would change the supersession semantics two existing tests pin. Deliberately deferred, not overlooked.
- `keepsDrainingPastOneBufferful` (Task 7's reader tests, untouched by this branch) fails roughly 1 run in 6 **under load**, asserting `(status → nil) == .exited(code: 0)`. Established as pre-existing by reproducing it on an unmodified tree under matched load — 5 of 6 loaded runs failed with the identical signature, while 5 of 5 quiet runs passed, which is why a quiet baseline proves nothing here. Not fixed in this commit and not papered over with a retry. The likely cause for whoever takes it: `awaitJobExit` waits 25 s for the reap and then calls `describe()`, while the holder's exit-report window is 10 s — a wait budget that outlives the window it depends on.

https://claude.ai/code/session_01UXqxcPYizvznh99Qb8JKrD

[20260830-boring-panda](https://cheapsteak.github.io/tbd/open/?worktree=A1E9CF50-E608-4F3C-BA8F-377D60BB7478)
