### PR TITLE
docs(scripts): make the zero-token fake model API discoverable, with a claude-stub.py front door

### DIFF
--- a/.claude/skills/tbd-project/references/file-map.md
+++ b/.claude/skills/tbd-project/references/file-map.md
@@ -121,5 +121,6 @@ Key source files and what they do. Not exhaustive — see the directory listing 
 Swift Testing framework. `TBDDaemonTests/` (database, git, lifecycle, tmux, hooks, RPC routing, model profiles, sessions, transcripts, suspend/resume, ...), `TBDSharedTests/` (models, emoji), `TBDAppTests/` (layout, pane content).
 
 ## Scripts & Docs
-- `scripts/restart.sh` — rebuild + restart; `install-hooks.sh` — git hooks; `import-conductor.sh` / `import-claude-code-desktop.sh` — one-script migrations into TBD; `move-home-dir.sh`; `recipe-check.sh`; `git-hooks/`
-- `docs/` — `tmux-integration.md`, `diagnostics-strategy.md`, `worktree-hooks.md`, `worktree-location-design.md`, `transcript-context-usage.md`, `env-overrides.md`, `tcc-signing.md`, plus `specs/`, `plans/` & `perf/`
+- `scripts/restart.sh` — rebuild + restart; `install-hooks.sh` — git hooks; `import-conductor.sh` / `import-claude-code-desktop.sh` — one-script migrations into TBD; `move-home-dir.sh`; `recipe-check.sh`; `git-hooks/`; `mock.sh` — isolated seeded daemon+app for UI work; `claude-stub.py` — runs the real `claude` against the fake model API (zero tokens); `dev/dummy-remote-provider.sh` — file-backed fake remote provider
+- `.github/workflows/claude-review-v2/tests/e2e/stub_server.py` — the fake model API itself (stdlib `POST /v1/messages`, SSE, canned turns); shared by the review-gate e2e tests and `scripts/claude-stub.py`
+- `docs/` — `tmux-integration.md`, `diagnostics-strategy.md`, `worktree-hooks.md`, `worktree-location-design.md`, `transcript-context-usage.md`, `env-overrides.md`, `tcc-signing.md`, `test-doubles.md` (index of the fakes), `fake-model-api.md`, `mock-harness.md`, plus `specs/`, `plans/` & `perf/`

--- a/.github/workflows/claude-review-v2/tests/e2e/README.md
+++ b/.github/workflows/claude-review-v2/tests/e2e/README.md
@@ -59,6 +59,14 @@ role's first response to simulate a straggling specialist.
 - The CLI sends one `/api/hello` connectivity preflight per invocation and
   tolerates the stub's 404 (`harness.tolerated_unexpected_paths`).
 
+## General use outside the review gate
+
+`stub_server.py` is not review-gate-specific — anything that needs a real
+`claude` session without spending tokens can use it. `scripts/claude-stub.py`
+is the general-purpose front door: it builds the sandbox, starts the server
+with turns you script, and runs `claude` (headless or the interactive TUI) in
+your current directory. See [`docs/fake-model-api.md`](../../../../../docs/fake-model-api.md).
+
 ## Running locally
 
 ```sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,7 +150,10 @@ jobs:
       #
       # Nothing here touches the network, a real remote, `~/tbd`, or a real
       # `gh`: each harness builds a fixture repo in a temp dir and puts a stub
-      # `gh` first on PATH.
+      # `gh` first on PATH. `test-claude-stub.py` does bind a loopback socket,
+      # and where a `claude` binary is on PATH it runs the real CLI against
+      # that socket — still no egress, and it self-skips on runners, which
+      # have no `claude` installed.
       - name: Test agent guardrails and the script harnesses
         run: |
           python3 .claude/hooks/guardrails/dispatch.py --self-test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,6 +155,7 @@ jobs:
         run: |
           python3 .claude/hooks/guardrails/dispatch.py --self-test
           python3 scripts/test-swift-safe.py
+          python3 scripts/test-claude-stub.py
           python3 scripts/test-remote-verify.py
           bash scripts/remote-verify.test.sh
           bash scripts/sweep-preflight-refs.test.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,6 +221,7 @@ Enforced mechanically by two SwiftLint custom rules in `.swiftlint.yml` (`no_tui
 - **Restart**: `scripts/restart.sh`
 - **Send a starving test run to CI instead of waiting**: `export TBD_REMOTE_VERIFY=1` (default off; needs a clean tree). See the remote verification valve under "Workflow" above.
 - **Install git hooks** (one-time setup after cloning): `scripts/install-hooks.sh`
+- **Run the real `claude` with zero tokens** (fake model API): `scripts/claude-stub.py -- -p "hi"` — see [`docs/fake-model-api.md`](docs/fake-model-api.md); all stand-ins for external dependencies: [`docs/test-doubles.md`](docs/test-doubles.md)
 - **Diagnostics**: see [`docs/diagnostics-strategy.md`](docs/diagnostics-strategy.md). Quick recipes:
   - Stream one feature area live: `log stream --level debug --predicate 'subsystem BEGINSWITH "com.tbd" AND category == "markdown"'`
   - Replay the last 5 minutes after reproducing a bug: `log show --last 5m --level debug --predicate 'subsystem BEGINSWITH "com.tbd"'` (requires `sudo log config --subsystem com.tbd.app --mode "level:debug,persist:debug"` once per subsystem to capture `.debug` rows)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,7 +221,7 @@ Enforced mechanically by two SwiftLint custom rules in `.swiftlint.yml` (`no_tui
 - **Restart**: `scripts/restart.sh`
 - **Send a starving test run to CI instead of waiting**: `export TBD_REMOTE_VERIFY=1` (default off; needs a clean tree). See the remote verification valve under "Workflow" above.
 - **Install git hooks** (one-time setup after cloning): `scripts/install-hooks.sh`
-- **Run the real `claude` with zero tokens** (fake model API): `scripts/claude-stub.py -- -p "hi"` — see [`docs/fake-model-api.md`](docs/fake-model-api.md); all stand-ins for external dependencies: [`docs/test-doubles.md`](docs/test-doubles.md)
+- **Run the real `claude` with zero tokens** (fake model API): `scripts/claude-stub.py -- -p "hi"` — see [`docs/fake-model-api.md`](docs/fake-model-api.md); every test double the repo has: [`docs/test-doubles.md`](docs/test-doubles.md)
 - **Diagnostics**: see [`docs/diagnostics-strategy.md`](docs/diagnostics-strategy.md). Quick recipes:
   - Stream one feature area live: `log stream --level debug --predicate 'subsystem BEGINSWITH "com.tbd" AND category == "markdown"'`
   - Replay the last 5 minutes after reproducing a bug: `log show --last 5m --level debug --predicate 'subsystem BEGINSWITH "com.tbd"'` (requires `sudo log config --subsystem com.tbd.app --mode "level:debug,persist:debug"` once per subsystem to capture `.debug` rows)

--- a/docs/fake-model-api.md
+++ b/docs/fake-model-api.md
@@ -37,10 +37,10 @@ scripts/claude-stub.py --text "hello from the stub" -- -p "say hello"
 
 ```
 hello from the stub
-claude-stub: 1 request(s) served at http://127.0.0.1:51548
+claude-stub: 1 request(s) served at http://127.0.0.1:49431
 claude-stub: unexpected paths: none
 claude-stub: client disconnects: 0
-claude-stub: no request left this machine — ANTHROPIC_BASE_URL was http://127.0.0.1:51548 (loopback)
+claude-stub: no model request left this machine — ANTHROPIC_BASE_URL was http://127.0.0.1:49431 (loopback)
 ```
 
 Everything after `--` goes to `claude`. With nothing after it you get the
@@ -55,20 +55,21 @@ callers.
 
 With no arguments after `--`, `claude-stub.py` opens the real TUI. The default
 turn script is one long numbered answer (`--lines`, default 200) — the shape
-that fills the scrollback and exercises the renderer:
+that fills the scrollback and exercises the renderer. A smaller count is easier
+to read back out of a capture:
 
 ```sh
-scripts/claude-stub.py --lines 200
+scripts/claude-stub.py --lines 50
 ```
 
 Driven inside a 120x40 tmux window, typing a prompt renders the whole scripted
 answer:
 
 ```
-  197. stub answer line 197 of 200 — filler so the answer is long enough to scroll.
-  198. stub answer line 198 of 200 — filler so the answer is long enough to scroll.
-  199. stub answer line 199 of 200 — filler so the answer is long enough to scroll.
-  200. stub answer line 200 of 200 — filler so the answer is long enough to scroll.
+  47. stub answer line 47 of 50 — filler so the answer is long enough to scroll.
+  48. stub answer line 48 of 50 — filler so the answer is long enough to scroll.
+  49. stub answer line 49 of 50 — filler so the answer is long enough to scroll.
+  50. stub answer line 50 of 50 — filler so the answer is long enough to scroll.
 ```
 
 Resizing that window to 100x30 delivers a SIGWINCH to the CLI, which reflows
@@ -79,18 +80,21 @@ long answer on screen, resize, read what came back.
 `/exit` ends the session and the summary follows:
 
 ```
-claude-stub: 2 request(s) served at http://127.0.0.1:51707
+claude-stub: 2 request(s) served at http://127.0.0.1:50079
 claude-stub:   route (ordered turns): 1
 claude-stub:   route session title: 1
 claude-stub: unexpected paths: none
 claude-stub: client disconnects: 0
-claude-stub: no request left this machine — ANTHROPIC_BASE_URL was http://127.0.0.1:51707 (loopback)
+claude-stub: no model request left this machine — ANTHROPIC_BASE_URL was http://127.0.0.1:50079 (loopback)
 ```
 
 Two requests, because the TUI opens every session with a second, concurrent
-request asking the model to name the session. That one is answered from its
-own content-keyed route so it cannot eat a scripted turn; headless `-p` sends
-none.
+request asking the model to name the session (observed on claude 2.1.258 — the
+e2e README beside the stub dates its own CLI observations the same way). That
+one is answered from its own content-keyed route so it cannot eat a scripted
+turn; headless `-p` sends none. A future CLI that drops the request, or wraps
+it in something other than `<session>…</session>`, would simply leave the route
+unused.
 
 The interactive TUI also raises one dialog headless mode never does — "Detected
 a custom API key in your environment … use this API key?" — so the wrapper
@@ -104,38 +108,55 @@ composer.
 `--print-env` starts the server, prints shell-quoted `export` lines, and keeps
 serving until SIGINT or SIGTERM. Use it when you want to type into `claude`
 yourself, or run it under instrumentation, rather than have the wrapper launch
-it:
+it.
+
+The exports go to stdout and everything else to stderr, so redirect stdout to a
+file the other pane can source:
 
 ```sh
 # pane 1
-scripts/claude-stub.py --print-env --text 'served via print-env' --sandbox /tmp/stub-sandbox
+scripts/claude-stub.py --print-env --text 'served via print-env' \
+  --sandbox /tmp/stub-sandbox > /tmp/stub-sandbox-exports.sh
 ```
+
+That leaves `/tmp/stub-sandbox-exports.sh` holding:
 
 ```
 export ANTHROPIC_API_KEY=stub-key
-export ANTHROPIC_BASE_URL=http://127.0.0.1:64112
+export ANTHROPIC_BASE_URL=http://127.0.0.1:49593
 export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
 export CLAUDE_CONFIG_DIR=/tmp/stub-sandbox/config
+export COLORTERM=truecolor
 export HOME=/tmp/stub-sandbox
+export LANG=C.UTF-8
 export NO_PROXY=127.0.0.1,localhost
 export TERM=tmux-256color
 export TMPDIR=/tmp/stub-sandbox/tmp
+# eval these in another pane, then run: claude
+```
+
+while pane 1 keeps serving and says so on stderr:
+
+```
+claude-stub: serving; Ctrl-C (or SIGTERM) to stop
 ```
 
 ```sh
 # pane 2
-eval "$(cat exports.sh)"
+eval "$(cat /tmp/stub-sandbox-exports.sh)"
 claude -p 'hi'          # -> served via print-env
 ```
 
-`PATH` is deliberately not exported — you already have your own. Ctrl-C (or a
+`PATH` is deliberately not exported — you already have your own. `TERM`,
+`COLORTERM` and `LANG` are whatever pane 1's own terminal had. Ctrl-C (or a
 `SIGTERM` to the process) stops the server and prints the same summary:
 
 ```
-claude-stub: 1 request(s) served at http://127.0.0.1:64112
+claude-stub: 1 request(s) served at http://127.0.0.1:49593
 claude-stub: unexpected paths: none
 claude-stub: client disconnects: 0
-claude-stub: no request left this machine — ANTHROPIC_BASE_URL was http://127.0.0.1:64112 (loopback)
+claude-stub: no model request left this machine — ANTHROPIC_BASE_URL was http://127.0.0.1:49593 (loopback)
+claude-stub: sandbox kept at /tmp/stub-sandbox
 ```
 
 ## The turn file
@@ -180,6 +201,9 @@ back to `turns`:
 ```
 
 Put the sentinel in the subagent's Task prompt, and the routing follows it.
+One sentinel is reserved: `</session>` belongs to the TUI's session-title
+request, and the wrapper's route for it wins over a turn file that names the
+same key.
 
 ## What the stub models, and what it does not
 
@@ -206,10 +230,15 @@ is always kept). `TERM`, `COLORTERM`, `LANG` and `LC_ALL` pass through from
 your terminal, and `--env KEY=VALUE` overrides anything.
 
 Tokens are zero by construction rather than by policy: `ANTHROPIC_BASE_URL`
-points at `http://127.0.0.1:<port>`, so requests cannot leave the machine, and
-the only credential in the environment is a placeholder. The summary's request
-count is what the loopback server actually answered — if the CLI had reached an
-upstream, the count would not add up.
+points at `http://127.0.0.1:<port>`, so no model request can leave the machine,
+and the only credential in the environment is a placeholder. The summary's
+request count is what the loopback server actually answered — if the CLI had
+reached an upstream, the count would not add up.
+
+The claim is about model traffic, which is all the stub can see. The CLI's
+other outbound calls — telemetry and the like — are not observed to be absent;
+they are switched off, by the `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1` the
+sandbox env carries.
 
 ## Pointing a TBD session at it
 

--- a/docs/fake-model-api.md
+++ b/docs/fake-model-api.md
@@ -106,9 +106,9 @@ composer.
 ## Driving `claude` by hand from another pane
 
 `--print-env` starts the server, prints shell-quoted `export` lines, and keeps
-serving until SIGINT or SIGTERM. Use it when you want to type into `claude`
-yourself, or run it under instrumentation, rather than have the wrapper launch
-it.
+serving until SIGINT, SIGTERM or SIGHUP. Use it when you want to type into
+`claude` yourself, or run it under instrumentation, rather than have the
+wrapper launch it.
 
 The exports go to stdout and everything else to stderr, so redirect stdout to a
 file the other pane can source:
@@ -156,7 +156,8 @@ block prints.
 
 `PATH` is deliberately not exported — you already have your own. `TERM`,
 `COLORTERM` and `LANG` are whatever pane 1's own terminal had. Ctrl-C (or a
-`SIGTERM` to the process) stops the server and prints the same summary:
+`SIGTERM` or `SIGHUP` to the process) stops the server and prints the same
+summary:
 
 ```text
 claude-stub: 1 request(s) served at http://127.0.0.1:49593

--- a/docs/fake-model-api.md
+++ b/docs/fake-model-api.md
@@ -246,6 +246,16 @@ and the only credential in the environment is a placeholder. The summary's
 request count is what the loopback server actually answered — if the CLI had
 reached an upstream, the count would not add up.
 
+Ctrl-C behaves as it would in a bare `claude`: when the wrapper is running in
+the foreground of a terminal, the terminal delivers the SIGINT to `claude`
+directly — the child shares the wrapper's process group so it can own the tty —
+and the wrapper does not forward a second one, which the TUI would read as the
+double Ctrl-C it exits on. To stop a wrapped session from another shell, send
+`SIGTERM` to the wrapper: it forwards that to `claude`, waits for it, prints the
+summary, and removes the sandbox. A `kill -INT` aimed at a wrapper running in a
+terminal's foreground is not forwarded, by design — the terminal is what
+delivers SIGINT there, and the wrapper cannot tell the two apart.
+
 The claim is about model traffic, which is all the stub can see. The CLI's
 other outbound calls — telemetry and the like — are not observed to be absent;
 they are switched off, by the `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1` the

--- a/docs/fake-model-api.md
+++ b/docs/fake-model-api.md
@@ -133,6 +133,7 @@ export NO_PROXY=127.0.0.1,localhost
 export TERM=tmux-256color
 export TMPDIR=/tmp/stub-sandbox/tmp
 # eval these in another pane, then run: claude
+# run claude from this directory (the sandbox trusts it): /path/to/your/repo
 ```
 
 while pane 1 keeps serving and says so on stderr:
@@ -146,6 +147,12 @@ claude-stub: serving; Ctrl-C (or SIGTERM) to stop
 eval "$(cat /tmp/stub-sandbox-exports.sh)"
 claude -p 'hi'          # -> served via print-env
 ```
+
+Run pane 2's `claude` from the same directory pane 1 was started in — the
+trusted-project entry pane 1 wrote into the sandbox names that one cwd, and
+from anywhere else the CLI treats the project as untrusted and silently skips
+its project hooks. That is the directory the last comment line of the exports
+block prints.
 
 `PATH` is deliberately not exported — you already have your own. `TERM`,
 `COLORTERM` and `LANG` are whatever pane 1's own terminal had. Ctrl-C (or a
@@ -227,7 +234,11 @@ its own `TMPDIR` and a pre-written `.claude.json`. Your real `~/.claude` is
 untouched, and the session's transcript lands in the sandbox. It is deleted at
 exit unless you pass `--keep` or name it with `--sandbox` (an explicit sandbox
 is always kept). `TERM`, `COLORTERM`, `LANG` and `LC_ALL` pass through from
-your terminal, and `--env KEY=VALUE` overrides anything.
+your terminal, and `--env KEY=VALUE` overrides anything — including
+`ANTHROPIC_BASE_URL`, which is how you would point `claude` at some other
+server while still holding this one open. Do that and the summary says so
+instead of claiming loopback: it names the URL the CLI was given and notes
+that requests to it are not counted here.
 
 Tokens are zero by construction rather than by policy: `ANTHROPIC_BASE_URL`
 points at `http://127.0.0.1:<port>`, so no model request can leave the machine,

--- a/docs/fake-model-api.md
+++ b/docs/fake-model-api.md
@@ -2,11 +2,11 @@
 
 `scripts/claude-stub.py` starts a mock of the Anthropic Messages API on
 loopback and runs the **real** `claude` CLI against it, so a whole session —
-headless `-p` or the interactive TUI — happens offline, with no API key and
-without spending tokens. The stub is a fake model, not a fake CLI: the binary,
-its config, its hooks, its terminal rendering are all the genuine article;
-only the answers are scripted locally, which makes them deterministic and
-makes the run structurally zero-token.
+headless `-p` or the interactive TUI — happens offline, without a real API key
+and without spending tokens. The stub is a fake model, not a fake CLI: the
+binary, its config, its hooks, its terminal rendering are all the genuine
+article; only the answers are scripted locally, which makes them deterministic
+and makes the run structurally zero-token.
 
 Reach for it when you need a live agent session to look at something that has
 nothing to do with what the model says — terminal rendering, resize behavior,
@@ -35,7 +35,7 @@ Headless, one scripted answer:
 scripts/claude-stub.py --text "hello from the stub" -- -p "say hello"
 ```
 
-```
+```text
 hello from the stub
 claude-stub: 1 request(s) served at http://127.0.0.1:49431
 claude-stub: unexpected paths: none
@@ -65,7 +65,7 @@ scripts/claude-stub.py --lines 50
 Driven inside a 120x40 tmux window, typing a prompt renders the whole scripted
 answer:
 
-```
+```text
   47. stub answer line 47 of 50 — filler so the answer is long enough to scroll.
   48. stub answer line 48 of 50 — filler so the answer is long enough to scroll.
   49. stub answer line 49 of 50 — filler so the answer is long enough to scroll.
@@ -79,7 +79,7 @@ long answer on screen, resize, read what came back.
 
 `/exit` ends the session and the summary follows:
 
-```
+```text
 claude-stub: 2 request(s) served at http://127.0.0.1:50079
 claude-stub:   route (ordered turns): 1
 claude-stub:   route session title: 1
@@ -121,7 +121,7 @@ scripts/claude-stub.py --print-env --text 'served via print-env' \
 
 That leaves `/tmp/stub-sandbox-exports.sh` holding:
 
-```
+```sh
 export ANTHROPIC_API_KEY=stub-key
 export ANTHROPIC_BASE_URL=http://127.0.0.1:49593
 export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
@@ -138,7 +138,7 @@ export TMPDIR=/tmp/stub-sandbox/tmp
 
 while pane 1 keeps serving and says so on stderr:
 
-```
+```text
 claude-stub: serving; Ctrl-C (or SIGTERM) to stop
 ```
 
@@ -158,7 +158,7 @@ block prints.
 `COLORTERM` and `LANG` are whatever pane 1's own terminal had. Ctrl-C (or a
 `SIGTERM` to the process) stops the server and prints the same summary:
 
-```
+```text
 claude-stub: 1 request(s) served at http://127.0.0.1:49593
 claude-stub: unexpected paths: none
 claude-stub: client disconnects: 0

--- a/docs/fake-model-api.md
+++ b/docs/fake-model-api.md
@@ -1,0 +1,220 @@
+# Fake model API: run the real `claude` with zero tokens
+
+`scripts/claude-stub.py` starts a mock of the Anthropic Messages API on
+loopback and runs the **real** `claude` CLI against it, so a whole session —
+headless `-p` or the interactive TUI — happens offline, with no API key and
+without spending tokens. The stub is a fake model, not a fake CLI: the binary,
+its config, its hooks, its terminal rendering are all the genuine article;
+only the answers are scripted locally, which makes them deterministic and
+makes the run structurally zero-token.
+
+Reach for it when you need a live agent session to look at something that has
+nothing to do with what the model says — terminal rendering, resize behavior,
+hook wiring, session files, spawn plumbing.
+
+## What it is
+
+The server is `stub_server.py` under
+`.github/workflows/claude-review-v2/tests/e2e/`: a stdlib fake of
+`POST /v1/messages` that answers in SSE from a list of canned turns. It was
+built for the PR-review gate's e2e tests, and that directory's `README.md`
+documents the review-gate scenarios it scripts. `claude-stub.py` is the
+general-purpose front door to the same server: it builds the sandbox, starts
+the server, runs `claude` in your current directory, and prints a summary of
+what the stub served.
+
+## Quick start
+
+Run it from a throwaway directory unless you mean otherwise — `claude` runs in
+your current working directory and picks up that project's
+`.claude/settings.json`, hooks and permissions.
+
+Headless, one scripted answer:
+
+```sh
+scripts/claude-stub.py --text "hello from the stub" -- -p "say hello"
+```
+
+```
+hello from the stub
+claude-stub: 1 request(s) served at http://127.0.0.1:51548
+claude-stub: unexpected paths: none
+claude-stub: client disconnects: 0
+claude-stub: no request left this machine — ANTHROPIC_BASE_URL was http://127.0.0.1:51548 (loopback)
+```
+
+Everything after `--` goes to `claude`. With nothing after it you get the
+interactive TUI. The summary goes to stderr, so `-p` output stays pipeable, and
+the wrapper exits with `claude`'s own status.
+
+Piping into it from a script is worth one flag: `claude -p` waits ~3 s for
+stdin when stdin is not a terminal, so add `< /dev/null` in non-interactive
+callers.
+
+## Interactive TUI, and resize
+
+With no arguments after `--`, `claude-stub.py` opens the real TUI. The default
+turn script is one long numbered answer (`--lines`, default 200) — the shape
+that fills the scrollback and exercises the renderer:
+
+```sh
+scripts/claude-stub.py --lines 200
+```
+
+Driven inside a 120x40 tmux window, typing a prompt renders the whole scripted
+answer:
+
+```
+  197. stub answer line 197 of 200 — filler so the answer is long enough to scroll.
+  198. stub answer line 198 of 200 — filler so the answer is long enough to scroll.
+  199. stub answer line 199 of 200 — filler so the answer is long enough to scroll.
+  200. stub answer line 200 of 200 — filler so the answer is long enough to scroll.
+```
+
+Resizing that window to 100x30 delivers a SIGWINCH to the CLI, which reflows
+and repaints against the new width — the session survives it and stays at the
+prompt. That is the loop for measuring what the CLI emits on a resize: hold a
+long answer on screen, resize, read what came back.
+
+`/exit` ends the session and the summary follows:
+
+```
+claude-stub: 2 request(s) served at http://127.0.0.1:51707
+claude-stub:   route (ordered turns): 1
+claude-stub:   route session title: 1
+claude-stub: unexpected paths: none
+claude-stub: client disconnects: 0
+claude-stub: no request left this machine — ANTHROPIC_BASE_URL was http://127.0.0.1:51707 (loopback)
+```
+
+Two requests, because the TUI opens every session with a second, concurrent
+request asking the model to name the session. That one is answered from its
+own content-keyed route so it cannot eat a scripted turn; headless `-p` sends
+none.
+
+The interactive TUI also raises one dialog headless mode never does — "Detected
+a custom API key in your environment … use this API key?" — so the wrapper
+pre-approves the stub key under `customApiKeyResponses` in the sandbox's
+`.claude.json`, on top of the trust and onboarding keys the e2e harness already
+writes. Without it the session stops on that prompt instead of reaching the
+composer.
+
+## Driving `claude` by hand from another pane
+
+`--print-env` starts the server, prints shell-quoted `export` lines, and keeps
+serving until SIGINT or SIGTERM. Use it when you want to type into `claude`
+yourself, or run it under instrumentation, rather than have the wrapper launch
+it:
+
+```sh
+# pane 1
+scripts/claude-stub.py --print-env --text 'served via print-env' --sandbox /tmp/stub-sandbox
+```
+
+```
+export ANTHROPIC_API_KEY=stub-key
+export ANTHROPIC_BASE_URL=http://127.0.0.1:64112
+export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
+export CLAUDE_CONFIG_DIR=/tmp/stub-sandbox/config
+export HOME=/tmp/stub-sandbox
+export NO_PROXY=127.0.0.1,localhost
+export TERM=tmux-256color
+export TMPDIR=/tmp/stub-sandbox/tmp
+```
+
+```sh
+# pane 2
+eval "$(cat exports.sh)"
+claude -p 'hi'          # -> served via print-env
+```
+
+`PATH` is deliberately not exported — you already have your own. Ctrl-C (or a
+`SIGTERM` to the process) stops the server and prints the same summary:
+
+```
+claude-stub: 1 request(s) served at http://127.0.0.1:64112
+claude-stub: unexpected paths: none
+claude-stub: client disconnects: 0
+claude-stub: no request left this machine — ANTHROPIC_BASE_URL was http://127.0.0.1:64112 (loopback)
+```
+
+## The turn file
+
+`--turns FILE.json` scripts more than one answer. Request N is served turn N:
+
+```json
+[
+  {"text": "first scripted answer"},
+  {"text": "second scripted answer"}
+]
+```
+
+A turn may also carry tool calls, which is how you drive the CLI's tool loop:
+
+```json
+[
+  {
+    "text": "Writing the file.",
+    "tool_calls": [
+      {"name": "Write", "input": {"file_path": "/tmp/out.json", "content": "{}"}}
+    ]
+  },
+  {"text": "Done."}
+]
+```
+
+The object form adds content-keyed routing for parallel subagents, where
+request order is nondeterministic and ordered indexing cannot work. Each key is
+a sentinel string; a request whose **first** message contains it is served from
+that key's own list, with its own per-route index, and anything unmatched falls
+back to `turns`:
+
+```json
+{
+  "turns": [{"text": "orchestrator turn 1"}],
+  "role_turns": {
+    "ROLE-CORRECTNESS": [{"text": "correctness specialist"}],
+    "ROLE-SECURITY": [{"text": "security specialist"}]
+  }
+}
+```
+
+Put the sentinel in the subagent's Task prompt, and the routing follows it.
+
+## What the stub models, and what it does not
+
+- **Only `POST /v1/messages`.** Every other path — `count_tokens` included —
+  gets a 404 and is recorded. The summary reports those as unexpected paths,
+  minus the one `/api/hello` connectivity preflight the CLI sends per
+  invocation and shrugs off.
+- **SSE only, never plain JSON.** The CLI sends `stream: true`; answered with
+  a plain body it silently retries a byte-identical request forever while
+  executing nothing.
+- **Scripted turns, not a model.** Answers are whatever you wrote. Requests
+  past the end of the script get the overflow turn, whose text is
+  `STUB-TERMINAL`, so a short script ends a session instead of hanging it.
+- **No usage accounting, no rate limits, no auth.** The key is the literal
+  string `stub-key` and nothing checks it.
+
+## Isolation, and why tokens are structurally zero
+
+The sandbox is a fresh directory used as `HOME` and `CLAUDE_CONFIG_DIR`, with
+its own `TMPDIR` and a pre-written `.claude.json`. Your real `~/.claude` is
+untouched, and the session's transcript lands in the sandbox. It is deleted at
+exit unless you pass `--keep` or name it with `--sandbox` (an explicit sandbox
+is always kept). `TERM`, `COLORTERM`, `LANG` and `LC_ALL` pass through from
+your terminal, and `--env KEY=VALUE` overrides anything.
+
+Tokens are zero by construction rather than by policy: `ANTHROPIC_BASE_URL`
+points at `http://127.0.0.1:<port>`, so requests cannot leave the machine, and
+the only credential in the environment is a placeholder. The summary's request
+count is what the loopback server actually answered — if the CLI had reached an
+upstream, the count would not add up.
+
+## Pointing a TBD session at it
+
+A TBD `proxy` model profile carries its own `ANTHROPIC_BASE_URL`, and that env
+is what a spawned Claude session gets (see [`env-overrides.md`](env-overrides.md)
+for how profile env layers over repo and global overrides). That is the seam
+for aiming a TBD-spawned session at a running `--print-env` server rather than
+at the real API.

--- a/docs/mock-harness.md
+++ b/docs/mock-harness.md
@@ -32,3 +32,7 @@ running `scripts/mock.sh up <name>`. Use only placeholder repo names
 Tier 1: sidebar, transcript pane, dialogs, toolbars, PR badges. Terminal
 *scrollback* panes are not populated (no live tmux) — that is a deferred Tier 2
 follow-up. No live `claude`/`codex` process is spawned.
+
+This harness fakes TBD's own state, not the model; to run a real `claude`
+against a fake model API for zero tokens, see
+[`fake-model-api.md`](fake-model-api.md).

--- a/docs/test-doubles.md
+++ b/docs/test-doubles.md
@@ -1,14 +1,14 @@
-# Stand-ins for external dependencies
+# Test doubles: stand-ins for external dependencies and TBD's own state
 
-TBD's development loop leans on four fakes. Each replaces a different external
-dependency, and picking the wrong one wastes an afternoon, so this is the
-index.
+TBD's development loop leans on four fakes. Three replace an external
+dependency and one replaces TBD's own state; each answers a different question,
+and picking the wrong one wastes an afternoon, so this is the index.
 
 - **Fake model API** — `scripts/claude-stub.py`, documented in
   [`fake-model-api.md`](fake-model-api.md). Fakes the Anthropic Messages API on
   loopback and runs the **real** `claude` CLI against it, headless or in the
-  interactive TUI, for zero tokens and with no API key. Reach for it when you
-  need a genuine live agent session but not a genuine answer: terminal
+  interactive TUI, for zero tokens and without a real API key. Reach for it
+  when you need a genuine live agent session but not a genuine answer: terminal
   rendering and resize behavior, hook wiring, session files, spawn plumbing.
   The server itself is `stub_server.py` under
   `.github/workflows/claude-review-v2/tests/e2e/`, where it also scripts the

--- a/docs/test-doubles.md
+++ b/docs/test-doubles.md
@@ -1,0 +1,33 @@
+# Stand-ins for external dependencies
+
+TBD's development loop leans on four fakes. Each replaces a different external
+dependency, and picking the wrong one wastes an afternoon, so this is the
+index.
+
+- **Fake model API** — `scripts/claude-stub.py`, documented in
+  [`fake-model-api.md`](fake-model-api.md). Fakes the Anthropic Messages API on
+  loopback and runs the **real** `claude` CLI against it, headless or in the
+  interactive TUI, for zero tokens and with no API key. Reach for it when you
+  need a genuine live agent session but not a genuine answer: terminal
+  rendering and resize behavior, hook wiring, session files, spawn plumbing.
+  The server itself is `stub_server.py` under
+  `.github/workflows/claude-review-v2/tests/e2e/`, where it also scripts the
+  PR-review gate's e2e scenarios.
+- **UI mock harness** — `scripts/mock.sh`, documented in
+  [`mock-harness.md`](mock-harness.md). Fakes TBD's *own* state: an isolated
+  daemon and app pair seeded from a committed scenario file, under a scratch
+  `TBD_HOME`. It spawns no agent and talks to no model. Reach for it for UI
+  work and staged screenshots — sidebar, dialogs, badges, transcript pane —
+  where what matters is the state the app renders.
+- **Dummy remote provider** — `scripts/dev/dummy-remote-provider.sh`. Fakes a
+  remote agent backend, implementing the v1 provider contract
+  ([`remote-provider-contract.md`](remote-provider-contract.md)) against plain
+  JSON files in a temp directory: no network, no auth. Register it in
+  `~/tbd/agent-providers.json` and hand-edit a session file to drive the
+  remote-backend UI through states a real provider would take hours to reach.
+- **tmux executable fixture** — `Tests/TestSupport/TmuxExecutableTestFixture.swift`.
+  Fakes the `tmux` binary itself for Swift tests: a stub executable that
+  reports a known version and logs each invocation, plus a resolver pinned to
+  it. Reach for it when a test's behavior turns on the tmux version and must
+  not depend on the host's `PATH` or the developer's saved fallback — a live
+  tmux is the other tool, and slower.

--- a/scripts/claude-stub.py
+++ b/scripts/claude-stub.py
@@ -219,34 +219,117 @@ def report(lines: list[str]) -> None:
         print(f"claude-stub: {line}", file=sys.stderr)
 
 
+class Terminated(Exception):
+    """SIGTERM or SIGHUP arrived with nothing else to hand it to.
+
+    Raised out of the signal handler so the signal unwinds through `main`'s
+    cleanup instead of the interpreter dying where it stands.
+    """
+
+    def __init__(self, signum: int) -> None:
+        super().__init__(f"terminated by signal {signum}")
+        self.signum = signum
+
+
+class SignalTargets:
+    """Who owns a stop signal right now, as the run moves through its phases.
+
+    The handler tests these in order: a live `claude` owns the signal and gets
+    it forwarded; a spawn in flight queues it, because the fork may already
+    exist under a name nothing has been handed yet; a `--print-env` server
+    stops serving; otherwise nothing is running that can take it, so the
+    signal becomes a `Terminated`.
+    """
+
+    def __init__(self) -> None:
+        self.child: subprocess.Popen | None = None
+        self.spawning = False
+        self.pending_signum: int | None = None
+        self.serving_event: threading.Event | None = None
+
+
+SIGNAL_TARGETS = SignalTargets()
+STOP_SIGNALS = (signal.SIGTERM, signal.SIGHUP)
+
+
+def handle_stop_signal(signum: int, _frame: Any) -> None:
+    child = SIGNAL_TARGETS.child
+    if child is not None:
+        # PEP 475 retries the interrupted `wait()` once this returns, so the
+        # wrapper's own status follows however the child answers the signal.
+        try:
+            child.send_signal(signum)
+        except OSError:  # the child died between the check and the signal
+            pass
+        return
+    if SIGNAL_TARGETS.spawning:
+        SIGNAL_TARGETS.pending_signum = signum
+        return
+    event = SIGNAL_TARGETS.serving_event
+    if event is not None:
+        event.set()
+        return
+    raise Terminated(signum)
+
+
+def install_signal_handlers() -> dict[int, Any]:
+    """Take SIGTERM and SIGHUP; return what they were, for restoring after."""
+    return {sig: signal.signal(sig, handle_stop_signal) for sig in STOP_SIGNALS}
+
+
+def restore_signal_handlers(previous: dict[int, Any]) -> None:
+    for sig, handler in previous.items():
+        if handler is not None:  # None = a handler Python cannot reinstate
+            signal.signal(sig, handler)
+
+
 def run_claude(binary: str, claude_args: list[str], env: dict[str, str]) -> int:
     """Run claude with stdio inherited; signals reach it, we still summarize.
 
     The child deliberately stays in this process's own group and session: the
     interactive TUI has to remain in the terminal's foreground process group to
     own the tty, so it cannot be put behind `start_new_session`. Signals are
-    therefore forwarded by pid. Without that forwarding a SIGTERM to the
-    wrapper takes the interpreter's default disposition — the process dies
-    where it stands, `main`'s `finally` never runs, the sandbox is left on
-    disk, and `claude` keeps running with nobody waiting on it.
+    therefore forwarded by pid, and all this has to do is publish the child for
+    the handlers `main` installed before any resource existed. Without that
+    forwarding a SIGTERM to the wrapper would take the interpreter's default
+    disposition — the process dies where it stands, `main`'s `finally` never
+    runs, the sandbox is left on disk, and `claude` keeps running with nobody
+    waiting on it.
 
     PEP 475 retries the interrupted `wait()` once a handler returns, so the
     call resumes and returns the child's status as soon as the forwarded
     signal lands.
+
+    The spawn itself is the one moment the child cannot be named: a signal
+    landing inside `Popen` — after the fork, before the object comes back —
+    would unwind past a process nothing can signal or wait for, orphaning it.
+    Masking the signals across the spawn is not the fix, because the mask
+    survives `exec` and would hand `claude` a blocked SIGTERM. So the handler
+    queues instead, and the signal is delivered by hand once the child has a
+    name.
     """
+    SIGNAL_TARGETS.pending_signum = None
+    SIGNAL_TARGETS.spawning = True
+    child: subprocess.Popen | None = None
     try:
         child = subprocess.Popen([binary, *claude_args], env=env)
+        # Published before `spawning` is cleared, so no signal can fall
+        # between the two and find nothing willing to take it.
+        SIGNAL_TARGETS.child = child
     except FileNotFoundError:
         report([f"claude binary not found: {binary}"])
+    finally:
+        SIGNAL_TARGETS.spawning = False
+
+    queued = SIGNAL_TARGETS.pending_signum
+    if child is None:
+        if queued is not None:
+            raise Terminated(queued)
         return 127
 
-    def forward(signum: int, _frame: Any) -> None:
-        child.send_signal(signum)
-
-    previous: dict[int, Any] = {}
     try:
-        for sig in (signal.SIGTERM, signal.SIGHUP):
-            previous[sig] = signal.signal(sig, forward)
+        if queued is not None:
+            child.send_signal(queued)
         while True:
             try:
                 status = child.wait()
@@ -254,8 +337,7 @@ def run_claude(binary: str, claude_args: list[str], env: dict[str, str]) -> int:
             except KeyboardInterrupt:
                 child.send_signal(signal.SIGINT)
     finally:
-        for sig, handler in previous.items():
-            signal.signal(sig, handler)
+        SIGNAL_TARGETS.child = None
     # Popen.wait reports a signal death as a negative signal number; callers
     # reading an exit status expect the shell's conventional 128 + signal.
     return status if status >= 0 else 128 - status
@@ -264,17 +346,29 @@ def run_claude(binary: str, claude_args: list[str], env: dict[str, str]) -> int:
 def serve_until_signalled(
     env: dict[str, str], binary: str, extra_env: dict[str, str] | None = None
 ) -> None:
-    """--print-env: hand the caller exports, keep serving until SIGINT/SIGTERM."""
+    """--print-env: hand the caller exports, keep serving until a stop signal.
+
+    No handler is installed here: SIGTERM and SIGHUP are already `main`'s, and
+    publishing the event is what turns them into a clean stop rather than a
+    `Terminated` unwind. SIGINT keeps its default disposition and arrives as a
+    KeyboardInterrupt, which stops serving the same way. Either route returns
+    normally, so the caller still gets the closing summary.
+    """
     for line in export_lines(env, extra_env):
         print(line)
     print(f"# eval these in another pane, then run: {shlex.quote(binary)}")
     print(f"# run claude from this directory (the sandbox trusts it): {Path.cwd()}")
     sys.stdout.flush()
     stop = threading.Event()
-    for sig in (signal.SIGINT, signal.SIGTERM):
-        signal.signal(sig, lambda *_: stop.set())
-    report(["serving; Ctrl-C (or SIGTERM) to stop"])
-    stop.wait()
+    SIGNAL_TARGETS.serving_event = stop
+    try:
+        report(["serving; Ctrl-C (or SIGTERM) to stop"])
+        try:
+            stop.wait()
+        except KeyboardInterrupt:
+            pass
+    finally:
+        SIGNAL_TARGETS.serving_event = None
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
@@ -305,42 +399,72 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 
 
 def main(argv: list[str]) -> int:
-    if "--" in argv:
-        split = argv.index("--")
-        argv, claude_args = argv[:split], argv[split + 1 :]
-    else:
-        claude_args = []
-    args = parse_args(argv)
-    turns, role_turns = resolve_turns(args)
+    """Serve the fake API for one run, and reclaim the sandbox afterwards.
 
-    keep = args.keep or args.sandbox is not None
-    sandbox = Path(args.sandbox) if args.sandbox else Path(tempfile.mkdtemp(prefix="claude-stub-"))
-
-    routes = build_routes(role_turns)
-    # Everything after the directory exists belongs inside the cleanup scope:
-    # a corrupted `.claude.json` in a reused sandbox or an unwritable path
-    # would otherwise fail between creation and the `finally`, stranding a
-    # fresh temp dir that nothing ever removes.
+    The stop-signal handlers go on first, before a single resource exists, so
+    a SIGTERM or SIGHUP anywhere below — building the sandbox, binding the
+    stub server, spawning claude — unwinds through the cleanup instead of
+    taking the interpreter's default disposition. Only SIGKILL or a hard crash
+    can leave the sandbox on disk or the child unwaited-for.
+    """
+    previous_handlers = install_signal_handlers()
     try:
-        sandbox.mkdir(parents=True, exist_ok=True)
-        (sandbox / "tmp").mkdir(exist_ok=True)
-        write_config(sandbox, Path.cwd())
-        with StubServer(turns, role_turns=routes) as server:
-            base_url = server.base_url
-            extra_env = parse_env_assignments(args.env)
-            env = build_env(sandbox, base_url, dict(os.environ), extra_env)
-            if args.print_env:
-                serve_until_signalled(env, args.claude_binary, extra_env)
-                status = 0
-            else:
-                status = run_claude(args.claude_binary, claude_args, env)
-            report(summary_lines(server, env))
-    finally:
-        if keep:
-            report([f"sandbox kept at {sandbox}"])
+        if "--" in argv:
+            split = argv.index("--")
+            argv, claude_args = argv[:split], argv[split + 1 :]
         else:
-            shutil.rmtree(sandbox, ignore_errors=True)
-    return status
+            claude_args = []
+        args = parse_args(argv)
+        turns, role_turns = resolve_turns(args)
+
+        keep = args.keep or args.sandbox is not None
+        routes = build_routes(role_turns)
+        sandbox: Path | None = None
+        # The sandbox is created inside the cleanup scope, not before it: a
+        # corrupted `.claude.json` in a reused sandbox, an unwritable path, or
+        # a signal would otherwise fail between creation and the `finally`,
+        # stranding a fresh temp dir that nothing ever removes.
+        try:
+            # The one gap a stop signal must not land in: `tempfile.mkdtemp`
+            # creates the directory and only then returns its name, and a
+            # handler runs between the two, so a `Terminated` raised there
+            # would unwind past a sandbox nobody can name, let alone remove.
+            # Held off across the assignment the signal merely stays pending,
+            # and lands the moment the sandbox is reachable by the `finally`.
+            blocked = signal.pthread_sigmask(signal.SIG_BLOCK, STOP_SIGNALS)
+            try:
+                sandbox = (
+                    Path(args.sandbox)
+                    if args.sandbox
+                    else Path(tempfile.mkdtemp(prefix="claude-stub-"))
+                )
+            finally:
+                signal.pthread_sigmask(signal.SIG_SETMASK, blocked)
+            sandbox.mkdir(parents=True, exist_ok=True)
+            (sandbox / "tmp").mkdir(exist_ok=True)
+            write_config(sandbox, Path.cwd())
+            with StubServer(turns, role_turns=routes) as server:
+                base_url = server.base_url
+                extra_env = parse_env_assignments(args.env)
+                env = build_env(sandbox, base_url, dict(os.environ), extra_env)
+                if args.print_env:
+                    serve_until_signalled(env, args.claude_binary, extra_env)
+                    status = 0
+                else:
+                    status = run_claude(args.claude_binary, claude_args, env)
+                report(summary_lines(server, env))
+        finally:
+            if sandbox is not None:
+                if keep:
+                    report([f"sandbox kept at {sandbox}"])
+                else:
+                    shutil.rmtree(sandbox, ignore_errors=True)
+        return status
+    except Terminated as terminated:
+        report([f"stopped by signal {terminated.signum}"])
+        return 128 + terminated.signum
+    finally:
+        restore_signal_handlers(previous_handlers)
 
 
 if __name__ == "__main__":

--- a/scripts/claude-stub.py
+++ b/scripts/claude-stub.py
@@ -499,11 +499,17 @@ def serve_until_signalled(
         report(["serving; Ctrl-C (or SIGTERM) to stop"])
         stop.wait()
     finally:
-        SIGNAL_TARGETS.serving_event = None
-        # Same as after the child is waited for: serving is over, so a stop
-        # signal arriving during the summary and the sandbox removal has
-        # nothing left to stop and must not unwind the cleanup.
+        # Serving is over, so from here the wrapper is only unwinding — a few
+        # milliseconds of summary, sandbox removal, and return. A stop signal
+        # landing in that window has nothing to reach, so the handler
+        # swallows it rather than interrupting the sandbox removal.
+        #
+        # Latched before serving_event is cleared, never after: the handler
+        # tests `finishing` first and `serving_event` second, so this order
+        # leaves no bytecode gap in which a signal finds neither. The reverse
+        # order has one, and a signal landing in it raises `Terminated`.
         SIGNAL_TARGETS.finishing = True
+        SIGNAL_TARGETS.serving_event = None
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:

--- a/scripts/claude-stub.py
+++ b/scripts/claude-stub.py
@@ -287,7 +287,12 @@ def forward(child: subprocess.Popen, signum: int) -> None:
 
 
 def deliver(child: subprocess.Popen, signum: int) -> None:
-    """Forward `signum` to the child, unless the terminal already has.
+    """Forward `signum` to a *live* child, unless the terminal already has.
+
+    This is the rule for a child old enough to own a SIGINT handler of its
+    own — the handler's live-child branch. A signal queued across the spawn
+    goes through `forward` instead and is handed over unconditionally; see
+    `run_claude`.
 
     Only SIGINT can have reached the child on its own: a tty delivers it to
     every process in the foreground group, and `claude` deliberately shares the
@@ -402,8 +407,9 @@ def run_claude(binary: str, claude_args: list[str], env: dict[str, str]) -> int:
     would unwind past a process nothing can signal or wait for, orphaning it.
     Masking the signals across the spawn is not the fix, because the mask
     survives `exec` and would hand `claude` a blocked SIGTERM. So the handler
-    queues instead, and the signal is delivered by hand once the child has a
-    name.
+    queues instead, and the signal is handed over by hand once the child has a
+    name — unconditionally, through `forward`, without the foreground-group
+    check `deliver` applies to a live child.
     """
     SIGNAL_TARGETS.pending_signum = None
     SIGNAL_TARGETS.spawning = True
@@ -429,7 +435,18 @@ def run_claude(binary: str, claude_args: list[str], env: dict[str, str]) -> int:
 
     try:
         if queued is not None:
-            deliver(child, queued)
+            # `forward`, not `deliver`: the position check answers whether the
+            # terminal delivered this signal to the child. For a signal that
+            # arrived before the fork the answer is no — the child did not
+            # exist to be in any process group — yet the check runs after the
+            # child exists and shares the group, so it would answer "already
+            # delivered" and drop a Ctrl-C the child never received. For one
+            # that arrived after the fork the child is microseconds old and has
+            # not installed any handler, so the terminal's copy already
+            # terminates it with the default disposition and a second copy is
+            # harmless (and `forward` swallows the error if it is already
+            # gone). Either way forwarding is right and dropping is wrong.
+            forward(child, queued)
         # No `except KeyboardInterrupt` here: SIGINT is in STOP_SIGNALS, so
         # `handle_stop_signal` owns it for the whole of this call — installed
         # by `main` before any resource existed and restored only in `main`'s

--- a/scripts/claude-stub.py
+++ b/scripts/claude-stub.py
@@ -220,17 +220,45 @@ def report(lines: list[str]) -> None:
 
 
 def run_claude(binary: str, claude_args: list[str], env: dict[str, str]) -> int:
-    """Run claude with stdio inherited; Ctrl-C reaches it, we still summarize."""
+    """Run claude with stdio inherited; signals reach it, we still summarize.
+
+    The child deliberately stays in this process's own group and session: the
+    interactive TUI has to remain in the terminal's foreground process group to
+    own the tty, so it cannot be put behind `start_new_session`. Signals are
+    therefore forwarded by pid. Without that forwarding a SIGTERM to the
+    wrapper takes the interpreter's default disposition — the process dies
+    where it stands, `main`'s `finally` never runs, the sandbox is left on
+    disk, and `claude` keeps running with nobody waiting on it.
+
+    PEP 475 retries the interrupted `wait()` once a handler returns, so the
+    call resumes and returns the child's status as soon as the forwarded
+    signal lands.
+    """
     try:
         child = subprocess.Popen([binary, *claude_args], env=env)
     except FileNotFoundError:
         report([f"claude binary not found: {binary}"])
         return 127
-    while True:
-        try:
-            return child.wait()
-        except KeyboardInterrupt:
-            child.send_signal(signal.SIGINT)
+
+    def forward(signum: int, _frame: Any) -> None:
+        child.send_signal(signum)
+
+    previous: dict[int, Any] = {}
+    try:
+        for sig in (signal.SIGTERM, signal.SIGHUP):
+            previous[sig] = signal.signal(sig, forward)
+        while True:
+            try:
+                status = child.wait()
+                break
+            except KeyboardInterrupt:
+                child.send_signal(signal.SIGINT)
+    finally:
+        for sig, handler in previous.items():
+            signal.signal(sig, handler)
+    # Popen.wait reports a signal death as a negative signal number; callers
+    # reading an exit status expect the shell's conventional 128 + signal.
+    return status if status >= 0 else 128 - status
 
 
 def serve_until_signalled(
@@ -286,12 +314,16 @@ def main(argv: list[str]) -> int:
 
     keep = args.keep or args.sandbox is not None
     sandbox = Path(args.sandbox) if args.sandbox else Path(tempfile.mkdtemp(prefix="claude-stub-"))
-    sandbox.mkdir(parents=True, exist_ok=True)
-    (sandbox / "tmp").mkdir(exist_ok=True)
-    write_config(sandbox, Path.cwd())
 
     routes = build_routes(role_turns)
+    # Everything after the directory exists belongs inside the cleanup scope:
+    # a corrupted `.claude.json` in a reused sandbox or an unwritable path
+    # would otherwise fail between creation and the `finally`, stranding a
+    # fresh temp dir that nothing ever removes.
     try:
+        sandbox.mkdir(parents=True, exist_ok=True)
+        (sandbox / "tmp").mkdir(exist_ok=True)
+        write_config(sandbox, Path.cwd())
         with StubServer(turns, role_turns=routes) as server:
             base_url = server.base_url
             extra_env = parse_env_assignments(args.env)

--- a/scripts/claude-stub.py
+++ b/scripts/claude-stub.py
@@ -44,15 +44,18 @@ PASSTHROUGH_ENV = ("TERM", "COLORTERM", "LANG", "LC_ALL")
 UNEXPORTED_ENV = ("PATH",)
 
 # The one dialog the e2e harness has no reason to pre-accept and the
-# interactive TUI raises anyway: the custom-API-key approval, keyed on the
-# trailing characters of ANTHROPIC_API_KEY. Headless `-p` never asks.
-STUB_API_KEY = "stub-key"
+# interactive TUI raises anyway: the custom-API-key approval, keyed on a
+# fingerprint of ANTHROPIC_API_KEY. Headless `-p` never asks. The key is read
+# back out of the harness rather than restated here, so the value approved in
+# the config cannot drift from the value the environment actually carries.
+STUB_API_KEY = harness.sandbox_env(Path("/"), "http://127.0.0.1:0")["ANTHROPIC_API_KEY"]
 
 # The interactive TUI opens every session with a second, concurrent request
 # that asks the model to name the session; headless `-p` sends none. Left
 # unrouted it eats a scripted turn (and racing with the real request, a
 # nondeterministic one), so it gets its own content-keyed route: the CLI wraps
-# the user's message in <session>…</session> there and nowhere else.
+# the user's message in <session>…</session> there and nowhere else. Observed
+# on claude 2.1.258.
 TITLE_SENTINEL = "</session>"
 TITLE_LABEL = "session title"
 TITLE_TURN = Turn(text="Stub session")
@@ -79,6 +82,16 @@ def parse_turns_document(document: Any) -> tuple[list[Turn], dict[str, list[Turn
         for sentinel, entries in (document.get("role_turns") or {}).items()
     }
     return turns, role_turns
+
+
+def build_routes(role_turns: dict[str, list[Turn]]) -> dict[str, list[Turn]]:
+    """Content-keyed routes, with `</session>` reserved for the title request.
+
+    A turn file may define any sentinel it likes, including that one; the
+    wrapper's own route wins, so a turn file cannot silently take over the
+    route that keeps the title request from eating a scripted turn.
+    """
+    return {**role_turns, TITLE_SENTINEL: [TITLE_TURN]}
 
 
 def long_answer(lines: int) -> str:
@@ -152,6 +165,8 @@ def write_config(sandbox: Path, project: Path) -> None:
         "hasTrustDialogAccepted": True,
         "hasCompletedProjectOnboarding": True,
     }
+    # The CLI stores an approval under the key's last 20 characters rather than
+    # the key itself; a key shorter than that is its own fingerprint.
     config["customApiKeyResponses"] = {"approved": [STUB_API_KEY[-20:]], "rejected": []}
     config_dir.mkdir(parents=True, exist_ok=True)
     config_path.write_text(json.dumps(config, indent=2), encoding="utf-8")
@@ -171,7 +186,7 @@ def summary_lines(server: StubServer, base_url: str) -> list[str]:
     lines.append(f"unexpected paths: {', '.join(unexpected) if unexpected else 'none'}")
     lines.append(f"client disconnects: {len(capture.client_disconnects)}")
     lines.append(
-        f"no request left this machine — ANTHROPIC_BASE_URL was {base_url} (loopback)"
+        f"no model request left this machine — ANTHROPIC_BASE_URL was {base_url} (loopback)"
     )
     return lines
 
@@ -195,11 +210,11 @@ def run_claude(binary: str, claude_args: list[str], env: dict[str, str]) -> int:
             child.send_signal(signal.SIGINT)
 
 
-def serve_until_signalled(env: dict[str, str]) -> None:
+def serve_until_signalled(env: dict[str, str], binary: str) -> None:
     """--print-env: hand the caller exports, keep serving until SIGINT/SIGTERM."""
     for line in export_lines(env):
         print(line)
-    print(f"# eval these in another pane, then run: {shlex.quote('claude')}")
+    print(f"# eval these in another pane, then run: {shlex.quote(binary)}")
     sys.stdout.flush()
     stop = threading.Event()
     for sig in (signal.SIGINT, signal.SIGTERM):
@@ -249,13 +264,13 @@ def main(argv: list[str]) -> int:
     (sandbox / "tmp").mkdir(exist_ok=True)
     write_config(sandbox, Path.cwd())
 
-    routes = {TITLE_SENTINEL: [TITLE_TURN], **role_turns}
+    routes = build_routes(role_turns)
     try:
         with StubServer(turns, role_turns=routes) as server:
             base_url = server.base_url
             env = build_env(sandbox, base_url, dict(os.environ), parse_env_assignments(args.env))
             if args.print_env:
-                serve_until_signalled(env)
+                serve_until_signalled(env, args.claude_binary)
                 status = 0
             else:
                 status = run_claude(args.claude_binary, claude_args, env)

--- a/scripts/claude-stub.py
+++ b/scripts/claude-stub.py
@@ -217,6 +217,10 @@ def summary_lines(server: StubServer, env: dict[str, str]) -> list[str]:
 def report(lines: list[str]) -> None:
     for line in lines:
         print(f"claude-stub: {line}", file=sys.stderr)
+    # Flushed rather than left to stderr's buffering: the `serving` line is
+    # what a caller (and the tests) wait on to know the server is up, so it
+    # has to reach a redirected stderr as soon as it is written.
+    sys.stderr.flush()
 
 
 class Terminated(Exception):
@@ -248,8 +252,9 @@ class SignalTargets:
         self.spawning = False
         self.pending_signum: int | None = None
         self.serving_event: threading.Event | None = None
-        # Set once the child has been waited for (or the `--print-env` server
-        # has stopped): from there on the wrapper is only unwinding.
+        # Set once the child has been waited for, the `--print-env` server has
+        # stopped, or `main` has reached its cleanup by any route at all:
+        # from there on the wrapper is only unwinding.
         self.finishing = False
         # A stop signal that arrived during that unwind, kept for the summary.
         self.late_signum: int | None = None
@@ -282,15 +287,23 @@ def forward(child: subprocess.Popen, signum: int) -> None:
 
 
 def deliver(child: subprocess.Popen, signum: int) -> None:
-    """Forward `signum` to the child, unless the terminal beat us to it.
+    """Forward `signum` to the child, unless the terminal already has.
 
     Only SIGINT can have reached the child on its own: a tty delivers it to
     every process in the foreground group, and `claude` deliberately shares the
     wrapper's group so it can own the tty. A second one would read as the
-    double Ctrl-C the TUI exits on, so a Ctrl-C typed at the terminal is not
-    forwarded — while a `kill -INT` aimed at the wrapper alone still is
-    (`sigint_reached_child_already`). Every other signal is forwarded
-    unconditionally; nothing else reaches the child by any route but this one.
+    double Ctrl-C the TUI exits on, so the rule is by position rather than by
+    sender: when the wrapper is the terminal's foreground process group, a
+    SIGINT is treated as a Ctrl-C the child already received and is not
+    forwarded, whatever sent it. A `kill -INT` aimed at a foreground wrapper is
+    indistinguishable from the keypress and is dropped with it. A SIGINT that
+    arrives while the wrapper has no controlling terminal or is not the
+    foreground group — from a script, `nohup`, `start_new_session` — is
+    forwarded (`sigint_reached_child_already`).
+
+    SIGTERM is the signal for stopping a wrapped session from outside: it, like
+    every stop signal that is not SIGINT, is forwarded unconditionally, and
+    nothing reaches the child by any route but this one.
     """
     if signum == signal.SIGINT and sigint_reached_child_already():
         return
@@ -335,19 +348,28 @@ def restore_signal_handlers(previous: dict[int, Any]) -> None:
 
 
 def sigint_reached_child_already(stdin_fd: int = 0) -> bool:
-    """True when the terminal delivered this Ctrl-C to the child as well.
+    """True when the wrapper sits where the terminal delivers SIGINT itself.
 
     A tty sends its SIGINT to every process in the terminal's foreground
     process group, and `claude` deliberately stays in the wrapper's own group
-    so it can own the tty — so when the wrapper is that foreground group, the
-    child already has the signal. Forwarding a second one is not harmless: the
-    TUI exits on a double Ctrl-C, so the wrapper would be answering the user's
-    first press with the confirmation for a second.
+    so it can own the tty — so when the wrapper is that foreground group, a
+    Ctrl-C reached the child directly. Forwarding a second one is not harmless:
+    the TUI exits on a double Ctrl-C, so the wrapper would be answering the
+    user's first press with the confirmation for a second.
 
-    False whenever that reasoning does not hold — stdin is not a tty, there is
-    no controlling terminal, or the wrapper is in the background — because the
-    SIGINT then came from a `kill` aimed at the wrapper alone and the child
-    has not seen it. False is the safe answer either way: it forwards.
+    This is a test of *position*, not of provenance, and it cannot be anything
+    else: a Python handler is handed a signal number and no siginfo, so a
+    `kill -INT <wrapper pid>` and a keypress are the same event here. The rule
+    the wrapper commits to is therefore stated in those terms — in the
+    foreground-group case a SIGINT is treated as a terminal Ctrl-C the child
+    already has, whatever sent it, and is not forwarded. Use SIGTERM to stop a
+    wrapped session from outside; that is forwarded from every position.
+
+    False whenever the foreground reasoning does not hold — stdin is not a tty,
+    there is no controlling terminal, or the wrapper is in the background
+    (a script, `nohup`, `start_new_session`) — because nothing but this wrapper
+    can have handed the child that signal. False is the safe answer either
+    way: it forwards.
     """
     try:
         return os.isatty(stdin_fd) and os.tcgetpgrp(stdin_fd) == os.getpgrp()
@@ -361,12 +383,15 @@ def run_claude(binary: str, claude_args: list[str], env: dict[str, str]) -> int:
     The child deliberately stays in this process's own group and session: the
     interactive TUI has to remain in the terminal's foreground process group to
     own the tty, so it cannot be put behind `start_new_session`. That shared
-    group is why `deliver` drops a Ctrl-C typed at the terminal rather than
-    forwarding it. All this has to do is publish the child for the handlers
-    `main` installed before any resource existed. Without those a stop signal
-    to the wrapper would take the interpreter's default disposition — the
-    process dies where it stands, `main`'s `finally` never runs, the sandbox is
-    left on disk, and `claude` keeps running with nobody waiting on it.
+    group is why `deliver` does not forward a SIGINT the wrapper takes while it
+    is the foreground group: there the terminal delivered it to the child too,
+    so it is treated as a Ctrl-C the child already has whatever sent it, and
+    SIGTERM is the signal for stopping the pair from outside. All this has to
+    do is publish the child for the handlers `main` installed before any
+    resource existed. Without those a stop signal to the wrapper would take the
+    interpreter's default disposition — the process dies where it stands,
+    `main`'s `finally` never runs, the sandbox is left on disk, and `claude`
+    keeps running with nobody waiting on it.
 
     PEP 475 retries the interrupted `wait()` once a handler returns, so the
     call resumes and returns the child's status as soon as the forwarded
@@ -413,13 +438,18 @@ def run_claude(binary: str, claude_args: list[str], env: dict[str, str]) -> int:
         # so the wait can only be interrupted and then resumed by PEP 475.
         status = child.wait()
     finally:
-        SIGNAL_TARGETS.child = None
         # The child has been waited for, so from here the wrapper is only
         # unwinding — a few milliseconds of summary, sandbox removal, and
         # return. A stop signal landing in that window has nothing to reach,
         # so the handler swallows it rather than replacing the child's status
         # with a `Terminated` or interrupting the sandbox removal.
+        #
+        # Latched before the child is dropped, never after: the handler tests
+        # `finishing` first and `child` second, so this order leaves no
+        # bytecode gap in which a signal finds neither. The reverse order has
+        # one, and a signal landing in it raises `Terminated`.
         SIGNAL_TARGETS.finishing = True
+        SIGNAL_TARGETS.child = None
     # Popen.wait reports a signal death as a negative signal number; callers
     # reading an exit status expect the shell's conventional 128 + signal.
     return status if status >= 0 else 128 - status
@@ -443,6 +473,10 @@ def serve_until_signalled(
     print(f"# run claude from this directory (the sandbox trusts it): {Path.cwd()}")
     sys.stdout.flush()
     stop = threading.Event()
+    # Published before the line that announces it, never after: the `serving`
+    # line is what a caller waits on to know the server is up, and a signal
+    # arriving between the line and the event would find no target and raise
+    # `Terminated` instead of stopping the server cleanly.
     SIGNAL_TARGETS.serving_event = stop
     try:
         report(["serving; Ctrl-C (or SIGTERM) to stop"])
@@ -489,12 +523,20 @@ def main(argv: list[str]) -> int:
     any of SIGTERM, SIGHUP and SIGINT arriving anywhere below — building the
     sandbox, binding the stub server, spawning claude — unwinds through the
     cleanup instead of taking the interpreter's default disposition. Once the
-    run is finishing — the child waited for, or the `--print-env` server
-    stopped — a stop signal is instead recorded and swallowed, so the last few
-    milliseconds of summary and sandbox removal cannot be interrupted either,
-    and the status stays the one the child exited with. The guarantee is the
-    same for all three: only SIGKILL or a hard crash can leave the sandbox on
-    disk or the child unwaited-for.
+    run is finishing — the child waited for, the `--print-env` server stopped,
+    or the run failing its way into the cleanup below — a stop signal is
+    instead recorded and swallowed, so the last few milliseconds of summary and
+    sandbox removal cannot be interrupted either, and the status stays the one
+    the child exited with. The guarantee is the same for all three: only
+    SIGKILL or a hard crash can leave the sandbox on disk or the child
+    unwaited-for.
+
+    What the three do differs only for SIGINT, and only by where the wrapper
+    sits: as the terminal's foreground process group it treats a SIGINT as a
+    Ctrl-C `claude` already received and does not forward it, whatever sent it,
+    while a SIGINT arriving with no controlling terminal or from the background
+    is forwarded like any other. SIGTERM is the signal for stopping the wrapper
+    and its child from outside.
     """
     previous_handlers = install_signal_handlers()
     try:
@@ -543,6 +585,17 @@ def main(argv: list[str]) -> int:
                     status = run_claude(args.claude_binary, claude_args, env)
                 report(summary_lines(server, env))
         finally:
+            # Armed here for every path into this block, not just the two that
+            # arm it themselves: by the time control reaches it any child has
+            # been waited for or never existed, and the wrapper is a few
+            # milliseconds from returning. An exception out of `mkdir`,
+            # `write_config` or the server's socket bind would otherwise get
+            # here with the latch unset, and a stop signal landing during the
+            # `rmtree` below would raise `Terminated` out of a half-walked
+            # sandbox. `run_claude` and `serve_until_signalled` still latch on
+            # their own way out — that covers the window between the child
+            # exiting and control reaching this line.
+            SIGNAL_TARGETS.finishing = True
             if sandbox is not None:
                 if keep:
                     report([f"sandbox kept at {sandbox}"])

--- a/scripts/claude-stub.py
+++ b/scripts/claude-stub.py
@@ -309,13 +309,37 @@ def restore_signal_handlers(previous: dict[int, Any]) -> None:
             signal.signal(sig, handler)
 
 
+def sigint_reached_child_already(stdin_fd: int = 0) -> bool:
+    """True when the terminal delivered this Ctrl-C to the child as well.
+
+    A tty sends its SIGINT to every process in the terminal's foreground
+    process group, and `claude` deliberately stays in the wrapper's own group
+    so it can own the tty — so when the wrapper is that foreground group, the
+    child already has the signal. Forwarding a second one is not harmless: the
+    TUI exits on a double Ctrl-C, so the wrapper would be answering the user's
+    first press with the confirmation for a second.
+
+    False whenever that reasoning does not hold — stdin is not a tty, there is
+    no controlling terminal, or the wrapper is in the background — because the
+    SIGINT then came from a `kill` aimed at the wrapper alone and the child
+    has not seen it. False is the safe answer either way: it forwards.
+    """
+    try:
+        return os.isatty(stdin_fd) and os.tcgetpgrp(stdin_fd) == os.getpgrp()
+    except OSError:  # no controlling tty, or a closed or unreadable fd
+        return False
+
+
 def run_claude(binary: str, claude_args: list[str], env: dict[str, str]) -> int:
     """Run claude with stdio inherited; signals reach it, we still summarize.
 
     The child deliberately stays in this process's own group and session: the
     interactive TUI has to remain in the terminal's foreground process group to
-    own the tty, so it cannot be put behind `start_new_session`. Signals are
-    therefore forwarded by pid, and all this has to do is publish the child for
+    own the tty, so it cannot be put behind `start_new_session`. That shared
+    group is also why a Ctrl-C typed at the terminal is not forwarded — the tty
+    already delivered it to the child, and a second one would read as the
+    double Ctrl-C the TUI exits on (`sigint_reached_child_already`). Other
+    signals are forwarded by pid, and all this has to do is publish the child for
     the handlers `main` installed before any resource existed. Without that
     forwarding a SIGTERM to the wrapper would take the interpreter's default
     disposition — the process dies where it stands, `main`'s `finally` never
@@ -364,7 +388,10 @@ def run_claude(binary: str, claude_args: list[str], env: dict[str, str]) -> int:
                 status = child.wait()
                 break
             except KeyboardInterrupt:
-                forward(child, signal.SIGINT)
+                # Only when the child cannot have had it already; either way
+                # the loop goes back to waiting for the child to answer.
+                if not sigint_reached_child_already():
+                    forward(child, signal.SIGINT)
     finally:
         SIGNAL_TARGETS.child = None
         # The child has been waited for, so from here the wrapper is only
@@ -513,6 +540,13 @@ def main(argv: list[str]) -> int:
     except Terminated as terminated:
         report([f"stopped by signal {terminated.signum}"])
         return 128 + terminated.signum
+    except KeyboardInterrupt:
+        # A Ctrl-C before `claude` is running — while the sandbox is built or
+        # the stub server binds — has nowhere to be forwarded, and is the same
+        # outcome as the SIGTERM above: report the signal, keep the cleanup the
+        # `finally` blocks already did, and answer 130 rather than a traceback.
+        report([f"stopped by signal {int(signal.SIGINT)}"])
+        return 128 + int(signal.SIGINT)
     finally:
         restore_signal_handlers(previous_handlers)
 

--- a/scripts/claude-stub.py
+++ b/scripts/claude-stub.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Run the real `claude` CLI against a fake model API — zero tokens, offline.
+
+A mock/stub of the Anthropic Messages API stands in for the model, so a real
+`claude` session (interactive TUI or `-p` headless) runs end to end without
+spending tokens and with no API key: `ANTHROPIC_BASE_URL` points at a loopback
+server started here, and every answer is scripted locally. Nothing leaves the
+machine.
+
+The fake server itself is `stub_server.py` under
+`.github/workflows/claude-review-v2/tests/e2e/` (SSE streaming, canned turns,
+content-keyed routing); this wrapper makes it usable outside the review gate.
+See `docs/fake-model-api.md`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import threading
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+E2E_DIR = REPO_ROOT / ".github" / "workflows" / "claude-review-v2" / "tests" / "e2e"
+sys.path.insert(0, str(E2E_DIR))
+
+import harness  # noqa: E402
+from stub_server import StubServer, ToolCall, Turn  # noqa: E402
+
+# Env the caller's terminal owns. The e2e harness forces TERM=dumb, which is
+# right for `-p` and wrong for the TUI, so these pass through when set.
+PASSTHROUGH_ENV = ("TERM", "COLORTERM", "LANG", "LC_ALL")
+
+# Passed through from the caller's own shell, so --print-env leaves it out —
+# re-exporting a plugin-laden PATH buries the four lines that matter.
+UNEXPORTED_ENV = ("PATH",)
+
+# The one dialog the e2e harness has no reason to pre-accept and the
+# interactive TUI raises anyway: the custom-API-key approval, keyed on the
+# trailing characters of ANTHROPIC_API_KEY. Headless `-p` never asks.
+STUB_API_KEY = "stub-key"
+
+# The interactive TUI opens every session with a second, concurrent request
+# that asks the model to name the session; headless `-p` sends none. Left
+# unrouted it eats a scripted turn (and racing with the real request, a
+# nondeterministic one), so it gets its own content-keyed route: the CLI wraps
+# the user's message in <session>…</session> there and nowhere else.
+TITLE_SENTINEL = "</session>"
+TITLE_LABEL = "session title"
+TITLE_TURN = Turn(text="Stub session")
+
+
+def turn_from_dict(entry: dict[str, Any]) -> Turn:
+    """One scripted assistant turn: `{"text": ..., "tool_calls": [...]}`."""
+    calls = [
+        ToolCall(call["name"], call.get("input", {}), id=call.get("id", "toolu_stub"))
+        for call in entry.get("tool_calls", [])
+    ]
+    return Turn(text=entry.get("text", ""), tool_calls=calls)
+
+
+def parse_turns_document(document: Any) -> tuple[list[Turn], dict[str, list[Turn]]]:
+    """A turn file is either a plain list of turns or `{turns, role_turns}`."""
+    if isinstance(document, list):
+        return [turn_from_dict(entry) for entry in document], {}
+    if not isinstance(document, dict):
+        raise ValueError("turn file must be a JSON list or object")
+    turns = [turn_from_dict(entry) for entry in document.get("turns", [])]
+    role_turns = {
+        sentinel: [turn_from_dict(entry) for entry in entries]
+        for sentinel, entries in (document.get("role_turns") or {}).items()
+    }
+    return turns, role_turns
+
+
+def long_answer(lines: int) -> str:
+    """A numbered multi-line answer — the shape that scrolls in the TUI."""
+    return "\n".join(
+        f"{n}. stub answer line {n} of {lines} "
+        "— filler so the answer is long enough to scroll."
+        for n in range(1, lines + 1)
+    )
+
+
+def resolve_turns(args: argparse.Namespace) -> tuple[list[Turn], dict[str, list[Turn]]]:
+    """The scripted conversation: --turns, --text, or the default long answer."""
+    if args.turns:
+        return parse_turns_document(json.loads(Path(args.turns).read_text(encoding="utf-8")))
+    if args.text is not None:
+        return [Turn(text=args.text)], {}
+    return [Turn(text=long_answer(args.lines))], {}
+
+
+def parse_env_assignments(assignments: list[str]) -> dict[str, str]:
+    env: dict[str, str] = {}
+    for item in assignments:
+        key, separator, value = item.partition("=")
+        if not separator or not key:
+            raise ValueError(f"--env expects KEY=VALUE, got {item!r}")
+        env[key] = value
+    return env
+
+
+def build_env(
+    sandbox: Path,
+    base_url: str,
+    parent_env: dict[str, str],
+    extra_env: dict[str, str],
+) -> dict[str, str]:
+    """Harness isolation, with the caller's terminal env and --env on top."""
+    env = harness.sandbox_env(sandbox, base_url)
+    for key in PASSTHROUGH_ENV:
+        if parent_env.get(key):
+            env[key] = parent_env[key]
+    env.update(extra_env)
+    return env
+
+
+def export_lines(env: dict[str, str]) -> list[str]:
+    """`export` lines for --print-env, minus the PATH the caller already has."""
+    return [
+        f"export {key}={shlex.quote(value)}"
+        for key, value in sorted(env.items())
+        if key not in UNEXPORTED_ENV
+    ]
+
+
+def write_config(sandbox: Path, project: Path) -> None:
+    """Pre-accept every dialog, including the one only the TUI raises.
+
+    A reused --sandbox is patched rather than rebuilt: its config dir also
+    holds the session transcripts, which is what `claude --resume` reads. The
+    keys re-asserted here are the ones a second run can find stale — a run
+    from a different cwd needs its own trusted-project entry.
+    """
+    config_dir = sandbox / "config"
+    config_path = config_dir / ".claude.json"
+    if not config_dir.exists():
+        harness.write_config(sandbox, project)
+    config = json.loads(config_path.read_text(encoding="utf-8")) if config_path.exists() else {}
+    config["hasTrustDialogAccepted"] = True
+    config["hasCompletedOnboarding"] = True
+    config.setdefault("projects", {})[str(project)] = {
+        "hasTrustDialogAccepted": True,
+        "hasCompletedProjectOnboarding": True,
+    }
+    config["customApiKeyResponses"] = {"approved": [STUB_API_KEY[-20:]], "rejected": []}
+    config_dir.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(json.dumps(config, indent=2), encoding="utf-8")
+
+
+def summary_lines(server: StubServer, base_url: str) -> list[str]:
+    capture = server.capture
+    unexpected = harness.tolerated_unexpected_paths(capture.unexpected_paths)
+    lines = [f"{len(capture.raw_bodies)} request(s) served at {base_url}"]
+    counts: dict[str, int] = {}
+    for route in capture.routes:
+        label = TITLE_LABEL if route == TITLE_SENTINEL else (route or "(ordered turns)")
+        counts[label] = counts.get(label, 0) + 1
+    if len(counts) > 1:  # a single route is just the request count again
+        for label, count in sorted(counts.items()):
+            lines.append(f"  route {label}: {count}")
+    lines.append(f"unexpected paths: {', '.join(unexpected) if unexpected else 'none'}")
+    lines.append(f"client disconnects: {len(capture.client_disconnects)}")
+    lines.append(
+        f"no request left this machine — ANTHROPIC_BASE_URL was {base_url} (loopback)"
+    )
+    return lines
+
+
+def report(lines: list[str]) -> None:
+    for line in lines:
+        print(f"claude-stub: {line}", file=sys.stderr)
+
+
+def run_claude(binary: str, claude_args: list[str], env: dict[str, str]) -> int:
+    """Run claude with stdio inherited; Ctrl-C reaches it, we still summarize."""
+    try:
+        child = subprocess.Popen([binary, *claude_args], env=env)
+    except FileNotFoundError:
+        report([f"claude binary not found: {binary}"])
+        return 127
+    while True:
+        try:
+            return child.wait()
+        except KeyboardInterrupt:
+            child.send_signal(signal.SIGINT)
+
+
+def serve_until_signalled(env: dict[str, str]) -> None:
+    """--print-env: hand the caller exports, keep serving until SIGINT/SIGTERM."""
+    for line in export_lines(env):
+        print(line)
+    print(f"# eval these in another pane, then run: {shlex.quote('claude')}")
+    sys.stdout.flush()
+    stop = threading.Event()
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        signal.signal(sig, lambda *_: stop.set())
+    report(["serving; Ctrl-C (or SIGTERM) to stop"])
+    stop.wait()
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="claude-stub.py",
+        description=(
+            "Run the real claude CLI against a fake model API on loopback. "
+            "Zero tokens, no network, no real API key. Arguments after `--` go "
+            "to claude (none = interactive TUI; `-p PROMPT` = headless)."
+        ),
+        epilog=(
+            "Requests past the end of the scripted turns are answered with the "
+            "server's overflow turn, whose text is STUB-TERMINAL, so a session "
+            "never hangs waiting for a turn that was never written."
+        ),
+    )
+    script = parser.add_mutually_exclusive_group()
+    script.add_argument("--turns", metavar="FILE.json", help="JSON list of turns, or {turns, role_turns}")
+    script.add_argument("--text", help="serve a single text turn with this content")
+    parser.add_argument("--lines", type=int, default=200, help="lines in the default long answer (default: 200)")
+    parser.add_argument("--sandbox", help="sandbox dir (default: a fresh temp dir; an explicit one is kept)")
+    parser.add_argument("--keep", action="store_true", help="keep the sandbox dir at exit")
+    parser.add_argument("--env", action="append", default=[], metavar="KEY=VALUE", help="extra env for claude (repeatable)")
+    parser.add_argument("--print-env", action="store_true", help="print `export` lines and keep serving instead of running claude")
+    parser.add_argument("--claude-binary", default="claude", help="claude executable (default: claude from PATH)")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    if "--" in argv:
+        split = argv.index("--")
+        argv, claude_args = argv[:split], argv[split + 1 :]
+    else:
+        claude_args = []
+    args = parse_args(argv)
+    turns, role_turns = resolve_turns(args)
+
+    keep = args.keep or args.sandbox is not None
+    sandbox = Path(args.sandbox) if args.sandbox else Path(tempfile.mkdtemp(prefix="claude-stub-"))
+    sandbox.mkdir(parents=True, exist_ok=True)
+    (sandbox / "tmp").mkdir(exist_ok=True)
+    write_config(sandbox, Path.cwd())
+
+    routes = {TITLE_SENTINEL: [TITLE_TURN], **role_turns}
+    try:
+        with StubServer(turns, role_turns=routes) as server:
+            base_url = server.base_url
+            env = build_env(sandbox, base_url, dict(os.environ), parse_env_assignments(args.env))
+            if args.print_env:
+                serve_until_signalled(env)
+                status = 0
+            else:
+                status = run_claude(args.claude_binary, claude_args, env)
+            report(summary_lines(server, base_url))
+    finally:
+        if keep:
+            report([f"sandbox kept at {sandbox}"])
+        else:
+            shutil.rmtree(sandbox, ignore_errors=True)
+    return status
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/claude-stub.py
+++ b/scripts/claude-stub.py
@@ -87,9 +87,11 @@ def parse_turns_document(document: Any) -> tuple[list[Turn], dict[str, list[Turn
 def build_routes(role_turns: dict[str, list[Turn]]) -> dict[str, list[Turn]]:
     """Content-keyed routes, with `</session>` reserved for the title request.
 
-    A turn file may define any sentinel it likes, including that one; the
-    wrapper's own route wins, so a turn file cannot silently take over the
-    route that keeps the title request from eating a scripted turn.
+    The reservation is over the key alone: a turn file that names `</session>`
+    does not replace the wrapper's title turn. It does not change how the
+    server matches, which is still a substring test over the first message, so
+    a user sentinel that also happens to appear inside the CLI's title prompt
+    can still win that request on its own.
     """
     return {**role_turns, TITLE_SENTINEL: [TITLE_TURN]}
 
@@ -137,12 +139,18 @@ def build_env(
     return env
 
 
-def export_lines(env: dict[str, str]) -> list[str]:
-    """`export` lines for --print-env, minus the PATH the caller already has."""
+def export_lines(env: dict[str, str], extra_env: dict[str, str] | None = None) -> list[str]:
+    """`export` lines for --print-env, minus the PATH the caller already has.
+
+    Only the *inherited* PATH is dropped. An explicit `--env PATH=...` is the
+    caller asking for a different one, and the run mode honours it, so
+    --print-env has to hand it over too or the two modes disagree.
+    """
+    overridden = extra_env or {}
     return [
         f"export {key}={shlex.quote(value)}"
         for key, value in sorted(env.items())
-        if key not in UNEXPORTED_ENV
+        if key not in UNEXPORTED_ENV or key in overridden
     ]
 
 
@@ -172,8 +180,16 @@ def write_config(sandbox: Path, project: Path) -> None:
     config_path.write_text(json.dumps(config, indent=2), encoding="utf-8")
 
 
-def summary_lines(server: StubServer, base_url: str) -> list[str]:
+def summary_lines(server: StubServer, env: dict[str, str]) -> list[str]:
+    """What the stub served, and whether claude was actually pointed at it.
+
+    `env` is the environment claude was handed, not the server's own view:
+    `--env ANTHROPIC_BASE_URL=...` can aim the CLI somewhere else entirely,
+    and the loopback claim would be a lie about traffic the stub never saw.
+    """
     capture = server.capture
+    base_url = server.base_url
+    claude_url = env.get("ANTHROPIC_BASE_URL", "")
     unexpected = harness.tolerated_unexpected_paths(capture.unexpected_paths)
     lines = [f"{len(capture.raw_bodies)} request(s) served at {base_url}"]
     counts: dict[str, int] = {}
@@ -185,9 +201,16 @@ def summary_lines(server: StubServer, base_url: str) -> list[str]:
             lines.append(f"  route {label}: {count}")
     lines.append(f"unexpected paths: {', '.join(unexpected) if unexpected else 'none'}")
     lines.append(f"client disconnects: {len(capture.client_disconnects)}")
-    lines.append(
-        f"no model request left this machine — ANTHROPIC_BASE_URL was {base_url} (loopback)"
-    )
+    if claude_url == base_url:
+        lines.append(
+            f"no model request left this machine — ANTHROPIC_BASE_URL was {base_url} (loopback)"
+        )
+    else:
+        lines.append(
+            f"ANTHROPIC_BASE_URL was overridden to {claude_url}; the stub served "
+            f"{len(capture.raw_bodies)} request(s), and requests to that URL are "
+            "not counted here"
+        )
     return lines
 
 
@@ -210,11 +233,14 @@ def run_claude(binary: str, claude_args: list[str], env: dict[str, str]) -> int:
             child.send_signal(signal.SIGINT)
 
 
-def serve_until_signalled(env: dict[str, str], binary: str) -> None:
+def serve_until_signalled(
+    env: dict[str, str], binary: str, extra_env: dict[str, str] | None = None
+) -> None:
     """--print-env: hand the caller exports, keep serving until SIGINT/SIGTERM."""
-    for line in export_lines(env):
+    for line in export_lines(env, extra_env):
         print(line)
     print(f"# eval these in another pane, then run: {shlex.quote(binary)}")
+    print(f"# run claude from this directory (the sandbox trusts it): {Path.cwd()}")
     sys.stdout.flush()
     stop = threading.Event()
     for sig in (signal.SIGINT, signal.SIGTERM):
@@ -268,13 +294,14 @@ def main(argv: list[str]) -> int:
     try:
         with StubServer(turns, role_turns=routes) as server:
             base_url = server.base_url
-            env = build_env(sandbox, base_url, dict(os.environ), parse_env_assignments(args.env))
+            extra_env = parse_env_assignments(args.env)
+            env = build_env(sandbox, base_url, dict(os.environ), extra_env)
             if args.print_env:
-                serve_until_signalled(env, args.claude_binary)
+                serve_until_signalled(env, args.claude_binary, extra_env)
                 status = 0
             else:
                 status = run_claude(args.claude_binary, claude_args, env)
-            report(summary_lines(server, base_url))
+            report(summary_lines(server, env))
     finally:
         if keep:
             report([f"sandbox kept at {sandbox}"])

--- a/scripts/claude-stub.py
+++ b/scripts/claude-stub.py
@@ -3,9 +3,9 @@
 
 A mock/stub of the Anthropic Messages API stands in for the model, so a real
 `claude` session (interactive TUI or `-p` headless) runs end to end without
-spending tokens and with no API key: `ANTHROPIC_BASE_URL` points at a loopback
-server started here, and every answer is scripted locally. Nothing leaves the
-machine.
+spending tokens and without a real API key: `ANTHROPIC_BASE_URL` points at a
+loopback server started here, and every answer is scripted locally. Nothing
+leaves the machine.
 
 The fake server itself is `stub_server.py` under
 `.github/workflows/claude-review-v2/tests/e2e/` (SSE streaming, canned turns,
@@ -282,8 +282,9 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         prog="claude-stub.py",
         description=(
             "Run the real claude CLI against a fake model API on loopback. "
-            "Zero tokens, no network, no real API key. Arguments after `--` go "
-            "to claude (none = interactive TUI; `-p PROMPT` = headless)."
+            "Zero tokens, no network, runs without a real API key. Arguments "
+            "after `--` go to claude (none = interactive TUI; `-p PROMPT` = "
+            "headless)."
         ),
         epilog=(
             "Requests past the end of the scripted turns are answered with the "

--- a/scripts/claude-stub.py
+++ b/scripts/claude-stub.py
@@ -220,7 +220,7 @@ def report(lines: list[str]) -> None:
 
 
 class Terminated(Exception):
-    """SIGTERM or SIGHUP arrived with nothing else to hand it to.
+    """A stop signal arrived with nothing else to hand it to.
 
     Raised out of the signal handler so the signal unwinds through `main`'s
     cleanup instead of the interpreter dying where it stands.
@@ -236,7 +236,8 @@ class SignalTargets:
 
     The handler tests these in order: once the run is `finishing` there is
     nothing left to signal and the signal is swallowed; a live `claude` owns
-    the signal and gets it forwarded; a spawn in flight queues it, because the
+    the signal and is handed it by `deliver`; a spawn in flight queues it (to
+    be handed over the same way once the child has a name), because the
     fork may already exist under a name nothing has been handed yet; a
     `--print-env` server stops serving; otherwise nothing is running that can
     take it, so the signal becomes a `Terminated`.
@@ -255,7 +256,15 @@ class SignalTargets:
 
 
 SIGNAL_TARGETS = SignalTargets()
-STOP_SIGNALS = (signal.SIGTERM, signal.SIGHUP)
+# SIGINT is one of these rather than being left to Python's default
+# `KeyboardInterrupt`, so a Ctrl-C gets the same phase-aware treatment as the
+# other two: held off across `mkdtemp`, queued across the spawn, turned into a
+# clean stop while `--print-env` is serving, and swallowed while finishing.
+# Under the default disposition it could land between `mkdtemp` creating the
+# directory and the name reaching `sandbox` (the sandbox then leaks), or
+# between the fork inside `Popen` and the child reaching `SIGNAL_TARGETS`
+# (the sandbox is then removed out from under a still-running `claude`).
+STOP_SIGNALS = (signal.SIGTERM, signal.SIGHUP, signal.SIGINT)
 
 
 def forward(child: subprocess.Popen, signum: int) -> None:
@@ -272,6 +281,22 @@ def forward(child: subprocess.Popen, signum: int) -> None:
         pass
 
 
+def deliver(child: subprocess.Popen, signum: int) -> None:
+    """Forward `signum` to the child, unless the terminal beat us to it.
+
+    Only SIGINT can have reached the child on its own: a tty delivers it to
+    every process in the foreground group, and `claude` deliberately shares the
+    wrapper's group so it can own the tty. A second one would read as the
+    double Ctrl-C the TUI exits on, so a Ctrl-C typed at the terminal is not
+    forwarded — while a `kill -INT` aimed at the wrapper alone still is
+    (`sigint_reached_child_already`). Every other signal is forwarded
+    unconditionally; nothing else reaches the child by any route but this one.
+    """
+    if signum == signal.SIGINT and sigint_reached_child_already():
+        return
+    forward(child, signum)
+
+
 def handle_stop_signal(signum: int, _frame: Any) -> None:
     if SIGNAL_TARGETS.finishing:
         # The child has already been waited for and the wrapper is at most a
@@ -286,7 +311,7 @@ def handle_stop_signal(signum: int, _frame: Any) -> None:
     if child is not None:
         # PEP 475 retries the interrupted `wait()` once this returns, so the
         # wrapper's own status follows however the child answers the signal.
-        forward(child, signum)
+        deliver(child, signum)
         return
     if SIGNAL_TARGETS.spawning:
         SIGNAL_TARGETS.pending_signum = signum
@@ -299,7 +324,7 @@ def handle_stop_signal(signum: int, _frame: Any) -> None:
 
 
 def install_signal_handlers() -> dict[int, Any]:
-    """Take SIGTERM and SIGHUP; return what they were, for restoring after."""
+    """Take every stop signal; return what they were, for restoring after."""
     return {sig: signal.signal(sig, handle_stop_signal) for sig in STOP_SIGNALS}
 
 
@@ -336,15 +361,12 @@ def run_claude(binary: str, claude_args: list[str], env: dict[str, str]) -> int:
     The child deliberately stays in this process's own group and session: the
     interactive TUI has to remain in the terminal's foreground process group to
     own the tty, so it cannot be put behind `start_new_session`. That shared
-    group is also why a Ctrl-C typed at the terminal is not forwarded — the tty
-    already delivered it to the child, and a second one would read as the
-    double Ctrl-C the TUI exits on (`sigint_reached_child_already`). Other
-    signals are forwarded by pid, and all this has to do is publish the child for
-    the handlers `main` installed before any resource existed. Without that
-    forwarding a SIGTERM to the wrapper would take the interpreter's default
-    disposition — the process dies where it stands, `main`'s `finally` never
-    runs, the sandbox is left on disk, and `claude` keeps running with nobody
-    waiting on it.
+    group is why `deliver` drops a Ctrl-C typed at the terminal rather than
+    forwarding it. All this has to do is publish the child for the handlers
+    `main` installed before any resource existed. Without those a stop signal
+    to the wrapper would take the interpreter's default disposition — the
+    process dies where it stands, `main`'s `finally` never runs, the sandbox is
+    left on disk, and `claude` keeps running with nobody waiting on it.
 
     PEP 475 retries the interrupted `wait()` once a handler returns, so the
     call resumes and returns the child's status as soon as the forwarded
@@ -382,16 +404,14 @@ def run_claude(binary: str, claude_args: list[str], env: dict[str, str]) -> int:
 
     try:
         if queued is not None:
-            forward(child, queued)
-        while True:
-            try:
-                status = child.wait()
-                break
-            except KeyboardInterrupt:
-                # Only when the child cannot have had it already; either way
-                # the loop goes back to waiting for the child to answer.
-                if not sigint_reached_child_already():
-                    forward(child, signal.SIGINT)
+            deliver(child, queued)
+        # No `except KeyboardInterrupt` here: SIGINT is in STOP_SIGNALS, so
+        # `handle_stop_signal` owns it for the whole of this call — installed
+        # by `main` before any resource existed and restored only in `main`'s
+        # outermost `finally`. Python raises KeyboardInterrupt from the default
+        # SIGINT disposition alone, and that disposition is not installed here,
+        # so the wait can only be interrupted and then resumed by PEP 475.
+        status = child.wait()
     finally:
         SIGNAL_TARGETS.child = None
         # The child has been waited for, so from here the wrapper is only
@@ -410,11 +430,12 @@ def serve_until_signalled(
 ) -> None:
     """--print-env: hand the caller exports, keep serving until a stop signal.
 
-    No handler is installed here: SIGTERM and SIGHUP are already `main`'s, and
-    publishing the event is what turns them into a clean stop rather than a
-    `Terminated` unwind. SIGINT keeps its default disposition and arrives as a
-    KeyboardInterrupt, which stops serving the same way. Either route returns
-    normally, so the caller still gets the closing summary.
+    No handler is installed here: every stop signal is already `main`'s, and
+    publishing the event is what turns one into a clean stop rather than a
+    `Terminated` unwind. Ctrl-C takes that same route, since SIGINT is a stop
+    signal like the other two — the handler sets the event and returns, the
+    `wait()` resumes and sees it set, and the caller still gets the closing
+    summary.
     """
     for line in export_lines(env, extra_env):
         print(line)
@@ -425,10 +446,7 @@ def serve_until_signalled(
     SIGNAL_TARGETS.serving_event = stop
     try:
         report(["serving; Ctrl-C (or SIGTERM) to stop"])
-        try:
-            stop.wait()
-        except KeyboardInterrupt:
-            pass
+        stop.wait()
     finally:
         SIGNAL_TARGETS.serving_event = None
         # Same as after the child is waited for: serving is over, so a stop
@@ -468,14 +486,15 @@ def main(argv: list[str]) -> int:
     """Serve the fake API for one run, and reclaim the sandbox afterwards.
 
     The stop-signal handlers go on first, before a single resource exists, so
-    a SIGTERM or SIGHUP anywhere below — building the sandbox, binding the
-    stub server, spawning claude — unwinds through the cleanup instead of
-    taking the interpreter's default disposition. Once the run is finishing —
-    the child waited for, or the `--print-env` server stopped — a stop signal
-    is instead recorded and swallowed, so the last few milliseconds of summary
-    and sandbox removal cannot be interrupted either, and the status stays the
-    one the child exited with. Only SIGKILL or a hard crash can leave the
-    sandbox on disk or the child unwaited-for.
+    any of SIGTERM, SIGHUP and SIGINT arriving anywhere below — building the
+    sandbox, binding the stub server, spawning claude — unwinds through the
+    cleanup instead of taking the interpreter's default disposition. Once the
+    run is finishing — the child waited for, or the `--print-env` server
+    stopped — a stop signal is instead recorded and swallowed, so the last few
+    milliseconds of summary and sandbox removal cannot be interrupted either,
+    and the status stays the one the child exited with. The guarantee is the
+    same for all three: only SIGKILL or a hard crash can leave the sandbox on
+    disk or the child unwaited-for.
     """
     previous_handlers = install_signal_handlers()
     try:
@@ -541,10 +560,13 @@ def main(argv: list[str]) -> int:
         report([f"stopped by signal {terminated.signum}"])
         return 128 + terminated.signum
     except KeyboardInterrupt:
-        # A Ctrl-C before `claude` is running — while the sandbox is built or
-        # the stub server binds — has nowhere to be forwarded, and is the same
-        # outcome as the SIGTERM above: report the signal, keep the cleanup the
-        # `finally` blocks already did, and answer 130 rather than a traceback.
+        # A belt for the instants either side of the handler's reign: SIGINT is
+        # a stop signal, so a Ctrl-C from here on arrives as `Terminated` like
+        # any other, and only one landing before `install_signal_handlers` has
+        # returned — or after `restore_signal_handlers` puts the default back —
+        # can still take the KeyboardInterrupt disposition. Same outcome as the
+        # `Terminated` above: report the signal, keep the cleanup the `finally`
+        # blocks already did, and answer 130 rather than a traceback.
         report([f"stopped by signal {int(signal.SIGINT)}"])
         return 128 + int(signal.SIGINT)
     finally:

--- a/scripts/claude-stub.py
+++ b/scripts/claude-stub.py
@@ -234,11 +234,12 @@ class Terminated(Exception):
 class SignalTargets:
     """Who owns a stop signal right now, as the run moves through its phases.
 
-    The handler tests these in order: a live `claude` owns the signal and gets
-    it forwarded; a spawn in flight queues it, because the fork may already
-    exist under a name nothing has been handed yet; a `--print-env` server
-    stops serving; otherwise nothing is running that can take it, so the
-    signal becomes a `Terminated`.
+    The handler tests these in order: once the run is `finishing` there is
+    nothing left to signal and the signal is swallowed; a live `claude` owns
+    the signal and gets it forwarded; a spawn in flight queues it, because the
+    fork may already exist under a name nothing has been handed yet; a
+    `--print-env` server stops serving; otherwise nothing is running that can
+    take it, so the signal becomes a `Terminated`.
     """
 
     def __init__(self) -> None:
@@ -246,21 +247,46 @@ class SignalTargets:
         self.spawning = False
         self.pending_signum: int | None = None
         self.serving_event: threading.Event | None = None
+        # Set once the child has been waited for (or the `--print-env` server
+        # has stopped): from there on the wrapper is only unwinding.
+        self.finishing = False
+        # A stop signal that arrived during that unwind, kept for the summary.
+        self.late_signum: int | None = None
 
 
 SIGNAL_TARGETS = SignalTargets()
 STOP_SIGNALS = (signal.SIGTERM, signal.SIGHUP)
 
 
+def forward(child: subprocess.Popen, signum: int) -> None:
+    """Hand `signum` to the child, tolerating a child that just exited.
+
+    Every forwarding site races the child's own exit: between deciding to
+    forward and the `kill(2)` the child can die and be reaped, and signalling
+    a pid that is gone raises `ProcessLookupError`. There is nothing left to
+    signal, which is the outcome that was wanted, so it is not an error.
+    """
+    try:
+        child.send_signal(signum)
+    except OSError:  # the child died between the check and the signal
+        pass
+
+
 def handle_stop_signal(signum: int, _frame: Any) -> None:
+    if SIGNAL_TARGETS.finishing:
+        # The child has already been waited for and the wrapper is at most a
+        # few milliseconds from returning through its own cleanup, so nothing
+        # here can take the signal and nothing needs to. Raising `Terminated`
+        # instead would clobber the status the child actually exited with, and
+        # could unwind out of `shutil.rmtree` mid-walk and strand half a
+        # sandbox. Record it for the summary and swallow it.
+        SIGNAL_TARGETS.late_signum = signum
+        return
     child = SIGNAL_TARGETS.child
     if child is not None:
         # PEP 475 retries the interrupted `wait()` once this returns, so the
         # wrapper's own status follows however the child answers the signal.
-        try:
-            child.send_signal(signum)
-        except OSError:  # the child died between the check and the signal
-            pass
+        forward(child, signum)
         return
     if SIGNAL_TARGETS.spawning:
         SIGNAL_TARGETS.pending_signum = signum
@@ -325,19 +351,28 @@ def run_claude(binary: str, claude_args: list[str], env: dict[str, str]) -> int:
     if child is None:
         if queued is not None:
             raise Terminated(queued)
+        # Nothing was spawned and nothing else will be, so the same rule as
+        # below applies: a stop signal from here on has nothing to act on.
+        SIGNAL_TARGETS.finishing = True
         return 127
 
     try:
         if queued is not None:
-            child.send_signal(queued)
+            forward(child, queued)
         while True:
             try:
                 status = child.wait()
                 break
             except KeyboardInterrupt:
-                child.send_signal(signal.SIGINT)
+                forward(child, signal.SIGINT)
     finally:
         SIGNAL_TARGETS.child = None
+        # The child has been waited for, so from here the wrapper is only
+        # unwinding — a few milliseconds of summary, sandbox removal, and
+        # return. A stop signal landing in that window has nothing to reach,
+        # so the handler swallows it rather than replacing the child's status
+        # with a `Terminated` or interrupting the sandbox removal.
+        SIGNAL_TARGETS.finishing = True
     # Popen.wait reports a signal death as a negative signal number; callers
     # reading an exit status expect the shell's conventional 128 + signal.
     return status if status >= 0 else 128 - status
@@ -369,6 +404,10 @@ def serve_until_signalled(
             pass
     finally:
         SIGNAL_TARGETS.serving_event = None
+        # Same as after the child is waited for: serving is over, so a stop
+        # signal arriving during the summary and the sandbox removal has
+        # nothing left to stop and must not unwind the cleanup.
+        SIGNAL_TARGETS.finishing = True
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
@@ -404,8 +443,12 @@ def main(argv: list[str]) -> int:
     The stop-signal handlers go on first, before a single resource exists, so
     a SIGTERM or SIGHUP anywhere below — building the sandbox, binding the
     stub server, spawning claude — unwinds through the cleanup instead of
-    taking the interpreter's default disposition. Only SIGKILL or a hard crash
-    can leave the sandbox on disk or the child unwaited-for.
+    taking the interpreter's default disposition. Once the run is finishing —
+    the child waited for, or the `--print-env` server stopped — a stop signal
+    is instead recorded and swallowed, so the last few milliseconds of summary
+    and sandbox removal cannot be interrupted either, and the status stays the
+    one the child exited with. Only SIGKILL or a hard crash can leave the
+    sandbox on disk or the child unwaited-for.
     """
     previous_handlers = install_signal_handlers()
     try:
@@ -459,6 +502,13 @@ def main(argv: list[str]) -> int:
                     report([f"sandbox kept at {sandbox}"])
                 else:
                     shutil.rmtree(sandbox, ignore_errors=True)
+        if SIGNAL_TARGETS.late_signum is not None:
+            report(
+                [
+                    f"signal {SIGNAL_TARGETS.late_signum} arrived while exiting; "
+                    "nothing left to stop"
+                ]
+            )
         return status
     except Terminated as terminated:
         report([f"stopped by signal {terminated.signum}"])

--- a/scripts/test-claude-stub.py
+++ b/scripts/test-claude-stub.py
@@ -340,6 +340,110 @@ class ConfigTests(unittest.TestCase):
             self.assertTrue(config["projects"][str(project)]["hasTrustDialogAccepted"])
 
 
+class FakeChild:
+    """Stands in for `subprocess.Popen`, recording what was sent to it."""
+
+    def __init__(self, send_error: BaseException | None = None) -> None:
+        self.sent: list[int] = []
+        self.send_error = send_error
+
+    def send_signal(self, signum: int) -> None:
+        self.sent.append(signum)
+        if self.send_error is not None:
+            raise self.send_error
+
+
+class SignalTargetsFixture(unittest.TestCase):
+    """A private `SignalTargets` for tests that drive the handler directly.
+
+    `handle_stop_signal` reads the module global, and `finishing` is a one-way
+    latch, so a test that set it on the real one would silence every later
+    in-process test that expects a signal to be acted on.
+    """
+
+    def setUp(self):
+        self.targets = claude_stub.SignalTargets()
+        patch = mock.patch.object(claude_stub, "SIGNAL_TARGETS", self.targets)
+        patch.start()
+        self.addCleanup(patch.stop)
+
+
+class SignalHandlerStateTests(SignalTargetsFixture):
+    def test_a_stop_signal_while_finishing_is_recorded_and_swallowed(self):
+        # After the child is waited for there is nothing to forward to and
+        # nothing to unwind: raising here would replace the child's status and
+        # could interrupt the sandbox removal.
+        child = FakeChild()
+        self.targets.child = child
+        self.targets.finishing = True
+
+        self.assertIsNone(claude_stub.handle_stop_signal(signal.SIGTERM, None))
+
+        self.assertEqual([], child.sent, "a finishing run still forwarded")
+        self.assertEqual(int(signal.SIGTERM), self.targets.late_signum)
+
+    def test_a_stop_signal_with_nothing_finishing_still_terminates(self):
+        # The discriminator for the test above: without `finishing`, a signal
+        # nobody owns is still the `Terminated` that unwinds through cleanup.
+        with self.assertRaises(claude_stub.Terminated) as raised:
+            claude_stub.handle_stop_signal(signal.SIGHUP, None)
+        self.assertEqual(int(signal.SIGHUP), raised.exception.signum)
+        self.assertIsNone(self.targets.late_signum)
+
+    def test_a_live_child_is_still_sent_the_signal(self):
+        child = FakeChild()
+        self.targets.child = child
+        self.assertIsNone(claude_stub.handle_stop_signal(signal.SIGTERM, None))
+        self.assertEqual([int(signal.SIGTERM)], child.sent)
+
+    def test_forwarding_tolerates_a_child_that_exited_first(self):
+        # The race every forwarding site runs: the pid is gone by the time the
+        # signal is sent, which is the outcome that was wanted, not a crash.
+        child = FakeChild(send_error=ProcessLookupError())
+        claude_stub.forward(child, signal.SIGINT)
+        self.assertEqual([int(signal.SIGINT)], child.sent)
+
+    def test_forwarding_a_signal_to_a_live_child_delivers_it(self):
+        child = FakeChild()
+        claude_stub.forward(child, signal.SIGTERM)
+        self.assertEqual([int(signal.SIGTERM)], child.sent)
+
+
+class LateSignalExitStatusTests(SignalTargetsFixture):
+    def test_a_signal_after_the_child_exits_keeps_the_status_and_cleans_up(self):
+        # A self-signal is delivered to the calling thread before `os.kill`
+        # returns, so this lands exactly in the window between the child being
+        # waited for and `main` finishing its cleanup. Unswallowed it becomes
+        # a `Terminated`: status 143 instead of 7, out of a `shutil.rmtree`
+        # that may have walked only half the sandbox.
+        root = Path(tempfile.mkdtemp(prefix="claudestub-test-"))
+        self.addCleanup(shutil.rmtree, root, ignore_errors=True)
+        created: list[str] = []
+        real_mkdtemp = tempfile.mkdtemp
+
+        def recording_mkdtemp(*args, **kwargs):
+            kwargs["dir"] = str(root)
+            path = real_mkdtemp(*args, **kwargs)
+            created.append(path)
+            return path
+
+        def finishing_then_signalled(binary, claude_args, env):
+            claude_stub.SIGNAL_TARGETS.finishing = True
+            os.kill(os.getpid(), signal.SIGTERM)
+            return 7
+
+        with mock.patch.object(claude_stub.tempfile, "mkdtemp", recording_mkdtemp):
+            with mock.patch.object(
+                claude_stub, "run_claude", finishing_then_signalled
+            ):
+                status = claude_stub.main(["--text", "x", "--", "-p", "hi"])
+
+        self.assertEqual(7, status)
+        self.assertEqual(int(signal.SIGTERM), self.targets.late_signum)
+        self.assertEqual(1, len(created), "the wrapper did not create a temp sandbox")
+        self.assertFalse(Path(created[0]).exists(), "the temp sandbox leaked")
+
+
 class WrapperProcessTests(unittest.TestCase):
     """The wrapper as a process: signal handling and the cleanup scope.
 

--- a/scripts/test-claude-stub.py
+++ b/scripts/test-claude-stub.py
@@ -1,9 +1,11 @@
 """Tests for scripts/claude-stub.py (stdlib only).
 
 Mostly the pure parts: turn scripting, the env overlay, the `--print-env`
-exports, the sandbox config, and the closing summary. One smoke test spawns the
-real `claude` against the stub end to end, and skips when no `claude` is on
-PATH. The e2e suite under `.github/workflows/claude-review-v2/tests/e2e/`
+exports, the sandbox config, and the closing summary. A second group runs the
+wrapper as a process against a shell script standing in for `claude`, which is
+the only way to observe signal handling and sandbox cleanup. One smoke test
+spawns the real `claude` against the stub end to end, and skips when no
+`claude` is on PATH. The e2e suite under `.github/workflows/claude-review-v2/tests/e2e/`
 exercises the same fake server, but it drives the review gate's own scenarios
 and never runs this wrapper, so nothing there covers the code here.
 """
@@ -15,12 +17,15 @@ import importlib.util
 import json
 import os
 from pathlib import Path
+import shlex
 import shutil
 import signal
 import subprocess
 import sys
 import tempfile
+import time
 import unittest
+from unittest import mock
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -333,6 +338,174 @@ class ConfigTests(unittest.TestCase):
         self.assertTrue(config["hasTrustDialogAccepted"])
         for project in (first, second):
             self.assertTrue(config["projects"][str(project)]["hasTrustDialogAccepted"])
+
+
+class WrapperProcessTests(unittest.TestCase):
+    """The wrapper as a process: signal handling and the cleanup scope.
+
+    These run the wrapper by subprocess against a shell script standing in for
+    `claude`, so they need no CLI and cost no tokens. Every wait is bounded and
+    the wrapper gets its own process group, so a hang is killed rather than
+    left behind.
+    """
+
+    DEADLINE = 30.0
+
+    def _root(self) -> Path:
+        root = Path(tempfile.mkdtemp(prefix="claudestub-test-"))
+        self.addCleanup(shutil.rmtree, root, ignore_errors=True)
+        return root
+
+    @staticmethod
+    def _fake_claude(path: Path, body: str) -> Path:
+        path.write_text(f"#!/bin/sh\n{body}", encoding="utf-8")
+        path.chmod(0o755)
+        return path
+
+    def _spawn_wrapper(self, root: Path, binary: Path, *extra: str) -> subprocess.Popen:
+        cwd = root / "project"
+        cwd.mkdir(exist_ok=True)
+        devnull = open(os.devnull, "rb")
+        self.addCleanup(devnull.close)
+        # A new process group so a hung run is killed whole, never orphaned.
+        wrapper = subprocess.Popen(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--text",
+                "stubbed",
+                "--claude-binary",
+                str(binary),
+                *extra,
+                "--",
+                "-p",
+                "hi",
+            ],
+            cwd=cwd,
+            stdin=devnull,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            start_new_session=True,
+        )
+        self.addCleanup(self._kill_group, wrapper)
+        return wrapper
+
+    @staticmethod
+    def _kill_group(wrapper: subprocess.Popen) -> None:
+        """Kill the whole group, whether or not the wrapper is still alive.
+
+        `start_new_session` made the wrapper its own group leader, so its pid
+        is the group id and stays usable while any member survives — which is
+        exactly the case that matters: a wrapper that died without forwarding
+        leaves the stub `claude` behind in that group.
+        """
+        try:
+            os.killpg(wrapper.pid, signal.SIGKILL)
+        except (ProcessLookupError, PermissionError):
+            pass
+        if wrapper.poll() is None:
+            wrapper.communicate()
+
+    def _wait_for(self, predicate, description: str):
+        deadline = time.monotonic() + self.DEADLINE
+        while time.monotonic() < deadline:
+            result = predicate()
+            if result:
+                return result
+            time.sleep(0.05)
+        self.fail(f"timed out after {self.DEADLINE}s waiting for {description}")
+
+    def test_a_sigterm_to_the_wrapper_reaches_claude_and_still_cleans_up(self):
+        # Without signal forwarding the interpreter dies where it stands: the
+        # sandbox survives and `claude` is left running with nobody waiting.
+        root = self._root()
+        report = root / "child.txt"
+        binary = self._fake_claude(
+            root / "fake-claude.sh",
+            f'printf \'%s\\n%s\\n\' "$$" "$HOME" > {shlex.quote(str(report))}\n'
+            # `exec` keeps the pid just written, and the sleep outlasts the
+            # deadline so "the child is gone" cannot pass by expiry.
+            "exec sleep 600\n",
+        )
+        wrapper = self._spawn_wrapper(root, binary)
+
+        def spawned():
+            if wrapper.poll() is not None:
+                self.fail("the wrapper exited before the stub claude reported in")
+            lines = report.read_text(encoding="utf-8").splitlines() if report.exists() else []
+            return lines if len(lines) == 2 else None
+
+        child_pid, sandbox = self._wait_for(spawned, "the stub claude to report its pid")
+        child_pid = int(child_pid)
+        sandbox = Path(sandbox)
+        time.sleep(0.2)  # the wrapper installs its handlers just after spawning
+
+        wrapper.send_signal(signal.SIGTERM)
+        try:
+            stdout, stderr = wrapper.communicate(timeout=self.DEADLINE)
+        except subprocess.TimeoutExpired:
+            # An unforwarded SIGTERM kills the wrapper but leaves the child
+            # holding its pipes open, so this is the shape that failure takes.
+            self.fail(f"the wrapper did not finish {self.DEADLINE}s after SIGTERM")
+
+        def child_gone():
+            try:
+                os.kill(child_pid, 0)
+            except ProcessLookupError:
+                return True
+            return False
+
+        self._wait_for(child_gone, f"the stub claude (pid {child_pid}) to exit")
+        self.assertFalse(sandbox.exists(), f"the temp sandbox {sandbox} leaked")
+        # A signal death is negative from Popen.wait; callers get 128 + signal.
+        self.assertEqual(128 + int(signal.SIGTERM), wrapper.returncode, stderr)
+        self.assertIn("request(s) served", stderr, stdout)
+
+    def test_a_corrupted_reused_sandbox_config_fails_without_running_claude(self):
+        # An explicit --sandbox is always kept, so this is about the failure
+        # being reported and bounded rather than about cleanup.
+        root = self._root()
+        sandbox = root / "sandbox"
+        (sandbox / "config").mkdir(parents=True)
+        (sandbox / "config" / ".claude.json").write_text("{not json", encoding="utf-8")
+        marker = root / "ran.txt"
+        binary = self._fake_claude(
+            root / "fake-claude.sh", f"touch {shlex.quote(str(marker))}\n"
+        )
+        wrapper = self._spawn_wrapper(root, binary, "--sandbox", str(sandbox))
+
+        _, stderr = wrapper.communicate(timeout=self.DEADLINE)
+
+        self.assertNotEqual(0, wrapper.returncode)
+        self.assertIn("JSONDecodeError", stderr)
+        self.assertFalse(marker.exists(), "claude ran despite the unreadable config")
+
+
+class SandboxCleanupTests(unittest.TestCase):
+    def test_a_failure_after_the_temp_sandbox_exists_still_removes_it(self):
+        # The auto-created sandbox is only reclaimable by the wrapper's own
+        # `finally`, so setup that can fail has to sit inside it.
+        root = Path(tempfile.mkdtemp(prefix="claudestub-test-"))
+        self.addCleanup(shutil.rmtree, root, ignore_errors=True)
+        created: list[str] = []
+        real_mkdtemp = tempfile.mkdtemp
+
+        def recording_mkdtemp(*args, **kwargs):
+            kwargs["dir"] = str(root)
+            path = real_mkdtemp(*args, **kwargs)
+            created.append(path)
+            return path
+
+        with mock.patch.object(claude_stub.tempfile, "mkdtemp", recording_mkdtemp):
+            with mock.patch.object(
+                claude_stub, "write_config", side_effect=RuntimeError("boom")
+            ):
+                with self.assertRaises(RuntimeError):
+                    claude_stub.main(["--text", "x", "--", "-p", "hi"])
+
+        self.assertEqual(1, len(created), "the wrapper did not create a temp sandbox")
+        self.assertFalse(Path(created[0]).exists(), "the temp sandbox leaked")
 
 
 @unittest.skipUnless(shutil.which("claude"), "no claude binary on PATH")

--- a/scripts/test-claude-stub.py
+++ b/scripts/test-claude-stub.py
@@ -362,7 +362,13 @@ class WrapperProcessTests(unittest.TestCase):
         path.chmod(0o755)
         return path
 
-    def _spawn_wrapper(self, root: Path, binary: Path, *extra: str) -> subprocess.Popen:
+    def _spawn_wrapper(
+        self,
+        root: Path,
+        binary: Path,
+        *extra: str,
+        env: dict[str, str] | None = None,
+    ) -> subprocess.Popen:
         cwd = root / "project"
         cwd.mkdir(exist_ok=True)
         devnull = open(os.devnull, "rb")
@@ -382,6 +388,7 @@ class WrapperProcessTests(unittest.TestCase):
                 "hi",
             ],
             cwd=cwd,
+            env=env,
             stdin=devnull,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -439,7 +446,6 @@ class WrapperProcessTests(unittest.TestCase):
         child_pid, sandbox = self._wait_for(spawned, "the stub claude to report its pid")
         child_pid = int(child_pid)
         sandbox = Path(sandbox)
-        time.sleep(0.2)  # the wrapper installs its handlers just after spawning
 
         wrapper.send_signal(signal.SIGTERM)
         try:
@@ -480,6 +486,127 @@ class WrapperProcessTests(unittest.TestCase):
         self.assertNotEqual(0, wrapper.returncode)
         self.assertIn("JSONDecodeError", stderr)
         self.assertFalse(marker.exists(), "claude ran despite the unreadable config")
+
+    @staticmethod
+    def _exit_status(returncode: int) -> int:
+        """Popen reports a signal death as -N; a shell would report 128 + N.
+
+        Both spellings are legitimate answers here: dying under the default
+        disposition before the handlers exist and returning 128 + N from a
+        handled signal are the same outcome to anyone reading `$?`.
+        """
+        return returncode if returncode >= 0 else 128 - returncode
+
+    @staticmethod
+    def _pid_gone(pid: int) -> bool:
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return True
+        return False
+
+    def _stop_signal_leaves_nothing_behind(self, sig: int, *, at_sandbox: bool) -> None:
+        """Signal one wrapper run and assert the three invariants hold.
+
+        `at_sandbox` waits for the temp sandbox to appear first, which puts the
+        signal inside the window between the first resource existing and
+        `claude` being spawned — the window the handlers used to leave open.
+        Otherwise the signal goes immediately, landing before any resource
+        exists at all. Whichever window it hits, the wrapper must report the
+        signal, strand no sandbox, and leave no `claude` behind.
+        """
+        root = self._root()
+        tmpdir = root / "tmp"
+        tmpdir.mkdir()
+        child_report = root / "child.txt"
+        binary = self._fake_claude(
+            root / "fake-claude.sh",
+            f'printf \'%s\\n\' "$$" > {shlex.quote(str(child_report))}\n'
+            # `exec` keeps the pid just written, and the sleep outlasts the
+            # deadline so "the child is gone" cannot pass by expiry.
+            "exec sleep 600\n",
+        )
+        wrapper = self._spawn_wrapper(
+            root, binary, env={**os.environ, "TMPDIR": str(tmpdir)}
+        )
+        if at_sandbox:
+            # Polled tightly on purpose: the window this aims at is only a few
+            # milliseconds wide, so `_wait_for`'s 50 ms step would step over it.
+            deadline = time.monotonic() + self.DEADLINE
+            while time.monotonic() < deadline and not list(tmpdir.glob("claude-stub-*")):
+                if wrapper.poll() is not None:
+                    self.fail("the wrapper exited before creating a sandbox")
+                time.sleep(0.001)
+
+        wrapper.send_signal(sig)
+        try:
+            _, stderr = wrapper.communicate(timeout=self.DEADLINE)
+        except subprocess.TimeoutExpired:
+            self.fail(f"the wrapper did not finish {self.DEADLINE}s after signal {sig}")
+
+        self.assertEqual([], list(tmpdir.glob("claude-stub-*")), f"a sandbox leaked\n{stderr}")
+        if child_report.exists():
+            child_pid = int(child_report.read_text(encoding="utf-8").split()[0])
+            self._wait_for(
+                lambda: self._pid_gone(child_pid),
+                f"the stub claude (pid {child_pid}) to exit",
+            )
+        self.assertEqual(
+            128 + int(sig), self._exit_status(wrapper.returncode), stderr
+        )
+
+    def test_a_sigterm_before_claude_starts_strands_neither_sandbox_nor_child(self):
+        # The handlers have to be installed before the first resource exists.
+        # Installed inside `run_claude` instead, a signal arriving while the
+        # sandbox is built, the config written, or the stub server bound takes
+        # the interpreter's default disposition: the wrapper dies where it
+        # stands and the sandbox is stranded. Five runs are signalled the
+        # instant the sandbox appears — inside that window — and one before
+        # any resource exists at all.
+        for attempt in range(5):
+            with self.subTest(attempt=attempt):
+                self._stop_signal_leaves_nothing_behind(signal.SIGTERM, at_sandbox=True)
+        self._stop_signal_leaves_nothing_behind(signal.SIGTERM, at_sandbox=False)
+
+    def test_a_sighup_before_claude_starts_is_handled_like_a_sigterm(self):
+        self._stop_signal_leaves_nothing_behind(signal.SIGHUP, at_sandbox=True)
+
+    def test_print_env_stops_on_sighup_and_still_reports_the_summary(self):
+        # `serve_until_signalled` used to take SIGINT and SIGTERM only, so a
+        # SIGHUP — the signal a closing terminal sends — killed the server
+        # outright: no summary, and the temp sandbox left on disk.
+        root = self._root()
+        tmpdir = root / "tmp"
+        tmpdir.mkdir()
+        cwd = root / "project"
+        cwd.mkdir()
+        out, err = root / "out.txt", root / "err.txt"
+        with open(out, "w") as stdout, open(err, "w") as stderr, open(os.devnull, "rb") as devnull:
+            wrapper = subprocess.Popen(
+                [sys.executable, str(SCRIPT), "--print-env", "--text", "hi"],
+                cwd=cwd,
+                env={**os.environ, "TMPDIR": str(tmpdir)},
+                stdin=devnull,
+                stdout=stdout,
+                stderr=stderr,
+                start_new_session=True,
+            )
+        self.addCleanup(self._kill_group, wrapper)
+        self._wait_for(
+            lambda: "ANTHROPIC_BASE_URL" in out.read_text(encoding="utf-8"),
+            "the export lines on stdout",
+        )
+
+        wrapper.send_signal(signal.SIGHUP)
+        try:
+            wrapper.communicate(timeout=self.DEADLINE)
+        except subprocess.TimeoutExpired:
+            self.fail(f"the wrapper kept serving {self.DEADLINE}s after SIGHUP")
+
+        stderr_text = err.read_text(encoding="utf-8")
+        self.assertEqual(0, wrapper.returncode, stderr_text)
+        self.assertIn("request(s) served", stderr_text)
+        self.assertEqual([], list(tmpdir.glob("claude-stub-*")), "a sandbox leaked")
 
 
 class SandboxCleanupTests(unittest.TestCase):

--- a/scripts/test-claude-stub.py
+++ b/scripts/test-claude-stub.py
@@ -1,0 +1,265 @@
+"""Tests for scripts/claude-stub.py (stdlib only).
+
+Only the pure parts: turn scripting, the env overlay, the `--print-env`
+exports, and the closing summary. Nothing here spawns `claude` — the live
+sessions against the fake model API are covered by the e2e suite under
+`.github/workflows/claude-review-v2/tests/e2e/`.
+"""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "claude-stub.py"
+
+
+def _load_script_module():
+    """Import scripts/claude-stub.py (hyphenated) as `claude_stub`."""
+    loader = importlib.machinery.SourceFileLoader("claude_stub", str(SCRIPT))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    assert spec is not None, f"no import spec for {SCRIPT}"
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+claude_stub = _load_script_module()
+
+
+def parse(*argv: str):
+    return claude_stub.parse_args(list(argv))
+
+
+class TurnScriptTests(unittest.TestCase):
+    def _turns_file(self, document: object) -> str:
+        handle = tempfile.NamedTemporaryFile(
+            "w", suffix=".json", delete=False, encoding="utf-8"
+        )
+        json.dump(document, handle)
+        handle.close()
+        self.addCleanup(lambda: Path(handle.name).unlink(missing_ok=True))
+        return handle.name
+
+    def test_a_turn_file_can_be_a_plain_list_of_turns(self):
+        path = self._turns_file(
+            [
+                {"text": "first"},
+                {
+                    "text": "second",
+                    "tool_calls": [{"name": "Write", "input": {"file_path": "a.txt"}}],
+                },
+            ]
+        )
+        turns, role_turns = claude_stub.resolve_turns(parse("--turns", path))
+        self.assertEqual({}, role_turns)
+        self.assertEqual(["first", "second"], [turn.text for turn in turns])
+        self.assertEqual([], turns[0].tool_calls)
+        self.assertEqual("Write", turns[1].tool_calls[0].name)
+        self.assertEqual({"file_path": "a.txt"}, turns[1].tool_calls[0].input)
+        # tool_use turns must stop with tool_use, or the CLI never runs the tool.
+        self.assertEqual("end_turn", turns[0].stop_reason)
+        self.assertEqual("tool_use", turns[1].stop_reason)
+
+    def test_the_object_form_carries_role_turns_for_content_keyed_routing(self):
+        path = self._turns_file(
+            {
+                "turns": [{"text": "orchestrator"}],
+                "role_turns": {
+                    "ROLE-CORRECTNESS": [{"text": "correctness"}],
+                    "ROLE-SECURITY": [{"text": "security 1"}, {"text": "security 2"}],
+                },
+            }
+        )
+        turns, role_turns = claude_stub.resolve_turns(parse("--turns", path))
+        self.assertEqual(["orchestrator"], [turn.text for turn in turns])
+        self.assertEqual({"ROLE-CORRECTNESS", "ROLE-SECURITY"}, set(role_turns))
+        self.assertEqual(
+            ["security 1", "security 2"],
+            [turn.text for turn in role_turns["ROLE-SECURITY"]],
+        )
+
+    def test_a_turn_file_that_is_neither_a_list_nor_an_object_is_rejected(self):
+        path = self._turns_file("just a string")
+        with self.assertRaises(ValueError):
+            claude_stub.resolve_turns(parse("--turns", path))
+
+    def test_text_serves_exactly_one_turn_with_that_content(self):
+        turns, role_turns = claude_stub.resolve_turns(parse("--text", "hello stub"))
+        self.assertEqual({}, role_turns)
+        self.assertEqual(["hello stub"], [turn.text for turn in turns])
+
+    def test_the_default_answer_is_one_turn_of_n_numbered_lines(self):
+        turns, role_turns = claude_stub.resolve_turns(parse("--lines", "12"))
+        self.assertEqual({}, role_turns)
+        self.assertEqual(1, len(turns))
+        lines = turns[0].text.splitlines()
+        self.assertEqual(12, len(lines))
+        self.assertEqual(
+            [f"{n}." for n in range(1, 13)],
+            [line.split(" ", 1)[0] for line in lines],
+        )
+
+    def test_the_default_lines_count_is_two_hundred(self):
+        turns, _ = claude_stub.resolve_turns(parse())
+        self.assertEqual(200, len(turns[0].text.splitlines()))
+
+
+class EnvOverlayTests(unittest.TestCase):
+    def setUp(self):
+        self.sandbox = Path(tempfile.mkdtemp(prefix="claudestub-test-"))
+
+    def test_the_harness_isolation_is_the_base(self):
+        env = claude_stub.build_env(self.sandbox, "http://127.0.0.1:1", {}, {})
+        self.assertEqual(str(self.sandbox), env["HOME"])
+        self.assertEqual(str(self.sandbox / "config"), env["CLAUDE_CONFIG_DIR"])
+        self.assertEqual("http://127.0.0.1:1", env["ANTHROPIC_BASE_URL"])
+        self.assertEqual("stub-key", env["ANTHROPIC_API_KEY"])
+
+    def test_a_real_terminal_beats_the_harness_dumb_terminal(self):
+        bare = claude_stub.build_env(self.sandbox, "http://127.0.0.1:1", {}, {})
+        self.assertEqual("dumb", bare["TERM"])
+        env = claude_stub.build_env(
+            self.sandbox,
+            "http://127.0.0.1:1",
+            {"TERM": "xterm-256color", "COLORTERM": "truecolor", "LANG": "en_US.UTF-8"},
+            {},
+        )
+        self.assertEqual("xterm-256color", env["TERM"])
+        self.assertEqual("truecolor", env["COLORTERM"])
+        self.assertEqual("en_US.UTF-8", env["LANG"])
+
+    def test_an_empty_terminal_variable_does_not_displace_the_harness_value(self):
+        env = claude_stub.build_env(self.sandbox, "http://127.0.0.1:1", {"TERM": ""}, {})
+        self.assertEqual("dumb", env["TERM"])
+
+    def test_explicit_env_beats_both_the_harness_and_the_caller(self):
+        env = claude_stub.build_env(
+            self.sandbox,
+            "http://127.0.0.1:1",
+            {"TERM": "xterm-256color"},
+            claude_stub.parse_env_assignments(["TERM=vt100", "ANTHROPIC_MODEL=stub-model"]),
+        )
+        self.assertEqual("vt100", env["TERM"])
+        self.assertEqual("stub-model", env["ANTHROPIC_MODEL"])
+
+    def test_an_env_assignment_may_hold_equals_signs_in_its_value(self):
+        self.assertEqual(
+            {"A": "b=c="}, claude_stub.parse_env_assignments(["A=b=c="])
+        )
+
+    def test_an_env_argument_without_a_value_is_rejected(self):
+        for bad in ("NOEQUALS", "=novalue"):
+            with self.subTest(bad=bad), self.assertRaises(ValueError):
+                claude_stub.parse_env_assignments([bad])
+
+
+class PrintEnvTests(unittest.TestCase):
+    def test_export_lines_quote_values_a_shell_would_otherwise_split(self):
+        lines = claude_stub.export_lines(
+            {"HOME": "/tmp/a b", "NO_PROXY": "127.0.0.1,localhost", "Q": "it's"}
+        )
+        self.assertIn("export HOME='/tmp/a b'", lines)
+        self.assertIn("export NO_PROXY=127.0.0.1,localhost", lines)
+        self.assertIn("""export Q='it'"'"'s'""", lines)
+
+    def test_export_lines_are_sorted_so_the_block_is_stable(self):
+        lines = claude_stub.export_lines({"B": "2", "A": "1"})
+        self.assertEqual(["export A=1", "export B=2"], lines)
+
+    def test_the_callers_own_path_is_not_re_exported(self):
+        lines = claude_stub.export_lines({"PATH": "/usr/bin", "HOME": "/tmp/x"})
+        self.assertEqual(["export HOME=/tmp/x"], lines)
+
+
+class SummaryTests(unittest.TestCase):
+    def _server(self, **kwargs):
+        from stub_server import StubServer, Turn
+
+        server = StubServer([Turn(text="one")], **kwargs)
+        self.addCleanup(server._httpd.server_close)
+        return server
+
+    def test_the_summary_counts_requests_and_names_the_loopback_url(self):
+        server = self._server()
+        server.capture.raw_bodies.extend([b"{}", b"{}"])
+        server.capture.routes.extend([None, None])
+        lines = claude_stub.summary_lines(server, "http://127.0.0.1:4242")
+        self.assertIn("2 request(s) served at http://127.0.0.1:4242", lines)
+        self.assertIn(
+            "no request left this machine — ANTHROPIC_BASE_URL was "
+            "http://127.0.0.1:4242 (loopback)",
+            lines,
+        )
+
+    def test_the_connectivity_preflight_is_not_reported_as_unexpected(self):
+        server = self._server()
+        server.capture.unexpected_paths.extend(["/api/hello", "/v1/messages/count_tokens"])
+        lines = claude_stub.summary_lines(server, "http://127.0.0.1:4242")
+        self.assertIn("unexpected paths: /v1/messages/count_tokens", lines)
+
+    def test_routes_are_broken_out_when_the_run_uses_content_keyed_routing(self):
+        server = self._server(
+            role_turns={
+                claude_stub.TITLE_SENTINEL: [claude_stub.TITLE_TURN],
+                "ROLE-SECURITY": [],
+            }
+        )
+        server.capture.raw_bodies.extend([b"{}", b"{}", b"{}"])
+        server.capture.routes.extend([claude_stub.TITLE_SENTINEL, "ROLE-SECURITY", None])
+        lines = claude_stub.summary_lines(server, "http://127.0.0.1:4242")
+        self.assertIn(f"  route {claude_stub.TITLE_LABEL}: 1", lines)
+        self.assertIn("  route ROLE-SECURITY: 1", lines)
+        self.assertIn("  route (ordered turns): 1", lines)
+
+    def test_a_run_without_routing_reports_no_route_breakdown(self):
+        server = self._server()
+        server.capture.raw_bodies.append(b"{}")
+        server.capture.routes.append(None)
+        lines = claude_stub.summary_lines(server, "http://127.0.0.1:4242")
+        self.assertFalse([line for line in lines if line.startswith("  route ")])
+
+
+class ConfigTests(unittest.TestCase):
+    def test_the_config_pre_accepts_trust_and_the_custom_api_key_dialog(self):
+        sandbox = Path(tempfile.mkdtemp(prefix="claudestub-test-"))
+        project = sandbox / "project"
+        project.mkdir()
+        claude_stub.write_config(sandbox, project)
+        config = json.loads(
+            (sandbox / "config" / ".claude.json").read_text(encoding="utf-8")
+        )
+        self.assertTrue(config["hasTrustDialogAccepted"])
+        self.assertTrue(config["projects"][str(project)]["hasTrustDialogAccepted"])
+        # The interactive TUI otherwise stops on "use this API key?".
+        self.assertEqual(["stub-key"], config["customApiKeyResponses"]["approved"])
+
+    def test_a_reused_sandbox_keeps_its_transcripts_and_gains_the_new_project(self):
+        sandbox = Path(tempfile.mkdtemp(prefix="claudestub-test-"))
+        first, second = sandbox / "one", sandbox / "two"
+        first.mkdir()
+        second.mkdir()
+        claude_stub.write_config(sandbox, first)
+        transcript = sandbox / "config" / "projects" / "session.jsonl"
+        transcript.parent.mkdir(parents=True)
+        transcript.write_text("{}\n", encoding="utf-8")
+
+        claude_stub.write_config(sandbox, second)  # second run, different cwd
+
+        self.assertTrue(transcript.is_file(), "the reused sandbox lost its transcripts")
+        config = json.loads(
+            (sandbox / "config" / ".claude.json").read_text(encoding="utf-8")
+        )
+        self.assertTrue(config["hasTrustDialogAccepted"])
+        for project in (first, second):
+            self.assertTrue(config["projects"][str(project)]["hasTrustDialogAccepted"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test-claude-stub.py
+++ b/scripts/test-claude-stub.py
@@ -13,8 +13,10 @@ from __future__ import annotations
 import importlib.machinery
 import importlib.util
 import json
+import os
 from pathlib import Path
 import shutil
+import signal
 import subprocess
 import sys
 import tempfile
@@ -203,6 +205,19 @@ class PrintEnvTests(unittest.TestCase):
         lines = claude_stub.export_lines({"PATH": "/usr/bin", "HOME": "/tmp/x"})
         self.assertEqual(["export HOME=/tmp/x"], lines)
 
+    def test_a_path_the_caller_overrode_with_env_is_exported(self):
+        # The run mode honours --env PATH=..., so --print-env must too.
+        lines = claude_stub.export_lines(
+            {"PATH": "/opt/stub/bin", "HOME": "/tmp/x"}, {"PATH": "/opt/stub/bin"}
+        )
+        self.assertEqual(["export HOME=/tmp/x", "export PATH=/opt/stub/bin"], lines)
+
+    def test_overriding_an_unrelated_variable_still_drops_the_inherited_path(self):
+        lines = claude_stub.export_lines(
+            {"PATH": "/usr/bin", "HOME": "/tmp/x"}, {"TERM": "vt100"}
+        )
+        self.assertEqual(["export HOME=/tmp/x"], lines)
+
 
 class SummaryTests(unittest.TestCase):
     def _server(self, **kwargs):
@@ -212,22 +227,44 @@ class SummaryTests(unittest.TestCase):
         self.addCleanup(server._httpd.server_close)
         return server
 
+    @staticmethod
+    def _env(server, base_url=None):
+        """The env claude was handed; by default the one aimed at this server."""
+        return {"ANTHROPIC_BASE_URL": base_url or server.base_url}
+
     def test_the_summary_counts_requests_and_names_the_loopback_url(self):
         server = self._server()
         server.capture.raw_bodies.extend([b"{}", b"{}"])
         server.capture.routes.extend([None, None])
-        lines = claude_stub.summary_lines(server, "http://127.0.0.1:4242")
-        self.assertIn("2 request(s) served at http://127.0.0.1:4242", lines)
+        lines = claude_stub.summary_lines(server, self._env(server))
+        self.assertIn(f"2 request(s) served at {server.base_url}", lines)
         self.assertIn(
             "no model request left this machine — ANTHROPIC_BASE_URL was "
-            "http://127.0.0.1:4242 (loopback)",
+            f"{server.base_url} (loopback)",
             lines,
         )
+
+    def test_an_overridden_base_url_is_reported_instead_of_a_loopback_claim(self):
+        # --env ANTHROPIC_BASE_URL=... points claude somewhere the stub cannot
+        # see, so the summary must not vouch for traffic it never observed.
+        server = self._server()
+        server.capture.raw_bodies.append(b"{}")
+        server.capture.routes.append(None)
+        lines = claude_stub.summary_lines(
+            server, self._env(server, "https://api.example.invalid")
+        )
+        self.assertIn(
+            "ANTHROPIC_BASE_URL was overridden to https://api.example.invalid; "
+            "the stub served 1 request(s), and requests to that URL are not "
+            "counted here",
+            lines,
+        )
+        self.assertFalse([line for line in lines if "loopback" in line])
 
     def test_the_connectivity_preflight_is_not_reported_as_unexpected(self):
         server = self._server()
         server.capture.unexpected_paths.extend(["/api/hello", "/v1/messages/count_tokens"])
-        lines = claude_stub.summary_lines(server, "http://127.0.0.1:4242")
+        lines = claude_stub.summary_lines(server, self._env(server))
         self.assertIn("unexpected paths: /v1/messages/count_tokens", lines)
 
     def test_routes_are_broken_out_when_the_run_uses_content_keyed_routing(self):
@@ -239,7 +276,7 @@ class SummaryTests(unittest.TestCase):
         )
         server.capture.raw_bodies.extend([b"{}", b"{}", b"{}"])
         server.capture.routes.extend([claude_stub.TITLE_SENTINEL, "ROLE-SECURITY", None])
-        lines = claude_stub.summary_lines(server, "http://127.0.0.1:4242")
+        lines = claude_stub.summary_lines(server, self._env(server))
         self.assertIn(f"  route {claude_stub.TITLE_LABEL}: 1", lines)
         self.assertIn("  route ROLE-SECURITY: 1", lines)
         self.assertIn("  route (ordered turns): 1", lines)
@@ -248,7 +285,7 @@ class SummaryTests(unittest.TestCase):
         server = self._server()
         server.capture.raw_bodies.append(b"{}")
         server.capture.routes.append(None)
-        lines = claude_stub.summary_lines(server, "http://127.0.0.1:4242")
+        lines = claude_stub.summary_lines(server, self._env(server))
         self.assertFalse([line for line in lines if line.startswith("  route ")])
 
 
@@ -303,20 +340,45 @@ class LiveSmokeTests(unittest.TestCase):
     """One end-to-end run of the real CLI against the stub. Costs no tokens."""
 
     def test_a_headless_run_answers_from_the_stub_and_reports_one_request(self):
-        cwd = Path(tempfile.mkdtemp(prefix="claudestub-smoke-"))
-        self.addCleanup(shutil.rmtree, cwd, ignore_errors=True)
+        root = Path(tempfile.mkdtemp(prefix="claudestub-smoke-"))
+        self.addCleanup(shutil.rmtree, root, ignore_errors=True)
+        cwd = root / "project"
+        cwd.mkdir()
+        # An explicit sandbox under the temp dir this test already reclaims:
+        # on a timeout the wrapper is killed outright and its own `finally`
+        # never runs, so the cleanup above has to be what removes the sandbox.
+        sandbox = root / "sandbox"
         with open("/dev/null", "rb") as devnull:
-            result = subprocess.run(
-                [sys.executable, str(SCRIPT), "--text", "smoke", "--", "-p", "hi"],
+            # A new process group, so a timeout kills claude too rather than
+            # orphaning it when only the wrapper is signalled.
+            child = subprocess.Popen(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--text",
+                    "smoke",
+                    "--sandbox",
+                    str(sandbox),
+                    "--",
+                    "-p",
+                    "hi",
+                ],
                 cwd=cwd,
                 stdin=devnull,
-                capture_output=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
                 text=True,
-                timeout=180,
+                start_new_session=True,
             )
-        self.assertEqual(0, result.returncode, result.stderr)
-        self.assertIn("smoke", result.stdout)
-        self.assertIn("1 request(s) served", result.stderr)
+            try:
+                stdout, stderr = child.communicate(timeout=180)
+            except subprocess.TimeoutExpired:
+                os.killpg(os.getpgid(child.pid), signal.SIGKILL)
+                stdout, stderr = child.communicate()
+                self.fail(f"the wrapper did not finish in 180s\n{stderr}")
+        self.assertEqual(0, child.returncode, stderr)
+        self.assertIn("smoke", stdout)
+        self.assertIn("1 request(s) served", stderr)
 
 
 if __name__ == "__main__":

--- a/scripts/test-claude-stub.py
+++ b/scripts/test-claude-stub.py
@@ -467,6 +467,32 @@ class SignalHandlerStateTests(SignalTargetsFixture):
         claude_stub.forward(child, signal.SIGTERM)
         self.assertEqual([int(signal.SIGTERM)], child.sent)
 
+    def test_the_serving_cleanup_order_leaves_no_gap_for_a_late_signal(self):
+        # `serve_until_signalled`'s `finally` latches `finishing` before
+        # clearing `serving_event`, the same order `run_claude`'s `finally`
+        # latches `finishing` before dropping `child`: a signal landing
+        # between the two statements finds `finishing` already set and is
+        # recorded and swallowed rather than raising `Terminated`.
+        self.targets.serving_event = claude_stub.threading.Event()
+
+        self.targets.finishing = True
+        self.assertIsNone(claude_stub.handle_stop_signal(signal.SIGTERM, None))
+        self.targets.serving_event = None
+
+        self.assertEqual(int(signal.SIGTERM), self.targets.late_signum)
+
+    def test_the_old_gap_between_finishing_and_serving_event_would_terminate(self):
+        # The discriminator for the test above: with `finishing` still False
+        # and `serving_event` already cleared — the reversed order the bug
+        # produced — the handler has nothing to hand the signal to and raises
+        # `Terminated` instead of swallowing it.
+        self.targets.serving_event = None
+        self.targets.finishing = False
+
+        with self.assertRaises(claude_stub.Terminated) as raised:
+            claude_stub.handle_stop_signal(signal.SIGTERM, None)
+        self.assertEqual(int(signal.SIGTERM), raised.exception.signum)
+
 
 class LateSignalExitStatusTests(SignalTargetsFixture):
     def test_a_signal_after_the_child_exits_keeps_the_status_and_cleans_up(self):

--- a/scripts/test-claude-stub.py
+++ b/scripts/test-claude-stub.py
@@ -397,6 +397,38 @@ class SignalHandlerStateTests(SignalTargetsFixture):
         self.assertIsNone(claude_stub.handle_stop_signal(signal.SIGTERM, None))
         self.assertEqual([int(signal.SIGTERM)], child.sent)
 
+    def _handle_with_predicate(self, signum: int, already_delivered: bool) -> list[int]:
+        """Signal a live child with the foreground-group answer forced."""
+        child = FakeChild()
+        self.targets.child = child
+        with mock.patch.object(
+            claude_stub, "sigint_reached_child_already", return_value=already_delivered
+        ):
+            self.assertIsNone(claude_stub.handle_stop_signal(signum, None))
+        return child.sent
+
+    def test_a_terminal_ctrl_c_is_not_forwarded_to_the_child_a_second_time(self):
+        # The tty already delivered it to the whole foreground process group,
+        # which the child shares; the TUI exits on a double Ctrl-C, so a second
+        # one would answer the user's first press with the exit confirmation.
+        self.assertEqual([], self._handle_with_predicate(signal.SIGINT, True))
+
+    def test_a_kill_int_the_child_cannot_have_seen_is_forwarded(self):
+        # `kill -INT` aimed at the wrapper alone never reached the child.
+        self.assertEqual(
+            [int(signal.SIGINT)], self._handle_with_predicate(signal.SIGINT, False)
+        )
+
+    def test_a_sigterm_is_forwarded_whatever_the_terminal_did(self):
+        # Only SIGINT can reach the child by the tty, so the check must not
+        # start swallowing signals that arrive by no route but this one.
+        for shared in (True, False):
+            with self.subTest(shared=shared):
+                self.assertEqual(
+                    [int(signal.SIGTERM)],
+                    self._handle_with_predicate(signal.SIGTERM, shared),
+                )
+
     def test_forwarding_tolerates_a_child_that_exited_first(self):
         # The race every forwarding site runs: the pid is gone by the time the
         # signal is sent, which is the outcome that was wanted, not a crash.
@@ -470,43 +502,54 @@ class TerminalSigintTests(unittest.TestCase):
             self.assertTrue(claude_stub.sigint_reached_child_already(0))
 
 
-class RunClaudeInterruptTests(SignalTargetsFixture):
-    """Both branches of the Ctrl-C decision, with a stand-in for Popen."""
+class QueuedSpawnSignalTests(SignalTargetsFixture):
+    """A signal queued across the spawn, delivered once the child has a name.
 
-    def _run_with_interrupt(self, already_delivered: bool) -> list[int]:
-        sent: list[int] = []
+    The handler cannot forward to a child that does not exist yet, so a stop
+    signal landing inside `Popen` is parked in `pending_signum` and handed over
+    by `run_claude`. That hand-off runs the same foreground-group check the
+    handler does, or a terminal Ctrl-C queued across the spawn would reach the
+    child a second time.
+    """
 
-        class InterruptingChild(FakeChild):
-            def __init__(self) -> None:
-                super().__init__()
-                self.waits = 0
-
-            def send_signal(self, signum):
-                sent.append(signum)
-
+    def _run_with_queued(self, signum: int, already_delivered: bool) -> list[int]:
+        class WaitableChild(FakeChild):
             def wait(self):
-                self.waits += 1
-                if self.waits == 1:
-                    raise KeyboardInterrupt
                 return 0
 
+        child = WaitableChild()
+
+        def popen(*args, **kwargs):
+            # What the handler does when it fires between the fork and the
+            # `child = ...` assignment: nothing to forward to, so it queues.
+            claude_stub.SIGNAL_TARGETS.pending_signum = signum
+            return child
+
         with mock.patch.object(
-            claude_stub.subprocess, "Popen", lambda *a, **k: InterruptingChild()
+            claude_stub.subprocess, "Popen", popen
         ), mock.patch.object(
             claude_stub,
             "sigint_reached_child_already",
             return_value=already_delivered,
         ):
             self.assertEqual(0, claude_stub.run_claude("claude", [], {}))
-        return sent
+        return child.sent
 
-    def test_a_terminal_ctrl_c_is_not_delivered_to_the_child_a_second_time(self):
-        # The TUI exits on a double Ctrl-C, so forwarding the one the tty
-        # already delivered would turn one press into the exit confirmation.
-        self.assertEqual([], self._run_with_interrupt(True))
+    def test_a_queued_terminal_ctrl_c_is_not_delivered_to_the_child_again(self):
+        self.assertEqual([], self._run_with_queued(signal.SIGINT, True))
 
-    def test_an_interrupt_the_child_cannot_have_seen_is_forwarded(self):
-        self.assertEqual([int(signal.SIGINT)], self._run_with_interrupt(False))
+    def test_a_queued_interrupt_the_child_cannot_have_seen_is_delivered(self):
+        self.assertEqual(
+            [int(signal.SIGINT)], self._run_with_queued(signal.SIGINT, False)
+        )
+
+    def test_a_queued_sigterm_is_delivered_whatever_the_terminal_did(self):
+        for shared in (True, False):
+            with self.subTest(shared=shared):
+                self.assertEqual(
+                    [int(signal.SIGTERM)],
+                    self._run_with_queued(signal.SIGTERM, shared),
+                )
 
 
 class EarlyInterruptTests(SignalTargetsFixture):
@@ -765,10 +808,76 @@ class WrapperProcessTests(unittest.TestCase):
     def test_a_sighup_before_claude_starts_is_handled_like_a_sigterm(self):
         self._stop_signal_leaves_nothing_behind(signal.SIGHUP, at_sandbox=True)
 
-    def test_print_env_stops_on_sighup_and_still_reports_the_summary(self):
-        # `serve_until_signalled` used to take SIGINT and SIGTERM only, so a
-        # SIGHUP — the signal a closing terminal sends — killed the server
-        # outright: no summary, and the temp sandbox left on disk.
+    def test_a_sigint_before_claude_starts_is_handled_like_a_sigterm(self):
+        # SIGINT is a stop signal like the other two rather than being left to
+        # Python's default KeyboardInterrupt, so it has to hold the same two
+        # windows: the instant the sandbox appears, and before any resource
+        # exists at all.
+        #
+        # `send_signal` here is `os.kill(wrapper.pid, SIGINT)`, not a Ctrl-C
+        # typed at a terminal: `_spawn_wrapper` launches the wrapper with
+        # `start_new_session=True`, so it has no controlling tty,
+        # `sigint_reached_child_already` answers False, and the signal is
+        # forwarded like any other. The foreground-group case — where the tty
+        # delivered the Ctrl-C to the child too and the wrapper must not
+        # forward a second — is covered by the unit tests instead.
+        for attempt in range(5):
+            with self.subTest(attempt=attempt):
+                self._stop_signal_leaves_nothing_behind(signal.SIGINT, at_sandbox=True)
+        self._stop_signal_leaves_nothing_behind(signal.SIGINT, at_sandbox=False)
+
+    def test_a_sigint_while_claude_runs_reaches_it_and_still_cleans_up(self):
+        # The window `wait()` occupies for the whole of a real session. Left to
+        # KeyboardInterrupt the exception unwinds out of `run_claude` with the
+        # child neither signalled nor waited for, and `main` removes the
+        # sandbox under a `claude` that is still running.
+        root = self._root()
+        tmpdir = root / "tmp"
+        tmpdir.mkdir()
+        child_report = root / "child.txt"
+        binary = self._fake_claude(
+            root / "fake-claude.sh",
+            f'printf \'%s\\n\' "$$" > {shlex.quote(str(child_report))}\n'
+            # `exec` keeps the pid just written, and the sleep outlasts the
+            # deadline so "the child is gone" cannot pass by expiry.
+            "exec sleep 600\n",
+        )
+        wrapper = self._spawn_wrapper(
+            root, binary, env={**os.environ, "TMPDIR": str(tmpdir)}
+        )
+
+        def reported():
+            if wrapper.poll() is not None:
+                self.fail("the wrapper exited before the stub claude reported in")
+            text = child_report.read_text(encoding="utf-8").strip() if child_report.exists() else ""
+            return int(text) if text else None
+
+        child_pid = self._wait_for(reported, "the stub claude to report its pid")
+
+        wrapper.send_signal(signal.SIGINT)
+        try:
+            _, stderr = wrapper.communicate(timeout=self.DEADLINE)
+        except subprocess.TimeoutExpired:
+            self.fail(f"the wrapper did not finish {self.DEADLINE}s after SIGINT")
+
+        self._wait_for(
+            lambda: self._pid_gone(child_pid),
+            f"the stub claude (pid {child_pid}) to exit",
+        )
+        self.assertEqual(
+            [], list(tmpdir.glob("claude-stub-*")), f"a sandbox leaked\n{stderr}"
+        )
+        self.assertEqual(130, self._exit_status(wrapper.returncode), stderr)
+        self.assertIn("request(s) served", stderr)
+
+    def _print_env_stops_on(self, sig: int) -> None:
+        """Signal a `--print-env` server and assert it stopped cleanly.
+
+        Every stop signal takes the same route here: the handler sets the
+        serving event, `serve_until_signalled` returns normally, and the caller
+        gets the closing summary and an exit status of 0 rather than a signal
+        death with the temp sandbox left on disk.
+        """
         root = self._root()
         tmpdir = root / "tmp"
         tmpdir.mkdir()
@@ -791,16 +900,28 @@ class WrapperProcessTests(unittest.TestCase):
             "the export lines on stdout",
         )
 
-        wrapper.send_signal(signal.SIGHUP)
+        wrapper.send_signal(sig)
         try:
             wrapper.communicate(timeout=self.DEADLINE)
         except subprocess.TimeoutExpired:
-            self.fail(f"the wrapper kept serving {self.DEADLINE}s after SIGHUP")
+            self.fail(f"the wrapper kept serving {self.DEADLINE}s after signal {sig}")
 
         stderr_text = err.read_text(encoding="utf-8")
         self.assertEqual(0, wrapper.returncode, stderr_text)
         self.assertIn("request(s) served", stderr_text)
         self.assertEqual([], list(tmpdir.glob("claude-stub-*")), "a sandbox leaked")
+
+    def test_print_env_stops_on_sighup_and_still_reports_the_summary(self):
+        # `serve_until_signalled` used to take SIGINT and SIGTERM only, so a
+        # SIGHUP — the signal a closing terminal sends — killed the server
+        # outright: no summary, and the temp sandbox left on disk.
+        self._print_env_stops_on(signal.SIGHUP)
+
+    def test_print_env_stops_on_sigint_and_still_reports_the_summary(self):
+        # Ctrl-C is the documented way to stop a `--print-env` server, and it
+        # now arrives at the handler rather than as a KeyboardInterrupt out of
+        # `Event.wait()`. The summary has to survive the change of route.
+        self._print_env_stops_on(signal.SIGINT)
 
 
 class SandboxCleanupTests(unittest.TestCase):

--- a/scripts/test-claude-stub.py
+++ b/scripts/test-claude-stub.py
@@ -1,9 +1,11 @@
 """Tests for scripts/claude-stub.py (stdlib only).
 
-Only the pure parts: turn scripting, the env overlay, the `--print-env`
-exports, and the closing summary. Nothing here spawns `claude` — the live
-sessions against the fake model API are covered by the e2e suite under
-`.github/workflows/claude-review-v2/tests/e2e/`.
+Mostly the pure parts: turn scripting, the env overlay, the `--print-env`
+exports, the sandbox config, and the closing summary. One smoke test spawns the
+real `claude` against the stub end to end, and skips when no `claude` is on
+PATH. The e2e suite under `.github/workflows/claude-review-v2/tests/e2e/`
+exercises the same fake server, but it drives the review gate's own scenarios
+and never runs this wrapper, so nothing there covers the code here.
 """
 
 from __future__ import annotations
@@ -12,6 +14,9 @@ import importlib.machinery
 import importlib.util
 import json
 from pathlib import Path
+import shutil
+import subprocess
+import sys
 import tempfile
 import unittest
 
@@ -111,16 +116,37 @@ class TurnScriptTests(unittest.TestCase):
         self.assertEqual(200, len(turns[0].text.splitlines()))
 
 
+class RouteTests(unittest.TestCase):
+    def test_role_turns_keep_their_own_routes(self):
+        role_turns = {"ROLE-SECURITY": [claude_stub.Turn(text="security")]}
+        routes = claude_stub.build_routes(role_turns)
+        self.assertEqual(
+            ["security"], [turn.text for turn in routes["ROLE-SECURITY"]]
+        )
+        self.assertEqual(
+            [claude_stub.TITLE_TURN], routes[claude_stub.TITLE_SENTINEL]
+        )
+
+    def test_the_reserved_title_route_beats_a_turn_file_that_claims_it(self):
+        routes = claude_stub.build_routes(
+            {claude_stub.TITLE_SENTINEL: [claude_stub.Turn(text="hijacked")]}
+        )
+        self.assertEqual(
+            [claude_stub.TITLE_TURN], routes[claude_stub.TITLE_SENTINEL]
+        )
+
+
 class EnvOverlayTests(unittest.TestCase):
     def setUp(self):
         self.sandbox = Path(tempfile.mkdtemp(prefix="claudestub-test-"))
+        self.addCleanup(shutil.rmtree, self.sandbox, ignore_errors=True)
 
     def test_the_harness_isolation_is_the_base(self):
         env = claude_stub.build_env(self.sandbox, "http://127.0.0.1:1", {}, {})
         self.assertEqual(str(self.sandbox), env["HOME"])
         self.assertEqual(str(self.sandbox / "config"), env["CLAUDE_CONFIG_DIR"])
         self.assertEqual("http://127.0.0.1:1", env["ANTHROPIC_BASE_URL"])
-        self.assertEqual("stub-key", env["ANTHROPIC_API_KEY"])
+        self.assertEqual(claude_stub.STUB_API_KEY, env["ANTHROPIC_API_KEY"])
 
     def test_a_real_terminal_beats_the_harness_dumb_terminal(self):
         bare = claude_stub.build_env(self.sandbox, "http://127.0.0.1:1", {}, {})
@@ -193,7 +219,7 @@ class SummaryTests(unittest.TestCase):
         lines = claude_stub.summary_lines(server, "http://127.0.0.1:4242")
         self.assertIn("2 request(s) served at http://127.0.0.1:4242", lines)
         self.assertIn(
-            "no request left this machine — ANTHROPIC_BASE_URL was "
+            "no model request left this machine — ANTHROPIC_BASE_URL was "
             "http://127.0.0.1:4242 (loopback)",
             lines,
         )
@@ -227,8 +253,13 @@ class SummaryTests(unittest.TestCase):
 
 
 class ConfigTests(unittest.TestCase):
-    def test_the_config_pre_accepts_trust_and_the_custom_api_key_dialog(self):
+    def _sandbox(self) -> Path:
         sandbox = Path(tempfile.mkdtemp(prefix="claudestub-test-"))
+        self.addCleanup(shutil.rmtree, sandbox, ignore_errors=True)
+        return sandbox
+
+    def test_the_config_pre_accepts_trust_and_the_custom_api_key_dialog(self):
+        sandbox = self._sandbox()
         project = sandbox / "project"
         project.mkdir()
         claude_stub.write_config(sandbox, project)
@@ -237,11 +268,17 @@ class ConfigTests(unittest.TestCase):
         )
         self.assertTrue(config["hasTrustDialogAccepted"])
         self.assertTrue(config["projects"][str(project)]["hasTrustDialogAccepted"])
-        # The interactive TUI otherwise stops on "use this API key?".
-        self.assertEqual(["stub-key"], config["customApiKeyResponses"]["approved"])
+        # The interactive TUI otherwise stops on "use this API key?". The
+        # approved fingerprint must be of the key claude actually gets, so it
+        # is checked against the env rather than against a restated literal.
+        env = claude_stub.build_env(sandbox, "http://127.0.0.1:1", {}, {})
+        self.assertEqual(
+            [env["ANTHROPIC_API_KEY"][-20:]],
+            config["customApiKeyResponses"]["approved"],
+        )
 
     def test_a_reused_sandbox_keeps_its_transcripts_and_gains_the_new_project(self):
-        sandbox = Path(tempfile.mkdtemp(prefix="claudestub-test-"))
+        sandbox = self._sandbox()
         first, second = sandbox / "one", sandbox / "two"
         first.mkdir()
         second.mkdir()
@@ -259,6 +296,27 @@ class ConfigTests(unittest.TestCase):
         self.assertTrue(config["hasTrustDialogAccepted"])
         for project in (first, second):
             self.assertTrue(config["projects"][str(project)]["hasTrustDialogAccepted"])
+
+
+@unittest.skipUnless(shutil.which("claude"), "no claude binary on PATH")
+class LiveSmokeTests(unittest.TestCase):
+    """One end-to-end run of the real CLI against the stub. Costs no tokens."""
+
+    def test_a_headless_run_answers_from_the_stub_and_reports_one_request(self):
+        cwd = Path(tempfile.mkdtemp(prefix="claudestub-smoke-"))
+        self.addCleanup(shutil.rmtree, cwd, ignore_errors=True)
+        with open("/dev/null", "rb") as devnull:
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT), "--text", "smoke", "--", "-p", "hi"],
+                cwd=cwd,
+                stdin=devnull,
+                capture_output=True,
+                text=True,
+                timeout=180,
+            )
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn("smoke", result.stdout)
+        self.assertIn("1 request(s) served", result.stderr)
 
 
 if __name__ == "__main__":

--- a/scripts/test-claude-stub.py
+++ b/scripts/test-claude-stub.py
@@ -3,7 +3,10 @@
 Mostly the pure parts: turn scripting, the env overlay, the `--print-env`
 exports, the sandbox config, and the closing summary. A second group runs the
 wrapper as a process against a shell script standing in for `claude`, which is
-the only way to observe signal handling and sandbox cleanup. One smoke test
+the only way to observe a real stop signal racing a real spawn. In-process
+tests cover the same handler logic where a stand-in can make the timing
+deterministic — driving `handle_stop_signal` directly, or handing `run_claude`
+a fake `Popen` — and say so where the distinction matters. One smoke test
 spawns the real `claude` against the stub end to end, and skips when no
 `claude` is on PATH. The e2e suite under `.github/workflows/claude-review-v2/tests/e2e/`
 exercises the same fake server, but it drives the review gate's own scenarios
@@ -48,6 +51,25 @@ claude_stub = _load_script_module()
 
 def parse(*argv: str):
     return claude_stub.parse_args(list(argv))
+
+
+def recording_mkdtemp(created: list[str], tmp_root: Path):
+    """A `tempfile.mkdtemp` replacement that records the sandbox it makes.
+
+    Patched over `claude_stub.tempfile.mkdtemp`, it pins the wrapper's auto
+    sandbox under `tmp_root` — which the test already reclaims, so a wrapper
+    that fails to remove its own leaves nothing behind — and appends the path,
+    which is how the test names a directory the wrapper never printed.
+    """
+    real_mkdtemp = tempfile.mkdtemp
+
+    def mkdtemp(*args, **kwargs):
+        kwargs["dir"] = str(tmp_root)
+        path = real_mkdtemp(*args, **kwargs)
+        created.append(path)
+        return path
+
+    return mkdtemp
 
 
 class TurnScriptTests(unittest.TestCase):
@@ -411,10 +433,14 @@ class SignalHandlerStateTests(SignalTargetsFixture):
         # The tty already delivered it to the whole foreground process group,
         # which the child shares; the TUI exits on a double Ctrl-C, so a second
         # one would answer the user's first press with the exit confirmation.
+        # The rule is by position, so a `kill -INT` at a foreground wrapper is
+        # dropped with the keypress — SIGTERM is the way to stop it from
+        # outside.
         self.assertEqual([], self._handle_with_predicate(signal.SIGINT, True))
 
-    def test_a_kill_int_the_child_cannot_have_seen_is_forwarded(self):
-        # `kill -INT` aimed at the wrapper alone never reached the child.
+    def test_a_sigint_from_outside_the_foreground_group_is_forwarded(self):
+        # No controlling terminal, or the wrapper in the background: nothing
+        # but this wrapper can have handed the child that signal.
         self.assertEqual(
             [int(signal.SIGINT)], self._handle_with_predicate(signal.SIGINT, False)
         )
@@ -452,20 +478,15 @@ class LateSignalExitStatusTests(SignalTargetsFixture):
         root = Path(tempfile.mkdtemp(prefix="claudestub-test-"))
         self.addCleanup(shutil.rmtree, root, ignore_errors=True)
         created: list[str] = []
-        real_mkdtemp = tempfile.mkdtemp
-
-        def recording_mkdtemp(*args, **kwargs):
-            kwargs["dir"] = str(root)
-            path = real_mkdtemp(*args, **kwargs)
-            created.append(path)
-            return path
 
         def finishing_then_signalled(binary, claude_args, env):
             claude_stub.SIGNAL_TARGETS.finishing = True
             os.kill(os.getpid(), signal.SIGTERM)
             return 7
 
-        with mock.patch.object(claude_stub.tempfile, "mkdtemp", recording_mkdtemp):
+        with mock.patch.object(
+            claude_stub.tempfile, "mkdtemp", recording_mkdtemp(created, root)
+        ):
             with mock.patch.object(
                 claude_stub, "run_claude", finishing_then_signalled
             ):
@@ -478,18 +499,24 @@ class LateSignalExitStatusTests(SignalTargetsFixture):
 
 
 class TerminalSigintTests(unittest.TestCase):
-    """When a Ctrl-C has already reached the child through the shared tty."""
+    """The position test that decides whether a SIGINT is forwarded.
+
+    True means the wrapper is the terminal's foreground process group, so the
+    tty delivered the SIGINT to the child as well and the wrapper must not send
+    a second. It is a test of position and not of provenance — a Python handler
+    gets no siginfo, so nothing here can tell a keypress from a `kill -INT`.
+    """
 
     def test_a_tty_the_wrapper_is_not_the_foreground_group_of_is_not_shared(self):
         # A fresh pty is nobody's controlling terminal, so this process cannot
-        # be its foreground group: the SIGINT did not come from there.
+        # be its foreground group: no tty delivered this SIGINT to the child.
         master, slave = pty.openpty()
         self.addCleanup(os.close, master)
         self.addCleanup(os.close, slave)
         self.assertTrue(os.isatty(slave))
         self.assertFalse(claude_stub.sigint_reached_child_already(slave))
 
-    def test_a_non_tty_stdin_means_the_signal_came_from_a_kill(self):
+    def test_a_non_tty_stdin_means_no_terminal_delivered_it(self):
         read_fd, write_fd = os.pipe()
         self.addCleanup(os.close, read_fd)
         self.addCleanup(os.close, write_fd)
@@ -510,6 +537,13 @@ class QueuedSpawnSignalTests(SignalTargetsFixture):
     by `run_claude`. That hand-off runs the same foreground-group check the
     handler does, or a terminal Ctrl-C queued across the spawn would reach the
     child a second time.
+
+    What these exercise is the hand-off, not the race that fills the queue: a
+    stand-in `Popen` parks `pending_signum` the way the handler would, because
+    landing a real signal between a real fork and its `child = ...` assignment
+    is a window microseconds wide and cannot be hit on demand. The real-signal
+    races are covered by the subprocess tests below, which signal a live
+    wrapper before `claude` is spawned.
     """
 
     def _run_with_queued(self, signum: int, already_delivered: bool) -> list[int]:
@@ -554,21 +588,22 @@ class QueuedSpawnSignalTests(SignalTargetsFixture):
 
 class EarlyInterruptTests(SignalTargetsFixture):
     def test_a_ctrl_c_before_claude_runs_exits_130_and_removes_the_sandbox(self):
+        # `main`'s KeyboardInterrupt belt, raised by a stand-in `run_claude`
+        # rather than by a real SIGINT: this is the disposition that can still
+        # fire either side of the handler's reign, and raising it directly is
+        # the only way to land it there on demand. That a real SIGINT before
+        # `claude` starts also exits 130 and strands nothing is the subprocess
+        # test `test_a_sigint_before_claude_starts_is_handled_like_a_sigterm`.
         root = Path(tempfile.mkdtemp(prefix="claudestub-test-"))
         self.addCleanup(shutil.rmtree, root, ignore_errors=True)
         created: list[str] = []
-        real_mkdtemp = tempfile.mkdtemp
-
-        def recording_mkdtemp(*args, **kwargs):
-            kwargs["dir"] = str(root)
-            path = real_mkdtemp(*args, **kwargs)
-            created.append(path)
-            return path
 
         def interrupted(binary, claude_args, env):
             raise KeyboardInterrupt
 
-        with mock.patch.object(claude_stub.tempfile, "mkdtemp", recording_mkdtemp):
+        with mock.patch.object(
+            claude_stub.tempfile, "mkdtemp", recording_mkdtemp(created, root)
+        ):
             with mock.patch.object(claude_stub, "run_claude", interrupted):
                 status = claude_stub.main(["--text", "x", "--", "-p", "hi"])
 
@@ -895,10 +930,18 @@ class WrapperProcessTests(unittest.TestCase):
                 start_new_session=True,
             )
         self.addCleanup(self._kill_group, wrapper)
+        # Gated on the stderr `serving` line, not on the exports: the exports
+        # are printed and flushed *before* `serve_until_signalled` publishes
+        # the serving event, so a signal sent on the strength of stdout can
+        # land in that gap, find no target, and unwind as `Terminated` with
+        # status 130 instead of stopping the server. The `serving` line is
+        # written after the event is published, so it is a true readiness
+        # signal; `report` flushes, so it reaches this file as it is written.
         self._wait_for(
-            lambda: "ANTHROPIC_BASE_URL" in out.read_text(encoding="utf-8"),
-            "the export lines on stdout",
+            lambda: "serving; Ctrl-C" in err.read_text(encoding="utf-8"),
+            "the serving line on stderr",
         )
+        self.assertIn("ANTHROPIC_BASE_URL", out.read_text(encoding="utf-8"))
 
         wrapper.send_signal(sig)
         try:
@@ -924,30 +967,56 @@ class WrapperProcessTests(unittest.TestCase):
         self._print_env_stops_on(signal.SIGINT)
 
 
-class SandboxCleanupTests(unittest.TestCase):
-    def test_a_failure_after_the_temp_sandbox_exists_still_removes_it(self):
-        # The auto-created sandbox is only reclaimable by the wrapper's own
-        # `finally`, so setup that can fail has to sit inside it.
-        root = Path(tempfile.mkdtemp(prefix="claudestub-test-"))
-        self.addCleanup(shutil.rmtree, root, ignore_errors=True)
+class SandboxCleanupTests(SignalTargetsFixture):
+    """Setup that fails after the sandbox exists, and what the latch does then.
+
+    `SignalTargetsFixture` is not optional here: `main`'s cleanup latches
+    `finishing` on the module global, so without the swap these runs would
+    silence every later in-process test that expects a signal to be acted on.
+    """
+
+    def _failed_setup(self, root: Path) -> list[str]:
+        """Run `main` with `write_config` raising; return the sandboxes made."""
         created: list[str] = []
-        real_mkdtemp = tempfile.mkdtemp
-
-        def recording_mkdtemp(*args, **kwargs):
-            kwargs["dir"] = str(root)
-            path = real_mkdtemp(*args, **kwargs)
-            created.append(path)
-            return path
-
-        with mock.patch.object(claude_stub.tempfile, "mkdtemp", recording_mkdtemp):
+        with mock.patch.object(
+            claude_stub.tempfile, "mkdtemp", recording_mkdtemp(created, root)
+        ):
             with mock.patch.object(
                 claude_stub, "write_config", side_effect=RuntimeError("boom")
             ):
                 with self.assertRaises(RuntimeError):
                     claude_stub.main(["--text", "x", "--", "-p", "hi"])
+        return created
+
+    def test_a_failure_after_the_temp_sandbox_exists_still_removes_it(self):
+        # The auto-created sandbox is only reclaimable by the wrapper's own
+        # `finally`, so setup that can fail has to sit inside it.
+        root = Path(tempfile.mkdtemp(prefix="claudestub-test-"))
+        self.addCleanup(shutil.rmtree, root, ignore_errors=True)
+
+        created = self._failed_setup(root)
 
         self.assertEqual(1, len(created), "the wrapper did not create a temp sandbox")
         self.assertFalse(Path(created[0]).exists(), "the temp sandbox leaked")
+
+    def test_a_failure_during_setup_still_arms_the_finishing_latch(self):
+        # `write_config` failing means neither `run_claude` nor
+        # `serve_until_signalled` ran, so the latch those two arm themselves
+        # was never touched. Unarmed, a stop signal landing in the wrapper's
+        # `shutil.rmtree` would find no target at all and raise `Terminated`
+        # out of a half-walked sandbox — so `main`'s own cleanup has to arm it
+        # for every path into that block, this one included.
+        root = Path(tempfile.mkdtemp(prefix="claudestub-test-"))
+        self.addCleanup(shutil.rmtree, root, ignore_errors=True)
+
+        created = self._failed_setup(root)
+
+        self.assertEqual(1, len(created), "the wrapper did not create a temp sandbox")
+        self.assertFalse(Path(created[0]).exists(), "the temp sandbox leaked")
+        self.assertTrue(
+            self.targets.finishing,
+            "a run that failed before spawning claude left the latch unarmed",
+        )
 
 
 @unittest.skipUnless(shutil.which("claude"), "no claude binary on PATH")

--- a/scripts/test-claude-stub.py
+++ b/scripts/test-claude-stub.py
@@ -534,9 +534,13 @@ class QueuedSpawnSignalTests(SignalTargetsFixture):
 
     The handler cannot forward to a child that does not exist yet, so a stop
     signal landing inside `Popen` is parked in `pending_signum` and handed over
-    by `run_claude`. That hand-off runs the same foreground-group check the
-    handler does, or a terminal Ctrl-C queued across the spawn would reach the
-    child a second time.
+    by `run_claude`. That hand-off is unconditional — it skips the
+    foreground-group check `deliver` applies to a live child, because the check
+    answers whether the terminal delivered this signal to the child and for a
+    queued signal it cannot: a signal from before the fork never reached a
+    child that did not exist, and one from after it reaches a child too young
+    to have installed a handler, which the terminal's own copy has already
+    killed under the default disposition.
 
     What these exercise is the hand-off, not the race that fills the queue: a
     stand-in `Popen` parks `pending_signum` the way the handler would, because
@@ -546,7 +550,7 @@ class QueuedSpawnSignalTests(SignalTargetsFixture):
     wrapper before `claude` is spawned.
     """
 
-    def _run_with_queued(self, signum: int, already_delivered: bool) -> list[int]:
+    def _run_with_queued(self, signum: int, foreground: bool) -> list[int]:
         class WaitableChild(FakeChild):
             def wait(self):
                 return 0
@@ -564,15 +568,22 @@ class QueuedSpawnSignalTests(SignalTargetsFixture):
         ), mock.patch.object(
             claude_stub,
             "sigint_reached_child_already",
-            return_value=already_delivered,
+            return_value=foreground,
         ):
             self.assertEqual(0, claude_stub.run_claude("claude", [], {}))
         return child.sent
 
-    def test_a_queued_terminal_ctrl_c_is_not_delivered_to_the_child_again(self):
-        self.assertEqual([], self._run_with_queued(signal.SIGINT, True))
+    def test_a_queued_sigint_is_forwarded_even_from_the_foreground_group(self):
+        # The discriminating case. The check is patched True — the answer a
+        # real wrapper gets, since it runs after the child exists and shares
+        # the group — and the queued SIGINT must be forwarded anyway: it landed
+        # before the fork, so the terminal never delivered it to a child that
+        # did not yet exist, and dropping it loses the user's Ctrl-C entirely.
+        self.assertEqual(
+            [int(signal.SIGINT)], self._run_with_queued(signal.SIGINT, True)
+        )
 
-    def test_a_queued_interrupt_the_child_cannot_have_seen_is_delivered(self):
+    def test_a_queued_sigint_is_forwarded_from_outside_the_foreground_group(self):
         self.assertEqual(
             [int(signal.SIGINT)], self._run_with_queued(signal.SIGINT, False)
         )

--- a/scripts/test-claude-stub.py
+++ b/scripts/test-claude-stub.py
@@ -17,6 +17,7 @@ import importlib.util
 import json
 import os
 from pathlib import Path
+import pty
 import shlex
 import shutil
 import signal
@@ -440,6 +441,95 @@ class LateSignalExitStatusTests(SignalTargetsFixture):
 
         self.assertEqual(7, status)
         self.assertEqual(int(signal.SIGTERM), self.targets.late_signum)
+        self.assertEqual(1, len(created), "the wrapper did not create a temp sandbox")
+        self.assertFalse(Path(created[0]).exists(), "the temp sandbox leaked")
+
+
+class TerminalSigintTests(unittest.TestCase):
+    """When a Ctrl-C has already reached the child through the shared tty."""
+
+    def test_a_tty_the_wrapper_is_not_the_foreground_group_of_is_not_shared(self):
+        # A fresh pty is nobody's controlling terminal, so this process cannot
+        # be its foreground group: the SIGINT did not come from there.
+        master, slave = pty.openpty()
+        self.addCleanup(os.close, master)
+        self.addCleanup(os.close, slave)
+        self.assertTrue(os.isatty(slave))
+        self.assertFalse(claude_stub.sigint_reached_child_already(slave))
+
+    def test_a_non_tty_stdin_means_the_signal_came_from_a_kill(self):
+        read_fd, write_fd = os.pipe()
+        self.addCleanup(os.close, read_fd)
+        self.addCleanup(os.close, write_fd)
+        self.assertFalse(claude_stub.sigint_reached_child_already(read_fd))
+
+    def test_owning_the_terminals_foreground_group_means_the_child_got_it_too(self):
+        with mock.patch.object(claude_stub.os, "isatty", return_value=True), \
+             mock.patch.object(claude_stub.os, "tcgetpgrp", return_value=4242), \
+             mock.patch.object(claude_stub.os, "getpgrp", return_value=4242):
+            self.assertTrue(claude_stub.sigint_reached_child_already(0))
+
+
+class RunClaudeInterruptTests(SignalTargetsFixture):
+    """Both branches of the Ctrl-C decision, with a stand-in for Popen."""
+
+    def _run_with_interrupt(self, already_delivered: bool) -> list[int]:
+        sent: list[int] = []
+
+        class InterruptingChild(FakeChild):
+            def __init__(self) -> None:
+                super().__init__()
+                self.waits = 0
+
+            def send_signal(self, signum):
+                sent.append(signum)
+
+            def wait(self):
+                self.waits += 1
+                if self.waits == 1:
+                    raise KeyboardInterrupt
+                return 0
+
+        with mock.patch.object(
+            claude_stub.subprocess, "Popen", lambda *a, **k: InterruptingChild()
+        ), mock.patch.object(
+            claude_stub,
+            "sigint_reached_child_already",
+            return_value=already_delivered,
+        ):
+            self.assertEqual(0, claude_stub.run_claude("claude", [], {}))
+        return sent
+
+    def test_a_terminal_ctrl_c_is_not_delivered_to_the_child_a_second_time(self):
+        # The TUI exits on a double Ctrl-C, so forwarding the one the tty
+        # already delivered would turn one press into the exit confirmation.
+        self.assertEqual([], self._run_with_interrupt(True))
+
+    def test_an_interrupt_the_child_cannot_have_seen_is_forwarded(self):
+        self.assertEqual([int(signal.SIGINT)], self._run_with_interrupt(False))
+
+
+class EarlyInterruptTests(SignalTargetsFixture):
+    def test_a_ctrl_c_before_claude_runs_exits_130_and_removes_the_sandbox(self):
+        root = Path(tempfile.mkdtemp(prefix="claudestub-test-"))
+        self.addCleanup(shutil.rmtree, root, ignore_errors=True)
+        created: list[str] = []
+        real_mkdtemp = tempfile.mkdtemp
+
+        def recording_mkdtemp(*args, **kwargs):
+            kwargs["dir"] = str(root)
+            path = real_mkdtemp(*args, **kwargs)
+            created.append(path)
+            return path
+
+        def interrupted(binary, claude_args, env):
+            raise KeyboardInterrupt
+
+        with mock.patch.object(claude_stub.tempfile, "mkdtemp", recording_mkdtemp):
+            with mock.patch.object(claude_stub, "run_claude", interrupted):
+                status = claude_stub.main(["--text", "x", "--", "-p", "hi"])
+
+        self.assertEqual(130, status)
         self.assertEqual(1, len(created), "the wrapper did not create a temp sandbox")
         self.assertFalse(Path(created[0]).exists(), "the temp sandbox leaked")
 


### PR DESCRIPTION
## Summary

An agent working in this repo needed to run the real `claude` CLI without spending tokens. It was measuring what Claude Code emits on SIGWINCH, which needs a live TUI session with a long answer on screen, so it drove `~/.local/bin/claude` against the real API and spent real tokens across several turns. The repo already had a zero-token way to do exactly that: `.github/workflows/claude-review-v2/tests/e2e/stub_server.py`, a stdlib fake of `POST /v1/messages` with SSE streaming that the review-gate e2e tests point the real CLI at. The agent did not find it, and the miss was not careless. The stub lives under a path that reads as "CI for the PR review gate"; nothing in `CLAUDE.md`, `docs/`, or `scripts/` pointed at it; and in this repo the word "mock" already means the UI mock harness (`scripts/mock.sh`), whose doc says "no live `claude` process is spawned". Every obvious search ("mock", "stub", "fake api", "zero token", "without spending tokens") either found the wrong tool or nothing.

The problem is discoverability, not capability, and the stub is not the only case. `scripts/dev/dummy-remote-provider.sh` (a fake remote agent backend) is referenced by no doc at all, and the UI mock harness is documented in `docs/` but indexed nowhere an agent reads first. So the fix is one general entry point for the stub, a doc the obvious searches hit, and a short index of every stand-in for an external dependency the repo has.

## Why this shape

- **The stub stays where it is.** `claude-review-v2/` is live state matched verbatim on every open PR, so moving anything under it is a design change with a blast radius, and it would need a spec with a human answering the brainstorming questions. `scripts/claude-stub.py` imports `stub_server.py` and `harness.py` in place through `sys.path`. If the stub should later be extracted to a neutral home (say `scripts/claude-stub/` with the e2e tests importing from there), that is a one-line path change in the wrapper and a spec-first follow-up; nothing here commits to it either way.
- **A wrapper, not just a pointer.** The stub's own harness only knew how to drive headless `-p` sessions for the review gate. The interactive TUI, which is what the SIGWINCH measurement needed, has two extra behaviors the harness does not handle: it raises a "use this custom API key?" dialog, and it opens every session with a second, concurrent request asking the model to name the session. Left unrouted, that title request eats the first scripted turn nondeterministically. The wrapper pre-approves the placeholder key in the sandbox's `.claude.json` and gives the title request its own content-keyed route, so the default one-turn script always lands on the user's prompt. A pointer alone would have sent the next agent to a tool that stalls on a dialog.
- **The stub is general-purpose.** Its content-keyed `ROLE-<NAME>` routing is an optional mode for parallel subagents; the ordered-turns mode serves any session. It could have served the SIGWINCH measurement as-is, and the interactive proof below is exactly that scenario: a 200-line answer held on screen, a resize, the session still at its prompt.
- **No spec.** This is a developer-experience change that adds no daemon or app behavior, no flag, and no revision to the system's theory. Per the "Work starts with a brainstormed spec" rule, saying so here is the required step.
- **Reconciler doctrine.** The wrapper creates a temp sandbox directory and a child process, and releases both itself. SIGINT, SIGTERM and SIGHUP share one handler, installed at the top of `main` before the temp dir, the socket, or the child exist. With a live child the handler forwards the signal to it by pid (not a new process group, because the interactive TUI must stay in the terminal's foreground group to own the tty) and the wrapper waits for it; in `--print-env` mode it stops serving; before any resource exists it raises, so the `finally` that removes the sandbox runs. The signals are blocked across the `mkdtemp` call itself, and a signal that lands inside `Popen` is queued and delivered once the child has a pid, because blocking there would be inherited across `exec`. Every manual forward is guarded against a child that already exited. Once the child has been waited for, and again at the top of the outer cleanup regardless of how it was reached, the handler becomes a no-op, so a late signal can neither clobber the child's real exit status nor interrupt the directory removal. SIGINT has one deliberate difference: when the wrapper is in a terminal's foreground process group, a SIGINT is treated as a Ctrl-C the terminal already delivered to the child and is not forwarded, whatever sent it, since a second SIGINT would read as the TUI's exit confirmation and a Python handler cannot tell the two origins apart; a SIGINT that arrives with no controlling terminal is forwarded, and SIGTERM is the signal for stopping a wrapped session from outside. A SIGINT queued during the spawn is forwarded unconditionally: if it arrived before the fork the child never received it, and if it arrived after, the child is microseconds old with no handler installed, so the terminal's copy already terminates it and a second copy is harmless. The sandbox is kept only on `--keep` or an explicit `--sandbox`. Only SIGKILL or a hard crash can leave a `claude-stub-*` directory under `$TMPDIR`, the same class of leftover as any `tempfile.mkdtemp` in the existing script harnesses, so no sweep is added.

## What this PR does

- `scripts/claude-stub.py` (new, stdlib only): starts the stub on loopback, builds the sandbox (`HOME`, `CLAUDE_CONFIG_DIR`, `TMPDIR`, pre-accepted dialogs), and runs `claude` in the current directory with any arguments after `--` (none means the interactive TUI, `-p` means headless). Turn scripts come from `--turns FILE.json`, `--text`, or the default long numbered answer (`--lines`, default 200). `--print-env` prints shell-quoted exports and keeps serving so `claude` can be driven by hand from another pane. On exit it prints what the stub served, any unexpected paths, and the loopback base URL.
- `scripts/test-claude-stub.py` (new): unit tests for the pure parts plus one live smoke test that self-skips without a `claude` binary; wired into the script-harness step of `.github/workflows/test.yml`.
- `docs/fake-model-api.md` (new): the guide, with the exact invocations that were run and their real output. Its first paragraph carries the search terms a newcomer tries.
- `docs/test-doubles.md` (new): index of the four stand-ins for external dependencies: fake model API, UI mock harness, dummy remote provider, tmux executable fixture.
- One Quick Reference line in `CLAUDE.md`; cross-references in `docs/mock-harness.md` and the e2e README; the `tbd-project` file map lists the scripts and the stub.

## Assumptions

- Assumes the CLI fingerprints a custom API key by its last 20 characters under `customApiKeyResponses`, and that the interactive session-title request wraps the user message in `<session>…</session>` (both observed on claude 2.1.258). If a future CLI changes either, the TUI stops at the key dialog or the title request falls through to the ordered turns; the doc names the version and the failure shape.
- Assumes `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1` keeps non-model traffic off. Zero *model* tokens is structural (loopback base URL, placeholder key); non-model traffic is switched off by that flag, not observed absent.

## Evidence & verification

Every invocation the doc shows was run from a throwaway directory; the outputs in the doc are the real ones. Highlights:

- Headless: `scripts/claude-stub.py --text "hello from the stub" -- -p "say hello"` printed the scripted text and a summary of one request served at `http://127.0.0.1:<port>`, no unexpected paths.
- Interactive TUI in a fenced tmux server at 120x40: `scripts/claude-stub.py --lines 200` went straight to the composer, rendered all 200 numbered lines after a prompt, survived `resize-window -x 100 -y 30` (repainted at the new width, still at the prompt), and exited on `/exit` with a summary of two requests: one from the ordered turns, one on the session-title route.
- `--print-env`: exports evaluated in a second pane, `claude -p 'hi'` there answered from the stub, SIGINT to the server printed the summary with one request served.
- `python3 scripts/test-claude-stub.py`: 55 tests, run by the Lint job's script-harness step on every push. That includes a live smoke test (skipped on CI, where no `claude` binary exists) and a regression test that SIGTERMs only the wrapper and asserts the child is gone and the temp sandbox removed; both the SIGTERM test and the cleanup-scope test fail against the pre-fix wrapper.
- Existing review-gate e2e suite still green: `python3 -m pytest .github/workflows/claude-review-v2/tests/e2e -q` reported 21 passed.
- Two `code-review` passes over the branch. The first pass's findings (a doc example that read a file it never wrote, a duplicated key literal, an over-broad "no request left" claim, a hint ignoring `--claude-binary`, a clobberable reserved route, uncleaned test temp dirs) are fixed in the third commit. The second pass found that the summary asserted loopback from the stub's URL even when `--env` pointed `claude` elsewhere; the fourth commit reports the URL `claude` was actually given and warns instead of claiming loopback when it differs, and closes the pass's smaller notes (shared-cwd requirement for the two-pane recipe, `--env PATH` parity in `--print-env`, process-group cleanup in the live smoke test).
- The review gate's seventh verdict caught the `--print-env` cleanup clearing its serving event before arming the no-op latch, the mirror of the order the child path already gets right; the thirteenth commit swaps the two statements and adds a handler-state test for a second signal during that cleanup.
- The review gate's sixth verdict found that a SIGINT queued during the spawn was later dropped by the position check, which by then saw a child sharing the group; the twelfth commit forwards a queued SIGINT unconditionally, with the reasoning above, and the queued-delivery unit test now asserts that.
- The review gate's fifth verdict was right that the foreground-group check cannot tell `kill -INT` from a terminal Ctrl-C, so the earlier claim that a SIGINT from `kill` is always forwarded was false in the foreground case; the eleventh commit states the rule as it actually is, in the code and in the doc, and arms the no-op latch at the top of the outer cleanup so an exception during setup cannot leave the directory removal exposed to a second signal. On the tests: the real-signal races are the pre-child subprocess tests, which land wherever the wrapper happens to be, including inside a real spawn on some iterations; the spawn-window delivery logic is unit-tested with a stand-in `Popen`; there is no test that deterministically lands a real signal inside a real fork, and none is claimed.
- The review gate's fourth verdict noted that SIGINT was still on Python's default disposition and so missed the temp-dir and spawn windows; the tenth commit routes it through the same handler, with the subprocess window tests and the handler unit tests extended to SIGINT. The foreground-group predicate it reuses is the one the previous round verified live: a single Ctrl-C in a tmux pane cleared the composer and left the TUI running.
- The review gate's third verdict found two residual windows in the signal path: unguarded manual forwards to a child that may already have exited, and a late signal after the child finished that could clobber the exit status or interrupt cleanup. CodeRabbit added that a terminal Ctrl-C reached the child twice and that an early Ctrl-C exited with a traceback. The eighth and ninth commits close all four, with unit tests on the handler state machine and the foreground-group predicate, and an interactive check that a single Ctrl-C leaves the TUI running.
- The review gate's second verdict pointed out that installing the handlers after `Popen` left a pre-handler window in which SIGTERM still skipped cleanup; the seventh commit installs them before any resource exists and adds SIGHUP handling to `--print-env`, with tests that SIGTERM or SIGHUP the wrapper the instant its sandbox appears and once before any resource exists, plus a SIGHUP test for the serving mode; all of them fail against the previous wrapper.
- The review gate's first verdict asked for SIGTERM handling in the run mode and for sandbox setup to sit inside the cleanup scope; both are in the fifth commit with the discriminating tests above. CodeRabbit's fence-language, heading and "without a real API key" notes are in the sixth. Its workflow-permissions note is a pre-existing gap in `test.yml` unrelated to this diff and is left for its own PR; its route-precedence suggestion is answered on the thread (the server matches over sorted keys, so registration order has no effect).

No Swift was touched, so no `scripts/test.sh` run. The Test workflow, including its Swift job, is green on the branch head. Earlier pushes hit three different timing-sensitive Swift failures (`PaneFanoutFlowControlTests`, the tier-3 quiet pass timing out at 15 minutes, `ActuationLogTeardownWiringTests`), one of which also failed main's Test run at the time; this diff changes no Swift.

https://claude.ai/code/session_01RWbDRrWu2mCMvuhGR3gt1t

[surface-mock-api](https://cheapsteak.github.io/tbd/open/?worktree=DCB3421C-8E3D-4792-A63E-51720F84D967)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a local, zero-token Claude session tool supporting scripted turns, interactive or headless use, sandboxing, environment configuration, and simulated model responses.
  * Added support for routing scripted sessions and testing tool calls through a local fake model API.

* **Documentation**
  * Added guides for the fake model API, mock harness, test doubles, and Claude stub usage.
  * Expanded quick references and file maps with setup instructions and usage examples.

* **Tests**
  * Added comprehensive automated coverage for session routing, configuration, signal handling, cleanup, and optional live execution.
  * Integrated the Claude stub checks into the test workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->