### PR TITLE
Fix: A pull request you didn't open is invisible to TBD

### DIFF
--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -964,8 +964,9 @@ public final class TBDDatabase: Sendable {
 
         // Number of the GitHub PR a worktree was created from, if any. Nullable —
         // NULL means "not created from a PR". Lets PRStatusManager resolve status
-        // by direct number lookup instead of viewer-authored/branch-name matching,
-        // which is the only way fork PRs (no matching local branch) get tracked.
+        // by direct number lookup instead of head-branch matching, which is the
+        // only way fork PRs (whose head ref lives in the fork, so no query
+        // against this repo's head refs reaches it) get tracked.
         migrator.registerMigration("v54_worktree_pr_number") { db in
             try db.addColumnIfMissing(table: "worktree", column: "pr_number", type: .integer)
         }

--- a/Sources/TBDDaemon/PR/PRBindingCoordinator.swift
+++ b/Sources/TBDDaemon/PR/PRBindingCoordinator.swift
@@ -77,9 +77,10 @@ public actor PRBindingCoordinator {
     ///
     /// Without this such a worktree owns a number and no binding, so its PR is
     /// invisible to `tbd pr list`, to the toolbar dropdown and to the status-bar
-    /// chips. Fork PRs are the sharpest case: a fork head never appears in the
-    /// viewer-authored batch, so branch matching is structurally unable to find
-    /// them and the stored number is the only handle that exists.
+    /// chips. Fork PRs are the sharpest case: a fork PR's head ref lives in the
+    /// fork, so no query against this repo's head refs can reach it, branch
+    /// matching is structurally unable to find them, and the stored number is
+    /// the only handle that exists.
     ///
     /// The source is `.manual` — naming a PR row at creation is as explicit as
     /// an attach — but seeding is **reconciled on every poll**, and `.manual` is

--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -49,7 +49,12 @@ enum PRUndeterminedCause {
 
 /// In-memory cache of GitHub PR status per worktree.
 ///
-/// `fetchAll` runs one batch GraphQL call for all viewer PRs, plus one combined per-PR
+/// `fetchAll` runs repo-scoped GraphQL calls — one per repo the fleet spans,
+/// split again when a repo's worktrees carry more candidate head refs than one
+/// query may ask about, and all of them concurrently. Each carries one aliased
+/// `pullRequests(headRefName:)` field per candidate head branch, so the forge
+/// does the matching and a pull request opened by a bot, a teammate, or
+/// the web UI is found — plus one combined per-PR
 /// GraphQL call (run concurrently) for each OPEN PR whose aggregate rollup isn't SUCCESS —
 /// that call returns the aggregate state, every check context with its `isRequired`
 /// flag, and a pagination flag in a single round trip. `refresh` runs
@@ -388,7 +393,11 @@ public actor PRStatusManager {
     /// Whether a forge CLI could be launched at all — the difference between
     /// "asked and got nothing back" and "there was nobody to ask". An injected
     /// runner counts as available: it is what stands in for the binary.
-    private var forgeCLIAvailable: Bool {
+    ///
+    /// `nonisolated` because the GitHub branch-match path is, and it reads only
+    /// immutable state — a `let` runner and a static path. Isolated callers
+    /// still read it unchanged.
+    private nonisolated var forgeCLIAvailable: Bool {
         ghRunner != nil || Self.resolvedGHPath != nil
     }
 
@@ -595,7 +604,7 @@ public actor PRStatusManager {
         public var disproved: [(worktreeID: UUID, parsed: ParsedPRURL)] = []
     }
 
-    /// Fetch all viewer PRs in one GraphQL call and update cache for all known worktrees.
+    /// Fetch every worktree's pull request state and update the cache for all known worktrees.
     /// worktrees: one `PollWorktree` per active non-main worktree.
     ///
     /// Returns the branch-matched PRs as `ParsedPRURL`s in `discovered` — the
@@ -637,28 +646,32 @@ public actor PRStatusManager {
         // "every considered worktree gets exactly one observation" rule is
         // visible in one place instead of spread across six early exits.
         var outcomes: [UUID: PRObservation.Outcome] = [:]
-        // Worktrees may span multiple repos. repoPath is only gh's working
-        // directory for the viewer batch (gh auth is host-scoped, so any
-        // checkout works); by-number lookups resolve each worktree's own repo.
-        // Any entry's path serves, and every entry has a real directory —
+        // Worktrees may span multiple repos. `repoPath` is only gh's working
+        // directory for the per-PR check queries, which carry their own
+        // owner/name in the query text (gh auth is host-scoped, so any checkout
+        // works); the branch and by-number queries scope themselves to each
+        // worktree's own repo and run in that repo's own checkout. Any entry's
+        // path serves, and every entry has a real directory —
         // `RPCRouter.pollWorkingDirectory` is where that is guaranteed.
         let repoPath = worktrees[0].worktreePath
 
         // Worktrees created from a PR row carry its number; resolve those
-        // directly (a fork PR's head never appears in the viewer-authored batch).
-        // Everything else uses the viewer-batch branch-name matching, scoped to
-        // each worktree's own repo (see `matchUnnumbered`).
+        // directly — a fork PR's head ref lives in the fork, so no query against
+        // this repo's head refs can name it. Everything else is matched by head
+        // branch, scoped to each worktree's own repo (see `matchUnnumbered`).
         let (numbered, unnumbered) = Self.partitionByPRNumber(worktrees) { $0.prNumber }
 
-        // Do NOT clear entries for missing worktrees — the batch query is
-        // limited to 100 PRs across all repos, so older PRs may not appear.
-        // Those entries may have been populated by a targeted `refresh` call.
+        // Do NOT clear entries for missing worktrees. A branch query answers
+        // only about head refs the candidate list could name, so a pull request
+        // on a ref nobody named (a fork head, a rename-push) is absent from the
+        // answer without being absent from the forge — and those entries may
+        // have been populated by a targeted `refresh` call.
         var matches: [(worktreeID: UUID, node: PRNode)] = []
 
         // Which of `matches` came from the branch matcher, so the emitter can
         // tell a branch discovery from a by-number resolution. The two sets are
         // disjoint by construction (the fallback only re-queries worktrees the
-        // batch left unmatched).
+        // branch query left unmatched).
         var branchMatchedIDs: Set<UUID> = []
 
         // Numbered path: one aliased by-number query (skipped when none stored).
@@ -666,21 +679,23 @@ public actor PRStatusManager {
             matches += await fetchNumberedMatches(numbered)
         }
 
-        // Legacy path: viewer-authored batch + branch-name matching, scoped to
-        // each worktree's own repo (the batch spans every repo the viewer
-        // authored PRs in, and the same branch name can exist in several). On a
-        // fetch or parse failure it contributes no matches, but the numbered
-        // path above has already resolved independently.
-        var batchSucceeded = false
-        /// Which failure class the viewer batch hit, when it hit one. Retained
-        /// rather than collapsed to a Bool so an unnumbered worktree's
-        /// `.undetermined` names what actually went wrong.
-        var batchFailureCause = PRUndeterminedCause.queryFailed
-        /// Which unnumbered worktrees are on a GitLab host, which of those a
-        /// project query actually answered for, and — for the ones it matched —
-        /// whether their project gates merges on the pipeline. The GitLab side
-        /// is judged per project rather than by one fleet-wide batch, so
-        /// `batchSucceeded` cannot speak for it.
+        // By-branch path: repo-scoped queries, matched back to each worktree's
+        // own repo (several repos can hold the same branch name, and
+        // `matchUnnumbered` is what keeps one repo's PR off another's worktree).
+        // Both forges degrade per query: one whose query fails contributes no
+        // matches and no answered ids, while the numbered path above has already
+        // resolved independently.
+        /// Which unnumbered GitHub worktrees a repo query actually answered for,
+        /// and which failure class the rest hit. The cause is retained rather
+        /// than collapsed to a Bool so an unnumbered worktree's `.undetermined`
+        /// can say something about why — one value per forge, so read it as a
+        /// display hint rather than a per-worktree verdict (see
+        /// `fetchGitHubBranchMatches`).
+        var gitHubAnsweredIDs: Set<UUID> = []
+        var gitHubFailureCause = PRUndeterminedCause.queryFailed
+        /// The same two facts on the GitLab side, plus which unnumbered
+        /// worktrees are on a GitLab host at all and — for the ones a project
+        /// matched — whether that project gates merges on the pipeline.
         var gitLabUnnumberedIDs: Set<UUID> = []
         var gitLabAnsweredIDs: Set<UUID> = []
         // Keyed only where the project said; see `fetchGitLabBranchMatches`.
@@ -742,31 +757,21 @@ public actor PRStatusManager {
             let gitHubUnnumbered = unnumbered.filter { !gitLabPaths.contains($0.worktreePath) }
             gitLabUnnumberedIDs = Set(gitLabUnnumbered.map(\.id))
 
-            // The viewer batch is GitHub's only branch-matching route, and it is
-            // skipped outright when no worktree is on GitHub — a GitLab-only
+            // GitHub asks each repo about its worktrees' candidate head refs,
+            // in one query per repo per alias-cap chunk, all run concurrently.
+            // Skipped outright when no worktree is on GitHub — a GitLab-only
             // fleet never spawns `gh`.
             if !gitHubUnnumbered.isEmpty {
-                if let jsonData = await runGHGraphQL(repoPath: repoPath) {
-                    if let nodes = try? Self.parsePRNodes(from: jsonData) {
-                        batchSucceeded = true   // empty nodes is still a valid answer (viewer has no PRs)
-                        let branchMatches = Self.matchUnnumbered(gitHubUnnumbered, nodes: nodes,
-                                                                 resolveRepo: { unnumberedRepos[$0] })
-                        branchMatchedIDs.formUnion(branchMatches.map(\.worktreeID))
-                        matches += branchMatches
-                    } else {
-                        logger.warning("Failed to parse GraphQL response")
-                        batchFailureCause = PRUndeterminedCause.unparseableResponse
-                    }
-                } else {
-                    batchFailureCause = forgeCLIAvailable
-                        ? PRUndeterminedCause.queryFailed
-                        : PRUndeterminedCause.cliUnavailable
-                }
+                let gitHub = await fetchGitHubBranchMatches(gitHubUnnumbered, repos: unnumberedRepos)
+                branchMatchedIDs.formUnion(gitHub.matches.map(\.worktreeID))
+                matches += gitHub.matches
+                gitHubAnsweredIDs = gitHub.answeredIDs
+                gitHubFailureCause = gitHub.failureCause
             }
 
-            // GitLab asks the server for the branches instead, one query per
-            // project — author-blind, so a merge request opened through the web
-            // UI or by a teammate is found, which the viewer batch can never do.
+            // GitLab asks the same author-blind question one project at a time,
+            // carrying the whole branch list in a single argument rather than
+            // one alias per branch — the only difference between the two paths.
             if !gitLabUnnumbered.isEmpty {
                 let gitLab = await fetchGitLabBranchMatches(
                     gitLabUnnumbered, repos: unnumberedRepos, hosts: unnumberedHosts)
@@ -778,10 +783,10 @@ public actor PRStatusManager {
             }
         }
 
-        // Fallback: unnumbered worktrees a *successful* batch left unmatched
-        // whose cached status still carries a PR number — resolve those by
-        // number (one extra aliased round trip, only when such worktrees
-        // exist). See `cachedNumberFallback` for the gating rationale.
+        // Fallback: unnumbered worktrees whose own repo answered and left them
+        // unmatched, and whose cached status still carries a PR number —
+        // resolve those by number (one extra aliased round trip, only when such
+        // worktrees exist). See `cachedNumberFallback` for the gating rationale.
         //
         // GitHub worktrees only: both this fallback and the head-ref
         // verification below resolve their numbers through the `gh` by-number
@@ -792,7 +797,7 @@ public actor PRStatusManager {
         let fallback = Self.cachedNumberFallback(
             unnumbered: gitHubUnnumberedEntries,
             matchedIDs: Set(matches.map(\.worktreeID)),
-            batchSucceeded: batchSucceeded,
+            answeredIDs: gitHubAnsweredIDs,
             cachedStatus: { cache[$0] })
         if !fallback.isEmpty {
             matches += await fetchNumberedMatches(fallback)
@@ -834,7 +839,7 @@ public actor PRStatusManager {
         let verificationTargets = Self.headRefVerificationTargets(
             unnumbered: gitHubUnnumberedEntries,
             matchedIDs: Set(matches.map(\.worktreeID)).union(fallback.map(\.id)),
-            batchSucceeded: batchSucceeded,
+            answeredIDs: gitHubAnsweredIDs,
             verifiedIDs: headRefVerifiedIDs,
             cachedStatus: { cache[$0] })
         if !verificationTargets.isEmpty {
@@ -919,13 +924,17 @@ public actor PRStatusManager {
         // - A NUMBERED worktree that did not resolve is always `.undetermined`.
         //   It carries a PR number, so "this branch has no PR" is a conclusion
         //   the evidence cannot support — only the lookup failing can explain it.
-        // - An UNNUMBERED worktree is `.none` only when the viewer batch
-        //   actually parsed. `batchSucceeded` is exactly the "the forge
-        //   answered" predicate the fallback and the head-ref heals already
-        //   gate on: with a failed batch, "unmatched" means nothing at all.
+        // - An UNNUMBERED worktree is `.none` only when the query covering ITS
+        //   OWN repo actually parsed. That per-repo "the forge answered"
+        //   predicate — `gitHubAnsweredIDs` on one forge, `gitLabAnsweredIDs` on
+        //   the other — is exactly what the fallback and the head-ref heals
+        //   already gate on: where no query answered, "unmatched" means nothing
+        //   at all. A worktree whose repo could not be named is grouped into no
+        //   query, so nobody answered for it and it lands here `.undetermined`
+        //   rather than reading as "no pull request".
         //
-        // Worktrees cleared by a head-ref heal land here unmatched and, on a
-        // succeeded batch, correctly read `.none`: the heal's evidence is that
+        // Worktrees cleared by a head-ref heal land here unmatched and, on an
+        // answered repo, correctly read `.none`: the heal's evidence is that
         // the PR belonged to a branch this worktree merely tracks, so this
         // worktree has none of its own.
         for wt in numbered where outcomes[wt.id] == nil && !directRefreshLanded(wt.id, after: batchStartedAt) {
@@ -934,14 +943,17 @@ public actor PRStatusManager {
         for wt in unnumbered where outcomes[wt.id] == nil && !directRefreshLanded(wt.id, after: batchStartedAt) {
             if gitLabUnnumberedIDs.contains(wt.id) {
                 // Judged by the project query that covered THIS worktree, never
-                // by the viewer batch — which was not asked about it, and on a
-                // GitLab-only fleet was not run at all.
+                // by a query that was not asked about it — and on a GitHub-only
+                // fleet was not run at all.
                 outcomes[wt.id] = gitLabAnsweredIDs.contains(wt.id)
                     ? PRObservation.Outcome.none
                     : .undetermined(cause: gitLabFailureCause)
             } else {
-                outcomes[wt.id] = batchSucceeded ? PRObservation.Outcome.none
-                                                 : .undetermined(cause: batchFailureCause)
+                // The symmetric judgment on GitHub: the repo query that covered
+                // THIS worktree, never one that covered some other repo.
+                outcomes[wt.id] = gitHubAnsweredIDs.contains(wt.id)
+                    ? PRObservation.Outcome.none
+                    : .undetermined(cause: gitHubFailureCause)
             }
         }
         for (id, observedOutcome) in outcomes {
@@ -1026,8 +1038,8 @@ public actor PRStatusManager {
     /// The binding-keyed sibling of `fetchAll`'s worktree-keyed path, and
     /// deliberately not a replacement for it: one worktree may own several PRs,
     /// so its answer cannot be a `[worktreeID: PRStatus]`. Bindings already
-    /// carry their own `owner`/`repo`, so this needs neither the viewer batch
-    /// nor `gh repo view` — one aliased `pullRequest(number:)` query per
+    /// carry their own `owner`/`repo`, so this needs neither a branch query nor
+    /// `gh repo view` — one aliased `pullRequest(number:)` query per
     /// (host, owner, repo) group, through the same `numberedPRQuery` /
     /// `parseNumberedPRNodes` / `mapStateAndReason` / `fetchCheckSignals` path
     /// the by-number poll uses.
@@ -1357,7 +1369,8 @@ public actor PRStatusManager {
         case .answered(let nodes, let pipelineGated):
             return .success(nodes: nodes, pipelineGated: pipelineGated)
         case .unreadable:
-            // The same outcome the `gh` arm reaches when `parsePRNodes` throws.
+            // The same outcome the `gh` arm reaches when `parseBranchPRNodes`
+            // returns nil.
             // A response nobody could read settles nothing, so the worktrees it
             // covers record undetermined rather than "no merge request".
             logger.warning("GitLab query for \(projectPath, privacy: .public) returned a response this build could not read")
@@ -1423,9 +1436,10 @@ public actor PRStatusManager {
     /// `isInMergeQueue` nor `mergeQueueEntry`, so a manual refresh through it
     /// would clobber `mergeQueuePosition` back to nil and flicker the bus away
     /// until the next batch poll. The GraphQL path requests the same
-    /// merge-queue field set the batch query does. `gh repo view` resolves the
-    /// checkout's `owner/name` so the query can scope to this repo+branch —
-    /// which, unlike the 100-PR viewer batch, always finds an old PR.
+    /// merge-queue field set the poll's queries do. `gh repo view` resolves the
+    /// checkout's `owner/name` so the query can scope to this repo+branch — the
+    /// same repo-scoped, author-blind question the poll asks, narrowed to the
+    /// one branch a user asked about.
     public func refresh(worktreeID: UUID, branch: String, upstreamBranch: String?, defaultBranch: String?,
                         pushBranch: GitManager.PushBranchResolution,
                         repoPath: String, prNumber: Int? = nil) async -> PRStatus? {
@@ -2004,11 +2018,16 @@ public actor PRStatusManager {
         """
     }
 
-    /// Single-PR refresh query: the same per-PR field set as the batch query
-    /// (including `mergeQueueEntry { position }`), scoped to one repo + head
-    /// branch. Ordered newest-first so `parsePRByBranch` can pick the best node
-    /// without a separate `createdAt` tiebreak. `first: 10` covers a branch
-    /// reused across a closed+reopened PR pair.
+    /// Single-PR refresh query: one repo + head branch, asking for the fields
+    /// this path renders. It shares the poll's `mergeQueueEntry { position }` —
+    /// the field this note exists for, since a refresh that dropped it would
+    /// blank a merge-queue chip the poll had just set — but it is deliberately
+    /// not `prNodeFieldSelection` itself, which additionally carries `title`,
+    /// `headRefName`, `baseRefName`, `createdAt` and `statusCheckRollup { state
+    /// }`, none of which this path has anywhere to put. Ordered newest-first so
+    /// `parsePRByBranch` can pick the best node without a separate `createdAt`
+    /// tiebreak. `first: 10` covers a branch reused across a closed+reopened
+    /// PR pair.
     ///
     /// `owner`/`name`/`branch` are GraphQL **variables**, never interpolated
     /// into the query text: a git ref may legally contain `"`, and interpolating
@@ -2216,9 +2235,10 @@ public actor PRStatusManager {
     }
 
     /// Split poll inputs by whether the worktree carries a stored PR number.
-    /// Numbered entries resolve via a direct `pullRequest(number:)` lookup (the
-    /// only way to reach a fork PR, whose head never appears in the viewer batch);
-    /// the rest fall through to the legacy viewer-authored branch-name matching.
+    /// Numbered entries resolve via a direct `pullRequest(number:)` lookup — the
+    /// only way to reach a fork PR, whose head ref lives in the fork and so
+    /// appears under none of this repo's head refs. The rest are matched by head
+    /// branch against their own repo's pull requests.
     static func partitionByPRNumber<T>(_ items: [T], prNumber: (T) -> Int?) -> (numbered: [T], unnumbered: [T]) {
         var numbered: [T] = []
         var unnumbered: [T] = []
@@ -2228,39 +2248,44 @@ public actor PRStatusManager {
         return (numbered, unnumbered)
     }
 
-    /// Select the unnumbered worktrees the viewer batch left unmatched whose
+    /// Select the unnumbered worktrees the branch query left unmatched whose
     /// cached status still carries a PR number, rewriting each with that number
-    /// so `fetchNumberedMatches` can resolve it directly. Once 100 newer PRs
-    /// exist, an old PR falls out of the viewer-authored batch (first 100 by
-    /// CREATED_AT DESC) and the cached number is the only remaining handle —
-    /// without it the stale cached status (e.g. "in merge queue") persists
-    /// forever and the merged transition / auto-archive never fires. Batch
-    /// matches always win: a branch re-pointed to a NEW PR must not get pinned
-    /// to the stale cached number, so only unmatched worktrees fall back.
+    /// so `fetchNumberedMatches` can resolve it directly.
     ///
-    /// `batchSucceeded` must reflect whether the viewer batch actually parsed
-    /// (empty nodes still counts — the viewer legitimately has no PRs). On a
-    /// fetch/parse failure "unmatched" means nothing, and falling back would
-    /// resolve stale cached numbers for branches that may point at NEW PRs
-    /// (worst case: a stale MERGED number fires auto-archive off an unrelated
-    /// PR) — keeping the stale cache on failure is the pre-existing, safe
-    /// behavior, so a failed batch yields no fallback at all.
+    /// The branch query is repo-scoped and asks about every candidate head ref,
+    /// so what it cannot see is precisely a pull request on a head ref no
+    /// candidate names — a fork head, a rename-push nothing tracks — and for
+    /// those the cached number is the only remaining handle. Without it the stale cached
+    /// status (e.g. "in merge queue") persists forever and the merged transition
+    /// / auto-archive never fires. Branch matches always win: a branch
+    /// re-pointed to a NEW pull request must not get pinned to the stale cached
+    /// number, so only unmatched worktrees fall back.
+    ///
+    /// `answeredIDs` is the set of worktrees whose own repo query actually
+    /// parsed (an empty node list still counts — a repo legitimately has no pull
+    /// request on that branch). For a worktree outside it "unmatched" means
+    /// nothing, and falling back would resolve a stale cached number for a
+    /// branch that may point at a NEW pull request (worst case: a stale MERGED
+    /// number fires auto-archive off an unrelated PR) — keeping the stale cache
+    /// is the safe direction, so an unanswered worktree yields no fallback. The
+    /// gate is per worktree rather than fleet-wide: one repo going dark must not
+    /// suspend the fallback for every other repo in the fleet.
     ///
     /// Terminal cached states are excluded: `.merged` has no further transition
     /// to observe, and `.closed` would otherwise be a permanent per-poll
     /// by-number re-query — a reopened PR is recovered by the on-select
-    /// `refresh()` path (or a restored batch match), not this fallback. The
+    /// `refresh()` path (or a restored branch match), not this fallback. The
     /// merged-transition case is unaffected: the pre-transition cached state is
     /// non-terminal by definition.
     static func cachedNumberFallback(
         unnumbered: [PollWorktree],
         matchedIDs: Set<UUID>,
-        batchSucceeded: Bool,
+        answeredIDs: Set<UUID>,
         cachedStatus: (UUID) -> PRStatus?
     ) -> [PollWorktree] {
-        guard batchSucceeded else { return [] }
-        return unnumbered.compactMap { wt in
-            guard !matchedIDs.contains(wt.id),
+        unnumbered.compactMap { wt in
+            guard answeredIDs.contains(wt.id),
+                  !matchedIDs.contains(wt.id),
                   let cached = cachedStatus(wt.id),
                   cached.state != .merged, cached.state != .closed else { return nil }
             return (wt.id, wt.branch, wt.upstreamBranch, wt.defaultBranch, wt.pushBranch,
@@ -2277,11 +2302,12 @@ public actor PRStatusManager {
         "\(owner.lowercased())\u{1}\(name.lowercased())\u{1}\(branch)"
     }
 
-    /// Build the (repo, branch) → best-PR lookup used by the legacy (unnumbered)
-    /// path. The viewer batch spans every repo the viewer authored PRs in, and
-    /// the same branch name can legitimately exist in several of them; keying on
-    /// branch alone handed one repo's PR to another repo's worktree (and
-    /// persisted it) — the cross-repo collision this fix removes. Nodes whose
+    /// Build the (repo, branch) → best-PR lookup used by the by-branch
+    /// (unnumbered) path. One pass carries nodes from every repo the fleet
+    /// spans, and the same branch name legitimately exists in several of them;
+    /// keying on branch alone handed one repo's PR to another repo's worktree
+    /// (and persisted it) — the cross-repo collision this scoping removes.
+    /// Nodes whose
     /// URL doesn't parse to owner/name are dropped: they cannot be scoped, and
     /// an unscoped match is exactly the bug. When multiple PRs share a
     /// repo+branch, pick the best: highest state priority
@@ -2306,10 +2332,11 @@ public actor PRStatusManager {
         return byKey
     }
 
-    /// Match unnumbered worktrees against the viewer batch, scoped to each
-    /// worktree's own repo: a node only matches when its URL's owner/name
-    /// equals the worktree's resolved repo. Candidate order is preserved
-    /// (own branch first, then any tracked/push branch — see `branchCandidates`). A worktree
+    /// Match unnumbered worktrees against the nodes a branch query returned,
+    /// scoped to each worktree's own repo: a node only matches when its URL's
+    /// owner/name equals the worktree's resolved repo. Candidate order is
+    /// preserved (own branch first, then any tracked/push branch — see
+    /// `branchCandidates`). A worktree
     /// whose repo can't be resolved gets NO match, so the caller keeps its
     /// cached status — the same degrade behavior as the numbered path
     /// (`groupNumberedByRepo`); matching it unscoped could apply another
@@ -2364,10 +2391,11 @@ public actor PRStatusManager {
 
     /// Matches this worktree can be *positively shown* to be mis-attached to.
     ///
-    /// A clear deletes state a user cannot recreate once the PR ages out of the
-    /// 100-PR viewer batch, so "not a candidate" alone is not enough to justify
-    /// one. `matches` reaches here from two producers with different strengths:
-    /// the viewer batch matches BY CANDIDATE, but `cachedNumberFallback` →
+    /// A clear deletes state a user cannot recreate once the PR's head ref drops
+    /// off the candidate list, so "not a candidate" alone is not enough to
+    /// justify one. `matches` reaches here from two producers with different
+    /// strengths: the branch query matches BY CANDIDATE, but
+    /// `cachedNumberFallback` →
     /// `fetchNumberedMatches` resolves BY NUMBER and never consults candidates.
     /// So a momentarily narrower candidate list would otherwise turn a
     /// conservative failure-to-attach into a destructive delete.
@@ -2435,9 +2463,10 @@ public actor PRStatusManager {
     /// deliberately never re-queries — precisely the ones that would otherwise
     /// display a mis-attached PR forever.
     ///
-    /// `batchSucceeded` gates it for the same reason the fallback is gated: on a
-    /// fetch/parse failure every worktree is "unmatched" and the word means
-    /// nothing. Absence of evidence is not proof of mis-attachment.
+    /// `answeredIDs` gates it for the same reason the fallback is gated, and per
+    /// worktree for the same reason: where this worktree's own repo query did
+    /// not parse, it is "unmatched" only because nobody asked, and the word
+    /// means nothing. Absence of evidence is not proof of mis-attachment.
     ///
     /// Worktrees that could never satisfy `headRefMismatchedMatches` — a
     /// `.lookupFailed` push resolution, no known tracked branch, or no known
@@ -2446,13 +2475,13 @@ public actor PRStatusManager {
     static func headRefVerificationTargets(
         unnumbered: [PollWorktree],
         matchedIDs: Set<UUID>,
-        batchSucceeded: Bool,
+        answeredIDs: Set<UUID>,
         verifiedIDs: Set<UUID>,
         cachedStatus: (UUID) -> PRStatus?
     ) -> [PollWorktree] {
-        guard batchSucceeded else { return [] }
-        return unnumbered.compactMap { wt in
-            guard !matchedIDs.contains(wt.id),
+        unnumbered.compactMap { wt in
+            guard answeredIDs.contains(wt.id),
+                  !matchedIDs.contains(wt.id),
                   !verifiedIDs.contains(wt.id),
                   wt.pushBranch != .lookupFailed,
                   wt.upstreamBranch != nil, wt.defaultBranch != nil,
@@ -2462,17 +2491,18 @@ public actor PRStatusManager {
         }
     }
 
-    /// The per-PR field selection shared by the viewer batch and the by-number
+    /// The per-PR field selection shared by the branch query and the by-number
     /// aliased query, so the two can't drift and both parse into `PRNode`.
     /// `title` rides along because it is what turns a bare `#21156` into
     /// something a person can decide about. It is a real addition to the poll's
-    /// payload, not a free one: this selection is shared with the viewer batch,
-    /// which pulls up to 100 PRs, so it costs one short string per PR per pass
-    /// there — and those titles are discarded, since only the by-number path
-    /// has a binding row to persist them onto. One title is a rounding error
-    /// beside the check rollup the same node already carries, and splitting the
-    /// selection in two to avoid it would give up the guarantee that the two
-    /// queries cannot drift and both parse into `PRNode`.
+    /// payload, not a free one: the branch query pulls this selection for up to
+    /// ten pull requests per candidate branch, so it costs one short string per
+    /// pull request per pass there — and those titles are discarded, since only
+    /// the by-number path has a binding row to persist them onto. Ten per branch
+    /// is a narrow bill, and one title is a rounding error beside the check
+    /// rollup the same node already carries; splitting the selection in two to
+    /// avoid it would give up the guarantee that the two queries cannot drift
+    /// and both parse into `PRNode`.
     static let prNodeFieldSelection =
         "number url title state mergeStateStatus reviewDecision headRefName baseRefName createdAt isDraft "
         + "statusCheckRollup { state } mergeQueueEntry { position }"
@@ -2494,6 +2524,153 @@ public actor PRStatusManager {
         """
     }
 
+    /// One aliased query asking a repo about several head refs in a single
+    /// round trip: `b0: pullRequests(headRefName: $b0, …)` etc. under the repo
+    /// object, `first: 10` each so a branch reused across a closed-and-reopened
+    /// pair is fully covered, newest-first so `bestNodeByRepoBranch`'s
+    /// `createdAt` tiebreak and the server agree.
+    ///
+    /// Repo-scoped and author-blind: it asks what pull requests exist on these
+    /// head refs, not who opened them, so a pull request from a bot, a teammate,
+    /// or the web UI is found exactly as the author's own is.
+    ///
+    /// Every branch is a declared `String!` **variable**, and its text appears
+    /// nowhere in the query: a git ref may legally contain `"`, and
+    /// interpolating `headRefName: "\(branch)"` for a branch like `foo"bar`
+    /// produced a malformed query. `branchPRsArgs` binds the values as
+    /// raw-string fields.
+    static func branchPRsQuery(aliasCount: Int) -> String {
+        let variables = (["$owner: String!", "$name: String!"]
+                         + (0..<aliasCount).map { "$b\($0): String!" }).joined(separator: ", ")
+        let selections = (0..<aliasCount).map {
+            "b\($0): pullRequests(headRefName: $b\($0), first: 10, "
+            + "orderBy: {field: CREATED_AT, direction: DESC}) { nodes { \(prNodeFieldSelection) } }"
+        }.joined(separator: "\n    ")
+        return """
+        query(\(variables)) {
+          repository(owner: $owner, name: $name) {
+            \(selections)
+          }
+        }
+        """
+    }
+
+    /// The `gh api graphql` argument vector for the branch query, binding
+    /// `owner`, `name` and one `b<N>` per branch as GraphQL variables. Uses `-f`
+    /// (raw string), not `-F` (typed): the variables are declared `String!`, and
+    /// `-F` would coerce a branch named like a number or `true`/`false`/`null`
+    /// into the wrong JSON type and be rejected. Passing the branches as fields
+    /// — not interpolated text — also makes a `"` in any ref harmless.
+    ///
+    /// An **empty `branches` yields an empty argument vector**, and an empty
+    /// vector means "there is nothing to ask" rather than "ask about nothing".
+    /// A zero-alias document is `repository(owner: $owner, name: $name) { }` —
+    /// an empty selection set, which is not a valid GraphQL document — so
+    /// returning `[]` here makes that document unrepresentable through the only
+    /// path that ever runs one, instead of leaving it merely unreached behind a
+    /// caller's guard. Callers treat an empty vector as a skip.
+    static func branchPRsArgs(owner: String, name: String, branches: [String]) -> [String] {
+        guard !branches.isEmpty else { return [] }
+        var args = [
+            "api", "graphql",
+            "-f", "query=\(branchPRsQuery(aliasCount: branches.count))",
+            "-f", "owner=\(owner)",
+            "-f", "name=\(name)"
+        ]
+        for (index, branch) in branches.enumerated() {
+            args += ["-f", "b\(index)=\(branch)"]
+        }
+        return args
+    }
+
+    /// The most head refs one branch query may carry.
+    ///
+    /// Not a limit the forge imposes. Measured against a real large monorepo, 96
+    /// aliases came back in 3.96 s and 288 aliases in 5.25 s, both at a GraphQL
+    /// rate-limit cost of 3 points — so the cap is not rescuing a query that
+    /// would otherwise fail today. It buys two other things. First, blast
+    /// radius: `pullRequests` is a non-null `PullRequestConnection!`, so an
+    /// error on ONE aliased field null-propagates up to the nullable
+    /// `repository`, and `parseBranchPRNodes` then reads the whole response as
+    /// "the forge did not answer" — one bad head ref would otherwise cost every
+    /// worktree in that repo its answer, every poll, for as long as it stayed
+    /// bad. Second, headroom: a repository much larger than the one measured
+    /// stays inside GitHub's request timeout.
+    static let branchQueryAliasCap = 50
+
+    /// Split one repo's poll entries into the chunks its branch queries ask
+    /// about, each holding at most `branchQueryAliasCap` distinct head refs.
+    ///
+    /// **Chunked by worktree, never by branch, and that is load-bearing.**
+    /// `matchUnnumbered` walks a worktree's candidates in priority order and
+    /// takes the first hit. Split one worktree's candidates across two chunks
+    /// and a failure of the chunk holding candidate[0] would let candidate[1] —
+    /// the branch this worktree merely tracks, or its push target — answer in
+    /// its place, attaching the worktree to its SECOND-choice branch's pull
+    /// request while its own branch's pull request went unseen. That is a
+    /// mis-attachment, and this file's mis-attachments reach
+    /// `onMergedTransition` and auto-archive, so a second-choice answer is not a
+    /// smaller version of the right one.
+    ///
+    /// Chunking by worktree instead makes a chunk atomic over whole worktrees: a
+    /// failed chunk contributes no matches and no answered ids for exactly the
+    /// worktrees in it, and its siblings are unaffected. A chunk therefore
+    /// always holds at least one worktree, even one whose own candidate list
+    /// exceeds the cap — a worktree nobody can ask about is strictly worse than
+    /// one oversized query.
+    static func branchQueryChunks(
+        _ entries: [PollWorktree]
+    ) -> [(entries: [PollWorktree], branches: [String])] {
+        var chunks: [(entries: [PollWorktree], branches: [String])] = []
+        var currentEntries: [PollWorktree] = []
+        var currentBranches: [String] = []
+        for wt in entries {
+            let combined = orderedUniqueBranches(currentBranches + candidatesFor(wt))
+            if !currentEntries.isEmpty && combined.count > branchQueryAliasCap {
+                chunks.append((entries: currentEntries, branches: currentBranches))
+                currentEntries = [wt]
+                currentBranches = orderedUniqueBranches(candidatesFor(wt))
+                continue
+            }
+            currentEntries.append(wt)
+            currentBranches = combined
+        }
+        if !currentEntries.isEmpty {
+            chunks.append((entries: currentEntries, branches: currentBranches))
+        }
+        return chunks
+    }
+
+    /// Pure parse of the branch query's aliased response, flattened to one node
+    /// list for `matchUnnumbered` to scope and rank.
+    ///
+    /// **nil and `[]` are different answers, and the distinction is the whole
+    /// point of the `PRObservation` vocabulary this feeds.** nil means the forge
+    /// did not answer — no `data`, or a null/absent `repository` (renamed,
+    /// inaccessible, or a token that lost access), so the worktrees this query
+    /// covered learned nothing and must record `.undetermined`. `[]` means it
+    /// answered and there is no pull request on any of these head refs, which is
+    /// settled knowledge a program can act on.
+    ///
+    /// An alias that is absent or null is skipped rather than failing the whole
+    /// response: `gh api graphql` emits partial `data` alongside per-node
+    /// errors, and one unreadable branch says nothing about the others.
+    static func parseBranchPRNodes(from data: Data, aliasCount: Int) -> [PRNode]? {
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let dataObj = root["data"] as? [String: Any],
+              let repository = dataObj["repository"] as? [String: Any] else {
+            logger.debug("fetchAll: branch query response carried no repository object; the forge did not answer")
+            return nil
+        }
+        var out: [PRNode] = []
+        for index in 0..<aliasCount {
+            guard let alias = repository["b\(index)"] as? [String: Any],
+                  let nodes = alias["nodes"] as? [Any] else { continue }
+            out += nodes.compactMap { $0 as? [String: Any] }.compactMap(prNode(from:))
+        }
+        return out
+    }
+
     /// Pure parse of the by-number aliased response. Each alias maps to a
     /// worktree; a null/absent `pullRequest` (deleted or inaccessible PR) or a
     /// malformed shape yields no match for that worktree — never a crash.
@@ -2511,19 +2688,7 @@ public actor PRStatusManager {
         }
     }
 
-    public static func parsePRNodes(from data: Data) throws -> [PRNode] {
-        guard let root = try JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let dataObj = root["data"] as? [String: Any],
-              let viewer = dataObj["viewer"] as? [String: Any],
-              let prs = viewer["pullRequests"] as? [String: Any],
-              let nodes = prs["nodes"] as? [Any] else {
-            throw PRStatusError.invalidJSON
-        }
-
-        return nodes.compactMap { $0 as? [String: Any] }.compactMap(prNode(from:))
-    }
-
-    /// Extract one `PRNode` from a GraphQL PR object, shared by the viewer-batch
+    /// Extract one `PRNode` from a GraphQL PR object, shared by the branch-query
     /// parse and the by-number parse (same `prNodeFieldSelection`).
     static func prNode(from node: [String: Any]) -> PRNode? {
         guard let number = node["number"] as? Int,
@@ -2642,7 +2807,8 @@ public actor PRStatusManager {
         // `gh api graphql` exits non-zero when ANY node errors (a stale/deleted/
         // inaccessible fork PR) yet still emits usable `data` for the rest. Parse
         // whatever came back rather than discarding the whole batch — mirrors
-        // `runGHGraphQL`'s partial-results tolerance (regression guard, PR #208).
+        // the branch and by-number queries' partial-results tolerance
+        // (regression guard, PR #208).
         if result.exitStatus != 0 {
             let errSuffix = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
             logger.debug("listOpenPRs: gh graphql exited \(result.exitStatus, privacy: .public) with partial data: \(errSuffix, privacy: .public)")
@@ -3030,9 +3196,9 @@ public actor PRStatusManager {
     }
 
     /// Resolve stored PR numbers directly via aliased `pullRequest(number:)`
-    /// queries — the only way to reach a fork PR, whose head branch never
-    /// appears in the viewer-authored batch. Each worktree's number is scoped
-    /// to its OWN repo: one aliased query per repo group (see
+    /// queries — the only way to reach a fork PR, whose head ref lives in the
+    /// fork and so appears under none of this repo's head refs. Each
+    /// worktree's number is scoped to its OWN repo: one aliased query per repo group (see
     /// `groupNumberedByRepo`), with the TTL cache keeping `gh repo view`
     /// spawns bounded. Degrades per group to no matches on any failure
     /// (owner/name unresolved, gh missing, non-zero exit, unparseable); the
@@ -3088,16 +3254,207 @@ public actor PRStatusManager {
         return matches
     }
 
+    /// Branch matching on GitHub: repo-scoped queries with each candidate head
+    /// ref bound to its own aliased `pullRequests(headRefName:)` field.
+    ///
+    /// The sibling of `fetchGitLabBranchMatches`, and deliberately the same
+    /// shape. Both ask the forge itself, scoped to one repository or project and
+    /// blind to who authored anything, so a pull request opened by a bot, a
+    /// teammate, or the web UI is found exactly as the authenticated account's
+    /// own is. They differ only in how the branch list is carried: GitHub takes
+    /// one head ref per aliased field, GitLab takes the whole list in a single
+    /// argument.
+    ///
+    /// **Chunked, and run concurrently.** Each repo's entries are split by
+    /// `branchQueryChunks` into queries of at most `branchQueryAliasCap`
+    /// distinct head refs (that cap states why), and every (repo, chunk) query
+    /// runs inside one `withTaskGroup` rather than one after another — the poll
+    /// interval this feeds is 30 seconds (`GitPollingPolicy.prInterval`), which
+    /// a serial walk of a many-repo fleet has no business spending. The fan-out
+    /// is unbounded, matching the `signalsByID` fan-out `fetchAll` already runs
+    /// over every match — a far larger set than the repo chunks here — so this
+    /// introduces no concurrency shape the same function does not already have.
+    /// Results are folded back in the chunks' first-seen order, so two runs of
+    /// the same poll cannot disagree about anything an ordering could decide.
+    ///
+    /// Degrades per chunk: a chunk whose query fails contributes no matches and
+    /// no answered ids, so its worktrees keep whatever they had and record
+    /// `.undetermined` rather than "no pull request", while every other chunk —
+    /// in this repo and in every other — is unaffected. A worktree whose repo
+    /// could not be named lands in no group at all, so nobody answers for it and
+    /// it degrades the same way — which is why the question is asked per repo
+    /// rather than once for the fleet: a worktree that could not even be asked
+    /// about must never read as "there is no pull request here".
+    ///
+    /// `failureCause` is a single value for the whole call, overwritten by each
+    /// failing chunk in fold order. So with two differently-failing repos every
+    /// unanswered worktree records the last cause folded, and a worktree whose
+    /// repo could not be named records the initial default though no query was
+    /// ever issued on its behalf. That is tolerable because the cause is
+    /// display-only — it reaches a tooltip — while the distinction that carries
+    /// weight, answered versus not, is `answeredIDs` and is per worktree. The
+    /// GitLab sibling behaves the same way.
+    ///
+    /// Matching goes through `matchUnnumbered` rather than a second matcher, and
+    /// that is what gives these results their precedence for free. It already
+    /// scopes each node to the worktree's own repo by parsing the node URL,
+    /// already walks `candidatesFor` in priority order, and already picks the
+    /// best node per repo+branch through `bestNodeByRepoBranch` — highest
+    /// `prPriority` (OPEN > MERGED > CLOSED), then newest `createdAt`. That is
+    /// the same precedence `parsePRByBranch` applies for the single-PR refresh,
+    /// said the same way (the query's `CREATED_AT DESC` order and the `createdAt`
+    /// tiebreak express one rule), so a branch carrying a closed pull request
+    /// and a newer open one — a reopen, or a second attempt at the same work —
+    /// resolves to the open one through code that is already tested.
+    ///
+    /// KNOWN RESIDUAL, in the spirit of the list at `branchCandidates`: a fork
+    /// pull request whose head ref name collides with a local branch.
+    /// `repository.pullRequests(headRefName:)` filters on the head **ref name**
+    /// regardless of which repository that head lives in, so a pull request an
+    /// outside fork opened into this repo comes back too. `prNodeFieldSelection`
+    /// carries no `isCrossRepository`, and `parseOwnerRepo(fromURL:)` reads the
+    /// BASE repo out of a fork pull request's URL, so such a node satisfies
+    /// every scoping check here and can be matched to a local worktree whose
+    /// branch happens to share that name.
+    ///
+    /// Cross-repository nodes are deliberately **not** filtered out.
+    /// `resolveNameWithOwner` resolves the *base* repo for a fork checkout on
+    /// purpose — that is where a fork's pull requests actually live — so for
+    /// anyone working from a fork every pull request of theirs is
+    /// cross-repository, and dropping those would remove branch discovery for
+    /// them entirely. The collision is accepted instead: it takes an outside
+    /// fork opening a pull request into this repo whose head ref name exactly
+    /// equals a local worktree's branch, TBD's own branches are
+    /// `tbd/<slug>`-shaped, and the actions a mis-attachment could trigger on
+    /// merge are default-off. The same exposure is already carried by
+    /// `prByBranchQuery`, which the interactive `refresh()` runs, and by the
+    /// GitLab `sourceBranches` path — it is a property of asking a forge by head
+    /// ref, not of asking it per repo. Closing it needs a fact the poll does not
+    /// resolve: the worktree's own HEAD-repository identity, which `gh repo
+    /// view` deliberately does not report.
+    private nonisolated func fetchGitHubBranchMatches(
+        _ unnumbered: [PollWorktree],
+        repos: [String: (owner: String, name: String)]
+    ) async -> (matches: [(worktreeID: UUID, node: PRNode)],
+                answeredIDs: Set<UUID>,
+                failureCause: String) {
+        // One group per repo, so several worktrees in one repo share as few
+        // round trips as the alias cap allows — the same economy the aliased
+        // by-number query buys. A worktree whose repo could not be resolved is
+        // in no group, so it is never answered for.
+        var order: [String] = []
+        var groups: [String: (owner: String, name: String, entries: [PollWorktree])] = [:]
+        for wt in unnumbered {
+            guard let repo = repos[wt.worktreePath] else { continue }
+            let key = "\(repo.owner.lowercased())\u{1}\(repo.name.lowercased())"
+            if groups[key] == nil {
+                groups[key] = (repo.owner, repo.name, [])
+                order.append(key)
+            }
+            groups[key]?.entries.append(wt)
+        }
+
+        // Flatten the groups into (repo, chunk) queries in first-seen order.
+        // That order is what makes the fold below deterministic; the queries
+        // themselves are all issued at once.
+        var queries: [(owner: String, name: String, repoPath: String,
+                       entries: [PollWorktree], branches: [String])] = []
+        for key in order {
+            guard let group = groups[key] else { continue }
+            for chunk in Self.branchQueryChunks(group.entries) where !chunk.branches.isEmpty {
+                queries.append((owner: group.owner, name: group.name,
+                                repoPath: chunk.entries[0].worktreePath,
+                                entries: chunk.entries, branches: chunk.branches))
+            }
+        }
+
+        typealias ChunkResult = (matches: [(worktreeID: UUID, node: PRNode)],
+                                 answered: Set<UUID>,
+                                 failureCause: String?)
+        let results = await withTaskGroup(
+            of: (index: Int, result: ChunkResult).self,
+            returning: [Int: ChunkResult].self
+        ) { group in
+            for (index, query) in queries.enumerated() {
+                group.addTask {
+                    let chunkResult = await self.fetchGitHubBranchChunk(
+                        owner: query.owner, name: query.name, repoPath: query.repoPath,
+                        entries: query.entries, branches: query.branches, repos: repos)
+                    return (index: index, result: chunkResult)
+                }
+            }
+            var out: [Int: ChunkResult] = [:]
+            for await finished in group { out[finished.index] = finished.result }
+            return out
+        }
+
+        var matches: [(worktreeID: UUID, node: PRNode)] = []
+        var answered: Set<UUID> = []
+        var failureCause = PRUndeterminedCause.queryFailed
+        for index in queries.indices {
+            guard let result = results[index] else { continue }
+            matches += result.matches
+            answered.formUnion(result.answered)
+            if let cause = result.failureCause { failureCause = cause }
+        }
+        return (matches: matches, answeredIDs: answered, failureCause: failureCause)
+    }
+
+    /// One branch query: the round trip, the parse, and the match for exactly
+    /// the worktrees this chunk carries — the unit `fetchGitHubBranchMatches`
+    /// fans out over.
+    ///
+    /// A failure yields no matches AND no answered ids, so the chunk's worktrees
+    /// keep whatever they had and record `.undetermined` rather than "no pull
+    /// request". `failureCause` is nil exactly when the chunk answered.
+    private nonisolated func fetchGitHubBranchChunk(
+        owner: String,
+        name: String,
+        repoPath: String,
+        entries: [PollWorktree],
+        branches: [String],
+        repos: [String: (owner: String, name: String)]
+    ) async -> (matches: [(worktreeID: UUID, node: PRNode)],
+                answered: Set<UUID>,
+                failureCause: String?) {
+        let args = Self.branchPRsArgs(owner: owner, name: name, branches: branches)
+        // Belt and braces beside `branchPRsArgs`' own empty-vector rule: with
+        // nothing to ask about there is no query to run, and the only query
+        // there would be to run is an invalid document.
+        guard !args.isEmpty else { return (matches: [], answered: [], failureCause: nil) }
+        guard let result = await runGHResult(args: args, repoPath: repoPath),
+              let data = Self.graphQLOutputData(stdout: result.stdout) else {
+            logger.debug("fetchAll: branch query produced no data for \(owner, privacy: .public)/\(name, privacy: .public)")
+            return (matches: [], answered: [],
+                    failureCause: forgeCLIAvailable
+                        ? PRUndeterminedCause.queryFailed
+                        : PRUndeterminedCause.cliUnavailable)
+        }
+        // `gh api graphql` exits non-zero when ONE aliased field errors while
+        // still emitting usable `data` for the others. Parse whatever came
+        // back regardless of exit status; log the partial failure
+        // (regression guard, PR #208).
+        if result.exitStatus != 0 {
+            let errSuffix = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+            logger.debug("fetchAll: branch query exited \(result.exitStatus, privacy: .public) with partial data for \(owner, privacy: .public)/\(name, privacy: .public): \(errSuffix, privacy: .public)")
+        }
+        guard let nodes = Self.parseBranchPRNodes(from: data, aliasCount: branches.count) else {
+            logger.warning("fetchAll: branch query for \(owner, privacy: .public)/\(name, privacy: .public) returned a response this build could not read")
+            return (matches: [], answered: [],
+                    failureCause: PRUndeterminedCause.unparseableResponse)
+        }
+        // An empty node list is still an answer: this repo has no pull request
+        // on any of these head refs.
+        return (matches: Self.matchUnnumbered(entries, nodes: nodes, resolveRepo: { repos[$0] }),
+                answered: Set(entries.map(\.id)),
+                failureCause: nil)
+    }
+
     /// Branch matching on GitLab: one `sourceBranches` query per project.
     ///
-    /// The counterpart of `runGHGraphQL` + `matchUnnumbered`, and deliberately
-    /// shaped differently. GitHub can only be asked for the *viewer's* pull
-    /// requests, so branch matching there is a local join over whatever the
-    /// authenticated account happens to have authored. GitLab takes the branch
-    /// list as a query argument with no author filter, so the instance does the
-    /// matching and a merge request opened by a teammate or through the web UI
-    /// is found — the coverage gap that makes this the discovery route worth
-    /// having.
+    /// The sibling of `fetchGitHubBranchMatches`, which states the shape both
+    /// share; the only difference here is that the whole branch list rides in
+    /// one query argument instead of one aliased field per branch.
     ///
     /// Degrades per project: a project whose query fails contributes no matches
     /// and no answered ids, so its worktrees keep whatever they had and record
@@ -3178,35 +3535,6 @@ public actor PRStatusManager {
             out.append(branch)
         }
         return out
-    }
-
-    private nonisolated func runGHGraphQL(repoPath: String) async -> Data? {
-        let query = """
-        {
-          viewer {
-            pullRequests(first: 100, states: [OPEN, MERGED, CLOSED],
-                         orderBy: {field: CREATED_AT, direction: DESC}) {
-              nodes { \(Self.prNodeFieldSelection) }
-            }
-          }
-        }
-        """
-        let args = ["api", "graphql", "-f", "query=\(query)"]
-        guard let result = await runGHResult(args: args, repoPath: repoPath),
-              let data = Self.graphQLOutputData(stdout: result.stdout) else {
-            return nil
-        }
-
-        if result.exitStatus != 0 {
-            let errSuffix = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
-            if errSuffix.isEmpty {
-                logger.debug("gh graphql exited \(result.exitStatus, privacy: .public) with partial stdout")
-            } else {
-                logger.debug("gh graphql exited \(result.exitStatus, privacy: .public) with partial stdout: \(errSuffix, privacy: .public)")
-            }
-        }
-
-        return data
     }
 
     /// One combined GraphQL round trip for a PR's check signals.

--- a/Sources/TBDShared/PRBinding.swift
+++ b/Sources/TBDShared/PRBinding.swift
@@ -4,7 +4,7 @@ import Foundation
 /// and so a manual attach can be told apart from an inferred one.
 public enum PRBindingSource: String, Codable, Sendable, CaseIterable {
     case hook       // scraped from a `gh pr create` tool result
-    case branch     // matched by head branch against the viewer's PRs
+    case branch     // matched by head branch against the repo's PRs, whoever opened them
     case manual     // `tbd pr attach`, or seeded from Worktree.prNumber
 }
 

--- a/Tests/TBDDaemonTests/PRObservationRecordingTests.swift
+++ b/Tests/TBDDaemonTests/PRObservationRecordingTests.swift
@@ -15,7 +15,7 @@ import TestSupport
 // is producible: an implementation that recorded `.none` for both would satisfy
 // "records an observation" and still be the bug.
 
-/// A `gh` stand-in whose viewer batch and by-number lookups can each be told to
+/// A `gh` stand-in whose branch query and by-number lookups can each be told to
 /// succeed with given nodes, return no output at all, or return garbage.
 /// `acme/acme-prod` is a placeholder, as everywhere in this suite.
 private actor ScriptedGH {
@@ -28,33 +28,32 @@ private actor ScriptedGH {
         case garbage
     }
 
-    private var viewer: Answer
+    private var branch: Answer
     private let byNumber: [Int: String]
     private let byNumberAnswer: Answer
     private let checkSignals: Answer
 
-    init(viewer: Answer = .nodes([]),
+    init(branch: Answer = .nodes([]),
          byNumber: [Int: String] = [:],
          byNumberAnswer: Answer = .nodes([]),
          checkSignals: Answer = .nodes([])) {
-        self.viewer = viewer
+        self.branch = branch
         self.byNumber = byNumber
         self.byNumberAnswer = byNumberAnswer
         self.checkSignals = checkSignals
     }
 
-    /// Change what the viewer batch answers, so one manager can see a pull
+    /// Change what the branch query answers, so one manager can see a pull
     /// request change between two polls.
-    func replaceViewer(_ answer: Answer) { viewer = answer }
+    func replaceBranchAnswer(_ answer: Answer) { branch = answer }
 
     func run(args: [String], repoPath: String) -> GHCommandResult? {
         if args.first == "repo" { return GHCommandResult(stdout: #"{"nameWithOwner":"acme/acme-prod","url":"https://github.com/acme/acme-prod"}"#) }
         guard let query = args.first(where: { $0.hasPrefix("query=") }) else { return nil }
-        if query.contains("viewer {") {
-            switch viewer {
+        if BranchQueryStub.isBranchQuery(query) {
+            switch branch {
             case .nodes(let nodes):
-                return GHCommandResult(
-                    stdout: #"{"data":{"viewer":{"pullRequests":{"nodes":[\#(nodes.joined(separator: ","))]}}}}"#)
+                return BranchQueryStub.response(args: args, nodes: nodes)
             case .noOutput: return nil
             case .garbage: return GHCommandResult(stdout: "{\"nope\":true}")
             }
@@ -127,7 +126,7 @@ struct PRObservationRecordingTests {
         // An empty node list from a query that PARSED is the forge saying "no
         // pull request here" — settled knowledge a program can act on.
         let wt = UUID()
-        let manager = Self.makeManager(ScriptedGH(viewer: .nodes([])))
+        let manager = Self.makeManager(ScriptedGH(branch: .nodes([])))
 
         await manager.fetchAll(worktrees: [Self.worktree(wt)])
 
@@ -140,7 +139,7 @@ struct PRObservationRecordingTests {
     @Test("a failed batch records .undetermined with a cause, never .none")
     func failedBatchRecordsUndetermined() async {
         let wt = UUID()
-        let manager = Self.makeManager(ScriptedGH(viewer: .noOutput))
+        let manager = Self.makeManager(ScriptedGH(branch: .noOutput))
 
         await manager.fetchAll(worktrees: [Self.worktree(wt)])
 
@@ -156,7 +155,7 @@ struct PRObservationRecordingTests {
     @Test("an unparseable response is undetermined and names the parse failure")
     func unparseableResponseNamesItsCause() async {
         let wt = UUID()
-        let manager = Self.makeManager(ScriptedGH(viewer: .garbage))
+        let manager = Self.makeManager(ScriptedGH(branch: .garbage))
 
         await manager.fetchAll(worktrees: [Self.worktree(wt)])
 
@@ -170,8 +169,8 @@ struct PRObservationRecordingTests {
         // side so the assertion is about the pair, not about either alone.
         let answered = UUID()
         let unreachable = UUID()
-        let answeredManager = Self.makeManager(ScriptedGH(viewer: .nodes([])))
-        let unreachableManager = Self.makeManager(ScriptedGH(viewer: .noOutput))
+        let answeredManager = Self.makeManager(ScriptedGH(branch: .nodes([])))
+        let unreachableManager = Self.makeManager(ScriptedGH(branch: .noOutput))
 
         await answeredManager.fetchAll(worktrees: [Self.worktree(answered)])
         await unreachableManager.fetchAll(worktrees: [Self.worktree(unreachable)])
@@ -197,7 +196,7 @@ struct PRObservationRecordingTests {
         // implementation that dropped the other.
         let wt = UUID()
         let gh = ScriptedGH(
-            viewer: .nodes([Self.nodeJSON(number: 12, head: "tbd/w", rollup: "FAILURE")]),
+            branch: .nodes([Self.nodeJSON(number: 12, head: "tbd/w", rollup: "FAILURE")]),
             checkSignals: .noOutput)
         let manager = Self.makeManager(gh)
         let cached = PRStatus(number: 12, url: "https://github.com/acme/acme-prod/pull/12",
@@ -214,7 +213,7 @@ struct PRObservationRecordingTests {
     @Test("a failed fetch with no prior status does not invent .none")
     func failedFetchWithNoCacheDoesNotInventNone() async {
         let wt = UUID()
-        let manager = Self.makeManager(ScriptedGH(viewer: .noOutput))
+        let manager = Self.makeManager(ScriptedGH(branch: .noOutput))
 
         await manager.fetchAll(worktrees: [Self.worktree(wt)])
 
@@ -247,7 +246,7 @@ struct PRObservationRecordingTests {
     func resolvedPRStampsObservedAt() async {
         let wt = UUID()
         let manager = Self.makeManager(
-            ScriptedGH(viewer: .nodes([Self.nodeJSON(number: 12, head: "tbd/w")])))
+            ScriptedGH(branch: .nodes([Self.nodeJSON(number: 12, head: "tbd/w")])))
 
         await manager.fetchAll(worktrees: [Self.worktree(wt)])
 
@@ -269,7 +268,7 @@ struct PRObservationRecordingTests {
         // SQLite transaction per worktree per cadence, forever, on a fleet
         // whose steady state was zero. Change detection is `sameValue(as:)`.
         let wt = UUID()
-        let gh = ScriptedGH(viewer: .nodes([Self.nodeJSON(number: 12, head: "tbd/w")]))
+        let gh = ScriptedGH(branch: .nodes([Self.nodeJSON(number: 12, head: "tbd/w")]))
         let later = Self.stamp.addingTimeInterval(600)
         let clock = MutableStamp(Self.stamp)
         let manager = PRStatusManager(
@@ -313,9 +312,9 @@ struct PRObservationRecordingTests {
             ghRunner: { args, _ in
                 if args.first == "repo" { return GHCommandResult(stdout: #"{"nameWithOwner":"acme/acme-prod","url":"https://github.com/acme/acme-prod"}"#) }
                 guard let query = args.first(where: { $0.hasPrefix("query=") }) else { return nil }
-                // Everything except the viewer batch fails: that outage is what
+                // Everything except the branch query fails: that outage is what
                 // the user's refresh runs into.
-                guard query.contains("viewer {") else { return nil }
+                guard BranchQueryStub.isBranchQuery(query) else { return nil }
                 if interrupt.claim() {
                     clock.value = refreshedAt
                     _ = await box.value?.refresh(
@@ -323,8 +322,7 @@ struct PRObservationRecordingTests {
                         defaultBranch: "main", pushBranch: .noPushDestination,
                         repoPath: "/wt/acme-prod")
                 }
-                return GHCommandResult(
-                    stdout: #"{"data":{"viewer":{"pullRequests":{"nodes":[]}}}}"#)
+                return BranchQueryStub.response(args: args, nodes: [])
             },
             now: { clock.value })
         box.set(manager)
@@ -345,7 +343,7 @@ struct PRObservationRecordingTests {
     @Test("retain drops the outcomes of worktrees that left the fleet, and keeps the values")
     func retainBoundsTheOutcomeMapToTheActiveFleet() async {
         let alive = UUID(), archived = UUID()
-        let manager = Self.makeManager(ScriptedGH(viewer: .nodes([])))
+        let manager = Self.makeManager(ScriptedGH(branch: .nodes([])))
         await manager.seedForTesting(
             worktreeID: archived,
             status: PRStatus(number: 5, url: "https://github.com/acme/acme-prod/pull/5",
@@ -368,7 +366,7 @@ struct PRObservationRecordingTests {
     @Test("a pull request whose value changed is persisted")
     func aChangedValueStillPersists() async {
         let wt = UUID()
-        let gh = ScriptedGH(viewer: .nodes([Self.nodeJSON(number: 12, head: "tbd/w")]))
+        let gh = ScriptedGH(branch: .nodes([Self.nodeJSON(number: 12, head: "tbd/w")]))
         let clock = MutableStamp(Self.stamp)
         let manager = PRStatusManager(
             ghRunner: { args, path in await gh.run(args: args, repoPath: path) },
@@ -377,7 +375,7 @@ struct PRObservationRecordingTests {
         await manager.setOnStatusPersist { id, status in await persisted.record(id, status) }
 
         await manager.fetchAll(worktrees: [Self.worktree(wt)])
-        await gh.replaceViewer(.nodes([Self.nodeJSON(number: 12, head: "tbd/w", state: "CLOSED")]))
+        await gh.replaceBranchAnswer(.nodes([Self.nodeJSON(number: 12, head: "tbd/w", state: "CLOSED")]))
         clock.value = Self.stamp.addingTimeInterval(600)
         await manager.fetchAll(worktrees: [Self.worktree(wt)])
 

--- a/Tests/TBDDaemonTests/PRPollReconcileTests.swift
+++ b/Tests/TBDDaemonTests/PRPollReconcileTests.swift
@@ -287,9 +287,10 @@ struct PRPollReconcileTests {
         #expect(afterFirst.map(\.number) == [90])
         #expect(afterFirst.first?.source == .branch)
 
-        // Poll 2: `@{push}` now resolves and the branch query no longer offers the PR,
-        // so the cached number is re-resolved — and its head turns out to be the
-        // branch this worktree merely TRACKS, which is the repo default. The
+        // Poll 2: the branch query answers with nothing, so this worktree is
+        // answered-but-unmatched and its cached number is re-resolved — and its
+        // head turns out to be the branch this worktree merely TRACKS, which is
+        // the repo default. The
         // heal clears the cache; without this fix the binding row survived,
         // kept driving the icon, and on merge auto-archived the worktree.
         await harness.gh.set(branchNodes: [])

--- a/Tests/TBDDaemonTests/PRPollReconcileTests.swift
+++ b/Tests/TBDDaemonTests/PRPollReconcileTests.swift
@@ -20,18 +20,19 @@ struct PRPollReconcileTests {
 
     // MARK: - Scripted `gh`
 
-    /// Answers the four query shapes a poll issues: `repo view`, the viewer
-    /// batch, the aliased by-number lookup, and the per-PR check query. Nodes
-    /// are green (`SUCCESS`), so the check query is never reached.
+    /// Answers the four query shapes a poll issues: `repo view`, the
+    /// repo-scoped branch query, the aliased by-number lookup, and the per-PR
+    /// check query. Nodes are green (`SUCCESS`), so the check query is never
+    /// reached.
     ///
     /// Mutable between polls, which is the whole point: a heal is a *later*
     /// pass contradicting an earlier one.
     private actor ScriptedGH {
         var nameWithOwner = "acme/acme-prod"
-        var viewerNodes: [String] = []
+        var branchNodes: [String] = []
         var nodesByNumber: [Int: String] = [:]
 
-        func set(viewerNodes: [String]) { self.viewerNodes = viewerNodes }
+        func set(branchNodes: [String]) { self.branchNodes = branchNodes }
         func set(nodesByNumber: [Int: String]) { self.nodesByNumber = nodesByNumber }
 
         func run(args: [String], repoPath: String) -> GHCommandResult? {
@@ -43,10 +44,8 @@ struct PRPollReconcileTests {
             }
             guard let query = args.first(where: { $0.hasPrefix("query=") }) else { return nil }
             if query.contains("commits(last: 1)") { return nil }
-            if query.contains("viewer {") {
-                return GHCommandResult(
-                    stdout: "{\"data\":{\"viewer\":{\"pullRequests\":{\"nodes\":["
-                        + viewerNodes.joined(separator: ",") + "]}}}}")
+            if BranchQueryStub.isBranchQuery(query) {
+                return BranchQueryStub.response(args: args, nodes: branchNodes)
             }
             if query.contains("pullRequest(number:") {
                 let fields = Self.aliasedNumbers(inQuery: query).map { alias, number in
@@ -280,20 +279,20 @@ struct PRPollReconcileTests {
         let harness = try await Harness()
         let wt = try await harness.newWorktree()
 
-        // Poll 1: the viewer batch matches the worktree's own branch, so the
-        // branch matcher binds PR #90.
-        await harness.gh.set(viewerNodes: [Self.nodeJSON(number: 90, head: "tbd/feature")])
+        // Poll 1: the branch query answers with the worktree's own branch, so
+        // the branch matcher binds PR #90.
+        await harness.gh.set(branchNodes: [Self.nodeJSON(number: 90, head: "tbd/feature")])
         #expect(await harness.poll())
         let afterFirst = try await harness.bindings(wt)
         #expect(afterFirst.map(\.number) == [90])
         #expect(afterFirst.first?.source == .branch)
 
-        // Poll 2: `@{push}` now resolves and the batch no longer offers the PR,
+        // Poll 2: `@{push}` now resolves and the branch query no longer offers the PR,
         // so the cached number is re-resolved — and its head turns out to be the
         // branch this worktree merely TRACKS, which is the repo default. The
         // heal clears the cache; without this fix the binding row survived,
         // kept driving the icon, and on merge auto-archived the worktree.
-        await harness.gh.set(viewerNodes: [])
+        await harness.gh.set(branchNodes: [])
         await harness.gh.set(nodesByNumber: [90: Self.nodeJSON(number: 90, head: "main")])
         #expect(await harness.poll())
 
@@ -370,7 +369,7 @@ struct PRPollReconcileTests {
 
         // #1 resolves green by branch match and by number; #2 does not resolve,
         // so it keeps its previous failing status.
-        await harness.gh.set(viewerNodes: [Self.nodeJSON(number: 1, head: "tbd/feature")])
+        await harness.gh.set(branchNodes: [Self.nodeJSON(number: 1, head: "tbd/feature")])
         await harness.gh.set(nodesByNumber: [1: Self.nodeJSON(number: 1, head: "tbd/feature")])
         #expect(await harness.poll())
 
@@ -535,11 +534,11 @@ struct PRPollReconcileTests {
         try await harness.db.worktrees.setAutoHibernateOnMerge(id: wt, value: true)
         #expect(try await harness.bindings(wt).isEmpty)
 
-        // The viewer batch offers PR #30, already MERGED, on the worktree's own
+        // The branch query offers PR #30, already MERGED, on the worktree's own
         // branch: `fetchAll` matches it (firing the un-bound fallback) and the
         // branch matcher binds it in the same pass.
         let merged = Self.nodeJSON(number: 30, head: "tbd/feature", state: "MERGED")
-        await harness.gh.set(viewerNodes: [merged])
+        await harness.gh.set(branchNodes: [merged])
         await harness.gh.set(nodesByNumber: [30: merged])
         #expect(await harness.poll())
 

--- a/Tests/TBDDaemonTests/PRPollRemoteLaneTests.swift
+++ b/Tests/TBDDaemonTests/PRPollRemoteLaneTests.swift
@@ -316,6 +316,14 @@ private actor RecordingGH {
         recordedPaths.append(repoPath)
         if args.first == "repo" { return GHCommandResult(stdout: #"{"nameWithOwner":"acme/acme-prod","url":"https://github.com/acme/acme-prod"}"#) }
         guard let query = args.first(where: { $0.hasPrefix("query=") }) else { return nil }
+        // The aliased branch query the poll issues, checked before the
+        // single-branch refresh query below: both select `pullRequests(headRefName:)`,
+        // and only the poll's binds `$b0`.
+        if BranchQueryStub.isBranchQuery(query) {
+            let nodes = prsByBranch.sorted { $0.value < $1.value }
+                .map { Self.node(number: $0.value, head: $0.key) }
+            return BranchQueryStub.response(args: args, nodes: nodes)
+        }
         if query.contains("pullRequests(headRefName:") {
             guard let branch = args.first(where: { $0.hasPrefix("branch=") })?
                 .dropFirst("branch=".count) else { return nil }
@@ -323,12 +331,6 @@ private actor RecordingGH {
             let node = prsByBranch[String(branch)].map { Self.node(number: $0, head: String(branch)) }
             return GHCommandResult(
                 stdout: #"{"data":{"repository":{"pullRequests":{"nodes":[\#(node ?? "")]}}}}"#)
-        }
-        if query.contains("viewer {") {
-            let nodes = prsByBranch.sorted { $0.value < $1.value }
-                .map { Self.node(number: $0.value, head: $0.key) }
-            return GHCommandResult(
-                stdout: #"{"data":{"viewer":{"pullRequests":{"nodes":[\#(nodes.joined(separator: ","))]}}}}"#)
         }
         if query.contains("pullRequest(number:") {
             let fields = Self.aliasedNumbers(inQuery: query).map { alias, number in

--- a/Tests/TBDDaemonTests/PRPollerTests.swift
+++ b/Tests/TBDDaemonTests/PRPollerTests.swift
@@ -23,11 +23,11 @@ import TestSupport
 // (auto-archive, auto-hibernate-on-merge) would silently stop firing. `pr.list`
 // is that second driver's obvious hiding place, so it gets its own test.
 
-/// A `gh` stand-in that counts viewer-batch queries and answers with a fixed
-/// node list. `acme/acme-prod` is a placeholder, as everywhere in this suite.
+/// A `gh` stand-in that counts branch queries and answers with a fixed node
+/// list. `acme/acme-prod` is a placeholder, as everywhere in this suite.
 private actor CountingGH {
     private let nodes: [String]
-    private(set) var viewerQueries = 0
+    private(set) var branchQueries = 0
 
     init(nodes: [String] = []) {
         self.nodes = nodes
@@ -36,10 +36,9 @@ private actor CountingGH {
     func run(args: [String], repoPath: String) -> GHCommandResult? {
         if args.first == "repo" { return GHCommandResult(stdout: #"{"nameWithOwner":"acme/acme-prod","url":"https://github.com/acme/acme-prod"}"#) }
         guard let query = args.first(where: { $0.hasPrefix("query=") }) else { return nil }
-        guard query.contains("viewer {") else { return nil }
-        viewerQueries += 1
-        return GHCommandResult(
-            stdout: #"{"data":{"viewer":{"pullRequests":{"nodes":[\#(nodes.joined(separator: ","))]}}}}"#)
+        guard BranchQueryStub.isBranchQuery(query) else { return nil }
+        branchQueries += 1
+        return BranchQueryStub.response(args: args, nodes: nodes)
     }
 }
 
@@ -131,7 +130,7 @@ struct PRPollerTests {
         await clock.advanceWhenSuspended(by: Self.tick)
         await clock.waitForSuspension()
 
-        let queries = await gh.viewerQueries
+        let queries = await gh.branchQueries
         #expect(queries == 1, "expected 1 daemon-driven fetch with no app connected, observed \(queries)")
         #expect(await manager.allStatuses()[wtID]?.number == 41)
         await poller.stop()
@@ -153,7 +152,7 @@ struct PRPollerTests {
         await clock.advanceWhenSuspended(by: Self.tick)
         await clock.waitForSuspension()
 
-        let queries = await gh.viewerQueries
+        let queries = await gh.branchQueries
         #expect(queries == 1, "expected the 30s foreground cadence to be due after one 150s tick, observed \(queries) fetches")
         await poller.stop()
     }
@@ -175,12 +174,12 @@ struct PRPollerTests {
         await clock.advanceWhenSuspended(by: Self.tick)
         await clock.waitForSuspension()
 
-        let early = await gh.viewerQueries
+        let early = await gh.branchQueries
         #expect(early == 0, "150s waited against the 300s background cadence should not have fetched; observed \(early)")
 
         await clock.advanceWhenSuspended(by: Self.tick)
         await clock.waitForSuspension()
-        let after = await gh.viewerQueries
+        let after = await gh.branchQueries
         #expect(after == 1, "the 300s background cadence should be due after two 150s ticks, observed \(after)")
         await poller.stop()
     }
@@ -235,7 +234,7 @@ struct PRPollerTests {
         #expect(beforeResponse.success)
         let before = try beforeResponse.decodeResult(PRListResult.self)
         #expect(before.statuses.isEmpty)
-        #expect(await gh.viewerQueries == 0, "pr.list must not fetch while the daemon clock owns the poll")
+        #expect(await gh.branchQueries == 0, "pr.list must not fetch while the daemon clock owns the poll")
 
         // Now the poller's tick supplies the fact — and the edge.
         await router.prPoller.tick()
@@ -244,7 +243,7 @@ struct PRPollerTests {
 
         #expect(after.statuses[wtID]?.state == .merged)
         #expect(await recorder.count == 1)
-        #expect(await gh.viewerQueries == 1, "exactly one driver should have fetched")
+        #expect(await gh.branchQueries == 1, "exactly one driver should have fetched")
     }
 
     @Test("repeated pr.list calls neither fetch nor re-fire the edge")
@@ -269,7 +268,7 @@ struct PRPollerTests {
         for _ in 0..<3 {
             _ = await router.handle(RPCRequest(method: RPCMethod.prList))
         }
-        let beforeFetches = await gh.viewerQueries
+        let beforeFetches = await gh.branchQueries
         #expect(beforeFetches == 0, "pr.list must never fetch; observed \(beforeFetches) fetches over 3 calls")
         #expect(await recorder.count == 0)
 
@@ -282,7 +281,7 @@ struct PRPollerTests {
         let result = try response.decodeResult(PRListResult.self)
 
         #expect(result.statuses[wtID]?.state == .merged)
-        let fetches = await gh.viewerQueries
+        let fetches = await gh.branchQueries
         #expect(fetches == 1, "only the poller's single tick should have fetched, observed \(fetches)")
         let count = await recorder.count
         #expect(count == 1, "expected exactly 1 merged transition, observed \(count)")

--- a/Tests/TBDDaemonTests/PRProvenanceSeedingTests.swift
+++ b/Tests/TBDDaemonTests/PRProvenanceSeedingTests.swift
@@ -7,9 +7,9 @@ import TestSupport
 /// A worktree created from a PR row carries `Worktree.prNumber` and, before
 /// this, no binding — so its PR was invisible to `tbd pr list`, to the toolbar
 /// dropdown and to the status-bar chips. Fork PRs are the sharpest case: a fork
-/// head never appears in the viewer-authored batch, so branch matching is
-/// structurally unable to find them and the stored number is the only handle
-/// that exists.
+/// head lives in the fork, so it appears under none of the base repo's head refs
+/// — branch matching is structurally unable to find them and the stored number
+/// is the only handle that exists.
 ///
 /// Two levels are covered here: the coordinator's `seedProvenance` policy, and
 /// the poll call site that actually runs it.

--- a/Tests/TBDDaemonTests/PRStatusManagerBindingTests.swift
+++ b/Tests/TBDDaemonTests/PRStatusManagerBindingTests.swift
@@ -7,10 +7,10 @@ import TestSupport
 
 // MARK: - Injected `gh`
 
-/// A stand-in for the `gh` CLI answering the three query shapes the binding
+/// A stand-in for the `gh` CLI answering the four query shapes the binding
 /// refresh and the branch-match emitter issue: `repo view` (owner/name), the
 /// aliased by-number lookup (one per repo group), the per-PR check-signal
-/// query, and the viewer batch.
+/// query, and the repo-scoped branch query.
 ///
 /// It records every aliased query with the repo it was scoped to, so a test can
 /// assert not just the resulting statuses but how many round trips — and to
@@ -20,20 +20,20 @@ private actor BindingGH {
     private let nodes: [String: String]
     /// Check-detail JSON keyed by PR number.
     private let checks: [Int: String]
-    private let viewerNodes: [String]
+    private let branchNodes: [String]
     private let aliasedSucceeds: Bool
 
     private(set) var aliasedQueries: [(owner: String, name: String, numbers: [Int])] = []
     private(set) var checkQueries: [Int] = []
-    private(set) var viewerQueries = 0
+    private(set) var branchQueries = 0
 
     init(nodes: [String: String] = [:],
          checks: [Int: String] = [:],
-         viewerNodes: [String] = [],
+         branchNodes: [String] = [],
          aliasedSucceeds: Bool = true) {
         self.nodes = nodes
         self.checks = checks
-        self.viewerNodes = viewerNodes
+        self.branchNodes = branchNodes
         self.aliasedSucceeds = aliasedSucceeds
     }
 
@@ -55,10 +55,9 @@ private actor BindingGH {
             return GHCommandResult(stdout: detail)
         }
 
-        if query.contains("viewer {") {
-            viewerQueries += 1
-            return GHCommandResult(
-                stdout: #"{"data":{"viewer":{"pullRequests":{"nodes":[\#(viewerNodes.joined(separator: ","))]}}}}"#)
+        if BranchQueryStub.isBranchQuery(query) {
+            branchQueries += 1
+            return BranchQueryStub.response(args: args, nodes: branchNodes)
         }
 
         if query.contains("pullRequest(number:") {
@@ -231,11 +230,11 @@ private actor GitLabFake {
 
 /// A `gh` that can answer nothing, only count what it was asked.
 private actor GHCallLog {
-    private(set) var viewerQueries = 0
+    private(set) var branchQueries = 0
 
     func record(_ args: [String]) -> GHCommandResult? {
-        if args.contains(where: { $0.hasPrefix("query=") && $0.contains("viewer {") }) {
-            viewerQueries += 1
+        if args.contains(where: { $0.hasPrefix("query=") && BranchQueryStub.isBranchQuery($0) }) {
+            branchQueries += 1
         }
         return nil
     }
@@ -647,7 +646,7 @@ struct PRStatusManagerBindingTests {
     @Test("fetchAll emits a branch-matched PR as a ParsedPRURL for the coordinator")
     func emitsBranchMatches() async {
         let wt = UUID()
-        let gh = BindingGH(viewerNodes: [Self.nodeJSON(number: 89, head: "tbd/my-branch")])
+        let gh = BindingGH(branchNodes: [Self.nodeJSON(number: 89, head: "tbd/my-branch")])
         let manager = Self.manager(gh)
 
         let emitted = await manager.fetchAll(worktrees: [Self.pollWorktree(wt)]).discovered
@@ -662,19 +661,43 @@ struct PRStatusManagerBindingTests {
         #expect(await manager.allStatuses()[wt]?.number == 89)
     }
 
-    @Test("a head-ref-mismatched match is healed away and never emitted")
+    @Test("a healed match is dropped while a legitimate one is still emitted")
     func healedMatchIsNotEmitted() async {
-        // The PR's head is the branch this worktree merely tracks, and that
-        // branch is the repo default — the heal clears it, so binding it would
-        // durably attach the base branch's PR.
-        let wt = UUID()
-        let gh = BindingGH(viewerNodes: [Self.nodeJSON(number: 90, head: "main")])
+        // Two worktrees in one repo, so the emitter has to DISCRIMINATE rather
+        // than come back empty by construction.
+        //
+        // `healed` carries a cached #90, and the branch query answers with
+        // nothing on its own branch, so `cachedNumberFallback` re-resolves that
+        // number — the only producer whose match can be head-ref mismatched,
+        // since a branch match is matched BY candidate and so always names one.
+        // #90's head is `main`: the branch this worktree merely tracks, and the
+        // repo default. The heal clears it before the apply loop, so nothing is
+        // applied and nothing is bound.
+        //
+        // `found` matches its own branch in the same pass, so the emitter is
+        // shown carrying exactly one of the two.
+        let healed = UUID(); let found = UUID()
+        let gh = BindingGH(
+            nodes: [BindingGH.key(owner: "acme", repo: "acme-prod", number: 90):
+                        Self.nodeJSON(number: 90, head: "main")],
+            branchNodes: [Self.nodeJSON(number: 91, head: "tbd/other-branch")])
         let manager = Self.manager(gh)
+        await manager.seedForTesting(
+            worktreeID: healed,
+            status: PRStatus(number: 90, url: "https://github.com/acme/acme-prod/pull/90",
+                             state: .pending))
 
-        let outcome = await manager.fetchAll(worktrees: [Self.pollWorktree(wt)])
+        let outcome = await manager.fetchAll(worktrees: [
+            Self.pollWorktree(healed),
+            Self.pollWorktree(found, branch: "tbd/other-branch")
+        ])
 
-        #expect(outcome.discovered.isEmpty)
-        #expect(await manager.allStatuses()[wt] == nil)
+        #expect(outcome.discovered.map(\.worktreeID) == [found])
+        #expect(outcome.discovered.map(\.parsed.number) == [91])
+        // Without the heal the freshly-resolved #90 would land in the cache
+        // here, so this is the assertion that fails if the heal stops working.
+        #expect(await manager.allStatuses()[healed] == nil)
+        #expect(await manager.allStatuses()[found]?.number == 91)
     }
 
     // MARK: - Heal emitter
@@ -733,7 +756,7 @@ struct PRStatusManagerBindingTests {
     @Test("a poll that heals nothing disproves nothing")
     func healthyPollDisprovesNothing() async {
         let wt = UUID()
-        let gh = BindingGH(viewerNodes: [Self.nodeJSON(number: 89, head: "tbd/my-branch")])
+        let gh = BindingGH(branchNodes: [Self.nodeJSON(number: 89, head: "tbd/my-branch")])
         let manager = Self.manager(gh)
 
         let outcome = await manager.fetchAll(worktrees: [Self.pollWorktree(wt)])
@@ -1136,8 +1159,9 @@ struct PRStatusManagerBindingTests {
     @Test("branch matching finds a GitLab merge request opened by someone else")
     func gitLabBranchMatch() async {
         // `sourceBranches` has no author filter, so this is the route that finds
-        // a merge request opened through the web UI or by another account —
-        // GitHub's viewer batch structurally cannot.
+        // a merge request opened through the web UI or by another account. Its
+        // GitHub sibling asks the same author-blind question one alias per
+        // branch.
         let gl = GitLabFake()
         let wt = UUID()
         let manager = PRStatusManager(
@@ -1162,11 +1186,11 @@ struct PRStatusManagerBindingTests {
         #expect(await manager.observation(for: wt)?.outcome == .observed)
     }
 
-    @Test("a GitLab-only fleet never asks gh for the viewer batch")
-    func gitLabOnlyFleetSkipsViewerBatch() async {
+    @Test("a GitLab-only fleet never asks gh a branch query")
+    func gitLabOnlyFleetSkipsGitHubBranchQuery() async {
         // `gh` cannot name this checkout — it is not a host it speaks to — so
         // identity comes from the remote, and nothing on this fleet is GitHub.
-        // The viewer batch is then not merely fruitless but never issued.
+        // The GitHub branch query is then not merely fruitless but never issued.
         let gl = GitLabFake()
         let gh = GHCallLog()
         let manager = PRStatusManager(
@@ -1180,7 +1204,7 @@ struct PRStatusManagerBindingTests {
         let wt = UUID()
         _ = await manager.fetchAll(worktrees: [Self.pollWorktree(wt)])
 
-        #expect(await gh.viewerQueries == 0)
+        #expect(await gh.branchQueries == 0)
         // And the GitLab side still answered, so this is not a vacuous pass.
         #expect(await manager.allStatuses()[wt]?.number == 412)
     }

--- a/Tests/TBDDaemonTests/PRStatusManagerTests.swift
+++ b/Tests/TBDDaemonTests/PRStatusManagerTests.swift
@@ -264,157 +264,139 @@ struct PRStatusManagerTests {
 
     // MARK: - JSON parsing
 
-    @Test("parseGraphQLResponse keeps all branch names")
-    func parsesResponse() throws {
-        let json = """
-        {
-          "data": {
-            "viewer": {
-              "pullRequests": {
-                "nodes": [
-                  {
-                    "number": 42,
-                    "url": "https://github.com/owner/repo/pull/42",
-                    "state": "OPEN",
-                    "mergeStateStatus": "CLEAN",
-                    "isDraft": true,
-                    "statusCheckRollup": { "state": "FAILURE" },
-                    "reviewDecision": null,
-                    "headRefName": "tbd/cool-feature",
-                    "createdAt": "2026-03-24T10:00:00Z"
-                  },
-                  {
-                    "number": 7,
-                    "url": "https://github.com/owner/repo/pull/7",
-                    "state": "MERGED",
-                    "mergeStateStatus": "UNKNOWN",
-                    "reviewDecision": null,
-                    "headRefName": "tbd/old-feature",
-                    "createdAt": "2026-03-20T10:00:00Z"
-                  },
-                  {
-                    "number": 99,
-                    "url": "https://github.com/owner/repo/pull/99",
-                    "state": "OPEN",
-                    "mergeStateStatus": "CLEAN",
-                    "reviewDecision": null,
-                    "headRefName": "feature/not-tbd",
-                    "createdAt": "2026-03-24T12:00:00Z"
-                  }
-                ]
-              }
-            }
-          }
-        }
-        """.data(using: .utf8)!
+    /// One branch-query alias, as `gh api graphql` returns it: the alias GitHub
+    /// was asked for, carrying whatever pull requests sit on that head ref.
+    private func aliasJSON(_ alias: String, _ nodes: String...) -> String {
+        "\"\(alias)\": {\"nodes\": [\(nodes.joined(separator: ","))]}"
+    }
 
-        let nodes = try PRStatusManager.parsePRNodes(from: json)
+    /// The branch query's envelope around a set of aliases.
+    private func branchResponse(_ aliases: String...) -> Data {
+        "{\"data\": {\"repository\": {\(aliases.joined(separator: ","))}}}".data(using: .utf8)!
+    }
+
+    /// A PR node fixture. `extra` appends raw JSON so a test can add or omit an
+    /// optional field without writing a second whole literal.
+    private func branchNodeJSON(number: Int, head: String, state: String = "OPEN",
+                                repo: String = "owner/repo", extra: String = "") -> String {
+        """
+        {"number": \(number), "url": "https://github.com/\(repo)/pull/\(number)",
+         "state": "\(state)", "mergeStateStatus": "CLEAN", "reviewDecision": null,
+         "headRefName": "\(head)", "createdAt": "2026-03-24T10:00:00Z"\(extra)}
+        """
+    }
+
+    @Test("branchPRsQuery declares one String! variable per alias and carries no branch text")
+    func branchPRsQueryBindsEachBranchAsAVariable() {
+        // A git ref may legally contain `"`, and interpolating one into
+        // `headRefName: "…"` produced a malformed query. A declared variable per
+        // alias is the fix; this is what pins it.
+        let query = PRStatusManager.branchPRsQuery(aliasCount: 2)
+        let opens = query.filter { $0 == "{" }.count
+        let closes = query.filter { $0 == "}" }.count
+        #expect(opens == closes, "unbalanced braces (\(opens) open vs \(closes) close) in: \(query)")
+        #expect(query.contains("$b0: String!"))
+        #expect(query.contains("$b1: String!"))
+        #expect(query.contains("b0: pullRequests(headRefName: $b0,"))
+        #expect(query.contains("b1: pullRequests(headRefName: $b1,"))
+        #expect(query.contains("repository(owner: $owner, name: $name)"))
+        // The selection is shared with the by-number query: a title nothing asks
+        // for is a title no response can carry.
+        #expect(query.contains("title"))
+
+        let quoted = #"feature/say-"hi""#
+        let args = PRStatusManager.branchPRsArgs(owner: "acme", name: "acme-prod",
+                                                 branches: [quoted, "main"])
+        let queryArg = args.first { $0.hasPrefix("query=") }
+        #expect(queryArg?.contains(quoted) == false, "the branch text must never reach the query")
+        #expect(queryArg?.contains("say-") == false)
+        // It survives intact as its own field value (an execve arg), quote and all.
+        #expect(args.contains("b0=\(quoted)"))
+        #expect(args.contains("b1=main"))
+        // `-f` (raw string), never `-F`: `-F` would coerce a branch named `123`
+        // or `true` into the wrong JSON type against a `String!` variable.
+        #expect(!args.contains("-F"))
+        #expect(args.filter { $0 == "-f" }.count == 5)   // query, owner, name, b0, b1
+    }
+
+    @Test("parseBranchPRNodes keeps every alias's nodes and decodes their fields")
+    func parseBranchPRNodesKeepsEveryAlias() throws {
+        let json = branchResponse(
+            aliasJSON("b0",
+                      branchNodeJSON(number: 42, head: "tbd/cool-feature",
+                                     extra: #", "isDraft": true, "statusCheckRollup": {"state": "FAILURE"}"#),
+                      branchNodeJSON(number: 7, head: "tbd/cool-feature", state: "MERGED")),
+            aliasJSON("b1", branchNodeJSON(number: 99, head: "feature/not-tbd")))
+
+        let nodes = try #require(PRStatusManager.parseBranchPRNodes(from: json, aliasCount: 2))
+
         #expect(nodes.count == 3)
-        #expect(nodes[0].headRefName == "tbd/cool-feature")
+        #expect(nodes.map(\.number) == [42, 7, 99])
+        #expect(nodes.map(\.headRefName) == ["tbd/cool-feature", "tbd/cool-feature", "feature/not-tbd"])
         #expect(nodes[0].state == "OPEN")
         #expect(nodes[0].mergeVerdictRaw == "CLEAN")
         #expect(nodes[0].isDraft == true)
         #expect(nodes[0].statusCheckRollupState == "FAILURE")
-        #expect(nodes[1].headRefName == "tbd/old-feature")
-        #expect(nodes[2].headRefName == "feature/not-tbd")
+        #expect(nodes[1].state == "MERGED")
     }
 
-    @Test("parseGraphQLResponse ignores null nodes in partial results")
-    func parsesResponseWithNullNodes() throws {
-        let json = """
-        {
-          "data": {
-            "viewer": {
-              "pullRequests": {
-                "nodes": [
-                  null,
-                  {
-                    "number": 42,
-                    "url": "https://github.com/owner/repo/pull/42",
-                    "state": "OPEN",
-                    "mergeStateStatus": "CLEAN",
-                    "reviewDecision": null,
-                    "headRefName": "tbd/cool-feature",
-                    "createdAt": "2026-03-24T10:00:00Z"
-                  },
-                  null,
-                  {
-                    "number": 7,
-                    "url": "https://github.com/owner/repo/pull/7",
-                    "state": "MERGED",
-                    "mergeStateStatus": "UNKNOWN",
-                    "reviewDecision": null,
-                    "headRefName": "tbd/old-feature",
-                    "createdAt": "2026-03-20T10:00:00Z"
-                  },
-                  {
-                    "number": 99,
-                    "url": "https://github.com/owner/repo/pull/99",
-                    "state": "OPEN",
-                    "mergeStateStatus": "CLEAN",
-                    "reviewDecision": null,
-                    "headRefName": "feature/not-tbd",
-                    "createdAt": "2026-03-24T12:00:00Z"
-                  }
-                ]
-              }
-            }
-          }
-        }
-        """.data(using: .utf8)!
+    @Test("parseBranchPRNodes ignores null entries inside an alias's node list")
+    func parseBranchPRNodesIgnoresNullNodes() throws {
+        let json = branchResponse(
+            "\"b0\": {\"nodes\": [null, \(branchNodeJSON(number: 42, head: "tbd/cool-feature")), null]}",
+            aliasJSON("b1", branchNodeJSON(number: 99, head: "feature/not-tbd")))
 
-        let nodes = try PRStatusManager.parsePRNodes(from: json)
-        #expect(nodes.count == 3)
-        #expect(nodes[0].headRefName == "tbd/cool-feature")
-        #expect(nodes[1].headRefName == "tbd/old-feature")
-        #expect(nodes[2].headRefName == "feature/not-tbd")
+        let nodes = try #require(PRStatusManager.parseBranchPRNodes(from: json, aliasCount: 2))
+
+        #expect(nodes.map(\.number) == [42, 99])
     }
 
-    @Test("parsePRNodes decodes mergeQueueEntry.position and tolerates a null entry")
-    func parsesMergeQueuePosition() throws {
-        let json = """
-        {
-          "data": {
-            "viewer": {
-              "pullRequests": {
-                "nodes": [
-                  {
-                    "number": 12,
-                    "url": "https://github.com/acme/acme-prod/pull/12",
-                    "state": "OPEN",
-                    "mergeStateStatus": "UNKNOWN",
-                    "reviewDecision": null,
-                    "headRefName": "acme/queued-feature",
-                    "createdAt": "2026-03-24T10:00:00Z",
-                    "mergeQueueEntry": { "position": 3 }
-                  },
-                  {
-                    "number": 34,
-                    "url": "https://github.com/acme/acme-prod/pull/34",
-                    "state": "OPEN",
-                    "mergeStateStatus": "CLEAN",
-                    "reviewDecision": null,
-                    "headRefName": "acme/not-queued",
-                    "createdAt": "2026-03-24T11:00:00Z",
-                    "mergeQueueEntry": null
-                  },
-                  {
-                    "number": 56,
-                    "url": "https://github.com/acme/acme-prod/pull/56",
-                    "state": "OPEN",
-                    "mergeStateStatus": "CLEAN",
-                    "reviewDecision": null,
-                    "headRefName": "acme/no-entry-key",
-                    "createdAt": "2026-03-24T12:00:00Z"
-                  }
-                ]
-              }
-            }
-          }
-        }
-        """.data(using: .utf8)!
+    @Test("parseBranchPRNodes skips a null alias without discarding the others")
+    func parseBranchPRNodesSkipsNullAlias() throws {
+        // `gh api graphql` emits partial `data` alongside per-node errors, so one
+        // branch nobody could read must not cost the answer for every other.
+        let json = branchResponse(
+            "\"b0\": null",
+            aliasJSON("b1", branchNodeJSON(number: 99, head: "feature/not-tbd")))
 
-        let nodes = try PRStatusManager.parsePRNodes(from: json)
+        let nodes = try #require(PRStatusManager.parseBranchPRNodes(from: json, aliasCount: 2))
+
+        #expect(nodes.map(\.number) == [99])
+    }
+
+    @Test("parseBranchPRNodes answers [] for a branch with no PR and nil when the forge did not answer")
+    func parseBranchPRNodesSeparatesEmptyFromUnanswered() {
+        // The distinction the whole `PRObservation` vocabulary rests on:
+        // "answered, nothing here" is settled knowledge a program can act on;
+        // "no answer" is not, and folding one into the other is the bug.
+        let answered = PRStatusManager.parseBranchPRNodes(
+            from: branchResponse(aliasJSON("b0")), aliasCount: 1)
+        #expect(answered != nil, "an empty node list is an answer, not a failure")
+        #expect(answered?.isEmpty == true)
+
+        let repositoryNull = "{\"data\": {\"repository\": null}}".data(using: .utf8)!
+        #expect(PRStatusManager.parseBranchPRNodes(from: repositoryNull, aliasCount: 1) == nil,
+                "a repository the token cannot reach settles nothing")
+
+        let noData = "{\"nope\": true}".data(using: .utf8)!
+        #expect(PRStatusManager.parseBranchPRNodes(from: noData, aliasCount: 1) == nil)
+
+        let notJSON = "gh: could not resolve host".data(using: .utf8)!
+        #expect(PRStatusManager.parseBranchPRNodes(from: notJSON, aliasCount: 1) == nil)
+    }
+
+    @Test("parseBranchPRNodes decodes mergeQueueEntry.position and tolerates a null entry")
+    func parseBranchPRNodesDecodesMergeQueuePosition() throws {
+        let json = branchResponse(aliasJSON(
+            "b0",
+            branchNodeJSON(number: 12, head: "acme/queued-feature", repo: "acme/acme-prod",
+                           extra: #", "mergeQueueEntry": {"position": 3}"#),
+            branchNodeJSON(number: 34, head: "acme/queued-feature", repo: "acme/acme-prod",
+                           extra: #", "mergeQueueEntry": null"#),
+            branchNodeJSON(number: 56, head: "acme/queued-feature", repo: "acme/acme-prod")))
+
+        let nodes = try #require(PRStatusManager.parseBranchPRNodes(from: json, aliasCount: 1))
+
         #expect(nodes.count == 3)
         #expect(nodes[0].mergeQueuePosition == 3)      // front-of-queue is 1-indexed; this PR is 3rd
         #expect(nodes[1].mergeQueuePosition == nil)    // explicit null entry
@@ -582,7 +564,7 @@ struct PRStatusManagerTests {
     @Test("graphQLOutputData keeps non-empty stdout")
     func graphQLOutputDataUsesNonEmptyStdout() {
         let stdout = """
-        {"data":{"viewer":{"pullRequests":{"nodes":[]}}}}
+        {"data":{"repository":{"b0":{"nodes":[]}}}}
         """
 
         let data = PRStatusManager.graphQLOutputData(stdout: stdout)
@@ -1452,7 +1434,7 @@ struct PRStatusManagerTests {
         let a = UUID(); let b = UUID(); let c = UUID()
         let items: [(id: UUID, prNumber: Int?)] = [
             (a, 454),   // numbered → by-number path
-            (b, nil),   // unnumbered → legacy branch-name path
+            (b, nil),   // unnumbered → by-branch path
             (c, 12)     // numbered → by-number path
         ]
         let (numbered, unnumbered) = PRStatusManager.partitionByPRNumber(items) { $0.prNumber }
@@ -1462,8 +1444,9 @@ struct PRStatusManagerTests {
 
     @Test("parseNumberedPRNodes resolves a numbered (fork) worktree from the by-number response")
     func parseNumberedPRNodesResolvesForkPR() {
-        // The fork PR's head branch never appears in the viewer-authored batch;
-        // the stored number resolves it directly under its alias.
+        // The fork PR's head ref lives in the fork, so it appears under none of
+        // the base repo's head refs; the stored number resolves it directly
+        // under its alias.
         let wt = UUID()
         let json = """
         {
@@ -1553,16 +1536,16 @@ struct PRStatusManagerTests {
         #expect(matches.isEmpty)
     }
 
-    @Test("unnumbered worktree still resolves via the viewer-authored branch match when the repo matches (regression)")
+    @Test("unnumbered worktree still resolves via the branch match when the repo matches (regression)")
     func unnumberedResolvesViaLegacyBranchMatch() throws {
-        // The viewer batch carries a node for the worktree's branch; a worktree
+        // The branch query carries a node for the worktree's branch; a worktree
         // with no stored number must still match it when its own repo agrees
         // with the node's URL repo.
         let json = """
         {
           "data": {
-            "viewer": {
-              "pullRequests": {
+            "repository": {
+              "b0": {
                 "nodes": [
                   {
                     "number": 7,
@@ -1582,7 +1565,7 @@ struct PRStatusManagerTests {
         }
         """.data(using: .utf8)!
 
-        let nodes = try PRStatusManager.parsePRNodes(from: json)
+        let nodes = try #require(PRStatusManager.parseBranchPRNodes(from: json, aliasCount: 1))
         let wt = UUID()
         let matches = PRStatusManager.matchUnnumbered(
             [(id: wt, branch: "feature-x", upstreamBranch: nil, defaultBranch: "main", pushBranch: .noPushDestination,
@@ -1594,7 +1577,7 @@ struct PRStatusManagerTests {
         #expect(matches.first?.node.number == 7)
     }
 
-    // MARK: - Repo-scoped viewer-batch branch matching (cross-repo collision regression)
+    // MARK: - Repo-scoped branch matching (cross-repo collision regression)
 
     /// Convenience PRNode factory for the matching tests.
     private func prNode(number: Int, url: String, branch: String, state: String = "OPEN",
@@ -1877,7 +1860,7 @@ struct PRStatusManagerTests {
             [(id: wt, branch: "tbd/my-branch", upstreamBranch: "main", defaultBranch: "main", pushBranch: .noPushDestination,
               worktreePath: "/wt/acme-prod", prNumber: nil)]
         let out = PRStatusManager.headRefVerificationTargets(
-            unnumbered: unnumbered, matchedIDs: [], batchSucceeded: true, verifiedIDs: [],
+            unnumbered: unnumbered, matchedIDs: [], answeredIDs: [wt], verifiedIDs: [],
             cachedStatus: { _ in PRStatus(number: 88, url: "https://github.com/acme/acme-prod/pull/88",
                                           state: .closed) })
         #expect(out.count == 1)
@@ -1892,7 +1875,7 @@ struct PRStatusManagerTests {
             [(id: wt, branch: "tbd/my-branch", upstreamBranch: "main", defaultBranch: "main", pushBranch: .noPushDestination,
               worktreePath: "/wt/acme-prod", prNumber: nil)]
         let out = PRStatusManager.headRefVerificationTargets(
-            unnumbered: unnumbered, matchedIDs: [wt], batchSucceeded: true, verifiedIDs: [],
+            unnumbered: unnumbered, matchedIDs: [wt], answeredIDs: [wt], verifiedIDs: [],
             cachedStatus: { _ in PRStatus(number: 88, url: "https://github.com/acme/acme-prod/pull/88",
                                           state: .closed) })
         #expect(out.isEmpty)
@@ -1907,7 +1890,7 @@ struct PRStatusManagerTests {
             [(id: wt, branch: "tbd/my-branch", upstreamBranch: "main", defaultBranch: "main", pushBranch: .noPushDestination,
               worktreePath: "/wt/acme-prod", prNumber: nil)]
         let out = PRStatusManager.headRefVerificationTargets(
-            unnumbered: unnumbered, matchedIDs: [], batchSucceeded: true, verifiedIDs: [wt],
+            unnumbered: unnumbered, matchedIDs: [], answeredIDs: [wt], verifiedIDs: [wt],
             cachedStatus: { _ in PRStatus(number: 88, url: "https://github.com/acme/acme-prod/pull/88",
                                           state: .closed) })
         #expect(out.isEmpty)
@@ -1921,7 +1904,8 @@ struct PRStatusManagerTests {
             [(id: UUID(), branch: "local-x", upstreamBranch: "renamed-on-remote", defaultBranch: "main", pushBranch: .lookupFailed,
               worktreePath: "/wt/acme-prod", prNumber: nil)]
         let out = PRStatusManager.headRefVerificationTargets(
-            unnumbered: unnumbered, matchedIDs: [], batchSucceeded: true, verifiedIDs: [],
+            unnumbered: unnumbered, matchedIDs: [], answeredIDs: Set(unnumbered.map(\.id)),
+            verifiedIDs: [],
             cachedStatus: { _ in PRStatus(number: 9, url: "https://github.com/acme/acme-prod/pull/9",
                                           state: .closed) })
         #expect(out.isEmpty)
@@ -1933,7 +1917,8 @@ struct PRStatusManagerTests {
             [(id: UUID(), branch: "tbd/my-branch", upstreamBranch: "main", defaultBranch: nil,
               pushBranch: .noPushDestination, worktreePath: "/wt/acme-prod", prNumber: nil)]
         let out = PRStatusManager.headRefVerificationTargets(
-            unnumbered: unnumbered, matchedIDs: [], batchSucceeded: true, verifiedIDs: [],
+            unnumbered: unnumbered, matchedIDs: [], answeredIDs: Set(unnumbered.map(\.id)),
+            verifiedIDs: [],
             cachedStatus: { _ in PRStatus(number: 88, url: "https://github.com/acme/acme-prod/pull/88",
                                           state: .closed) })
         #expect(out.isEmpty)
@@ -1945,7 +1930,8 @@ struct PRStatusManagerTests {
             [(id: UUID(), branch: "tbd/my-branch", upstreamBranch: nil, defaultBranch: "main", pushBranch: .noPushDestination,
               worktreePath: "/wt/acme-prod", prNumber: nil)]
         let out = PRStatusManager.headRefVerificationTargets(
-            unnumbered: unnumbered, matchedIDs: [], batchSucceeded: true, verifiedIDs: [],
+            unnumbered: unnumbered, matchedIDs: [], answeredIDs: Set(unnumbered.map(\.id)),
+            verifiedIDs: [],
             cachedStatus: { _ in PRStatus(number: 88, url: "https://github.com/acme/acme-prod/pull/88",
                                           state: .closed) })
         #expect(out.isEmpty)
@@ -1957,23 +1943,31 @@ struct PRStatusManagerTests {
             [(id: UUID(), branch: "tbd/my-branch", upstreamBranch: "main", defaultBranch: "main", pushBranch: .noPushDestination,
               worktreePath: "/wt/acme-prod", prNumber: nil)]
         let out = PRStatusManager.headRefVerificationTargets(
-            unnumbered: unnumbered, matchedIDs: [], batchSucceeded: true, verifiedIDs: [],
+            unnumbered: unnumbered, matchedIDs: [], answeredIDs: Set(unnumbered.map(\.id)),
+            verifiedIDs: [],
             cachedStatus: { _ in nil })
         #expect(out.isEmpty)
     }
 
-    @Test("headRefVerificationTargets yields nothing when the viewer batch failed")
-    func headRefVerificationTargetsSkippedOnBatchFailure() {
-        // Absence of evidence is not proof of mis-attachment: on a fetch/parse
-        // failure every worktree is "unmatched" and the word means nothing.
-        let unnumbered: [PRStatusManager.PollWorktree] =
-            [(id: UUID(), branch: "tbd/my-branch", upstreamBranch: "main", defaultBranch: "main", pushBranch: .noPushDestination,
-              worktreePath: "/wt/acme-prod", prNumber: nil)]
+    @Test("headRefVerificationTargets yields nothing for a worktree nobody answered for")
+    func headRefVerificationTargetsSkipsUnansweredWorktree() {
+        // Absence of evidence is not proof of mis-attachment: where this
+        // worktree's own repo query did not parse it is "unmatched" only
+        // because nobody asked, and the word means nothing. The gate is per
+        // worktree — a sibling in an answered repo must not carry it in.
+        let unanswered = UUID(); let answered = UUID()
+        let unnumbered: [PRStatusManager.PollWorktree] = [
+            (id: unanswered, branch: "tbd/dark-repo", upstreamBranch: "main", defaultBranch: "main",
+             pushBranch: .noPushDestination, worktreePath: "/wt/dark", prNumber: nil),
+            (id: answered, branch: "tbd/lit-repo", upstreamBranch: "main", defaultBranch: "main",
+             pushBranch: .noPushDestination, worktreePath: "/wt/lit", prNumber: nil)
+        ]
         let out = PRStatusManager.headRefVerificationTargets(
-            unnumbered: unnumbered, matchedIDs: [], batchSucceeded: false, verifiedIDs: [],
+            unnumbered: unnumbered, matchedIDs: [], answeredIDs: [answered], verifiedIDs: [],
             cachedStatus: { _ in PRStatus(number: 88, url: "https://github.com/acme/acme-prod/pull/88",
                                           state: .closed) })
-        #expect(out.isEmpty)
+        #expect(out.map(\.id) == [answered],
+                "only the worktree whose own repo answered is eligible for verification")
     }
 
     @Test("bestNodeByRepoBranch keeps the tie-break within one repo: OPEN beats MERGED, newest wins within a state")
@@ -2090,21 +2084,22 @@ struct PRStatusManagerTests {
             [(id: wt, branch: "feature-x", upstreamBranch: nil, defaultBranch: "main", pushBranch: .noPushDestination,
               worktreePath: "/tmp/repo", prNumber: nil)]
         let out = PRStatusManager.cachedNumberFallback(
-            unnumbered: unnumbered, matchedIDs: [wt], batchSucceeded: true,
+            unnumbered: unnumbered, matchedIDs: [wt], answeredIDs: [wt],
             cachedStatus: { _ in PRStatus(number: 42, url: "https://example.com/pr/42", state: .pending) })
         #expect(out.isEmpty)
     }
 
     @Test("cachedNumberFallback includes an unmatched worktree, carrying its cached PR number")
     func cachedNumberFallbackIncludesUnmatchedWithCachedNumber() {
-        // The stale PR fell out of the 100-PR viewer batch; the cached number is
-        // the only remaining handle to observe the merged transition.
+        // The pull request sits on a head ref no candidate names — a fork head,
+        // a rename-push — so the branch query cannot see it and the cached
+        // number is the only remaining handle to observe the merged transition.
         let wt = UUID()
         let unnumbered: [PRStatusManager.PollWorktree] =
             [(id: wt, branch: "old-branch", upstreamBranch: "origin/old-branch", defaultBranch: "main", pushBranch: .noPushDestination,
               worktreePath: "/tmp/repo", prNumber: nil)]
         let out = PRStatusManager.cachedNumberFallback(
-            unnumbered: unnumbered, matchedIDs: [], batchSucceeded: true,
+            unnumbered: unnumbered, matchedIDs: [], answeredIDs: [wt],
             cachedStatus: { _ in PRStatus(number: 457, url: "https://example.com/pr/457", state: .mergeable) })
         #expect(out.count == 1)
         #expect(out.first?.id == wt)
@@ -2114,25 +2109,34 @@ struct PRStatusManagerTests {
 
     @Test("cachedNumberFallback excludes an unmatched worktree with no cached entry")
     func cachedNumberFallbackExcludesNoCachedEntry() {
+        let wt = UUID()
         let unnumbered: [PRStatusManager.PollWorktree] =
-            [(id: UUID(), branch: "feature-y", upstreamBranch: nil, defaultBranch: "main", pushBranch: .noPushDestination,
+            [(id: wt, branch: "feature-y", upstreamBranch: nil, defaultBranch: "main", pushBranch: .noPushDestination,
               worktreePath: "/tmp/repo", prNumber: nil)]
         let out = PRStatusManager.cachedNumberFallback(
-            unnumbered: unnumbered, matchedIDs: [], batchSucceeded: true, cachedStatus: { _ in nil })
+            unnumbered: unnumbered, matchedIDs: [], answeredIDs: [wt], cachedStatus: { _ in nil })
         #expect(out.isEmpty)
     }
 
-    @Test("cachedNumberFallback yields nothing when the viewer batch failed, even with unmatched cached numbers")
-    func cachedNumberFallbackSkippedOnBatchFailure() {
-        // On a fetch/parse failure "unmatched" means nothing — falling back could
-        // resolve a stale MERGED number and auto-archive off an unrelated PR.
-        let unnumbered: [PRStatusManager.PollWorktree] =
-            [(id: UUID(), branch: "old-branch", upstreamBranch: nil, defaultBranch: "main", pushBranch: .noPushDestination,
-              worktreePath: "/tmp/repo", prNumber: nil)]
+    @Test("cachedNumberFallback yields nothing for a worktree nobody answered for, even with a cached number")
+    func cachedNumberFallbackSkipsUnansweredWorktree() {
+        // Where this worktree's own repo query did not parse, "unmatched" means
+        // nothing — falling back could resolve a stale MERGED number and
+        // auto-archive off an unrelated PR. And the gate is per worktree: a
+        // sibling in a repo that DID answer is eligible in the same call, which
+        // is what one repo going dark must not take away.
+        let dark = UUID(); let lit = UUID()
+        let unnumbered: [PRStatusManager.PollWorktree] = [
+            (id: dark, branch: "old-branch", upstreamBranch: nil, defaultBranch: "main", pushBranch: .noPushDestination,
+             worktreePath: "/tmp/dark", prNumber: nil),
+            (id: lit, branch: "other-branch", upstreamBranch: nil, defaultBranch: "main", pushBranch: .noPushDestination,
+             worktreePath: "/tmp/lit", prNumber: nil)
+        ]
         let out = PRStatusManager.cachedNumberFallback(
-            unnumbered: unnumbered, matchedIDs: [], batchSucceeded: false,
+            unnumbered: unnumbered, matchedIDs: [], answeredIDs: [lit],
             cachedStatus: { _ in PRStatus(number: 457, url: "https://example.com/pr/457", state: .mergeable) })
-        #expect(out.isEmpty)
+        #expect(out.map(\.id) == [lit],
+                "only the worktree whose own repo answered may fall back to its cached number")
     }
 
     @Test("cachedNumberFallback excludes worktrees whose cached state is terminal (.merged / .closed)")
@@ -2151,7 +2155,7 @@ struct PRStatusManagerTests {
             closedWT: PRStatus(number: 12, url: "https://example.com/pr/12", state: .closed)
         ]
         let out = PRStatusManager.cachedNumberFallback(
-            unnumbered: unnumbered, matchedIDs: [], batchSucceeded: true,
+            unnumbered: unnumbered, matchedIDs: [], answeredIDs: Set(unnumbered.map(\.id)),
             cachedStatus: { statuses[$0] })
         #expect(out.isEmpty)
     }
@@ -2302,38 +2306,90 @@ struct PRStatusManagerTests {
     }
 }
 
+// MARK: - The poll's branch query, as every `gh` stub in this target sees it
+
+/// Shared decoding of the repo-scoped branch query for the `gh` stubs in this
+/// target, so all of them answer it the same way.
+///
+/// The response is built by filtering the offered nodes on each node's OWN
+/// `headRefName`: a stub that returned every node under every alias would let a
+/// matcher that ignores head refs pass. The head ref is read out of the node
+/// JSON rather than matched as text, so this does not depend on how each suite
+/// formats its fixtures.
+enum BranchQueryStub {
+
+    /// Whether this query text is the aliased branch query rather than the
+    /// single-branch refresh query, whose one variable is `$branch`. Matching
+    /// `$b0` and not `$b` is what keeps the two apart.
+    static func isBranchQuery(_ query: String) -> Bool { query.contains("headRefName: $b0") }
+
+    /// The `-f b<N>=<branch>` bindings the branch query carries, in alias order.
+    /// Read out of the argument vector because the branch text appears nowhere
+    /// in the query itself — that is the point of binding it as a variable.
+    static func boundBranches(in args: [String]) -> [(alias: String, branch: String)] {
+        args.compactMap { arg -> (alias: String, branch: String)? in
+            guard let eq = arg.firstIndex(of: "=") else { return nil }
+            let key = String(arg[arg.startIndex..<eq])
+            guard key.hasPrefix("b"), Int(key.dropFirst()) != nil else { return nil }
+            return (key, String(arg[arg.index(after: eq)...]))
+        }
+    }
+
+    /// The aliased response `gh api graphql` returns for that query: one alias
+    /// per bound branch, carrying only the nodes whose own head ref is that
+    /// branch.
+    static func response(args: [String], nodes: [String]) -> GHCommandResult {
+        let fields = boundBranches(in: args).map { alias, branch in
+            let onBranch = nodes.filter { headRef(of: $0) == branch }
+            return "\"\(alias)\":{\"nodes\":[\(onBranch.joined(separator: ","))]}"
+        }
+        return GHCommandResult(stdout: "{\"data\":{\"repository\":{\(fields.joined(separator: ","))}}}")
+    }
+
+    /// A node fixture's own head ref.
+    static func headRef(of nodeJSON: String) -> String? {
+        guard let data = nodeJSON.data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
+        return obj["headRefName"] as? String
+    }
+}
+
 // MARK: - fetchAll end-to-end (injected gh)
 
 /// A stand-in for the `gh` CLI. Answers the three query shapes `fetchAll`
-/// issues — `repo view` (owner/name), the viewer batch, and the aliased
-/// by-number lookup — and counts them, so tests can assert not just the
+/// issues — `repo view` (owner/name), the repo-scoped branch query, and the
+/// aliased by-number lookup — and counts them, so tests can assert not just the
 /// resulting cache but how many round trips it took to get there.
 private actor FakeGH {
-    private let viewerNodes: [String]
+    private let branchNodes: [String]
     private let prsByNumber: [Int: String]
-    private let viewerSucceeds: Bool
+    private let branchQuerySucceeds: Bool
     private let byNumberSucceeds: Bool
-    private(set) var viewerQueries = 0
+    private(set) var branchQueries = 0
     private(set) var numberedQueries = 0
+    /// Every query text this stub was handed. Author-blindness is a negative
+    /// claim — "no query ever named the viewer" — so it needs the whole record,
+    /// not a count.
+    private(set) var queryTexts: [String] = []
 
-    init(viewerNodes: [String] = [],
+    init(branchNodes: [String] = [],
          prsByNumber: [Int: String] = [:],
-         viewerSucceeds: Bool = true,
+         branchQuerySucceeds: Bool = true,
          byNumberSucceeds: Bool = true) {
-        self.viewerNodes = viewerNodes
+        self.branchNodes = branchNodes
         self.prsByNumber = prsByNumber
-        self.viewerSucceeds = viewerSucceeds
+        self.branchQuerySucceeds = branchQuerySucceeds
         self.byNumberSucceeds = byNumberSucceeds
     }
 
     func run(args: [String], repoPath: String) -> GHCommandResult? {
         if args.first == "repo" { return GHCommandResult(stdout: #"{"nameWithOwner":"acme/acme-prod","url":"https://github.com/acme/acme-prod"}"#) }
         guard let query = args.first(where: { $0.hasPrefix("query=") }) else { return nil }
-        if query.contains("viewer {") {
-            viewerQueries += 1
-            guard viewerSucceeds else { return nil }
-            return GHCommandResult(
-                stdout: #"{"data":{"viewer":{"pullRequests":{"nodes":[\#(viewerNodes.joined(separator: ","))]}}}}"#)
+        queryTexts.append(query)
+        if BranchQueryStub.isBranchQuery(query) {
+            branchQueries += 1
+            guard branchQuerySucceeds else { return nil }
+            return BranchQueryStub.response(args: args, nodes: branchNodes)
         }
         if query.contains("pullRequest(number:") {
             numberedQueries += 1
@@ -2439,7 +2495,7 @@ struct PRStatusManagerFetchAllTests {
         // The heal's OFF branch: nothing is flagged, nothing is verified, and the
         // status lands in the cache as usual.
         let wt = UUID()
-        let gh = FakeGH(viewerNodes: [Self.nodeJSON(number: 89, head: "tbd/my-branch")])
+        let gh = FakeGH(branchNodes: [Self.nodeJSON(number: 89, head: "tbd/my-branch")])
         let manager = PRStatusManager(ghRunner: { args, path in await gh.run(args: args, repoPath: path) })
         let recorder = CallbackRecorder()
         await Self.attach(recorder, to: manager)
@@ -2543,7 +2599,7 @@ struct PRStatusManagerFetchAllTests {
         // Drives the real path twice, including the fallback → by-number route
         // that produced the match in the first place.
         let wt = UUID()
-        let gh = FakeGH(viewerNodes: [Self.nodeJSON(number: 88, head: "main", state: "CLOSED")],
+        let gh = FakeGH(branchNodes: [Self.nodeJSON(number: 88, head: "main", state: "CLOSED")],
                         prsByNumber: [88: Self.nodeJSON(number: 88, head: "main", state: "CLOSED")])
         let manager = PRStatusManager(ghRunner: { args, path in await gh.run(args: args, repoPath: path) })
         await manager.seedForTesting(
@@ -2570,8 +2626,8 @@ struct PRStatusManagerFetchAllTests {
         let gh = FakeGH(prsByNumber: [88: Self.nodeJSON(number: 88, head: "main", state: "CLOSED")])
         let holder = ManagerHolder()
         let manager = PRStatusManager(ghRunner: { args, path in
-            // The user hits Refresh while the viewer batch is still in flight.
-            if args.contains(where: { $0.contains("viewer {") }) {
+            // The user hits Refresh while the branch query is still in flight.
+            if args.contains(where: { BranchQueryStub.isBranchQuery($0) }) {
                 await holder.refreshDuringBatch(worktreeID: wt, number: 88)
             }
             return await gh.run(args: args, repoPath: path)
@@ -2587,6 +2643,455 @@ struct PRStatusManagerFetchAllTests {
 
         #expect(await manager.allStatuses()[wt]?.number == 88)
         #expect(await recorder.clearedIDs.isEmpty)
+    }
+
+    @Test("a branch carrying a closed and an open PR resolves to the open one")
+    func picksTheOpenPRWhenABranchCarriesBoth() async {
+        // The shape seen in the field: a closed pull request and a newer open
+        // one on one head ref. The branch query returns both under that alias,
+        // and the OPEN > MERGED > CLOSED precedence in `bestNodeByRepoBranch`
+        // decides — the same rule `parsePRByBranch` applies on the single-PR
+        // refresh.
+        let wt = UUID()
+        let gh = FakeGH(branchNodes: [
+            Self.nodeJSON(number: 101, head: "tbd/my-branch", state: "CLOSED"),
+            Self.nodeJSON(number: 104, head: "tbd/my-branch")
+        ])
+        let manager = PRStatusManager(ghRunner: { args, path in await gh.run(args: args, repoPath: path) })
+
+        await manager.fetchAll(worktrees: [Self.worktree(wt)])
+
+        #expect(await manager.allStatuses()[wt]?.number == 104)
+        #expect(await manager.allStatuses()[wt]?.state != .closed)
+    }
+
+    @Test("a pull request this account did not author is discovered, and no query names the viewer")
+    func discoversAPullRequestNobodyHereAuthored() async {
+        // The point of asking the repo rather than the account: the stub exposes
+        // #77 only through the repo-scoped branch query. Both halves are
+        // load-bearing — resolving it while still issuing a `viewer` query would
+        // be the author-scoped behaviour wearing a new stub.
+        let wt = UUID()
+        let gh = FakeGH(branchNodes: [Self.nodeJSON(number: 77, head: "tbd/my-branch")])
+        let manager = PRStatusManager(ghRunner: { args, path in await gh.run(args: args, repoPath: path) })
+
+        await manager.fetchAll(worktrees: [Self.worktree(wt)])
+
+        #expect(await manager.allStatuses()[wt]?.number == 77)
+        #expect(await manager.observation(for: wt)?.outcome == .observed)
+        #expect(await gh.branchQueries == 1)
+        let asked = await gh.queryTexts
+        #expect(!asked.isEmpty, "no query at all would make the claim below vacuous")
+        #expect(asked.allSatisfy { !$0.contains("viewer") },
+                "a query scoped to the viewer can only ever see what this account authored")
+    }
+}
+
+/// A `gh` whose `repo view` answer depends on the checkout, and whose branch
+/// query can be made to fail for one repo while answering for another — the
+/// shape a per-repo degradation claim needs. A path absent from `reposByPath`
+/// is a checkout `gh` cannot name at all.
+private actor MultiRepoGH {
+    private let reposByPath: [String: String]
+    private let nodesByRepo: [String: [String]]
+    private let failingRepos: Set<String>
+    /// Which repos a branch query and a by-number query were scoped to, in order.
+    private(set) var branchQueriedRepos: [String] = []
+    private(set) var numberedQueriedRepos: [String] = []
+
+    init(reposByPath: [String: String],
+         nodesByRepo: [String: [String]] = [:],
+         failingRepos: Set<String> = []) {
+        self.reposByPath = reposByPath
+        self.nodesByRepo = nodesByRepo
+        self.failingRepos = failingRepos
+    }
+
+    func run(args: [String], repoPath: String) -> GHCommandResult? {
+        if args.first == "repo" {
+            guard let nameWithOwner = reposByPath[repoPath] else { return nil }
+            return GHCommandResult(
+                stdout: #"{"nameWithOwner":"\#(nameWithOwner)","url":"https://github.com/\#(nameWithOwner)"}"#)
+        }
+        guard let query = args.first(where: { $0.hasPrefix("query=") }) else { return nil }
+        let repo = "\(Self.value(of: "owner", in: args) ?? "")/\(Self.value(of: "name", in: args) ?? "")"
+        if BranchQueryStub.isBranchQuery(query) {
+            branchQueriedRepos.append(repo)
+            guard !failingRepos.contains(repo) else { return nil }
+            return BranchQueryStub.response(args: args, nodes: nodesByRepo[repo] ?? [])
+        }
+        if query.contains("pullRequest(number:") {
+            numberedQueriedRepos.append(repo)
+            return GHCommandResult(stdout: #"{"data":{"repository":{}}}"#)
+        }
+        return nil
+    }
+
+    /// Read a `-f key=value` argument back out of the vector.
+    private static func value(of key: String, in args: [String]) -> String? {
+        args.first { $0.hasPrefix("\(key)=") }.map { String($0.dropFirst(key.count + 1)) }
+    }
+}
+
+/// The branch query is asked per repo, so one repo going dark is one repo's
+/// problem. These drive that claim through `fetchAll` end to end: the old
+/// fleet-wide predicate would have suspended the whole pass on either failure
+/// here, and read a worktree nobody could ask about as "there is no pull
+/// request".
+@Suite("PRStatusManager author-blind branch discovery")
+struct PRStatusManagerBranchDiscoveryTests {
+
+    private static func nodeJSON(number: Int, repo: String, head: String,
+                                 state: String = "OPEN") -> String {
+        """
+        {"number": \(number), "url": "https://github.com/\(repo)/pull/\(number)",
+         "state": "\(state)", "mergeStateStatus": "CLEAN", "reviewDecision": "APPROVED",
+         "headRefName": "\(head)", "createdAt": "2026-07-01T00:00:00Z", "isDraft": false,
+         "statusCheckRollup": {"state": "SUCCESS"}}
+        """
+    }
+
+    private static func worktree(_ id: UUID, branch: String, path: String) -> PRStatusManager.PollWorktree {
+        (id: id, branch: branch, upstreamBranch: "main", defaultBranch: "main",
+         pushBranch: .noPushDestination, worktreePath: path, prNumber: nil)
+    }
+
+    private static func manager(_ gh: MultiRepoGH) -> PRStatusManager {
+        PRStatusManager(ghRunner: { args, path in await gh.run(args: args, repoPath: path) })
+    }
+
+    @Test("one repo's branch query failing leaves the other repo's worktree resolved")
+    func perRepoDegradation() async {
+        let dark = UUID(); let lit = UUID()
+        let gh = MultiRepoGH(
+            reposByPath: ["/wt/dark": "acme/dark-repo", "/wt/lit": "acme/lit-repo"],
+            nodesByRepo: ["acme/lit-repo": [Self.nodeJSON(number: 55, repo: "acme/lit-repo",
+                                                          head: "tbd/lit")]],
+            failingRepos: ["acme/dark-repo"])
+        let manager = Self.manager(gh)
+        let seeded = PRStatus(number: 11, url: "https://github.com/acme/dark-repo/pull/11",
+                              state: .mergeable, reason: "Ready to merge")
+        await manager.seedForTesting(worktreeID: dark, status: seeded)
+
+        await manager.fetchAll(worktrees: [
+            Self.worktree(dark, branch: "tbd/dark", path: "/wt/dark"),
+            Self.worktree(lit, branch: "tbd/lit", path: "/wt/lit")
+        ])
+
+        // The dark repo keeps the newest value anyone has and admits it was not
+        // reconfirmed. Both halves, together, are the point.
+        #expect(await manager.allStatuses()[dark] == seeded)
+        let darkOutcome = await manager.observation(for: dark)?.outcome
+        #expect(darkOutcome != PRObservation.Outcome.none,
+                "a repo that could not answer must never read as 'no pull request'")
+        if case .undetermined = darkOutcome {} else {
+            Issue.record("expected .undetermined for the dark repo, observed \(String(describing: darkOutcome))")
+        }
+
+        // And the repo that answered is untouched by its neighbour going dark.
+        #expect(await manager.allStatuses()[lit]?.number == 55)
+        #expect(await manager.observation(for: lit)?.outcome == .observed)
+    }
+
+    @Test("a worktree whose repo went dark is not handed to the by-number fallback")
+    func unansweredWorktreeIsNeverResolvedByNumber() async {
+        // The mirror of the degradation claim. Where nobody answered,
+        // "unmatched" means nothing, so re-resolving the cached number there
+        // could reattach a stale MERGED pull request and fire auto-archive on a
+        // worktree that has nothing to do with it. The lit repo's own unmatched
+        // worktree IS handed over in the same pass, so this is a discrimination
+        // rather than "the fallback never runs".
+        let dark = UUID(); let lit = UUID()
+        let gh = MultiRepoGH(
+            reposByPath: ["/wt/dark": "acme/dark-repo", "/wt/lit": "acme/lit-repo"],
+            nodesByRepo: [:],
+            failingRepos: ["acme/dark-repo"])
+        let manager = Self.manager(gh)
+        await manager.seedForTesting(
+            worktreeID: dark,
+            status: PRStatus(number: 11, url: "https://github.com/acme/dark-repo/pull/11", state: .mergeable))
+        await manager.seedForTesting(
+            worktreeID: lit,
+            status: PRStatus(number: 22, url: "https://github.com/acme/lit-repo/pull/22", state: .mergeable))
+
+        await manager.fetchAll(worktrees: [
+            Self.worktree(dark, branch: "tbd/dark", path: "/wt/dark"),
+            Self.worktree(lit, branch: "tbd/lit", path: "/wt/lit")
+        ])
+
+        #expect(await gh.branchQueriedRepos.contains("acme/dark-repo"),
+                "the dark repo was asked; it simply could not answer")
+        #expect(await gh.numberedQueriedRepos.contains("acme/dark-repo") == false,
+                "a worktree nobody answered for must not have its cached number re-resolved")
+        #expect(await gh.numberedQueriedRepos.contains("acme/lit-repo"),
+                "the answered repo's unmatched worktree still falls back to its cached number")
+    }
+
+    @Test("a worktree whose repo cannot be named records .undetermined, not .none")
+    func unnameableRepoRecordsUndetermined() async {
+        // It lands in no repo group, so no query ever covers it. Silence from a
+        // question nobody asked is not the forge saying "there is no pull
+        // request here" — and the named worktree beside it, which really was
+        // answered with nothing, is what makes the two readings distinguishable.
+        let nameless = UUID(); let named = UUID()
+        let gh = MultiRepoGH(reposByPath: ["/wt/named": "acme/lit-repo"])
+        let manager = Self.manager(gh)
+
+        await manager.fetchAll(worktrees: [
+            Self.worktree(nameless, branch: "tbd/nameless", path: "/wt/nameless"),
+            Self.worktree(named, branch: "tbd/named", path: "/wt/named")
+        ])
+
+        let namelessOutcome = await manager.observation(for: nameless)?.outcome
+        #expect(namelessOutcome != PRObservation.Outcome.none,
+                "nobody asked about this worktree; that is not 'no pull request'")
+        if case .undetermined = namelessOutcome {} else {
+            Issue.record("expected .undetermined, observed \(String(describing: namelessOutcome))")
+        }
+        #expect(await manager.observation(for: named)?.outcome == PRObservation.Outcome.none,
+                "a repo that answered with no nodes really has no pull request on that branch")
+    }
+}
+
+/// A `gh` observed one branch query at a time: it records the head refs each
+/// query was bound to (so a test can count chunks and see what each carried),
+/// can fail exactly the query carrying a named branch, and reports the most
+/// branch queries it ever had open at once.
+///
+/// The in-flight count is taken around a plain `Task.yield()` window rather than
+/// a barrier: yielding waits on nothing, so a serial caller returns to one in
+/// flight and a concurrent one does not — and neither can hang.
+private actor ChunkedBranchGH {
+    private let reposByPath: [String: String]
+    private let nodes: [String]
+    private let failingBranch: String?
+    private let yields: Int
+
+    /// The `b<N>` bindings of every branch query, one entry per query, in
+    /// arrival order.
+    private(set) var branchQueryBranches: [[String]] = []
+    /// The most branch queries open at the same time. 1 means they ran one
+    /// after another.
+    private(set) var maxInFlight = 0
+    private var inFlight = 0
+
+    init(reposByPath: [String: String] = ["/wt/acme-prod": "acme/acme-prod"],
+         nodes: [String] = [],
+         failingBranch: String? = nil,
+         yields: Int = 0) {
+        self.reposByPath = reposByPath
+        self.nodes = nodes
+        self.failingBranch = failingBranch
+        self.yields = yields
+    }
+
+    func run(args: [String], repoPath: String) async -> GHCommandResult? {
+        if args.first == "repo" {
+            guard let nameWithOwner = reposByPath[repoPath] else { return nil }
+            return GHCommandResult(
+                stdout: #"{"nameWithOwner":"\#(nameWithOwner)","url":"https://github.com/\#(nameWithOwner)"}"#)
+        }
+        guard let query = args.first(where: { $0.hasPrefix("query=") }),
+              BranchQueryStub.isBranchQuery(query) else { return nil }
+        let branches = BranchQueryStub.boundBranches(in: args).map(\.branch)
+        branchQueryBranches.append(branches)
+        inFlight += 1
+        maxInFlight = max(maxInFlight, inFlight)
+        for _ in 0..<yields { await Task.yield() }
+        inFlight -= 1
+        if let failingBranch, branches.contains(failingBranch) { return nil }
+        return BranchQueryStub.response(args: args, nodes: nodes)
+    }
+}
+
+/// One repo's branch question is asked in chunks, and every chunk is asked at
+/// once. Both halves have teeth: a chunk is the unit a bad head ref can poison,
+/// and the poll that runs these has a 30-second interval to fit inside.
+@Suite("PRStatusManager branch query chunking")
+struct PRStatusManagerBranchChunkingTests {
+
+    private static let cap = PRStatusManager.branchQueryAliasCap
+
+    private static func nodeJSON(number: Int, repo: String = "acme/acme-prod",
+                                 head: String) -> String {
+        """
+        {"number": \(number), "url": "https://github.com/\(repo)/pull/\(number)",
+         "state": "OPEN", "mergeStateStatus": "CLEAN", "reviewDecision": "APPROVED",
+         "headRefName": "\(head)", "createdAt": "2026-07-01T00:00:00Z", "isDraft": false,
+         "statusCheckRollup": {"state": "SUCCESS"}}
+        """
+    }
+
+    private static func worktree(_ id: UUID, branch: String, upstream: String? = "main",
+                                 path: String = "/wt/acme-prod") -> PRStatusManager.PollWorktree {
+        (id: id, branch: branch, upstreamBranch: upstream, defaultBranch: "main",
+         pushBranch: .noPushDestination, worktreePath: path, prNumber: nil)
+    }
+
+    private static func manager(_ gh: ChunkedBranchGH) -> PRStatusManager {
+        PRStatusManager(ghRunner: { args, path in await gh.run(args: args, repoPath: path) })
+    }
+
+    private static func isUndetermined(_ outcome: PRObservation.Outcome?) -> Bool {
+        if case .undetermined = outcome { return true }
+        return false
+    }
+
+    // MARK: - The chunker itself (pure)
+
+    @Test("chunking splits at the alias cap and never splits one worktree's candidates")
+    func chunkingKeepsAWorktreesCandidatesTogether() {
+        // Two candidates each (its own branch and a tracked branch that is not
+        // the repo default), so `cap / 2` worktrees fill a chunk exactly and the
+        // next one cannot fit without splitting a pair. Splitting a pair is the
+        // failure this shape exists to rule out: `matchUnnumbered` takes a
+        // worktree's FIRST hit, so a candidate answered from a surviving chunk
+        // while its own branch's chunk failed is a mis-attachment, not a partial
+        // answer.
+        let perChunk = Self.cap / 2
+        let entries = (0..<(perChunk + 1)).map {
+            Self.worktree(UUID(), branch: "tbd/w\($0)", upstream: "up/w\($0)")
+        }
+
+        let chunks = PRStatusManager.branchQueryChunks(entries)
+
+        #expect(chunks.count == 2)
+        #expect(chunks[0].entries.count == perChunk)
+        #expect(chunks[0].branches.count == Self.cap)
+        #expect(chunks[1].entries.count == 1)
+        #expect(chunks.allSatisfy { $0.branches.count <= Self.cap })
+        // The invariant, stated over every chunk rather than inferred from the
+        // counts: whatever chunk a worktree landed in asks about ALL of its
+        // candidates.
+        for chunk in chunks {
+            for entry in chunk.entries {
+                let candidates = PRStatusManager.candidatesFor(entry)
+                #expect(candidates.allSatisfy { chunk.branches.contains($0) },
+                        "worktree \(entry.branch) had candidates \(candidates) split out of its own chunk")
+            }
+        }
+        // Every worktree is in exactly one chunk — no entry dropped, none asked twice.
+        #expect(chunks.flatMap { $0.entries.map(\.id) }.count == entries.count)
+        #expect(Set(chunks.flatMap { $0.entries.map(\.id) }) == Set(entries.map(\.id)))
+    }
+
+    @Test("a branch list that fits stays one chunk")
+    func smallRepoIsOneChunk() {
+        let entries = (0..<3).map { Self.worktree(UUID(), branch: "tbd/w\($0)") }
+        let chunks = PRStatusManager.branchQueryChunks(entries)
+        #expect(chunks.count == 1)
+        #expect(chunks[0].branches == ["tbd/w0", "tbd/w1", "tbd/w2"])
+    }
+
+    // MARK: - The argument vector
+
+    @Test("an empty branch list yields no argument vector at all")
+    func emptyBranchesYieldNoArguments() {
+        // A zero-alias document is `repository(…) { }` — an invalid GraphQL
+        // document — so the vector that would run it must not exist.
+        #expect(PRStatusManager.branchPRsArgs(owner: "acme", name: "acme-prod",
+                                              branches: []).isEmpty)
+        // And the ordinary case is untouched, so the guard is not just a
+        // blanket refusal.
+        let args = PRStatusManager.branchPRsArgs(owner: "acme", name: "acme-prod",
+                                                 branches: ["tbd/x"])
+        #expect(args.contains("b0=tbd/x"))
+        #expect(args.contains("owner=acme"))
+    }
+
+    // MARK: - End to end through `fetchAll`
+
+    @Test("a repo with more head refs than one query may carry is split, and every worktree resolves")
+    func oversizedRepoIsChunkedAndFullyResolved() async {
+        let count = Self.cap + 10
+        let ids = (0..<count).map { _ in UUID() }
+        let gh = ChunkedBranchGH(
+            nodes: (0..<count).map { Self.nodeJSON(number: 200 + $0, head: "tbd/wt-\($0)") })
+        let manager = Self.manager(gh)
+
+        await manager.fetchAll(
+            worktrees: ids.enumerated().map { index, id in
+                Self.worktree(id, branch: "tbd/wt-\(index)")
+            })
+
+        let queries = await gh.branchQueryBranches
+        #expect(queries.count == 2, "\(count) head refs cannot ride one \(Self.cap)-alias query")
+        #expect(queries.allSatisfy { $0.count <= Self.cap },
+                "a chunk over the cap defeats the point of having one: \(queries.map(\.count))")
+        #expect(queries.flatMap { $0 }.count == count, "every head ref must still be asked about")
+        let statuses = await manager.allStatuses()
+        for (index, id) in ids.enumerated() {
+            #expect(statuses[id]?.number == 200 + index,
+                    "worktree \(index) lost its pull request to the split")
+        }
+    }
+
+    @Test("one failed chunk leaves the other chunk's worktrees resolved")
+    func chunkFailureIsScopedToItsOwnWorktrees() async {
+        // The blast radius the cap buys. One head ref's field erroring
+        // null-propagates to `repository`, so the whole response reads as "the
+        // forge did not answer" — for that chunk, and for nothing else.
+        let count = Self.cap + 10
+        let ids = (0..<count).map { _ in UUID() }
+        let gh = ChunkedBranchGH(
+            nodes: (0..<count).map { Self.nodeJSON(number: 200 + $0, head: "tbd/wt-\($0)") },
+            failingBranch: "tbd/wt-0")
+        let manager = Self.manager(gh)
+
+        await manager.fetchAll(
+            worktrees: ids.enumerated().map { index, id in
+                Self.worktree(id, branch: "tbd/wt-\(index)")
+            })
+
+        let statuses = await manager.allStatuses()
+        for index in 0..<Self.cap {
+            #expect(statuses[ids[index]] == nil, "the failed chunk must contribute no matches")
+            let outcome = await manager.observation(for: ids[index])?.outcome
+            #expect(Self.isUndetermined(outcome),
+                    "a chunk that could not answer must never read as 'no pull request', observed \(String(describing: outcome))")
+        }
+        for index in Self.cap..<count {
+            #expect(statuses[ids[index]]?.number == 200 + index,
+                    "worktree \(index) is in the healthy chunk and must still resolve")
+            #expect(await manager.observation(for: ids[index])?.outcome == .observed)
+        }
+    }
+
+    @Test("every repo's chunk queries are in flight together, and every repo's matches come back")
+    func chunkQueriesRunConcurrently() async {
+        // Two repos, each needing two chunks: four queries that a serial walk
+        // would run one at a time. `maxInFlight` is the discriminator — it is
+        // exactly 1 for a sequential loop.
+        let count = Self.cap + 1
+        let alpha = (0..<count).map { _ in UUID() }
+        let beta = (0..<count).map { _ in UUID() }
+        let gh = ChunkedBranchGH(
+            reposByPath: ["/wt/alpha": "acme/alpha", "/wt/beta": "acme/beta"],
+            nodes: [Self.nodeJSON(number: 301, repo: "acme/alpha", head: "a-wt-0"),
+                    Self.nodeJSON(number: 302, repo: "acme/beta", head: "b-wt-0")],
+            yields: 4)
+        let manager = Self.manager(gh)
+
+        let alphaWorktrees = alpha.enumerated().map { index, id in
+            Self.worktree(id, branch: "a-wt-\(index)", path: "/wt/alpha")
+        }
+        let betaWorktrees = beta.enumerated().map { index, id in
+            Self.worktree(id, branch: "b-wt-\(index)", path: "/wt/beta")
+        }
+        await manager.fetchAll(worktrees: alphaWorktrees + betaWorktrees)
+
+        let queryCount = await gh.branchQueryBranches.count
+        #expect(queryCount == 4, "two repos over the cap is four chunks, observed \(queryCount)")
+        let maxInFlight = await gh.maxInFlight
+        #expect(maxInFlight > 1,
+                "the chunk queries ran one at a time (max in flight \(maxInFlight))")
+        // Concurrency changed nothing about the answers: each repo's own match
+        // landed on its own worktree, and neither reached the other's.
+        let statuses = await manager.allStatuses()
+        #expect(statuses[alpha[0]]?.number == 301)
+        #expect(statuses[beta[0]]?.number == 302)
+        #expect(statuses[alpha[1]] == nil)
+        #expect(statuses[beta[1]] == nil)
     }
 }
 

--- a/docs/specs/2026-08-10-multi-pr-per-worktree-design.md
+++ b/docs/specs/2026-08-10-multi-pr-per-worktree-design.md
@@ -8,10 +8,10 @@ starts the next piece of work on a fresh branch, and opens another. TBD shows
 exactly one of them.
 
 The single-PR assumption is not merely a display limit. TBD discovers a
-worktree's PR by matching the worktree's **head branch** against the viewer's
-authored PRs. A subagent's PR is typically on a branch the worktree never had
-checked out, so no amount of polling will find it: it is invisible by
-construction, not by omission.
+worktree's PR by asking the repo about the worktree's **candidate head
+branches**. A subagent's PR is typically on a branch the worktree never had
+checked out, so it is named by no candidate and no amount of polling will find
+it: it is invisible by construction, not by omission.
 
 ## What exists today
 
@@ -21,8 +21,9 @@ construction, not by omission.
   (migrations `v34`, `v54`).
 - `PRStatusManager` keys its cache `[UUID: PRStatus]` — one status per worktree.
   It resolves a stored number directly via an aliased `pullRequest(number:)`
-  query, and otherwise matches the viewer-authored batch by head branch, scoped
-  to the worktree's own repo.
+  query, and otherwise asks each repo about its worktrees' candidate head refs
+  — one aliased `pullRequests(headRefName:)` field per branch, author-blind —
+  and matches the answer back, scoped to the worktree's own repo.
 - `PRStatusManager.apply` fires `onMergedTransition` when a worktree's status
   moves from non-merged to `.merged`. That drives auto-archive
   (`AutoArchiveOnMergeCoordinator`) and auto-hibernate
@@ -78,11 +79,12 @@ defaulted so existing rows and JSON still decode.
 `Worktree.prNumber` keeps its present meaning — provenance for a worktree
 created from a PR row — and additionally seeds a `manual`-source binding, so
 that PR appears in the list like any other. Fork PRs make this load-bearing
-rather than tidy: their head branch never appears in the viewer-authored batch,
-so branch matching can never find them and the stored number is the only handle
-that exists. Seeding runs as a poll reconciliation rather than at creation,
-which covers worktrees that predate bindings and avoids the moment during
-creation when the checkout does not yet exist and its repo cannot be resolved.
+rather than tidy: a fork PR's head ref lives in the fork, so no query against
+this repo's head refs reaches it, branch matching can never find them, and the
+stored number is the only handle that exists. Seeding runs as a poll
+reconciliation rather than at creation, which covers worktrees that predate
+bindings and avoids the moment during creation when the checkout does not yet
+exist and its repo cannot be resolved.
 Because it re-runs every poll, the seed is explicitly barred from reviving a
 tombstone, which a `manual` source would otherwise do.
 

--- a/docs/specs/2026-08-16-pr-chip-untrack-design.md
+++ b/docs/specs/2026-08-16-pr-chip-untrack-design.md
@@ -319,12 +319,13 @@ is one click away.
 
 Titles are fetched by adding `title` to `prNodeFieldSelection`, the by-number
 selection the binding refresh already issues. That selection is shared with the
-viewer-authored batch, which pulls up to a hundred PRs, so this is a real
-addition to the poll's payload rather than a free one — one short string per PR
-per pass, and the batch's copies are discarded, because only the by-number path
-has a binding row to persist them onto. It is a rounding error beside the check
-rollup the same node already carries, and forking the selection in two to avoid
-it would give up the guarantee that the two queries cannot drift.
+poll's repo-scoped branch query, which pulls up to ten PRs per candidate head
+ref, so this is a real addition to the poll's payload rather than a free one —
+one short string per PR per pass, and the branch query's copies are discarded,
+because only the by-number path has a binding row to persist them onto. It is a
+rounding error beside the check rollup the same node already carries, and
+forking the selection in two to avoid it would give up the guarantee that the
+two queries cannot drift.
 
 The title is persisted on the binding row, in a new nullable `title` column
 (the migration follows the shared-model rule: column, GRDB record, and Codable


### PR DESCRIPTION
## What's broken

A pull request opened on a worktree's branch by anyone other than you is invisible to TBD. No chip appears, nothing binds, and auto-archive never fires — the worktree looks like it has no PR at all, forever.

Anyone whose PRs are opened on their behalf hits this on every single PR: a bot or GitHub App that opens the PR so a human can approve it, a teammate who opens it for you, a PR raised through the web UI, or an agent session running `gh pr create` on a remote box where no local daemon sees the hook. Concretely: a worktree whose branch carried two PRs — one you opened and later closed, one a GitHub App opened and merged — showed the closed one indefinitely and never learned the merged one existed.

## Why it happens

TBD has three ways to discover a worktree's PR, and a PR someone else opened misses all three.

The hook that watches for `gh pr create` never fires, because the command that ran was a wrapper driving `gh` on another machine. That gate is deliberately fail-closed and is left alone here — a false bind hands `allResolved` an auto-archive nobody asked for.

Provenance seeding only applies to worktrees created *from* a PR row, which this is not.

That leaves branch matching, and this is the actual bug: it asked GitHub `viewer { pullRequests(first: 100, …) }` — *the authenticated account's own pull requests* — and then matched branch names locally. A PR you didn't author is not in that list, so it is invisible by construction rather than by omission. The 100-PR cap silently lost older PRs on top of that.

The premise behind this shape was written down in the code — that GitHub can only be asked for the viewer's pull requests, and that author-blind branch matching was a GitLab-only capability. That premise is false, and this same file already disproved it twice: `prByBranchQuery` (the single-PR refresh) and `openPRsQuery` (the PR picker) are both repo-scoped and author-blind. The viewer batch was simply the older shape, and the GitLab work fixed the asymmetry on one forge without going back for the other.

## What this PR does

Asks the repo instead of the account. One repo-scoped query per repo per pass, with one aliased field per candidate head branch:

```graphql
b0: pullRequests(headRefName: $b0, first: 10, orderBy: {field: CREATED_AT, direction: DESC}) { … }
```

This is the same question the GitLab path has always asked, so the two forges now read as siblings differing only in how the branch list is carried. Author-blind, no fleet-wide page cap, and `first: 10` newest-first covers a branch reused across a closed-and-reopened pair.

Every branch is a declared `String!` **variable** bound with `-f`, never interpolated into the query text. A git ref may legally contain `"`, and interpolating one produced a malformed query — a regression that had a comment recording it and no test. It has a test now.

**Judgement moved from the fleet to the repo.** The old `batchSucceeded` was a single boolean speaking for every worktree everywhere: one failed call suspended the by-number fallback and the head-ref heals for the entire fleet. It is replaced by `answeredIDs`, mirroring the GitLab side's existing per-project tracking. A repo whose query fails contributes no matches *and* no answered ids, so its worktrees keep their cached status and record `.undetermined` — never "no PR". This also fixes a case the fleet-wide predicate got wrong: a worktree whose repo can't be resolved was read as "no PR", when nobody could ask about it at all.

**Queries are chunked by worktree and fanned out concurrently.** Chunked because `pullRequests` is a non-null connection, so a GraphQL error on one aliased field null-propagates to `repository` and reads as "the forge did not answer" for the whole repo; a cap bounds that blast radius. Chunked *by worktree* specifically, never by branch: `matchUnnumbered` takes a worktree's first matching candidate, so splitting one worktree's candidates across chunks could attach it to its second-choice branch's PR while its own branch's PR sat in the failed chunk — and mis-attachments here reach `onMergedTransition` and auto-archive. Fanned out because the GitHub path went from one fleet-wide call to one per repo against a 30-second foreground poll.

`runGHGraphQL` and `parsePRNodes` had no callers left and are deleted, along with every comment asserting the retired premise.

This is a bug fix — it restores the system to the theory it already held, that branch discovery asks the forge what exists on a branch — so it ships without a spec.

## Assumptions

- **`pullRequests(headRefName:)` matches on head ref name regardless of which repository the head lives in**, so a cross-repository (fork) PR opened into this repo is returned too. Cross-repo nodes are deliberately *not* filtered out: `resolveNameWithOwner` resolves the base repo for a fork checkout on purpose, so for a fork user every PR of theirs is cross-repository and filtering would remove branch discovery for them entirely. The residual is that an outside fork opening a PR whose head ref exactly equals a local worktree's branch name could be matched to it. Accepted because TBD's branches are `tbd/<slug>`-shaped, merge-triggered actions default off, and the identical exposure already exists in `prByBranchQuery` (used by the interactive refresh) and the GitLab `sourceBranches` path — it is a property of asking a forge by head ref, not something new here. A real fix needs the worktree's own head-repository identity, which the poll does not resolve today. Documented as a `KNOWN RESIDUAL` in the code.
- The alias cap assumes GitHub keeps serving a few hundred aliased connection fields inside its request timeout. If that stops holding, the symptom is a repo going `.undetermined` every poll — safe, self-healing, and visible in the log.

## Evidence & verification

**The repro, before the fix.** A worktree on branch `tbd/<slug>` in a repo where that branch carried two PRs: one authored by the viewer (closed) and one authored by a GitHub App (merged). TBD showed only the closed viewer-authored one; the App-authored PR had never been seen. Its stored binding table held only the closed PR.

**Discriminating tests** (all fail without the fix):
- A PR exposed *only* through the repo-scoped branch query is discovered — and the stub asserts no query text ever contained `viewer`, so resolving it while still issuing an author-scoped query cannot pass.
- A branch carrying a closed PR and a newer open one resolves to the open one.
- Per-repo degradation: one repo's query fails while another's succeeds — the failing repo's worktree keeps its cached status and records `.undetermined`, its sibling resolves and records `.observed`. Mirrored on the by-number path: the dark repo is never re-queried by number while the answered repo's unmatched worktree still is.
- A worktree whose repo cannot be named records `.undetermined`, while a worktree whose repo answered with nothing records `.none`.
- A branch name containing `"` is bound as a field value and appears nowhere in the query text; `-F` is never used.
- Chunking splits at the cap and never splits one worktree's candidates; one failed chunk leaves the other chunk's worktrees resolved; chunk queries are in flight together (the probe reads `maxInFlight > 1`, which is exactly 1 under a serial loop).
- `parseBranchPRNodes` separates "answered with nothing" (`[]`) from "did not answer" (`nil`) across four response shapes.

**Suite.** 459 tests in 21 PR suites pass. Full local suite: 9257 tests, all PR suites green; the failures present are wait-timeouts in unrelated PTY/holder/ControlMode/subprocess-timeout tests on a box that was running another worktree's live tests concurrently — CI is the authoritative whole-suite verdict.

**Live verification**, against the real case, with the daemon rebuilt and restarted from this worktree. Before: the worktree's only binding was the closed viewer-authored PR (tombstoned), and its cached status named that PR. After one poll tick, with no manual attach:

```
number = 24926
source = branch            ← discovered by the author-blind matcher
detached = 0
headBranch = tbd/…         ← matched on the worktree's own branch
prStatus = {"state":"merged","reason":"Merged", …}
```

The App-authored PR is bound, on the right branch, with the right state, and precedence picked it over the closed PR on the same head ref. The worktree stayed `active` — the merged transition fired and auto-archive correctly did not, since it defaults off. The closed PR's `detached=1` tombstone was left untouched, so the coordinator's tombstone rule held.

**Cost, measured against the real forge** rather than assumed, since a per-repo query carries far more aliases than the old fleet-wide batch (the largest repo on the test box has 97 active worktrees): 96 aliases returned in 3.96s, 288 aliases in 5.25s at a GraphQL rate-limit cost of 3 points out of 5000/hr.

https://claude.ai/code/session_016dDWV996GHuDakWtiupDjf

[20260902-hissing-giraffe](https://cheapsteak.github.io/tbd/open/?worktree=5A13765D-A97A-47E2-8EDF-FFB3035AC1D8)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Pull request discovery now works across repositories and does not depend on the current account’s authored pull requests.
  * Fork-based pull requests are resolved more reliably using stored pull request information.
  * Status polling and refreshes better isolate repository-specific failures while preserving valid cached results.
  * GitLab-only worktrees avoid unnecessary GitHub lookups.
* **Documentation**
  * Updated pull request discovery and fork handling documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->