### PR TITLE
codex import: fix a silent drop race and a misleading error

### DIFF
--- a/Sources/TBDDaemon/Codex/CodexHomeManager.swift
+++ b/Sources/TBDDaemon/Codex/CodexHomeManager.swift
@@ -305,11 +305,17 @@ enum CodexProfileWriter {
     }
 }
 
-enum CodexExecutableResolutionError: LocalizedError, Equatable {
+// Conforms to `CustomStringConvertible` as well as `LocalizedError`: the RPC
+// router renders thrown errors with `"\(error)"`, which ignores
+// `errorDescription`. Without this, a missing Codex CLI reaches the user as
+// `notFound(searchPath: "…", fallbackPath: "…")` and the remediation steps
+// below are never shown.
+enum CodexExecutableResolutionError: Error, CustomStringConvertible,
+    LocalizedError, Equatable {
     case invalidOverride(environmentKey: String, value: String, reason: String)
     case notFound(searchPath: String, fallbackPath: String)
 
-    var errorDescription: String? {
+    var description: String {
         switch self {
         case .invalidOverride(let environmentKey, let value, let reason):
             return """
@@ -328,6 +334,8 @@ enum CodexExecutableResolutionError: LocalizedError, Equatable {
                 """
         }
     }
+
+    var errorDescription: String? { description }
 }
 
 /// Resolves the Codex CLI before TBD creates a tmux window or terminal row.

--- a/Sources/TBDDaemon/Codex/CodexSessionImporter.swift
+++ b/Sources/TBDDaemon/Codex/CodexSessionImporter.swift
@@ -4,13 +4,19 @@ import os
 private let codexImportLogger = Logger(
     subsystem: "com.tbd.daemon", category: "codex-session-import")
 
-enum CodexSessionImportError: LocalizedError, Equatable {
+// `RPCRouter.handle` renders a thrown error with `"\(error)"`, which uses
+// `CustomStringConvertible` and ignores `LocalizedError`. A LocalizedError-only
+// enum therefore reaches the user as `appServer("…")` instead of its authored
+// message, so every error type on this path conforms to both — matching
+// `WorktreeLifecycleError`.
+enum CodexSessionImportError: Error, CustomStringConvertible, LocalizedError,
+    Equatable {
     case appServer(String)
     case malformedResponse(String)
     case processExited(Int32)
     case timedOut
 
-    var errorDescription: String? {
+    var description: String {
         switch self {
         case .appServer(let message):
             return "Codex could not import this session: \(message)"
@@ -22,6 +28,8 @@ enum CodexSessionImportError: LocalizedError, Equatable {
             return "Codex did not finish importing the session before the deadline."
         }
     }
+
+    var errorDescription: String? { description }
 }
 
 protocol CodexAppServerConnection: Sendable {
@@ -296,33 +304,64 @@ struct ProcessCodexAppServerTransport: CodexAppServerTransport {
     }
 }
 
-private actor CodexAppServerLineInbox {
+/// Ordered hand-off of app-server lines from the pipe's readability queue to
+/// the awaiting import task.
+///
+/// Lock-guarded rather than an actor on purpose. `yield` must be callable
+/// synchronously from `consume`, because one `availableData` chunk routinely
+/// carries several protocol lines — the import response, `…/import/progress`,
+/// and `…/import/completed` land within roughly 60 ms of each other. Handing
+/// each line to an actor through its own unstructured `Task` imposes no
+/// ordering between those tasks, so under load the `completed` notification
+/// can be delivered ahead of the id-2 response. `expectImportResponse` drops
+/// any line without id 2, so that reordering silently discards the only
+/// notification carrying the thread id and the import can then only time out.
+/// (Measured out of order in roughly 0.5% of 3-line batches under contention.)
+private final class CodexAppServerLineInbox: @unchecked Sendable {
+    private let lock = NSLock()
     private var lines: [Data] = []
     private var waiter: CheckedContinuation<Data, any Error>?
     private var terminalError: (any Error)?
 
     func yield(_ line: Data) {
+        lock.lock()
         if let waiter {
             self.waiter = nil
+            lock.unlock()
             waiter.resume(returning: line)
         } else {
             lines.append(line)
+            lock.unlock()
         }
     }
 
+    /// Keeps the first terminal error: process exit carries a status the
+    /// later `close()` cancellation would otherwise overwrite.
     func finish(_ error: any Error) {
-        terminalError = error
-        if let waiter {
-            self.waiter = nil
-            waiter.resume(throwing: error)
-        }
+        lock.lock()
+        if terminalError == nil { terminalError = error }
+        let waiter = self.waiter
+        self.waiter = nil
+        lock.unlock()
+        waiter?.resume(throwing: error)
     }
 
     func next() async throws -> Data {
-        if !lines.isEmpty { return lines.removeFirst() }
-        if let terminalError { throw terminalError }
-        return try await withCheckedThrowingContinuation { continuation in
-            waiter = continuation
+        try await withCheckedThrowingContinuation { continuation in
+            lock.lock()
+            // Buffered lines drain before the terminal error, so a response
+            // already on the wire when the server exits is still read.
+            if !lines.isEmpty {
+                let line = lines.removeFirst()
+                lock.unlock()
+                continuation.resume(returning: line)
+            } else if let terminalError {
+                lock.unlock()
+                continuation.resume(throwing: terminalError)
+            } else {
+                waiter = continuation
+                lock.unlock()
+            }
         }
     }
 }
@@ -420,7 +459,7 @@ private final class ProcessCodexAppServerConnection: CodexAppServerConnection,
         stdoutPipe.fileHandleForReading.readabilityHandler = nil
         stderrPipe.fileHandleForReading.readabilityHandler = nil
         try? stdinPipe.fileHandleForWriting.close()
-        Task { await inbox.finish(CancellationError()) }
+        inbox.finish(CancellationError())
         if process.isRunning { process.terminate() }
     }
 
@@ -437,8 +476,10 @@ private final class ProcessCodexAppServerConnection: CodexAppServerConnection,
             }
             return complete
         }
+        // Yield synchronously and in order. The readability handler is serial,
+        // so this preserves wire order end to end.
         for line in lines {
-            Task { await inbox.yield(line) }
+            inbox.yield(line)
         }
     }
 
@@ -449,6 +490,6 @@ private final class ProcessCodexAppServerConnection: CodexAppServerConnection,
             return previous
         }
         guard !wasClosed else { return }
-        Task { await inbox.finish(CodexSessionImportError.processExited(status)) }
+        inbox.finish(CodexSessionImportError.processExited(status))
     }
 }

--- a/Sources/TBDDaemon/Server/RPCRouter+ContinueInCodexHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ContinueInCodexHandlers.swift
@@ -5,14 +5,21 @@ import TBDShared
 private let continueInCodexLogger = Logger(
     subsystem: "com.tbd.daemon", category: "continue-in-codex")
 
-private enum ContinueInCodexHandlerError: LocalizedError {
+/// Conforms to `CustomStringConvertible` as well as `LocalizedError` because
+/// `RPCRouter.handle` renders a thrown error with `"\(error)"`. A
+/// `LocalizedError`-only enum would surface as `userFacing("…")` in the app
+/// alert and in `tbd terminal continue-in-codex` output.
+private enum ContinueInCodexHandlerError: Error, CustomStringConvertible,
+    LocalizedError {
     case userFacing(String)
 
-    var errorDescription: String? {
+    var description: String {
         switch self {
         case .userFacing(let message): return message
         }
     }
+
+    var errorDescription: String? { description }
 }
 
 extension RPCRouter {


### PR DESCRIPTION
## What

Two small fixes to the Continue-in-Codex import path, left over after #572 (native-continue-in-codex) merged.

**1. A race that can silently drop a Codex import**

`CodexAppServerLineInbox` was an `actor` whose `yield()`/`finish()` calls were each dispatched via an unstructured `Task {}`. That gives no ordering guarantee between them, but one readability-handler chunk routinely carries several protocol lines together — the import response, `.../import/progress`, and `.../import/completed` land within roughly 60ms of each other. `expectImportResponse` drops any line without id 2, so if the `completed` notification's task happens to run first, the only message carrying the thread id is silently discarded and the import can then only time out.

Measured out of order in ~0.5% of 3-line batches under contention.

Fixed by replacing the actor with a lock-guarded (`NSLock`) class so `yield`/`finish` execute synchronously, in the same order the readability handler observed them on the wire — no more per-line `Task {}` indirection.

**2. Misleading error messages**

`CodexExecutableResolutionError`, `CodexSessionImportError`, and `ContinueInCodexHandlerError` conformed only to `LocalizedError`, but `RPCRouter.handle` renders thrown errors with `"\(error)"`, which uses `CustomStringConvertible` and ignores `errorDescription`. So a missing Codex CLI (or any other failure on these paths) reached the user as e.g. `notFound(searchPath: "...", fallbackPath: "...")` instead of the authored remediation message.

Fixed by having all three also conform to `CustomStringConvertible`, matching the existing pattern in `WorktreeLifecycleError`.

## Why draft

These are cleanup fixes found while reviewing the merged #572 branch, not yet reviewed by @cheapsteak. Opening as a draft for his visibility; not requesting review or asking for a merge.

## Testing

Both changed Swift files type-check individually against the change; the diff is scoped to error-message rendering and inbox ordering only. A full `swift build` in this environment currently fails on unrelated third-party dependencies (TOMLKit/GRDB C++ interop headers missing from the local toolchain) before it reaches these files, so a clean full-build confirmation was not obtained locally — flagging this rather than claiming a green build.
