### PR TITLE
Fix: A re-adopted holder session came back at the wrong size, and never let go

### DIFF
--- a/Sources/TBDDaemon/Holder/HolderReader.swift
+++ b/Sources/TBDDaemon/Holder/HolderReader.swift
@@ -85,6 +85,8 @@ actor HolderReader {
     private let emulator: HolderEmulator
     private let stopTimeout: Duration
     private let clock: any Clock<Duration>
+    /// Handed to the drain loop when it starts; see `init`.
+    private let onEndOfOutput: (@Sendable () -> Void)?
 
     private var state: State = .idle
     /// The write end of the self-pipe that wakes a blocked `poll`. Held by the
@@ -100,6 +102,10 @@ actor HolderReader {
     ///   throughout still says "pty master", which is what `forkpty` calls it.
     /// - Parameter readFault: a test seam. Production passes nothing; see
     ///   `HolderReadFault` for why the branch it reaches has no other way in.
+    /// - Parameter onEndOfOutput: announced once, on the drain thread, when the
+    ///   session's output is exhausted — see `hasReachedEndOfOutput`. It must
+    ///   not block, and must not stop this reader inline; the registry's
+    ///   reclaimer hops onto the actor instead.
     init(
         sessionID: UUID,
         ptyFD: Int32,
@@ -108,11 +114,13 @@ actor HolderReader {
         scrollbackLines: Int = HolderReader.scrollbackLines,
         stopTimeout: Duration = HolderReader.defaultStopTimeout,
         readFault: HolderReadFault? = nil,
+        onEndOfOutput: (@Sendable () -> Void)? = nil,
         clock: any Clock<Duration> = ContinuousClock()
     ) {
         self.sessionID = sessionID
         self.stopTimeout = stopTimeout
         self.clock = clock
+        self.onEndOfOutput = onEndOfOutput
         let descriptor = PTYDescriptor(fd: ptyFD, readFault: readFault)
         self.descriptor = descriptor
         // The emulator's replies go straight back down the same descriptor.
@@ -163,6 +171,53 @@ actor HolderReader {
         return !drain.isFinished
     }
 
+    /// Whether the drain has reached the end of this session's output — end of
+    /// file on the pty master, or a read failure no waiting can undo.
+    ///
+    /// **It is the only safe moment to let go of a session's output**, and that
+    /// is what it is for. The drain reads until the descriptor would block
+    /// before it can ever see end of file, so once this is true nothing the job
+    /// wrote is still queued anywhere; before it is true, whatever is queued is
+    /// still owed to somebody. `HolderRegistry` releases a finished session's
+    /// reader on exactly this edge.
+    ///
+    /// Reads the drain thread's own flag rather than the actor's intent, for
+    /// the same reason `isDraining` does.
+    var hasReachedEndOfOutput: Bool {
+        drain?.hasReachedEndOfOutput ?? false
+    }
+
+    /// The emulator's grid, in columns and rows.
+    ///
+    /// Test-facing, and the honest instrument for adoption geometry: a
+    /// re-adopted session whose grid does not match its pty is a job painting
+    /// into a differently-shaped screen, and nothing else in the daemon can see
+    /// the difference.
+    var gridSize: (columns: Int, rows: Int) {
+        emulator.size
+    }
+
+    /// The window size the pty itself reports, or nil when the ioctl fails or
+    /// answers a degenerate size.
+    ///
+    /// **The pty is the authority on its own geometry.** A launch request
+    /// records the size a session was *asked* for once, and nothing updates it
+    /// afterwards; `TIOCSWINSZ` — which every resize goes through — moves the
+    /// terminal itself. So anything reconstructing a session's screen asks the
+    /// descriptor, not the request that opened it.
+    ///
+    /// The parameter is spelled `ptyFD` for the reason given on `init`.
+    static func windowSize(ptyFD: Int32) -> (columns: Int, rows: Int)? {
+        guard ptyFD >= 0 else { return nil }
+        var size = winsize(ws_row: 0, ws_col: 0, ws_xpixel: 0, ws_ypixel: 0)
+        guard ioctl(ptyFD, TIOCGWINSZ, &size) == 0 else { return nil }
+        // A zero in either axis is not a size a grid can be built at, and a
+        // terminal that has never been sized reports one. Answering nil sends
+        // the caller to its fallback rather than to `max(1, 0)`.
+        guard size.ws_col > 0, size.ws_row > 0 else { return nil }
+        return (Int(size.ws_col), Int(size.ws_row))
+    }
+
     // MARK: - Lifecycle
 
     /// Starts draining. Idempotent; a stopped reader stays stopped.
@@ -183,7 +238,8 @@ actor HolderReader {
             sessionID: sessionID,
             descriptor: descriptor,
             emulator: emulator,
-            wakeReadFD: pipeFDs[0])
+            wakeReadFD: pipeFDs[0],
+            onEndOfOutput: onEndOfOutput)
         drain = loop
         state = .draining
 
@@ -337,20 +393,55 @@ private final class DrainLoop: @unchecked Sendable {
     private let descriptor: PTYDescriptor
     private let emulator: HolderEmulator
     private let wakeReadFD: Int32
+    /// Announced once, the first time the descriptor is classified as
+    /// exhausted. Called **on the drain thread**, so it must not block: the
+    /// thread's next job is to keep answering the wake pipe, and a reclaimer
+    /// that stopped this reader from inside the callback would be waiting on
+    /// the very thread it is running on.
+    private let onEndOfOutput: (@Sendable () -> Void)?
     private let stateLock = NSLock()
     private var finished = false
+    private var endOfOutput = false
 
-    init(sessionID: UUID, descriptor: PTYDescriptor, emulator: HolderEmulator, wakeReadFD: Int32) {
+    init(
+        sessionID: UUID,
+        descriptor: PTYDescriptor,
+        emulator: HolderEmulator,
+        wakeReadFD: Int32,
+        onEndOfOutput: (@Sendable () -> Void)? = nil
+    ) {
         self.sessionID = sessionID
         self.descriptor = descriptor
         self.emulator = emulator
         self.wakeReadFD = wakeReadFD
+        self.onEndOfOutput = onEndOfOutput
     }
 
     var isFinished: Bool {
         stateLock.lock()
         defer { stateLock.unlock() }
         return finished
+    }
+
+    var hasReachedEndOfOutput: Bool {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return endOfOutput
+    }
+
+    /// Records the exhausted edge and announces it exactly once.
+    ///
+    /// Once, because the announcement is a *transition* — a second one for the
+    /// same reader would ask a reclaimer to reclaim what it has already
+    /// reclaimed, and the reader whose slot it names may by then be a different
+    /// one.
+    private func noteEndOfOutput() {
+        stateLock.lock()
+        let firstTime = !endOfOutput
+        endOfOutput = true
+        stateLock.unlock()
+        guard firstTime else { return }
+        onEndOfOutput?()
     }
 
     func run() {
@@ -467,6 +558,11 @@ private final class DrainLoop: @unchecked Sendable {
             canYield = false
             failures = 0
             backoff = 0
+            // Announced only from here, which is the one place the loop knows
+            // the descriptor was read until it would block and then said it was
+            // done. Everything the job wrote has reached the emulator; nothing
+            // more ever will.
+            noteEndOfOutput()
         case .retryable(let code):
             failures += 1
             backoff = Self.backoffMilliseconds(forAttempt: failures)
@@ -819,6 +915,11 @@ private final class HolderEmulator: @unchecked Sendable {
         terminal.terminalLock.withLock {
             terminal.resize(cols: columns, rows: rows)
         }
+    }
+
+    /// The grid's dimensions, read under the same lock as everything else here.
+    var size: (columns: Int, rows: Int) {
+        terminal.terminalLock.withLock { (terminal.cols, terminal.rows) }
     }
 
     /// Trailing blank lines are dropped — a screen is 24 rows whether or not

--- a/Sources/TBDDaemon/Holder/HolderRegistry.swift
+++ b/Sources/TBDDaemon/Holder/HolderRegistry.swift
@@ -302,7 +302,10 @@ actor HolderRegistry {
         let adoption: Adoption
         do {
             adoption = try await Self.take(
-                terminalID: terminalID, over: spawned.client, expecting: owner)
+                terminalID: terminalID,
+                over: spawned.client,
+                expecting: owner,
+                onEndOfOutput: endOfOutputNotifier(for: terminalID))
         } catch {
             // The holder is up and supervising a job that no row will ever
             // name, so leaving it would orphan both. Best-effort, and the
@@ -595,13 +598,15 @@ actor HolderRegistry {
         let expected = owner
         let budget = busyRetryBudget
         let clock = self.clock
+        let notifyEndOfOutput = endOfOutputNotifier(for: terminalID)
         let task = Task<Adoption, Swift.Error> {
             try await Self.attach(
                 terminalID: terminalID,
                 socketPath: socketPath,
                 expecting: expected,
                 busyRetryBudget: budget,
-                clock: clock)
+                clock: clock,
+                onEndOfOutput: notifyEndOfOutput)
         }
         attachRoundTripsStarted += 1
         slots[terminalID] = .adopting(task)
@@ -761,13 +766,17 @@ actor HolderRegistry {
         socketPath: String,
         expecting owner: HolderOwnerToken,
         busyRetryBudget: Duration,
-        clock: any Clock<Duration>
+        clock: any Clock<Duration>,
+        onEndOfOutput: (@Sendable () -> Void)?
     ) async throws -> Adoption {
         var waited: Duration = .zero
         while true {
             do {
                 return try await attemptAttach(
-                    terminalID: terminalID, socketPath: socketPath, expecting: owner)
+                    terminalID: terminalID,
+                    socketPath: socketPath,
+                    expecting: owner,
+                    onEndOfOutput: onEndOfOutput)
             } catch HolderClient.Error.rejected(let version) {
                 guard waited < busyRetryBudget else {
                     throw HolderClient.Error.rejected(version: version)
@@ -787,12 +796,14 @@ actor HolderRegistry {
     private static func attemptAttach(
         terminalID: UUID,
         socketPath: String,
-        expecting owner: HolderOwnerToken
+        expecting owner: HolderOwnerToken,
+        onEndOfOutput: (@Sendable () -> Void)?
     ) async throws -> Adoption {
         try await take(
             terminalID: terminalID,
             over: HolderClient(socketPath: socketPath),
-            expecting: owner)
+            expecting: owner,
+            onEndOfOutput: onEndOfOutput)
     }
 
     /// The hand-over itself, over a connection the caller supplies.
@@ -807,7 +818,8 @@ actor HolderRegistry {
     private static func take(
         terminalID: UUID,
         over client: HolderClient,
-        expecting owner: HolderOwnerToken
+        expecting owner: HolderOwnerToken,
+        onEndOfOutput: (@Sendable () -> Void)? = nil
     ) async throws -> Adoption {
         let description: HolderChildDescription
         let ptyFD: Int32
@@ -825,11 +837,32 @@ actor HolderRegistry {
                 terminalID: terminalID, holderOwner: description.owner.rawValue)
         }
 
+        // **The pty is the authority on the grid, not the launch request.**
+        // `HolderLaunchRequest` records the size a session was asked for once,
+        // at spawn, and nothing ever updates it; every resize since — the app's
+        // `setMainAreaSize` fan-out reaching `HolderReader.resize` — moved the
+        // terminal itself with `TIOCSWINSZ`. Rebuilding the emulator from the
+        // request would hand a re-adopted session a grid the child stopped
+        // drawing into long ago: a job laying out 123 columns wraps every line
+        // into an 80-column emulator, and nothing in the daemon would say so.
+        // The request is the fallback for the one case the ioctl cannot answer.
+        let launched = (columns: Int(description.launch.columns), rows: Int(description.launch.rows))
+        let grid = HolderReader.windowSize(ptyFD: ptyFD) ?? launched
+        if grid != launched {
+            Self.logger.debug(
+                """
+                session \(terminalID.uuidString, privacy: .public) was resized since it was \
+                launched; building its emulator at \(grid.columns, privacy: .public)x\
+                \(grid.rows, privacy: .public) rather than the launch request's \
+                \(launched.columns, privacy: .public)x\(launched.rows, privacy: .public)
+                """)
+        }
         let reader = HolderReader(
             sessionID: terminalID,
             ptyFD: ptyFD,
-            columns: Int(description.launch.columns),
-            rows: Int(description.launch.rows))
+            columns: grid.columns,
+            rows: grid.rows,
+            onEndOfOutput: onEndOfOutput)
         do {
             try await reader.start()
         } catch {
@@ -840,6 +873,156 @@ actor HolderRegistry {
             throw error
         }
         return Adoption(reader: reader, description: description)
+    }
+
+    // MARK: - Reclaiming a finished session
+
+    /// How long the reclaimer keeps asking a holder whose pty has gone quiet
+    /// whether its child has actually exited.
+    ///
+    /// End of file on the master and the holder's `waitpid` are two different
+    /// observations of one event, made by two processes: the slave closes as
+    /// the job's descriptors are released, and the holder learns of the exit on
+    /// its next poll slice. So the first ask can legitimately answer "alive",
+    /// and a reclaimer that gave up on it would keep the reader forever. The
+    /// budget is comfortably longer than the holder's 50 ms poll slice and
+    /// finite next to the ten-second window a holder keeps its rendezvous bound
+    /// after its child dies.
+    static let exitConfirmationBudget: Duration = .seconds(2)
+    static let exitConfirmationInterval: Duration = .milliseconds(50)
+
+    /// The callback a reader announces its exhausted drain on.
+    ///
+    /// Weak, and that is not a formality: the reader is owned by this registry,
+    /// so a strong capture here would be a cycle keeping every reader — and its
+    /// thread, its emulator and its pty dup — alive for as long as the process
+    /// runs, which is the leak this whole section exists to close. The hop onto
+    /// a `Task` is what keeps the drain thread free: it is the thread the
+    /// release will have to join.
+    private func endOfOutputNotifier(for terminalID: UUID) -> @Sendable () -> Void {
+        { [weak self] in
+            guard let self else { return }
+            Task { await self.reclaimIfSessionEnded(terminalID) }
+        }
+    }
+
+    /// **The reclaimer for a reader whose session is over.**
+    ///
+    /// A reader is not free. It owns a dedicated thread with a 1 MB stack, a
+    /// 64 KB read buffer, an emulator holding thousands of lines of scrollback,
+    /// and a dup of the pty master — and after end of file its drain thread
+    /// parks on the wake pipe rather than exiting, deliberately, so that the
+    /// descriptor's close stays on the stop path. Nothing but a `release`
+    /// unwinds that, so without this the daemon's memory tracked sessions
+    /// *adopted since it started*, not sessions alive.
+    ///
+    /// Two conditions, and both are load-bearing:
+    ///
+    ///   - **The drain has reached the end of the output.** A holder hands its
+    ///     master over even after its child has exited, precisely so the bytes
+    ///     the job wrote and nobody read can still be drained; releasing on the
+    ///     exit alone would throw away exactly what that rule rescues. The
+    ///     exhausted edge is the proof that nothing is left queued.
+    ///   - **The holder says the child exited.** End of file means the last
+    ///     slave closed, which is nearly always the job exiting — but a job that
+    ///     closes its terminal and keeps running is entitled to, and its session
+    ///     row is still live. So the holder is asked, and a child it still
+    ///     reports as alive keeps its reader.
+    ///
+    /// Idempotent and safe to call for any session: it re-reads the slot on
+    /// both sides of every suspension and does nothing unless the reader it
+    /// finds is one that has genuinely finished.
+    func reclaimIfSessionEnded(_ terminalID: UUID) async {
+        guard case .adopted(let reader) = slots[terminalID] else { return }
+        guard await reader.hasReachedEndOfOutput else { return }
+        // Re-read after the suspension, as everywhere else here: an actor's
+        // methods are not atomic across `await`, and a release or a re-adoption
+        // could have taken this slot while the reader was answering.
+        guard case .adopted(let stillAdopted) = slots[terminalID],
+            stillAdopted === reader
+        else { return }
+
+        let status: HolderChildStatus?
+        switch statuses[terminalID] {
+        case .exited, .exitedStatusUnknown:
+            // Already established — a job that ended before this daemon adopted
+            // it reports its status on the hand-over itself.
+            status = statuses[terminalID]
+        case .alive, nil:
+            guard
+                let socketPath = try? HolderRendezvous.socketPath(
+                    sessionID: terminalID, environment: environment)
+            else { return }
+            status = await Self.confirmChildExit(
+                socketPath: socketPath,
+                expecting: owner,
+                budget: Self.exitConfirmationBudget,
+                clock: clock)
+        }
+
+        // A child that is still running, a holder somebody else is attached to,
+        // or one that answered for another installation: nothing here
+        // establishes that this session is over, so its reader stays.
+        guard let status else { return }
+        guard case .adopted(let current) = slots[terminalID], current === reader else { return }
+
+        statuses[terminalID] = status
+        await release(terminalID: terminalID)
+        Self.logger.info(
+            """
+            released the reader for session \(terminalID.uuidString, privacy: .public): its \
+            output is drained and its job is \(String(describing: status), privacy: .public)
+            """)
+    }
+
+    /// Asks a holder whether its child has exited, briefly retrying while the
+    /// answer is "alive".
+    ///
+    /// Returns the terminal status when one is established, and nil when this
+    /// registry must keep its reader — a child still running, a holder serving
+    /// somebody else, or one that turns out to belong to another installation.
+    ///
+    /// **`describe` is safe here and nowhere earlier.** A holder winds itself
+    /// down the moment an answer carrying the terminal status reaches a client,
+    /// which is why adoption asks for the hand-over instead: a `describe` before
+    /// the master had been taken would end the holder and take everything the
+    /// job wrote and nobody read down with it. This runs only past the exhausted
+    /// edge, where there is nothing left to lose — and winding the holder down
+    /// is then the right outcome rather than a cost.
+    ///
+    /// An unreachable rendezvous is `exitedStatusUnknown`, the same convention
+    /// `adoptAll` uses: the holder is gone, the session is over, and the only
+    /// honest thing to say about how it ended is that nobody collected it.
+    private static func confirmChildExit(
+        socketPath: String,
+        expecting owner: HolderOwnerToken,
+        budget: Duration,
+        clock: any Clock<Duration>
+    ) async -> HolderChildStatus? {
+        var waited: Duration = .zero
+        while true {
+            let client = HolderClient(socketPath: socketPath)
+            do {
+                let description = try await client.describe()
+                await client.close()
+                guard description.owner == owner else { return nil }
+                switch description.status {
+                case .exited, .exitedStatusUnknown:
+                    return description.status
+                case .alive:
+                    break
+                }
+            } catch HolderClient.Error.rejected {
+                await client.close()
+                return nil
+            } catch {
+                await client.close()
+                return .exitedStatusUnknown
+            }
+            guard waited < budget else { return nil }
+            try? await clock.sleep(for: Self.exitConfirmationInterval)
+            waited += Self.exitConfirmationInterval
+        }
     }
 
     // MARK: - Release

--- a/Sources/TBDDaemon/Holder/HolderRegistry.swift
+++ b/Sources/TBDDaemon/Holder/HolderRegistry.swift
@@ -929,6 +929,14 @@ actor HolderRegistry {
     ///     row is still live. So the holder is asked, and a child it still
     ///     reports as alive keeps its reader.
     ///
+    /// The second condition is only a condition if it takes an *answer*. A
+    /// holder that could not be reached has told us nothing, and a probe that
+    /// failed must never be read as one that succeeded — otherwise a single
+    /// dropped connection at the instant the drain runs dry collapses the two
+    /// conditions back to the first, which is the shape that throws a live
+    /// session's scrollback away. `exitProbeOutcome` is where each way a probe
+    /// can fail is ruled on.
+    ///
     /// Idempotent and safe to call for any session: it re-reads the slot on
     /// both sides of every suspension and does nothing unless the reader it
     /// finds is one that has genuinely finished.
@@ -990,9 +998,10 @@ actor HolderRegistry {
     /// edge, where there is nothing left to lose — and winding the holder down
     /// is then the right outcome rather than a cost.
     ///
-    /// An unreachable rendezvous is `exitedStatusUnknown`, the same convention
-    /// `adoptAll` uses: the holder is gone, the session is over, and the only
-    /// honest thing to say about how it ended is that nobody collected it.
+    /// **A failed probe is not an answer.** Only a holder that says so, or a
+    /// rendezvous that provably has nobody behind it, establishes that this
+    /// session is over; every other way a round trip can fail is retried within
+    /// the same budget and then kept. See `exitProbeOutcome`.
     private static func confirmChildExit(
         socketPath: String,
         expecting owner: HolderOwnerToken,
@@ -1012,16 +1021,131 @@ actor HolderRegistry {
                 case .alive:
                     break
                 }
-            } catch HolderClient.Error.rejected {
-                await client.close()
-                return nil
             } catch {
                 await client.close()
-                return .exitedStatusUnknown
+                switch exitProbeOutcome(for: error) {
+                case .established(let status):
+                    return status
+                case .keep:
+                    return nil
+                case .retry:
+                    break
+                }
             }
-            guard waited < budget else { return nil }
+            guard waited < budget else {
+                Self.logger.debug(
+                    """
+                    keeping the reader for a session at \(socketPath, privacy: .public): its \
+                    holder never established that the job had exited within \
+                    \(String(describing: budget), privacy: .public)
+                    """)
+                return nil
+            }
             try? await clock.sleep(for: Self.exitConfirmationInterval)
             waited += Self.exitConfirmationInterval
+        }
+    }
+
+    /// What one failed exit probe bears on the question "is this session over?".
+    ///
+    /// Three outcomes rather than two, because "the round trip failed" and "the
+    /// holder is gone" are different facts and only the second one is evidence.
+    enum ExitProbeOutcome: Equatable {
+        /// The session is over, and this is how it ended.
+        case established(HolderChildStatus)
+        /// This attempt failed in a way another one might not. Ask again, on
+        /// the same budget the "alive" answer is retried on.
+        case retry
+        /// Nothing here says the session ended. The reader stays.
+        case keep
+    }
+
+    /// How a thrown `describe` bears on releasing a reader.
+    ///
+    /// **The two conditions are only two if the second one takes positive
+    /// evidence.** A release is irreversible and asymmetric: it stops the drain
+    /// thread, closes the pty dup, and drops an emulator holding everything the
+    /// session ever printed, while a reader kept in error costs one emulator
+    /// until its session row is closed or the daemon restarts. So a probe that
+    /// merely failed must never stand in for a holder that answered — otherwise
+    /// one dropped connection at the instant the drain runs dry silently
+    /// collapses "end of output **and** confirmed exit" back to "end of
+    /// output", which is the condition that would throw away a job that closed
+    /// its terminal and kept running.
+    ///
+    /// Exhaustive on purpose: a new `HolderClient.Error` case must be classified
+    /// here rather than inheriting a catch-all.
+    ///
+    /// Internal rather than private so the classification can be pinned case by
+    /// case without standing up a holder for each one.
+    static func exitProbeOutcome(for error: Swift.Error) -> ExitProbeOutcome {
+        guard let clientError = error as? HolderClient.Error else {
+            // Nothing else is thrown on this path today. Whatever a future one
+            // throws, it is not an answer from a holder, so it cannot license a
+            // release.
+            return .keep
+        }
+        switch clientError {
+        case .rejected:
+            // A live holder, busy serving somebody else. That is evidence of
+            // liveness and explicitly not of exit — the same reading `adoptAll`
+            // and the row-less sweep both take of a refusal.
+            return .keep
+
+        case .cannotConnect(_, let code) where code == ENOENT || code == ECONNREFUSED:
+            // Nothing is listening at the rendezvous, so the holder process is
+            // gone. These are the only two errnos that mean absence rather than
+            // this daemon's own failure to reach a socket, and they are read
+            // that way in exactly one other place already —
+            // `RowlessHolderCollector.productionHandshake` and
+            // `HolderRendezvousCollector.probeForListener` — which must not
+            // disagree with this one.
+            //
+            // Established rather than retried, because absence is monotone
+            // here: this session's holder provably bound the path once, since a
+            // hand-over came over it, and a holder that has gone does not come
+            // back. Recorded the way `adoptAll` records the same observation —
+            // `exitedStatusUnknown`, never a fabricated code, which downstream
+            // could not tell from a real one.
+            return .established(.exitedStatusUnknown)
+
+        case .cannotConnect:
+            // Any other errno describes *this* process failing to open a
+            // connection — `EINTR`, `EMFILE`/`ENFILE` under descriptor
+            // pressure, `ENOBUFS`/`ENOMEM`, `ETIMEDOUT` — and says nothing
+            // whatever about the child.
+            return .retry
+
+        case .peerClosed, .transportFailed:
+            // The socket was reached and the round trip failed: a hang-up
+            // between the accept and the answer, `EPIPE`, `ECONNRESET`, or the
+            // receive timeout expiring. A holder winding down looks exactly
+            // like this, and so does one killed mid-frame — and neither says
+            // whether the child exited. The next attempt either finds no
+            // listener, which is established above, or gets a real answer.
+            return .retry
+
+        case .unexpectedResponse:
+            // A frame that is not the description that was asked for. Retried
+            // because the client's queue can carry an unsolicited push that
+            // crossed the wire with somebody else's answer, and kept if it
+            // persists: a protocol disagreement is a reason to stop trusting
+            // the answer, never a reason to believe the job is dead.
+            return .retry
+
+        case .socketPathTooLong:
+            // Deterministic, so retrying is pointless — and nothing was ever
+            // asked, so there is nothing to conclude either.
+            return .keep
+
+        case .noDescriptor, .notConnected:
+            // Neither is reachable from a `describe` over a client built for
+            // this one call: `noDescriptor` belongs to the hand-over, and
+            // `notConnected` to a client that has already been closed. Named so
+            // that they are classified rather than swept into a fall-through,
+            // and classified as keeps for the same reason as everything else
+            // here.
+            return .keep
         }
     }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -1072,13 +1072,13 @@ extension RPCRouter {
     /// reasoning behind both of its polarities.
     ///
     /// It is the *last known* status, not a fresh probe, and that is the one
-    /// place the two legs are not equivalent: a child that exits while the
-    /// daemon is up leaves `.alive` behind until the next adoption, because
-    /// Milestone A publishes no holder-death fact for this rail to read (the
-    /// drain loop keeps polling a pty that will yield no more bytes rather
-    /// than ending). Until Milestone B's holder-death watch lands, such a row
-    /// needs `--force` — a nuisance the message names, and the opposite of the
-    /// live session it used to close silently.
+    /// place the two legs are not equivalent. What keeps the gap small is the
+    /// registry's own reclaimer: when a session's drain reaches the end of its
+    /// output it asks the holder whether the child exited, records the answer,
+    /// and releases the reader — so a child that exits while the daemon is up
+    /// stops reading as `.alive` within a poll slice or two of its exit rather
+    /// than waiting for the next adoption. A session whose job closed its
+    /// terminal and kept running still reads `.alive`, correctly.
     private func sessionLivenessForActivityRails(
         terminal: Terminal, actuationID: String
     ) async throws -> ActivityRailLiveness {

--- a/Tests/TBDDaemonLiveTests/Holder/HolderAdoptionTests.swift
+++ b/Tests/TBDDaemonLiveTests/Holder/HolderAdoptionTests.swift
@@ -73,6 +73,55 @@ struct HolderAdoptionTests {
         #expect(holderProcessIsAlive(fixture.handle.childPID))
     }
 
+    /// The re-adopted emulator is built at the size of the **pty**, not the size
+    /// the session was launched at.
+    ///
+    /// A session resized while it ran has a pty whose window size moved
+    /// (`HolderReader.resize` sets `TIOCSWINSZ` so the child gets `SIGWINCH`
+    /// and lays itself out) and a `HolderLaunchRequest` that did not: the
+    /// request records what was asked for once at spawn, and the hand-over
+    /// carries it unchanged forever after. Building the new emulator from it
+    /// gives the child a grid narrower and shorter than the one it is drawing
+    /// into — 123 columns of output wrapping into 80 — and nothing in the
+    /// daemon reports the mismatch.
+    ///
+    /// The numbers are the ones a real session was measured at, and the
+    /// assertion is deliberately on the pty's size rather than "not the launch
+    /// size": a fix that guessed, or that read some other geometry, must fail
+    /// here too.
+    @Test func adoptionBuildsTheEmulatorAtThePTYSizeNotTheLaunchSize() async throws {
+        let fixture = try await HolderProcessFixture.start(command: "sleep 30")
+        defer { fixture.tearDown() }
+
+        // The daemon that spawned this session resized it while it was running,
+        // through the production path. Everything else about the session is
+        // untouched: the holder, the pty and the job all outlive the reader.
+        let (described, ptyFD) = try await fixture.client.handOverPTY()
+        #expect(
+            described.launch.columns == 80 && described.launch.rows == 24,
+            "the fixture no longer launches at 80x24, so this test proves nothing")
+        let previous = HolderReader(
+            sessionID: fixture.sessionID, ptyFD: ptyFD, columns: 80, rows: 24)
+        try await previous.start()
+        await previous.resize(columns: 123, rows: 41)
+        await previous.stop()
+        await fixture.client.close()
+
+        let registry = makeRegistry(owner: fixture.owner, home: fixture.home)
+        defer { releaseInBackground(registry) }
+
+        let reader = try await registry.adopt(
+            terminal: holderTerminal(id: fixture.sessionID))
+        let grid = await reader.gridSize
+        #expect(
+            grid.columns == 123 && grid.rows == 41,
+            """
+            the re-adopted emulator is \(grid.columns)x\(grid.rows); the pty is 123x41 and the \
+            launch request — which nothing updates on a resize — is \
+            \(described.launch.columns)x\(described.launch.rows)
+            """)
+    }
+
     // MARK: - One reader, ever
 
     /// Two adoptions of one session yield one reader and one drain loop.

--- a/Tests/TBDDaemonLiveTests/Holder/HolderReaderTests.swift
+++ b/Tests/TBDDaemonLiveTests/Holder/HolderReaderTests.swift
@@ -1,5 +1,6 @@
 import Darwin
 import Foundation
+import SwiftTerm
 import Testing
 @testable import TBDDaemonLib
 @testable import TBDShared
@@ -22,6 +23,32 @@ import Testing
 /// the reason a screenful of expected output is never enough on its own.
 @Suite(.serialized)
 struct HolderReaderTests {
+
+    // MARK: - What a session's history costs
+
+    /// The per-cell size the scrollback budget is computed from.
+    ///
+    /// `HolderReader.scrollbackLines` is a memory decision as much as a history
+    /// one, and the design spec states the worst case it implies. That number is
+    /// computed from SwiftTerm's cell layout, so it is only true while the
+    /// layout is: a `BufferLine` holds a flat `UnsafeMutableBufferPointer` of
+    /// `CharData`, one per column, and `CharData` carries a rune, a width, an
+    /// atom and a full `Attribute` (two colours, a style, an underline style and
+    /// an optional underline colour).
+    ///
+    /// This goes red when a SwiftTerm upgrade changes that layout — which is its
+    /// whole job. The fix is to recompute the figure in
+    /// `docs/specs/2026-08-30-pty-holder-session-transport-design.md` and update
+    /// the number here, not to relax the assertion.
+    @Test func theScrollbackBudgetIsComputedFromSwiftTermsCellSize() {
+        let bytesPerCell = MemoryLayout<CharData>.stride
+        #expect(
+            bytesPerCell == 40,
+            """
+            SwiftTerm's per-cell size is now \(bytesPerCell) bytes, so the worst-case scrollback \
+            figure in docs/specs/2026-08-30-pty-holder-session-transport-design.md is stale
+            """)
+    }
 
     // MARK: - The drain is what lets jobs die
 

--- a/Tests/TBDDaemonLiveTests/Holder/HolderReaderTests.swift
+++ b/Tests/TBDDaemonLiveTests/Holder/HolderReaderTests.swift
@@ -1,6 +1,6 @@
 import Darwin
 import Foundation
-import SwiftTerm
+@testable import SwiftTerm
 import Testing
 @testable import TBDDaemonLib
 @testable import TBDShared
@@ -29,24 +29,30 @@ struct HolderReaderTests {
     /// The per-cell size the scrollback budget is computed from.
     ///
     /// `HolderReader.scrollbackLines` is a memory decision as much as a history
-    /// one, and the design spec states the worst case it implies. That number is
-    /// computed from SwiftTerm's cell layout, so it is only true while the
-    /// layout is: a `BufferLine` holds a flat `UnsafeMutableBufferPointer` of
-    /// `CharData`, one per column, and `CharData` carries a rune, a width, an
-    /// atom and a full `Attribute` (two colours, a style, an underline style and
-    /// an optional underline colour).
+    /// one, and the design spec states the worst case it implies. The type that
+    /// governs that number is **`PackedCell`**, not `CharData`: a `BufferLine`
+    /// holds a `CellStoragePage` (`BufferLine.swift:122`), which owns the row's
+    /// cells as an `UnsafeMutableBufferPointer<PackedCell>`
+    /// (`CellStorage.swift:811`), and a `PackedCell` is one `UInt64`
+    /// (`CellStorage.swift:16,31`). `CharData` is the read-side interface —
+    /// what `arena.unpack` expands a cell into — and is several times larger,
+    /// so measuring it would overstate a session's cost by that factor.
     ///
-    /// This goes red when a SwiftTerm upgrade changes that layout — which is its
-    /// whole job. The fix is to recompute the figure in
+    /// `PackedCell` is internal to SwiftTerm, hence `@testable import`: the size
+    /// that governs storage is not visible to an ordinary importer, and pinning
+    /// the public type that is visible would pin the wrong number.
+    ///
+    /// This goes red when a SwiftTerm upgrade changes the representation —
+    /// which is its whole job. The fix is to recompute the figure in
     /// `docs/specs/2026-08-30-pty-holder-session-transport-design.md` and update
     /// the number here, not to relax the assertion.
-    @Test func theScrollbackBudgetIsComputedFromSwiftTermsCellSize() {
-        let bytesPerCell = MemoryLayout<CharData>.stride
+    @Test func theScrollbackBudgetIsComputedFromSwiftTermsPackedCellSize() {
+        let bytesPerCell = MemoryLayout<PackedCell>.stride
         #expect(
-            bytesPerCell == 40,
+            bytesPerCell == 8,
             """
-            SwiftTerm's per-cell size is now \(bytesPerCell) bytes, so the worst-case scrollback \
-            figure in docs/specs/2026-08-30-pty-holder-session-transport-design.md is stale
+            SwiftTerm stores \(bytesPerCell) bytes per cell, so the worst-case scrollback figure \
+            in docs/specs/2026-08-30-pty-holder-session-transport-design.md is stale
             """)
     }
 

--- a/Tests/TBDDaemonLiveTests/Holder/HolderReclaimTests.swift
+++ b/Tests/TBDDaemonLiveTests/Holder/HolderReclaimTests.swift
@@ -204,6 +204,127 @@ struct HolderReclaimTests {
         #expect(holderProcessIsAlive(fixture.handle.childPID))
     }
 
+    // MARK: - A holder that cannot be reached
+
+    /// A probe that could not reach the holder is not a confirmed exit, and
+    /// does not license a release.
+    ///
+    /// This is the failure the two-condition policy exists to prevent, seen
+    /// from the one angle that makes it look harmless: end of file has been
+    /// reached, so the first condition holds, and the only thing standing
+    /// between a live session and a discarded reader is whether the second one
+    /// takes an *answer* or merely an attempt. A holder killed between the
+    /// accept and its reply — which is what the stranger on the rendezvous here
+    /// imitates — makes every probe fail without ever saying anything about the
+    /// child, and a reclaimer that read that as "exited" would release a reader
+    /// whose session row is still live and lose its scrollback for good.
+    ///
+    /// The real holder is taken down first, and taking it down does **not**
+    /// take the job with it: the reader holds its own dup of the pty master, so
+    /// nothing hangs the foreground group up. That is what lets this test put a
+    /// stranger on the rendezvous path while the session underneath is still a
+    /// perfectly ordinary live one.
+    @Test func keepsTheReaderWhenTheExitProbeCannotReachTheHolder() async throws {
+        let fixture = try await HolderProcessFixture.start(
+            command: "while IFS= read -r line; do printf 'GOT:%s\\n' \"$line\"; done")
+        defer { fixture.tearDown() }
+        await fixture.client.close()
+
+        let registry = makeRegistry(owner: fixture.owner, home: fixture.home)
+        defer { releaseInBackground(registry) }
+
+        let reader = try await registry.adopt(
+            terminal: holderTerminal(id: fixture.sessionID))
+        try await reader.write(Data("HELLO\n".utf8))
+        let answered = await pollUntil("the job's answer") {
+            await reader.renderScreen().contains("GOT:HELLO")
+        }
+        #expect(answered)
+
+        let socketPath = try HolderRendezvous.socketPath(
+            sessionID: fixture.sessionID,
+            environment: HolderProcessFixture.environment(home: fixture.home))
+        killAndReapHolder(fixture)
+        let stranger = try #require(
+            HangUpListener.bind(replacing: socketPath),
+            "the stranger could not take over the rendezvous path")
+        defer { stranger.shutDown() }
+
+        // Closing the job's stdin is what drives the pty to end of file, which
+        // is the edge the reclaimer fires on.
+        try await reader.write(Data([0x04]))
+        let drained = await pollUntil("the reader to reach the end of the session's output") {
+            await reader.hasReachedEndOfOutput
+        }
+        #expect(drained)
+
+        // Longer than the confirmation budget, so a registry that released on a
+        // failed probe has had every chance to do so.
+        try await Task.sleep(for: HolderRegistry.exitConfirmationBudget + .seconds(1))
+
+        let stored = await registry.reader(for: fixture.sessionID)
+        #expect(
+            stored === reader,
+            """
+            a holder that never answered was read as a confirmed exit, and the reader — with \
+            everything the session had printed — was released
+            """)
+        let status = await registry.lastKnownStatus(for: fixture.sessionID)
+        #expect(
+            status == .alive,
+            """
+            a failed probe was recorded as a terminal status: \
+            \(String(describing: status))
+            """)
+    }
+
+    /// Nothing listening at the rendezvous *is* an answer, and the reader is
+    /// released.
+    ///
+    /// The other branch of the same decision, and the reason the fix above is a
+    /// classification rather than a blanket "keep on any error". A holder that
+    /// has gone cannot unlink its own socket when it is killed, so the file
+    /// stays and the connect is refused — and that refusal is evidence of
+    /// absence rather than of this daemon failing to reach something. Nothing
+    /// will ever be learned about this session again, so keeping its reader
+    /// would be the unbounded leak the reclaimer exists to close.
+    @Test func releasesTheReaderWhenNothingIsListeningAtTheRendezvous() async throws {
+        let fixture = try await HolderProcessFixture.start(
+            command: "while IFS= read -r line; do printf 'GOT:%s\\n' \"$line\"; done")
+        defer { fixture.tearDown() }
+        await fixture.client.close()
+
+        let registry = makeRegistry(owner: fixture.owner, home: fixture.home)
+        defer { releaseInBackground(registry) }
+
+        let reader = try await registry.adopt(
+            terminal: holderTerminal(id: fixture.sessionID))
+        try await reader.write(Data("HELLO\n".utf8))
+        let answered = await pollUntil("the job's answer") {
+            await reader.renderScreen().contains("GOT:HELLO")
+        }
+        #expect(answered)
+
+        // The socket file is deliberately left where it is: a SIGKILLed holder
+        // cannot unlink it, so a bound path with nobody behind it is what
+        // production actually leaves behind.
+        killAndReapHolder(fixture)
+
+        try await reader.write(Data([0x04]))
+
+        let released = await pollUntil("the registry to release the ended session's reader") {
+            await registry.reader(for: fixture.sessionID) == nil
+        }
+        #expect(released, "a session whose holder is gone kept its reader forever")
+        let status = await registry.lastKnownStatus(for: fixture.sessionID)
+        #expect(
+            status == .exitedStatusUnknown,
+            """
+            releasing a session whose holder had gone should record that nobody collected its \
+            status, not a fabricated one: \(String(describing: status))
+            """)
+    }
+
     // MARK: - Support
 
     /// A holder-transport row; the same shape `HolderAdoptionTests` uses, and
@@ -229,4 +350,103 @@ struct HolderReclaimTests {
 /// `HolderAdoptionTests`.
 private func releaseInBackground(_ registry: HolderRegistry) {
     Task.detached { await registry.releaseAll() }
+}
+
+/// Kills a fixture's holder and collects its corpse, leaving the job running.
+///
+/// **Holder death is not job death**, and that is what this leans on: the
+/// registry's reader holds its own dup of the pty master, so closing the
+/// holder's copy hangs nothing up and the session underneath stays exactly as
+/// live as it was. The reap is owed to this process — the spawner
+/// `posix_spawn`s the holder directly, so nobody else can collect it — and
+/// `noteHolderReaped` is what stops the fixture signalling a pid number the
+/// kernel has already handed to somebody else.
+private func killAndReapHolder(_ fixture: HolderProcessFixture) {
+    kill(fixture.handle.holderPID, SIGKILL)
+    var ignored: Int32 = 0
+    _ = waitpid(fixture.handle.holderPID, &ignored, 0)
+    fixture.noteHolderReaped()
+}
+
+/// A stranger bound to a holder's rendezvous path that accepts every
+/// connection and immediately hangs up.
+///
+/// It stands for every way a round trip can fail without establishing
+/// anything: the path is reachable, so nothing here says the holder is *gone*,
+/// and the probe fails all the same. Whether the client reports the hang-up as
+/// `peerClosed` or as a broken pipe on the way out is decided by microseconds,
+/// and the reclaimer must reach the same conclusion either way — so the test
+/// that uses this asserts on the outcome rather than on which of the two
+/// arrived.
+///
+/// The accept loop owns the descriptor and closes it itself, rather than being
+/// woken by a close from another thread: closing a descriptor out from under a
+/// blocked `accept` is not a documented wake-up on Darwin, and a test helper
+/// that parked a pooled thread forever would be a worse bug than the one it is
+/// here to catch.
+private final class HangUpListener: @unchecked Sendable {
+    private let listenFD: Int32
+    private let path: String
+    private let lock = NSLock()
+    private var stopping = false
+
+    private init(listenFD: Int32, path: String) {
+        self.listenFD = listenFD
+        self.path = path
+    }
+
+    /// Unlinks whatever is at `path` and binds there instead.
+    static func bind(replacing path: String) -> HangUpListener? {
+        unlink(path)
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else { return nil }
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        path.withCString { source in
+            withUnsafeMutablePointer(to: &address.sun_path) { destination in
+                UnsafeMutableRawPointer(destination)
+                    .copyMemory(from: source, byteCount: strlen(source) + 1)
+            }
+        }
+        let bound = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { generic in
+                Darwin.bind(fd, generic, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard bound == 0, Darwin.listen(fd, 16) == 0 else {
+            Darwin.close(fd)
+            return nil
+        }
+        let listener = HangUpListener(listenFD: fd, path: path)
+        DispatchQueue.global().async { listener.run() }
+        return listener
+    }
+
+    /// Asks the accept loop to stop. It closes the descriptor and unlinks the
+    /// path on its way out, within one poll slice.
+    func shutDown() {
+        lock.lock()
+        stopping = true
+        lock.unlock()
+    }
+
+    private var isStopping: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return stopping
+    }
+
+    private func run() {
+        // A ceiling, so a helper that somehow outlived its test cannot poll for
+        // the life of the process.
+        let deadline = Date().addingTimeInterval(120)
+        while !isStopping, Date() < deadline {
+            var descriptor = pollfd(fd: listenFD, events: Int16(POLLIN), revents: 0)
+            guard poll(&descriptor, 1, 50) > 0 else { continue }
+            let accepted = accept(listenFD, nil, nil)
+            if accepted >= 0 { Darwin.close(accepted) }
+        }
+        Darwin.close(listenFD)
+        unlink(path)
+    }
 }

--- a/Tests/TBDDaemonLiveTests/Holder/HolderReclaimTests.swift
+++ b/Tests/TBDDaemonLiveTests/Holder/HolderReclaimTests.swift
@@ -1,0 +1,232 @@
+import Darwin
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Letting go of a session that has ended.
+///
+/// A `HolderReader` is expensive — a dedicated thread with a 1 MB stack, a
+/// 64 KB read buffer, an emulator holding thousands of lines of scrollback, and
+/// a dup of the pty master — and after end of file its drain thread parks on
+/// its wake pipe rather than exiting, so nothing but a `release` unwinds any of
+/// it. Without a reclaimer the daemon's memory tracks sessions *adopted since
+/// it started* rather than sessions alive, and a long-lived daemon on a busy
+/// fleet grows without bound.
+///
+/// The two conditions are what these tests pin, and each has a failure of its
+/// own:
+///
+///   - Releasing on the exit alone would throw away output. A holder hands its
+///     master over even after its child has exited, precisely so that what the
+///     job wrote and nobody read can still be drained;
+///     `drainsAFinishedJobsOutputBeforeReleasingIt` asserts the bytes reached
+///     the emulator before the release did.
+///   - Releasing on end of file alone would drop a live session. A job may
+///     close its terminal and keep running, and
+///     `keepsTheReaderForAJobThatIsStillRunning` is the other polarity.
+@Suite(.serialized)
+struct HolderReclaimTests {
+
+    // MARK: - A job that ended before the daemon adopted it
+
+    /// A job that ran out during an outage has its reader released as soon as
+    /// the restarted daemon has adopted and drained it.
+    ///
+    /// The job writes nothing, deliberately: a job that wrote would still be
+    /// half-exited in `ttywait` behind its own unread output, and this test
+    /// would be measuring that instead. Here the exit is complete before
+    /// adoption, so the status rides the hand-over and no probe is needed —
+    /// which makes this the leg that proves the reclaimer does not depend on
+    /// one.
+    @Test func releasesTheReaderForAJobThatEndedDuringTheOutage() async throws {
+        let fixture = try await HolderProcessFixture.start(command: "sleep 1; exit 7")
+        defer { fixture.tearDown() }
+        await fixture.client.close()
+
+        let ended = await pollUntil("the job to finish exiting") {
+            !holderProcessIsAlive(fixture.handle.childPID)
+        }
+        #expect(ended)
+
+        let registry = makeRegistry(owner: fixture.owner, home: fixture.home)
+        defer { releaseInBackground(registry) }
+
+        _ = try await registry.adopt(terminal: holderTerminal(id: fixture.sessionID))
+        let released = await pollUntil("the registry to release the finished session's reader") {
+            await registry.reader(for: fixture.sessionID) == nil
+        }
+        #expect(
+            released,
+            "the reader for a job that had already exited was never released")
+        let status = await registry.lastKnownStatus(for: fixture.sessionID)
+        #expect(
+            status == .exited(code: 7),
+            "releasing the reader lost the exit status: \(String(describing: status))")
+    }
+
+    // MARK: - Output the job left behind
+
+    /// A finished job's queued output reaches the emulator before its reader is
+    /// released.
+    ///
+    /// The setup is the wedge this transport exists to survive: the job wrote a
+    /// line and exited while nobody was reading, so it is **not** finished — it
+    /// is stopped inside `proc_exit`, in `ttywait`, behind its own output. The
+    /// holder hands the master over anyway, precisely so an adopter can rescue
+    /// those bytes, and a reclaimer that let go on the exit alone would throw
+    /// away exactly what that rule rescues.
+    ///
+    /// The reader object is held here, so its emulator outlives the release and
+    /// the screen can be read afterwards. The order of the assertions is the
+    /// point: the release is waited for first, and the bytes must already be
+    /// there when it has happened.
+    @Test func drainsAFinishedJobsOutputBeforeReleasingIt() async throws {
+        let fixture = try await HolderProcessFixture.start(command: "printf 'LAST\\n'; exit 7")
+        defer { fixture.tearDown() }
+        await fixture.client.close()
+
+        let registry = makeRegistry(owner: fixture.owner, home: fixture.home)
+        defer { releaseInBackground(registry) }
+
+        let reader = try await registry.adopt(
+            terminal: holderTerminal(id: fixture.sessionID))
+        let released = await pollUntil("the registry to release the finished session's reader") {
+            await registry.reader(for: fixture.sessionID) == nil
+        }
+        #expect(
+            released,
+            "the reader for a job that has exited and been drained was never released")
+
+        let screen = await reader.renderScreen()
+        #expect(
+            screen.contains("LAST"),
+            """
+            the reader was released before the job's queued output reached the emulator: \
+            \(screen.debugDescription)
+            """)
+        let status = await registry.lastKnownStatus(for: fixture.sessionID)
+        #expect(
+            status == .exited(code: 7),
+            "releasing the reader lost the exit status: \(String(describing: status))")
+        // The drain is what let the job finish exiting at all.
+        let gone = await pollUntil("the drained job to finish exiting") {
+            !holderProcessIsAlive(fixture.handle.childPID)
+        }
+        #expect(gone)
+    }
+
+    // MARK: - A job that ends while the daemon is watching
+
+    /// A job that exits *after* it was adopted is reclaimed too.
+    ///
+    /// This is the case the leak was actually made of. The status recorded at
+    /// adoption says `.alive` and nothing ever updates it on its own — the
+    /// daemon closes its connection after the hand-over, so the holder has
+    /// nobody to push the exit at. The reclaimer asks, over a fresh connection,
+    /// on the one edge where asking is free: past end of file there is no
+    /// queued output left for the holder's wind-down to take with it.
+    ///
+    /// The job is ended by closing its stdin (`EOT` on a canonical-mode pty),
+    /// so nothing here signals or kills anything: the shell's read loop simply
+    /// runs out of input and the script exits 0.
+    @Test func reclaimsAReaderWhoseJobExitsWhileItIsAdopted() async throws {
+        let fixture = try await HolderProcessFixture.start(
+            command: "while IFS= read -r line; do printf 'GOT:%s\\n' \"$line\"; done")
+        defer { fixture.tearDown() }
+        await fixture.client.close()
+
+        let registry = makeRegistry(owner: fixture.owner, home: fixture.home)
+        defer { releaseInBackground(registry) }
+
+        let reader = try await registry.adopt(
+            terminal: holderTerminal(id: fixture.sessionID))
+        try await reader.write(Data("HELLO\n".utf8))
+        let answered = await pollUntil("the job's answer") {
+            await reader.renderScreen().contains("GOT:HELLO")
+        }
+        #expect(answered)
+
+        // Still running, still adopted: the reclaimer must not have fired on a
+        // session that is merely quiet.
+        let whileAlive = await registry.reader(for: fixture.sessionID)
+        #expect(whileAlive === reader, "a live session's reader was released")
+
+        try await reader.write(Data([0x04]))
+
+        let released = await pollUntil("the registry to release the ended session's reader") {
+            await registry.reader(for: fixture.sessionID) == nil
+        }
+        #expect(released, "the reader for a job that exited under the daemon was never released")
+
+        let status = await registry.lastKnownStatus(for: fixture.sessionID)
+        #expect(
+            status == .exited(code: 0),
+            """
+            the reclaimer released the reader without establishing how the job ended: \
+            \(String(describing: status))
+            """)
+    }
+
+    // MARK: - The other polarity
+
+    /// A reader whose job is still running is kept, however quiet the session
+    /// is.
+    ///
+    /// The gate is end of file on the pty master, not idleness: a reclaimer that
+    /// reached for "no output lately" would stop draining a live job's terminal,
+    /// which is the wedge the whole transport is built to avoid.
+    @Test func keepsTheReaderForAJobThatIsStillRunning() async throws {
+        let fixture = try await HolderProcessFixture.start(
+            command: "printf 'ALIVE\\n'; sleep 30")
+        defer { fixture.tearDown() }
+        await fixture.client.close()
+
+        let registry = makeRegistry(owner: fixture.owner, home: fixture.home)
+        defer { releaseInBackground(registry) }
+
+        let reader = try await registry.adopt(
+            terminal: holderTerminal(id: fixture.sessionID))
+        let spoke = await pollUntil("the job's first line") {
+            await reader.renderScreen().contains("ALIVE")
+        }
+        #expect(spoke)
+
+        // Long enough to outlast the reclaimer's own confirmation budget, so a
+        // registry that released on quiet rather than on end of file has had
+        // every chance to do so.
+        try await Task.sleep(for: HolderRegistry.exitConfirmationBudget)
+
+        let stored = await registry.reader(for: fixture.sessionID)
+        #expect(stored === reader, "the reader for a running job was released")
+        let draining = await reader.isDraining
+        #expect(draining, "the reader for a running job stopped draining its pty")
+        #expect(holderProcessIsAlive(fixture.handle.childPID))
+    }
+
+    // MARK: - Support
+
+    /// A holder-transport row; the same shape `HolderAdoptionTests` uses, and
+    /// for the same reason — `tmuxWindowID`/`tmuxPaneID` are NOT NULL from the
+    /// v1 schema and a holder row has no tmux coordinate to put in them.
+    private func holderTerminal(id: UUID) -> Terminal {
+        Terminal(
+            id: id, worktreeID: UUID(), tmuxWindowID: "", tmuxPaneID: "", transport: .holder)
+    }
+
+    /// A registry whose rendezvous paths come from an explicit environment, so
+    /// nothing here can reach the developer's real `~/tbd` even for an instant.
+    private func makeRegistry(owner: HolderOwnerToken, home: String) -> HolderRegistry {
+        HolderRegistry(
+            owner: owner,
+            environment: HolderProcessFixture.environment(home: home),
+            listTerminals: { [] })
+    }
+}
+
+/// Releases a registry's readers from a `defer`, which cannot `await`.
+/// Idempotent, and needed on every exit path: see the note in
+/// `HolderAdoptionTests`.
+private func releaseInBackground(_ registry: HolderRegistry) {
+    Task.detached { await registry.releaseAll() }
+}

--- a/Tests/TBDDaemonTests/Holder/HolderExitProbeClassificationTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HolderExitProbeClassificationTests.swift
@@ -1,0 +1,141 @@
+import Darwin
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// What the reclaimer is allowed to conclude from a probe that threw.
+///
+/// The reclaimer releases a reader on two conditions — the drain has reached
+/// the end of the session's output, **and** the holder says the child exited —
+/// and the second one is only a condition if it takes an *answer*. A probe that
+/// merely failed collapses the pair back to the first condition, which is the
+/// one that would throw away the scrollback of a job that closed its terminal
+/// and kept running.
+///
+/// So every way a round trip can fail is ruled on by name here rather than
+/// inheriting a catch-all. The suite is the table: one case per
+/// `HolderClient.Error`, plus the shape that is not one at all.
+///
+/// Tier 1 — no holder is spawned and no socket is opened. The end-to-end
+/// polarities live in `HolderReclaimTests` (tier 3), which spawns real holders;
+/// this suite is what makes the classification cheap to pin case by case.
+@Suite struct HolderExitProbeClassificationTests {
+
+    // MARK: - Evidence that the session is over
+
+    /// Nothing listening at the rendezvous is the one failure that establishes
+    /// anything: the holder process is gone.
+    ///
+    /// `ENOENT` and `ECONNREFUSED` are the only two errnos read as absence,
+    /// and they are read that way in two other places already —
+    /// `RowlessHolderCollector.productionHandshake` and
+    /// `HolderRendezvousCollector.probeForListener`. Three readers of the same
+    /// two errnos must not disagree, so this pins the agreement rather than
+    /// trusting it.
+    ///
+    /// It is established rather than retried because absence is monotone here:
+    /// the session's holder provably bound the path once, since a hand-over
+    /// came over it, and a holder that has gone does not come back.
+    @Test func nothingListeningIsEvidenceTheSessionIsOver() {
+        for code in [ENOENT, ECONNREFUSED] {
+            let outcome = HolderRegistry.exitProbeOutcome(
+                for: HolderClient.Error.cannotConnect(path: "/tmp/gone.sock", errno: code))
+            #expect(
+                outcome == .established(.exitedStatusUnknown),
+                """
+                errno \(code) at the rendezvous means the holder is gone, and the honest record \
+                of how the job ended is that nobody collected it: \(outcome)
+                """)
+        }
+    }
+
+    // MARK: - Failures worth asking again about
+
+    /// A connect that failed for any other reason describes this daemon's own
+    /// attempt, not the holder.
+    ///
+    /// Descriptor exhaustion, an interrupted syscall, buffer pressure, a
+    /// connect timeout: none of them is a fact about the child, and every one
+    /// of them can be gone by the next attempt.
+    @Test func anyOtherConnectFailureIsRetried() {
+        for code in [EINTR, EMFILE, ENFILE, ENOBUFS, ENOMEM, ETIMEDOUT, EACCES] {
+            let outcome = HolderRegistry.exitProbeOutcome(
+                for: HolderClient.Error.cannotConnect(path: "/tmp/holder.sock", errno: code))
+            #expect(
+                outcome == .retry,
+                "errno \(code) says nothing about the child and must be asked again: \(outcome)")
+        }
+    }
+
+    /// A round trip that reached the socket and then failed is retried.
+    ///
+    /// A holder winding down hangs up mid-frame, and so does one killed between
+    /// the accept and its answer; whether that surfaces as `peerClosed` or as a
+    /// broken pipe on the way out is decided by microseconds, and the two must
+    /// not reach different conclusions. The receive timeout arrives as
+    /// `transportFailed` too.
+    @Test func aFailedRoundTripIsRetried() {
+        #expect(HolderRegistry.exitProbeOutcome(for: HolderClient.Error.peerClosed) == .retry)
+        #expect(
+            HolderRegistry.exitProbeOutcome(
+                for: HolderClient.Error.transportFailed("Broken pipe")) == .retry)
+    }
+
+    /// A frame that is not the description asked for is retried, never read as
+    /// an exit.
+    ///
+    /// The client's own queue can carry an unsolicited push that crossed the
+    /// wire with somebody else's answer, so one wrong frame is worth asking
+    /// past. A disagreement that persists is a reason to stop trusting the
+    /// answer, and the budget then expires into a keep — which is what the
+    /// end-to-end suite asserts.
+    @Test func anUnreadableAnswerIsRetried() {
+        #expect(
+            HolderRegistry.exitProbeOutcome(
+                for: HolderClient.Error.unexpectedResponse("handedOverPTY")) == .retry)
+    }
+
+    // MARK: - Failures that establish nothing at all
+
+    /// A refusal is a *live* holder, busy serving somebody else.
+    ///
+    /// The one failure that was always classified correctly, and the polarity
+    /// everything else here was brought into line with: evidence of liveness is
+    /// not evidence of exit.
+    @Test func aRefusalKeepsTheReader() {
+        #expect(HolderRegistry.exitProbeOutcome(for: HolderClient.Error.rejected(version: 1)) == .keep)
+    }
+
+    /// A path that cannot be represented was never asked anything, and asking
+    /// again would ask the same unrepresentable path.
+    @Test func anUnrepresentablePathKeepsTheReader() {
+        let outcome = HolderRegistry.exitProbeOutcome(
+            for: HolderClient.Error.socketPathTooLong(path: String(repeating: "x", count: 200), limit: 104))
+        #expect(outcome == .keep, "a deterministic failure is neither retried nor believed: \(outcome)")
+    }
+
+    /// The two cases a `describe` over a fresh client cannot reach are still
+    /// classified, and classified as keeps.
+    ///
+    /// Named rather than left to a fall-through so that unreachability is a
+    /// claim the suite makes rather than a gap it leaves: if either ever
+    /// becomes reachable, it already has the conservative answer.
+    @Test func structurallyUnreachableFailuresKeepTheReader() {
+        #expect(HolderRegistry.exitProbeOutcome(for: HolderClient.Error.noDescriptor) == .keep)
+        #expect(HolderRegistry.exitProbeOutcome(for: HolderClient.Error.notConnected) == .keep)
+    }
+
+    /// Anything that is not a `HolderClient.Error` at all keeps.
+    ///
+    /// This is the fall-through, and it is the one the bug lived in: a
+    /// catch-all that released meant every unclassified failure licensed
+    /// throwing a live session's scrollback away.
+    @Test func anErrorFromNowhereKeepsTheReader() {
+        struct SomethingElse: Swift.Error {}
+        #expect(HolderRegistry.exitProbeOutcome(for: SomethingElse()) == .keep)
+        #expect(
+            HolderRegistry.exitProbeOutcome(for: CancellationError()) == .keep,
+            "a cancelled probe answered nothing and must not release a reader")
+    }
+}

--- a/docs/specs/2026-08-30-pty-holder-session-transport-design.md
+++ b/docs/specs/2026-08-30-pty-holder-session-transport-design.md
@@ -434,13 +434,30 @@ history is the argument against a purpose-built minimal parser: the
 and a `hasPrefix` broke title parsing — the escape-sequence long tail is
 precisely what bites.
 
-The emulator keeps a bounded in-memory scrollback (on the order of 10k lines;
-a plain constant, not a flag) and is **not persisted to disk**. The constant
-is a memory decision as much as a history one: at the design point there are
-~150 emulators resident, and a naive per-cell buffer representation across
-150 sessions can reach into gigabytes, so the limit must be sized against
-SwiftTerm's measured per-line cost at implementation time — and the limit, or
-the representation, gives way first if field memory pressure says so.
+The emulator keeps a bounded in-memory scrollback — 5,000 lines, a plain
+constant (`HolderReader.scrollbackLines`), not a flag — and is **not persisted
+to disk**. The constant is a memory decision as much as a history one, and the
+cost follows from SwiftTerm's layout rather than from a measurement: a
+`BufferLine` holds a flat buffer of one `CharData` per column, and `CharData`
+is 40 bytes (a rune, a width, an atom, and an `Attribute` carrying two colours,
+a style, an underline style and an optional underline colour). So a line is
+`columns × 40` bytes, a full 120-column scrollback is
+`5,000 × 120 × 40 ≈ 24 MB`, and at the design point's ~150 resident emulators
+the worst case is several gigabytes.
+
+Three things keep that worst case off the table in practice, and none of them
+is a promise:
+
+- **Lines are materialized lazily.** The buffer preallocates a
+  `[BufferLine?]` of `scrollback + rows` slots — around 40 KB of pointers —
+  and fills a slot only when a line is written, so a session that has printed
+  a screenful costs a screenful.
+- **The figure is per *filled* session.** Reaching 24 MB takes 5,000 lines of
+  120-column output that nothing has scrolled past; an agent session that goes
+  quiet holds what it printed and no more.
+- **The limit and the representation are both still open.** If field memory
+  pressure says so, the constant comes down or the per-cell representation
+  changes; nothing else in the design depends on either.
 
 A daemon restart starts the emulator empty; the jiggle on re-adoption makes
 full-screen programs repaint into the fresh emulator, and the durable record

--- a/docs/specs/2026-08-30-pty-holder-session-transport-design.md
+++ b/docs/specs/2026-08-30-pty-holder-session-transport-design.md
@@ -437,27 +437,38 @@ precisely what bites.
 The emulator keeps a bounded in-memory scrollback — 5,000 lines, a plain
 constant (`HolderReader.scrollbackLines`), not a flag — and is **not persisted
 to disk**. The constant is a memory decision as much as a history one, and the
-cost follows from SwiftTerm's layout rather than from a measurement: a
-`BufferLine` holds a flat buffer of one `CharData` per column, and `CharData`
-is 40 bytes (a rune, a width, an atom, and an `Attribute` carrying two colours,
-a style, an underline style and an optional underline colour). So a line is
-`columns × 40` bytes, a full 120-column scrollback is
-`5,000 × 120 × 40 ≈ 24 MB`, and at the design point's ~150 resident emulators
-the worst case is several gigabytes.
+cost follows from SwiftTerm's cell layout rather than from a measurement.
 
-Three things keep that worst case off the table in practice, and none of them
-is a promise:
+**Storage is 8 bytes per cell.** A `BufferLine` holds a `CellStoragePage`
+(`BufferLine.swift:122`), which owns the row's cells as an
+`UnsafeMutableBufferPointer<PackedCell>` (`CellStorage.swift:811`), and a
+`PackedCell` is a single `UInt64` (`CellStorage.swift:16,31`) packing the
+content tag, the codepoint or grapheme id, a 16-bit style id, the width state
+and a payload id. Everything variable-sized lives in a `CellArena`
+(`CellStorage.swift:284`) shared by every line of one terminal, which interns
+each distinct attribute and grapheme **once** rather than per cell — so a
+heavily coloured screen costs the same per cell as a plain one. `CharData` is
+the read-side interface the arena expands a cell into, not what is stored;
+sizing the budget against it would overstate a session by several times.
+
+So a line is `columns × 8` bytes, a fully materialized 120-column 5,000-line
+scrollback is `5,000 × 120 × 8 ≈ 4.8 MB` of cell bytes — call it 5–6 MB with
+the per-line `BufferLine` and `CellStoragePage` objects — and the design
+point's ~150 resident emulators come to roughly 0.8 GB in the worst case.
+
+That worst case is a ceiling, not an expectation, for two reasons:
 
 - **Lines are materialized lazily.** The buffer preallocates a
   `[BufferLine?]` of `scrollback + rows` slots — around 40 KB of pointers —
   and fills a slot only when a line is written, so a session that has printed
   a screenful costs a screenful.
-- **The figure is per *filled* session.** Reaching 24 MB takes 5,000 lines of
+- **Reaching it takes a filled scrollback.** It needs 5,000 lines of
   120-column output that nothing has scrolled past; an agent session that goes
   quiet holds what it printed and no more.
-- **The limit and the representation are both still open.** If field memory
-  pressure says so, the constant comes down or the per-cell representation
-  changes; nothing else in the design depends on either.
+
+The limit and the representation both remain open: if field memory pressure
+says so, the constant comes down or the per-cell representation changes, and
+nothing else in the design depends on either.
 
 A daemon restart starts the emulator empty; the jiggle on re-adoption makes
 full-screen programs repaint into the fresh emulator, and the durable record

--- a/docs/specs/2026-08-30-pty-holder-session-transport-design.md
+++ b/docs/specs/2026-08-30-pty-holder-session-transport-design.md
@@ -666,6 +666,113 @@ the process table — the same argument as every other resource here.
   the backstop for holder deaths the daemon was down for; the prompt path is
   the daemon's own holder-connection watch ("Holder death" above).
 
+### Letting go of a finished session's reader
+
+The reconcilers above reclaim things that outlive the daemon. A `HolderReader`
+does not, and it is expensive all the same: a dedicated thread with a 1 MB
+stack, a 64 KB read buffer, an emulator holding thousands of lines of
+scrollback, and a dup of the pty master. After end of file its drain thread
+parks on its wake pipe rather than exiting — deliberately, so the descriptor's
+close stays on the stop path where no `write` can race a reused fd number — so
+nothing but an explicit release unwinds any of it. Without one the daemon's
+memory tracks sessions **adopted since it started** rather than sessions alive,
+and a long-lived daemon on a busy fleet grows without bound.
+
+**Release takes two conditions, and both are load-bearing.**
+
+- **The drain has reached the end of the session's output.** A holder hands its
+  master over even after its child has exited, precisely so the bytes the job
+  wrote and nobody read can still be drained; releasing on the exit alone would
+  throw away exactly what that rule rescues. The exhausted edge — the drain read
+  until the descriptor would block and then classified it as done — is the proof
+  that nothing is left queued.
+- **The holder says the child exited.** End of file means the last slave closed,
+  which is nearly always the job exiting — but a job is entitled to close its
+  terminal and keep running, and its session row is still live. So the holder is
+  asked over a fresh connection, and a child it still reports as alive keeps its
+  reader.
+
+The second condition is only a condition if it takes an **answer**. A probe that
+merely failed collapses the pair back to the first, which is the shape that
+discards a live session's scrollback — so the ruling on a failed probe is where
+the policy is actually decided.
+
+**Only positive evidence licenses a release**, because the two errors are not
+symmetric. A reader kept in error costs one emulator until its session row is
+closed or the daemon restarts; a reader released in error stops the drain
+thread, closes the pty dup and drops everything the session ever printed, for
+good. Each way a round trip can fail is therefore classified by name:
+
+- **A refusal** — the holder answered with the busy sentinel — is a *live*
+  holder serving somebody else. Evidence of liveness, explicitly not of exit,
+  and the same reading the row-less sweep and startup adoption both take. Keeps.
+- **Nothing listening at the rendezvous** — `ENOENT` or `ECONNREFUSED` on the
+  connect — is the one failure that establishes something: the holder process is
+  gone. Those two errnos are the only ones that mean absence rather than this
+  daemon failing to reach a socket, and they are read that way in two other
+  places already, which must not disagree. It is *established* rather than
+  retried because absence is monotone here: the session's holder provably bound
+  the path once, since a hand-over came over it, and a holder that has gone does
+  not come back. Recorded as **status unknown**, never a fabricated code, the
+  same convention startup adoption uses for the same observation.
+- **Any other connect failure** — an interrupted syscall, descriptor exhaustion,
+  buffer pressure, a connect timeout — describes this daemon's own attempt and
+  says nothing whatever about the child. Retried.
+- **A round trip that reached the socket and then failed** — a hang-up between
+  the accept and the answer, a broken pipe, a connection reset, the receive
+  timeout expiring — is what a holder winding down looks like, and equally what
+  one killed mid-frame looks like. Which of the two arrives is decided by
+  microseconds, so neither may reach a different conclusion. Retried.
+- **An answer that is not the description asked for** is retried, because the
+  client's frame queue can carry an unsolicited push that crossed the wire with
+  somebody else's answer. A disagreement that persists is a reason to stop
+  trusting the answer, never a reason to believe the job is dead.
+- **Everything else** — a path too long for `sun_path`, a case structurally
+  unreachable from this call, anything a future client throws — keeps. The
+  fall-through is the conservative direction by construction.
+
+A session whose holder stays reachable but never answers is therefore kept
+indefinitely, and that is the intended trade: the cost is one emulator, ended by
+the session's own teardown or by a daemon restart, against the permanent loss of
+a live session's screen.
+
+**The constants.** The probe retries on a **2-second budget** at a **50 ms
+interval**. End of file on the master and the holder's `waitpid` are two
+observations of one event made by two processes — the slave closes as the job's
+descriptors are released, and the holder learns of the exit on its next poll
+slice — so the first ask can legitimately answer "alive", and a reclaimer that
+gave up on that would keep every reader forever. The budget is comfortably
+longer than the holder's 50 ms poll slice, and finite next to the ten-second
+window a holder keeps its rendezvous bound after its child dies; the interval
+matches that poll slice, so a retry costs one connect per slice rather than
+spinning. The same budget covers the retried failures above: they are asking the
+same question, and giving them a second budget would only be a second number to
+get wrong.
+
+**The lifecycle is a weak closure, and that is not a formality.** The reader
+announces its exhausted edge on a callback the registry supplies, which captures
+the registry weakly and hops onto a task. Weakly, because the registry owns the
+reader: a strong capture would be a cycle keeping every reader — and its thread,
+its emulator and its pty dup — alive for as long as the process runs, which is
+the leak this whole mechanism exists to close. Onto a task, because the callback
+runs on the drain thread, and a release driven inline would be waiting on the
+very thread it is running on. The announcement fires **once**, on the
+transition: a second one would ask the registry to reclaim what it has already
+reclaimed, and the slot it names may by then belong to a different reader.
+
+**This is not an `AgentReaper` leg, and not a sweep at all.** The named-reconciler
+doctrine asks who reclaims the orphans of a *durable* resource — one the external
+world commits to before TBD records the intent, which survives a crash with
+nobody owning it. A reader is the opposite: it lives only in the memory of the
+daemon that made it, and a daemon that dies takes every reader with it, so there
+is no orphan for a sweep to find. What is left behind on that path is the
+holder, the job and the rendezvous files, and those already have their
+reconcilers above. A periodic sweep would also be strictly worse at the job: the
+only safe moment to let go is the exhausted edge, which is an edge rather than a
+state a sweep could sample, and asking every session's holder on a timer would
+put a fleet's worth of round trips per interval against holders that wind down
+when they answer.
+
 ## Rollout
 
 This wholesale-replaces a load-bearing path, so it ships behind a default-off


### PR DESCRIPTION
## Summary

Two defects in holder adoption, found by an adversarial review of where terminal scrollback should
live. Both are real, both are reproduced by a test that fails without the fix.

## 1. A re-adopted emulator was built at the wrong size

`HolderRegistry.take` built the `HolderReader` from `description.launch.columns/rows` — the
**original launch request** — and nothing in the daemon ever called `TIOCGWINSZ`. But
`HolderReader.resize` moves the pty as well as the emulator (`TIOCSWINSZ`), so a session resized
while running came back after a daemon restart with its emulator at launch size and its pty at the
real size. The child paints 123 columns into a 100-column grid.

Not hypothetical: a pty resized to 41×123 was measured in the app-gap probe
([#784](../pull/784)).

Adoption now reads the true window size off the adopted master and builds the emulator from it,
falling back to the launch request only when the ioctl cannot answer. **The pty is the authority;
the launch request is a stale intent.**

**This unblocks the jiggle, and had to land first.** The spec's repaint mechanism is a SIGWINCH
nudge at every reader-handoff edge. Built the obvious way — resize away from the emulator's current
size and back — it would have *shrunk every resized session to its launch geometry on every daemon
restart*, because `resize` sets the pty too. The jiggle is deliberately **not** implemented here.

## 2. Readers for exited sessions were never released

On EOF the drain thread parks by design. `release` had exactly three callers: `releaseAll` at daemon
shutdown, and `abandon(terminal:)` on row deletion. So a job that exited while its terminal row
still existed kept its emulator, its dedicated thread (1 MB stack), its 64 KB buffer and its pty dup
for the daemon's whole lifetime. **Daemon memory scaled with sessions-adopted-this-lifetime, not
live sessions.**

### Named reconciler: the registry, on the exhausted-drain edge

`HolderRegistry.reclaimIfSessionEnded(_:)`, announced once by the drain loop from the `.exhausted`
arm — the one place it knows the descriptor was read until it would block. Two conditions, both
load-bearing:

- **the drain reached end of output** — the proof nothing is queued. A holder hands its master over
  *after* the child exits precisely so those bytes can be rescued, so releasing on the exit alone
  would discard exactly what that rule saves; and
- **the holder confirms the child exited** — from the status the hand-over carried, else a
  `describe` retried for 2 s. A `describe` winds the holder down, which is why adoption must not use
  one and why past the exhausted edge it is the right outcome rather than a cost.

**The second condition only holds if it takes an answer.** A probe that merely *failed* is not a
confirmed exit, and reading it as one collapses the pair back to the first condition — which is
exactly the shape that discards a live session's scrollback. The two errors are not symmetric: a
reader kept in error costs one emulator until the row is closed or the daemon restarts, while a
reader released in error stops the drain thread, closes the pty dup, and drops everything the
session ever printed. So every way a probe can fail is classified by name in `exitProbeOutcome`,
exhaustively, and the fall-through keeps:

- **keep** — a busy-sentinel refusal (a *live* holder serving somebody else), a `sun_path`-too-long
  path, the two cases a fresh-client `describe` cannot reach (`noDescriptor`, `notConnected`), and
  anything that is not a `HolderClient.Error` at all;
- **established, `exitedStatusUnknown`** — `ENOENT` or `ECONNREFUSED` on the connect. Nothing is
  listening, so the holder is gone; those are the only two errnos that mean absence rather than this
  daemon failing to reach a socket, and `RowlessHolderCollector.productionHandshake` and
  `HolderRendezvousCollector.probeForListener` already read them that way. Not retried, because
  absence is monotone here — a hand-over provably came over that path once, and a holder that has
  gone does not come back;
- **retry, on the existing 2 s budget** — every other connect errno (`EINTR`, `EMFILE`/`ENFILE`,
  `ENOBUFS`/`ENOMEM`, `ETIMEDOUT`), `peerClosed` and `transportFailed` (a hang-up between the accept
  and the answer, `EPIPE`, `ECONNRESET`, the receive timeout — what a holder winding down and one
  killed mid-frame both look like, told apart only by microseconds), and `unexpectedResponse`. Each
  describes a failed attempt, never the child.

Deliberately **not** an `AgentReaper` leg: the reaper sweeps the process table by tmux server name
and holds no registry reference, while a reader is daemon memory keyed by session and the fact that
licenses reclaiming it is observable only inside the reader. The edge is also exact where a 60 s
timer is not — it cannot fire before the output is drained, and it does not hold ~1.1 MB per session
for up to a minute after it could have been freed. A missed edge is bounded: the flag is sticky,
the call is idempotent, and the next adoption re-arms it.

Two conservative non-releases, on purpose: a job that closed its terminal but kept running, and a
holder someone else is attached to.

## Spec corrections

**The reclaimer's policy is now in the spec**, under Reconciliation
(`docs/specs/2026-08-30-pty-holder-session-transport-design.md`, "Letting go of a finished
session's reader"). That section covered only the durable resources — holder processes, rendezvous
files, and the jobs beneath them — and the reclaimer is a new decision set that lived only in code
comments. It now records the two conditions and why each is load-bearing, the
transient-versus-terminal ruling above and the asymmetry that decides its direction, the
confirmation budget and interval and what sizes them, the weak-closure fire-once lifecycle of the
end-of-output announcement, and why a reader — daemon memory that dies with the daemon — is not a
durable resource and so needs no sweep of its own.

The spec said "~10k lines" of scrollback; the code ships 5,000. Corrected, and the per-line cost
the spec asked for and never got is now recorded: `PackedCell.rawValue` is a `UInt64`, so **8 bytes
per cell** (`CellStorage.swift:16,31`; storage via
`CellStoragePage.cells: UnsafeMutableBufferPointer<PackedCell>` at `:811-812`, held by
`BufferLine.swift:122`), with a per-terminal `CellArena` interning styles and graphemes so a heavily
coloured screen costs the same per cell as a plain one. Worst case `5,000 × 120 × 8 ≈ 4.8 MB` of
cell bytes, 5–6 MB with per-line objects, ≈0.8 GB at ~150 emulators — qualified by lazy
materialization out of a preallocated `[BufferLine?]` (~40 KB of pointers), which a session must
fill its scrollback to defeat.

`theScrollbackBudgetIsComputedFromSwiftTermsPackedCellSize` pins the 8 so a SwiftTerm bump reddens
instead of silently staling the spec. Its doc comment names which type governs storage and records
that `CharData` is the read-side interface — measuring *its* stride reports 40 and overstates the
cost 5x. Worth stating because that mistake was made while writing this PR, and it is easy to
repeat: this branch pins `cheapsteak/SwiftTerm`, and a sibling checkout on this machine pins
upstream `migueldeicaza/SwiftTerm`, whose `BufferLine` genuinely does hold `CharData`.

## Test plan

- [x] **RED first, defect 1** — the discriminating assertion, which would pass if the emulator were
      built from the launch request: `the re-adopted emulator is 80x24; the pty is 123x41 and the
      launch request — which nothing updates on a resize — is 80x24`.
- [x] **RED first, defect 2** — removing the end-of-output announcement reddens 3 of 4 reclaim
      tests, while the negative-polarity `keepsTheReaderForAJobThatIsStillRunning` **stays green**,
      so the suite discriminates on the release condition rather than on release happening at all.
- [x] **RED first, the release policy** — `keepsTheReaderWhenTheExitProbeCannotReachTheHolder`
      spawns a real holder, takes the holder down without taking the job with it (the reader's own
      dup of the master keeps the foreground group from being hung up), binds a stranger on the
      rendezvous that accepts and immediately hangs up, and only then drives the pty to end of file.
      Against the unfixed tree: `Expectation failed: (stored → nil) === (reader → HolderReader)` and
      `(status → .exitedStatusUnknown) == .alive` — the reader, and everything the session had
      printed, released on one failed probe.
- [x] **Mutation-checked** — restoring the catch-all `return .exitedStatusUnknown` reddens exactly
      that test (2 issues) while the other five reclaim tests and all eight classification tests
      stay green. Restored.
- [x] **The other branch** — `releasesTheReaderWhenNothingIsListeningAtTheRendezvous` kills the
      holder and leaves its socket file where a SIGKILL leaves it, so the connect is refused: the
      reader **is** released, with `exitedStatusUnknown`. The fix is a classification, not a blanket
      "keep on any error", and this is what stops it becoming one.
- [x] **The classification table** — `HolderExitProbeClassificationTests` (tier 1, no holder
      spawned) pins all eight arms case by case, including that `ENOENT`/`ECONNREFUSED` agree with
      the two existing readers of those errnos.
- [x] Mutation-checked pin: forcing the cell size to 9 fails with
      `Expectation failed: (bytesPerCell → 8) == 9`. Restored.
- [x] `scripts/swift-safe build --build-tests` exit 0, zero `error:` lines.
- [x] `--filter keepsTheReaderWhenTheExitProbeCannotReachTheHolder --filter
      releasesTheReaderWhenNothingIsListeningAtTheRendezvous --filter
      HolderExitProbeClassificationTests` → **10 tests in 2 suites passed**.
- [x] `--filter HolderReclaimTests` → **6 tests in 1 suite passed**, including the negative-polarity
      `keepsTheReaderForAJobThatIsStillRunning`.
- [x] Whole Tier-3 live suite serially: **175 tests in 36 suites passed**, 0 failures.
- [x] `swiftlint --strict` → 0 violations in 908 files.

## Known and deliberately unchanged

A holder whose child exits closes its rendezvous after its 10 s exit-report window and becomes a
zombie until the row is deleted, where `dispose` reaps it. Pre-existing and untouched — the
reclaimer's probe only makes the holder wind down sooner than it already would.

`AgentReaperHolderLegLiveTests.theFlagOffLeavesARealOrphanRunning` hung one whole-suite run in
`killAndReap`'s `Process.waitUntilExit()`, after the reaper had SIGKILLed the process out from under
Foundation. Not this branch's: that file and `AgentReaper.swift` are byte-identical to `origin/main`.
It passes alone in 0.66 s and passed on the re-run, so it is a load-dependent flake in that
teardown, filed here rather than fixed alongside an unrelated change.

https://claude.ai/code/session_01UXqxcPYizvznh99Qb8JKrD

[20260830-boring-panda](https://cheapsteak.github.io/tbd/open/?worktree=A1E9CF50-E608-4F3C-BA8F-377D60BB7478)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal sessions now preserve their current window size when reconnected.
  * Completed jobs are recognized promptly after pending terminal output is delivered.
  * Exit status and queued output remain available when sessions are reclaimed.
  * Running jobs continue to appear as active while their terminal remains open.

* **Documentation**
  * Clarified detached terminal output retention, including the 5,000-line scrollback limit and memory considerations.

* **Tests**
  * Added coverage for session resizing, output draining, exit handling, and active-session retention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
