### PR TITLE
Fix: A rejected setup token is retried forever, billing a request each time

### DIFF
--- a/Sources/TBDApp/AppState+ModelProfiles.swift
+++ b/Sources/TBDApp/AppState+ModelProfiles.swift
@@ -612,6 +612,10 @@ extension AppState {
     /// reachable from no other gesture in the app. Naming the id puts it on the
     /// daemon's targeted path, which covers every *supported* profile.
     ///
+    /// Naming the id is also what tells the daemon a user is asking, which
+    /// releases the hold it places on a token profile whose token was rejected
+    /// — the row's way out of "Token rejected" short of pasting a replacement.
+    ///
     /// The five-minute floor between token probes stays the daemon's to enforce
     /// (`OAuthProfileUsagePoller.freshnessWindow` raises any caller's requested
     /// window to `tokenProfileFloor` for that kind): this asks, it does not

--- a/Sources/TBDDaemon/Claude/OAuthProfileUsagePoller.swift
+++ b/Sources/TBDDaemon/Claude/OAuthProfileUsagePoller.swift
@@ -43,9 +43,12 @@ private let logger = Logger(subsystem: "com.tbd.daemon", category: "oauthUsagePo
 ///   instead HELD: no automatic retry at all, because every retry is a billed
 ///   request that cannot succeed until the user replaces the token. The hold
 ///   is released only by a credential change or the profile row's manual
-///   refresh. A signed-in `.oauth` profile is never held — its `.needsLogin`
-///   clears when the user re-runs `/login`, an act that emits no event, so the
-///   free cadence sweep re-reading the login identity IS its recovery path.
+///   refresh, so it is armed only for a rejection of the token the profile
+///   still has — one that describes a token already replaced takes the timed
+///   schedule instead (`credentialGeneration`). A signed-in `.oauth` profile is
+///   never held — its `.needsLogin` clears when the user re-runs `/login`, an
+///   act that emits no event, so the free cadence sweep re-reading the login
+///   identity IS its recovery path.
 /// - `broadcast` fires (once per sweep) only when snapshot data actually
 ///   changed — `lastAttemptAt` alone doesn't count, so a persistently failing
 ///   profile doesn't emit a delta every 90 s.
@@ -138,7 +141,9 @@ public actor OAuthProfileUsagePoller {
     ///   `.oauthToken` profile whose token was rejected, where a retry is a
     ///   billed request that cannot succeed until the token is replaced.
     ///   Released by a credential change (which clears the whole state) or by
-    ///   the profile row's manual refresh.
+    ///   the profile row's manual refresh. Because nothing else can release it,
+    ///   it is armed only when the rejection describes the credential the
+    ///   profile currently has — see `credentialGeneration`.
     private struct BackoffState {
         var consecutiveFailures: Int = 0
         var nextEligibleAt: Date?
@@ -146,6 +151,22 @@ public actor OAuthProfileUsagePoller {
         var awaitingUserAction: Bool = false
     }
     private var backoff: [UUID: BackoffState] = [:]
+
+    /// Monotonic per-profile counter of how many times the profile's
+    /// credential has been replaced. Absent means zero. In-memory only, like
+    /// `backoff`; a daemon restart resets it, which is harmless because it
+    /// resets the retry state it guards along with it.
+    ///
+    /// It exists to answer one question at the moment an outcome is recorded:
+    /// *does this outcome still describe the credential the profile has?*
+    /// `sweep` suspends at the fetch and the actor admits `noteCredentialChanged`
+    /// there, so a probe of the OLD token can land after the rotation that
+    /// replaced it. Arming a user-action hold on that outcome would pin the
+    /// NEW token behind a gesture the user has already made — indefinitely,
+    /// because a hold cannot expire. Comparing the generation captured before
+    /// the fetch against the current one distinguishes the two cases, and only
+    /// the retry regime keys off it (see `record`).
+    private var credentialGeneration: [UUID: Int] = [:]
 
     /// Profiles with a fetch currently in flight.
     ///
@@ -407,8 +428,18 @@ public actor OAuthProfileUsagePoller {
     /// cannot rotate in a loop, and every timer- and activity-driven caller
     /// still goes through `freshnessWindow(requested:kind:)` and the retry
     /// state.
+    ///
+    /// Bumping `credentialGeneration` is the other half of the release, and it
+    /// covers the case clearing `backoff` cannot: a probe of the OLD token that
+    /// is already in flight. Its sweep is dropped by the in-flight reservation,
+    /// so this clear happens BEFORE that probe's failure is recorded, and
+    /// without the generation bump the old token's rejection would arm a hold
+    /// after the release — pinning the new credential behind a gesture the user
+    /// has already made. `record` reads the bump and schedules that outcome
+    /// instead, so the next turn end re-probes with the new token.
     public func noteCredentialChanged(profileID: UUID) async {
         backoff[profileID] = nil
+        credentialGeneration[profileID, default: 0] += 1
         await sweep(only: profileID, skipFresherThan: nil, ignoringFreshness: true)
     }
 
@@ -499,6 +530,7 @@ public actor OAuthProfileUsagePoller {
         if only == nil {
             snapshots = snapshots.filter { supportedIDs.contains($0.key) }
             backoff = backoff.filter { supportedIDs.contains($0.key) }
+            credentialGeneration = credentialGeneration.filter { supportedIDs.contains($0.key) }
             if let prunePersisted {
                 await prunePersisted(supportedIDs)
             }
@@ -551,7 +583,10 @@ public actor OAuthProfileUsagePoller {
             // token is not verified until the next turn end or a manual
             // refresh. The window is the length of a single HTTP request, and
             // the alternative — exempting that path — is the double bill this
-            // guard exists to prevent.
+            // guard exists to prevent. The "next turn end" half of that promise
+            // is what `credentialGeneration` keeps true: the dropped rotation
+            // still bumps it, so the old credential's rejection cannot arm a
+            // hold that no turn end could ever lift.
             guard inFlight.insert(profile.id).inserted else {
                 logger.debug("usage probe already in flight for profile \(profile.id, privacy: .public); dropping duplicate")
                 continue
@@ -565,8 +600,13 @@ public actor OAuthProfileUsagePoller {
             // headers. Neither fetcher knows the other exists.
             let usageFetcher: any ProfileUsageFetching =
                 profile.kind == .oauthToken ? tokenFetcher : fetcher
+            // Captured on THIS side of the fetch's suspension, where it still
+            // describes the credential about to be sent. `noteCredentialChanged`
+            // can interleave during the await and bump it; `record` compares
+            // the two and refuses to hold an outcome about a replaced token.
+            let generation = credentialGeneration[profile.id] ?? 0
             let status = await usageFetcher.fetchUsage(credential: usageCredential)
-            await record(status, for: profile.id, kind: profile.kind)
+            await record(status, for: profile.id, kind: profile.kind, generation: generation)
         }
 
         if hasMeaningfulChange(from: before, to: snapshots) {
@@ -594,9 +634,18 @@ public actor OAuthProfileUsagePoller {
     /// else: the recorded snapshot (status text, `statusKind`, retained
     /// buckets and organization id) is identical either way, so the row goes
     /// on reading `Token rejected — Replace token…` off `statusKind`.
+    ///
+    /// `generation` is the profile's `credentialGeneration` as it stood when
+    /// the fetch was issued. It gates the retry REGIME and nothing else — a
+    /// stale outcome is still recorded as the snapshot, deliberately. Writing
+    /// an outcome the credential has outrun is pre-existing accepted behavior
+    /// (the fetch really did happen, and the next probe overwrites it moments
+    /// later); suppressing the write here would leave the row with no status
+    /// at all in the very window this is about, and is a separate change.
     private func record(_ status: ProfileUsageFetchStatus,
                         for profileID: UUID,
-                        kind: CredentialKind) async {
+                        kind: CredentialKind,
+                        generation: Int) async {
         let timestamp = now()
         switch status {
         case .ok(let buckets, let organizationID):
@@ -623,7 +672,15 @@ public actor OAuthProfileUsagePoller {
             } else {
                 statusText = "fetch failed: \(reason)"
             }
-            if kind == .oauthToken, case .needsLogin = status {
+            // A hold is only ever right about the credential the profile still
+            // has. If the token was replaced while this fetch was in flight,
+            // the rejection describes a token that no longer exists, and
+            // holding on it would pin the replacement behind a gesture the
+            // user already made. Such an outcome falls through to the timed
+            // schedule, which is bounded, self-releasing, and settled by the
+            // rotation's own probe at the next turn end.
+            let credentialIsCurrent = (credentialGeneration[profileID] ?? 0) == generation
+            if kind == .oauthToken, credentialIsCurrent, case .needsLogin = status {
                 holdForUserAction(profileID)
             } else {
                 scheduleBackoff(for: profileID, status: status, at: timestamp)
@@ -660,6 +717,13 @@ public actor OAuthProfileUsagePoller {
     /// probe whose own outcome re-arms whichever regime that outcome belongs
     /// to. A transient failure after the release is a new problem and starts
     /// at rung one, which is also what a credential change gives it.
+    ///
+    /// Only an outcome describing the credential the profile CURRENTLY has may
+    /// reach here — `record` checks `credentialGeneration` first. A rejection
+    /// of a token that was replaced while its probe was in flight says nothing
+    /// anyone can act on, and a hold armed on it would be unreleasable in
+    /// practice: the gesture that releases a hold has already happened. That
+    /// case takes the timed schedule instead.
     private func holdForUserAction(_ profileID: UUID) {
         backoff[profileID] = BackoffState(awaitingUserAction: true)
     }

--- a/Sources/TBDDaemon/Claude/OAuthProfileUsagePoller.swift
+++ b/Sources/TBDDaemon/Claude/OAuthProfileUsagePoller.swift
@@ -37,6 +37,15 @@ private let logger = Logger(subsystem: "com.tbd.daemon", category: "oauthUsagePo
 /// - A failing profile records a status ("stale since X; fetch failed: …")
 ///   without poisoning the rest of the sweep; previously fetched buckets are
 ///   retained so the picker can show stale-but-real numbers.
+/// - Two failure regimes, because two different things release them. A
+///   transient failure backs off on a timed schedule that elapses on its own.
+///   A `.oauthToken` profile whose token was rejected (`.needsLogin`) is
+///   instead HELD: no automatic retry at all, because every retry is a billed
+///   request that cannot succeed until the user replaces the token. The hold
+///   is released only by a credential change or the profile row's manual
+///   refresh. A signed-in `.oauth` profile is never held — its `.needsLogin`
+///   clears when the user re-runs `/login`, an act that emits no event, so the
+///   free cadence sweep re-reading the login identity IS its recovery path.
 /// - `broadcast` fires (once per sweep) only when snapshot data actually
 ///   changed — `lastAttemptAt` alone doesn't count, so a persistently failing
 ///   profile doesn't emit a delta every 90 s.
@@ -63,11 +72,12 @@ public actor OAuthProfileUsagePoller {
     /// including the picker-open refresh, which asks for a 30-second window.
     public static let tokenProfileFloor: TimeInterval = 300
 
-    /// Backoff schedule for a profile whose fetch failed. Doubles per
-    /// consecutive failure, jittered, capped. A 429 with a `Retry-After`
+    /// Backoff schedule for a profile whose fetch failed transiently. Doubles
+    /// per consecutive failure, jittered, capped. A 429 with a `Retry-After`
     /// overrides this with the server's own value. Kept below the picker's
     /// stale threshold at the low end so a single hiccup doesn't visibly stall
-    /// a profile.
+    /// a profile. A rejected token is not on this schedule at all — see
+    /// `BackoffState.awaitingUserAction`.
     public static let baseBackoff: TimeInterval = 30
     public static let maxBackoff: TimeInterval = 15 * 60
 
@@ -110,15 +120,30 @@ public actor OAuthProfileUsagePoller {
     /// can't launch a second loop.
     private var started = false
 
-    /// Per-profile backoff bookkeeping. `consecutiveFailures` drives the
-    /// exponential schedule; `nextEligibleAt` is when a sweep may try this
-    /// profile again. Isolated per profile so one account's rate limit never
-    /// delays another's polling. Every sweep honors this gate — including the
-    /// picker-open RPC path (`sweepNow`), which must not re-hammer a
-    /// rate-limited endpoint. In-memory only; a daemon restart resets it.
+    /// Per-profile retry bookkeeping. Isolated per profile so one account's
+    /// rate limit never delays another's polling. Every sweep honors it —
+    /// including the picker-open RPC path (`sweepNow`), which must not
+    /// re-hammer a rate-limited endpoint. In-memory only; a daemon restart
+    /// resets it.
+    ///
+    /// It carries two independent kinds of "not now", because they are
+    /// released by two different things and a timer can only ever release one
+    /// of them:
+    ///
+    /// - A **timed** window: `consecutiveFailures` drives the exponential
+    ///   schedule and `nextEligibleAt` is when a sweep may try again. It
+    ///   elapses on its own.
+    /// - A **hold**, `awaitingUserAction`: no sweep may retry this profile
+    ///   until the user acts, however long anyone waits. Set for an
+    ///   `.oauthToken` profile whose token was rejected, where a retry is a
+    ///   billed request that cannot succeed until the token is replaced.
+    ///   Released by a credential change (which clears the whole state) or by
+    ///   the profile row's manual refresh.
     private struct BackoffState {
         var consecutiveFailures: Int = 0
         var nextEligibleAt: Date?
+        /// Held until a user gesture, not until a deadline. See above.
+        var awaitingUserAction: Bool = false
     }
     private var backoff: [UUID: BackoffState] = [:]
 
@@ -267,12 +292,25 @@ public actor OAuthProfileUsagePoller {
     ///
     /// This is the RPC path (`modelProfile.usageRefresh`, fired on every
     /// picker open and by `tbd profile list --refresh`). It does NOT bypass
-    /// per-profile backoff windows — opening the picker against a 429ing
+    /// per-profile timed backoff windows — opening the picker against a 429ing
     /// endpoint must not re-hammer it — and skips profiles whose snapshot is
-    /// younger than `refreshFreshness`.
+    /// younger than `refreshFreshness` (floored to `tokenProfileFloor` for a
+    /// token profile).
+    ///
+    /// A NAMED profile does release the user-action hold, and only that. A
+    /// non-nil id reaches the daemon from exactly one place: the profile row's
+    /// explicit `⋯ ▸ Refresh usage`. Picker-open and `tbd profile list
+    /// --refresh` pass nil, which sweeps the cadence set — no held token
+    /// profile is in it — so the gesture stays a gesture. The hold exists
+    /// because only the user can clear a rejected token; asking for a refresh
+    /// on that very row IS the user acting, and if the token is still dead the
+    /// probe re-arms the hold. The timed window is untouched by the release:
+    /// a 429's `Retry-After` still holds this path back.
     @discardableResult
     public func sweepNow(profileID: UUID? = nil) async -> [UUID: ProfileUsageSnapshot] {
-        await sweep(only: profileID, skipFresherThan: Self.refreshFreshness)
+        await sweep(only: profileID,
+                    skipFresherThan: Self.refreshFreshness,
+                    releasingUserHold: profileID != nil)
         if let profileID {
             return snapshots.filter { $0.key == profileID }
         }
@@ -303,9 +341,10 @@ public actor OAuthProfileUsagePoller {
     /// fetch.
     ///
     /// Probes at most once per `tokenProfileFloor`, so a burst of short turns
-    /// collapses into one billed request. Per-profile backoff still applies on
-    /// top of that, so a rejected or rate-limited token is not hammered by
-    /// activity either.
+    /// collapses into one billed request. Per-profile retry state still applies
+    /// on top of that: a rate-limited token waits out its window, and a
+    /// rejected one is held indefinitely, so no amount of activity re-probes a
+    /// token only the user can fix.
     ///
     /// EVERY completed turn on every session in the fleet arrives here, and in
     /// an install with no token profiles at all none of them can act. So the
@@ -350,19 +389,24 @@ public actor OAuthProfileUsagePoller {
     ///
     /// Both per-profile gates are released for this one probe, and both for the
     /// same reason: they are bookkeeping about a credential that no longer
-    /// exists. The backoff schedule was earned by the old token's failures, and
-    /// the snapshot's freshness describes the old token's numbers. Leaving
-    /// either in force would defeat the gesture in exactly the case it exists
-    /// for — the overwhelmingly common repair is pasting a good token seconds
-    /// after a bad one was rejected, which lands inside both the 30s backoff
-    /// window and the 300s floor, so the row would go on asserting "Token
-    /// rejected" about a token the user has already fixed.
+    /// exists. The retry state was earned by the old token's failures, and the
+    /// snapshot's freshness describes the old token's numbers. Leaving either
+    /// in force would defeat the gesture in exactly the case it exists for —
+    /// the overwhelmingly common repair is pasting a good token seconds after a
+    /// bad one was rejected. That rejection is what put the profile in a
+    /// user-action hold, which by construction no wait can lift, and the
+    /// snapshot is inside the 300s floor; so without this release the row would
+    /// go on asserting "Token rejected" about a token the user has already
+    /// fixed.
+    ///
+    /// The retry state is dropped wholesale rather than probed around, which
+    /// releases the hold and the timed schedule at once and starts the fresh
+    /// credential on rung one instead of the dead one's exponent.
     ///
     /// This is a per-gesture release, not a hole in the activity gate: a user
     /// cannot rotate in a loop, and every timer- and activity-driven caller
-    /// still goes through `freshnessWindow(requested:kind:)` and the backoff.
-    /// Clearing rather than bypassing the backoff also restarts the exponential
-    /// schedule, so a fresh credential does not inherit the dead one's exponent.
+    /// still goes through `freshnessWindow(requested:kind:)` and the retry
+    /// state.
     public func noteCredentialChanged(profileID: UUID) async {
         backoff[profileID] = nil
         await sweep(only: profileID, skipFresherThan: nil, ignoringFreshness: true)
@@ -420,9 +464,14 @@ public actor OAuthProfileUsagePoller {
     /// snapshot then describes a credential that no longer exists, so its age
     /// says nothing about whether a fetch is warranted. Every other caller
     /// leaves it false and is floored by `freshnessWindow(requested:kind:)`.
+    ///
+    /// `releasingUserHold` says this sweep is the user gesture a held profile
+    /// has been waiting for (see `BackoffState.awaitingUserAction`). It lifts
+    /// the hold and nothing else — a timed backoff window still applies.
     private func sweep(only: UUID?,
                        skipFresherThan: TimeInterval?,
-                       ignoringFreshness: Bool = false) async {
+                       ignoringFreshness: Bool = false,
+                       releasingUserHold: Bool = false) async {
         let allProfiles: [ModelProfile]
         do {
             allProfiles = try await profilesProvider()
@@ -467,7 +516,9 @@ public actor OAuthProfileUsagePoller {
         let candidates = only.map { id in supported.filter { $0.id == id } } ?? cadenceEligible
         let currentTime = now()
         let targets = candidates.filter { profile in
-            guard isEligibleNow(profile.id, at: currentTime) else { return false }
+            guard isEligibleNow(profile.id,
+                                at: currentTime,
+                                releasingUserHold: releasingUserHold) else { return false }
             if !ignoringFreshness,
                let window = Self.freshnessWindow(requested: skipFresherThan, kind: profile.kind),
                let fetchedAt = snapshots[profile.id]?.fetchedAt,
@@ -515,7 +566,7 @@ public actor OAuthProfileUsagePoller {
             let usageFetcher: any ProfileUsageFetching =
                 profile.kind == .oauthToken ? tokenFetcher : fetcher
             let status = await usageFetcher.fetchUsage(credential: usageCredential)
-            await record(status, for: profile.id)
+            await record(status, for: profile.id, kind: profile.kind)
         }
 
         if hasMeaningfulChange(from: before, to: snapshots) {
@@ -523,14 +574,29 @@ public actor OAuthProfileUsagePoller {
         }
     }
 
-    /// Whether a scheduled sweep may attempt this profile now (its backoff
-    /// window, if any, has elapsed).
-    private func isEligibleNow(_ profileID: UUID, at time: Date) -> Bool {
-        guard let next = backoff[profileID]?.nextEligibleAt else { return true }
+    /// Whether a sweep may attempt this profile now: it is not held for a user
+    /// action, and its timed backoff window, if any, has elapsed.
+    ///
+    /// `releasingUserHold` lifts the hold for this one sweep. The timed check
+    /// below still runs, so releasing the hold never doubles as ignoring a
+    /// `Retry-After`.
+    private func isEligibleNow(_ profileID: UUID,
+                               at time: Date,
+                               releasingUserHold: Bool) -> Bool {
+        guard let state = backoff[profileID] else { return true }
+        if state.awaitingUserAction && !releasingUserHold { return false }
+        guard let next = state.nextEligibleAt else { return true }
         return time >= next
     }
 
-    private func record(_ status: ProfileUsageFetchStatus, for profileID: UUID) async {
+    /// Commit a fetch outcome. `kind` decides which retry regime a failure
+    /// enters — a timed backoff, or a hold until the user acts — and nothing
+    /// else: the recorded snapshot (status text, `statusKind`, retained
+    /// buckets and organization id) is identical either way, so the row goes
+    /// on reading `Token rejected — Replace token…` off `statusKind`.
+    private func record(_ status: ProfileUsageFetchStatus,
+                        for profileID: UUID,
+                        kind: CredentialKind) async {
         let timestamp = now()
         switch status {
         case .ok(let buckets, let organizationID):
@@ -557,7 +623,11 @@ public actor OAuthProfileUsagePoller {
             } else {
                 statusText = "fetch failed: \(reason)"
             }
-            scheduleBackoff(for: profileID, status: status, at: timestamp)
+            if kind == .oauthToken, case .needsLogin = status {
+                holdForUserAction(profileID)
+            } else {
+                scheduleBackoff(for: profileID, status: status, at: timestamp)
+            }
             snapshots[profileID] = ProfileUsageSnapshot(
                 buckets: previous?.buckets ?? [],
                 fetchedAt: previous?.fetchedAt,
@@ -573,13 +643,42 @@ public actor OAuthProfileUsagePoller {
         }
     }
 
-    /// Advance a profile's backoff after a failure. Honors a 429 `Retry-After`
-    /// verbatim; otherwise uses exponential backoff (base·2^failures) plus
-    /// additive jitter, capped at `maxBackoff`. `needsLogin`/`noCredentials`
-    /// aren't retry-worthy at high frequency, so they also back off (they'll
-    /// clear when the user re-logs in and the identity/credential reappears).
+    /// Stop retrying this profile until the user acts.
+    ///
+    /// A `.oauthToken` profile's probe is a real billed `max_tokens: 0`
+    /// request, and a rejected token (401/403 → `.needsLogin`) cannot start
+    /// working again on its own: only replacing the token can fix it. A timed
+    /// schedule would therefore bill the user forever at the `maxBackoff` cap
+    /// for an outcome that is known in advance. So the profile is held, and
+    /// the two gestures that can actually change the answer release it:
+    /// `noteCredentialChanged` (which clears this state outright) and the
+    /// profile row's manual refresh (`sweepNow(profileID:)`).
+    ///
+    /// The timed schedule is dropped rather than carried alongside the hold.
+    /// A hold cannot expire, so an exponent accumulated under it could never
+    /// be consumed as a wait; and whichever gesture releases the hold issues a
+    /// probe whose own outcome re-arms whichever regime that outcome belongs
+    /// to. A transient failure after the release is a new problem and starts
+    /// at rung one, which is also what a credential change gives it.
+    private func holdForUserAction(_ profileID: UUID) {
+        backoff[profileID] = BackoffState(awaitingUserAction: true)
+    }
+
+    /// Advance a profile's timed backoff after a failure. Honors a 429
+    /// `Retry-After` verbatim; otherwise uses exponential backoff
+    /// (base·2^failures) plus additive jitter, capped at `maxBackoff`.
+    ///
+    /// This is the regime for every failure that a later, identical request
+    /// might still resolve — including `.needsLogin` on a signed-in `.oauth`
+    /// profile, whose free cadence sweep re-reading the login identity is the
+    /// only way the daemon ever learns the user re-ran `/login`. The one
+    /// failure that goes elsewhere is a rejected token: see
+    /// `holdForUserAction(_:)`.
     private func scheduleBackoff(for profileID: UUID, status: ProfileUsageFetchStatus, at time: Date) {
         var state = backoff[profileID] ?? BackoffState()
+        // A timed window supersedes any hold: this outcome is one a wait can
+        // resolve, so the profile must not stay pinned behind a user gesture.
+        state.awaitingUserAction = false
         state.consecutiveFailures += 1
         let delay: TimeInterval
         if let retryAfter = status.retryAfter, retryAfter > 0 {

--- a/Sources/TBDDaemon/Claude/OAuthProfileUsagePoller.swift
+++ b/Sources/TBDDaemon/Claude/OAuthProfileUsagePoller.swift
@@ -724,6 +724,26 @@ public actor OAuthProfileUsagePoller {
     /// anyone can act on, and a hold armed on it would be unreleasable in
     /// practice: the gesture that releases a hold has already happened. That
     /// case takes the timed schedule instead.
+    ///
+    /// **Signed off as a design position, not derived from the code.** Three
+    /// choices here — a rejected token held while every other failure kind
+    /// stays on the timed schedule, exactly two gestures releasing that hold,
+    /// and a credential generation deciding whether a late-returning rejection
+    /// may arm one at all — were specified by the repository owner before any
+    /// of this was written; they are not an agent's inference from the
+    /// surrounding code. The asymmetry is the substance of the answer. A
+    /// signed-in `.oauth` profile recording `.needsLogin` must keep retrying,
+    /// because re-running `/login` emits no event the daemon can observe and
+    /// the free cadence sweep re-reading `loginIdentity` is that profile's only
+    /// recovery path. A `.httpError` must keep retrying too, because its repair
+    /// ships as a TBD change and the profile has to recover on its own once
+    /// that lands.
+    ///
+    /// So do not simplify this back into a single unified backoff regime for
+    /// all failure kinds. Collapsed toward the timed schedule it restores an
+    /// unbounded loop of billed requests against a credential only the user can
+    /// replace; collapsed the other way, toward the hold, it strands a
+    /// re-logged-in profile on "needs re-login" for as long as the daemon runs.
     private func holdForUserAction(_ profileID: UUID) {
         backoff[profileID] = BackoffState(awaitingUserAction: true)
     }

--- a/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
@@ -600,10 +600,16 @@ extension RPCRouter {
     /// `modelProfile.usageRefresh` — sweep stale, eligible profiles (all
     /// logged-in OAuth profiles when params.id == nil, else one) and return
     /// the post-sweep snapshots. Profiles with a snapshot fresher than
-    /// `OAuthProfileUsagePoller.refreshFreshness` or inside a backoff window
-    /// are skipped (cached snapshot returned) — the picker calls this on
-    /// every open, and that must never re-hammer a rate-limited endpoint.
+    /// `OAuthProfileUsagePoller.refreshFreshness` or inside a timed backoff
+    /// window are skipped (cached snapshot returned) — the picker calls this
+    /// on every open, and that must never re-hammer a rate-limited endpoint.
     /// The poller broadcasts `.modelProfilesChanged` itself when data changes.
+    ///
+    /// A non-nil `params.id` additionally releases the poller's user-action
+    /// hold for that one profile, so a token profile parked on "Token
+    /// rejected" is re-probed. That is sound because a named id arrives from
+    /// exactly one gesture — the profile row's `⋯ ▸ Refresh usage` — while the
+    /// picker and `tbd profile list --refresh` pass nil.
     func handleModelProfileUsageRefresh(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(ModelProfileUsageRefreshParams.self, from: paramsData)
         guard let poller = oauthUsagePoller else {

--- a/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
@@ -440,9 +440,12 @@ extension RPCRouter {
         //
         // Rotation is where it matters most. The user is looking at a row that
         // says "Token rejected" and has just pasted the fix; without this the
-        // row would keep saying it until the next `working -> idle` transition
-        // — which is the very confusion the creation probe removes, reproduced
-        // at the moment the user is most certainly watching.
+        // row would never correct itself at all. A rejected token puts the
+        // profile in a hold rather than on a timed schedule, so no turn end and
+        // no cadence tick re-probes it — only this call, or the row's own
+        // `⋯ ▸ Refresh usage`, can. That is the very confusion the creation
+        // probe removes, reproduced at the moment the user is most certainly
+        // watching.
         if let poller = oauthUsagePoller {
             let rotatedProfileID = params.id
             Task { await poller.noteCredentialChanged(profileID: rotatedProfileID) }

--- a/Tests/TBDDaemonTests/OAuthProfileUsagePollerTests.swift
+++ b/Tests/TBDDaemonTests/OAuthProfileUsagePollerTests.swift
@@ -1679,4 +1679,55 @@ private func makeGatedTokenPoller(
         await poller.noteSessionBecameIdle(profileID: token.id)
         #expect(fetcher.tokenProbeCount == 2)
     }
+
+    /// A rotation that lands while a probe of the OLD token is in flight must
+    /// leave the profile self-healing, not held.
+    ///
+    /// The rotation's own sweep is dropped by the in-flight reservation — the
+    /// residual the guard documents and accepts — so the release it performed
+    /// happens BEFORE the old token's rejection is recorded. A hold armed on
+    /// that rejection would be armed after its only release, and no timer,
+    /// turn end, or cadence tick can lift one: the freshly pasted token, which
+    /// may be perfectly good, would sit on "Token rejected" until the user
+    /// found `⋯ ▸ Refresh usage`. The credential generation is what stops it —
+    /// the outcome describes a token that no longer exists, so it takes the
+    /// timed schedule, and the next turn end settles the question with the new
+    /// token.
+    @Test func aRotationDuringAnInFlightProbeLeavesTheProfileSelfHealing() async {
+        let profile = tokenProfile(named: "Acme (token)")
+        // Never auto-opens. Exactly one probe reaches the fetcher (the second
+        // caller is dropped, which is the race under test), so a threshold of
+        // two would park the first one forever.
+        let gate = ProbeGate(autoOpenAt: Int.max)
+        let fetcher = GatedProfileUsageFetcher(
+            gate: gate, status: .needsLogin("token rejected (HTTP 401)"))
+        let clock = MutableClock(Date(timeIntervalSince1970: 1_000_000))
+        let poller = makeGatedTokenPoller(
+            profiles: [profile], tokens: [profile.id: "sk-ant-oat01-DEAD"],
+            fetcher: fetcher, clock: clock)
+
+        let activity = Task { await poller.noteSessionBecameIdle(profileID: profile.id) }
+        // Parked inside the fetcher with the OLD token: nothing recorded yet.
+        await gate.waitForArrivals(1)
+
+        // The user pastes a replacement. This runs its own sweep to
+        // completion, and that sweep issues no request.
+        await poller.noteCredentialChanged(profileID: profile.id)
+        // Still one probe: the rotation's sweep was DROPPED by the in-flight
+        // reservation. Without this the test would be exercising an ordinary
+        // sequential rotation and would pass either way.
+        #expect(fetcher.probeCount == 1)
+
+        // Now the old token's rejection lands, after the release.
+        await gate.open()
+        await activity.value
+        #expect(await poller.snapshot(for: profile.id)?.statusKind == .needsLogin)
+
+        // Nothing ever succeeded, so there is no `fetchedAt` and the 300s floor
+        // is not in play; +301s also clears the 30s first rung of the timed
+        // schedule the stale outcome armed. A hold would survive both.
+        clock.advance(301)
+        await poller.noteSessionBecameIdle(profileID: profile.id)
+        #expect(fetcher.probeCount == 2)
+    }
 }

--- a/Tests/TBDDaemonTests/OAuthProfileUsagePollerTests.swift
+++ b/Tests/TBDDaemonTests/OAuthProfileUsagePollerTests.swift
@@ -960,25 +960,26 @@ private func makeTokenPoller(
     }
 
     /// The other released gate, isolated: nothing here ever succeeded, so there
-    /// is no `fetchedAt` for the floor to act on and the backoff window is the
-    /// only thing that could hold the probe back. It is also the realistic
-    /// case — the repair for a rejected token is pasting a good one seconds
-    /// later, well inside the 30s window that rejection just armed.
+    /// is no `fetchedAt` for the floor to act on and the timed backoff window
+    /// is the only thing that could hold the probe back.
+    ///
+    /// A transient failure rather than a rejection, deliberately — a rejected
+    /// token is held rather than scheduled, and this is the timed regime's leg.
+    /// `credentialChangeReleasesTheUserActionHold` is the hold's.
     @Test func credentialChangeProbesInsideTheBackoffWindow() async {
         let profile = tokenProfile(named: "Acme (token)")
-        let fetcher = ScriptedProfileUsageFetcher(
-            default: .needsLogin("token rejected (HTTP 401)"))
+        let fetcher = ScriptedProfileUsageFetcher(default: .rateLimited(retryAfter: nil))
         let clock = MutableClock(Date(timeIntervalSince1970: 1_000_000))
         let poller = makeTokenPoller(
-            profiles: [profile], tokens: [profile.id: "sk-ant-oat01-DEAD"],
+            profiles: [profile], tokens: [profile.id: "sk-ant-oat01-A"],
             fetcher: fetcher, clock: clock)
 
         await poller.noteSessionBecameIdle(profileID: profile.id)
         #expect(fetcher.tokenProbeCount == 1)
-        #expect(await poller.snapshot(for: profile.id)?.statusKind == .needsLogin)
+        #expect(await poller.snapshot(for: profile.id)?.statusKind == .rateLimited)
 
-        // 10s in: `rejectedTokenRecordsNeedsLoginAndBacksOff` pins that an
-        // activity probe is still held here.
+        // 10s in: `transientTokenFailuresStayOnTheTimedSchedule` pins that an
+        // activity probe is still held here, by the 30s first rung.
         clock.advance(10)
         await poller.noteCredentialChanged(profileID: profile.id)
         #expect(fetcher.tokenProbeCount == 2)
@@ -987,8 +988,13 @@ private func makeTokenPoller(
     /// A rejected token records `.needsLogin` — the existing case, deliberately
     /// not a new `ProfileUsageStatusKind` (widening it would break snapshot
     /// decode on older apps, where `decodeIfPresent` THROWS on an unknown raw
-    /// value). Backoff then applies, so activity does not hammer a dead token.
-    @Test func rejectedTokenRecordsNeedsLoginAndBacksOff() async {
+    /// value) — and is then never re-probed on its own.
+    ///
+    /// This is the cost property the hold exists for. Every token probe is a
+    /// real billed request, and one against a rejected token cannot succeed
+    /// until the user replaces it, so no elapsed time and no amount of session
+    /// activity may buy another. A timed backoff would bill forever at its cap.
+    @Test func rejectedTokenIsNeverReprobedByActivity() async {
         let profile = tokenProfile(named: "Acme (token)")
         let fetcher = ScriptedProfileUsageFetcher(
             default: .needsLogin("token rejected (HTTP 401)"))
@@ -1001,16 +1007,189 @@ private func makeTokenPoller(
         #expect(await poller.snapshot(for: profile.id)?.statusKind == .needsLogin)
         #expect(fetcher.tokenProbeCount == 1)
 
-        // Nothing ever succeeded, so there is no `fetchedAt` for the floor to
-        // gate against — the backoff window is what holds the second probe
-        // back, which is the point: the two gates are independent.
+        // Nothing ever succeeded, so there is no `fetchedAt` for the freshness
+        // floor to gate against: the hold is the only thing that can hold these
+        // back, and the times chosen leave a timed schedule no excuse.
         clock.advance(10)
         await poller.noteSessionBecameIdle(profileID: profile.id)
         #expect(fetcher.tokenProbeCount == 1)
 
-        clock.advance(21)  // +31s: past the 30s window armed by failure 1
+        clock.advance(21)  // +31s: past the 30s first rung of the old schedule
+        await poller.noteSessionBecameIdle(profileID: profile.id)
+        #expect(fetcher.tokenProbeCount == 1)
+
+        clock.advance(3600)  // well past `maxBackoff` (15 min)
+        await poller.noteSessionBecameIdle(profileID: profile.id)
+        #expect(fetcher.tokenProbeCount == 1)
+
+        clock.advance(86_400)  // a day later, still held
+        await poller.noteSessionBecameIdle(profileID: profile.id)
+        #expect(fetcher.tokenProbeCount == 1)
+
+        // The internal targeted path the activity and cadence callers share,
+        // asking for no freshness window at all, is held too.
+        await poller.sweepForTest(only: profile.id, skipFresherThan: nil)
+        #expect(fetcher.tokenProbeCount == 1)
+
+        #expect(await poller.snapshot(for: profile.id)?.statusKind == .needsLogin)
+    }
+
+    /// Rotation is one of the two gestures that release the hold, and the
+    /// primary one: replacing the token is what can actually make a probe
+    /// succeed again.
+    @Test func credentialChangeReleasesTheUserActionHold() async {
+        let profile = tokenProfile(named: "Acme (token)")
+        let fetcher = ScriptedProfileUsageFetcher(
+            default: .needsLogin("token rejected (HTTP 401)"))
+        let clock = MutableClock(Date(timeIntervalSince1970: 1_000_000))
+        let poller = makeTokenPoller(
+            profiles: [profile], tokens: [profile.id: "sk-ant-oat01-DEAD"],
+            fetcher: fetcher, clock: clock)
+
+        await poller.noteSessionBecameIdle(profileID: profile.id)
+        #expect(fetcher.tokenProbeCount == 1)
+
+        // An hour of activity buys nothing. This leg is what makes the
+        // assertion below discriminate: without it, a probe at this point
+        // could be the hold expiring rather than the gesture releasing it.
+        clock.advance(3600)
+        await poller.noteSessionBecameIdle(profileID: profile.id)
+        #expect(fetcher.tokenProbeCount == 1)
+
+        await poller.noteCredentialChanged(profileID: profile.id)
+        #expect(fetcher.tokenProbeCount == 2)
+        // Both probes carried the stored credential, not an empty one.
+        #expect(fetcher.calls == ["token:sk-ant-oat01-DEAD", "token:sk-ant-oat01-DEAD"])
+    }
+
+    /// The row's `⋯ ▸ Refresh usage` is the other release. A non-nil id
+    /// reaches `sweepNow` from that gesture alone — picker-open and
+    /// `tbd profile list --refresh` pass nil — so naming a profile is the
+    /// daemon's evidence that a user is asking.
+    @Test func manualRefreshReleasesTheUserActionHold() async {
+        let profile = tokenProfile(named: "Acme (token)")
+        let fetcher = ScriptedProfileUsageFetcher(
+            default: .needsLogin("token rejected (HTTP 401)"))
+        let clock = MutableClock(Date(timeIntervalSince1970: 1_000_000))
+        let poller = makeTokenPoller(
+            profiles: [profile], tokens: [profile.id: "sk-ant-oat01-DEAD"],
+            fetcher: fetcher, clock: clock)
+
+        await poller.noteSessionBecameIdle(profileID: profile.id)
+        #expect(fetcher.tokenProbeCount == 1)
+
+        // 10s in — inside every window the old schedule could have armed.
+        clock.advance(10)
+        _ = await poller.sweepNow(profileID: profile.id)
+        #expect(fetcher.tokenProbeCount == 2)
+
+        // The unnamed sweep — picker-open, `tbd profile list --refresh` —
+        // never reaches a token profile at all: it visits the cadence set,
+        // which excludes them. That is all this leg can show, and it is the
+        // property that matters, since a caller who cannot see the profile
+        // cannot release its hold either.
+        _ = await poller.sweepNow()
+        #expect(fetcher.tokenProbeCount == 2)
+    }
+
+    /// Releasing the hold must not become "ignore the retry state". A 429's
+    /// `Retry-After` is a timed window that a wait genuinely does resolve, and
+    /// clicking Refresh usage inside it must not re-hammer the endpoint.
+    @Test func manualRefreshStillHonorsATimedBackoff() async {
+        let profile = tokenProfile(named: "Acme (token)")
+        let fetcher = ScriptedProfileUsageFetcher(default: .rateLimited(retryAfter: 120))
+        let clock = MutableClock(Date(timeIntervalSince1970: 1_000_000))
+        let poller = makeTokenPoller(
+            profiles: [profile], tokens: [profile.id: "sk-ant-oat01-A"],
+            fetcher: fetcher, clock: clock)
+
+        await poller.noteSessionBecameIdle(profileID: profile.id)
+        #expect(fetcher.tokenProbeCount == 1)
+        #expect(await poller.snapshot(for: profile.id)?.statusKind == .rateLimited)
+
+        clock.advance(10)
+        _ = await poller.sweepNow(profileID: profile.id)
+        #expect(fetcher.tokenProbeCount == 1)
+    }
+
+    /// Transient token failures stay on the timed schedule: held at +10s, and
+    /// admitted at +31s once the 30s first rung has elapsed. Each of these can
+    /// still come good on an identical retry — a 400 because the repair ships
+    /// as a TBD change and the profile must recover on its own once it lands —
+    /// so none of them may be held for a user gesture.
+    ///
+    /// Cannot fail against the current design; it exists to fail against an
+    /// over-broad one that holds every non-transient-looking status, or holds
+    /// on kind alone. Verified by temporarily widening the hold to all token
+    /// failures, which reddens every case here.
+    @Test(arguments: [
+        ProfileUsageFetchStatus.rateLimited(retryAfter: nil),
+        ProfileUsageFetchStatus.networkError("connection reset"),
+        ProfileUsageFetchStatus.httpError(400, detail: "anthropic-version: header is required"),
+    ])
+    func transientTokenFailuresStayOnTheTimedSchedule(status: ProfileUsageFetchStatus) async {
+        let profile = tokenProfile(named: "Acme (token)")
+        let fetcher = ScriptedProfileUsageFetcher(default: status)
+        let clock = MutableClock(Date(timeIntervalSince1970: 1_000_000))
+        let poller = makeTokenPoller(
+            profiles: [profile], tokens: [profile.id: "sk-ant-oat01-A"],
+            fetcher: fetcher, clock: clock)
+
+        await poller.noteSessionBecameIdle(profileID: profile.id)
+        #expect(fetcher.tokenProbeCount == 1)
+
+        clock.advance(10)
+        await poller.noteSessionBecameIdle(profileID: profile.id)
+        #expect(fetcher.tokenProbeCount == 1)
+
+        clock.advance(21)  // +31s: past rung 1 (jitter is injected as 0)
         await poller.noteSessionBecameIdle(profileID: profile.id)
         #expect(fetcher.tokenProbeCount == 2)
+    }
+
+    /// THE regression guard. A signed-in profile's `.needsLogin` must keep
+    /// retrying on the cadence sweep: re-running `/login` emits no event the
+    /// daemon can observe, so the free sweep re-reading `loginIdentity` is the
+    /// only recovery path there is. Holding it would strand a re-logged-in
+    /// profile on "needs re-login" forever, and its sweep costs nothing.
+    ///
+    /// Cannot fail against the current design — the hold is scoped to
+    /// `.oauthToken`. It exists to fail against the over-broad fix of holding
+    /// every `.needsLogin`, which was checked by temporarily dropping the kind
+    /// condition and watching the +31s and recovery legs go red.
+    @Test func signedInProfileNeedsLoginStillRetriesOnTheCadenceSweep() async {
+        let profile = oauthProfile(named: "Acme")
+        let fetcher = ScriptedProfileUsageFetcher(
+            default: .needsLogin("refresh token rejected (invalid_grant)"))
+        let clock = MutableClock(Date(timeIntervalSince1970: 1_000_000))
+        let poller = makeTokenPoller(
+            profiles: [profile], tokens: [:], fetcher: fetcher, clock: clock,
+            loggedIn: [profile.id])
+        let configDir = "/profiles/\(profile.id.uuidString.lowercased())/claude"
+
+        await poller.sweepForTest()
+        #expect(fetcher.calls == [configDir])
+        #expect(await poller.snapshot(for: profile.id)?.statusKind == .needsLogin)
+
+        // Inside rung 1: the timed window holds it, as it does any failure.
+        clock.advance(10)
+        await poller.sweepForTest()
+        #expect(fetcher.calls.count == 1)
+
+        // +31s: the window elapsed, so the sweep tries again — on its own,
+        // with no user gesture anywhere.
+        clock.advance(21)
+        await poller.sweepForTest()
+        #expect(fetcher.calls.count == 2)
+
+        // And that is how a re-login is noticed: the next sweep past the
+        // window reads a working identity and the profile recovers.
+        fetcher.enqueue(configDirPath: configDir, .ok(okBuckets, organizationID: "org_acme"))
+        clock.advance(61)  // past rung 2 (60s)
+        await poller.sweepForTest()
+        #expect(fetcher.calls.count == 3)
+        #expect(await poller.snapshot(for: profile.id)?.statusKind == .ok)
+        #expect(await poller.snapshot(for: profile.id)?.buckets == okBuckets)
     }
 
     /// A token profile whose secret file was removed must report
@@ -1086,13 +1265,17 @@ private func makeTokenPoller(
     /// re-arms rung 1 (30s). With it merely waived, the same failure is the
     /// third in a row and arms rung 3 (120s) — so the probe asserted below
     /// would be held for another minute and a half.
+    ///
+    /// The scripted failure is transient, because only the timed regime has an
+    /// exponent to inherit: a rejected token is held instead of scheduled, so
+    /// repeated rejections climb no rungs and could not tell the two readings
+    /// apart.
     @Test func credentialChangeRestartsTheBackoffScheduleRatherThanWaivingIt() async {
         let profile = tokenProfile(named: "Acme (token)")
-        let fetcher = ScriptedProfileUsageFetcher(
-            default: .needsLogin("token rejected (HTTP 401)"))
+        let fetcher = ScriptedProfileUsageFetcher(default: .rateLimited(retryAfter: nil))
         let clock = MutableClock(Date(timeIntervalSince1970: 1_000_000))
         let poller = makeTokenPoller(
-            profiles: [profile], tokens: [profile.id: "sk-ant-oat01-DEAD"],
+            profiles: [profile], tokens: [profile.id: "sk-ant-oat01-A"],
             fetcher: fetcher, clock: clock)
 
         // Failure 1 arms rung 1: 30s. (`jitter` is injected as 0 by

--- a/docs/specs/2026-09-01-token-based-claude-profiles-design.md
+++ b/docs/specs/2026-09-01-token-based-claude-profiles-design.md
@@ -336,6 +336,15 @@ So:
   either way — the row goes on reading `Token rejected — Replace token…` off
   the status kind, and widening that enum would break snapshot decode on older
   apps, where `decodeIfPresent` throws on an unrecognised raw value.
+
+  The split into two regimes, and the choice of exactly two gestures to release
+  the hold, are design positions settled by the repository owner rather than
+  conclusions anyone should re-derive from the implementation. Neither regime
+  generalises to the other: unifying them under the timed schedule reinstates an
+  unbounded loop of billed requests against a credential only the user can
+  replace, and unifying them under the hold strands a re-logged-in `.oauth`
+  profile — and any profile whose `.httpError` waits on a TBD change — with no
+  recovery path at all.
 - **One probe whenever the credential changes** — creation *and* rotation — so a
   freshly pasted token shows bars immediately and a bad paste is caught at once
   rather than at first spawn. Rotation matters as much as creation: the user

--- a/docs/specs/2026-09-01-token-based-claude-profiles-design.md
+++ b/docs/specs/2026-09-01-token-based-claude-profiles-design.md
@@ -306,9 +306,36 @@ So:
 - **The refresh is `sweepNow(only: profileID)` with `skipFresherThan: 300`.**
   The five-minute floor is the existing freshness parameter, not new machinery,
   so a burst of turns collapses into at most one probe per five minutes.
-- **Failure backoff is unchanged.** The existing per-profile schedule and its
-  `Retry-After` override apply, so a rejected or rate-limited token is not
-  hammered by activity.
+- **Failures fall into two regimes, released by two different things.** A
+  *transient* failure — rate limiting, a network error, a 4xx whose repair
+  ships as a TBD change — goes on the existing per-profile exponential
+  schedule, with a 429's `Retry-After` overriding it, so a busy fleet does not
+  hammer a struggling endpoint and the profile recovers on its own. A *rejected
+  token* (401/403, recorded as `.needsLogin`) instead **holds** the profile:
+  no automatic retry at all, on any cadence, however long anyone waits. Every
+  token probe is a billed request and one against a revoked or expired token
+  cannot succeed until the user replaces it, so a timed schedule would bill
+  forever at its 15-minute cap for an outcome known in advance. The hold is
+  released by the two gestures that can change that answer: a credential
+  change, and the profile row's manual refresh. Releasing it lifts the hold and
+  nothing else — a timed window still applies, so clicking Refresh usage inside
+  a 429's `Retry-After` does not re-hammer the endpoint.
+
+  The hold is scoped to `.oauthToken`, and the contrast with signed-in profiles
+  is the reason. An `.oauth` profile's `.needsLogin` clears when the user
+  re-runs `/login`, which emits no event the daemon can observe — the free
+  90-second cadence sweep re-reading `loginIdentity` *is* the recovery path, so
+  holding it would strand a re-logged-in profile on "needs re-login"
+  indefinitely. A held state is only correct where the retry costs money and
+  the user is the only one who can change the outcome.
+
+  It is a state, not a sentinel deadline: a timer never releases a hold and a
+  user gesture never shortens a 429 window, so the poller's per-profile retry
+  record carries the hold as its own flag rather than folding it into
+  `nextEligibleAt`. `.needsLogin` stays an existing `ProfileUsageStatusKind`
+  either way — the row goes on reading `Token rejected — Replace token…` off
+  the status kind, and widening that enum would break snapshot decode on older
+  apps, where `decodeIfPresent` throws on an unrecognised raw value.
 - **One probe whenever the credential changes** — creation *and* rotation — so a
   freshly pasted token shows bars immediately and a bad paste is caught at once
   rather than at first spawn. Rotation matters as much as creation: the user
@@ -320,22 +347,30 @@ So:
   each of them, and reusing the ordinary path would produce a probe that never
   fires in its own motivating case:
 
-  - *Backoff.* A rejected token has already earned an exponential backoff
-    (30 s and doubling). Pasting the fix seconds later lands inside that window.
+  - *Retry state.* A rejected token is held, and a hold is by construction
+    something no wait can lift — the rotation is exactly the user action it is
+    waiting for. A token failing transiently instead sits inside an
+    exponential window that the paste, seconds later, lands well inside.
   - *Freshness.* A profile that previously succeeded keeps its `fetchedAt`, and
     the five-minute floor applies to a request that names no window — so a
     rotation within five minutes of any successful probe, including the
     creation probe, is skipped.
 
   Both gates are bookkeeping about a credential that no longer exists: the
-  backoff was earned by the old token's failures, and the snapshot's freshness
-  describes the old token's numbers. So the backoff is **cleared** rather than
-  bypassed — a fresh credential restarts the exponential schedule instead of
-  inheriting a dead one's exponent — and the freshness floor is waived for that
-  single call, leaving the cadence, manual-refresh and activity paths floored.
-  It is a per-gesture release, not a hole in the gate: a user cannot rotate in
-  a loop.
-- **Manual refresh** in the profile row's `⋯` menu, subject to the same floor.
+  retry state was earned by the old token's failures, and the snapshot's
+  freshness describes the old token's numbers. So the retry state is **cleared**
+  rather than bypassed — which releases the hold and the timed schedule at once,
+  and starts a fresh credential on the first rung instead of the dead one's
+  exponent — and the freshness floor is waived for that single call, leaving the
+  cadence, manual-refresh and activity paths floored. It is a per-gesture
+  release, not a hole in the gate: a user cannot rotate in a loop.
+- **Manual refresh** in the profile row's `⋯` menu, subject to the same floor,
+  and the second release of the hold. It names a profile id, and a named id
+  reaches the daemon from that gesture alone — picker-open and
+  `tbd profile list --refresh` sweep the cadence set unnamed, which excludes
+  token profiles — so the name is the daemon's evidence that a user is asking.
+  It releases the hold only: the freshness floor and any timed backoff still
+  apply, and if the token is still dead the probe re-arms the hold.
 
 An idle token profile issues zero requests. A continuously busy one issues at
 most 288 per day, and each is fresher than a timer's would be because it fires
@@ -460,11 +495,15 @@ expire — so this is the only way to recover a profile whose token has aged out
 - **Token rejected later** (revoked, expired) — the probe records `.needsLogin`;
   the row shows `Token rejected — Replace token…`. Spawning still works as far
   as TBD is concerned; the session itself will fail to authenticate, and the row
-  is where the user finds out first. Replacing the token probes immediately, so
-  the row clears (or re-reports) on the spot rather than at the next turn.
-- **Probe rate-limited (429)** — existing backoff with `Retry-After` override.
-  Bars keep showing last-known values with a staleness note; they are never
-  presented as current.
+  is where the user finds out first. The profile is then held: it is not probed
+  again by any timer or by session activity, because each attempt would be a
+  billed request that cannot succeed. Replacing the token probes immediately, so
+  the row clears (or re-reports) on the spot; clicking `⋯ ▸ Refresh usage` on
+  the row probes too, for a user who believes the token has come good.
+- **Probe rate-limited (429)** — the timed backoff with `Retry-After` override,
+  which elapses on its own; the profile is not held, because waiting is exactly
+  what resolves it. Bars keep showing last-known values with a staleness note;
+  they are never presented as current.
 - **Network failure** — `.networkError`, retried, last-known buckets retained.
 - **Missing secret file** — `.noCredentials`. Reachable if the secret file is
   removed out from under the profile.
@@ -499,12 +538,28 @@ Both branches of every conditional this adds, per the repo's branching rule.
 - **Credential-change probe** — creation probes once, carrying the new token;
   rotation probes once, and the assertion is that the probe carried the
   *replacement* credential rather than the one it replaced. Each gate is
-  isolated: one test rotates inside the freshness floor, another inside the
-  backoff window with nothing ever having succeeded. An activity probe at the
-  same instant must still be held, proving the release did not leak. Renaming a
-  profile probes nothing, and `updateToken` against a signed-in profile is
-  rejected by message rather than merely failing to probe — a probe count of
-  zero would pass for the wrong reason.
+  isolated: one test rotates inside the freshness floor, another inside a timed
+  backoff window with nothing ever having succeeded, a third out of a hold. An
+  activity probe at the same instant must still be held, proving the release did
+  not leak. Renaming a profile probes nothing, and `updateToken` against a
+  signed-in profile is rejected by message rather than merely failing to probe —
+  a probe count of zero would pass for the wrong reason.
+- **The hold on a rejected token** — a rejected token is probed once and then
+  never again by activity, however far the clock is advanced past the backoff
+  cap, nor by a targeted internal sweep. Both releases are exercised: a
+  credential change probes, and a manual refresh naming the profile probes,
+  each after an activity leg at the same instant has been shown to buy nothing
+  — without which a probe would not distinguish the gesture from an expiring
+  window. Two guards bound the release. Manual refresh against a token inside a
+  429's `Retry-After` still does not probe, so "release the hold" did not become
+  "ignore the retry state"; and an unnamed sweep releases nothing.
+- **The regimes stay separate** — a token profile failing transiently
+  (rate-limited, network, a 400) is still retried on the timed schedule; and a
+  *signed-in* profile recording `.needsLogin` is still retried by the free
+  cadence sweep once its window elapses, and recovers to `ok` when the identity
+  starts working. That second one is the load-bearing guard: holding every
+  `.needsLogin` rather than only a token profile's would strand a re-logged-in
+  profile forever, and nothing else in the suite would notice.
 - **Staleness threshold** — a token profile fetched four minutes ago renders no
   staleness note; a signed-in profile fetched four minutes ago does.
 - **Presentation** — `needsLogin` is false for `.oauthToken` regardless of
@@ -560,8 +615,10 @@ None blocking. Two things to watch once this is in use:
   passing outage. The retryable set is 401, 403 and 429 (each with its own
   handling) plus 408 Request Timeout and 425 Too Early, which invite the
   identical request again — RFC 9110 §15.5.9 and RFC 8470 respectively — and so
-  must not be told the user cannot fix them by waiting. Retries continue at the backoff cap regardless, because the
-  repair is a TBD change and the profile must recover on its own once it ships.
+  must not be told the user cannot fix them by waiting. Timed retries continue
+  at the backoff cap regardless — a `.httpError` never earns the hold a rejected
+  token does — because the repair is a TBD change and the profile must recover
+  on its own once it ships.
   A distinct "probe unsupported" state may still be worth adding if the beta
   header moves, but it cannot be a new `ProfileUsageStatusKind` case:
   `decodeIfPresent` throws on an unrecognised raw value, so widening that enum

--- a/docs/specs/2026-09-01-token-based-claude-profiles-design.md
+++ b/docs/specs/2026-09-01-token-based-claude-profiles-design.md
@@ -373,6 +373,34 @@ So:
   exponent — and the freshness floor is waived for that single call, leaving the
   cadence, manual-refresh and activity paths floored. It is a per-gesture
   release, not a hole in the gate: a user cannot rotate in a loop.
+
+  **A rotation can outrun a probe of the token it replaces.** At most one
+  billed request per profile is ever in flight, so a rotation that lands while
+  the previous token's probe is still out has its own probe dropped rather
+  than issued — and the previous token's rejection can therefore arrive after
+  the rotation. A hold does not expire, so left alone that late rejection
+  would arm a hold describing a credential the user has already replaced,
+  pinning a freshly pasted and possibly perfectly good token behind the very
+  gesture the user just made. A per-profile **credential generation** prevents
+  it: a counter bumped whenever the profile's credential changes, captured
+  before a request is sent and compared when that request's outcome is
+  recorded. A mismatch means the outcome describes a credential that no longer
+  exists, and such an outcome may not arm a hold.
+
+  The generation governs the **retry regime and nothing else**. The stale
+  outcome is still recorded as the profile's status — writing an outcome the
+  credential has outrun is pre-existing accepted behavior, and suppressing it
+  would leave the row with no status at all in exactly the window this is
+  about — so only the choice between holding and scheduling keys off the
+  comparison. A mismatch falls through to the **timed schedule** rather than to
+  no retry at all, so the profile self-heals at the next turn end rather than
+  waiting on a gesture — the same bounded recovery every failure that is not a
+  live rejection gets. That direction is the point:
+  the mechanism **fails open**, routing any uncertainty about which credential
+  an outcome describes to the bounded timed schedule and never to a hold
+  nothing can release. The counter is in memory beside the retry state it
+  guards and resets with the daemon, which is harmless for the same reason —
+  the state it would have gated resets with it.
 - **Manual refresh** in the profile row's `⋯` menu, subject to the same floor,
   and the second release of the hold. It names a profile id, and a named id
   reaches the daemon from that gesture alone — picker-open and


### PR DESCRIPTION
## What's broken

A Claude profile authenticated with a pasted setup token whose token is later
rejected — revoked, expired, or mistyped at creation — was probed again forever.
The row reads `Token rejected — Replace token…` and stays there, which is
correct, but behind it the daemon kept asking Anthropic whether the dead token
had started working, on an exponential schedule that settles at one attempt
every fifteen minutes and never stops.

Those attempts are not free. A signed-in profile's usage comes from a read-only
endpoint, but a setup token 403s there, so a token profile's usage is read from
the response headers of a real billed request. Every retry of a rejected token
is a billed request that is guaranteed to fail until the user pastes a new
token. Left alone, a profile the user has abandoned bills roughly a hundred
doomed requests a day, indefinitely.

## Why it happens

The usage poller treats every failed fetch the same way: record the reason,
then arm a backoff timer and try again when it elapses. That is right for a
rate limit, a network blip, or a malformed request of ours, because an
identical retry later can genuinely succeed. It is wrong for a rejected
credential, where the outcome is known in advance and only the user can change
it. The failure arm never distinguished the two, so the rejection fell into the
retry-with-backoff path along with everything else.

## When it broke

Shipped with #783, which added token-authenticated profiles. The poller's
backoff predates it and was correct while every profile it swept used the free
usage endpoint; the billed probe is what made an unbounded retry loop expensive
rather than merely pointless.

Found by CodeRabbit in review of that PR:
https://github.com/cheapsteak/tbd/pull/783#discussion_r3915936150

## What this PR does

Splits one notion of "not now" into the two that were always hiding inside it,
because they are released by different things. A **timed window** elapses on its
own. A **hold** does not expire at all and is lifted only when the user acts. A
token profile whose token was rejected is held. Everything else keeps the timed
schedule it has today.

Two gestures release the hold, and both already existed:

- Replacing the token clears the profile's whole retry record and probes
  immediately.
- The profile row's `⋯ ▸ Refresh usage` reaches the daemon naming that one
  profile, which is the daemon's evidence that a person is asking. Opening the
  account picker and `tbd profile list --refresh` name no profile and sweep only
  signed-in profiles, so neither can lift a hold by accident.

Releasing the hold lifts the hold and nothing else. A rate limit's `Retry-After`
still holds that same path back, and a token profile's five-minute floor between
billed probes still applies.

**This is deliberately narrower than the review comment proposed.** "Retry only
transient statuses" would also stop retrying a *signed-in* profile that needs a
fresh login, and that would strand it permanently. Re-running `/login` produces
no event the daemon can observe; the ninety-second sweep re-reading the profile's
login identity is the entire recovery mechanism, and those sweeps are free reads.
So a signed-in profile keeps retrying exactly as before. `.httpError` also keeps
retrying, for a different reason worth stating: a malformed request is our bug,
the repair ships as a TBD change, and a profile that had stopped retrying would
stay stuck after the fix landed.

The second commit fixes a race the first one introduced. A rotation that lands
while a probe of the old token is still in flight was already dropped rather than
double-billed, and the old probe's rejection would then arm a hold *after* the
rotation had released it, pinning a freshly pasted good token behind a manual
click. A per-profile credential generation, captured before the request and
compared when its outcome is recorded, means an outcome describing a replaced
credential can no longer arm a hold. It falls back to the timed schedule, which
is what that race did before this PR.

No new `ProfileUsageStatusKind` case. The row still renders off
`statusKind == .needsLogin`, and widening that enum would break snapshot decode
on older apps, where the decoder throws on an unrecognised value.

## Why no separate spec, and who decided

To be precise about this rather than wave at it: the design document previously
described a single backoff regime that explicitly covered rejected tokens, so
splitting that into a hold and a timed schedule does revise what the system
believes, not merely restore it. Three decisions here are genuinely new — that a
rejected token holds while every other failure stays on a timer, that exactly two
gestures release the hold, and that a credential generation decides whether a
late-returning rejection may arm one.

Those three were specified by the repository owner up front, in the terms used
here, before any code was written: the asymmetry between a signed-in profile and
a token profile and why a wholesale "retry only transient statuses" would strand
the former, the requirement that rotation and manual refresh both remain release
paths, the `.httpError` carve-out, and the constraint against adding a status
enum case. This PR implements those answers rather than an agent's own. The
design document is updated to carry that rationale, which is why it is not
restated as a separate file.

If a maintainer would rather see this as a standalone brainstormed spec, say so
and it becomes one. That call is a human's, not an agent's.

## Assumptions

Assumes that a usage refresh naming a single profile means a person clicked
that row's refresh item. That holds today because it is the only caller that
passes an id. If a future screen refreshes one profile automatically, it would
silently gain the power to lift a hold, and the release would need an explicit
"user initiated" marker rather than inferring it from the id.

## Evidence & verification

Tests are in `Tests/TBDDaemonTests/OAuthProfileUsagePollerTests.swift`, and the
ones that matter discriminate against two different wrong implementations:

- A rejected token is never re-probed by activity, however far the clock is
  advanced. Fails against the code on `main`, which re-probes.
- Rotation, and separately a manual refresh, do probe it again. Both fail
  against `main`.
- A manual refresh does not bypass a rate limit's timed window. Guards the
  release from becoming a general backoff bypass.
- **A signed-in profile that needs a login is still retried by the cadence
  sweep.** This one cannot fail against `main`; it exists to fail against the
  broader fix the review comment proposed, and it was confirmed to do so.
- Transient token failures stay on the timed schedule, checked for a rate
  limit, a network error, and an HTTP error.
- A rotation during an in-flight probe leaves the profile self-healing rather
  than held, with a positive assertion that the rotation's sweep really was
  dropped by the in-flight guard, so the test cannot pass as an ordinary
  sequential rotation.

The filtered suite was run locally on the first commit and reported 53 tests
across 6 suites passing, the count confirming the new tests were selected rather
than filtered to nothing. The second commit's tests have not been run locally:
this machine is heavily contended, so verification moved to CI, and the
red-without-fix claim for that commit's test is a read-only argument from the
eligibility check rather than an observed failing run. CI on this PR is the
verdict for the branch as a whole.

Not verified in the running app. The user-visible string is unchanged by design,
and what changed is the absence of background requests, which the UI does not
show.

https://claude.ai/code/session_01SpFq5EXCHtWvHEQcsUHsvM

[🚫 No Retry Rejected Tokens](https://cheapsteak.github.io/tbd/open/?worktree=9ACC5C17-E33D-487C-86D7-025D5283375A)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Rejected token credentials now remain on hold without repeated automatic retries.
  * Replacing a credential or requesting a targeted refresh can release the hold and resume usage checks.
  * Prevented failures from an older token from affecting a newly replaced credential.
  * Preserved scheduled backoff and retry behavior for transient errors and rate limits.
* **Documentation**
  * Clarified token rotation, refresh, recovery, and retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->