### PR TITLE
Feat: Reclaim a live pty holder that no session row claims

### DIFF
--- a/Sources/TBDCLI/Commands/GCCommands.swift
+++ b/Sources/TBDCLI/Commands/GCCommands.swift
@@ -8,7 +8,7 @@ struct GCCommand: ParsableCommand {
         abstract: "Orphan GC: list reaps, restore a reaped agent worktree, trigger a sweep",
         subcommands: [
             GCList.self, GCRestore.self, GCSweep.self, GCProfileDirs.self,
-            GCOrphanProcesses.self, GCHolders.self,
+            GCOrphanProcesses.self, GCHolders.self, GCRowlessHolders.self,
         ]
     )
 }
@@ -78,6 +78,31 @@ struct GCHolders: AsyncParsableCommand {
             method: RPCMethod.configSetGCHolderRendezvousEnabled,
             params: ConfigSetGCHolderRendezvousEnabledParams(enabled: enabled))
         print("Holder rendezvous GC \(enabled ? "enabled" : "disabled").")
+    }
+}
+
+/// The soak switch for the row-less holder sweep. It **kills** a pty holder
+/// this installation owns which no session row claims — the child first, then
+/// the holder — and is therefore a separate opt-in from `tbd gc holders`, which
+/// only unlinks files. A holder that will not talk to us, one another
+/// installation owns, and one younger than the GC grace window are all left
+/// running, whatever this is set to.
+struct GCRowlessHolders: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "rowless-holders",
+        abstract: "Enable or disable killing pty holders no session row claims (default off)")
+    @Argument(help: "on | off") var state: String
+    mutating func run() async throws {
+        let enabled: Bool
+        switch state.lowercased() {
+        case "on", "true", "enable": enabled = true
+        case "off", "false", "disable": enabled = false
+        default: throw ValidationError("Expected 'on' or 'off', got: \(state)")
+        }
+        try SocketClient().callVoid(
+            method: RPCMethod.configSetGCRowlessHoldersEnabled,
+            params: ConfigSetGCRowlessHoldersEnabledParams(enabled: enabled))
+        print("Row-less holder GC \(enabled ? "enabled" : "disabled").")
     }
 }
 

--- a/Sources/TBDDaemon/Database/ConfigStore.swift
+++ b/Sources/TBDDaemon/Database/ConfigStore.swift
@@ -100,6 +100,14 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     /// through `Config.gcHolderRendezvousEnabledDefault`, never through
     /// `?? false`.
     var gc_holder_rendezvous_enabled: Bool?
+    /// Gate for the GC phase that kills a row-less pty holder this installation
+    /// owns. **Genuinely tri-state**, same shape as
+    /// `gc_holder_rendezvous_enabled`: the
+    /// `20260901161500_config_gc_rowless_holders` migration carries no SQL
+    /// default, so `nil` here means "never chose" rather than "off". Resolve it
+    /// through `Config.gcRowlessHoldersEnabledDefault`, never through
+    /// `?? false`.
+    var gc_rowless_holders_enabled: Bool?
     /// This installation's holder owner token, minted once by the first daemon
     /// that needs one and read forever after. **Not a flag**: NULL means "not
     /// yet minted", and the mint is the conditional UPDATE in
@@ -141,6 +149,10 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     /// - Parameter gcHolderRendezvousDefault: and once more, for
     ///   `gc_holder_rendezvous_enabled` — the holder rendezvous sweep's soak
     ///   gate.
+    /// - Parameter gcRowlessHoldersDefault: and once more, for
+    ///   `gc_rowless_holders_enabled` — the row-less holder sweep's soak gate,
+    ///   which is a separate opt-in because it kills processes rather than
+    ///   unlinking files.
     func toModel(
         queuedPromptDefault: Bool = Config.queuedPromptDefault,
         autoCreateNotesDefault: Bool = Config.autoCreateNotesDefault,
@@ -150,7 +162,8 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         gcOrphanProcessesDefault: Bool = Config.gcOrphanProcessesEnabledDefault,
         remotePeerMessagingDefault: Bool = Config.remotePeerMessagingDefault,
         ptyHolderDefault: Bool = Config.ptyHolderDefault,
-        gcHolderRendezvousDefault: Bool = Config.gcHolderRendezvousEnabledDefault
+        gcHolderRendezvousDefault: Bool = Config.gcHolderRendezvousEnabledDefault,
+        gcRowlessHoldersDefault: Bool = Config.gcRowlessHoldersEnabledDefault
     ) -> Config {
         Config(
             defaultProfileID: default_profile_id.flatMap(UUID.init(uuidString:)),
@@ -213,6 +226,9 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             // And the last of them, for the holder rendezvous sweep's gate —
             // NOT `?? false`.
             gcHolderRendezvousEnabled: gc_holder_rendezvous_enabled ?? gcHolderRendezvousDefault,
+            // And its process-killing sibling, resolved the same way and from
+            // its own column — NOT `?? false`, and NOT the rendezvous flag.
+            gcRowlessHoldersEnabled: gc_rowless_holders_enabled ?? gcRowlessHoldersDefault,
             remoteCreateDefaults: EnvOverridesCoding.decode(remote_create_defaults),
             // Passed straight through, NULL included: "not yet minted" is a
             // real state and has no default to resolve to.
@@ -653,6 +669,21 @@ public struct ConfigStore: Sendable {
         try await writer.write { db in
             try db.execute(
                 sql: "UPDATE config SET gc_holder_rendezvous_enabled = ? WHERE id = ?",
+                arguments: [enabled, Self.singletonID]
+            )
+        }
+    }
+
+    /// Persist the row-less holder sweep gate (default OFF, soaking) — read on
+    /// top of the GC master switch, so both must be on for the phase to run.
+    /// Separate from `setGCHolderRendezvousEnabled` on purpose: that gate
+    /// unlinks files, this one kills processes. The column is written on every
+    /// call, because writing either value is the explicit gesture that lifts it
+    /// out of NULL forever after.
+    public func setGCRowlessHoldersEnabled(_ enabled: Bool) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE config SET gc_rowless_holders_enabled = ? WHERE id = ?",
                 arguments: [enabled, Self.singletonID]
             )
         }

--- a/Sources/TBDDaemon/Database/Migrations/20260901161500_config_gc_rowless_holders.sql
+++ b/Sources/TBDDaemon/Database/Migrations/20260901161500_config_gc_rowless_holders.sql
@@ -1,0 +1,15 @@
+-- Gate for the orphan-GC phase that kills a pty holder this installation owns
+-- which no session row claims — the holder-versus-database half of the design
+-- spec's Reconciliation section.
+--
+-- Deliberately NOT the same flag as gc_holder_rendezvous_enabled. That one
+-- unlinks files; this one kills processes. Someone who opted into file cleanup
+-- must not silently acquire a process killer.
+--
+-- No DEFAULT clause, deliberately. ADD COLUMN ... DEFAULT would backfill every
+-- existing row, destroying the distinction between "nobody has chosen" (NULL)
+-- and "chose off" (0) — which is what made auto_hibernate_enabled impossible to
+-- graduate without a forcing UPDATE that also reset deliberate opt-ins.
+-- The shipped default lives in exactly one place:
+-- Config.gcRowlessHoldersEnabledDefault.
+ALTER TABLE config ADD COLUMN gc_rowless_holders_enabled INTEGER;

--- a/Sources/TBDDaemon/GC/OrphanGC.swift
+++ b/Sources/TBDDaemon/GC/OrphanGC.swift
@@ -63,6 +63,7 @@ public actor OrphanGC {
     private let deletionQueueCollector: DeletionQueueCollector
     private let profileDirCollector: ProfileDirCollector
     private let holderRendezvousCollector: HolderRendezvousCollector
+    private let rowlessHolderCollector: RowlessHolderCollector
     /// Deletes the path-keyed Claude Code credentials item belonging to a
     /// quarantined profile dir. Injected so tests never reach the real login
     /// keychain, which `scripts/test.sh` cannot fence.
@@ -147,7 +148,9 @@ public actor OrphanGC {
         orphanProcessPollInterval: Duration = .milliseconds(100),
         clock: any Clock<Duration> = ContinuousClock(),
         holdersBase: URL? = nil,
-        holderListenerProbe: (@Sendable (String) async -> Bool)? = nil
+        holderListenerProbe: (@Sendable (String) async -> Bool)? = nil,
+        rowlessHolderHandshake: (@Sendable (String) async -> RowlessHolderHandshake)? = nil,
+        rowlessHolderReclaimer: (any RowlessHolderReclaiming)? = nil
     ) {
         let resolvedNow = now ?? Date.init
         let resolvedScratchpadBase = scratchpadBase ?? TBDConstants.claudeScratchpadBase
@@ -173,10 +176,16 @@ public actor OrphanGC {
         self.deletionQueueCollector = DeletionQueueCollector(git: git, now: resolvedNow)
         self.profileDirCollector = ProfileDirCollector(
             base: resolvedProfileDirBase, now: resolvedNow)
+        let resolvedHoldersBase = holdersBase ?? TBDConstants.holdersDir()
         self.holderRendezvousCollector = HolderRendezvousCollector(
-            base: holdersBase ?? TBDConstants.holdersDir(),
+            base: resolvedHoldersBase,
             now: resolvedNow,
             isListening: holderListenerProbe ?? HolderRendezvousCollector.probeForListener)
+        self.rowlessHolderCollector = RowlessHolderCollector(
+            base: resolvedHoldersBase,
+            now: resolvedNow,
+            handshake: rowlessHolderHandshake,
+            reclaimer: rowlessHolderReclaimer)
         self.processCWDsProvider = processCWDsProvider
         let resolvedSnapshotProvider: @Sendable () async -> [ProcessSnapshotEntry]? =
             processSnapshotProvider ?? { await OrphanProcessCollector.realProcessSnapshot() }
@@ -268,6 +277,15 @@ public actor OrphanGC {
         await reclaimOrphanProcesses(
             config: config, repos: repos, live: live,
             dryRun: dryRun, planned: &planned, reaped: &reaped
+        )
+
+        // Before the rendezvous file sweep, deliberately. A holder this phase
+        // kills leaves a socket behind that nothing else will ever unlink, and
+        // running the file sweep next means one pass reclaims both the process
+        // and its residue — for an installation that has opted into both, which
+        // is the only way either runs.
+        await reclaimRowlessHolders(
+            config: config, dryRun: dryRun, planned: &planned, reaped: &reaped
         )
 
         await reclaimHolderRendezvous(
@@ -729,6 +747,94 @@ public actor OrphanGC {
                 // as things reclaimed. No `ReapRecord` is written — these files
                 // are unlinked, not quarantined, and there is nothing a
                 // `tbd gc restore` could put back.
+                reaped += 1
+            }
+        }
+    }
+
+    // MARK: - Row-less holders
+
+    /// Kills a pty holder this installation owns which no session row claims —
+    /// the holder-versus-database half of
+    /// `docs/specs/2026-08-30-pty-holder-session-transport-design.md`,
+    /// "Reconciliation". The child first, then the holder.
+    ///
+    /// Gated by `gcRowlessHoldersEnabled` on top of `gcEnabled`, and **not** by
+    /// `gcHolderRendezvousEnabled`: that flag unlinks files, this one signals
+    /// processes, and enabling the first must never enable the second.
+    ///
+    /// `dryRun` bypasses the flag exactly as `sweep` lets it bypass `gcEnabled`:
+    /// planning is read-only, and somebody deciding whether to enable a
+    /// default-off process killer needs to see what enabling it would kill. A
+    /// NON-dry run still requires the flag.
+    ///
+    /// Two reads bound what this may do, and both fail toward keeping:
+    ///
+    ///   - **The owner token is read, never minted.** `HolderRegistry` mints on
+    ///     the spawn path; a sweep that minted one would hand itself an identity
+    ///     no holder on disk was ever stamped with. A NULL token means this
+    ///     installation has never spawned a holder, so nothing out there can be
+    ///     ours and every candidate is kept.
+    ///   - **The session rows are read here**, not handed down from `sweep`,
+    ///     and a failed read skips the phase entirely rather than proceeding on
+    ///     an empty list — which would read as "nothing is claimed" and license
+    ///     killing the whole fleet.
+    ///
+    /// The row is then **re-read immediately before the kill**, the same
+    /// pre-reap re-read `reapOrphanProfileDirs` keeps. The gates above run
+    /// against one snapshot, and the handshake round trip in between is the
+    /// window a session's row can commit in.
+    private func reclaimRowlessHolders(
+        config: Config, dryRun: Bool, planned: inout [String], reaped: inout Int
+    ) async {
+        guard config.gcRowlessHoldersEnabled || dryRun else { return }
+        let candidates = rowlessHolderCollector.candidates()
+        guard !candidates.isEmpty else { return }
+
+        guard let terminals = try? await db.terminals.list() else {
+            logger.error("gc: session rows unreadable this sweep — skipping the row-less holder phase")
+            planned.append("KEEP rows-unreadable rowless-holder phase")
+            return
+        }
+        let claimed = Set(terminals.map(\.id))
+        let owner = config.holderOwnerToken.map(HolderOwnerToken.init(rawValue:))
+
+        for candidate in candidates {
+            switch await rowlessHolderCollector.decide(
+                candidate, graceSeconds: config.gcGraceSeconds,
+                owner: owner, claimedSessionIDs: claimed
+            ) {
+            case .keep(let reason):
+                planned.append("KEEP \(reason) \(candidate.socketPath)")
+                logger.debug("""
+                gc: keep \(reason, privacy: .public) \(candidate.socketPath, privacy: .public)
+                """)
+            case .kill(let childPID, let holderPID):
+                planned.append("REAP rowless-holder \(candidate.socketPath)")
+                // This arm's guard is `gcRowlessHoldersEnabled || dryRun`, so
+                // every line below runs only with the flag actually on.
+                guard !dryRun else { continue }
+                // The late gate. A row that committed during the handshake makes
+                // this holder somebody's live session after all.
+                if let row = try? await db.terminals.get(id: candidate.sessionID), row != nil {
+                    planned.append("KEEP raced-row \(candidate.socketPath)")
+                    logger.info("""
+                    gc: row-less holder \(candidate.socketPath, privacy: .public) acquired a \
+                    session row during the handshake — left alone
+                    """)
+                    continue
+                }
+                guard await rowlessHolderCollector.reclaim(
+                    candidate, childPID: childPID, holderPID: holderPID)
+                else {
+                    planned.append("KEEP reclaim-refused \(candidate.socketPath)")
+                    continue
+                }
+                // Counted once per holder. No `ReapRecord` is written: the
+                // record type is directory-shaped and keyed by the worktree a
+                // reap removed, and a row-less holder has neither — no row means
+                // no worktree to name. There is nothing a `tbd gc restore` could
+                // put back either; a killed process is not restorable.
                 reaped += 1
             }
         }

--- a/Sources/TBDDaemon/GC/OrphanGC.swift
+++ b/Sources/TBDDaemon/GC/OrphanGC.swift
@@ -816,11 +816,26 @@ public actor OrphanGC {
                 guard !dryRun else { continue }
                 // The late gate. A row that committed during the handshake makes
                 // this holder somebody's live session after all.
-                if let row = try? await db.terminals.get(id: candidate.sessionID), row != nil {
-                    planned.append("KEEP raced-row \(candidate.socketPath)")
-                    logger.info("""
-                    gc: row-less holder \(candidate.socketPath, privacy: .public) acquired a \
-                    session row during the handshake — left alone
+                //
+                // Spelled `do`/`catch` rather than `try?` deliberately: `try?`
+                // on a throwing call that already returns an optional flattens
+                // "the read failed" into "there is no row", which is the one
+                // direction this gate must never fail in.
+                do {
+                    if try await db.terminals.get(id: candidate.sessionID) != nil {
+                        planned.append("KEEP raced-row \(candidate.socketPath)")
+                        logger.info("""
+                        gc: row-less holder \(candidate.socketPath, privacy: .public) acquired a \
+                        session row during the handshake — left alone
+                        """)
+                        continue
+                    }
+                } catch {
+                    planned.append("KEEP row-reread-failed \(candidate.socketPath)")
+                    logger.error("""
+                    gc: could not re-read the session row for \
+                    \(candidate.socketPath, privacy: .public) \
+                    (\(error.localizedDescription, privacy: .public)) — left alone
                     """)
                     continue
                 }

--- a/Sources/TBDDaemon/GC/RowlessHolderCollector.swift
+++ b/Sources/TBDDaemon/GC/RowlessHolderCollector.swift
@@ -1,0 +1,321 @@
+import Darwin
+import Foundation
+import os
+import TBDShared
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "gc")
+
+/// One holder socket the row-less sweep may have an opinion about.
+public struct RowlessHolderCandidate: Sendable, Equatable {
+    public var sessionID: UUID
+    public var socketPath: String
+    /// Socket creation date, or `nil` when it could not be read — which the
+    /// grace gate treats as "too young to touch".
+    public var createdAt: Date?
+
+    public init(sessionID: UUID, socketPath: String, createdAt: Date?) {
+        self.sessionID = sessionID
+        self.socketPath = socketPath
+        self.createdAt = createdAt
+    }
+}
+
+/// What one handshake against a holder socket established.
+///
+/// The four cases are deliberately not collapsed. `rejected` and `unreachable`
+/// both mean "leave it alone", but they mean it for opposite reasons — a
+/// refusal is a *healthy* holder busy serving somebody, an unreachable one is a
+/// holder we cannot judge — and a log that could not tell them apart would make
+/// the soak unreadable.
+public enum RowlessHolderHandshake: Sendable, Equatable {
+    /// The holder answered. Its `holderPID` comes from `LOCAL_PEERPID` on the
+    /// connected socket and is `nil` when the kernel would not say.
+    case described(HolderChildDescription, holderPID: Int32?)
+    /// The holder answered with the busy sentinel: it is alive and already has
+    /// a client. **Terminal in both directions** — not exited, not killed.
+    case rejected
+    /// `ECONNREFUSED` or `ENOENT`: a bound path with nothing behind it. That is
+    /// the *rendezvous file* sweep's business, not this one's.
+    case noListener
+    /// Anything else — a timeout, a protocol error, a socket that connects and
+    /// says nothing. An unreadable answer, and an unreadable answer keeps.
+    case unreachable(String)
+}
+
+/// Outcome of gating one candidate.
+///
+/// `reason` is one of `"unknown-age"`, `"grace"`, `"has-row"`,
+/// `"no-owner-token"`, `"rejected"`, `"no-listener"`, `"unreachable"`,
+/// `"foreign-owner"`, `"no-child"`.
+public enum RowlessHolderDecision: Sendable, Equatable {
+    case keep(reason: String)
+    case kill(childPID: Int32, holderPID: Int32?)
+}
+
+/// The actuation half of the sweep, injected so a unit test can prove that a
+/// candidate the gates kept was never signalled — an assertion no return value
+/// can carry, because "left alone" is the absence of an effect.
+public protocol RowlessHolderReclaiming: Sendable {
+    /// Kill the job the holder forked, then the holder itself.
+    func reclaim(socketPath: String, childPID: Int32, holderPID: Int32?) async
+}
+
+/// The named reconciler for **row-less pty holders**: a holder process that is
+/// alive, speaks the protocol, proves it belongs to this installation, and yet
+/// has no session row claiming it
+/// (`docs/specs/2026-08-30-pty-holder-session-transport-design.md`,
+/// "Reconciliation").
+///
+/// It is the process-shaped twin of `HolderRendezvousCollector`, which reclaims
+/// the *files* a dead holder left behind. This one reclaims a holder that is
+/// very much alive, so every gate is stricter and the flag is its own.
+///
+/// Five rules govern it, and dropping any one of them turns it into a way to
+/// kill somebody's healthy session:
+///
+///   1. **A completed handshake is proof of liveness, not of ownership**, and
+///      only ownership licenses a kill. The default `TBD_HOME` is shared by
+///      every checkout on a machine, so "reachable and absent from *my*
+///      database" is exactly the shape a foreign but perfectly healthy session
+///      presents.
+///   2. **The owner token decides.** Minted once per installation and persisted
+///      in the `config` row, it is returned by every handshake. A holder whose
+///      token differs is left alone and logged. So is every holder, always,
+///      when this installation has no token at all: a daemon that never minted
+///      one has never spawned a holder, so nothing out there can be ours.
+///   3. **A rejected connection is terminal in both directions** — not exited,
+///      and not killed either. A stale daemon from a different checkout is a
+///      known hazard on a development machine, and a holder that will not talk
+///      to us is exactly what one looks like.
+///   4. **Keep-biased for young holders.** `OrphanGC` runs on demand from RPC
+///      handlers, so a sweep can land between a holder becoming connectable and
+///      its session row committing; killing there destroys a session being
+///      born. A socket newer than the grace window is left alone whatever the
+///      other gates would say — the same guard `HolderRendezvousCollector`
+///      applies to the same race shape.
+///   5. **Kill, not adopt.** iTerm2 adopts unclaimed survivors because its live
+///      processes are the only copy of anything; TBD's transcripts persist
+///      independently, so adoption would buy a mystery-session UI and cut
+///      against the database-is-intent model the other reconcilers follow.
+///
+/// The gate order — age, then row, then handshake — is not arbitrary. Age is a
+/// `stat` and exists for a race rather than for a fact. The row check comes
+/// before any connect because **connecting is not free**: the holder serves one
+/// client at a time, so a probe against a holder that is mid-adoption would
+/// occupy the slot the daemon needs. Only a candidate that is old and unclaimed
+/// is worth a socket round trip.
+public struct RowlessHolderCollector: Sendable {
+    let base: URL
+    let now: @Sendable () -> Date
+    /// Connect, handshake, and report what came back. Injected so a test can
+    /// pin the answer; production is `Self.productionHandshake`.
+    let handshake: @Sendable (String) async -> RowlessHolderHandshake
+    let reclaimer: any RowlessHolderReclaiming
+
+    public init(
+        base: URL,
+        now: @escaping @Sendable () -> Date = Date.init,
+        handshake: (@Sendable (String) async -> RowlessHolderHandshake)? = nil,
+        reclaimer: (any RowlessHolderReclaiming)? = nil
+    ) {
+        self.base = base
+        self.now = now
+        self.handshake = handshake ?? Self.productionHandshake
+        self.reclaimer = reclaimer ?? ProductionRowlessHolderReclaimer()
+    }
+
+    /// Immediate children named `<uuid>.sock`, exactly as
+    /// `HolderRendezvousCollector` enumerates them: the two sweeps read the same
+    /// directory for opposite reasons and must agree on what a candidate is.
+    public func candidates() -> [RowlessHolderCandidate] {
+        guard let names = try? FileManager.default.contentsOfDirectory(atPath: base.path) else {
+            return []
+        }
+        return names.compactMap { name -> RowlessHolderCandidate? in
+            guard name.hasSuffix(".sock"),
+                  let id = UUID(uuidString: String(name.dropLast(".sock".count)))
+            else { return nil }
+            let url = base.appendingPathComponent(name)
+            var isDir: ObjCBool = false
+            guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDir),
+                  !isDir.boolValue else { return nil }
+            let attributes = try? FileManager.default.attributesOfItem(atPath: url.path)
+            return RowlessHolderCandidate(
+                sessionID: id, socketPath: url.path,
+                createdAt: attributes?[.creationDate] as? Date)
+        }.sorted { $0.socketPath < $1.socketPath }
+    }
+
+    /// Gate order: age → row → handshake → owner. Every gate fails toward
+    /// keeping, and only the last one can license a kill.
+    ///
+    /// - Parameter owner: this installation's token, or `nil` when none has been
+    ///   minted — in which case nothing out there can be ours and every
+    ///   candidate is kept.
+    /// - Parameter claimedSessionIDs: the ids of every session row that exists.
+    ///   A candidate in this set is claimed and is not this sweep's business.
+    public func decide(
+        _ candidate: RowlessHolderCandidate,
+        graceSeconds: Int,
+        owner: HolderOwnerToken?,
+        claimedSessionIDs: Set<UUID>
+    ) async -> RowlessHolderDecision {
+        guard let owner else { return .keep(reason: "no-owner-token") }
+        guard let created = candidate.createdAt else {
+            return .keep(reason: "unknown-age")
+        }
+        if now().timeIntervalSince(created) < Double(graceSeconds) {
+            return .keep(reason: "grace")
+        }
+        if claimedSessionIDs.contains(candidate.sessionID) {
+            return .keep(reason: "has-row")
+        }
+        switch await handshake(candidate.socketPath) {
+        case .rejected:
+            return .keep(reason: "rejected")
+        case .noListener:
+            return .keep(reason: "no-listener")
+        case .unreachable:
+            return .keep(reason: "unreachable")
+        case .described(let description, let holderPID):
+            guard description.owner == owner else {
+                return .keep(reason: "foreign-owner")
+            }
+            // `killJob` refuses anything at or below pid 1, and a description
+            // that cannot name a child names nothing this sweep may signal.
+            guard description.childPID > 1 else { return .keep(reason: "no-child") }
+            return .kill(childPID: description.childPID, holderPID: holderPID)
+        }
+    }
+
+    /// Kills the job and then the holder. Anchored first, the same guard
+    /// `HolderRendezvousCollector.reap` keeps in front of its unlink: this is a
+    /// public value type anyone can construct, so the invariant that a candidate
+    /// names an immediate `<uuid>.sock` child of `base` is checked rather than
+    /// assumed — a path that wandered would send the round trip, and the kill,
+    /// somewhere nobody sanctioned.
+    public func reclaim(
+        _ candidate: RowlessHolderCandidate, childPID: Int32, holderPID: Int32?
+    ) async -> Bool {
+        guard isAnchored(candidate) else {
+            logger.warning("""
+            gc: refusing to reclaim \(candidate.socketPath, privacy: .public) — not a \
+            \(candidate.sessionID.uuidString.lowercased(), privacy: .public).sock immediate child \
+            of \(self.base.path, privacy: .public)
+            """)
+            return false
+        }
+        logger.info("""
+        gc: reclaiming row-less holder for session \
+        \(candidate.sessionID.uuidString, privacy: .public) — child pid \
+        \(childPID, privacy: .public), holder pid \
+        \(holderPID.map(String.init) ?? "unknown", privacy: .public)
+        """)
+        await reclaimer.reclaim(
+            socketPath: candidate.socketPath, childPID: childPID, holderPID: holderPID)
+        return true
+    }
+
+    // MARK: - The production handshake
+
+    /// Connect, `describe`, and read the holder pid off the connection.
+    ///
+    /// The errno reading is deliberately the same one
+    /// `HolderRendezvousCollector.probeForListener` takes, because the two ask
+    /// the same question for opposite reasons and must not disagree: only
+    /// `ECONNREFUSED` (bound, nobody accepting) and `ENOENT` (gone since the
+    /// listing) are evidence of absence. Everything else is an unreadable
+    /// answer, and an unreadable answer keeps.
+    public static let productionHandshake: @Sendable (String) async
+        -> RowlessHolderHandshake = { socketPath in
+        let client = HolderClient(socketPath: socketPath, receiveTimeout: handshakeTimeout)
+        let outcome: RowlessHolderHandshake
+        do {
+            let description = try await client.describe()
+            // Read AFTER the handshake, so the pid belongs to a connection that
+            // has provably answered — and while it is still open, because
+            // `LOCAL_PEERPID` is a property of the socket, not of the path.
+            outcome = .described(description, holderPID: await client.peerPID())
+        } catch HolderClient.Error.rejected {
+            outcome = .rejected
+        } catch HolderClient.Error.cannotConnect(_, let code) {
+            outcome = (code == ECONNREFUSED || code == ENOENT)
+                ? .noListener
+                : .unreachable("connect failed (errno \(code))")
+        } catch {
+            outcome = .unreachable(error.localizedDescription)
+        }
+        await client.close()
+        return outcome
+    }
+
+    /// Bounded well under the hourly sweep interval, for the same reason the
+    /// rendezvous probe is: a stranger that connects but never answers must not
+    /// stall a sweep with hundreds of candidates.
+    static let handshakeTimeout: Duration = .seconds(2)
+
+    /// The candidate names an immediate child of `base` called
+    /// `<sessionID>.sock` — exactly what `candidates()` produces. Requiring the
+    /// parent to *equal* `base` rejects anything nested, along with any `..`,
+    /// which no longer resolves to `base` once the last component is dropped.
+    private func isAnchored(_ candidate: RowlessHolderCandidate) -> Bool {
+        let url = URL(fileURLWithPath: candidate.socketPath)
+        guard url.deletingLastPathComponent().path == base.path else { return false }
+        return url.lastPathComponent == "\(candidate.sessionID.uuidString.lowercased()).sock"
+    }
+}
+
+/// The real killer: the job's process group, then the job, then the holder.
+///
+/// The ordering is the one `HolderRegistry.dispose` established and is
+/// load-bearing at every step:
+///
+///   - **The group is resolved first**, before anything hangs the job up.
+///     `forget` closes the pty master, which usually kills the job outright,
+///     after which `getpgid` answers `ESRCH` and the group can no longer be
+///     named — while a member that ignored `SIGHUP` is still sitting in it.
+///   - **The job dies before the holder**, because the holder owns the only
+///     reference to the pty master and killing it first would hang the job up
+///     on a terminal nobody is draining.
+///   - **The holder is killed rather than merely forgotten.** A forgotten
+///     holder does break its own loop, but a holder that never answered the
+///     `forget` would otherwise be left running with a socket nothing reclaims.
+///
+/// `waitpid` is `WNOHANG` and bounded: a holder spawned by *this* daemon
+/// incarnation is our child and leaves a corpse nobody else can collect, while
+/// one inherited from a previous incarnation answers `ECHILD` immediately. Both
+/// must be cheap, and neither may park the sweep.
+public struct ProductionRowlessHolderReclaimer: RowlessHolderReclaiming {
+    private let clock: any Clock<Duration>
+
+    public init(clock: any Clock<Duration> = ContinuousClock()) {
+        self.clock = clock
+    }
+
+    static let reapBudget: Duration = .seconds(2)
+    static let reapPollInterval: Duration = .milliseconds(50)
+
+    public func reclaim(socketPath: String, childPID: Int32, holderPID: Int32?) async {
+        let group = HolderRegistry.jobProcessGroup(childPID: childPID)
+        let client = HolderClient(socketPath: socketPath)
+        try? await client.forget()
+        await client.close()
+        HolderRegistry.killJob(childPID: childPID, group: group)
+        guard let holderPID, holderPID > 1 else { return }
+        _ = kill(holderPID, SIGKILL)
+        var waited: Duration = .zero
+        while waited < Self.reapBudget {
+            var status: Int32 = 0
+            let collected = waitpid(holderPID, &status, WNOHANG)
+            if collected == holderPID { return }
+            // ECHILD: not our child — a holder inherited from a previous daemon,
+            // which the kernel's reparenting will collect. Nothing to wait for.
+            if collected < 0 && errno != EINTR { return }
+            // Accumulated from the interval rather than measured against a
+            // deadline, for the same reason as everywhere else in this code:
+            // `any Clock<Duration>` pins `Duration` but not `Instant`.
+            try? await clock.sleep(for: Self.reapPollInterval)
+            waited += Self.reapPollInterval
+        }
+    }
+}

--- a/Sources/TBDDaemon/Holder/HolderClient.swift
+++ b/Sources/TBDDaemon/Holder/HolderClient.swift
@@ -215,6 +215,29 @@ actor HolderClient {
         _ = setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &value, socklen_t(MemoryLayout<timeval>.size))
     }
 
+    /// The pid at the other end of this connection, or `nil` when there is no
+    /// connection or the kernel would not say.
+    ///
+    /// `LOCAL_PEERPID` is a property of the **socket**, not of the path, so it
+    /// can only be read while the connection is open — and it is the only way a
+    /// reconciler can learn a holder's pid without a session row to read it
+    /// from, since the handshake deliberately does not carry one (the holder is
+    /// kept small enough to essentially never change, and this needs no protocol
+    /// version).
+    ///
+    /// Read it *after* a verb has been answered, so the pid belongs to a peer
+    /// that has provably spoken the protocol rather than to whatever happened to
+    /// own the path at connect time.
+    func peerPID() -> Int32? {
+        guard fd >= 0 else { return nil }
+        var pid: pid_t = 0
+        var size = socklen_t(MemoryLayout<pid_t>.size)
+        guard getsockopt(fd, SOL_LOCAL, LOCAL_PEERPID, &pid, &size) == 0, pid > 0 else {
+            return nil
+        }
+        return pid
+    }
+
     /// Drops the connection. Idempotent; the client reconnects on the next
     /// verb, which is what makes a `HolderClient` reusable across a holder's
     /// life without pinning its single client slot between requests.

--- a/Sources/TBDDaemon/Holder/HolderRegistry.swift
+++ b/Sources/TBDDaemon/Holder/HolderRegistry.swift
@@ -431,7 +431,11 @@ actor HolderRegistry {
     /// every process it owns — so a `0` that reached the negation below would
     /// take down the fleet, and `getpgid` returns `-1` for a pid that is
     /// already gone.
-    private static func jobProcessGroup(childPID: Int32) -> Int32? {
+    /// Internal rather than private because `ProductionRowlessHolderReclaimer`
+    /// must kill a holder's job by exactly these rules. Reimplementing them
+    /// beside a second caller is how the `> 1` guards and the resolve-before-
+    /// hang-up ordering get quietly dropped.
+    static func jobProcessGroup(childPID: Int32) -> Int32? {
         guard childPID > 1 else { return nil }
         let pgid = getpgid(childPID)
         guard pgid > 1, pgid == childPID else { return nil }
@@ -456,7 +460,9 @@ actor HolderRegistry {
     ///
     /// Both signals are best-effort: a teardown must never fail because
     /// something it meant to kill was already gone.
-    private static func killJob(childPID: Int32, group: Int32?) {
+    /// Internal for the same reason as `jobProcessGroup` above: one
+    /// implementation of the kill, two callers.
+    static func killJob(childPID: Int32, group: Int32?) {
         guard childPID > 1 else { return }
         if let group { _ = kill(-group, SIGKILL) }
         _ = kill(childPID, SIGKILL)

--- a/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
@@ -224,6 +224,22 @@ extension RPCRouter {
         return .ok()
     }
 
+    /// Persist the row-less holder sweep gate — the default-off soak switch for
+    /// killing a pty holder this installation owns which no session row claims,
+    /// read on top of the GC master switch. Deliberately a different verb from
+    /// the rendezvous gate above: enabling file cleanup must never enable a
+    /// process killer. Like the master switch, flipping it off does not cancel
+    /// an in-progress sweep: `OrphanGC.sweep` re-reads the flag on its next
+    /// pass.
+    func handleConfigSetGCRowlessHoldersEnabled(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(
+            ConfigSetGCRowlessHoldersEnabledParams.self, from: paramsData)
+        try await db.config.setGCRowlessHoldersEnabled(params.enabled)
+        // Reuse the existing config-change channel so the app reloads Config.
+        subscriptions.broadcast(delta: .modelProfilesChanged)
+        return .ok()
+    }
+
     /// Persist the orphaned-process collector gate — the default-off soak
     /// switch for reclaiming processes that outlived the worktree they were
     /// rooted in, read on top of the GC master switch.

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -686,6 +686,8 @@ public final class RPCRouter: Sendable {
                 return try await handleConfigSetGCOrphanProcessesEnabled(request.paramsData)
             case RPCMethod.configSetGCHolderRendezvousEnabled:
                 return try await handleConfigSetGCHolderRendezvousEnabled(request.paramsData)
+            case RPCMethod.configSetGCRowlessHoldersEnabled:
+                return try await handleConfigSetGCRowlessHoldersEnabled(request.paramsData)
             case RPCMethod.configSetSupervisionEnabled:
                 return try await handleConfigSetSupervisionEnabled(request.paramsData)
             case RPCMethod.remoteProviders:

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -1469,6 +1469,24 @@ public struct Config: Codable, Sendable, Equatable {
     /// NULL means "never chose" and follows the shipped default wherever it
     /// goes; `0`/`1` is an explicit gesture and is honored forever.
     public var gcHolderRendezvousEnabled: Bool
+    /// Gate for the orphan-GC phase that **kills** a pty holder this
+    /// installation owns which no session row claims — the holder-versus-
+    /// database half of
+    /// `docs/specs/2026-08-30-pty-holder-session-transport-design.md`,
+    /// "Reconciliation". Read on top of `gcEnabled`: both must be on.
+    ///
+    /// **Deliberately not `gcHolderRendezvousEnabled`.** That flag unlinks
+    /// files; this one signals processes. They are independent opt-ins because
+    /// somebody enabling file cleanup must not silently acquire a process
+    /// killer, and because what this phase misjudges cannot be restored.
+    ///
+    /// **Resolved, not stored**, like `gcHolderRendezvousEnabled`: the backing
+    /// column carries no SQL default and stays NULL until somebody touches the
+    /// toggle, so this property is
+    /// `gc_rowless_holders_enabled ?? Config.gcRowlessHoldersEnabledDefault`.
+    /// NULL means "never chose" and follows the shipped default wherever it
+    /// goes; `0`/`1` is an explicit gesture and is honored forever.
+    public var gcRowlessHoldersEnabled: Bool
     /// The single opt-in for remote peer messaging
     /// (`docs/specs/2026-08-29-remote-peer-messaging-design.md`, "Flag and
     /// rollout"): publishing a shadow peer for each remote session and carrying
@@ -1579,6 +1597,12 @@ public struct Config: Codable, Sendable, Equatable {
     /// this constant, with no forcing `UPDATE` migration and every explicit
     /// opt-out left alone.
     public static let gcHolderRendezvousEnabledDefault = false
+    /// The shipped default for `gcRowlessHoldersEnabled`, and the single place
+    /// it lives. The row-less holder sweep ships off; graduation — after a soak
+    /// in which it never kills a holder that turned out to be somebody's live
+    /// session — is a change to this constant, with no forcing `UPDATE`
+    /// migration and every explicit opt-out left alone.
+    public static let gcRowlessHoldersEnabledDefault = false
 
     public init(defaultProfileID: UUID? = nil,
                 primaryAgentPreference: PrimaryAgentPreference = .defaultValue,
@@ -1614,6 +1638,7 @@ public struct Config: Codable, Sendable, Equatable {
                 remotePeerMessagingEnabled: Bool = Config.remotePeerMessagingDefault,
                 ptyHolderEnabled: Bool = Config.ptyHolderDefault,
                 gcHolderRendezvousEnabled: Bool = Config.gcHolderRendezvousEnabledDefault,
+                gcRowlessHoldersEnabled: Bool = Config.gcRowlessHoldersEnabledDefault,
                 remoteCreateDefaults: [String: String] = [:],
                 holderOwnerToken: String? = nil) {
         self.defaultProfileID = defaultProfileID
@@ -1650,6 +1675,7 @@ public struct Config: Codable, Sendable, Equatable {
         self.remotePeerMessagingEnabled = remotePeerMessagingEnabled
         self.ptyHolderEnabled = ptyHolderEnabled
         self.gcHolderRendezvousEnabled = gcHolderRendezvousEnabled
+        self.gcRowlessHoldersEnabled = gcRowlessHoldersEnabled
         self.remoteCreateDefaults = remoteCreateDefaults
         self.holderOwnerToken = holderOwnerToken
     }
@@ -1745,6 +1771,12 @@ public struct Config: Codable, Sendable, Equatable {
         gcHolderRendezvousEnabled = try c.decodeIfPresent(
             Bool.self, forKey: .gcHolderRendezvousEnabled)
             ?? Config.gcHolderRendezvousEnabledDefault
+        // Same reading for the row-less holder sweep's gate: absent means the
+        // sender knew nothing about the flag, which is the NULL column's
+        // situation — follow the shipped default, never a hardcoded `false`.
+        gcRowlessHoldersEnabled = try c.decodeIfPresent(
+            Bool.self, forKey: .gcRowlessHoldersEnabled)
+            ?? Config.gcRowlessHoldersEnabledDefault
         // Absent means the sender knew nothing about global create defaults —
         // the same state as an empty map: no opinion at this level, so every
         // field falls through to its provider-declared `default`.

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -290,6 +290,7 @@ public enum RPCMethod {
     public static let configSetGCProfileDirsEnabled = "config.setGCProfileDirsEnabled"
     public static let configSetGCOrphanProcessesEnabled = "config.setGCOrphanProcessesEnabled"
     public static let configSetGCHolderRendezvousEnabled = "config.setGCHolderRendezvousEnabled"
+    public static let configSetGCRowlessHoldersEnabled = "config.setGCRowlessHoldersEnabled"
     public static let remoteProviders = "remote.providers"
     public static let remoteSessions = "remote.sessions"
     public static let remoteCreate = "remote.create"
@@ -2944,6 +2945,17 @@ public struct ConfigSetGCProfileDirsEnabledParams: Codable, Sendable {
 /// gone (default OFF during soak, on top of the GC master switch). Design:
 /// `docs/specs/2026-08-30-pty-holder-session-transport-design.md`.
 public struct ConfigSetGCHolderRendezvousEnabledParams: Codable, Sendable {
+    public var enabled: Bool
+    public init(enabled: Bool) { self.enabled = enabled }
+}
+
+/// Params for `config.setGCRowlessHoldersEnabled` — the gate for the sweep that
+/// **kills** a pty holder this installation owns which no session row claims
+/// (default OFF during soak, on top of the GC master switch). A separate opt-in
+/// from the rendezvous-file sweep because it signals processes rather than
+/// unlinking files. Design:
+/// `docs/specs/2026-08-30-pty-holder-session-transport-design.md`.
+public struct ConfigSetGCRowlessHoldersEnabledParams: Codable, Sendable {
     public var enabled: Bool
     public init(enabled: Bool) { self.enabled = enabled }
 }

--- a/Tests/TBDDaemonLiveTests/Holder/OrphanGCRowlessHolderLiveTests.swift
+++ b/Tests/TBDDaemonLiveTests/Holder/OrphanGCRowlessHolderLiveTests.swift
@@ -63,6 +63,32 @@ struct OrphanGCRowlessHolderLiveTests {
             .appendingPathComponent("\(session.uuidString.lowercased()).sock").path
     }
 
+    /// Sweeps until `planned` carries `marker`, and returns that pass's result.
+    ///
+    /// **The retry exists for exactly one race and no other.** Closing a client
+    /// is not the same instant the holder notices: it learns its peer is gone on
+    /// its next poll slice, and a probe that lands in between is answered with
+    /// the busy sentinel — after which the sweep, correctly, keeps. A production
+    /// sweep runs hourly and simply sees it the next time round; a test cannot
+    /// wait an hour, and on a loaded box that slice is long enough to have
+    /// reddened a run.
+    ///
+    /// It cannot paper over a real failure: every marker below is one a *single*
+    /// correct sweep produces, so the loop only ever converts "not yet" into
+    /// "now", never "never" into "yes". Exhausting the budget returns the last
+    /// result and the caller's assertion fails on it.
+    private func sweepUntil(
+        _ marker: String, gc: OrphanGC, timeout: TimeInterval = 20.0
+    ) async -> GCSweepResult {
+        var last = await gc.sweep()
+        let deadline = Date().addingTimeInterval(timeout)
+        while !last.planned.contains(marker), Date() < deadline {
+            try? await Task.sleep(for: .milliseconds(100))
+            last = await gc.sweep()
+        }
+        return last
+    }
+
     // MARK: - The kill
 
     /// **The discriminating test.** A live holder we own, claimed by no session
@@ -87,10 +113,11 @@ struct OrphanGCRowlessHolderLiveTests {
         await fixture.client.close()
 
         let db = try await armedDatabase(owner: fixture.owner.rawValue)
-        let result = await makeGC(db: db, home: fixture.home).sweep()
+        let socket = socketPath(home: fixture.home, session: fixture.sessionID)
+        let result = await sweepUntil(
+            "REAP rowless-holder \(socket)", gc: makeGC(db: db, home: fixture.home))
 
-        #expect(result.planned.contains(
-            "REAP rowless-holder \(socketPath(home: fixture.home, session: fixture.sessionID))"))
+        #expect(result.planned.contains("REAP rowless-holder \(socket)"))
         #expect(result.reaped >= 1)
 
         let childGone = await pollUntil("the job to be killed", timeout: 10.0) {
@@ -105,6 +132,43 @@ struct OrphanGCRowlessHolderLiveTests {
         // Only now: the pid number is free the instant its corpse is collected,
         // and the fixture must not signal it again.
         if holderGone { fixture.noteHolderReaped() }
+    }
+
+    /// The kill needs a holder pid, and the handshake deliberately does not
+    /// carry one — the holder is kept small enough to essentially never change,
+    /// so `LOCAL_PEERPID` on the answering connection is where the pid comes
+    /// from. Nothing above can check that number is the *right* one: the kill
+    /// test would pass just as well against a `nil` pid, because `forget` alone
+    /// usually ends a holder. This pins it against the pid the spawner reported.
+    @Test func theHandshakeConnectionNamesTheHolderProcess() async throws {
+        let fixture = try await HolderProcessFixture.start(command: Self.job)
+        defer { fixture.tearDown() }
+        await fixture.client.close()
+
+        // Retried for the same slot-release race `sweepUntil` documents: the
+        // holder notices the handshake connection has gone on its next poll
+        // slice, and answers anything sooner with the busy sentinel.
+        let socket = socketPath(home: fixture.home, session: fixture.sessionID)
+        var peer: Int32?
+        _ = await pollUntil("the holder to answer a fresh client", timeout: 20.0) {
+            let client = HolderClient(socketPath: socket, receiveTimeout: .seconds(5))
+            do {
+                _ = try await client.describe()
+            } catch {
+                await client.close()
+                return false
+            }
+            peer = await client.peerPID()
+            await client.close()
+            return true
+        }
+
+        #expect(
+            peer == fixture.handle.holderPID,
+            """
+            LOCAL_PEERPID named \(String(describing: peer)), not the spawned holder \
+            \(fixture.handle.holderPID)
+            """)
     }
 
     // MARK: - The two holders that must survive
@@ -127,10 +191,11 @@ struct OrphanGCRowlessHolderLiveTests {
         await fixture.client.close()
 
         let db = try await armedDatabase(owner: "a-different-checkout")
-        let result = await makeGC(db: db, home: fixture.home).sweep()
+        let socket = socketPath(home: fixture.home, session: fixture.sessionID)
+        let result = await sweepUntil(
+            "KEEP foreign-owner \(socket)", gc: makeGC(db: db, home: fixture.home))
 
-        #expect(result.planned.contains(
-            "KEEP foreign-owner \(socketPath(home: fixture.home, session: fixture.sessionID))"))
+        #expect(result.planned.contains("KEEP foreign-owner \(socket)"))
         #expect(holderProcessIsAlive(holderPID), "a foreign holder was killed")
         #expect(holderProcessIsAlive(childPID), "a foreign holder's job was killed")
         #expect(result.reaped == 0)

--- a/Tests/TBDDaemonLiveTests/Holder/OrphanGCRowlessHolderLiveTests.swift
+++ b/Tests/TBDDaemonLiveTests/Holder/OrphanGCRowlessHolderLiveTests.swift
@@ -1,0 +1,187 @@
+import Darwin
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// The row-less holder sweep against **real holder processes**.
+///
+/// Three cases, and the whole safety argument rests on them being three rather
+/// than one. Each spawns a genuine `TBDHolder` through the real `HolderSpawner`,
+/// forked onto a real pty, and then reads the kernel's view of the result:
+///
+///   - a holder this installation owns, past the grace window, claimed by no
+///     session row → the child **and** the holder are gone;
+///   - the same holder with a different owner token in the `config` row → still
+///     running, because a completed handshake proves liveness, not ownership;
+///   - the same holder with the *same* owner token but its one client slot
+///     already taken → still running, because a rejected connection is terminal
+///     in both directions.
+///
+/// The last two are what make the first one safe to ship. Nothing in an
+/// injected-handshake test can prove a real holder refuses a real second client,
+/// nor that a real `SIGKILL` reached a real process group.
+///
+/// **Tier 3**, and serialized: it spawns processes, waits on bounded deadlines,
+/// and would not survive the parallel pass.
+@Suite(.serialized)
+struct OrphanGCRowlessHolderLiveTests {
+
+    /// A job that simply waits to be killed. It writes nothing to the pty, so
+    /// nothing here can die of a full terminal buffer instead of the kill.
+    private static let job = "exec sleep 300"
+
+    /// The sweep, pointed at the fixture's own holders directory and running the
+    /// **production** handshake and killer — the two pieces this suite exists to
+    /// exercise, so neither may be injected.
+    ///
+    /// `now` is pushed a day ahead so the freshly bound socket reads as older
+    /// than the GC grace window. The alternative — sleeping out a real grace
+    /// window — measures the clock, not the sweep.
+    private func makeGC(db: TBDDatabase, home: String) -> OrphanGC {
+        let horizon = Date().addingTimeInterval(86_400)
+        return OrphanGC(
+            db: db, git: GitManager(),
+            broadcast: { _ in },
+            liveCWDsProvider: { [] },
+            scratchpadBase: URL(fileURLWithPath: home + "/s", isDirectory: true),
+            now: { horizon },
+            profileDirBase: URL(fileURLWithPath: home + "/p", isDirectory: true),
+            holdersBase: TBDConstants.holdersDir(
+                environment: HolderProcessFixture.environment(home: home)))
+    }
+
+    private func armedDatabase(owner: String) async throws -> TBDDatabase {
+        let db = try TBDDatabase(inMemory: true)
+        _ = try await db.config.ensureHolderOwnerToken(minting: owner)
+        try await db.config.setGCRowlessHoldersEnabled(true)
+        return db
+    }
+
+    private func socketPath(home: String, session: UUID) -> String {
+        TBDConstants.holdersDir(environment: HolderProcessFixture.environment(home: home))
+            .appendingPathComponent("\(session.uuidString.lowercased()).sock").path
+    }
+
+    // MARK: - The kill
+
+    /// **The discriminating test.** A live holder we own, claimed by no session
+    /// row, is reclaimed child-first — and both pids are really gone afterwards.
+    ///
+    /// Asserted on the process table rather than on a return value: the sweep
+    /// reporting `reaped` proves it believed it killed something.
+    @Test func aRowlessHolderWeOwnIsKilledChildAndAll() async throws {
+        let fixture = try await HolderProcessFixture.start(command: Self.job)
+        defer { fixture.tearDown() }
+        let holderPID = fixture.handle.holderPID
+        let childPID = fixture.handle.childPID
+
+        // The premise, asserted rather than assumed: both are running before the
+        // sweep, so their absence afterwards can only be the sweep's doing.
+        #expect(holderProcessIsAlive(holderPID))
+        #expect(holderProcessIsAlive(childPID))
+
+        // The spawner's handshake connection is the holder's one client slot,
+        // and the sweep's probe needs it free — an occupied slot is the
+        // `rejected` case, which is a different test.
+        await fixture.client.close()
+
+        let db = try await armedDatabase(owner: fixture.owner.rawValue)
+        let result = await makeGC(db: db, home: fixture.home).sweep()
+
+        #expect(result.planned.contains(
+            "REAP rowless-holder \(socketPath(home: fixture.home, session: fixture.sessionID))"))
+        #expect(result.reaped >= 1)
+
+        let childGone = await pollUntil("the job to be killed", timeout: 10.0) {
+            !holderProcessIsAlive(childPID)
+        }
+        #expect(childGone, "the holder's job survived the sweep")
+
+        let holderGone = await pollUntil("the holder to be gone", timeout: 10.0) {
+            holderProcessState(holderPID) == nil
+        }
+        #expect(holderGone, "the holder survived the sweep")
+        // Only now: the pid number is free the instant its corpse is collected,
+        // and the fixture must not signal it again.
+        if holderGone { fixture.noteHolderReaped() }
+    }
+
+    // MARK: - The two holders that must survive
+
+    /// A completed handshake is proof of **liveness, not ownership**. The
+    /// default `TBD_HOME` is shared by every checkout on a machine, so a
+    /// perfectly healthy foreign session presents exactly as "reachable and
+    /// absent from my database". Only the owner token tells them apart.
+    ///
+    /// Identical to the kill test in every respect but the token in the `config`
+    /// row.
+    @Test func aHolderWithADifferentOwnerTokenIsLeftRunning() async throws {
+        let fixture = try await HolderProcessFixture.start(command: Self.job)
+        defer { fixture.tearDown() }
+        let holderPID = fixture.handle.holderPID
+        let childPID = fixture.handle.childPID
+
+        // Free, so the handshake really completes and `foreign-owner` is the
+        // only thing standing between this holder and a kill.
+        await fixture.client.close()
+
+        let db = try await armedDatabase(owner: "a-different-checkout")
+        let result = await makeGC(db: db, home: fixture.home).sweep()
+
+        #expect(result.planned.contains(
+            "KEEP foreign-owner \(socketPath(home: fixture.home, session: fixture.sessionID))"))
+        #expect(holderProcessIsAlive(holderPID), "a foreign holder was killed")
+        #expect(holderProcessIsAlive(childPID), "a foreign holder's job was killed")
+        #expect(result.reaped == 0)
+    }
+
+    /// **A rejected connection is terminal in both directions** — not exited,
+    /// and not killed either. The holder serves one client at a time and answers
+    /// a second with the busy sentinel; a stale daemon from a different checkout
+    /// is exactly what that looks like from here, and it is a known hazard on a
+    /// development machine.
+    ///
+    /// The owner token matches, so ownership cannot be what saves this holder:
+    /// the refusal is.
+    @Test func aHolderThatRefusesTheConnectionIsLeftRunning() async throws {
+        let fixture = try await HolderProcessFixture.start(command: Self.job)
+        defer { fixture.tearDown() }
+        let holderPID = fixture.handle.holderPID
+        let childPID = fixture.handle.childPID
+
+        // Deliberately NOT closed: the spawner's handshake connection keeps the
+        // single client slot, so the sweep's probe is refused.
+        let refused = try await HolderClient(
+            socketPath: socketPath(home: fixture.home, session: fixture.sessionID),
+            receiveTimeout: .seconds(5)
+        ).describeExpectingRefusal()
+        #expect(refused, "the fixture must be occupying the holder's client slot")
+
+        let db = try await armedDatabase(owner: fixture.owner.rawValue)
+        let result = await makeGC(db: db, home: fixture.home).sweep()
+
+        #expect(result.planned.contains(
+            "KEEP rejected \(socketPath(home: fixture.home, session: fixture.sessionID))"))
+        #expect(holderProcessIsAlive(holderPID), "a holder that refused us was killed")
+        #expect(holderProcessIsAlive(childPID), "a refusing holder's job was killed")
+        #expect(result.reaped == 0)
+    }
+}
+
+private extension HolderClient {
+    /// Whether this holder answers a second client with the busy sentinel.
+    ///
+    /// Used to assert the *premise* of the refusal test rather than its
+    /// conclusion: without this, a holder that had quietly freed its slot would
+    /// make the test pass for the wrong reason.
+    func describeExpectingRefusal() async throws -> Bool {
+        defer { close() }
+        do {
+            _ = try await describe()
+            return false
+        } catch HolderClient.Error.rejected {
+            return true
+        }
+    }
+}

--- a/Tests/TBDDaemonTests/Config/GCRowlessHoldersFlagTests.swift
+++ b/Tests/TBDDaemonTests/Config/GCRowlessHoldersFlagTests.swift
@@ -1,0 +1,201 @@
+import Foundation
+import GRDB
+import Testing
+
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Schema and resolution guards for `config.gc_rowless_holders_enabled`, the
+/// soak gate on the sweep that kills a pty holder this installation owns which
+/// no session row claims.
+///
+/// The column is added by `20260901161500_config_gc_rowless_holders` with **no
+/// SQL default**, so "never chose" (NULL) stays distinguishable from
+/// "explicitly off" (0). If someone adds a `DEFAULT` clause to that migration,
+/// `nullBeforeAnyGesture` and `rowWrittenBeforeTheMigrationStillReadsNull` go
+/// red — that is their only job. The distinction earns its keep because this
+/// phase kills processes: somebody who turned it off did so deliberately and
+/// must stay opted out through graduation.
+///
+/// It is a **different flag** from `gc_holder_rendezvous_enabled`, and
+/// `theTwoHolderGCFlagsAreIndependent` is what holds that apart: one unlinks
+/// files, the other signals processes, and enabling the first must never enable
+/// the second.
+@Suite("GCRowlessHoldersFlag")
+struct GCRowlessHoldersFlagTests {
+
+    /// The last migration identifier that predates the flag's column. Migrating
+    /// only this far reproduces the schema a real pre-flag daemon ran on.
+    private static let lastIdentifierBeforeTheFlag = "20260901135111_config_gc_holder_rendezvous"
+
+    private func fetchConfigRecord(_ db: TBDDatabase) async throws -> ConfigRecord? {
+        try await db.writerForTests.read { conn in
+            try ConfigRecord.fetchOne(conn, key: ConfigStore.singletonID)
+        }
+    }
+
+    // MARK: - Storage: the column is genuinely NULL until somebody chooses
+
+    /// **The load-bearing test.** The `config` singleton row is inserted by v1,
+    /// so every install has a row that predates this column. After the
+    /// migration that row must read NULL, not `0`.
+    @Test func nullBeforeAnyGesture() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let record = try #require(try await fetchConfigRecord(db))
+        #expect(
+            record.gc_rowless_holders_enabled == nil,
+            """
+            config.gc_rowless_holders_enabled must be NULL until the toggle is \
+            touched — read back \
+            \(String(describing: record.gc_rowless_holders_enabled)). A non-nil \
+            value here means 20260901161500_config_gc_rowless_holders grew a \
+            DEFAULT clause; remove it.
+            """)
+    }
+
+    /// The same guard against a row written by a real pre-flag daemon: migrate
+    /// only as far as the last identifier that predates the column, write to the
+    /// config row, then finish migrating.
+    @Test func rowWrittenBeforeTheMigrationStillReadsNull() throws {
+        let queue = try DatabaseQueue()
+        let migrator = TBDDatabase.buildMigratorForTests()
+        try migrator.migrate(queue, upTo: Self.lastIdentifierBeforeTheFlag)
+
+        try queue.write { db in
+            try db.execute(
+                sql: "UPDATE config SET auto_create_notes_enabled = 1 WHERE id = ?",
+                arguments: [ConfigStore.singletonID])
+        }
+
+        try migrator.migrate(queue)
+
+        try queue.read { db in
+            let row = try #require(try Row.fetchOne(
+                db, sql: "SELECT * FROM config WHERE id = ?",
+                arguments: [ConfigStore.singletonID]))
+            let raw: DatabaseValue = row["gc_rowless_holders_enabled"]
+            #expect(
+                raw.isNull,
+                "a config row written before the migration must read NULL, not \(raw)")
+            // The pre-existing write survived — the migration is purely additive.
+            #expect(row["auto_create_notes_enabled"] == true)
+        }
+    }
+
+    // MARK: - Resolution: the three states are distinguishable
+
+    /// NULL follows `Config.gcRowlessHoldersEnabledDefault` wherever it goes; an
+    /// explicit `false` does not. That property is what makes graduation a
+    /// one-line constant change with no forcing `UPDATE` migration. Exercised
+    /// against BOTH possible default values, so it fails if the resolution is
+    /// ever wired as `?? false`.
+    @Test func explicitFalseSurvivesADefaultFlipWhileNullFollowsIt() async throws {
+        let db = try TBDDatabase(inMemory: true)
+
+        let untouched = try #require(try await fetchConfigRecord(db))
+        #expect(untouched.gc_rowless_holders_enabled == nil)
+        #expect(
+            untouched.toModel(gcRowlessHoldersDefault: false).gcRowlessHoldersEnabled == false)
+        #expect(
+            untouched.toModel(gcRowlessHoldersDefault: true).gcRowlessHoldersEnabled == true,
+            "a never-chosen row must pick up a changed shipped default")
+
+        try await db.config.setGCRowlessHoldersEnabled(false)
+        let explicitlyOff = try #require(try await fetchConfigRecord(db))
+        #expect(explicitlyOff.gc_rowless_holders_enabled == false)
+        #expect(
+            explicitlyOff.toModel(gcRowlessHoldersDefault: false)
+                .gcRowlessHoldersEnabled == false)
+        #expect(
+            explicitlyOff.toModel(gcRowlessHoldersDefault: true)
+                .gcRowlessHoldersEnabled == false,
+            "an explicit opt-out must be honored forever, whatever the shipped default becomes")
+    }
+
+    /// Mirrored for an explicit `true`: an operator who opted into the soak
+    /// stays opted in even if the shipped default never moves.
+    @Test func explicitTrueSticks() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCRowlessHoldersEnabled(true)
+        let explicitlyOn = try #require(try await fetchConfigRecord(db))
+        #expect(explicitlyOn.gc_rowless_holders_enabled == true)
+        #expect(
+            explicitlyOn.toModel(gcRowlessHoldersDefault: false).gcRowlessHoldersEnabled == true)
+        #expect(
+            explicitlyOn.toModel(gcRowlessHoldersDefault: true).gcRowlessHoldersEnabled == true)
+    }
+
+    /// Isolates the RESOLUTION guard (`toModel()`'s `?? gcRowlessHoldersDefault`)
+    /// from the STORAGE guard (the migration's missing SQL default) by
+    /// constructing a `ConfigRecord` directly — no database, no migration.
+    @Test func toModelResolvesNullThroughTheInjectedDefault() {
+        let record = ConfigRecord(id: "unstored", gc_rowless_holders_enabled: nil)
+        #expect(record.toModel(gcRowlessHoldersDefault: false).gcRowlessHoldersEnabled == false)
+        #expect(
+            record.toModel(gcRowlessHoldersDefault: true).gcRowlessHoldersEnabled == true,
+            "a NULL record must pick up whatever default is injected, not a hardcoded false")
+    }
+
+    // MARK: - Independence from the file-unlinking sibling
+
+    /// **Enabling file cleanup must not enable a process killer**, and the
+    /// reverse. Two columns, two setters, and neither moves the other — the
+    /// whole reason this is not the rendezvous flag.
+    @Test func theTwoHolderGCFlagsAreIndependent() async throws {
+        let db = try TBDDatabase(inMemory: true)
+
+        try await db.config.setGCHolderRendezvousEnabled(true)
+        var config = try await db.config.get()
+        #expect(config.gcHolderRendezvousEnabled == true)
+        #expect(
+            config.gcRowlessHoldersEnabled == false,
+            "turning the rendezvous file sweep on must not turn the process killer on")
+
+        try await db.config.setGCRowlessHoldersEnabled(true)
+        try await db.config.setGCHolderRendezvousEnabled(false)
+        config = try await db.config.get()
+        #expect(config.gcHolderRendezvousEnabled == false)
+        #expect(
+            config.gcRowlessHoldersEnabled == true,
+            "turning the file sweep off must not turn the process killer off")
+    }
+
+    // MARK: - The shipped default, and the wire
+
+    /// The shipped default today: OFF. A background sweep that kills processes
+    /// soaks behind its own switch, and the transport whose orphans it reclaims
+    /// is itself still behind `ptyHolderEnabled`. Graduation edits this constant
+    /// and nothing else.
+    @Test func shippedDefaultIsOff() async throws {
+        #expect(Config.gcRowlessHoldersEnabledDefault == false)
+        let db = try TBDDatabase(inMemory: true)
+        #expect(try await db.config.get().gcRowlessHoldersEnabled == false)
+    }
+
+    @Test func setterRoundtrips() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCRowlessHoldersEnabled(true)
+        #expect(try await db.config.get().gcRowlessHoldersEnabled == true)
+        try await db.config.setGCRowlessHoldersEnabled(false)
+        #expect(try await db.config.get().gcRowlessHoldersEnabled == false)
+    }
+
+    /// JSON from a daemon that predates the flag still decodes, and the absent
+    /// key means the sender knew nothing about it — the NULL column's situation,
+    /// so it follows the shipped default rather than a hardcoded `false`.
+    @Test func configJSONWithoutTheKeyFollowsTheShippedDefault() throws {
+        let json = #"{"primaryAgentPreference":"claude"}"#
+        let config = try JSONDecoder().decode(Config.self, from: Data(json.utf8))
+        #expect(config.gcRowlessHoldersEnabled == Config.gcRowlessHoldersEnabledDefault)
+    }
+
+    /// An explicit `true` on the wire is carried, so the app and the CLI see the
+    /// same state the daemon resolved rather than re-deriving it.
+    @Test func configJSONRoundTripsAnExplicitChoice() throws {
+        var config = Config()
+        config.gcRowlessHoldersEnabled = true
+        let decoded = try JSONDecoder().decode(
+            Config.self, from: JSONEncoder().encode(config))
+        #expect(decoded.gcRowlessHoldersEnabled == true)
+    }
+}

--- a/Tests/TBDDaemonTests/OrphanGCRowlessHolderTests.swift
+++ b/Tests/TBDDaemonTests/OrphanGCRowlessHolderTests.swift
@@ -1,0 +1,352 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+import TBDShared
+
+/// Tier 2: a real rendezvous directory with real (abandoned) unix sockets plus
+/// an in-memory database. The holders base, the profiles base, the scratchpad
+/// base, the clock, the handshake and the killer are all injected; nothing here
+/// resolves a production path and **no process is spawned or signalled**.
+///
+/// The live half of this sweep — a real `TBDHolder`, really killed, and two
+/// really left alone — is `OrphanGCRowlessHolderLiveTests` in
+/// `TBDDaemonLiveTests`. This suite carries the gates that need no process:
+/// the flag's three states, the grace window, and the row check.
+///
+/// Rooted directly under `/tmp` so the socket paths fit darwin's 104-byte
+/// `sun_path`; removed in `deinit`.
+@Suite("OrphanGC sweeps row-less pty holders")
+struct OrphanGCRowlessHolderTests: ~Copyable {
+    let fm = FileManager.default
+    let sandbox: URL
+    let holdersBase: URL
+    let clock = Date(timeIntervalSince1970: 1_800_000_000)
+    let owner = HolderOwnerToken(rawValue: "acme-installation")
+
+    init() {
+        sandbox = URL(
+            fileURLWithPath: "/tmp/tbd-gcrh-\(UUID().uuidString.prefix(8))", isDirectory: true)
+        holdersBase = sandbox.appendingPathComponent("h", isDirectory: true)
+        try? fm.createDirectory(at: holdersBase, withIntermediateDirectories: true)
+    }
+
+    deinit { try? fm.removeItem(at: sandbox) }
+
+    // MARK: - Fixtures
+
+    /// Records every reclamation instead of performing one, so "left alone" is
+    /// asserted as the absence of a call rather than inferred from a return
+    /// value. `nothing was signalled` is the only shape four of these tests have.
+    actor RecordingReclaimer: RowlessHolderReclaiming {
+        struct Call: Equatable { var socketPath: String; var childPID: Int32; var holderPID: Int32? }
+        private(set) var calls: [Call] = []
+        func reclaim(socketPath: String, childPID: Int32, holderPID: Int32?) async {
+            calls.append(Call(socketPath: socketPath, childPID: childPID, holderPID: holderPID))
+        }
+    }
+
+    private func socketPath(_ id: UUID) -> String {
+        holdersBase.appendingPathComponent("\(id.uuidString.lowercased()).sock").path
+    }
+
+    /// A bound-then-abandoned socket, backdated so the GC grace window has
+    /// elapsed against this suite's fixed clock. A real socket rather than a
+    /// plain file so `candidates()` sees what production sees.
+    @discardableResult
+    private func makeHolderSocket(_ id: UUID, age: TimeInterval = 86_400) -> String {
+        let path = socketPath(id)
+        #expect(HolderRendezvousFixture.bindAndAbandon(at: path))
+        let created = clock.addingTimeInterval(-age)
+        try? fm.setAttributes([.creationDate: created, .modificationDate: created],
+                              ofItemAtPath: path)
+        return path
+    }
+
+    private static func described(
+        childPID: Int32 = 4242, owner: HolderOwnerToken, holderPID: Int32? = 4241
+    ) -> RowlessHolderHandshake {
+        .described(
+            HolderChildDescription(
+                childPID: childPID,
+                ttyName: "/dev/ttys999",
+                status: .alive,
+                launch: HolderLaunchRequest(
+                    executable: "/bin/sh", arguments: ["-c", "sleep 300"],
+                    workingDirectory: "/tmp", environment: [:], columns: 80, rows: 24),
+                owner: owner),
+            holderPID: holderPID)
+    }
+
+    private func makeGC(
+        db: TBDDatabase,
+        reclaimer: RecordingReclaimer,
+        handshake: @escaping @Sendable (String) async -> RowlessHolderHandshake
+    ) -> OrphanGC {
+        let fixed = clock
+        return OrphanGC(
+            db: db, git: GitManager(),
+            broadcast: { _ in },
+            liveCWDsProvider: { [] },
+            scratchpadBase: sandbox.appendingPathComponent("s", isDirectory: true),
+            now: { fixed },
+            profileDirBase: sandbox.appendingPathComponent("p", isDirectory: true),
+            holdersBase: holdersBase,
+            // The rendezvous sweep shares this directory and would unlink the
+            // fixture out from under these assertions if it ever ran. It cannot:
+            // its own flag is off. Pinned anyway so a future default flip does
+            // not silently rewrite what this suite measures.
+            holderListenerProbe: { _ in true },
+            rowlessHolderHandshake: handshake,
+            rowlessHolderReclaimer: reclaimer)
+    }
+
+    /// An installation that has minted a token and has a holder socket that no
+    /// session row claims — the setup every test below varies one thing from.
+    private func armedDatabase(enabled: Bool = true) async throws -> TBDDatabase {
+        let db = try TBDDatabase(inMemory: true)
+        _ = try await db.config.ensureHolderOwnerToken(minting: owner.rawValue)
+        if enabled { try await db.config.setGCRowlessHoldersEnabled(true) }
+        return db
+    }
+
+    // MARK: - The kill
+
+    /// **The discriminating sweep test**, in its process-free form: a holder
+    /// that handshakes, proves our owner token, is past the grace window and has
+    /// no session row is reclaimed — child pid and holder pid both named.
+    @Test func aRowlessHolderWeOwnIsReclaimed() async throws {
+        let db = try await armedDatabase()
+        let id = UUID()
+        let path = makeHolderSocket(id)
+        let reclaimer = RecordingReclaimer()
+        let mine = owner
+
+        let result = await makeGC(db: db, reclaimer: reclaimer, handshake: { _ in
+            Self.described(childPID: 4242, owner: mine, holderPID: 4241)
+        }).sweep()
+
+        #expect(await reclaimer.calls == [
+            .init(socketPath: path, childPID: 4242, holderPID: 4241)
+        ])
+        #expect(result.planned.contains("REAP rowless-holder \(path)"))
+        #expect(result.reaped >= 1)
+    }
+
+    // MARK: - The four ways a holder is left alone
+
+    /// Rule 1 and 2: a completed handshake proves liveness, not ownership. Two
+    /// installations share the default `TBD_HOME`, so a healthy foreign session
+    /// looks exactly like an orphan of ours until the token is compared.
+    @Test func aDifferentOwnerTokenIsLeftAlone() async throws {
+        let db = try await armedDatabase()
+        let id = UUID()
+        let path = makeHolderSocket(id)
+        let reclaimer = RecordingReclaimer()
+
+        let result = await makeGC(db: db, reclaimer: reclaimer, handshake: { _ in
+            Self.described(owner: HolderOwnerToken(rawValue: "some-other-checkout"))
+        }).sweep()
+
+        #expect(await reclaimer.calls.isEmpty, "a foreign holder must never be signalled")
+        #expect(result.planned.contains("KEEP foreign-owner \(path)"))
+    }
+
+    /// Rule 3: a rejected connection is terminal in both directions. The holder
+    /// is alive and busy serving somebody — very often a stale daemon from
+    /// another checkout, a known hazard on a development machine.
+    @Test func aRejectedConnectionIsLeftAlone() async throws {
+        let db = try await armedDatabase()
+        let id = UUID()
+        let path = makeHolderSocket(id)
+        let reclaimer = RecordingReclaimer()
+
+        let result = await makeGC(db: db, reclaimer: reclaimer, handshake: { _ in .rejected })
+            .sweep()
+
+        #expect(await reclaimer.calls.isEmpty, "a holder that refused us must never be killed")
+        #expect(result.planned.contains("KEEP rejected \(path)"))
+    }
+
+    /// An unreadable answer keeps, the direction every gate in this sweep fails
+    /// in.
+    @Test func anUnreachableHolderIsLeftAlone() async throws {
+        let db = try await armedDatabase()
+        let id = UUID()
+        let path = makeHolderSocket(id)
+        let reclaimer = RecordingReclaimer()
+
+        let result = await makeGC(db: db, reclaimer: reclaimer, handshake: { _ in
+            .unreachable("timed out")
+        }).sweep()
+
+        #expect(await reclaimer.calls.isEmpty)
+        #expect(result.planned.contains("KEEP unreachable \(path)"))
+    }
+
+    /// Rule 4: the keep-biased young-holder guard. `OrphanGC` runs on demand
+    /// from RPC handlers, so a sweep can land between a holder becoming
+    /// connectable and its row committing; killing there destroys a session
+    /// being born. The old sibling in the same sweep proves the gate is the age
+    /// and not the fixture.
+    @Test func aHolderInsideTheGraceWindowIsLeftAlone() async throws {
+        let db = try await armedDatabase()
+        let young = UUID()
+        let old = UUID()
+        let youngPath = makeHolderSocket(young, age: 60)
+        let oldPath = makeHolderSocket(old, age: 86_400)
+        let reclaimer = RecordingReclaimer()
+        let mine = owner
+
+        let result = await makeGC(db: db, reclaimer: reclaimer, handshake: { _ in
+            Self.described(owner: mine)
+        }).sweep()
+
+        #expect(result.planned.contains("KEEP grace \(youngPath)"))
+        #expect(await reclaimer.calls.map(\.socketPath) == [oldPath],
+                "only the holder past the grace window may be reclaimed")
+    }
+
+    /// A holder whose session row exists is claimed, and is not this sweep's
+    /// business. The row check runs **before** any connect, so a claimed holder
+    /// is never even probed — its single client slot belongs to the daemon.
+    @Test func aHolderWithASessionRowIsLeftAlone() async throws {
+        let db = try await armedDatabase()
+        let repo = try await db.repos.create(
+            path: "/tmp/gcrh-repo-\(UUID().uuidString)", displayName: "R", defaultBranch: "main")
+        let worktree = try await db.worktrees.create(
+            repoID: repo.id, name: "w", branch: "b",
+            path: "/tmp/gcrh-wt-\(UUID().uuidString)", tmuxServer: "tbd-gcrh")
+        let terminal = try await db.terminals.create(
+            worktreeID: worktree.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            transport: .holder, holderPID: 4241, childPID: 4242)
+        let path = makeHolderSocket(terminal.id)
+        let reclaimer = RecordingReclaimer()
+        let mine = owner
+
+        let probed = Probe()
+        let result = await makeGC(db: db, reclaimer: reclaimer, handshake: { _ in
+            await probed.fire()
+            return Self.described(owner: mine)
+        }).sweep()
+
+        #expect(await reclaimer.calls.isEmpty, "a claimed holder must never be signalled")
+        #expect(await probed.fired == false,
+                "a claimed holder must not even be connected to — the slot is the daemon's")
+        #expect(result.planned.contains("KEEP has-row \(path)"))
+    }
+
+    /// An installation that never minted an owner token has never spawned a
+    /// holder, so nothing out there can be ours. Every candidate is kept, and
+    /// none is probed.
+    @Test func anInstallationWithNoOwnerTokenKillsNothing() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCRowlessHoldersEnabled(true)
+        let id = UUID()
+        let path = makeHolderSocket(id)
+        let reclaimer = RecordingReclaimer()
+        let mine = owner
+
+        let result = await makeGC(db: db, reclaimer: reclaimer, handshake: { _ in
+            Self.described(owner: mine)
+        }).sweep()
+
+        #expect(await reclaimer.calls.isEmpty)
+        #expect(result.planned.contains("KEEP no-owner-token \(path)"))
+    }
+
+    // MARK: - The gate
+
+    /// The off branch — the state every install ships in. The same fixture the
+    /// kill test reclaims is left completely alone, and the sweep does not even
+    /// plan it.
+    @Test func aSweepWithTheFlagOffKillsNothing() async throws {
+        let db = try await armedDatabase(enabled: false)
+        #expect(try await db.config.get().gcRowlessHoldersEnabled == false,
+                "the shipped default must be off")
+        let id = UUID()
+        makeHolderSocket(id)
+        let reclaimer = RecordingReclaimer()
+        let mine = owner
+
+        let result = await makeGC(db: db, reclaimer: reclaimer, handshake: { _ in
+            Self.described(owner: mine)
+        }).sweep()
+
+        #expect(await reclaimer.calls.isEmpty)
+        #expect(result.planned.contains { $0.contains("rowless-holder") } == false)
+    }
+
+    /// An explicit `false` is the same as never having chosen, for behavior.
+    @Test func anExplicitOptOutKillsNothing() async throws {
+        let db = try await armedDatabase(enabled: false)
+        try await db.config.setGCRowlessHoldersEnabled(false)
+        let id = UUID()
+        makeHolderSocket(id)
+        let reclaimer = RecordingReclaimer()
+        let mine = owner
+        _ = await makeGC(db: db, reclaimer: reclaimer, handshake: { _ in
+            Self.described(owner: mine)
+        }).sweep()
+        #expect(await reclaimer.calls.isEmpty)
+    }
+
+    /// **The file sweep's flag does not arm the process killer.** Enabling
+    /// `gcHolderRendezvousEnabled` alone must leave every holder running: the
+    /// two gates are independent opt-ins precisely because one unlinks files and
+    /// the other kills processes.
+    @Test func theRendezvousFlagDoesNotArmTheProcessKiller() async throws {
+        let db = try await armedDatabase(enabled: false)
+        try await db.config.setGCHolderRendezvousEnabled(true)
+        let id = UUID()
+        makeHolderSocket(id)
+        let reclaimer = RecordingReclaimer()
+        let mine = owner
+
+        let result = await makeGC(db: db, reclaimer: reclaimer, handshake: { _ in
+            Self.described(owner: mine)
+        }).sweep()
+
+        #expect(await reclaimer.calls.isEmpty,
+                "the rendezvous file gate must never license a kill")
+        #expect(result.planned.contains { $0.contains("rowless-holder") } == false)
+    }
+
+    /// The GC master switch is read on top of the phase flag: both must be on.
+    @Test func theMasterSwitchStillGovernsThePhase() async throws {
+        let db = try await armedDatabase()
+        try await db.config.setGCEnabled(false)
+        let id = UUID()
+        makeHolderSocket(id)
+        let reclaimer = RecordingReclaimer()
+        let mine = owner
+        _ = await makeGC(db: db, reclaimer: reclaimer, handshake: { _ in
+            Self.described(owner: mine)
+        }).sweep()
+        #expect(await reclaimer.calls.isEmpty)
+    }
+
+    /// `dryRun` bypasses the flag, exactly as it bypasses `gcEnabled`: someone
+    /// deciding whether to turn a default-off process killer on needs to see
+    /// what it would kill first. It plans and signals nothing.
+    @Test func aDryRunPlansWithTheFlagOffAndKillsNothing() async throws {
+        let db = try await armedDatabase(enabled: false)
+        let id = UUID()
+        let path = makeHolderSocket(id)
+        let reclaimer = RecordingReclaimer()
+        let mine = owner
+
+        let result = await makeGC(db: db, reclaimer: reclaimer, handshake: { _ in
+            Self.described(owner: mine)
+        }).sweep(dryRun: true)
+
+        #expect(result.planned.contains("REAP rowless-holder \(path)"))
+        #expect(result.reaped == 0)
+        #expect(await reclaimer.calls.isEmpty, "a dry run must never signal a process")
+    }
+}
+
+/// A one-shot flag a `@Sendable` closure can set from anywhere.
+private actor Probe {
+    private(set) var fired = false
+    func fire() { fired = true }
+}

--- a/Tests/TBDDaemonTests/OrphanGCRowlessHolderTests.swift
+++ b/Tests/TBDDaemonTests/OrphanGCRowlessHolderTests.swift
@@ -235,6 +235,39 @@ struct OrphanGCRowlessHolderTests: ~Copyable {
         #expect(result.planned.contains("KEEP has-row \(path)"))
     }
 
+    /// **The late gate.** The gates run against one snapshot of the session
+    /// rows, and the handshake round trip that follows is a real window in which
+    /// a session being born can commit its row. The row is therefore re-read
+    /// immediately before the kill — the same pre-reap re-read
+    /// `reapOrphanProfileDirs` keeps.
+    ///
+    /// The injected handshake is what makes the race deterministic: it commits
+    /// the row from inside the window rather than hoping to land in it.
+    @Test func aRowThatCommitsDuringTheHandshakeIsHonored() async throws {
+        let db = try await armedDatabase()
+        let repo = try await db.repos.create(
+            path: "/tmp/gcrh-repo-\(UUID().uuidString)", displayName: "R", defaultBranch: "main")
+        let worktree = try await db.worktrees.create(
+            repoID: repo.id, name: "w", branch: "b",
+            path: "/tmp/gcrh-wt-\(UUID().uuidString)", tmuxServer: "tbd-gcrh")
+        let id = UUID()
+        let path = makeHolderSocket(id)
+        let reclaimer = RecordingReclaimer()
+        let mine = owner
+        let worktreeID = worktree.id
+
+        let result = await makeGC(db: db, reclaimer: reclaimer, handshake: { _ in
+            _ = try? await db.terminals.create(
+                id: id, worktreeID: worktreeID, tmuxWindowID: "@1", tmuxPaneID: "%1",
+                transport: .holder)
+            return Self.described(owner: mine)
+        }).sweep()
+
+        #expect(await reclaimer.calls.isEmpty,
+                "a session whose row committed mid-handshake must not be killed")
+        #expect(result.planned.contains("KEEP raced-row \(path)"))
+    }
+
     /// An installation that never minted an owner token has never spawned a
     /// holder, so nothing out there can be ours. Every candidate is kept, and
     /// none is probed.

--- a/Tests/TBDDaemonTests/SQLMigrationLoaderTests.swift
+++ b/Tests/TBDDaemonTests/SQLMigrationLoaderTests.swift
@@ -497,6 +497,7 @@ import Testing
             "20260831055719_terminal_transport",
             "20260831200151_config_holder_owner_token",
             "20260901135111_config_gc_holder_rendezvous",
+            "20260901161500_config_gc_rowless_holders",
         ]
         let found = try SQLMigrationLoader.bundled.get()
         #expect(found.files.map(\.identifier) == expected)


### PR DESCRIPTION
## Summary

The spec's Reconciliation section names two holder-versus-ground-truth sweeps. The
rendezvous file sweep landed in #779 and reclaims what a **dead** holder left behind.
This is the other one, and it has the opposite problem: a holder that is very much
**alive** — speaking the protocol, holding a pty, running somebody's job — that no
session row claims.

That state is reachable and nothing reclaimed it. A daemon killed between `posix_spawn`
and the row commit leaves one; so does a crash inside the create path after the
rendezvous binds. The holder keeps its child alive forever, and because the only record
of either pid died with the transaction, no other reconciler can name them.

A sweep that kills live processes on the strength of "absent from my database" is the
most dangerous thing in this subsystem, so the whole design is the argument for why it
is allowed to fire at all.

## Five rules, and why each one is load-bearing

1. **A completed handshake is proof of liveness, not of ownership**, and only ownership
   licenses a kill. The default `TBD_HOME` is shared by every checkout on a machine, so
   "reachable and absent from *my* database" is exactly the shape a **foreign but
   perfectly healthy** session presents.
2. **The owner token decides, and the sweep reads it — never mints it.** `HolderRegistry`
   mints on the spawn path. A sweep that minted one would hand itself an identity no
   holder on disk was ever stamped with, and then match nothing forever while believing
   it had checked. A NULL token means this installation has never spawned a holder, so
   nothing out there can be ours: every candidate is kept.
3. **A rejected connection is terminal in both directions** — not exited, and not killed
   either. `RowlessHolderHandshake.rejected` carries no child pid, so it *structurally
   cannot* reach the kill. A stale daemon from another checkout is a known hazard on a
   development machine, and a holder that will not talk to us is what one looks like.
4. **Keep-biased for young holders.** `OrphanGC` runs on demand from RPC handlers, so a
   sweep can land between a holder becoming connectable and its row committing. A socket
   newer than `gcGraceSeconds` is left alone whatever the other gates say — the same
   guard `HolderRendezvousCollector` applies to the same race.
5. **Kill, not adopt.** iTerm2 adopts unclaimed survivors because its live processes are
   the only copy of anything; TBD's transcripts persist independently, so adoption buys a
   mystery-session UI and cuts against the database-is-intent model.

## Gate order is a design decision, not an accident

**Age → row → handshake → owner.** The row check precedes any connect because
**connecting is not free**: a holder serves one client at a time, so probing a holder
that is mid-adoption would occupy the slot the daemon itself needs. A test asserts the
probe never fires for a claimed holder.

The row is then **re-read immediately before the kill** (`KEEP raced-row`). The gates run
against one snapshot of the session rows, and the handshake round trip that follows is a
real window in which a session being born can commit its row.

Every uncertain path keeps, each with its own named reason so a soak log is readable:
`unknown-age`, `grace`, `has-row`, `no-owner-token`, `rejected`, `no-listener`,
`unreachable`, `foreign-owner`, `no-child`, `rows-unreadable`, `raced-row`,
`row-reread-failed`, `reclaim-refused`.

## A bug this PR found in its own first cut

The late row gate was written `if let row = try? await db.terminals.get(id:)`. `try?` on
a throwing call that already returns an optional **flattens `Terminal??`**, so an
unreadable database and "no such session" arrived at the gate identically — failing in
the one direction the gate exists to prevent. It is now `do`/`catch`, and the same
reasoning is why a failed `terminals.list()` skips the phase rather than proceeding on an
empty set, which would read as "nothing is claimed" and license killing the whole fleet.

## The flag

`gc_rowless_holders_enabled`, tri-state with **no SQL `DEFAULT`**, shipped default-off in
the single `?? Config.gcRowlessHoldersEnabledDefault`. Deliberately **not** the rendezvous
flag: that one unlinks files, this one signals processes, and enabling the first must
never enable the second. `theTwoHolderGCFlagsAreIndependent` and
`theRendezvousFlagDoesNotArmTheProcessKiller` hold them apart.

Enable for soak: `tbd gc rowless-holders on`. Graduation is a one-line change to the
constant, which reaches everyone who never touched the toggle and preserves every
explicit opt-out.

`dryRun` bypasses the flag, the same shape as the three sibling phases — planning is
read-only, and somebody deciding whether to enable a default-off process killer needs to
see what enabling it would kill.

## Test plan

- [x] **RED first, explicitly.** With the collector and both test files present but
      `sweep()` not yet calling `reclaimRowlessHolders`: **15 tests / 2 suites, 19
      issues**. The live kill test failed on `childGone` and `holderGone` — a real
      `TBDHolder` and its job survived. Adding the one call turned it green.
- [x] **Mutation-checked**, each reverted in the same call:
      owner comparison removed → a real foreign holder was killed (2 tests);
      grace window removed → 1; row check moved after the handshake → the probe fired;
      the phase reading `gcHolderRendezvousEnabled` instead → 8;
      production handshake misclassifying a refusal → 1;
      `peerPID()` returning nil → 2, proving `forget` alone does not end the holder;
      the late row re-read removed → `aRowThatCommitsDuringTheHandshakeIsHonored`.
- [x] Three flag states distinguishable: a pre-migration row reads NULL (not `0`), NULL
      follows the injected default in both directions, an explicit `false` survives a
      default flip. **55 tests / 3 suites.**
- [x] New suites green: **17 tests / 2 suites.**
- [x] Full suite **9177 tests / 894 suites**; the 30 non-known failures were all
      timeout/starvation-shaped on a loaded box (`no answer after 500 polls over 98.6s of
      real time (budget 10.0s)`, `EventDrivenTestClock: zero registered sleepers`) and
      **all 30 passed re-run isolated: 111 tests / 21 suites in 11s.** None of this PR's
      suites appeared in any failure list. CI is the verdict that counts.
- [x] `swiftlint --strict` clean; `scripts/lint-migrations.py` OK (13 migrations, 7 checks).
- [ ] Soak with both `pty_holder_enabled` and `gc_rowless_holders_enabled` on, once the
      app learns the transport (Milestone B).

## Known gaps, stated rather than hidden

- **Three error branches are untested**: "session rows unreadable", "row re-read failed",
  and "reclaim refused (unanchored)". All three fail toward keeping, none is a feature
  gate, and inducing a GRDB read failure needs a fault-injection seam this PR does not
  otherwise want.
- **`WorktreeLifecycle+Reconcile` is untouched.** Its ground truth is still tmux windows,
  and the opposite direction — *holder gone → row marked exited with status unknown,
  never a fabricated `0`* — remains Milestone B work.
- Two `private static` kill helpers on `HolderRegistry` became internal so the kill has
  one implementation rather than two.

https://claude.ai/code/session_01UXqxcPYizvznh99Qb8JKrD

[20260830-boring-panda](https://cheapsteak.github.io/tbd/open/?worktree=A1E9CF50-E608-4F3C-BA8F-377D60BB7478)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added garbage collection for abandoned PTY holders without active session records.
  * Added CLI controls to enable or disable rowless-holder cleanup.
  * Added configuration persistence with a safe default of disabled.
  * Cleanup validates ownership, session claims, connection state, and grace periods before reclaiming processes.

* **Tests**
  * Added coverage for configuration behavior, safety checks, process cleanup, dry runs, and live holder scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->