### PR TITLE
Fix: A SwiftLint point release turned the required Lint check red on every PR

### DIFF
--- a/Sources/TBDApp/Panes/CodeViewerPaneView.swift
+++ b/Sources/TBDApp/Panes/CodeViewerPaneView.swift
@@ -581,7 +581,7 @@ private struct ImagePreviewView: View {
             if let image {
                 Image(nsImage: image)
                     .resizable()
-                    .aspectRatio(contentMode: .fit)
+                    .scaledToFit()
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .padding(12)
             } else {

--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -399,7 +399,7 @@ struct PanePlaceholder: View {
                     if let screenshot = appState.suspendingSnapshots[terminal.id] {
                         Image(nsImage: screenshot)
                             .resizable()
-                            .aspectRatio(contentMode: .fill)
+                            .scaledToFill()
                     } else {
                         Color.black
                     }

--- a/Sources/TBDApp/Panes/Transcript/TranscriptImageAttachmentView.swift
+++ b/Sources/TBDApp/Panes/Transcript/TranscriptImageAttachmentView.swift
@@ -101,7 +101,7 @@ struct TranscriptImageAttachmentView: View {
             if let image {
                 Image(nsImage: image)
                     .resizable()
-                    .aspectRatio(contentMode: .fit)
+                    .scaledToFit()
                     .clipShape(RoundedRectangle(cornerRadius: 6))
                     .opacity(hovering ? 0.85 : 1)
             } else {


### PR DESCRIPTION
## What's broken

`Lint` is a required check, and it is currently red on every open pull request — including ones whose diffs touch no SwiftUI at all. `main` itself does not satisfy it. Nobody changed the code that fails.

## Why it happens

The `Lint` job installs the linter with `brew install swiftlint`, which serves whatever the current release is. SwiftLint 0.65.1 adds the `legacy_swiftui_aspect_ratio` rule, and the version moved under us mid-afternoon.

Two runs over the same tree, thirteen minutes apart, show it directly:

- `17:53` — `Pouring swiftlint--0.65.0` → `Found 0 violations, 0 serious in 909 files`
- `18:06` — `Pouring swiftlint--0.65.1` → `Found 3 violations, 3 serious in 909 files`

The three violations are in `CodeViewerPaneView`, `PanePlaceholder`, and `TranscriptImageAttachmentView`, all last touched by unrelated work.

Because the job pins no version, this is not reproducible locally for anyone whose Homebrew has not caught up yet — a developer on 0.65.0 gets a clean `swiftlint --strict` and a red CI check for the same tree.

## What this PR does

Rewrites the three sites the new rule names. Each is `Image().resizable().aspectRatio(contentMode:)` — exactly the shape the rule targets — and `scaledToFit()` / `scaledToFill()` are defined as `aspectRatio(nil, contentMode:)`, so this is a rename and not a layout change.

Deliberately narrow: it unblocks the gate and nothing else. Whether the job should pin a SwiftLint version — trading these surprise breakages for a deliberate upgrade step — is a real question, but it is a change to the merge gate's own machinery and wants its own discussion rather than riding along here.

## Evidence & verification

- The rule and the three call sites were read from the failing run's log, not inferred: each violation names a file, a line, and `(legacy_swiftui_aspect_ratio)`.
- The version difference is quoted above from the two runs' own `Pouring swiftlint--*` lines, which is what establishes that the tree did not change and the linter did.
- `swiftlint --strict` locally: clean — though on 0.63.2, which does not carry the rule, so CI at 0.65.1 is the verdict that counts here.
- The `test` job compiles `TBDApp`, which is what confirms the three modifier swaps build.

https://claude.ai/code/session_016dDWV996GHuDakWtiupDjf

[20260902-hissing-giraffe](https://cheapsteak.github.io/tbd/open/?worktree=5A13765D-A97A-47E2-8EDF-FFB3035AC1D8)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved image preview rendering so images consistently fit within the available viewing area.
  - Updated terminal screenshots to fill their designated display area more reliably.
  - Applied consistent sizing behavior across code viewer, placeholder, and transcript image attachments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->