### PR TITLE
Fix: Stop test teardown wedging the serial live pass on a Foundation waitUntilExit hang (21 min at 0% CPU)

### DIFF
--- a/Tests/TBDDaemonLiveTests/ExternalAttachCommandLiveTests.swift
+++ b/Tests/TBDDaemonLiveTests/ExternalAttachCommandLiveTests.swift
@@ -999,7 +999,10 @@ private final class PTYProcess: @unchecked Sendable {
     /// the same few hundred milliseconds on the ordinary path and gives up
     /// rather than hanging on the pathological one. The escalation goes through
     /// `BoundedProcessTeardown.killAndReap`, so the SIGKILL precedes any reap
-    /// and carries that helper's `pid > 1` guard.
+    /// and carries that helper's `pid > 1` guard. An expired bound there is
+    /// recorded as `TeardownBoundExpired` rather than discarded, so a lost exit
+    /// reds the test that owned this client instead of passing silently — the
+    /// same shape as `AgentReaperHolderLegLiveTests.killAndReap`.
     func terminate() {
         terminationLock.lock()
         let alreadyTerminated = isTerminated
@@ -1010,7 +1013,11 @@ private final class PTYProcess: @unchecked Sendable {
         if process.isRunning {
             process.terminate()
             if !awaitExit(within: 2) {
-                _ = BoundedProcessTeardown.killAndReap(process, within: 2)
+                if case .unobserved(let pid, let diagnostic) =
+                    BoundedProcessTeardown.killAndReap(process, within: 2)
+                {
+                    Issue.record(TeardownBoundExpired(pid: pid, diagnostic: diagnostic))
+                }
             }
         }
         // Closing the primary ends the drain thread's blocking read.

--- a/Tests/TBDDaemonLiveTests/ExternalAttachCommandLiveTests.swift
+++ b/Tests/TBDDaemonLiveTests/ExternalAttachCommandLiveTests.swift
@@ -539,6 +539,8 @@ struct ExternalAttachCommandLiveTests {
         shell.standardOutput = FileHandle.nullDevice
         shell.standardError = FileHandle.nullDevice
         try shell.run()
+        // Launch and wait on one thread, which the per-thread task list that
+        // `BoundedProcessTeardown` documents leaves unaffected.
         shell.waitUntilExit()
 
         #expect(
@@ -881,6 +883,8 @@ private struct TmuxServer {
         do {
             try process.run()
             let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            // Launch and wait on one thread: not the cross-thread shape
+            // `BoundedProcessTeardown` exists for.
             process.waitUntilExit()
             let output = String(data: data, encoding: .utf8)?
                 .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
@@ -993,7 +997,9 @@ private final class PTYProcess: @unchecked Sendable {
     /// sitting in that call for thirteen minutes with no child process left
     /// alive, killed by hand. Polling `isRunning` against a deadline reaps in
     /// the same few hundred milliseconds on the ordinary path and gives up
-    /// rather than hanging on the pathological one.
+    /// rather than hanging on the pathological one. The escalation goes through
+    /// `BoundedProcessTeardown.killAndReap`, so the SIGKILL precedes any reap
+    /// and carries that helper's `pid > 1` guard.
     func terminate() {
         terminationLock.lock()
         let alreadyTerminated = isTerminated
@@ -1004,8 +1010,7 @@ private final class PTYProcess: @unchecked Sendable {
         if process.isRunning {
             process.terminate()
             if !awaitExit(within: 2) {
-                kill(process.processIdentifier, SIGKILL)
-                _ = awaitExit(within: 2)
+                _ = BoundedProcessTeardown.killAndReap(process, within: 2)
             }
         }
         // Closing the primary ends the drain thread's blocking read.

--- a/Tests/TBDDaemonLiveTests/ExternalAttachCommandLiveTests.swift
+++ b/Tests/TBDDaemonLiveTests/ExternalAttachCommandLiveTests.swift
@@ -1013,15 +1013,10 @@ private final class PTYProcess: @unchecked Sendable {
     }
 
     /// True once the child is no longer running, false when `limit` elapses
-    /// first. Bounded by construction — see `terminate()` for why the obvious
-    /// `waitUntilExit()` is not usable here.
+    /// first. Bounded by construction — `BoundedProcessTeardown` carries the
+    /// mechanism; see `terminate()` for the wedge measured here.
     private func awaitExit(within limit: TimeInterval) -> Bool {
-        let deadline = Date().addingTimeInterval(limit)
-        while Date() < deadline {
-            if !process.isRunning { return true }
-            usleep(20_000)
-        }
-        return !process.isRunning
+        BoundedProcessTeardown.awaitExit(process, within: limit) == .exited
     }
 
     /// Head-capped so a chatty tmux client cannot grow this without bound; the

--- a/Tests/TBDDaemonLiveTests/Process/AgentReaperHolderLegLiveTests.swift
+++ b/Tests/TBDDaemonLiveTests/Process/AgentReaperHolderLegLiveTests.swift
@@ -83,8 +83,10 @@ struct AgentReaperHolderLegLiveTests {
     /// to be handed to somebody else mid-test.
     private static func spentPID() throws -> Int32 {
         let p = try spawn("/usr/bin/true", [])
-        guard case .exited = BoundedProcessTeardown.awaitExit(p) else {
-            throw FixtureSpawnFailure(code: ETIMEDOUT)
+        // Thrown with the bound's own diagnostic rather than a bare code: this
+        // is a bounded-wait failure, and the text is the whole finding.
+        if case .unobserved(let pid, let diagnostic) = BoundedProcessTeardown.awaitExit(p) {
+            throw TeardownBoundExpired(pid: pid, diagnostic: diagnostic)
         }
         return p.processIdentifier
     }

--- a/Tests/TBDDaemonLiveTests/Process/AgentReaperHolderLegLiveTests.swift
+++ b/Tests/TBDDaemonLiveTests/Process/AgentReaperHolderLegLiveTests.swift
@@ -46,11 +46,16 @@ struct AgentReaperHolderLegLiveTests {
     /// A job that survives a hangup — the shape the acceptance harness measured
     /// outliving its teardown at `ppid=1` while its default-disposition sibling
     /// died. Spawned through `zsh` with no `-l`/`-i`, and `-f`, so it reads no
-    /// user rc file — `.zshenv` is otherwise read on every invocation, `-c`
-    /// included, which would pull the developer's shell configuration in from
-    /// outside the test fence.
+    /// user rc file (`/etc/zshenv` is read regardless of `-f`) — `.zshenv` is
+    /// otherwise read on every invocation, `-c` included, which would pull the
+    /// developer's shell configuration in from outside the test fence.
+    ///
+    /// The loop is **counted** for the reason `spawnSIGTERMProofJob` gives
+    /// below: a test host killed mid-run must not leave a `while :` running at
+    /// `ppid=1` that no reconciler can see.
     private static func spawnHangupProofShell() throws -> Process {
-        try spawn("/bin/zsh", ["-f", "-c", #"trap "" HUP; while :; do sleep 0.2; done"#])
+        try spawn(
+            "/bin/zsh", ["-f", "-c", #"trap "" HUP; for _ in {1..1500}; do sleep 0.2; done"#])
     }
 
     /// A live process that is emphatically not a holder's job: `cat` blocking

--- a/Tests/TBDDaemonLiveTests/Process/AgentReaperHolderLegLiveTests.swift
+++ b/Tests/TBDDaemonLiveTests/Process/AgentReaperHolderLegLiveTests.swift
@@ -45,10 +45,12 @@ struct AgentReaperHolderLegLiveTests {
 
     /// A job that survives a hangup — the shape the acceptance harness measured
     /// outliving its teardown at `ppid=1` while its default-disposition sibling
-    /// died. Spawned through `zsh -c` with no `-l`/`-i`, so it sources nothing
-    /// from the developer's shell configuration.
+    /// died. Spawned through `zsh` with no `-l`/`-i`, and `-f`, so it reads no
+    /// user rc file — `.zshenv` is otherwise read on every invocation, `-c`
+    /// included, which would pull the developer's shell configuration in from
+    /// outside the test fence.
     private static func spawnHangupProofShell() throws -> Process {
-        try spawn("/bin/zsh", ["-c", #"trap "" HUP; while :; do sleep 0.2; done"#])
+        try spawn("/bin/zsh", ["-f", "-c", #"trap "" HUP; while :; do sleep 0.2; done"#])
     }
 
     /// A live process that is emphatically not a holder's job: `cat` blocking

--- a/Tests/TBDDaemonLiveTests/Process/AgentReaperHolderLegLiveTests.swift
+++ b/Tests/TBDDaemonLiveTests/Process/AgentReaperHolderLegLiveTests.swift
@@ -334,7 +334,11 @@ struct AgentReaperHolderLegLiveTests {
         p.standardError = FileHandle.nullDevice
         guard (try? p.run()) != nil else { return [:] }
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
-        _ = BoundedProcessTeardown.awaitExit(p)
+        // stdout is already drained to EOF, so ending a straggler cannot lose
+        // output — and going through this file's own wrapper means an expired
+        // bound reds the test instead of leaving `lsof` running and returning a
+        // partial map with no signal at all.
+        Self.killAndReap(p)
         var result: [String: String] = [:]
         var fd: String?
         for line in String(decoding: data, as: UTF8.self).split(separator: "\n") {

--- a/Tests/TBDDaemonLiveTests/Process/AgentReaperHolderLegLiveTests.swift
+++ b/Tests/TBDDaemonLiveTests/Process/AgentReaperHolderLegLiveTests.swift
@@ -31,6 +31,18 @@ struct AgentReaperHolderLegLiveTests {
 
     // MARK: - Process helpers
 
+    // **Nothing in this file calls `Process.waitUntilExit()`, anywhere.** On
+    // macOS 26.1 that call can spin forever with `isRunning` already false, on
+    // any thread that did not launch the task — which is every `defer` that runs
+    // after an `await`, because an async test resumes on whichever
+    // cooperative-pool thread is free. `BoundedProcessTeardown` polls
+    // `isRunning` against a deadline instead and carries the measured defect,
+    // the reap proof, and the reason there is no injected clock; the
+    // deterministic reproduction is
+    // `scripts/diag/nstask-waituntilexit-stale-entry.swift`. The rule is written
+    // as "nowhere in this file" rather than "only where the wait is
+    // cross-thread" because the second is not checkable by reading a call site.
+
     /// A job that survives a hangup — the shape the acceptance harness measured
     /// outliving its teardown at `ppid=1` while its default-disposition sibling
     /// died. Spawned through `zsh -c` with no `-l`/`-i`, so it sources nothing
@@ -71,7 +83,9 @@ struct AgentReaperHolderLegLiveTests {
     /// to be handed to somebody else mid-test.
     private static func spentPID() throws -> Int32 {
         let p = try spawn("/usr/bin/true", [])
-        p.waitUntilExit()
+        guard case .exited = BoundedProcessTeardown.awaitExit(p) else {
+            throw FixtureSpawnFailure(code: ETIMEDOUT)
+        }
         return p.processIdentifier
     }
 
@@ -93,9 +107,17 @@ struct AgentReaperHolderLegLiveTests {
         return !pidExists(pid)
     }
 
+    /// SIGKILL, then a bounded wait for Foundation to observe the exit. A bound
+    /// that fires reds this test with what the kernel said about the pid, rather
+    /// than wedging the whole serial live pass in a `defer`.
+    ///
+    /// Recorded as an `Error` rather than a string: only
+    /// `Issue.record(_: some Error)` puts the diagnostic on the primary failure
+    /// line, which is the only line a CI summary keeps.
     private static func killAndReap(_ process: Process) {
-        if process.isRunning { kill(process.processIdentifier, SIGKILL) }
-        process.waitUntilExit()
+        if case .unobserved(let pid, let diagnostic) = BoundedProcessTeardown.killAndReap(process) {
+            Issue.record(TeardownBoundExpired(pid: pid, diagnostic: diagnostic))
+        }
     }
 
     // MARK: - A job that only SIGKILL can end
@@ -312,7 +334,7 @@ struct AgentReaperHolderLegLiveTests {
         p.standardError = FileHandle.nullDevice
         guard (try? p.run()) != nil else { return [:] }
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
-        p.waitUntilExit()
+        _ = BoundedProcessTeardown.awaitExit(p)
         var result: [String: String] = [:]
         var fd: String?
         for line in String(decoding: data, as: UTF8.self).split(separator: "\n") {

--- a/Tests/TBDDaemonLiveTests/Process/BoundedProcessTeardown.swift
+++ b/Tests/TBDDaemonLiveTests/Process/BoundedProcessTeardown.swift
@@ -52,7 +52,11 @@ extension Process: ExitObservableProcess {}
 /// - **There is no injected clock, deliberately.** This is a synchronous helper
 ///   called from `defer`, where `Task.sleep` is unavailable and the repo's
 ///   `Clock` seam — which is async — cannot be used. The deadline is a plain
-///   parameter instead, so a caller that needs a different bound states it.
+///   parameter instead, so a caller that needs a different bound states it. It
+///   is measured monotonically on purpose: a wall-clock step backwards, which
+///   an NTP correction on a shared box produces, would push a `Date()` deadline
+///   further into the future and re-open the unbounded wait this helper exists
+///   to close.
 enum BoundedProcessTeardown {
     enum Outcome: Equatable {
         /// Foundation observed the exit. Its handler clears `isRunning` only
@@ -84,12 +88,15 @@ enum BoundedProcessTeardown {
     static func awaitExit(
         _ process: any ExitObservableProcess, within seconds: Double = 10
     ) -> Outcome {
-        let deadline = Date().addingTimeInterval(seconds)
+        // `ContinuousClock`, not `Date()`: the bound must not be extendable by a
+        // wall-clock correction landing mid-wait.
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(seconds))
         while true {
             // Checked before the deadline and before any sleep, so a child that
             // has already exited costs nothing.
             if !process.isRunning { return .exited }
-            if Date() >= deadline { break }
+            if clock.now >= deadline { break }
             usleep(20_000)
         }
         let pid = process.processIdentifier
@@ -109,6 +116,12 @@ enum BoundedProcessTeardown {
     /// `isRunning`, verified against the running implementation — so the probe
     /// cannot wedge the process it is diagnosing.
     private static func diagnose(_ pid: Int32, after seconds: Double) -> String {
+        // Guarded on `pid > 0` for the same reason the kill above is:
+        // `waitpid(0, …)` collects any child in the caller's process group and
+        // `waitpid(-1, …)` any child at all, so a non-positive pid would reap a
+        // corpse this helper was never asked about.
+        guard pid > 0 else { return "pid \(pid): no pid to probe (never launched?)" }
+
         var status: Int32 = 0
         let reaped = waitpid(pid, &status, WNOHANG)
         // Captured immediately: `stat` below spawns `ps`, which overwrites errno.

--- a/Tests/TBDDaemonLiveTests/Process/BoundedProcessTeardown.swift
+++ b/Tests/TBDDaemonLiveTests/Process/BoundedProcessTeardown.swift
@@ -1,0 +1,149 @@
+import Darwin
+import Foundation
+
+@testable import TBDDaemonLib
+
+/// What teardown needs to know about a child — and nothing that can block.
+///
+/// `Process.waitUntilExit()` is deliberately absent from this protocol, so a
+/// helper written against it cannot reach the call. On macOS 26.1 that call can
+/// spin forever (62.5 ms run-loop polls, 0% CPU) with `isRunning` already
+/// `false`, and the mechanism is structural rather than a narrow race:
+/// `Process.run()` appends the task's pointer to a **per-thread** CFArray (CF
+/// thread-specific-data slot 30) created with NULL callbacks, and nothing prunes
+/// that array when a task is freed — so it accumulates dangling pointers of dead
+/// tasks. `waitUntilExit()` then reads "my pointer is in *this* thread's array"
+/// as "this thread launched me", and in that case keeps running the run loop
+/// until a termination block has run — a block the exit handler
+/// `CFRunLoopPerformBlock`s onto the **launching** thread's run loop. When the
+/// pointer matched only a stale entry, because the allocator handed a dead
+/// task's address to a live one, that block belongs to a different thread and
+/// the loop never ends.
+///
+/// A test suite is the ideal incubator for the stale entry: async tests resume
+/// on arbitrary cooperative-pool threads that live for the whole run, and the
+/// suite churns hundreds of short-lived `Process` objects on them — every `ps`
+/// call in `ProductionProcessSignaller` is one. Same-thread launch-and-wait is
+/// not exposed, which is why `runPS` and the shell helpers are left alone; a
+/// `defer` that runs after an `await` is the shape that is.
+/// `scripts/diag/nstask-waituntilexit-stale-entry.swift` reproduces the hang
+/// deterministically by planting the stale entry by hand.
+protocol ExitObservableProcess: AnyObject {
+    var processIdentifier: Int32 { get }
+    var isRunning: Bool { get }
+}
+
+extension Process: ExitObservableProcess {}
+
+/// Bounded replacement for `Process.waitUntilExit()` in test teardown.
+///
+/// Three properties are load-bearing.
+///
+/// - **`isRunning == false` is a reap proof, not merely an exit proof.**
+///   Foundation's exit handler clears that flag only *after* its own blocking
+///   `waitpid` has collected the corpse, so a child observed not-running has
+///   been reaped and is not a zombie. Teardown therefore needs no `waitpid` of
+///   its own, and Foundation stays the sole waiter for the pids it owns.
+/// - **The bound exists because a hung teardown is worse than a red test.** The
+///   live target runs `--no-parallel` on one machine; a `defer` that never
+///   returns burns the whole step's budget and reports nothing, while a bound
+///   that fires reds exactly one test and carries a diagnostic saying what the
+///   kernel thought of the pid at that moment.
+/// - **There is no injected clock, deliberately.** This is a synchronous helper
+///   called from `defer`, where `Task.sleep` is unavailable and the repo's
+///   `Clock` seam — which is async — cannot be used. The deadline is a plain
+///   parameter instead, so a caller that needs a different bound states it.
+enum BoundedProcessTeardown {
+    enum Outcome: Equatable {
+        /// Foundation observed the exit. Its handler clears `isRunning` only
+        /// after its own `waitpid` collected the corpse, so this also means
+        /// "reaped, not a zombie".
+        case exited
+        /// The deadline passed with `isRunning` still true. `diagnostic` says
+        /// what the kernel thought of the pid at that moment.
+        case unobserved(pid: Int32, diagnostic: String)
+    }
+
+    /// SIGKILL if the child is still running, then `awaitExit`.
+    ///
+    /// The signal is pid-exact and guarded on `pid > 0`: `kill(0, …)` signals
+    /// the caller's entire process group, which in a test process is the test
+    /// runner itself.
+    @discardableResult
+    static func killAndReap(
+        _ process: any ExitObservableProcess, within seconds: Double = 10
+    ) -> Outcome {
+        let pid = process.processIdentifier
+        if process.isRunning && pid > 0 { kill(pid, SIGKILL) }
+        return awaitExit(process, within: seconds)
+    }
+
+    /// Polls `isRunning` every 20 ms until it flips or `seconds` elapse. Never
+    /// signals anything, so it is safe on a process the caller must leave alive.
+    @discardableResult
+    static func awaitExit(
+        _ process: any ExitObservableProcess, within seconds: Double = 10
+    ) -> Outcome {
+        let deadline = Date().addingTimeInterval(seconds)
+        while true {
+            // Checked before the deadline and before any sleep, so a child that
+            // has already exited costs nothing.
+            if !process.isRunning { return .exited }
+            if Date() >= deadline { break }
+            usleep(20_000)
+        }
+        let pid = process.processIdentifier
+        return .unobserved(pid: pid, diagnostic: diagnose(pid, after: seconds))
+    }
+
+    /// One `waitpid(…, WNOHANG)` plus one `ps -o stat=`, to say which of the
+    /// several very different situations the bound just fired on.
+    ///
+    /// **The WNOHANG probe is acceptable here and only here.** Foundation owns
+    /// the corpse of every child it launched, and racing its handler for one is
+    /// how a sole waiter stops being sole. After the bound has already fired,
+    /// though, "the handler is merely late" is not a live possibility worth
+    /// protecting: the flag it would have cleared has not moved for the whole
+    /// deadline. And losing the race is survivable in the direction that matters
+    /// — Foundation's handler treats `ECHILD` as status −1 and still clears
+    /// `isRunning`, verified against the running implementation — so the probe
+    /// cannot wedge the process it is diagnosing.
+    private static func diagnose(_ pid: Int32, after seconds: Double) -> String {
+        var status: Int32 = 0
+        let reaped = waitpid(pid, &status, WNOHANG)
+        // Captured immediately: `stat` below spawns `ps`, which overwrites errno.
+        let probeErrno = errno
+
+        let finding: String
+        if reaped == pid {
+            finding = "zombie collected by the teardown diagnostic; Foundation never observed the exit"
+        } else if reaped == 0 {
+            finding = "still running \(seconds)s after the signal"
+        } else if reaped == -1 && probeErrno == ECHILD {
+            finding = "already collected by another waiter (sole-waiter violation)"
+        } else {
+            finding = "waitpid errno \(probeErrno)"
+        }
+
+        let psStat = ProductionProcessSignaller().stat(pid)
+        return "pid \(pid): \(finding) (ps stat: '\(psStat ?? "nil")')"
+    }
+}
+
+/// The bound fired. Thrown-`Error` shape on purpose: only
+/// `Issue.record(_: some Error)` puts the text on the primary failure line that
+/// CI summaries keep, while `Issue.record(String)` and `#expect(cond, "…")`
+/// demote it to a trailing `↳` line that those summaries drop
+/// (`Tests/CLAUDE.md`, "Assertion hygiene" rule 4).
+///
+/// It lives beside the helper rather than in one suite so every teardown that
+/// adopts the bound reports it the same way. Foundation-only by design — the
+/// recording is done by the suite, which already imports `Testing`.
+struct TeardownBoundExpired: Error, CustomStringConvertible {
+    let pid: Int32
+    let diagnostic: String
+
+    var description: String {
+        "teardown: pid \(pid) was not reaped within the bound — \(diagnostic)"
+    }
+}

--- a/Tests/TBDDaemonLiveTests/Process/BoundedProcessTeardown.swift
+++ b/Tests/TBDDaemonLiveTests/Process/BoundedProcessTeardown.swift
@@ -48,7 +48,12 @@ extension Process: ExitObservableProcess {}
 ///   live target runs `--no-parallel` on one machine; a `defer` that never
 ///   returns burns the whole step's budget and reports nothing, while a bound
 ///   that fires reds exactly one test and carries a diagnostic saying what the
-///   kernel thought of the pid at that moment.
+///   kernel thought of the pid at that moment. The 5-second default is sized
+///   against what the wait costs while it runs: it parks the calling thread —
+///   a cooperative-pool thread, when it is reached from a `defer` in an async
+///   test — so it is sized to how long a SIGKILLed child's exit handler takes
+///   under CI load, which is milliseconds, leaving two orders of magnitude of
+///   headroom. It is not sized to the unbounded wait it replaces.
 /// - **There is no injected clock, deliberately.** This is a synchronous helper
 ///   called from `defer`, where `Task.sleep` is unavailable and the repo's
 ///   `Clock` seam — which is async — cannot be used. The deadline is a plain
@@ -75,7 +80,7 @@ enum BoundedProcessTeardown {
     /// runner itself.
     @discardableResult
     static func killAndReap(
-        _ process: any ExitObservableProcess, within seconds: Double = 10
+        _ process: any ExitObservableProcess, within seconds: Double = 5
     ) -> Outcome {
         let pid = process.processIdentifier
         if process.isRunning && pid > 0 { kill(pid, SIGKILL) }
@@ -86,7 +91,7 @@ enum BoundedProcessTeardown {
     /// signals anything, so it is safe on a process the caller must leave alive.
     @discardableResult
     static func awaitExit(
-        _ process: any ExitObservableProcess, within seconds: Double = 10
+        _ process: any ExitObservableProcess, within seconds: Double = 5
     ) -> Outcome {
         // `ContinuousClock`, not `Date()`: the bound must not be extendable by a
         // wall-clock correction landing mid-wait.
@@ -131,7 +136,7 @@ enum BoundedProcessTeardown {
         if reaped == pid {
             finding = "zombie collected by the teardown diagnostic; Foundation never observed the exit"
         } else if reaped == 0 {
-            finding = "still running \(seconds)s after the signal"
+            finding = "still running \(seconds)s into the bound"
         } else if reaped == -1 && probeErrno == ECHILD {
             finding = "already collected by another waiter (sole-waiter violation)"
         } else {

--- a/Tests/TBDDaemonLiveTests/Process/BoundedProcessTeardown.swift
+++ b/Tests/TBDDaemonLiveTests/Process/BoundedProcessTeardown.swift
@@ -41,7 +41,10 @@ extension Process: ExitObservableProcess {}
 ///   Foundation's exit handler clears that flag only *after* its own blocking
 ///   `waitpid` has collected the corpse, so a child observed not-running has
 ///   been reaped and is not a zombie. Teardown therefore needs no `waitpid` of
-///   its own, and Foundation stays the sole waiter for the pids it owns.
+///   its own on the success path, and Foundation stays the sole waiter for the
+///   pids it owns. The single `waitpid` in this file is reached only after
+///   `killAndReap` has sent its own SIGKILL and then watched a full bound
+///   expire; `awaitExit` never reaches it at all.
 /// - **The bound exists because a hung teardown is worse than a red test.** The
 ///   live target runs `--no-parallel` on one machine; a `defer` that never
 ///   returns burns the whole step's budget and reports nothing, while a bound
@@ -71,7 +74,9 @@ enum BoundedProcessTeardown {
         case unobserved(pid: Int32, diagnostic: String)
     }
 
-    /// SIGKILL if the child is still running, then `awaitExit`.
+    /// SIGKILL if the child is still running, then a bounded wait for
+    /// Foundation to observe the exit — and, if that bound expires, the one
+    /// `waitpid` probe in this file.
     ///
     /// The signal is pid-exact and guarded on `pid > 1`, matching
     /// `ProductionProcessSignaller.signalPIDOnly`'s "never signal pid<=1":
@@ -83,18 +88,35 @@ enum BoundedProcessTeardown {
     ) -> Outcome {
         let pid = process.processIdentifier
         if process.isRunning && pid > 1 { kill(pid, SIGKILL) }
-        return awaitExit(process, within: seconds)
+        if poll(process, within: seconds) { return .exited }
+        // This path, and only this path, may probe: the caller asked for a reap,
+        // the SIGKILL has landed, and the bound has already expired.
+        return .unobserved(pid: pid, diagnostic: reapingDiagnostic(pid, after: seconds))
     }
 
-    /// Polls `isRunning` every 20 ms until it flips or `seconds` elapse. Never
-    /// signals, so it is safe on a process that must keep running. It is not
-    /// observe-only on expiry: the diagnostic's `waitpid` collects the corpse of
-    /// a child that has exited, so after a fired bound the child is gone from
-    /// Foundation's view as well as the kernel's.
+    /// Waits, bounded, for Foundation to observe the exit. **Never signals and
+    /// never reaps**, on any path.
+    ///
+    /// That makes it safe on two kinds of process a reaping wait is not: one
+    /// that must keep running, and one the caller intends to signal afterwards
+    /// — a reaped pid is a freed number, and the next thing signalled through it
+    /// may be a stranger. On expiry it reports what `kill(pid, 0)` says and
+    /// nothing more, so it cannot tell a running child from an uncollected
+    /// zombie and does not pretend to. A caller that wants the corpse collected
+    /// wants `killAndReap`.
     @discardableResult
     static func awaitExit(
         _ process: any ExitObservableProcess, within seconds: Double = 5
     ) -> Outcome {
+        if poll(process, within: seconds) { return .exited }
+        let pid = process.processIdentifier
+        return .unobserved(pid: pid, diagnostic: observeOnlyDiagnostic(pid, after: seconds))
+    }
+
+    /// The wait itself: true when `isRunning` goes false before the deadline.
+    private static func poll(
+        _ process: any ExitObservableProcess, within seconds: Double
+    ) -> Bool {
         // `ContinuousClock`, not `Date()`: the bound must not be extendable by a
         // wall-clock correction landing mid-wait.
         let clock = ContinuousClock()
@@ -102,16 +124,31 @@ enum BoundedProcessTeardown {
         while true {
             // Checked before the deadline and before any sleep, so a child that
             // has already exited costs nothing.
-            if !process.isRunning { return .exited }
-            if clock.now >= deadline { break }
+            if !process.isRunning { return true }
+            if clock.now >= deadline { return false }
             usleep(20_000)
         }
-        let pid = process.processIdentifier
-        return .unobserved(pid: pid, diagnostic: diagnose(pid, after: seconds))
+    }
+
+    /// Everything the bound can say without touching anything: one
+    /// `kill(pid, 0)`, no `waitpid`, no spawn.
+    ///
+    /// It therefore cannot separate a running child from an uncollected zombie
+    /// — a corpse nobody has collected answers `kill(pid, 0)` with success — and
+    /// says so rather than guessing. That ambiguity is the price of leaving the
+    /// pid alone, and it is the right price for a caller who has not asked for a
+    /// reap.
+    private static func observeOnlyDiagnostic(_ pid: Int32, after seconds: Double) -> String {
+        guard pid > 1 else { return "pid \(pid): not a pid this helper will touch" }
+        return """
+            pid \(pid): still running or a zombie \(seconds)s into the bound \
+            (kill(pid, 0): \(kernelView(of: pid))); observe-only, nothing probed
+            """
     }
 
     /// One `kill(pid, 0)` reading plus one `waitpid(…, WNOHANG)`, to say which of
-    /// the several very different situations the bound just fired on.
+    /// the several very different situations `killAndReap`'s bound just fired
+    /// on. Reached from that one path — `awaitExit` never gets here.
     ///
     /// **It spawns nothing, and that is not fastidiousness.** A `Process`
     /// launched here would be one more entry in this thread's per-thread task
@@ -120,16 +157,18 @@ enum BoundedProcessTeardown {
     /// wait into the one path that runs only when a wait has already failed.
     /// `kill(pid, 0)` answers the same question with a syscall.
     ///
-    /// **The WNOHANG probe is acceptable here and only here.** Foundation owns
+    /// **The WNOHANG probe is acceptable at this one point.** Foundation owns
     /// the corpse of every child it launched, and racing its handler for one is
-    /// how a sole waiter stops being sole. After the bound has already fired,
-    /// though, "the handler is merely late" is not a live possibility worth
-    /// protecting: the flag it would have cleared has not moved for the whole
-    /// deadline. And losing the race is survivable in the direction that matters
-    /// — Foundation's handler treats `ECHILD` as status −1 and still clears
-    /// `isRunning`, verified against the running implementation — so the probe
-    /// cannot wedge the process it is diagnosing.
-    private static func diagnose(_ pid: Int32, after seconds: Double) -> String {
+    /// how a sole waiter stops being sole. Here the race is not live: this runs
+    /// only after this helper sent its own SIGKILL and then watched `isRunning`
+    /// fail to move for a full bound, so "the handler is merely late" is not a
+    /// possibility worth protecting. And losing the race is survivable in the
+    /// direction that matters — Foundation's handler treats `ECHILD` as status
+    /// −1 and still clears `isRunning`. Verified rather than assumed: a
+    /// standalone probe collected the corpse with a raw `waitpid` ahead of
+    /// Foundation's handler 30 times out of 30 on macOS 26.1 (25B78);
+    /// `isRunning` flipped false and `waitUntilExit()` returned every time.
+    private static func reapingDiagnostic(_ pid: Int32, after seconds: Double) -> String {
         // Guarded on `pid > 1` for the same reason the kill above is:
         // `waitpid(0, …)` collects any child in the caller's process group and
         // `waitpid(-1, …)` any child at all, so a non-positive pid would reap a

--- a/Tests/TBDDaemonLiveTests/Process/BoundedProcessTeardown.swift
+++ b/Tests/TBDDaemonLiveTests/Process/BoundedProcessTeardown.swift
@@ -1,8 +1,6 @@
 import Darwin
 import Foundation
 
-@testable import TBDDaemonLib
-
 /// What teardown needs to know about a child — and nothing that can block.
 ///
 /// `Process.waitUntilExit()` is deliberately absent from this protocol, so a
@@ -52,7 +50,7 @@ extension Process: ExitObservableProcess {}
 ///   against what the wait costs while it runs: it parks the calling thread —
 ///   a cooperative-pool thread, when it is reached from a `defer` in an async
 ///   test — so it is sized to how long a SIGKILLed child's exit handler takes
-///   under CI load, which is milliseconds, leaving two orders of magnitude of
+///   under CI load, which is milliseconds, leaving orders of magnitude of
 ///   headroom. It is not sized to the unbounded wait it replaces.
 /// - **There is no injected clock, deliberately.** This is a synchronous helper
 ///   called from `defer`, where `Task.sleep` is unavailable and the repo's
@@ -88,7 +86,10 @@ enum BoundedProcessTeardown {
     }
 
     /// Polls `isRunning` every 20 ms until it flips or `seconds` elapse. Never
-    /// signals anything, so it is safe on a process the caller must leave alive.
+    /// signals, so it is safe on a process that must keep running. It is not
+    /// observe-only on expiry: the diagnostic's `waitpid` collects the corpse of
+    /// a child that has exited, so after a fired bound the child is gone from
+    /// Foundation's view as well as the kernel's.
     @discardableResult
     static func awaitExit(
         _ process: any ExitObservableProcess, within seconds: Double = 5
@@ -108,8 +109,15 @@ enum BoundedProcessTeardown {
         return .unobserved(pid: pid, diagnostic: diagnose(pid, after: seconds))
     }
 
-    /// One `waitpid(…, WNOHANG)` plus one `ps -o stat=`, to say which of the
-    /// several very different situations the bound just fired on.
+    /// One `kill(pid, 0)` reading plus one `waitpid(…, WNOHANG)`, to say which of
+    /// the several very different situations the bound just fired on.
+    ///
+    /// **It spawns nothing, and that is not fastidiousness.** A `Process`
+    /// launched here would be one more entry in this thread's per-thread task
+    /// list — the precondition of the hazard this helper exists for — and `ps` is
+    /// reached through a `waitUntilExit()`, so asking `ps` would put an unbounded
+    /// wait into the one path that runs only when a wait has already failed.
+    /// `kill(pid, 0)` answers the same question with a syscall.
     ///
     /// **The WNOHANG probe is acceptable here and only here.** Foundation owns
     /// the corpse of every child it launched, and racing its handler for one is
@@ -127,9 +135,14 @@ enum BoundedProcessTeardown {
         // corpse this helper was never asked about.
         guard pid > 0 else { return "pid \(pid): no pid to probe (never launched?)" }
 
+        // Read BEFORE the probe, deliberately: a WNOHANG that collects a zombie
+        // frees the number, and the kernel may hand it to somebody else
+        // immediately after — so a reading taken afterwards could describe a
+        // stranger.
+        let kernelBeforeProbe = kernelView(of: pid)
+
         var status: Int32 = 0
         let reaped = waitpid(pid, &status, WNOHANG)
-        // Captured immediately: `stat` below spawns `ps`, which overwrites errno.
         let probeErrno = errno
 
         let finding: String
@@ -143,8 +156,19 @@ enum BoundedProcessTeardown {
             finding = "waitpid errno \(probeErrno)"
         }
 
-        let psStat = ProductionProcessSignaller().stat(pid)
-        return "pid \(pid): \(finding) (ps stat: '\(psStat ?? "nil")')"
+        return "pid \(pid): \(finding) (kill(pid, 0) before the probe: \(kernelBeforeProbe))"
+    }
+
+    /// What `kill(pid, 0)` says about a pid, in one word. `"alive"` covers a
+    /// zombie too — an uncollected corpse answers with success — which is why it
+    /// is reported alongside the `waitpid` finding rather than instead of it.
+    private static func kernelView(of pid: Int32) -> String {
+        if kill(pid, 0) == 0 { return "alive" }
+        switch errno {
+        case ESRCH: return "ESRCH"
+        case EPERM: return "EPERM"
+        default: return "errno \(errno)"
+        }
     }
 }
 

--- a/Tests/TBDDaemonLiveTests/Process/BoundedProcessTeardown.swift
+++ b/Tests/TBDDaemonLiveTests/Process/BoundedProcessTeardown.swift
@@ -73,15 +73,16 @@ enum BoundedProcessTeardown {
 
     /// SIGKILL if the child is still running, then `awaitExit`.
     ///
-    /// The signal is pid-exact and guarded on `pid > 0`: `kill(0, …)` signals
-    /// the caller's entire process group, which in a test process is the test
-    /// runner itself.
+    /// The signal is pid-exact and guarded on `pid > 1`, matching
+    /// `ProductionProcessSignaller.signalPIDOnly`'s "never signal pid<=1":
+    /// `kill(0, …)` signals the caller's entire process group — in a test
+    /// process, the test runner itself — and pid 1 is launchd.
     @discardableResult
     static func killAndReap(
         _ process: any ExitObservableProcess, within seconds: Double = 5
     ) -> Outcome {
         let pid = process.processIdentifier
-        if process.isRunning && pid > 0 { kill(pid, SIGKILL) }
+        if process.isRunning && pid > 1 { kill(pid, SIGKILL) }
         return awaitExit(process, within: seconds)
     }
 
@@ -129,11 +130,11 @@ enum BoundedProcessTeardown {
     /// `isRunning`, verified against the running implementation — so the probe
     /// cannot wedge the process it is diagnosing.
     private static func diagnose(_ pid: Int32, after seconds: Double) -> String {
-        // Guarded on `pid > 0` for the same reason the kill above is:
+        // Guarded on `pid > 1` for the same reason the kill above is:
         // `waitpid(0, …)` collects any child in the caller's process group and
         // `waitpid(-1, …)` any child at all, so a non-positive pid would reap a
-        // corpse this helper was never asked about.
-        guard pid > 0 else { return "pid \(pid): no pid to probe (never launched?)" }
+        // corpse this helper was never asked about — and pid 1 is launchd.
+        guard pid > 1 else { return "pid \(pid): not a pid this helper will touch" }
 
         // Read BEFORE the probe, deliberately: a WNOHANG that collects a zombie
         // frees the number, and the kernel may hand it to somebody else

--- a/Tests/TBDDaemonLiveTests/Process/BoundedProcessTeardownTests.swift
+++ b/Tests/TBDDaemonLiveTests/Process/BoundedProcessTeardownTests.swift
@@ -29,7 +29,8 @@ struct BoundedProcessTeardownTests {
     /// reconciler that can see it. 1500 × 0.2 s is ~5 minutes, two orders of
     /// magnitude past what any assertion here needs.
     private static func spawnLongLived() throws -> Process {
-        try spawn("/bin/zsh", ["-c", #"trap "" HUP; for _ in {1..1500}; do sleep 0.2; done"#])
+        try spawn(
+            "/bin/zsh", ["-f", "-c", #"trap "" HUP; for _ in {1..1500}; do sleep 0.2; done"#])
     }
 
     private static func spawn(_ path: String, _ args: [String]) throws -> Process {
@@ -58,15 +59,19 @@ struct BoundedProcessTeardownTests {
     private static func spawnUnownedLongLived() throws -> pid_t {
         let path = "/bin/zsh"
         let script = #"trap "" HUP; for _ in {1..1500}; do sleep 0.2; done"#
-        let arguments: [String] = [path, "-c", script]
+        // `-f` so zsh reads no rc file at all — without it `.zshenv` is read on
+        // every invocation, `-c` included — and an explicit `HOME` inside the
+        // fence, because an env without one makes zsh look `HOME` up in the
+        // password database and land on the developer's real home.
+        //
+        // The environment is built by hand rather than passed through because
+        // `environ` is linked into the main executable and is not reachable from
+        // a test bundle; beyond `HOME`, the fixture needs nothing but a PATH
+        // that resolves `sleep`.
+        let arguments: [String] = [path, "-f", "-c", script]
         var argv: [UnsafeMutablePointer<CChar>?] = arguments.map { strdup($0) }
         argv.append(nil)
-        // An explicit one-entry environment rather than this process's own:
-        // `environ` is linked into the main executable and is not reachable from
-        // a test bundle, and the fixture needs nothing but a PATH that resolves
-        // `sleep`. No `-l`/`-i` either, so it sources nothing from the
-        // developer's shell configuration.
-        let environment: [String] = ["PATH=/usr/bin:/bin"]
+        let environment: [String] = ["PATH=/usr/bin:/bin", "HOME=\(NSTemporaryDirectory())"]
         var envp: [UnsafeMutablePointer<CChar>?] = environment.map { strdup($0) }
         envp.append(nil)
         defer {
@@ -212,13 +217,19 @@ struct BoundedProcessTeardownTests {
     @Test func theBoundFiresWhenTheExitIsNeverObserved() async throws {
         let pid = try Self.spawnUnownedLongLived()
         defer {
-            kill(pid, SIGKILL)
+            // Only `0` — "still our child, and not yet collected" — licenses a
+            // signal. By the time this runs the diagnostic probe has usually
+            // collected the corpse already, and a pid whose corpse is gone may
+            // name somebody else's process by now; `pid` (a zombie we own) and
+            // `-1`/`ECHILD` (already collected) both mean there is nothing left
+            // to signal. The blocking `waitpid` after the kill is bounded
+            // because SIGKILL cannot be blocked — the same shape as
+            // `SIGTERMProofJob.tearDown` in the sibling suite.
             var status: Int32 = 0
-            // SIGKILL cannot be blocked, so this is bounded; it returns
-            // immediately with ECHILD when the diagnostic probe already
-            // collected the corpse. Same shape as `SIGTERMProofJob.tearDown` in
-            // the sibling suite.
-            _ = waitpid(pid, &status, 0)
+            if waitpid(pid, &status, WNOHANG) == 0 {
+                kill(pid, SIGKILL)
+                _ = waitpid(pid, &status, 0)
+            }
         }
 
         let stub = ExitNeverObserved(pid: pid)

--- a/Tests/TBDDaemonLiveTests/Process/BoundedProcessTeardownTests.swift
+++ b/Tests/TBDDaemonLiveTests/Process/BoundedProcessTeardownTests.swift
@@ -104,7 +104,7 @@ struct BoundedProcessTeardownTests {
         if kill(pid, 0) == 0 { return "alive" }
         switch errno {
         case ESRCH: return "ESRCH"
-        case EPERM: return "EPERM (alive, another uid)"
+        case EPERM: return "EPERM"
         default: return "errno \(errno)"
         }
     }
@@ -144,9 +144,14 @@ struct BoundedProcessTeardownTests {
     }
 
     /// A child that exited before teardown reached it costs nothing. This is the
-    /// common case in practice — the test killed it, or it ended on its own —
-    /// and the helper must return on the first check rather than sleeping out a
-    /// poll interval per child.
+    /// common case in practice — the test killed it, or it ended on its own.
+    ///
+    /// What the one-second assertion discriminates: the helper must not wait out
+    /// its bound on an already-exited child. The bound here is the default, 5 s,
+    /// so a helper that polled to the deadline regardless would miss by four
+    /// seconds. It does **not** pin "returns without sleeping the 20 ms poll
+    /// interval" — no assertion that survives a loaded shared box can measure
+    /// 20 ms, and one that tried would be a flake rather than a proof.
     @Test func aChildThatAlreadyExitedIsReportedWithoutWaiting() async throws {
         let child = try Self.spawn("/usr/bin/true", [])
         defer { BoundedProcessTeardown.killAndReap(child) }
@@ -173,7 +178,7 @@ struct BoundedProcessTeardownTests {
     /// for what it does not do — and a contract nothing pins is one a later
     /// "signal just to be sure" edit can quietly break, under a name that still
     /// reads as harmless at every call site.
-    @Test func awaitExitNeverSignals() async throws {
+    @Test func awaitExitNeverSignals() throws {
         let child = try Self.spawnLongLived()
         defer { BoundedProcessTeardown.killAndReap(child) }
         let pid = child.processIdentifier
@@ -211,8 +216,11 @@ struct BoundedProcessTeardownTests {
     /// than on a made-up number that may belong to anybody — and because that
     /// child is `posix_spawn`ed rather than Foundation-launched, this test is
     /// its only waiter. So the sequence is deterministic: the SIGKILL lands at
-    /// t≈0, the child is a zombie well before the 0.3 s bound, and the
-    /// diagnostic probe is the thing that collects it. That is exactly what
+    /// t≈0, the child is a zombie well before the 2 s bound, and the
+    /// diagnostic probe is the thing that collects it. The bound is 2 s rather
+    /// than a few hundred milliseconds because under induced load a zsh and its
+    /// `sleep` are not always torn down that fast, and the corpse has to exist
+    /// before the probe can find it. That is exactly what
     /// production teardown does when Foundation has lost the exit, which is why
     /// the composed diagnostic is asserted rather than only its pid. And the
     /// bounded wait runs on a dedicated `Thread`, per `Tests/CLAUDE.md`
@@ -262,12 +270,12 @@ struct BoundedProcessTeardownTests {
         let started = clock.now
 
         let thread = Thread {
-            box.store(BoundedProcessTeardown.killAndReap(stub, within: 0.3))
+            box.store(BoundedProcessTeardown.killAndReap(stub, within: 2))
         }
         thread.name = "BoundedProcessTeardownTests.bound"
         thread.start()
 
-        let watchdog = Date().addingTimeInterval(5)
+        let watchdog = Date().addingTimeInterval(10)
         var collected: BoundedProcessTeardown.Outcome?
         while Date() < watchdog {
             if let value = box.value {
@@ -283,11 +291,11 @@ struct BoundedProcessTeardownTests {
         // `Issue.record(_: some Error)` puts its text where a CI summary keeps
         // it (`Tests/CLAUDE.md`, "Assertion hygiene" rule 4).
         guard let delivered = collected else {
-            Issue.record(BoundNeverReturned(pid: pid, watchdogSeconds: 5))
+            Issue.record(BoundNeverReturned(pid: pid, watchdogSeconds: 10))
             return
         }
         guard case .unobserved(let reportedPID, let diagnostic) = delivered else {
-            Issue.record("the bound did not fire; the wait reported \(delivered)")
+            Issue.record(BoundDidNotFire(outcome: delivered))
             return
         }
         #expect(reportedPID == pid)
@@ -299,8 +307,8 @@ struct BoundedProcessTeardownTests {
                 && diagnostic.contains("zombie collected by the teardown diagnostic"),
             "the diagnostic did not report the corpse it collected: \(diagnostic)")
         #expect(
-            elapsed >= .milliseconds(300),
-            "the wait returned after \(elapsed), which is short of its own 0.3 s bound")
+            elapsed >= .seconds(2),
+            "the wait returned after \(elapsed), which is short of its own 2 s bound")
     }
 }
 
@@ -308,6 +316,18 @@ struct BoundedProcessTeardownTests {
 /// `FixtureSpawnFailure` in the sibling suite.
 private struct SpawnFailure: Error {
     let code: Int32
+}
+
+/// The bound was reported as satisfied against a stub that can never satisfy it.
+///
+/// An `Error` for the same reason as `BoundNeverReturned`: this is the other
+/// half of the mutation check's verdict, and its text is the whole finding.
+private struct BoundDidNotFire: Error, CustomStringConvertible {
+    let outcome: BoundedProcessTeardown.Outcome
+
+    var description: String {
+        "the bound did not fire: the wait reported \(outcome) for a stub whose isRunning never flips"
+    }
 }
 
 /// The watchdog in the mutation check fired: the bounded wait published no

--- a/Tests/TBDDaemonLiveTests/Process/BoundedProcessTeardownTests.swift
+++ b/Tests/TBDDaemonLiveTests/Process/BoundedProcessTeardownTests.swift
@@ -1,0 +1,253 @@
+import Darwin
+import Foundation
+import Testing
+
+@testable import TBDDaemonLib
+
+/// `BoundedProcessTeardown` against real children and the kernel's own answers.
+///
+/// **Tier 3.** Every process here is real, because the property under test is a
+/// property of real reaping: that `isRunning == false` means Foundation has
+/// already collected the corpse, and that a bound which fires says so instead of
+/// spinning. A fake `Process` could state neither.
+///
+/// The last test is the mutation check for the deadline itself, and it is the
+/// reason `ExitObservableProcess` exists: a stub whose `isRunning` never flips
+/// cannot be built out of `Process`.
+@Suite(.serialized)
+struct BoundedProcessTeardownTests {
+
+    // MARK: - Process helpers
+
+    /// A child that stays alive for as long as any of these tests could need it,
+    /// and no longer.
+    ///
+    /// The loop is **counted**, not `while :`, for the reason the sibling
+    /// fixture in `AgentReaperHolderLegLiveTests` gives: a process this test
+    /// spawns and can no longer reach — the test host killed mid-run, which
+    /// happens on a shared machine — would otherwise spin forever with no
+    /// reconciler that can see it. 1500 × 0.2 s is ~5 minutes, two orders of
+    /// magnitude past what any assertion here needs.
+    private static func spawnLongLived() throws -> Process {
+        try spawn("/bin/zsh", ["-c", #"trap "" HUP; for _ in {1..1500}; do sleep 0.2; done"#])
+    }
+
+    private static func spawn(_ path: String, _ args: [String]) throws -> Process {
+        let p = Process()
+        p.executableURL = URL(fileURLWithPath: path)
+        p.arguments = args
+        p.standardInput = FileHandle.nullDevice
+        p.standardOutput = FileHandle.nullDevice
+        p.standardError = FileHandle.nullDevice
+        try p.run()
+        return p
+    }
+
+    /// What `kill(pid, 0)` says about a pid, as one word, so an assertion can be
+    /// made on composed output rather than on a bare `-1`.
+    ///
+    /// `"alive"` covers a zombie too — an uncollected corpse answers `kill(pid,
+    /// 0)` with success — which is exactly why `"ESRCH"` is the interesting
+    /// answer: it is the one that only a *collected* process gives.
+    private static func kernelView(of pid: Int32) -> String {
+        if kill(pid, 0) == 0 { return "alive" }
+        switch errno {
+        case ESRCH: return "ESRCH"
+        case EPERM: return "EPERM (alive, another uid)"
+        default: return "errno \(errno)"
+        }
+    }
+
+    /// Bounded poll of Foundation's own flag. Deliberately not
+    /// `BoundedProcessTeardown.awaitExit`, so a test that means to observe the
+    /// exit independently is not asserting the helper against itself.
+    private static func waitUntilNotRunning(
+        _ process: Process, within seconds: Double
+    ) async -> Bool {
+        let deadline = Date().addingTimeInterval(seconds)
+        while Date() < deadline {
+            if !process.isRunning { return true }
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+        return !process.isRunning
+    }
+
+    // MARK: - The ordinary teardown path
+
+    /// The case every `defer` in the live target takes: a child still running
+    /// when its test ends. It must be gone *and collected* afterwards — a
+    /// teardown that left zombies behind would pass a liveness check built on
+    /// `kill(pid, 0)` and quietly fill the process table for the rest of the run.
+    @Test func aRunningChildIsKilledAndCollected() throws {
+        let child = try Self.spawnLongLived()
+        defer { BoundedProcessTeardown.killAndReap(child) }
+        let pid = child.processIdentifier
+        #expect(Self.kernelView(of: pid) == "alive", "the fixture must be running before the kill")
+
+        #expect(BoundedProcessTeardown.killAndReap(child) == .exited)
+
+        #expect(child.isRunning == false)
+        #expect(
+            Self.kernelView(of: pid) == "ESRCH",
+            "pid \(pid) was not collected; a zombie would still answer kill(pid, 0)")
+    }
+
+    /// A child that exited before teardown reached it costs nothing. This is the
+    /// common case in practice — the test killed it, or it ended on its own —
+    /// and the helper must return on the first check rather than sleeping out a
+    /// poll interval per child.
+    @Test func aChildThatAlreadyExitedIsReportedWithoutWaiting() async throws {
+        let child = try Self.spawn("/usr/bin/true", [])
+        defer { BoundedProcessTeardown.killAndReap(child) }
+
+        #expect(
+            await Self.waitUntilNotRunning(child, within: 5),
+            "/usr/bin/true was still running after 5 seconds")
+
+        let clock = ContinuousClock()
+        let started = clock.now
+        let outcome = BoundedProcessTeardown.killAndReap(child)
+        let elapsed = started.duration(to: clock.now)
+
+        #expect(outcome == .exited)
+        #expect(
+            elapsed < .seconds(1),
+            "teardown of an already-exited child took \(elapsed); it should not have waited at all")
+    }
+
+    // MARK: - The bound
+
+    /// `awaitExit` observes and never actuates. The distinction matters because
+    /// two call sites in `AgentReaperHolderLegLiveTests` use it on processes the
+    /// test still needs alive, and a helper that signalled "just to be sure"
+    /// would silently invalidate their premises.
+    @Test func awaitExitNeverSignals() async throws {
+        let child = try Self.spawnLongLived()
+        defer { BoundedProcessTeardown.killAndReap(child) }
+        let pid = child.processIdentifier
+
+        let outcome = BoundedProcessTeardown.awaitExit(child, within: 0.3)
+        guard case .unobserved(let reportedPID, let diagnostic) = outcome else {
+            Issue.record("awaitExit reported \(outcome) for a child that is still running")
+            return
+        }
+        #expect(reportedPID == pid)
+        #expect(
+            diagnostic.contains("still running"),
+            "the diagnostic did not name what the kernel saw: \(diagnostic)")
+
+        let psStat = ProductionProcessSignaller().stat(pid) ?? ""
+        #expect(
+            !psStat.isEmpty && !psStat.hasPrefix("Z"),
+            "awaitExit signalled pid \(pid); ps stat is now '\(psStat)'")
+
+        #expect(BoundedProcessTeardown.killAndReap(child) == .exited)
+    }
+
+    /// **The mutation check.** A process whose exit is never observed must end
+    /// the wait at the deadline and report it, not spin.
+    ///
+    /// What it discriminates: delete the deadline from `awaitExit` and the
+    /// helper polls a flag that never flips, so no outcome is ever published and
+    /// the watchdog below reds the test with a named diagnostic. Change the
+    /// helper's parameter type back to `Process` and this test no longer
+    /// compiles at all, because the stub cannot be a `Process`.
+    ///
+    /// Two details keep it honest. The stub carries the pid of a **real**
+    /// long-lived child this test spawned, so the SIGKILL `killAndReap` sends
+    /// lands on something the test owns rather than on a made-up number that may
+    /// belong to anybody. And the bounded wait runs on a dedicated `Thread`, per
+    /// `Tests/CLAUDE.md` "Thread-blocking gates run off the cooperative pool":
+    /// the cooperative pool is only as wide as the machine has cores, and
+    /// parking one of its threads for the whole bound starves every suspended
+    /// task in the process, including the ones that would report a failure.
+    @Test func theBoundFiresWhenTheExitIsNeverObserved() async throws {
+        let child = try Self.spawnLongLived()
+        defer { BoundedProcessTeardown.killAndReap(child) }
+        let pid = child.processIdentifier
+
+        let stub = ExitNeverObserved(pid: pid)
+        let box = OutcomeBox()
+        let clock = ContinuousClock()
+        let started = clock.now
+
+        let thread = Thread {
+            box.store(BoundedProcessTeardown.killAndReap(stub, within: 0.3))
+        }
+        thread.name = "BoundedProcessTeardownTests.bound"
+        thread.start()
+
+        let watchdog = Date().addingTimeInterval(5)
+        var collected: BoundedProcessTeardown.Outcome?
+        while Date() < watchdog {
+            if let value = box.value {
+                collected = value
+                break
+            }
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+        let elapsed = started.duration(to: clock.now)
+
+        // The watchdog diagnostic is recorded as an `Error`, not as a `#require`
+        // comment: this is the failure a deleted deadline produces, and only
+        // `Issue.record(_: some Error)` puts its text where a CI summary keeps
+        // it (`Tests/CLAUDE.md`, "Assertion hygiene" rule 4).
+        guard let delivered = collected else {
+            Issue.record(BoundNeverReturned(pid: pid, watchdogSeconds: 5))
+            return
+        }
+        guard case .unobserved(let reportedPID, let diagnostic) = delivered else {
+            Issue.record("the bound did not fire; the wait reported \(delivered)")
+            return
+        }
+        #expect(reportedPID == pid)
+        #expect(
+            diagnostic.contains("\(pid)"),
+            "the diagnostic must name the pid it gave up on: \(diagnostic)")
+        #expect(
+            elapsed >= .milliseconds(300),
+            "the wait returned after \(elapsed), which is short of its own 0.3 s bound")
+
+        #expect(
+            BoundedProcessTeardown.killAndReap(child) == .exited,
+            "the real child the stub borrowed its pid from was not reaped")
+    }
+}
+
+/// The watchdog in the mutation check fired: the bounded wait published no
+/// outcome at all, which is what a deleted deadline looks like from outside.
+///
+/// An `Error` rather than a string for the reason `Tests/CLAUDE.md` gives under
+/// "Assertion hygiene" rule 4: `Issue.record(_: some Error)` is the only shape
+/// whose text lands on the primary failure line that CI summaries keep.
+private struct BoundNeverReturned: Error, CustomStringConvertible {
+    let pid: Int32
+    let watchdogSeconds: Int
+
+    var description: String {
+        """
+        the bounded wait never returned: no outcome was published within the \
+        \(watchdogSeconds) s watchdog for pid \(pid), whose isRunning never flips
+        """
+    }
+}
+
+/// A process that is forever about to exit: `isRunning` never flips, which is
+/// precisely the state `Process.waitUntilExit()` cannot escape and the deadline
+/// exists for.
+private final class ExitNeverObserved: ExitObservableProcess, @unchecked Sendable {
+    let processIdentifier: Int32
+    var isRunning: Bool { true }
+
+    init(pid: Int32) { processIdentifier = pid }
+}
+
+/// Publishes the outcome from the dedicated thread back to the test body.
+private final class OutcomeBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: BoundedProcessTeardown.Outcome?
+
+    var value: BoundedProcessTeardown.Outcome? { lock.withLock { stored } }
+
+    func store(_ outcome: BoundedProcessTeardown.Outcome) { lock.withLock { stored = outcome } }
+}

--- a/Tests/TBDDaemonLiveTests/Process/BoundedProcessTeardownTests.swift
+++ b/Tests/TBDDaemonLiveTests/Process/BoundedProcessTeardownTests.swift
@@ -82,14 +82,25 @@ struct BoundedProcessTeardownTests {
             for entry in envp { free(entry) }
         }
 
-        // No file actions and no attributes: the child inherits this process's
-        // stdio (it writes nothing) and its signal mask, which cannot matter
-        // because every signal sent to it here is SIGKILL. `POSIX_SPAWN_SETSID`
-        // is deliberately omitted too — the only descendant is a `sleep 0.2`,
-        // which orphans to launchd for at most 0.2 s when zsh is SIGKILLed, so
-        // nothing outlives the test for a reconciler to have to collect.
+        // stdio goes to `/dev/null` explicitly rather than being inherited, so
+        // the fixture can never write into the test runner's own streams.
+        var fileActions: posix_spawn_file_actions_t?
+        guard posix_spawn_file_actions_init(&fileActions) == 0 else {
+            throw SpawnFailure(code: errno)
+        }
+        defer { posix_spawn_file_actions_destroy(&fileActions) }
+        posix_spawn_file_actions_addopen(&fileActions, 0, "/dev/null", O_RDONLY, 0)
+        posix_spawn_file_actions_addopen(&fileActions, 1, "/dev/null", O_WRONLY, 0)
+        posix_spawn_file_actions_addopen(&fileActions, 2, "/dev/null", O_WRONLY, 0)
+
+        // No attributes, though: the child inherits this process's signal mask,
+        // which cannot matter because every signal sent to it here is SIGKILL.
+        // `POSIX_SPAWN_SETSID` is deliberately omitted too — the only descendant
+        // is a `sleep 0.2`, which orphans to launchd for at most 0.2 s when zsh
+        // is SIGKILLed, so nothing outlives the test for a reconciler to have to
+        // collect.
         var pid: pid_t = 0
-        let rc = posix_spawn(&pid, path, nil, nil, &argv, &envp)
+        let rc = posix_spawn(&pid, path, &fileActions, nil, &argv, &envp)
         guard rc == 0 else { throw SpawnFailure(code: rc) }
         return pid
     }
@@ -192,6 +203,11 @@ struct BoundedProcessTeardownTests {
         #expect(
             diagnostic.contains("still running"),
             "the diagnostic did not name what the kernel saw: \(diagnostic)")
+        // The branch matters as much as the text: `awaitExit` must report
+        // through the path that probes nothing, never through `killAndReap`'s.
+        #expect(
+            diagnostic.contains("observe-only"),
+            "awaitExit did not report through its observe-only branch: \(diagnostic)")
 
         let psStat = ProductionProcessSignaller().stat(pid) ?? ""
         #expect(

--- a/Tests/TBDDaemonLiveTests/Process/BoundedProcessTeardownTests.swift
+++ b/Tests/TBDDaemonLiveTests/Process/BoundedProcessTeardownTests.swift
@@ -59,10 +59,13 @@ struct BoundedProcessTeardownTests {
     private static func spawnUnownedLongLived() throws -> pid_t {
         let path = "/bin/zsh"
         let script = #"trap "" HUP; for _ in {1..1500}; do sleep 0.2; done"#
-        // `-f` so zsh reads no rc file at all — without it `.zshenv` is read on
-        // every invocation, `-c` included — and an explicit `HOME` inside the
-        // fence, because an env without one makes zsh look `HOME` up in the
-        // password database and land on the developer's real home.
+        // `-f` so zsh reads no user rc file (`/etc/zshenv` is read regardless of
+        // `-f`) — without it `.zshenv` is read on every invocation, `-c`
+        // included — and an explicit `HOME` inside the fence via
+        // `NSHomeDirectory()`, which honours `CFFIXED_USER_HOME` and is how
+        // `TestSupport/ShellHelpers.swift` resolves it. An env with no `HOME` at
+        // all is not neutral: zsh looks the value up in the password database
+        // and lands on the developer's real home.
         //
         // The environment is built by hand rather than passed through because
         // `environ` is linked into the main executable and is not reachable from
@@ -71,7 +74,7 @@ struct BoundedProcessTeardownTests {
         let arguments: [String] = [path, "-f", "-c", script]
         var argv: [UnsafeMutablePointer<CChar>?] = arguments.map { strdup($0) }
         argv.append(nil)
-        let environment: [String] = ["PATH=/usr/bin:/bin", "HOME=\(NSTemporaryDirectory())"]
+        let environment: [String] = ["PATH=/usr/bin:/bin", "HOME=\(NSHomeDirectory())"]
         var envp: [UnsafeMutablePointer<CChar>?] = environment.map { strdup($0) }
         envp.append(nil)
         defer {
@@ -81,7 +84,10 @@ struct BoundedProcessTeardownTests {
 
         // No file actions and no attributes: the child inherits this process's
         // stdio (it writes nothing) and its signal mask, which cannot matter
-        // because every signal sent to it here is SIGKILL.
+        // because every signal sent to it here is SIGKILL. `POSIX_SPAWN_SETSID`
+        // is deliberately omitted too — the only descendant is a `sleep 0.2`,
+        // which orphans to launchd for at most 0.2 s when zsh is SIGKILLed, so
+        // nothing outlives the test for a reconciler to have to collect.
         var pid: pid_t = 0
         let rc = posix_spawn(&pid, path, nil, nil, &argv, &envp)
         guard rc == 0 else { throw SpawnFailure(code: rc) }
@@ -216,24 +222,42 @@ struct BoundedProcessTeardownTests {
     /// including the ones that would report a failure.
     @Test func theBoundFiresWhenTheExitIsNeverObserved() async throws {
         let pid = try Self.spawnUnownedLongLived()
+        let stub = ExitNeverObserved(pid: pid)
+        let box = OutcomeBox()
         defer {
-            // Only `0` — "still our child, and not yet collected" — licenses a
-            // signal. By the time this runs the diagnostic probe has usually
-            // collected the corpse already, and a pid whose corpse is gone may
-            // name somebody else's process by now; `pid` (a zombie we own) and
-            // `-1`/`ECHILD` (already collected) both mean there is nothing left
-            // to signal. The blocking `waitpid` after the kill is bounded
-            // because SIGKILL cannot be blocked — the same shape as
-            // `SIGTERMProofJob.tearDown` in the sibling suite.
+            // Only reap once the helper has published an outcome. Until it does,
+            // its thread still owns this pid's `waitpid`, and a second waiter
+            // here would race it for one corpse. Declining leaks nothing: the
+            // helper's own SIGKILL has already landed, and the fixture's counted
+            // loop ends on its own regardless. Written as one condition rather
+            // than an early `return`, which a `defer` body may not use.
+            //
+            // The second half: only `0` — "still our child, and not yet
+            // collected" — licenses a signal. By the time this runs the
+            // diagnostic probe has usually collected the corpse already, and a
+            // pid whose corpse is gone may name somebody else's process by now;
+            // `pid` (a zombie we own) and `-1`/`ECHILD` (already collected) both
+            // mean there is nothing left to signal. The blocking `waitpid` after
+            // the kill is bounded because SIGKILL cannot be blocked — the same
+            // shape as `SIGTERMProofJob.tearDown` in the sibling suite.
             var status: Int32 = 0
-            if waitpid(pid, &status, WNOHANG) == 0 {
+            if box.value != nil, waitpid(pid, &status, WNOHANG) == 0 {
                 kill(pid, SIGKILL)
                 _ = waitpid(pid, &status, 0)
             }
         }
 
-        let stub = ExitNeverObserved(pid: pid)
-        let box = OutcomeBox()
+        // The premise, in two halves because the cheap half cannot state it: a
+        // zombie answers `kill(pid, 0)` with success, so liveness needs `ps` as
+        // well. Asking `ps` from a test body is fine — it is the helper's
+        // failure path, which must spawn nothing, that cannot.
+        #expect(
+            Self.kernelView(of: pid) == "alive",
+            "the unowned fixture must be running before the bound is exercised")
+        #expect(
+            ProductionProcessSignaller().stat(pid).map { !$0.hasPrefix("Z") } == true,
+            "the unowned fixture was already a corpse before the bound was exercised")
+
         let clock = ContinuousClock()
         let started = clock.now
 

--- a/Tests/TBDDaemonLiveTests/Process/BoundedProcessTeardownTests.swift
+++ b/Tests/TBDDaemonLiveTests/Process/BoundedProcessTeardownTests.swift
@@ -43,6 +43,46 @@ struct BoundedProcessTeardownTests {
         return p
     }
 
+    /// A long-lived child that **Foundation does not own**: `posix_spawn`ed
+    /// directly, so no `Process` object is monitoring it and this test is the
+    /// only waiter for its corpse.
+    ///
+    /// The mutation check needs that. A Foundation-launched child has a monitor
+    /// racing for the same corpse, and there the bounded wait polls a *stub's*
+    /// flag rather than that child's — so the helper's post-bound safety
+    /// argument, which is about the process whose own flag was polled, would not
+    /// cover the diagnostic's `waitpid`. With nothing else waiting, the probe is
+    /// the sole waiter and the outcome is deterministic.
+    ///
+    /// The loop is counted for the same reason `spawnLongLived`'s is.
+    private static func spawnUnownedLongLived() throws -> pid_t {
+        let path = "/bin/zsh"
+        let script = #"trap "" HUP; for _ in {1..1500}; do sleep 0.2; done"#
+        let arguments: [String] = [path, "-c", script]
+        var argv: [UnsafeMutablePointer<CChar>?] = arguments.map { strdup($0) }
+        argv.append(nil)
+        // An explicit one-entry environment rather than this process's own:
+        // `environ` is linked into the main executable and is not reachable from
+        // a test bundle, and the fixture needs nothing but a PATH that resolves
+        // `sleep`. No `-l`/`-i` either, so it sources nothing from the
+        // developer's shell configuration.
+        let environment: [String] = ["PATH=/usr/bin:/bin"]
+        var envp: [UnsafeMutablePointer<CChar>?] = environment.map { strdup($0) }
+        envp.append(nil)
+        defer {
+            for arg in argv { free(arg) }
+            for entry in envp { free(entry) }
+        }
+
+        // No file actions and no attributes: the child inherits this process's
+        // stdio (it writes nothing) and its signal mask, which cannot matter
+        // because every signal sent to it here is SIGKILL.
+        var pid: pid_t = 0
+        let rc = posix_spawn(&pid, path, nil, nil, &argv, &envp)
+        guard rc == 0 else { throw SpawnFailure(code: rc) }
+        return pid
+    }
+
     /// What `kill(pid, 0)` says about a pid, as one word, so an assertion can be
     /// made on composed output rather than on a bare `-1`.
     ///
@@ -117,10 +157,11 @@ struct BoundedProcessTeardownTests {
 
     // MARK: - The bound
 
-    /// `awaitExit` observes and never actuates. The distinction matters because
-    /// two call sites in `AgentReaperHolderLegLiveTests` use it on processes the
-    /// test still needs alive, and a helper that signalled "just to be sure"
-    /// would silently invalidate their premises.
+    /// `awaitExit` observes and never actuates. That split is the API's contract
+    /// — `killAndReap` is the only actuator, and the observe-only half is named
+    /// for what it does not do — and a contract nothing pins is one a later
+    /// "signal just to be sure" edit can quietly break, under a name that still
+    /// reads as harmless at every call site.
     @Test func awaitExitNeverSignals() async throws {
         let child = try Self.spawnLongLived()
         defer { BoundedProcessTeardown.killAndReap(child) }
@@ -154,17 +195,31 @@ struct BoundedProcessTeardownTests {
     /// compiles at all, because the stub cannot be a `Process`.
     ///
     /// Two details keep it honest. The stub carries the pid of a **real**
-    /// long-lived child this test spawned, so the SIGKILL `killAndReap` sends
-    /// lands on something the test owns rather than on a made-up number that may
-    /// belong to anybody. And the bounded wait runs on a dedicated `Thread`, per
-    /// `Tests/CLAUDE.md` "Thread-blocking gates run off the cooperative pool":
-    /// the cooperative pool is only as wide as the machine has cores, and
-    /// parking one of its threads for the whole bound starves every suspended
-    /// task in the process, including the ones that would report a failure.
+    /// long-lived child this test spawned and owns, so the SIGKILL
+    /// `killAndReap` sends lands on something the test is responsible for rather
+    /// than on a made-up number that may belong to anybody — and because that
+    /// child is `posix_spawn`ed rather than Foundation-launched, this test is
+    /// its only waiter. So the sequence is deterministic: the SIGKILL lands at
+    /// t≈0, the child is a zombie well before the 0.3 s bound, and the
+    /// diagnostic probe is the thing that collects it. That is exactly what
+    /// production teardown does when Foundation has lost the exit, which is why
+    /// the composed diagnostic is asserted rather than only its pid. And the
+    /// bounded wait runs on a dedicated `Thread`, per `Tests/CLAUDE.md`
+    /// "Thread-blocking gates run off the cooperative pool": the cooperative
+    /// pool is only as wide as the machine has cores, and parking one of its
+    /// threads for the whole bound starves every suspended task in the process,
+    /// including the ones that would report a failure.
     @Test func theBoundFiresWhenTheExitIsNeverObserved() async throws {
-        let child = try Self.spawnLongLived()
-        defer { BoundedProcessTeardown.killAndReap(child) }
-        let pid = child.processIdentifier
+        let pid = try Self.spawnUnownedLongLived()
+        defer {
+            kill(pid, SIGKILL)
+            var status: Int32 = 0
+            // SIGKILL cannot be blocked, so this is bounded; it returns
+            // immediately with ECHILD when the diagnostic probe already
+            // collected the corpse. Same shape as `SIGTERMProofJob.tearDown` in
+            // the sibling suite.
+            _ = waitpid(pid, &status, 0)
+        }
 
         let stub = ExitNeverObserved(pid: pid)
         let box = OutcomeBox()
@@ -201,17 +256,23 @@ struct BoundedProcessTeardownTests {
             return
         }
         #expect(reportedPID == pid)
+        // Composed, not just the pid: with this test the sole waiter, the probe
+        // must find and collect the corpse, so the branch it reports is itself
+        // part of the contract.
         #expect(
-            diagnostic.contains("\(pid)"),
-            "the diagnostic must name the pid it gave up on: \(diagnostic)")
+            diagnostic.contains("\(pid)")
+                && diagnostic.contains("zombie collected by the teardown diagnostic"),
+            "the diagnostic did not report the corpse it collected: \(diagnostic)")
         #expect(
             elapsed >= .milliseconds(300),
             "the wait returned after \(elapsed), which is short of its own 0.3 s bound")
-
-        #expect(
-            BoundedProcessTeardown.killAndReap(child) == .exited,
-            "the real child the stub borrowed its pid from was not reaped")
     }
+}
+
+/// `posix_spawn` refused. Bare `Error` with the raw code, matching
+/// `FixtureSpawnFailure` in the sibling suite.
+private struct SpawnFailure: Error {
+    let code: Int32
 }
 
 /// The watchdog in the mutation check fired: the bounded wait published no

--- a/scripts/diag/nstask-waituntilexit-stale-entry.swift
+++ b/scripts/diag/nstask-waituntilexit-stale-entry.swift
@@ -164,13 +164,17 @@ guard deallocated else {
 }
 
 // 1. Thread A has now launched a task, so its per-thread list exists.
-threadA.run {
+let listRead = threadA.run {
     guard let raw = getTSD(taskListSlot) else {
         print("thread A has no task list after one launch")
         return
     }
     let list = Unmanaged<CFMutableArray>.fromOpaque(raw).takeUnretainedValue()
     print("thread A task-list count after one launch: \(CFArrayGetCount(list))")
+}
+guard listRead else {
+    print("thread A did not finish reading its task list within its bound")
+    exit(2)
 }
 
 // 2. Thread B launches the task under test; a third party kills it. The loop is

--- a/scripts/diag/nstask-waituntilexit-stale-entry.swift
+++ b/scripts/diag/nstask-waituntilexit-stale-entry.swift
@@ -132,9 +132,12 @@ func finishedProcessIsDeallocated(on worker: Worker) -> Bool {
     // one.
     guard ran else { return false }
     // Bounded poll rather than one fixed sleep: a slow autorelease drain would
-    // otherwise read as a failed premise.
-    let drainDeadline = Date().addingTimeInterval(2)
-    while box.value != nil && Date() < drainDeadline { usleep(10_000) }
+    // otherwise read as a failed premise. Monotonic, like the deadlines in
+    // `BoundedProcessTeardown`, so a wall-clock step cannot stretch or shorten
+    // the bound.
+    let clock = ContinuousClock()
+    let drainDeadline = clock.now.advanced(by: .seconds(2))
+    while box.value != nil && clock.now < drainDeadline { usleep(10_000) }
     return box.value == nil
 }
 
@@ -195,8 +198,9 @@ guard pid > 0 else {
 }
 kill(pid, SIGTERM)
 
-let exitDeadline = Date().addingTimeInterval(10)
-while task.isRunning && Date() < exitDeadline { usleep(5_000) }
+let exitClock = ContinuousClock()
+let exitDeadline = exitClock.now.advanced(by: .seconds(10))
+while task.isRunning && exitClock.now < exitDeadline { usleep(5_000) }
 print("pid \(pid) isRunning=\(task.isRunning) kill(pid, 0)=\(kill(pid, 0))")
 // A child still running is not the hang under test: without this, exit code 1
 // would report "hang reproduced" for a wait that is simply waiting.

--- a/scripts/diag/nstask-waituntilexit-stale-entry.swift
+++ b/scripts/diag/nstask-waituntilexit-stale-entry.swift
@@ -186,11 +186,17 @@ guard !task.isRunning else {
 // 3. Plant the stale entry: thread A's list gets this task's pointer, exactly as
 //    it would have after a task A launched was freed and its address reused.
 var planted = false
-threadA.run {
+let plantFinished = threadA.run {
     guard let raw = getTSD(taskListSlot) else { return }
     let list = Unmanaged<CFMutableArray>.fromOpaque(raw).takeUnretainedValue()
     CFArrayAppendValue(list, Unmanaged.passUnretained(task).toOpaque())
     planted = true
+}
+// Two distinct failures, two distinct messages: a worker that never got to the
+// job at all, and a worker that ran it and found no list to plant into.
+guard plantFinished else {
+    print("thread A did not finish planting the entry within its bound")
+    exit(2)
 }
 guard planted else {
     print("thread A has no per-thread task list to plant into")

--- a/scripts/diag/nstask-waituntilexit-stale-entry.swift
+++ b/scripts/diag/nstask-waituntilexit-stale-entry.swift
@@ -30,11 +30,13 @@
 // EXIT CODES
 //   0  waitUntilExit returned on the thread with the stale entry (no hang)
 //   1  the hang reproduced — waitUntilExit did not return within 3 seconds
-//   2  the probe could not set itself up, or its premise did not hold (no
-//      `_CFGetTSD`, no per-thread list, a finished `Process` that was never
-//      deallocated so no stale entry can arise at all, or a task under test that
-//      never started, or never exited so there is no completed exit for the wait
-//      to observe)
+//   2  the probe could not set itself up, or a premise did not hold. Every
+//      case: `_CFGetTSD` could not be resolved; thread A has no per-thread task
+//      list; a finished `Process` was not deallocated, so no stale entry can
+//      arise at all; the task under test never started; it never exited, so
+//      there is no completed exit for the wait to observe; the plant job did not
+//      finish within its bound; or the control arm hung, which would leave a
+//      step-5 hang unattributable.
 //
 // `_CFGetTSD` is private CoreFoundation API. It is used here only to READ and
 // APPEND TO the per-thread list that Foundation itself creates and populates —
@@ -116,7 +118,7 @@ func launch(_ process: Process) -> Bool {
 /// entry it never earned.
 func finishedProcessIsDeallocated(on worker: Worker) -> Bool {
     let box = WeakProcessBox()
-    worker.run(timeout: 10) {
+    let ran = worker.run(timeout: 10) {
         var task: Process? = make("/usr/bin/true", [])
         if let task, launch(task) {
             // Same-thread launch and wait: this shape is not exposed to the
@@ -126,6 +128,9 @@ func finishedProcessIsDeallocated(on worker: Worker) -> Bool {
         box.value = task
         task = nil
     }
+    // A job that never ran is not a satisfied premise, so it must not read as
+    // one.
+    guard ran else { return false }
     // Bounded poll rather than one fixed sleep: a slow autorelease drain would
     // otherwise read as a failed premise.
     let drainDeadline = Date().addingTimeInterval(2)
@@ -171,7 +176,8 @@ threadA.run {
 // 2. Thread B launches the task under test; a third party kills it. The loop is
 //    counted, not `while :`, so a probe that is itself killed leaves nothing
 //    spinning for longer than five minutes.
-let task = make("/bin/zsh", ["-c", #"trap "" HUP; for _ in {1..1500}; do sleep 0.2; done"#])
+let task = make(
+    "/bin/zsh", ["-f", "-c", #"trap "" HUP; for _ in {1..1500}; do sleep 0.2; done"#])
 if useHandler { task.terminationHandler = { _ in } }
 let launchedOnB = threadB.run(timeout: 10, { _ = launch(task) })
 guard launchedOnB else {
@@ -220,6 +226,14 @@ guard planted else {
 //    blamed on the task rather than on the thread the wait ran on.
 let controlReturned = threadC.run { task.waitUntilExit() }
 print("waitUntilExit on thread C (no entry): \(controlReturned ? "returned" : "HUNG")")
+guard controlReturned else {
+    print(
+        """
+        control failed: waitUntilExit did not return on a thread with no entry, so a hang in \
+        step 5 could not be attributed to the stale entry
+        """)
+    exit(2)
+}
 
 // 5. The hazard: thread A's stale entry says "launched here", but the
 //    notification block went to thread B's run loop and will never run here.

--- a/scripts/diag/nstask-waituntilexit-stale-entry.swift
+++ b/scripts/diag/nstask-waituntilexit-stale-entry.swift
@@ -30,9 +30,11 @@
 // EXIT CODES
 //   0  waitUntilExit returned on the thread with the stale entry (no hang)
 //   1  the hang reproduced — waitUntilExit did not return within 3 seconds
-//   2  the probe could not set itself up (no `_CFGetTSD`, no per-thread list,
-//      or the task under test never started, or never exited so there is no
-//      completed exit for the wait to observe)
+//   2  the probe could not set itself up, or its premise did not hold (no
+//      `_CFGetTSD`, no per-thread list, a finished `Process` that was never
+//      deallocated so no stale entry can arise at all, or a task under test that
+//      never started, or never exited so there is no completed exit for the wait
+//      to observe)
 //
 // `_CFGetTSD` is private CoreFoundation API. It is used here only to READ and
 // APPEND TO the per-thread list that Foundation itself creates and populates —
@@ -124,7 +126,10 @@ func finishedProcessIsDeallocated(on worker: Worker) -> Bool {
         box.value = task
         task = nil
     }
-    usleep(300_000)
+    // Bounded poll rather than one fixed sleep: a slow autorelease drain would
+    // otherwise read as a failed premise.
+    let drainDeadline = Date().addingTimeInterval(2)
+    while box.value != nil && Date() < drainDeadline { usleep(10_000) }
     return box.value == nil
 }
 
@@ -144,7 +149,14 @@ let threadA = Worker("A")
 let threadB = Worker("B")
 let threadC = Worker("C")
 
-print("finished Process deallocated: \(finishedProcessIsDeallocated(on: threadA))")
+let deallocated = finishedProcessIsDeallocated(on: threadA)
+print("finished Process deallocated: \(deallocated)")
+// Enforced, not merely reported: if a finished task is never freed, its entry in
+// the per-thread list stays valid and the reuse this probe plants cannot happen.
+guard deallocated else {
+    print("premise failed: a finished Process was not deallocated, so a stale entry cannot arise")
+    exit(2)
+}
 
 // 1. Thread A has now launched a task, so its per-thread list exists.
 threadA.run {

--- a/scripts/diag/nstask-waituntilexit-stale-entry.swift
+++ b/scripts/diag/nstask-waituntilexit-stale-entry.swift
@@ -1,0 +1,204 @@
+// Deterministic reproduction of the `Process.waitUntilExit()` hang that
+// `Tests/TBDDaemonLiveTests/Process/BoundedProcessTeardown.swift` is the
+// standing defence against.
+//
+// WHAT IT DEMONSTRATES
+//   `Process.run()` appends the task's pointer to a PER-THREAD CFArray (CF
+//   thread-specific-data slot 30), created with NULL callbacks and never pruned
+//   when a task is freed — so the list accumulates dangling pointers of dead
+//   tasks. `waitUntilExit()` reads "my pointer is in THIS thread's list" as
+//   "this thread launched me", and in that case keeps running the run loop until
+//   a termination block has run — a block the exit handler queues onto the
+//   LAUNCHING thread's run loop. Plant one stale entry and the two facts
+//   disagree: the wait runs on a thread the block will never reach, and it spins
+//   forever at 0% CPU with `isRunning` already false.
+//
+//   The probe plants that entry by hand instead of waiting for the allocator to
+//   hand a dead task's address to a live one, which is what happens on its own
+//   in a test process that churns hundreds of short-lived `Process` objects on
+//   long-lived cooperative-pool threads (every `ps` call is one). A standalone
+//   loop hit it unaided at iteration 13 of 300.
+//
+// HOW TO RUN
+//   xcrun swiftc -O -o "$TMPDIR/stale" scripts/diag/nstask-waituntilexit-stale-entry.swift
+//   "$TMPDIR/stale"
+//
+//   Pass --termination-handler to re-run with a `terminationHandler` set on the
+//   task: that path is immune, because the handler forces the exit
+//   notification down a route the waiting thread can observe.
+//
+// EXIT CODES
+//   0  waitUntilExit returned on the thread with the stale entry (no hang)
+//   1  the hang reproduced — waitUntilExit did not return within 3 seconds
+//   2  the probe could not set itself up (no `_CFGetTSD`, no per-thread list,
+//      or the task under test never started)
+//
+// `_CFGetTSD` is private CoreFoundation API. It is used here only to READ and
+// APPEND TO the per-thread list that Foundation itself creates and populates —
+// the probe plants the state, it does not invent a mechanism. Nothing in
+// `Sources/` calls it; this file is a diagnostic and is not linked into any
+// product.
+//
+// Verified on macOS 26.1 (25B78).
+
+import Darwin
+import Foundation
+
+/// A thread with a job queue, so the probe can say exactly which thread runs
+/// which call. `Thread` rather than a `DispatchQueue` because the identity of
+/// the OS thread is the whole subject.
+final class Worker: @unchecked Sendable {
+    private let lock = NSCondition()
+    private var jobs: [() -> Void] = []
+
+    init(_ name: String) {
+        let thread = Thread { [self] in
+            while true {
+                lock.lock()
+                while jobs.isEmpty { lock.wait() }
+                let job = jobs.removeFirst()
+                lock.unlock()
+                autoreleasepool { job() }
+            }
+        }
+        thread.name = name
+        thread.start()
+    }
+
+    /// Runs `job` on this worker and waits, bounded, for it to finish. Returns
+    /// false when the bound fires — which for this probe IS the finding.
+    @discardableResult
+    func run(timeout: Double = 3, _ job: @escaping () -> Void) -> Bool {
+        let done = DispatchSemaphore(value: 0)
+        lock.lock()
+        jobs.append {
+            job()
+            done.signal()
+        }
+        lock.signal()
+        lock.unlock()
+        return done.wait(timeout: .now() + timeout) == .success
+    }
+}
+
+/// Holds a weak reference across the `autoreleasepool` boundary without needing
+/// a weak global.
+final class WeakProcessBox {
+    weak var value: Process?
+}
+
+func make(_ path: String, _ args: [String]) -> Process {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: path)
+    process.arguments = args
+    process.standardInput = FileHandle.nullDevice
+    process.standardOutput = FileHandle.nullDevice
+    process.standardError = FileHandle.nullDevice
+    return process
+}
+
+@discardableResult
+func launch(_ process: Process) -> Bool {
+    do {
+        try process.run()
+        return true
+    } catch {
+        return false
+    }
+}
+
+/// Step 0 — is a finished `Process` deallocated at all? It is, and that is what
+/// makes the per-thread list unsound: the list keeps the raw pointer, the object
+/// behind it goes away, and the next task allocated at that address inherits an
+/// entry it never earned.
+func finishedProcessIsDeallocated(on worker: Worker) -> Bool {
+    let box = WeakProcessBox()
+    worker.run(timeout: 10) {
+        var task: Process? = make("/usr/bin/true", [])
+        if let task, launch(task) {
+            // Same-thread launch and wait: this shape is not exposed to the
+            // defect, and the probe relies on that to get itself set up.
+            task.waitUntilExit()
+        }
+        box.value = task
+        task = nil
+    }
+    usleep(300_000)
+    return box.value == nil
+}
+
+typealias GetTSD = @convention(c) (UInt32) -> UnsafeMutableRawPointer?
+
+guard let getTSDSymbol = dlsym(UnsafeMutableRawPointer(bitPattern: -2), "_CFGetTSD") else {
+    print("could not resolve _CFGetTSD; this probe needs it to read the per-thread task list")
+    exit(2)
+}
+let getTSD = unsafeBitCast(getTSDSymbol, to: GetTSD.self)
+
+/// The slot Foundation stores the per-thread `NSTask` list in.
+let taskListSlot: UInt32 = 30
+
+let useHandler = CommandLine.arguments.contains("--termination-handler")
+let threadA = Worker("A")
+let threadB = Worker("B")
+let threadC = Worker("C")
+
+print("finished Process deallocated: \(finishedProcessIsDeallocated(on: threadA))")
+
+// 1. Thread A has now launched a task, so its per-thread list exists.
+threadA.run {
+    guard let raw = getTSD(taskListSlot) else {
+        print("thread A has no task list after one launch")
+        return
+    }
+    let list = Unmanaged<CFMutableArray>.fromOpaque(raw).takeUnretainedValue()
+    print("thread A task-list count after one launch: \(CFArrayGetCount(list))")
+}
+
+// 2. Thread B launches the task under test; a third party kills it. The loop is
+//    counted, not `while :`, so a probe that is itself killed leaves nothing
+//    spinning for longer than five minutes.
+let task = make("/bin/zsh", ["-c", #"trap "" HUP; for _ in {1..1500}; do sleep 0.2; done"#])
+if useHandler { task.terminationHandler = { _ in } }
+let launchedOnB = threadB.run(timeout: 10, { _ = launch(task) })
+guard launchedOnB else {
+    print("thread B did not launch the task under test in time")
+    exit(2)
+}
+let pid = task.processIdentifier
+guard pid > 0 else {
+    print("the task under test never started")
+    exit(2)
+}
+kill(pid, SIGTERM)
+
+let exitDeadline = Date().addingTimeInterval(10)
+while task.isRunning && Date() < exitDeadline { usleep(5_000) }
+print("pid \(pid) isRunning=\(task.isRunning) kill(pid, 0)=\(kill(pid, 0))")
+
+// 3. Plant the stale entry: thread A's list gets this task's pointer, exactly as
+//    it would have after a task A launched was freed and its address reused.
+var planted = false
+threadA.run {
+    guard let raw = getTSD(taskListSlot) else { return }
+    let list = Unmanaged<CFMutableArray>.fromOpaque(raw).takeUnretainedValue()
+    CFArrayAppendValue(list, Unmanaged.passUnretained(task).toOpaque())
+    planted = true
+}
+guard planted else {
+    print("thread A has no per-thread task list to plant into")
+    exit(2)
+}
+
+// 4. Control: thread C has no entry for this task, so it takes the ordinary
+//    path and returns at once. Without this arm, a hang in step 5 could be
+//    blamed on the task rather than on the thread the wait ran on.
+let controlReturned = threadC.run { task.waitUntilExit() }
+print("waitUntilExit on thread C (no entry): \(controlReturned ? "returned" : "HUNG")")
+
+// 5. The hazard: thread A's stale entry says "launched here", but the
+//    notification block went to thread B's run loop and will never run here.
+let hazardReturned = threadA.run(timeout: 3) { task.waitUntilExit() }
+print("waitUntilExit on thread A (stale entry): \(hazardReturned ? "returned" : "HUNG for 3s")")
+print("isRunning at the end: \(task.isRunning)")
+exit(hazardReturned ? 0 : 1)

--- a/scripts/diag/nstask-waituntilexit-stale-entry.swift
+++ b/scripts/diag/nstask-waituntilexit-stale-entry.swift
@@ -31,7 +31,8 @@
 //   0  waitUntilExit returned on the thread with the stale entry (no hang)
 //   1  the hang reproduced — waitUntilExit did not return within 3 seconds
 //   2  the probe could not set itself up (no `_CFGetTSD`, no per-thread list,
-//      or the task under test never started)
+//      or the task under test never started, or never exited so there is no
+//      completed exit for the wait to observe)
 //
 // `_CFGetTSD` is private CoreFoundation API. It is used here only to READ and
 // APPEND TO the per-thread list that Foundation itself creates and populates —
@@ -175,6 +176,12 @@ kill(pid, SIGTERM)
 let exitDeadline = Date().addingTimeInterval(10)
 while task.isRunning && Date() < exitDeadline { usleep(5_000) }
 print("pid \(pid) isRunning=\(task.isRunning) kill(pid, 0)=\(kill(pid, 0))")
+// A child still running is not the hang under test: without this, exit code 1
+// would report "hang reproduced" for a wait that is simply waiting.
+guard !task.isRunning else {
+    print("the task under test did not exit within 10 s; cannot test the wait")
+    exit(2)
+}
 
 // 3. Plant the stale entry: thread A's list gets this task's pointer, exactly as
 //    it would have after a task A launched was freed and its address reused.


### PR DESCRIPTION
## What's broken

A tier-3 test in `TBDDaemonLiveTests` can stop dead in its teardown and never return. It was observed once during a whole-suite run on a loaded machine: `AgentReaperHolderLegLiveTests.theFlagOffLeavesARealOrphanRunning` sat 21 minutes at 0% CPU inside `killAndReap`, in `Process.waitUntilExit()`. The test passes alone in well under a second and passed on re-run. Because the failure is a stall rather than a red assertion, nothing self-clears: the run burns its whole time budget, and CI executes this target `--no-parallel`, so one occurrence wedges every test queued behind it.

Every test in that file that tears a `Process` down from a `defer` is exposed, not just the one that was caught. The seven siblings have the same shape.

## Why it happens

Foundation's `Process.waitUntilExit()` is not safe to call on a thread other than the one that called `run()`. Confirmed by disassembling `-[NSConcreteTask waitUntilExit]` and its exit handler on macOS 26.1, then reproduced deterministically.

Three facts combine:

- **`run()` records the task in a per-thread list.** The launching thread appends the task's pointer to a thread-local array. That array is created with NULL callbacks, so it does not retain its entries, and nothing removes an entry when the task is deallocated. The list accumulates dangling pointers for the life of the thread.
- **`waitUntilExit()` decides "was this task launched here?" by pointer lookup in that list.** When it finds itself there, it does not stop when the child exits. It keeps running the current thread's run loop until a termination-notification block has run, and the exit handler queues that block onto the *launching* thread's run loop.
- **A recycled address makes a stranger match.** A new `Process` allocated at the address of a freed one, launched on thread B, is claimed by thread A's stale entry. When A later calls `waitUntilExit()`, the block it is waiting for sits on B's run loop and never runs on A. The loop polls the run loop in 62.5 ms slices forever, at 0% CPU, with `isRunning` already false. That is exactly the sample.

The test suite is an ideal incubator. Async tests resume on whichever cooperative-pool thread is free after each `await`, so a `defer` runs on an arbitrary long-lived thread. The suite churns hundreds of short-lived `Process` objects on those same threads (every `ps` call in `ProductionProcessSignaller` is one), which both seeds the stale entries and recycles addresses. Load widens the window by spreading work across more threads; it is not required.

The repo had already met this twice without naming the cause. `ExternalAttachCommandLiveTests` records a run that sat thirteen minutes in `waitUntilExit()` with no child left alive, and `SpawnedPeerHelper` in the peer-helper tests records twenty-four minutes at 0% CPU holding the build lock. Both replaced the call with a private `isRunning` poll and a partial theory. This PR supplies the mechanism they were missing.

Two other candidates were tested and ruled out:

- **A raw `waitpid` stealing the corpse.** No in-process caller can reach a Foundation-owned pid: every raw `waitpid` in `Sources/` and `Tests/` targets a `posix_spawn`'d pid and guards `pid > 0`. And even when the corpse is deliberately stolen (probe: 30 of 30 iterations), Foundation's handler treats `ECHILD` as an exit, clears `isRunning`, and `waitUntilExit()` returns.
- **A lost exit event.** An exit source armed against a child that is already a zombie still fires (probe: 10 of 10), so the exit-before-registration window that `spentPID()`'s `/usr/bin/true` could hit is closed by libdispatch.

## When it broke

Arrived with #781, which introduced the file. It slipped through because the hazard is probabilistic and needs the address reuse plus a cross-thread wait; the test is correct on every run where the allocator does not hand back a dead task's address.

## What this PR does

Test teardown never calls `waitUntilExit()` again.

- **`BoundedProcessTeardown`** (new, in the live test target) replaces it. `killAndReap` sends SIGKILL if the child is still running, then polls `isRunning` every 20 ms against a monotonic deadline (default 5 s, sized to a SIGKILLed child's exit handler under load with orders of magnitude of headroom). `isRunning` is an atomic flag that Foundation's exit handler clears only after its own blocking `waitpid` has collected the corpse, so "not running" is a proof of reaping, not a zombie's answer. When the bound fires the helper returns `.unobserved` with a one-line diagnostic built from `kill(pid, 0)` and one `waitpid(WNOHANG)`, spawning nothing, instead of hanging.
- The helper takes an `ExitObservableProcess` protocol that exposes only `processIdentifier` and `isRunning`. `waitUntilExit()` is not on it, so the helper cannot regress to the blocking call without changing its signature, and a stub can be handed to it for the mutation check.
- `AgentReaperHolderLegLiveTests` routes `killAndReap`, `spentPID`, and `openFiles` through it. `killAndReap` records an issue on `.unobserved`, so a lost exit is now a red test naming the pid and what the kernel said about it. No assertion and no liveness helper changed: the suite still avoids `kill(pid, 0)` for the fixture jobs for the reason its `isRunning(_:)` comment gives.
- `ExternalAttachCommandLiveTests`, in the same target, now routes its private bounded wait through the shared helper instead of carrying a copy. `SpawnedPeerHelper` keeps its own poll: it gives up silently by design, since its teardown runs on failing paths where a recorded issue would attach to the wrong test, and converting it is a semantic choice for a follow-up.
- The reaper suite's long-lived zsh fixture also becomes a counted loop, so a test host killed mid-run cannot leave a shell spinning at ppid 1 that no reconciler can see.
- `scripts/diag/nstask-waituntilexit-stale-entry.swift` is the deterministic reproduction, kept so the claim above can be re-checked on a future macOS.

Sole-waiter discipline is preserved: Foundation remains the only waiter for its pids. The helper has two entry points with different contracts. `awaitExit` observes and never reaps, so a caller may signal the pid afterwards. `killAndReap` sends the SIGKILL itself, and only its expiry path runs the one `waitpid(WNOHANG)` in the helper, as a diagnostic after its own kill and a full bound. The probe above shows Foundation tolerates losing that race.

Why not install a no-op `terminationHandler` instead? The disassembly shows it bypasses the notification path, and the reproduction confirms it (`--termination-handler` returns promptly). But that is an immunity that rests on undocumented internals, and it would leave the teardown unbounded on any other path. Bounding the wait on a documented property is the fix; the handler finding is recorded as evidence.

## Assumptions

- **The failure path parks the calling thread for the bound.** `killAndReap` runs from `defer` in async tests, so a fired bound holds a cooperative-pool thread for up to 5 s. Tests/CLAUDE.md warns that bounding converts a wedge into starvation. That is accepted here knowingly: the previous code parked the same thread forever, the happy path returns in milliseconds, the live target runs `--no-parallel`, and moving every `defer` onto a dedicated thread would reshape eight tests for a path that only runs once something has already failed.
- **The mutation check's watchdog path leaks on purpose.** If the helper ever fails to return, the test declines to reap the fixture, because the helper thread still owns that pid's `waitpid` and a second waiter would race it. That leaves one zombie and one parked thread in the test process for the rest of the run, only on a run that is already red.
- **`isRunning` keeps its current meaning.** The reap proof rests on Foundation clearing the flag after its own `waitpid`, read from the macOS 26.1 disassembly. If a future Foundation clears it earlier, "not running" would no longer imply "collected", and `aRunningChildIsKilledAndCollected` (which asserts `ESRCH` after teardown) is the test that would notice.

## Evidence & verification

**Reproduced, twice.** A standalone loop replicating the test's process mechanics (Foundation child, third-party SIGTERM, `kill(pid, 0)` polling, then `killAndReap` on the task's thread after `await`s) hung at iteration 13 of 300 with `isRunning=false`, `kill(pid,0)=-1`, `waitpid=ECHILD`, and `sample` showing a cooperative-pool thread in `-[NSConcreteTask waitUntilExit] + 340` → `__CFRunLoopRun`. The deterministic script then produced the hang on demand by planting the task's pointer in another thread's list: that thread hangs, a third thread returns at once, and 300 same-thread iterations never hang.

**Discriminating tests** (`BoundedProcessTeardownTests`, tier 3):
- `theBoundFiresWhenTheExitIsNeverObserved` hands the helper a stub whose `isRunning` never flips, backed by a real child spawned with `posix_spawn` so Foundation does not own it and the test is its only waiter. It asserts `.unobserved` arrives after the 0.3 s bound and before a 5 s watchdog, and that the diagnostic reads "zombie collected by the teardown diagnostic", which is the deterministic outcome when nothing else can reap. Remove the deadline and the watchdog reddens it; put `Process` back as the parameter type and it does not compile.
- `aRunningChildIsKilledAndCollected` proves the normal path reaps: `isRunning` false and `kill(pid, 0)` fails with `ESRCH`, which a zombie would not.
- `awaitExitNeverSignals` proves the observe-only path leaves a live child alone.
- `aChildThatAlreadyExitedIsReportedWithoutWaiting` covers the exit-before-teardown ordering the original report singled out.

**Mutation check, run by hand.** With the deadline line deleted from `awaitExit`, `theBoundFiresWhenTheExitIsNeverObserved` failed after 5.06 s with `Caught error: the bounded wait never returned: no outcome was published within the 5 s watchdog for pid …` on the primary failure line, and `awaitExitNeverSignals` failed once its fixture's counted loop ran out. Reverted, rebuilt, both suites green again (15 tests in 2 suites).

**Runs:**
- `scripts/test.sh --no-parallel --filter '^TBDDaemonLiveTests\.'` on the fifth commit: 171 tests in 36 suites passed, 101.4 s, exit 0; two earlier whole-target runs, on the first and fourth commits, also passed 171 tests. On the final (sixth) commit the local run yielded to the remote verification valve after queueing 300 s for the build slot, and CI ran the whole suite instead: 9,254 tests passed, lint green (https://github.com/cheapsteak/tbd/actions/runs/33659237747). The sixth commit's three touched suites also passed locally (25 tests in 3 suites). Five fresh-context review rounds ran across the six commits.
- `scripts/swift-safe build --build-tests`: clean.
- `swiftlint --strict`: 0 violations in 909 files.
- The diag script, compiled from the committed path: exit 1 (hang reproduced) without the flag, exit 0 with `--termination-handler`.

**Production code is not exposed.** Every `waitUntilExit()` in `Sources/` (relocate handler, SSH agent probe, Claude state detector, file viewer) runs on the same thread as its `run()` with no suspension between them, which is the safe shape. `TestSupport/ShellHelpers` likewise. Only a `Process` launched before an `await` and waited after it is at risk; this file was the only such site found.

https://claude.ai/code/session_0189YgLm7fWyVx3hCuYZ7T7g
[fix-process-hang](https://cheapsteak.github.io/tbd/open/?worktree=B42551D4-62BB-4C48-A51F-FA47EC4B62E8)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved live process and terminal-session test reliability with bounded cleanup and exit detection.
  - Added coverage for forced termination, process reaping, already-exited processes, observe-only monitoring, diagnostic reporting, and timeout handling.
  - Prevented test cleanup from waiting indefinitely, with clearer failure diagnostics when processes do not exit as expected.

- **Chores**
  - Added a standalone diagnostic utility for investigating process-wait hangs and distinguishing successful, reproduced, and setup-failure outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->