### PR TITLE
Fix: The app attacks healthy holder sessions with a tmux recovery mechanic

### DIFF
--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -23,6 +23,15 @@ enum TerminalPreparationPresentation {
         "TBD couldn't attach to this terminal. The terminal was left unchanged. Check diagnostics for details or close the tab."
     static let tmuxExecutableUnavailableMessage =
         "TBD couldn't find tmux — it is not in PATH and no fallback path is saved. Locate the tmux executable in Settings → Terminal, then reopen this terminal."
+    /// Shown for a session carried by the pty-holder transport, which the app
+    /// cannot render yet.
+    ///
+    /// Deliberately offers no remedy: there is no gesture that makes this pane
+    /// draw, so any call to action would be a lie. It says the session is fine
+    /// because it is — the daemon refuses every tmux mechanic for a holder row
+    /// before touching state, so nothing was parked, killed or lost.
+    static let holderTransportMessage =
+        "This session runs on the pty-holder transport, which TBD can't display yet. The session is unaffected and keeps running."
 }
 
 enum TerminalRecoveryPresentation {
@@ -491,6 +500,67 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
             appState?.registerTerminalCloseContext(context, for: terminalID)
         }
 
+        /// The notice to render *instead of* preparing a tmux view session, or
+        /// `nil` when this transport is carried by tmux and prepares as usual.
+        ///
+        /// Consulted before `prepareSession`, so a holder-backed session never
+        /// reaches the tmux failure classifier at all. That ordering is the
+        /// point. A holder row's `tmuxWindowID` is the empty string by
+        /// construction, so tmux preparation can only ever fail for it — and
+        /// *how* it fails is decided by something unrelated to the session:
+        ///
+        /// - The repo has some other tmux-backed session alive, so its (per-repo)
+        ///   tmux server is running. The window-inventory probe succeeds and
+        ///   omits the expected id, which classifies as `.windowMissing` — the
+        ///   app then fires automatic recovery, the daemon refuses
+        ///   `terminal.recreateWindow` for a holder row, and the user gets an
+        ///   orange banner with a Retry button that can only reproduce the
+        ///   refusal.
+        /// - Every session in the repo is holder-backed, so there is no tmux
+        ///   server. The probe itself fails, which is deliberately treated as
+        ///   ambiguous and classifies as `.commandFailed` — no recovery, but
+        ///   diagnostics copy about an attach that was never possible.
+        ///
+        /// Both are the wrong story, and neither is a property of the session,
+        /// which is running normally throughout. Branching on the transport the
+        /// app already receives in `Terminal` removes the whole question.
+        nonisolated static func transportPreparationNotice(
+            for transport: TerminalTransport
+        ) -> String? {
+            guard transport == .holder else { return nil }
+            return TerminalPreparationPresentation.holderTransportMessage
+        }
+
+        /// This panel's transport, or `.tmux` when AppState has not loaded the
+        /// terminal. The fallback is the pre-existing behavior: an unresolvable
+        /// panel must keep taking the tmux path rather than be suppressed.
+        @MainActor
+        func panelTransport() -> TerminalTransport {
+            appState?.terminals.values
+                .lazy
+                .flatMap { $0 }
+                .first(where: { $0.id == panelID })?
+                .transport ?? .tmux
+        }
+
+        @MainActor
+        func transportPreparationNoticeForPanel() -> String? {
+            Self.transportPreparationNotice(for: panelTransport())
+        }
+
+        /// Renders the transport notice and reports whether it took over.
+        /// `true` means the caller must not prepare or attach anything.
+        @MainActor
+        private func handleUnsupportedTransport(into terminalView: TerminalView) -> Bool {
+            guard let notice = transportPreparationNoticeForPanel() else { return false }
+            let worktreeID = worktreeIDForDiagnostics()?.uuidString ?? "unknown"
+            logger.info(
+                "terminal preparation skipped terminal=\(self.panelID, privacy: .public) worktree=\(worktreeID, privacy: .public) category=unsupportedTransport transport=\(self.panelTransport().rawValue, privacy: .public)"
+            )
+            feedPreparationMessage(notice, into: terminalView)
+            return true
+        }
+
         nonisolated static func preparationAction(
             for result: Result<TmuxSessionPreparation, TmuxPreparationFailure>
         ) -> TerminalPreparationAction {
@@ -700,6 +770,10 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
             // already ran; only deinit would remove the monitors, nothing
             // would terminate the process).
             guard ControlModeAttachAbort.shouldStartFallback(tornDown: isTornDown) else { return }
+            // A session this app cannot carry through tmux is settled here,
+            // before any tmux subprocess runs and before any classification —
+            // see `transportPreparationNotice(for:)`.
+            if handleUnsupportedTransport(into: terminalView) { return }
             // `prepareSession` is non-isolated and awaits tmux subprocesses
             // off the main actor — Swift releases main while we suspend here,
             // so SwiftUI's render loop is no longer blocked while tmux runs.
@@ -1041,6 +1115,11 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
             windowID: String,
             panelID: UUID
         ) async {
+            // Same gate as the grouped-sessions path: a holder-backed session
+            // has no pane for control mode to attach to either, and falling
+            // through to the fallback would only reach the tmux classifier by a
+            // longer route.
+            if handleUnsupportedTransport(into: terminalView) { return }
             // Reader-registry key: one reader per PANE (worktree/pane), not per
             // attach — a re-attach replaces the pane's reader. Distinct from
             // the sidecar's per-request demux key, which also carries the

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -1430,11 +1430,14 @@ extension RPCRouter {
         // holder branch is (see `handleTerminalOutput`): everything downstream
         // exists only to name a tmux server and window this row does not have.
         //
-        // This handler is reached automatically, not only by the Retry button:
-        // the app is transport-blind, so a holder tab whose repo happens to
-        // have a tmux server running for any other reason classifies as
-        // `.windowMissing` and fires automatic recovery. Both downstream
-        // branches would then act on `tmuxWindowID == ""`, which
+        // The current app no longer calls this for a holder row — it settles
+        // such a panel on the transport before tmux preparation runs (see
+        // `transportPreparationNotice` in `TerminalPanelView`), so neither its
+        // automatic nor its manual path reaches here. That gate spares the user
+        // a doomed round trip; it does not retire this guard, which is the only
+        // thing standing between a holder row and the CLI, an older app build,
+        // or any future caller. Both downstream branches would then act on
+        // `tmuxWindowID == ""`, which
         // `TmuxManager.windowExists` can only ever answer "gone" for — parking
         // a resumable row whose holder and child are still running, or standing
         // up a tmux window under a row that still reads `transport == .holder`.

--- a/Tests/TBDAppTests/TerminalHolderTransportGateTests.swift
+++ b/Tests/TBDAppTests/TerminalHolderTransportGateTests.swift
@@ -1,0 +1,285 @@
+import AppKit
+import Foundation
+import SwiftTerm
+import Testing
+@testable import TBDApp
+import TBDShared
+
+/// Tier 2: drives the **two real attach entry points** —
+/// `Coordinator.startTmuxClient` and `Coordinator.startControlModeClient` —
+/// for a holder-backed panel, and requires that neither reaches the machinery
+/// behind it.
+///
+/// `TerminalPanelViewTests` covers the pure decision function
+/// (`transportPreparationNotice(for:)`) and the `panelTransport()` lookup under
+/// it. Those would all stay green if someone deleted or reordered the
+/// `if handleUnsupportedTransport(into:) { return }` line at the top of either
+/// attach path, which is the whole defect this gate exists to prevent — a
+/// holder row would go back to being classified as a broken tmux window and
+/// the false "recovery" banner would return. So the assertions here are about
+/// **what did not run**, observed on the production call path:
+///
+/// - **No tmux command was issued.** `TmuxBridge` takes an injected
+///   `TmuxCommandRunner`; a holder panel must leave its log empty. This is the
+///   discriminator for `startTmuxClient`: dropping its guard sends
+///   `prepareSession` straight into `kill-session` / `new-session`.
+/// - **No control-mode attach was requested.** `startControlModeClient`'s
+///   failure path unconditionally clears two pieces of state before it falls
+///   back — the view's `onControlModePaste` interceptor and the pane's
+///   `controlModeAttachedPanes` record. Both are seeded here as probes, so a
+///   holder panel that leaves them untouched has demonstrably never called
+///   `openAttach`. Dropping that guard clears both, and the tmux recorder
+///   cannot see it: the fallback lands in `startTmuxClient`, whose own guard
+///   still suppresses tmux. The probes are the only thing that separates the
+///   two mutations.
+///
+/// Each gate also has a positive control on the same entry point with a
+/// `.tmux` panel, so a gate that suppressed *everything* would fail too.
+///
+/// **Nothing here talks to a live daemon or a live tmux.** Every tmux command
+/// goes through the recorder (the resolver points at a stub binary the runner
+/// never executes), and the control-mode positive control's `openAttach` runs
+/// against `TBD_SOCKET_PATH`, which `scripts/test.sh` fences onto a scratch
+/// path with no listener — the connect fails with ENOENT and returns at once.
+@Suite("A holder-backed panel is gated out of both attach paths", .timeLimit(.minutes(1)))
+struct TerminalHolderTransportGateTests {
+
+    /// Records every tmux invocation and refuses all of them, so a preparation
+    /// that does run fails at `new-session` and classifies as `.commandFailed`
+    /// without spawning a viewer process.
+    private actor RefusingTmuxRunner {
+        private(set) var invocations: [[String]] = []
+
+        func run(args: [String]) -> TmuxCommandOutcome {
+            invocations.append(args)
+            return TmuxCommandOutcome(success: false, output: "fixture refuses every tmux command")
+        }
+
+        func recorded() -> [[String]] { invocations }
+    }
+
+    /// A panel wired the way production wires one, plus the bridge whose
+    /// command log is the "did any tmux mechanic run" verdict.
+    @MainActor
+    private struct Panel {
+        let state: AppState
+        let coordinator: TerminalPanelRepresentable.Coordinator
+        let view: TBDTerminalView
+        let bridge: TmuxBridge
+        let runner: RefusingTmuxRunner
+        let worktreeID: UUID
+        let terminalID: UUID
+        let defaults: UserDefaults
+        let defaultsSuiteName: String
+    }
+
+    private static let paneID = "%1"
+    private static let windowID = "@1"
+    private static let server = "tbd-fixture"
+
+    @MainActor
+    private func makePanel(
+        transport: TerminalTransport,
+        fixture: TmuxBridgeFixture
+    ) throws -> Panel {
+        let worktreeID = UUID()
+        let terminalID = UUID()
+        let state = AppState()
+        // A holder row carries EMPTY tmux coordinates by construction — the v1
+        // schema's NOT NULL columns cannot be relaxed — so the gate must
+        // discriminate on `transport` alone, never on those strings.
+        let isHolder = transport == .holder
+        state.terminals[worktreeID] = [Terminal(
+            id: terminalID,
+            worktreeID: worktreeID,
+            tmuxWindowID: isHolder ? "" : Self.windowID,
+            tmuxPaneID: isHolder ? "" : Self.paneID,
+            label: "Shell",
+            kind: .shell,
+            transport: transport
+        )]
+
+        // Isolated defaults: AppearanceSettings must never read or write the
+        // developer's real TBDApp.plist.
+        let suiteName = "TBDAppTests.HolderTransportGate.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        let view = TBDTerminalView(
+            frame: CGRect(x: 0, y: 0, width: 600, height: 300),
+            font: TBDTerminalView.defaultMonospaceFont,
+            appearance: AppearanceSettings(defaults: defaults)
+        )
+
+        let runner = RefusingTmuxRunner()
+        let bridge = TmuxBridge(
+            tmuxExecutableResolver: try fixture.resolvingResolver(),
+            commandRunner: { _, _, args in await runner.run(args: args) }
+        )
+
+        let coordinator = TerminalPanelRepresentable.Coordinator()
+        coordinator.appState = state
+        coordinator.panelID = terminalID
+        coordinator.tmuxBridge = bridge
+        coordinator.tmuxServer = Self.server
+
+        return Panel(
+            state: state,
+            coordinator: coordinator,
+            view: view,
+            bridge: bridge,
+            runner: runner,
+            worktreeID: worktreeID,
+            terminalID: terminalID,
+            defaults: defaults,
+            defaultsSuiteName: suiteName
+        )
+    }
+
+    @MainActor
+    private func tearDown(_ panel: Panel) {
+        panel.defaults.removePersistentDomain(forName: panel.defaultsSuiteName)
+    }
+
+    /// Whether `message` had already been fed into the panel.
+    ///
+    /// `shouldFeedPreparationMessage` is the once-per-coordinator set the
+    /// production feed path itself consults, so "already present" is exactly
+    /// "this message was fed". The query **consumes** its answer (it inserts),
+    /// so ask about any one message at most once per coordinator.
+    @MainActor
+    private func didFeed(_ message: String, _ panel: Panel) -> Bool {
+        !panel.coordinator.shouldFeedPreparationMessage(message)
+    }
+
+    // MARK: - startTmuxClient
+
+    @MainActor
+    @Test("startTmuxClient issues no tmux command at all for a holder-backed panel")
+    func startTmuxClientRunsNoTmuxCommandForHolderPanel() async throws {
+        let fixture = try TmuxBridgeFixture()
+        defer { fixture.remove() }
+        let panel = try makePanel(transport: .holder, fixture: fixture)
+        defer { tearDown(panel) }
+
+        await panel.coordinator.startTmuxClient(
+            terminalView: panel.view,
+            bridge: panel.bridge,
+            server: Self.server,
+            windowID: "",
+            panelID: panel.terminalID
+        )
+
+        // The discriminator: `prepareSession`'s very first act is a
+        // pre-emptive `kill-session`, so a single recorded invocation means
+        // the guard did not run first.
+        let recorded = await panel.runner.recorded()
+        #expect(recorded.isEmpty,
+                "a holder-backed panel must reach no tmux mechanic whatsoever, ran \(recorded)")
+        #expect(panel.coordinator.localProcess == nil,
+                "no viewer process may be started for a transport the app cannot render")
+        #expect(didFeed(TerminalPreparationPresentation.holderTransportMessage, panel),
+                "the panel must explain itself with the holder notice")
+    }
+
+    @MainActor
+    @Test("startTmuxClient still prepares a tmux-backed panel through tmux")
+    func startTmuxClientStillPreparesTmuxPanel() async throws {
+        let fixture = try TmuxBridgeFixture()
+        defer { fixture.remove() }
+        let panel = try makePanel(transport: .tmux, fixture: fixture)
+        defer { tearDown(panel) }
+
+        await panel.coordinator.startTmuxClient(
+            terminalView: panel.view,
+            bridge: panel.bridge,
+            server: Self.server,
+            windowID: Self.windowID,
+            panelID: panel.terminalID
+        )
+
+        let recorded = await panel.runner.recorded()
+        #expect(!recorded.isEmpty,
+                "the gate must not suppress the tmux path it does not own")
+        #expect(!didFeed(TerminalPreparationPresentation.holderTransportMessage, panel),
+                "the holder notice must never appear on a tmux-backed panel")
+        // The refusing runner makes preparation fail at `new-session`, which
+        // classifies as `.commandFailed` — the pre-existing copy, unchanged.
+        #expect(didFeed(TerminalPreparationPresentation.commandFailedMessage, panel))
+    }
+
+    // MARK: - startControlModeClient
+
+    @MainActor
+    @Test("startControlModeClient requests no attach at all for a holder-backed panel")
+    func startControlModeClientRequestsNoAttachForHolderPanel() async throws {
+        let fixture = try TmuxBridgeFixture()
+        defer { fixture.remove() }
+        let panel = try makePanel(transport: .holder, fixture: fixture)
+        defer { tearDown(panel) }
+
+        // Two probes for state the attach path clears unconditionally on its
+        // failure route, before it falls back. Surviving both is the evidence
+        // that `openAttach` was never called — the tmux recorder cannot show
+        // it, because the fallback's own guard would suppress tmux anyway.
+        panel.view.onControlModePaste = { _ in true }
+        panel.state.controlModePaneAttached(
+            worktreeID: panel.worktreeID, paneID: Self.paneID, generation: nil)
+        let paneKey = ControlModePaneKey(worktreeID: panel.worktreeID, paneID: Self.paneID)
+
+        await panel.coordinator.startControlModeClient(
+            terminalView: panel.view,
+            appState: panel.state,
+            worktreeID: panel.worktreeID,
+            paneID: Self.paneID,
+            bridge: panel.bridge,
+            server: Self.server,
+            windowID: "",
+            panelID: panel.terminalID
+        )
+
+        #expect(panel.view.onControlModePaste != nil,
+                "the attach path's failure teardown ran, so an attach was attempted")
+        #expect(panel.state.controlModeAttachedPanes.index(forKey: paneKey) != nil,
+                "the attach path's failure teardown ran, so an attach was attempted")
+        let recorded = await panel.runner.recorded()
+        #expect(recorded.isEmpty,
+                "the grouped-sessions fallback must not be reached either, ran \(recorded)")
+        #expect(didFeed(TerminalPreparationPresentation.holderTransportMessage, panel),
+                "the panel must explain itself with the holder notice")
+    }
+
+    @MainActor
+    @Test("startControlModeClient still attempts an attach for a tmux-backed panel")
+    func startControlModeClientStillAttemptsAttachForTmuxPanel() async throws {
+        let fixture = try TmuxBridgeFixture()
+        defer { fixture.remove() }
+        let panel = try makePanel(transport: .tmux, fixture: fixture)
+        defer { tearDown(panel) }
+
+        panel.view.onControlModePaste = { _ in true }
+        panel.state.controlModePaneAttached(
+            worktreeID: panel.worktreeID, paneID: Self.paneID, generation: nil)
+        let paneKey = ControlModePaneKey(worktreeID: panel.worktreeID, paneID: Self.paneID)
+
+        await panel.coordinator.startControlModeClient(
+            terminalView: panel.view,
+            appState: panel.state,
+            worktreeID: panel.worktreeID,
+            paneID: Self.paneID,
+            bridge: panel.bridge,
+            server: Self.server,
+            windowID: Self.windowID,
+            panelID: panel.terminalID
+        )
+
+        // There is no daemon behind the fenced socket, so the attach fails and
+        // its teardown clears both probes on the way to the fallback. That is
+        // the pre-existing behavior the gate must leave alone.
+        #expect(panel.view.onControlModePaste == nil)
+        #expect(panel.state.controlModeAttachedPanes.index(forKey: paneKey) == nil)
+        let recorded = await panel.runner.recorded()
+        #expect(!recorded.isEmpty,
+                "the grouped-sessions fallback must still run for a tmux-backed panel")
+        #expect(!didFeed(TerminalPreparationPresentation.holderTransportMessage, panel),
+                "the holder notice must never appear on a tmux-backed panel")
+    }
+}

--- a/Tests/TBDAppTests/TerminalPanelViewTests.swift
+++ b/Tests/TBDAppTests/TerminalPanelViewTests.swift
@@ -40,6 +40,13 @@ struct TerminalPanelViewTests {
     }
 
     // MARK: - Transport gate (holder-backed sessions are not a tmux mechanic)
+    //
+    // These cover the pure decision (`transportPreparationNotice(for:)`) and
+    // the `panelTransport()` lookup under it, and nothing more: they would all
+    // stay green if the `handleUnsupportedTransport` guard were dropped from
+    // either attach path. `TerminalHolderTransportGateTests` is the suite that
+    // drives `startTmuxClient` and `startControlModeClient` themselves and
+    // pins that the guard is actually called, and called first.
 
     @Test("a holder-backed session is never prepared through tmux")
     func holderTransportSkipsTmuxPreparation() {

--- a/Tests/TBDAppTests/TerminalPanelViewTests.swift
+++ b/Tests/TBDAppTests/TerminalPanelViewTests.swift
@@ -39,6 +39,78 @@ struct TerminalPanelViewTests {
         #expect(action == .requestAutomaticRecovery(failedStage: .selectWindow))
     }
 
+    // MARK: - Transport gate (holder-backed sessions are not a tmux mechanic)
+
+    @Test("a holder-backed session is never prepared through tmux")
+    func holderTransportSkipsTmuxPreparation() {
+        #expect(TerminalPanelRepresentable.Coordinator.transportPreparationNotice(for: .holder) ==
+            "This session runs on the pty-holder transport, which TBD can't display yet. The session is unaffected and keeps running.")
+    }
+
+    @Test("a tmux-backed session still prepares through tmux")
+    func tmuxTransportStillPreparesThroughTmux() {
+        #expect(TerminalPanelRepresentable.Coordinator.transportPreparationNotice(for: .tmux) == nil)
+    }
+
+    @Test("the holder notice replaces the copy of BOTH tmux failure classifications")
+    func holderNoticeReplacesBothClassificationMessages() {
+        // A holder row's tmux preparation fails either way, and *which* way
+        // depends on whether an unrelated tmux server happens to be running for
+        // the repo: `.windowMissing` (recovery + Retry banner) when one is,
+        // `.commandFailed` (diagnostics copy) when none is. Neither classifier's
+        // copy may survive for a holder row.
+        let notice = TerminalPanelRepresentable.Coordinator.transportPreparationNotice(for: .holder)
+        #expect(notice != nil)
+        #expect(notice != TerminalPreparationPresentation.commandFailedMessage)
+        #expect(notice != TerminalPreparationPresentation.tmuxExecutableUnavailableMessage)
+        #expect(notice != TerminalRecoveryPresentation.failedMessage)
+        #expect(notice != TerminalRecoveryPresentation.exhaustedMessage)
+    }
+
+    @MainActor
+    @Test("a holder-backed terminal short-circuits preparation before tmux classification")
+    func holderTerminalShortCircuitsPreparation() {
+        let state = AppState()
+        let terminalID = UUID()
+        seedTerminal(terminalID, in: state, transport: .holder)
+
+        let coordinator = TerminalPanelRepresentable.Coordinator()
+        coordinator.appState = state
+        coordinator.panelID = terminalID
+
+        #expect(coordinator.panelTransport() == .holder)
+        #expect(coordinator.transportPreparationNoticeForPanel() ==
+            TerminalPreparationPresentation.holderTransportMessage)
+    }
+
+    @MainActor
+    @Test("a tmux-backed terminal is unaffected by the transport gate")
+    func tmuxTerminalIsUnaffectedByTransportGate() {
+        let state = AppState()
+        let terminalID = UUID()
+        seedTerminal(terminalID, in: state, transport: .tmux)
+
+        let coordinator = TerminalPanelRepresentable.Coordinator()
+        coordinator.appState = state
+        coordinator.panelID = terminalID
+
+        #expect(coordinator.panelTransport() == .tmux)
+        #expect(coordinator.transportPreparationNoticeForPanel() == nil)
+    }
+
+    @MainActor
+    @Test("an unresolvable terminal falls back to the tmux path")
+    func unresolvableTerminalFallsBackToTmuxPath() {
+        // AppState has not loaded this terminal (or it was removed). The gate
+        // must not invent a holder row and suppress a real tmux panel.
+        let coordinator = TerminalPanelRepresentable.Coordinator()
+        coordinator.appState = AppState()
+        coordinator.panelID = UUID()
+
+        #expect(coordinator.panelTransport() == .tmux)
+        #expect(coordinator.transportPreparationNoticeForPanel() == nil)
+    }
+
     @Test("prepared session starts the viewer")
     func preparedSessionStartsViewer() {
         let prepared = TmuxPreparedSession(
@@ -471,15 +543,21 @@ struct TerminalPanelViewTests {
     private func seedTerminal(
         _ terminalID: UUID,
         in state: AppState,
-        worktreeID: UUID = UUID()
+        worktreeID: UUID = UUID(),
+        transport: TerminalTransport = .tmux
     ) {
+        // A holder row carries EMPTY tmux coordinates by construction — the v1
+        // schema's NOT NULL columns cannot be relaxed — so it must be
+        // discriminated by `transport` alone, never by those strings.
+        let isHolder = transport == .holder
         state.terminals[worktreeID] = [Terminal(
             id: terminalID,
             worktreeID: worktreeID,
-            tmuxWindowID: "@1",
-            tmuxPaneID: "%1",
+            tmuxWindowID: isHolder ? "" : "@1",
+            tmuxPaneID: isHolder ? "" : "%1",
             label: "Shell",
-            kind: .shell
+            kind: .shell,
+            transport: transport
         )]
     }
 }


### PR DESCRIPTION
## Summary

With `pty_holder_enabled` on, opening a holder-backed tab shows a black pane reading
*"Automatic terminal recovery failed. Retry manually or close the tab."* under an orange banner
with a **Retry** button that reproduces the same refusal. None of that is true: the session is
running fine, nothing died, and Retry cannot ever succeed.

The cause is that the app has never learned the transport. `Sources/TBDApp` contains zero
references to `TerminalTransport`, and `Terminal.transport` — already decoded into the app's model —
is read nowhere. So a holder row goes down the tmux preparation path, which can only fail for it,
and the app then attacks a healthy session with a tmux mechanic.

Measured behavior, causes and boundaries are in the companion evidence report
([#784](../pull/784), `docs/specs/2026-09-01-holder-app-gap-findings.md`).

## What this changes

The app now settles a holder panel on the transport **before** preparing, so neither tmux
classification is reached:

- `Coordinator.transportPreparationNotice(for:)` — `nonisolated static`, pure: a notice for
  `.holder`, `nil` for `.tmux`. Testable without an `NSView`, matching the pure-decision seam the
  surrounding code already uses (`OutgoingInputRoute`, `ControlModeResizeGate`, `preparationAction`).
- `Coordinator.panelTransport()` reads `Terminal.transport` from `AppState`, falling back to
  `.tmux` when the terminal is not loaded.
- `Coordinator.handleUnsupportedTransport(into:)` renders the notice and reports that it took over.
  It is the first statement of **both** attach paths — `startTmuxClient` **and**
  `startControlModeClient` — and `TerminalHolderTransportGateTests` drives both entry points to pin
  that placement (see Test plan).

`preparationAction(for:)` is deliberately untouched: making the classifier transport-aware would
leave it reachable and require both call paths to agree. It still classifies tmux failures exactly
as before.

## Why the gate sits upstream of `prepareSession`

Two classifications produce this pane, and they depend on something unrelated to the holder — a
live tmux server for that repo, which is per-repo:

- a repo with any tmux-backed session alive → `.windowMissing` → automatic recovery + Retry
- a repo whose sessions are all holder-backed → `.commandFailed` → no recovery, different copy

Branching on the transport *above* `prepareSession` means neither is reached, so one guard covers
both **by construction** rather than by two parallel handlings. It also removes the doomed tmux
subprocesses, not just the doomed `terminal.recreateWindow` RPC. A fix covering only
`.windowMissing` would leave fresh installs — which have no tmux server at all — still broken.

The evidence report named `TmuxBridge.prepare` as the only route to a rendered pane. It is not:
`startControlModeClient` is a second, reached when `daemonCapabilities.controlModeEnabled` is on.
It resolves a holder row's pane id to the empty string and would attach on it. Both are gated.

## The copy

> This session runs on the pty-holder transport, which TBD can't display yet. The session is
> unaffected and keeps running.

It names the real reason and states the session is fine — which the evidence report established
measurably, not aspirationally. It deliberately ends **without** a call to action: every
neighbouring message ends in one ("close the tab", "Locate the tmux executable…"), but here no
gesture makes the pane draw, so any remedy would be false. The Retry banner disappears for free —
it is driven by `recoveryGuidanceMessage`, which only the recovery branch sets, and that branch is
now unreachable for holder rows.

## No flag

This is a correctness fix, not a feature: it stops the app doing something wrong to a session that
already exists only when `pty_holder_enabled` is on. Gating a fix behind a second flag would sprawl
flags to no benefit.

## Test plan

Two suites, and the split between them matters — the first cannot pin the second's property.

**`TerminalHolderTransportGateTests` (new) — the attach paths themselves.** Drives
`Coordinator.startTmuxClient` and `Coordinator.startControlModeClient` on a headless coordinator
and asserts what did **not** run, so deleting or reordering either
`if handleUnsupportedTransport(into: terminalView) { return }` reddens a named test:

- `startTmuxClientRunsNoTmuxCommandForHolderPanel` — `TmuxBridge` takes an injected
  `TmuxCommandRunner`; a holder panel must leave its log empty.
- `startControlModeClientRequestsNoAttachForHolderPanel` — the recorder cannot see this one (the
  attach failure falls back into `startTmuxClient`, whose own guard still suppresses tmux), so the
  test seeds two probes the attach path's failure teardown clears unconditionally — the view's
  `onControlModePaste` interceptor and the pane's `controlModeAttachedPanes` record — and requires
  both to survive. They survive only if `openAttach` was never called.
- `startTmuxClientStillPreparesTmuxPanel` and `startControlModeClientStillAttemptsAttachForTmuxPanel`
  are the positive controls on the same entry points: a gate that suppressed everything fails too.

Nothing in the suite reaches a live daemon or a live tmux — every tmux command goes through the
recorder, and `openAttach` runs against the socket path `scripts/test.sh` fences onto a scratch dir.

**`TerminalPanelViewTests` (extended) — the pure decision.** Six legs over
`transportPreparationNotice(for:)` and the `panelTransport()` lookup: holder vs tmux vs an
unresolvable panel, and a dedicated test pinning that neither tmux classifier's copy can survive
for a holder row. **These do not reach the attach paths and cannot**; a comment in the file now
says so and points at the suite that does.

- [x] **Mutation-checked one guard at a time, on the finished tree.**
  - Guard removed from `startTmuxClient` only → **only**
    `startTmuxClientRunsNoTmuxCommandForHolderPanel` reddens:
    `Expectation failed: (recorded → [["kill-session", …], ["new-session", …], ["has-session", …]]).isEmpty → false`.
  - Guard removed from `startControlModeClient` only → **only**
    `startControlModeClientRequestsNoAttachForHolderPanel` reddens:
    `Expectation failed: (panel.view.onControlModePaste → nil) != nil` and
    `Expectation failed: (panel.state.controlModeAttachedPanes.index(forKey: paneKey) → nil) != nil`.
  - All six pure legs in `TerminalPanelViewTests` stayed **green through both mutations** — which is
    exactly why the second suite exists. Guards restored verbatim; `git diff HEAD -- Sources/` is
    empty.
- [x] Both branches of the new conditional tested on both entry points: holder is settled before any
  tmux command or attach request, and a tmux-backed panel still prepares / still attaches.
- [x] Both tmux classifications covered, pinning that neither classifier's copy can survive for a
  holder row.
- [x] `scripts/test.sh --filter 'TerminalPanelViewTests|TerminalHolderTransportGateTests'` →
  **32 tests in 2 suites passed**, including the untouched
  `confirmed missing window requests automatic recovery`,
  `generic command failure renders diagnostics guidance without recovery`, and
  `unresolvable tmux executable names the remedy instead of diagnostics`. Re-run with
  `--fingerprint` over the ten transport-gate legs: 10 tests in 2 suites passed, no real store
  touched.
- [x] `scripts/swift-safe build --build-tests` exit 0; `swiftlint --strict` 0 violations in 909 files.
- [x] Full suite run; every non-known failure was a 60 s main-actor time limit or a debounce timing
      assert under saturation, and all passed re-run isolated (**68 tests in 12 suites, 2.1 s**).
      CI is the verdict that counts.
- [ ] Visual confirmation with the flag on, once the app can render a holder pane (Milestone B).

## Note

`RPCRouter+TerminalHandlers.swift` changes by one comment only. Its rationale asserted "the app is
transport-blind", which this PR makes false. The daemon guard itself stands unchanged — it still
covers the CLI and older app builds. **No second daemon guard was added**; the defect was on the
app side of the classification.

https://claude.ai/code/session_01UXqxcPYizvznh99Qb8JKrD

[20260830-boring-panda](https://cheapsteak.github.io/tbd/open/?worktree=A1E9CF50-E608-4F3C-BA8F-377D60BB7478)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Holder-backed terminal sessions now avoid unsupported tmux preparation and control-mode attachment.
  - These sessions display an explanatory message confirming that the underlying session remains unaffected.
  - Terminal sessions with unresolved metadata continue using the existing tmux fallback behavior.
  - Grouped-session and control-mode startup now consistently apply transport checks before connecting.
  - Tmux-backed sessions continue to use their existing preparation and control-mode fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
