### PR TITLE
Fix: main is red because a virtual-time suite was betting on scheduling latency

### DIFF
--- a/Tests/TBDDaemonLiveTests/PeerLinkSupervisorTests.swift
+++ b/Tests/TBDDaemonLiveTests/PeerLinkSupervisorTests.swift
@@ -5,14 +5,45 @@ import Testing
 @testable import TBDDaemonLib
 @testable import TBDShared
 
-/// Tier 2: short-lived local stub scripts this suite fully controls, driven
-/// entirely on virtual time.
+/// Tier 3: every test spawns real children and races a deadline to drive them,
+/// which is the tier-3 definition in `Tests/CLAUDE.md`. `ProviderEventsSupervisorTests`
+/// — the supervisor this one is modelled on, sharing its generation-guarded
+/// teardown, its backoff and its process-group kill — sits in this target for
+/// the same reason.
 ///
-/// The stubs are real `bash` children — a duplex NDJSON stream over two real
+/// The stubs are real `bash` children: a duplex NDJSON stream over two real
 /// pipes is the thing under test, and a fake would test the fake. Everything
-/// that *waits*, though, is on the injected `TestClock`: backoff, the keepalive
-/// cadence, the silence watchdog and the SIGTERM→SIGKILL grace. No test here
-/// waits out a production interval in real time.
+/// that *waits* is on the injected `TestClock` — backoff, the keepalive cadence,
+/// the silence watchdog and the SIGTERM→SIGKILL grace — so no test here waits
+/// out a production interval in real time.
+///
+/// **Advancing that clock is what makes the suite tier 3, not the waiting.**
+/// `advanceVirtualTime` cannot bind to an event, because `TestClock` publishes
+/// no "a sleeper armed" notification: each step has to *poll* `checkSuspension()`,
+/// and each poll pays a `megaYield` that re-enqueues the caller behind every
+/// runnable task in the process (`Tests/CLAUDE.md`, "Population is the
+/// scheduler"; `Tests/TestSupport/ClockTestSupport.swift` measured the same
+/// construct not converging under a large target). Driving one reconnect —
+/// drain grace, kill grace, backoff — takes roughly eight such steps, all
+/// inside a single wall-clock budget. So this suite's runtime is set by how
+/// many other tests are in flight, which it does not control.
+///
+/// Measured, and the contrast is the whole argument. Run alone the suite is
+/// 16 tests in 11.1 s, and `helloIsWrittenOnConnectAndOnEveryReconnect` — the
+/// heaviest, since it drives a full reconnect — takes **0.450 s**. Run inside
+/// the 4,600-test fast parallel pass, the same test takes **107.7 s** locally
+/// and took **81.1 s** on the one CI run it survived before timing out at
+/// **227.4 s** on the runs after. Its fifteen siblings in this same
+/// `.serialized` suite stay at 0.03–5.1 s in every one of those configurations,
+/// because a serialized suite runs its first test at peak population and the
+/// rest in the drained tail. Which side of that a run lands on is a coin flip,
+/// not a margin, and raising the budget only moves the coin.
+///
+/// The time limit is a hang catcher pinned here rather than inherited from
+/// `.clockDriven`, whose 240 s is sized for the fast parallel pass (the tier-3
+/// convention in `Tests/CLAUDE.md`). It must clear the worst-case failing chain
+/// in one test — a 45 s `advanceVirtualTime` budget, a 90 s `waitFor`, and
+/// `stopDriven`'s own 45 s, so ~180 s — with room for the run to report.
 ///
 /// `.serialized` because each test spawns children and drives a clock; running
 /// them against each other floods the pool with exactly the low-priority work
@@ -21,7 +52,7 @@ import Testing
 ///
 /// Contract under test: `docs/remote-provider-contract.md` § `messages`, and
 /// `docs/specs/2026-08-29-remote-peer-messaging-design.md`.
-@Suite("PeerLinkSupervisor", .clockDriven, .serialized)
+@Suite("PeerLinkSupervisor (live)", .timeLimit(.minutes(5)), .serialized)
 struct PeerLinkSupervisorTests {
 
     /// Mirrors the daemon's process-wide SIGPIPE stance (`Sources/TBDDaemon/main.swift`),

--- a/Tests/TBDDaemonTests/AttachReplayFenceTests.swift
+++ b/Tests/TBDDaemonTests/AttachReplayFenceTests.swift
@@ -1,5 +1,6 @@
 import Darwin
 import Foundation
+import TestSupport
 import Testing
 
 @testable import TBDDaemonLib

--- a/Tests/TBDDaemonTests/AttachReplayOrchestratorTests.swift
+++ b/Tests/TBDDaemonTests/AttachReplayOrchestratorTests.swift
@@ -1,5 +1,6 @@
 import Darwin
 import Foundation
+import TestSupport
 import Testing
 
 @testable import TBDDaemonLib

--- a/Tests/TBDDaemonTests/ControlModeInputHealthTests.swift
+++ b/Tests/TBDDaemonTests/ControlModeInputHealthTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import TestSupport
 import Testing
 import TBDShared
 @testable import TBDDaemonLib

--- a/Tests/TBDDaemonTests/ControlModeInputRouterTests.swift
+++ b/Tests/TBDDaemonTests/ControlModeInputRouterTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import TestSupport
 import Testing
 import TBDShared
 @testable import TBDDaemonLib

--- a/Tests/TBDDaemonTests/ControlModeTestSupport.swift
+++ b/Tests/TBDDaemonTests/ControlModeTestSupport.swift
@@ -137,69 +137,13 @@ func makeFakeClient() -> (TmuxControlCommandClient, LineRecorder) {
     return (client, recorder)
 }
 
-/// Carries a bounded wait's OBSERVED state on the primary failure line
-/// (assertion-hygiene rule 4: `#expect(cond, "…")` and `Issue.record(String)`
-/// both demote the message to a trailing `↳` line that CI summaries drop; only
-/// `Issue.record(_: some Error)` survives). `observed` is nil when the caller
-/// supplied no reporter — the text then matches the pre-#494 wording exactly.
-struct ControlModeWaitTimeout: Error, CustomStringConvertible {
-    let what: String
-    let observed: String?
-    let deadline: Duration
-
-    var description: String {
-        let seen = observed.map { " — observed \($0)" } ?? ""
-        return "timed out waiting for \(what)\(seen) after polling up to \(deadline)"
-    }
-}
-
-/// Poll every 10 ms until `condition`, recording an Issue at the caller's
-/// source location after `deadline`. A final post-deadline re-check absorbs
-/// sleep slices that overshoot the deadline AFTER the condition became true
-/// (observed live as `timedOut(got: N, want: N)` at loadavg ~40).
-///
-/// `observed` renders what the waiter actually saw at the moment it gave up; it
-/// is evaluated only on the failing path. Supply it for any wait whose
-/// condition is uninformative on its own ("2 health events" says nothing about
-/// how many arrived).
-///
-/// **The diagnostic reports the state that decided the failure, not the state
-/// at report time** (assertion-hygiene rule 4 — the
-/// `fileBytesMismatch(expected: 6150, actual: 6150)` shape). `observed` and
-/// `condition` are two closures over the same growing state, so reading
-/// `observed` *after* the last `condition()` lets an event that lands in the
-/// gap print the self-contradictory `timed out waiting for 2 health events —
-/// observed 2`. The order below closes that: `observed` is captured first, and
-/// the condition is then re-checked once more, so anything that arrived while
-/// the diagnostic was being composed makes this a PASS rather than a
-/// contradictory failure. The counters these waits watch are monotone, so a
-/// condition that is false after the capture was false at the capture too —
-/// the reported state and the verdict are consistent by construction.
-///
-/// Returns whether the condition was met (false on timeout) so callers that
-/// index into results afterwards can abort via `#require` instead of trapping
-/// out of range; count/equality-checking callers may ignore the result.
-@discardableResult
-func waitFor(
-    _ what: String, deadline: Duration = ciSafeDeadline,
-    observed: (@Sendable () async -> String)? = nil,
-    sourceLocation: SourceLocation = #_sourceLocation,
-    _ condition: @Sendable () async -> Bool
-) async throws -> Bool {
-    let end = ContinuousClock.now + deadline
-    while ContinuousClock.now < end {
-        if await condition() { return true }
-        try await Task.sleep(for: .milliseconds(10))
-    }
-    if await condition() { return true }
-    // Capture BEFORE deciding to fail, then re-check: see the doc comment.
-    let seen = await observed?()
-    if await condition() { return true }
-    Issue.record(
-        ControlModeWaitTimeout(what: what, observed: seen, deadline: deadline),
-        sourceLocation: sourceLocation)
-    return false
-}
+// `waitFor` and its `BoundedWaitTimeout` diagnostic live in
+// `Tests/TestSupport/BoundedGateSupport.swift`, beside the `TestDeadlines`
+// constant they default to. Two targets need them — the suites here and the
+// tier-3 supervisor suites in `Tests/TBDDaemonLiveTests`, which cannot import
+// this file — and one copy is what keeps the diagnostic wording and the
+// capture-then-recheck ordering from drifting apart. They arrive through
+// `import TestSupport` above; call sites read the same either way.
 
 // MARK: - Ordered reply feed
 

--- a/Tests/TBDDaemonTests/ControlModeTestSupportTests.swift
+++ b/Tests/TBDDaemonTests/ControlModeTestSupportTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import TestSupport
 import Testing
 
 @testable import TBDDaemonLib

--- a/Tests/TBDDaemonTests/LoginSessionCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/LoginSessionCoordinatorTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import TestSupport
 import Testing
 @testable import TBDDaemonLib
 @testable import TBDShared

--- a/Tests/TBDDaemonTests/ShadowPeerManagerTests.swift
+++ b/Tests/TBDDaemonTests/ShadowPeerManagerTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import os
+import TestSupport
 import Testing
 
 @testable import TBDDaemonLib

--- a/Tests/TestSupport/BoundedGateSupport.swift
+++ b/Tests/TestSupport/BoundedGateSupport.swift
@@ -130,6 +130,80 @@ public enum TestDeadlines {
     public static let saturatedPass: Duration = .seconds(saturatedPassSeconds)
 }
 
+/// Carries a bounded wait's OBSERVED state on the primary failure line
+/// (assertion-hygiene rule 4: `#expect(cond, "…")` and `Issue.record(String)`
+/// both demote the message to a trailing `↳` line that CI summaries drop; only
+/// `Issue.record(_: some Error)` survives). `observed` is nil when the caller
+/// supplied no reporter — the text then matches the no-reporter wording exactly.
+public struct BoundedWaitTimeout: Error, CustomStringConvertible {
+    public let what: String
+    public let observed: String?
+    public let deadline: Duration
+
+    public init(what: String, observed: String?, deadline: Duration) {
+        self.what = what
+        self.observed = observed
+        self.deadline = deadline
+    }
+
+    public var description: String {
+        let seen = observed.map { " — observed \($0)" } ?? ""
+        return "timed out waiting for \(what)\(seen) after polling up to \(deadline)"
+    }
+}
+
+/// Poll every 10 ms until `condition`, recording an Issue at the caller's
+/// source location after `deadline`. A final post-deadline re-check absorbs
+/// sleep slices that overshoot the deadline AFTER the condition became true
+/// (observed live as `timedOut(got: N, want: N)` at loadavg ~40).
+///
+/// It lives here, beside ``TestDeadlines`` whose value it defaults to, for the
+/// same reason that constant does: `Tests/TBDDaemonTests` and
+/// `Tests/TBDDaemonLiveTests` both need it, and neither can import the other.
+///
+/// `observed` renders what the waiter actually saw at the moment it gave up; it
+/// is evaluated only on the failing path. Supply it for any wait whose
+/// condition is uninformative on its own ("2 health events" says nothing about
+/// how many arrived).
+///
+/// **The diagnostic reports the state that decided the failure, not the state
+/// at report time** (assertion-hygiene rule 4 — the
+/// `fileBytesMismatch(expected: 6150, actual: 6150)` shape). `observed` and
+/// `condition` are two closures over the same growing state, so reading
+/// `observed` *after* the last `condition()` lets an event that lands in the
+/// gap print the self-contradictory `timed out waiting for 2 health events —
+/// observed 2`. The order below closes that: `observed` is captured first, and
+/// the condition is then re-checked once more, so anything that arrived while
+/// the diagnostic was being composed makes this a PASS rather than a
+/// contradictory failure. The counters these waits watch are monotone, so a
+/// condition that is false after the capture was false at the capture too —
+/// the reported state and the verdict are consistent by construction.
+///
+/// Returns whether the condition was met (false on timeout) so callers that
+/// index into results afterwards can abort via `#require` instead of trapping
+/// out of range; count/equality-checking callers may ignore the result.
+@discardableResult
+public func waitFor(
+    _ what: String, deadline: Duration = TestDeadlines.saturatedPass,
+    observed: (@Sendable () async -> String)? = nil,
+    sourceLocation: SourceLocation = #_sourceLocation,
+    _ condition: @Sendable () async -> Bool
+) async throws -> Bool {
+    let end = ContinuousClock.now + deadline
+    while ContinuousClock.now < end {
+        if await condition() { return true }
+        try await Task.sleep(for: .milliseconds(10))
+    }
+    if await condition() { return true }
+    // Capture BEFORE deciding to fail, then re-check: see the doc comment.
+    let seen = await observed?()
+    if await condition() { return true }
+    Issue.record(
+        BoundedWaitTimeout(what: what, observed: seen, deadline: deadline),
+        sourceLocation: sourceLocation)
+    return false
+}
+
 /// How long a bounded gate wait tolerates before it reports itself.
 ///
 /// **Sized to dominate the longest legitimate hold, not to be snappy.** A gate


### PR DESCRIPTION
## Summary

`main`'s `test` check has been red since `5b5207d8`, on
`PeerLinkSupervisorTests.helloIsWrittenOnConnectAndOnEveryReconnect`. This moves that suite to
the tier-3 target, where the supervisor it is modelled on has lived all along.

**The suite was never meaningfully green.** On the last green run it took **81.067 s** against
that pass's own per-test max of 82.2 s (p50 51.9 s, p90 68.2 s) — the top of the band — while
its sibling `reconnectBackoffGrowsAcrossRepeatedChildExit`, which drives the *same* reconnect
three times over, took **1.234 s**, and the other 14 siblings 0.03–2.8 s. It passed by luck.

## Why it is slow only in the herd

Only the **first** test of a `.serialized` suite runs at peak population, and this one needs
~8 sequential scheduler round-trips inside a 45 s wall budget. `advanceVirtualTime` cannot bind
to an event — `TestClock` publishes no "a sleeper armed" notification — so each step polls
`checkSuspension()`, whose `megaYield` re-enqueues the caller behind every runnable task in the
process. Driving one reconnect (drain grace → kill grace → backoff) costs about eight of those.
The budget is a bet on scheduling latency; the in-flight population sets the odds.

Measured, same tree:

| | alone | in the full pass-1/2 herd |
|---|---|---|
| `helloIsWrittenOnConnectAndOnEveryReconnect` | **0.450 s** | **107.699 s** |
| whole suite (16 tests) | **11.098 s** | **126.348 s** |

Local pass-1/2 p50 per-test span was 87.4 s (p90 99.9 s) — roughly twice what the first wait is
allowed. The budget was never affordable.

The nine-PR holder stack added 26 tests to `TBDDaemonTests` (4570 → 4596) and moved the
distribution enough that the coin stopped landing heads. Raising the budget would only move the
coin again, and a budget that actually covered this would have to exceed the suite's own 240 s
time limit — so no deadline is touched here.

## Why this layer

`Tests/CLAUDE.md` already scopes the live target to a suite that "spawns a child racing a
deadline", which is every test in this file. The clincher: **`ProviderEventsSupervisorTests`,
the supervisor this suite is explicitly modelled on, has been in that target since it was
written**, with a pinned time limit and 90 s deadlines. This one was in the parallel target by
oversight — the same mistake as the holder suites in `f8a008c1`. Its own header claimed
"Tier 2 … driven entirely on virtual time", which is where it came from: the *waiting* is
virtual, the *advancing* is not.

`.clockDriven` is swapped for a pinned `.timeLimit(.minutes(5))` per the tier-3 convention
(240 s is sized for the fast pass; the worst-case chain here is 45 + 90 + 45).

**One ripple:** `waitFor` was an in-module free function in `ControlModeTestSupport.swift`,
unreachable from the live target. It moves to `Tests/TestSupport/BoundedGateSupport.swift`
beside the `TestDeadlines` constant it already defaults to — the same cross-target reason that
constant lives there — which adds `import TestSupport` to seven `TBDDaemonTests` files.

## Ruled out

- The holder stack touches nothing `PeerLinkSupervisor` depends on.
- `Tests/TBDPeerHelperTests/SpawnedPeerHelper.swift`, which the stack *did* change, is in a
  different target that pass 1/2's `--filter` never runs.

## Test plan

- [x] Moved suite alone in the live target: 16 tests / 13.3 s green; the test 0.441 s.
- [x] Real CI quiet-pass shape (`--filter '^TBDDaemonLiveTests\.' --no-parallel`): 147 tests /
      101.9 s green; the test 0.447 s. Floor 35 and the 15-minute step budget both fine.
- [x] Real CI fast-pass-1/2 shape (`--parallel --filter '^TBDDaemonTests\.'`): 4580 tests green
      (was 4596; floor 1800 fine).
- [x] `swiftlint --strict` 0 violations in 906 files; build clean.
- [ ] CI green on `main` after merge — the point of the change.

## Stated rather than glossed

- **No fast-pass speedup is claimed.** The after-run took 312 s against the before-run's 279.7 s,
  but the box had other load between them, so that wall-clock pair is uncontrolled. The per-test
  numbers above are the controlled ones.
- **Why +26 tests (0.6% of the population) flipped a coin that had landed heads once is not
  isolated.** The threshold framing fits every number here, but the delta was not bisected.

https://claude.ai/code/session_01UXqxcPYizvznh99Qb8JKrD

[20260830-boring-panda](https://cheapsteak.github.io/tbd/open/?worktree=A1E9CF50-E608-4F3C-BA8F-377D60BB7478)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved asynchronous test waiting with bounded deadlines, final condition checks, and clearer timeout diagnostics.
  * Shared test utilities now provide consistent wait behavior across test suites.
  * Updated live-process tests with an explicit five-minute execution limit and documented runtime characteristics.
  * Expanded test coverage support for attach/replay, control-mode, login-session, and shadow-peer scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->