### PR TITLE
Feat: Show merge-queue position on status-bar PR chips instead of a dot reading "pending"

### DIFF
--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -1025,7 +1025,14 @@ struct PRButtonLabel: View {
     /// distinct. `nil` maps to `\0`, which escaping can never produce (its only
     /// outputs are `\\`, `\-` and `\|`), so a literal `"nil"` reason no longer
     /// reads as an absent one either.
-    static func escapedIDField(_ value: String?) -> String {
+    ///
+    /// `nonisolated` because it is a pure string transform and the other
+    /// once-materialized menu in the app — the status bar's `+N` overflow —
+    /// keys itself the same way from nonisolated
+    /// `PRBindingPresentation.menuRowsID`. `PRButtonLabel`'s `View` conformance
+    /// infers whole-type `@MainActor` isolation, which would otherwise put this
+    /// out of reach there and invite a second, subtly different copy.
+    nonisolated static func escapedIDField(_ value: String?) -> String {
         guard let value else { return #"\0"# }
         return value
             .replacingOccurrences(of: #"\"#, with: #"\\"#)

--- a/Sources/TBDApp/Helpers/StatusBarView.swift
+++ b/Sources/TBDApp/Helpers/StatusBarView.swift
@@ -134,6 +134,18 @@ struct StatusBarView: View {
         /// come from `binding.status`, so they are absent together — and a chip
         /// with no status carries no `mergeQueuePosition` either, so nothing is
         /// left unsaid by returning nil on that branch.
+        ///
+        /// It keeps the default interpunct even on the path that ends up spoken
+        /// (`openLabel`, which is this chip's `.help` AND its
+        /// `.accessibilityLabel`), where the sidebar row splits into two
+        /// joinings. The difference is that the sidebar's spoken label is a
+        /// comma-joined list this sentence is spliced INTO, so an interpunct
+        /// inside it collides with the commas around it; the chip's label is
+        /// `"Open PR #412 — <sentence>"`, already punctuated with an em-dash
+        /// and carrying no list. One string per chip is also what lets the
+        /// headline, the tooltip and the label be the same words by
+        /// construction — a spoken variant would be a second stored field and a
+        /// second thing to keep in step.
         var stateDescription: String? {
             guard let state, let reason else { return nil }
             return PRStatusPresentation.stateDescription(
@@ -360,11 +372,6 @@ struct StatusBarView: View {
         isHovering ? untrackLabel(chip) : openLabel(chip)
     }
 
-    /// The bus glyph's drawn side on a status-bar chip, kept identical to the
-    /// 12 `WorktreeRowView.prGlyph` draws at so the bar's bus and the sidebar's
-    /// are the same image at the same size.
-    nonisolated static let prChipBusSide: CGFloat = 12
-
     /// The side of one chip's leading icon slot — the square its resting glyph
     /// and the untrack xmark share.
     ///
@@ -374,16 +381,17 @@ struct StatusBarView: View {
     /// the cursor that summoned it.
     ///
     /// A queued chip draws the bus rather than a 6pt dot, which needs the same
-    /// 12 the sidebar row gives it, so the side depends on WHICH CHIP THIS IS —
-    /// never on hover state. That is the whole invariant: two chips in the same
-    /// bar may differ in width, but neither changes width under the pointer, so
-    /// hovering still cannot shove a neighbour or slide the xmark away. It is a
-    /// `static func` here rather than a computed property inside `PRChipView`
-    /// so that invariant is assertable at all — a `private var` on a `View` is
-    /// reachable from no test, which is how the rule the whole hover geometry
-    /// rests on went unpinned.
+    /// `PRStatusPresentation.busSide` the sidebar row gives it, so the side
+    /// depends on WHICH CHIP THIS IS — never on hover state. That is the whole
+    /// invariant: two chips in the same bar may differ in width, but neither
+    /// changes width under the pointer, so hovering still cannot shove a
+    /// neighbour or slide the xmark away. It is a `static func` here rather
+    /// than a computed property inside `PRChipView` so that invariant is
+    /// assertable at all — a `private var` on a `View` is reachable from no
+    /// test, which is how the rule the whole hover geometry rests on went
+    /// unpinned.
     nonisolated static func iconSlotSide(for chip: PRChip) -> CGFloat {
-        chip.mergeQueuePosition == nil ? 9 : prChipBusSide
+        chip.mergeQueuePosition == nil ? 9 : PRStatusPresentation.busSide
     }
 
     /// What the bar says when the selected worktree is armed to archive itself
@@ -750,7 +758,7 @@ private struct PRChipView: View {
                 // `.renderingMode(.original)` is what keeps the chip's
                 // `.foregroundStyle(.secondary)` off it.
                 Image(nsImage: PRStatusPresentation.busImage(
-                    position: position, side: StatusBarView.prChipBusSide))
+                    position: position, side: PRStatusPresentation.busSide))
                     .renderingMode(.original)
                     .resizable()
                     .scaledToFit()
@@ -818,16 +826,22 @@ private struct PRChipView: View {
 /// dropdown shows — `PRBindingPresentation.menuRows`, in bind order — so the
 /// two surfaces cannot describe the same worktree differently.
 ///
-/// It renders **no PR title**, and that is a decision rather than an omission.
-/// Titles reach the chips through the hover overlay, which is an ordinary
-/// SwiftUI view re-evaluated on every change. A title in these rows would have
-/// to survive AppKit's once-only `NSMenu` materialization — the constraint
-/// `PRButtonLabel.prSplitButtonID` exists for and `PRSplitButtonIDTests`
-/// tripwires — and this `Menu` has no `.id` key to fold it into, so a retitled
-/// PR would read stale here for as long as the menu lived. Sharing `menuRows`
-/// with the toolbar is also what keeps the two surfaces from disagreeing;
-/// forking it for one field would give that up to duplicate what the overlay
-/// already says better.
+/// AppKit materializes an `NSMenu` ONCE, and later SwiftUI state changes never
+/// reach the materialized copy — the constraint `PRButtonLabel.prSplitButtonID`
+/// exists for and `PRSplitButtonIDTests` tripwires. These rows carry two fields
+/// that move on their own: the queue position, which counts down on every merge
+/// ahead of the PR, and the status `reason`. A menu built at position 3 and left
+/// open would sit two pixels from a chip whose baked bus badge already read 1 —
+/// exactly the disagreement the shared sentence exists to remove. So the `Menu`
+/// takes an `.id` keyed on the rendered rows (`PRBindingPresentation.menuRowsID`)
+/// and is recreated whenever their text or targets change.
+///
+/// It still renders **no PR title**, and that is a decision rather than an
+/// omission: titles reach the chips through the hover overlay, an ordinary
+/// SwiftUI view re-evaluated on every change, which has room to show one
+/// properly. Sharing `menuRows` with the toolbar is what keeps the two surfaces
+/// from disagreeing; forking it for one field would give that up to duplicate
+/// what the overlay already says better.
 private struct PRChipOverflowMenu: View {
     let bindings: [PRBinding]
     let overflow: Int
@@ -835,8 +849,9 @@ private struct PRChipOverflowMenu: View {
     @State private var isHovering = false
 
     var body: some View {
+        let rows = PRBindingPresentation.menuRows(bindings)
         Menu {
-            ForEach(PRBindingPresentation.menuRows(bindings)) { row in
+            ForEach(rows) { row in
                 // The default browser, matching the chips beside it — see
                 // `PRChipView`'s tap handler for why the status bar differs
                 // from the toolbar here.
@@ -852,6 +867,10 @@ private struct PRChipOverflowMenu: View {
                 .underline(isHovering)
                 .foregroundStyle(.secondary)
         }
+        // Forces AppKit to re-materialize the NSMenu when the rows' text or
+        // targets move — see this view's doc comment for why a queued PR makes
+        // that mandatory rather than tidy.
+        .id(PRBindingPresentation.menuRowsID(rows))
         .menuStyle(.borderlessButton)
         .menuIndicator(.hidden)
         .fixedSize()

--- a/Sources/TBDApp/Helpers/StatusBarView.swift
+++ b/Sources/TBDApp/Helpers/StatusBarView.swift
@@ -117,21 +117,27 @@ struct StatusBarView: View {
         let mergeQueuePosition: Int?
         /// The status's own words for that state, when it has any — the same
         /// `reason ?? state.displayReason` the overflow menu and the toolbar
-        /// dropdown render. Carried rather than derived so the three surfaces
-        /// cannot describe one observation differently.
+        /// dropdown start from. Carried rather than re-derived because it is
+        /// half the input to `PRStatusPresentation.stateDescription`, which is
+        /// where the shared sentence is actually composed: a chip that recovered
+        /// these words some other way could hand that one function a different
+        /// reason than the menu row beside it hands it.
         let reason: String?
         /// The one sentence every chip surface uses to describe this PR's
-        /// state. The queue clause **supersedes** `reason` rather than
-        /// appending to it, for the same reason `PRStatusPresentation.make(for:)`
-        /// short-circuits before reading `state`: a queued PR's reason is the
-        /// pending wording its UNKNOWN check status decayed into, and a
-        /// sentence that said both would have the chip claim the PR is waiting
-        /// on its author *and* sitting in the queue. Reading it from one place
-        /// is what stops the words under the pointer from disagreeing with the
-        /// glyph the pointer is on.
+        /// state, composed by `PRStatusPresentation.stateDescription` — the
+        /// same function behind the sidebar row's tooltip and the dropdown menu
+        /// rows, so no two surfaces can word one observation differently.
+        /// See it for why a queue clause supersedes a `.pending` reason and
+        /// joins every other one.
+        ///
+        /// nil only when nothing has been observed. `state` and `reason` both
+        /// come from `binding.status`, so they are absent together — and a chip
+        /// with no status carries no `mergeQueuePosition` either, so nothing is
+        /// left unsaid by returning nil on that branch.
         var stateDescription: String? {
-            if let mergeQueuePosition { return "In merge queue, position \(mergeQueuePosition)" }
-            return reason
+            guard let state, let reason else { return nil }
+            return PRStatusPresentation.stateDescription(
+                state: state, reason: reason, mergeQueuePosition: mergeQueuePosition)
         }
         /// The PR's title, or nil when it was never observed (a chip lifted
         /// from a cached `Worktree.prStatus` has none). The hover overlay
@@ -279,9 +285,10 @@ struct StatusBarView: View {
     /// only for a caution the reader must not miss.
     nonisolated static func chipHeadline(_ chip: PRChip) -> String {
         var headline = "\(chip.forge.refNoun)\(chip.label)"
-        // The status's own words when it has any, exactly as the overflow menu
-        // and the toolbar dropdown render them — except for a queued PR, whose
-        // sentence `stateDescription` replaces outright. See it for why.
+        // The status's own words when it has any, composed by the very function
+        // the overflow menu and the toolbar dropdown compose their rows with —
+        // including the queue clause a queued PR leads with. See
+        // `PRStatusPresentation.stateDescription`.
         if let state = chip.stateDescription?.trimmingCharacters(in: .whitespacesAndNewlines),
            !state.isEmpty {
             headline += " (\(state))"
@@ -351,6 +358,32 @@ struct StatusBarView: View {
     /// open.
     nonisolated static func iconSlotLabel(_ chip: PRChip, isHovering: Bool) -> String {
         isHovering ? untrackLabel(chip) : openLabel(chip)
+    }
+
+    /// The bus glyph's drawn side on a status-bar chip, kept identical to the
+    /// 12 `WorktreeRowView.prGlyph` draws at so the bar's bus and the sidebar's
+    /// are the same image at the same size.
+    nonisolated static let prChipBusSide: CGFloat = 12
+
+    /// The side of one chip's leading icon slot — the square its resting glyph
+    /// and the untrack xmark share.
+    ///
+    /// Sized for the LARGER of the two glyphs, with both centred in it, so the
+    /// chip is exactly as wide hovered as at rest. A slot that grew on hover
+    /// would shove every chip to its right and slide the xmark out from under
+    /// the cursor that summoned it.
+    ///
+    /// A queued chip draws the bus rather than a 6pt dot, which needs the same
+    /// 12 the sidebar row gives it, so the side depends on WHICH CHIP THIS IS —
+    /// never on hover state. That is the whole invariant: two chips in the same
+    /// bar may differ in width, but neither changes width under the pointer, so
+    /// hovering still cannot shove a neighbour or slide the xmark away. It is a
+    /// `static func` here rather than a computed property inside `PRChipView`
+    /// so that invariant is assertable at all — a `private var` on a `View` is
+    /// reachable from no test, which is how the rule the whole hover geometry
+    /// rests on went unpinned.
+    nonisolated static func iconSlotSide(for chip: PRChip) -> CGFloat {
+        chip.mergeQueuePosition == nil ? 9 : prChipBusSide
     }
 
     /// What the bar says when the selected worktree is armed to archive itself
@@ -588,21 +621,11 @@ private struct PRChipView: View {
     @State private var isSlotHovered = false
 
     /// The fixed square this chip's resting glyph and the untrack xmark share.
-    ///
-    /// Sized for the LARGER of the two glyphs, with both centred in it, so the
-    /// chip is exactly as wide hovered as at rest. A slot that grew on hover
-    /// would shove every chip to its right and slide the xmark out from under
-    /// the cursor that summoned it.
-    ///
-    /// A queued chip draws the bus rather than a 6pt dot, which needs the same
-    /// 12 the sidebar row gives it, so the side depends on WHICH CHIP THIS IS —
-    /// never on hover state. That is the whole invariant: two chips in the same
-    /// bar may differ in width, but neither changes width under the pointer, so
-    /// hovering still cannot shove a neighbour or slide the xmark away.
-    private var iconSlotSide: CGFloat { chip.mergeQueuePosition == nil ? 9 : Self.busSide }
-    /// The bus glyph's drawn side, kept identical to `WorktreeRowView.prGlyph`'s
-    /// so the status bar's bus and the sidebar's are the same image.
-    private static let busSide: CGFloat = 12
+    /// Decided by `StatusBarView.iconSlotSide(for:)` rather than here — the
+    /// rule it encodes (width depends on which chip, never on hover state) is
+    /// the one this whole control rests on, and a `private var` on a `View`
+    /// cannot be asserted by a test.
+    private var iconSlotSide: CGFloat { StatusBarView.iconSlotSide(for: chip) }
     /// The drawn xmark's point size — under `iconSlotSide` in both axes.
     private static let xmarkPointSize: CGFloat = 8
     /// The untrack click region, contributed as a transparent **overlay** on
@@ -726,7 +749,8 @@ private struct PRChipView: View {
                 // color and NOT tinted: `busImage` is non-template, so
                 // `.renderingMode(.original)` is what keeps the chip's
                 // `.foregroundStyle(.secondary)` off it.
-                Image(nsImage: PRStatusPresentation.busImage(position: position, side: Self.busSide))
+                Image(nsImage: PRStatusPresentation.busImage(
+                    position: position, side: StatusBarView.prChipBusSide))
                     .renderingMode(.original)
                     .resizable()
                     .scaledToFit()
@@ -919,7 +943,7 @@ private struct AutoArchiveChipView: View {
     @State private var isHovering = false
 
     /// The fixed square `archivebox` and `xmark` share, named to match
-    /// `PRChipView.iconSlotSide` because it holds the same invariant: sized for
+    /// `StatusBarView.iconSlotSide(for:)` because it holds the same invariant: sized for
     /// the larger of the two glyphs, both centred, so the capsule cannot change
     /// width when the pointer crosses it.
     ///

--- a/Sources/TBDApp/Helpers/StatusBarView.swift
+++ b/Sources/TBDApp/Helpers/StatusBarView.swift
@@ -108,11 +108,31 @@ struct StatusBarView: View {
         /// PR to the daemon — a synthetic chip has no row to name by id.
         let url: URL?
         let state: PRMergeableState?
+        /// 1-indexed merge-queue position, or nil when the PR is not queued —
+        /// the fact `PRStatusPresentation.make(for:)` short-circuits to the bus
+        /// glyph on. Carried because the chip cannot derive it from `state`: a
+        /// queued PR reports UNKNOWN, which maps to the ordinary olive pending
+        /// dot, so the dot alone does not merely under-describe the PR, it
+        /// actively misdescribes it as still waiting on its author.
+        let mergeQueuePosition: Int?
         /// The status's own words for that state, when it has any — the same
         /// `reason ?? state.displayReason` the overflow menu and the toolbar
         /// dropdown render. Carried rather than derived so the three surfaces
         /// cannot describe one observation differently.
         let reason: String?
+        /// The one sentence every chip surface uses to describe this PR's
+        /// state. The queue clause **supersedes** `reason` rather than
+        /// appending to it, for the same reason `PRStatusPresentation.make(for:)`
+        /// short-circuits before reading `state`: a queued PR's reason is the
+        /// pending wording its UNKNOWN check status decayed into, and a
+        /// sentence that said both would have the chip claim the PR is waiting
+        /// on its author *and* sitting in the queue. Reading it from one place
+        /// is what stops the words under the pointer from disagreeing with the
+        /// glyph the pointer is on.
+        var stateDescription: String? {
+            if let mergeQueuePosition { return "In merge queue, position \(mergeQueuePosition)" }
+            return reason
+        }
         /// The PR's title, or nil when it was never observed (a chip lifted
         /// from a cached `Worktree.prStatus` has none). The hover overlay
         /// omits the line rather than fabricating a placeholder.
@@ -184,6 +204,7 @@ struct StatusBarView: View {
                 forge: Forge.forURL(binding.url),
                 url: URL(string: binding.url),
                 state: binding.status?.state,
+                mergeQueuePosition: binding.status?.mergeQueuePosition,
                 reason: binding.status.map { $0.reason ?? $0.state.displayReason },
                 title: binding.title,
                 observedAt: binding.status?.observedAt,
@@ -259,8 +280,9 @@ struct StatusBarView: View {
     nonisolated static func chipHeadline(_ chip: PRChip) -> String {
         var headline = "\(chip.forge.refNoun)\(chip.label)"
         // The status's own words when it has any, exactly as the overflow menu
-        // and the toolbar dropdown render them.
-        if let state = chip.reason?.trimmingCharacters(in: .whitespacesAndNewlines),
+        // and the toolbar dropdown render them — except for a queued PR, whose
+        // sentence `stateDescription` replaces outright. See it for why.
+        if let state = chip.stateDescription?.trimmingCharacters(in: .whitespacesAndNewlines),
            !state.isEmpty {
             headline += " (\(state))"
         }
@@ -308,12 +330,14 @@ struct StatusBarView: View {
     /// Tooltip and accessibility hint for the chip's own click target, e.g.
     /// `Open PR #412 — Checks failing`.
     ///
-    /// Reads the same carried `reason` the hover overlay does. Deriving it from
-    /// `state` here instead would put the generic label in the tooltip and in
-    /// VoiceOver while the card beside them showed the status's own words.
+    /// Reads the same `stateDescription` the hover overlay does. Deriving it
+    /// from `state` here instead would put the generic label in the tooltip and
+    /// in VoiceOver while the card beside them showed the status's own words —
+    /// and, for a queued PR, would announce the pending wording the bus glyph
+    /// under the pointer flatly contradicts.
     nonisolated static func openLabel(_ chip: PRChip) -> String {
-        guard let reason = chip.reason else { return "Open \(chip.refLabel)" }
-        return "Open \(chip.refLabel) — \(reason)"
+        guard let state = chip.stateDescription else { return "Open \(chip.refLabel)" }
+        return "Open \(chip.refLabel) — \(state)"
     }
 
     /// What the leading icon slot's tooltip says, and therefore what clicking it
@@ -563,13 +587,22 @@ private struct PRChipView: View {
     /// from the number onto the slot cannot flicker the xmark back to a dot.
     @State private var isSlotHovered = false
 
-    /// The fixed square the status dot and the untrack xmark share.
+    /// The fixed square this chip's resting glyph and the untrack xmark share.
     ///
     /// Sized for the LARGER of the two glyphs, with both centred in it, so the
     /// chip is exactly as wide hovered as at rest. A slot that grew on hover
     /// would shove every chip to its right and slide the xmark out from under
     /// the cursor that summoned it.
-    private static let iconSlotSide: CGFloat = 9
+    ///
+    /// A queued chip draws the bus rather than a 6pt dot, which needs the same
+    /// 12 the sidebar row gives it, so the side depends on WHICH CHIP THIS IS —
+    /// never on hover state. That is the whole invariant: two chips in the same
+    /// bar may differ in width, but neither changes width under the pointer, so
+    /// hovering still cannot shove a neighbour or slide the xmark away.
+    private var iconSlotSide: CGFloat { chip.mergeQueuePosition == nil ? 9 : Self.busSide }
+    /// The bus glyph's drawn side, kept identical to `WorktreeRowView.prGlyph`'s
+    /// so the status bar's bus and the sidebar's are the same image.
+    private static let busSide: CGFloat = 12
     /// The drawn xmark's point size — under `iconSlotSide` in both axes.
     private static let xmarkPointSize: CGFloat = 8
     /// The untrack click region, contributed as a transparent **overlay** on
@@ -578,7 +611,9 @@ private struct PRChipView: View {
     /// wider than the glyph costs no layout width. 12pt centred on the 6pt dot
     /// reaches 3pt past the dot on each side, well inside the 6pt gap
     /// `PRChipCluster` puts between chips, so no chip can take a neighbour's
-    /// click.
+    /// click. On a queued chip the slot is already 12, so the region covers the
+    /// bus exactly and overhangs nothing — the property that matters is that it
+    /// is never SMALLER than the glyph it arms, which holds in both cases.
     private static let untrackHitSide: CGFloat = 12
     /// Gap between the icon slot and the number. Applied as leading padding on
     /// the text rather than as `HStack` spacing so the gap belongs to the
@@ -587,8 +622,10 @@ private struct PRChipView: View {
 
     /// The dot color, taken from the shared PR palette so a chip cannot drift
     /// from the sidebar glyph or the toolbar icon for the same state. The
-    /// synthetic `PRStatus` exists only to reach that palette — `make(for:)`
-    /// reads nothing but `state` once `mergeQueuePosition` is nil.
+    /// synthetic `PRStatus` exists only to reach that palette, and passing no
+    /// position is faithful rather than lossy: this is reached only on the
+    /// non-queued branch, and `make(for:)` reads nothing but `state` once
+    /// `mergeQueuePosition` is nil.
     private var dotColor: Color {
         guard let state = chip.state,
               let presentation = PRStatusPresentation.make(
@@ -600,9 +637,10 @@ private struct PRChipView: View {
     var body: some View {
         HStack(spacing: 0) {
             // Above the number in z-order, so the 1.5pt by which the untrack
-            // region overhangs the slot on the trailing side wins the hit test
-            // against the text's own leading padding. Later `HStack` children
-            // are otherwise drawn — and hit-tested — on top.
+            // region overhangs a dot-sized slot on the trailing side wins the
+            // hit test against the text's own leading padding. Later `HStack`
+            // children are otherwise drawn — and hit-tested — on top. A queued
+            // chip has no overhang to defend, and is unharmed by the same rule.
             iconSlot.zIndex(1)
             Text(chip.label)
                 .lineLimit(1)
@@ -658,8 +696,9 @@ private struct PRChipView: View {
     /// can never advertise untracking while the slot is showing a status dot.
     private var isUntrackTarget: Bool { isHovering && isSlotHovered }
 
-    /// The fixed-size leading slot: the status dot at rest, the untrack xmark
-    /// while the chip is hovered. Both centred in the same square.
+    /// The fixed-size leading slot: at rest the merge-queue bus for a queued PR
+    /// and the status dot for every other, the untrack xmark while the chip is
+    /// hovered. All centred in the same square.
     private var iconSlot: some View {
         ZStack {
             if isHovering {
@@ -680,17 +719,29 @@ private struct PRChipView: View {
                             .fill(Color.primary.opacity(isSlotHovered ? 0.11 : 0))
                             .frame(width: Self.untrackHitSide, height: Self.untrackHitSide)
                     }
+            } else if let position = chip.mergeQueuePosition {
+                // The same bus, with the same baked position badge, at the same
+                // side as the sidebar row draws — one image, so the two
+                // surfaces cannot describe one queued PR differently. Full
+                // color and NOT tinted: `busImage` is non-template, so
+                // `.renderingMode(.original)` is what keeps the chip's
+                // `.foregroundStyle(.secondary)` off it.
+                Image(nsImage: PRStatusPresentation.busImage(position: position, side: Self.busSide))
+                    .renderingMode(.original)
+                    .resizable()
+                    .scaledToFit()
             } else {
                 Circle()
                     .fill(dotColor)
                     .frame(width: 6, height: 6)
             }
         }
-        .frame(width: Self.iconSlotSide, height: Self.iconSlotSide)
+        .frame(width: iconSlotSide, height: iconSlotSide)
         .overlay {
-            // Transparent, larger than the slot, and laid over it — sized by
-            // this overlay and not by the layout, so it widens the hit area
-            // without widening the chip.
+            // Transparent, never smaller than the slot, and laid over it —
+            // sized by this overlay and not by the layout, so it widens the hit
+            // area (on a queued chip, merely matches it) without widening the
+            // chip.
             Color.clear
                 .frame(width: Self.untrackHitSide, height: Self.untrackHitSide)
                 .contentShape(Rectangle())
@@ -872,9 +923,10 @@ private struct AutoArchiveChipView: View {
     /// the larger of the two glyphs, both centred, so the capsule cannot change
     /// width when the pointer crosses it.
     ///
-    /// 11, not `PRChipView`'s 9, and the difference is not drift. That slot is
-    /// sized to a 6pt status dot; this one holds SF Symbols, so it takes the
-    /// size the bar's other symbol slot already uses — `CopyableStatusText`
+    /// 11, not the 9 `PRChipView` uses for a dot-bearing chip, and the
+    /// difference is not drift. That slot is sized to a 6pt status dot (12 on
+    /// the queued chips that draw a bus); this one holds SF Symbols, so it
+    /// takes the size the bar's other symbol slot already uses — `CopyableStatusText`
     /// frames its leading `GitBranchIcon` at 11×11 to match the caption text
     /// this bar is set in. Following the neighbour that hosts the same kind of
     /// glyph is what keeps the bar even.

--- a/Sources/TBDApp/PRBindingPresentation.swift
+++ b/Sources/TBDApp/PRBindingPresentation.swift
@@ -118,10 +118,17 @@ enum PRBindingPresentation {
 
     /// Dropdown menu rows, in bind order — the same "don't move under the
     /// cursor" reasoning as `statusBarChips`. Each row's title carries the
-    /// request named in its own forge's vocabulary, its human-readable reason
-    /// (falling back to the state's default when `PRStatus.reason` is nil), and
-    /// the head branch, e.g. `"PR #412  Checks failing  fix-login-timeout"` or
+    /// request named in its own forge's vocabulary, the one shared sentence
+    /// describing its state, and the head branch, e.g.
+    /// `"PR #412  Checks failing  fix-login-timeout"` or
     /// `"MR !412  Checks failing  fix-login-timeout"`.
+    ///
+    /// That sentence comes from `PRStatusPresentation.stateDescription` rather
+    /// than being composed here, because these rows share a screen with the
+    /// surfaces that use it: the status bar's `+N` menu is opened from beside
+    /// the chips themselves, and a multi-PR worktree can show a chip reading
+    /// "In merge queue" next to a row that used to say only "Checks pending"
+    /// for the very same PR.
     ///
     /// A row describes ONE binding, so it takes the per-binding wording rule
     /// rather than the neutral aggregate one: `refLabel` reads the forge from
@@ -133,7 +140,7 @@ enum PRBindingPresentation {
         bindings.map { binding in
             var parts = [binding.refLabel]
             if let status = binding.status {
-                parts.append(status.reason ?? status.state.displayReason)
+                parts.append(PRStatusPresentation.stateDescription(for: status))
             }
             if let branch = binding.headBranch {
                 parts.append(branch)

--- a/Sources/TBDApp/PRBindingPresentation.swift
+++ b/Sources/TBDApp/PRBindingPresentation.swift
@@ -155,6 +155,34 @@ enum PRBindingPresentation {
         }
     }
 
+    /// The `.id` key for a `Menu` rendering `menuRows`, keyed on what those
+    /// rows actually draw. AppKit materializes an `NSMenu` ONCE and later
+    /// SwiftUI state changes do not reach it, so without a key that moves when
+    /// the rows do, a row reads stale for as long as the menu lives — the
+    /// constraint `PRButtonLabel.prSplitButtonID` exists for, in the smaller
+    /// shape a plain menu needs.
+    ///
+    /// Keyed on the composed `title` rather than on any one field, because the
+    /// title is the whole of what a row renders and it folds in every input
+    /// that can move underneath it: the queue position (3 → 2 → 1 on every
+    /// merge ahead of the PR, and the reason a stale row could contradict the
+    /// chip two pixels away), the status `reason`, and the head branch. `url`
+    /// joins it because the row's action captures it and `disabled` reads it, so
+    /// a re-pointed PR must rebuild the item even with identical text. `id`
+    /// pins which binding each row IS, so a reorder or a swap that happens to
+    /// preserve the titles still counts as a change.
+    ///
+    /// Fields go through `PRButtonLabel.escapedIDField` for the same reason
+    /// they do there: a title is free text that can contain the key's own
+    /// separators, and an unescaped collision does not merely look wrong — it
+    /// freezes the menu on the previous set.
+    static func menuRowsID(_ rows: [MenuRow]) -> String {
+        rows.map { row in
+            "\(row.id)-\(PRButtonLabel.escapedIDField(row.title))"
+                + "-\(PRButtonLabel.escapedIDField(row.url?.absoluteString))"
+        }.joined(separator: "|")
+    }
+
     /// Tooltip for the status bar's `+N` overflow chip.
     ///
     /// The chip is labelled by how many PRs did NOT fit, but its menu lists

--- a/Sources/TBDApp/PRStatusPresentation.swift
+++ b/Sources/TBDApp/PRStatusPresentation.swift
@@ -200,6 +200,18 @@ struct PRStatusPresentation: Equatable {
         return image
     }
 
+    /// The side, in points, every surface draws the bus glyph at.
+    ///
+    /// It lives here rather than at either call site because `busImage` caches
+    /// per `(position, side)`: two surfaces passing two literals would mint two
+    /// bitmaps, and the sidebar row and the status-bar chip would then draw
+    /// visibly different busses for one queued PR with every test still green.
+    /// One constant is what makes "the same image at the same size" a fact
+    /// rather than a comment. (The toolbar split button is the deliberate
+    /// exception — it composites the bus into a larger flattened label image
+    /// and passes its own `iconSide`.)
+    static let busSide: CGFloat = 12
+
     /// The full-color merge-queue bus glyph with its 1-indexed `position` baked
     /// into a small rounded-rect corner chip. Shared by BOTH render sites (the
     /// sidebar row and the flattened toolbar split-button label, which can only
@@ -239,6 +251,15 @@ struct PRStatusPresentation: Equatable {
     /// *and* queued, and it is about to be evicted from that queue. Dropping
     /// those words would hide the one fact worth acting on.
     ///
+    /// Note the rule whitelists the *state*, not that one artifact: the same
+    /// mapper also returns `(.pending, "Checks pending")` from an earlier
+    /// `requiredChecksPending` branch, where the words are a real observation
+    /// rather than decay. Nothing user-visible turns on the difference today
+    /// because both branches compose the identical string — but a second
+    /// `.pending` reason added later would be swallowed on queued PRs too, and
+    /// whoever adds one has to narrow this guard rather than assume it only
+    /// catches the UNKNOWN case.
+    ///
     /// The position is printed in full even though the bus glyph beside it
     /// clamps at `maxQueueBadgeValue` — a chip reading `99+` can sit next to a
     /// tooltip saying "position 150". The divergence is deliberate: the glyph
@@ -250,27 +271,36 @@ struct PRStatusPresentation: Equatable {
     /// it between interpuncts — but there it sits beside `reason`, which is
     /// capitalized too ("Checks failing"), so a lowercase queue clause was the
     /// odd one out rather than the sidebar's house style.
+    ///
+    /// `separator` defaults to the interpunct `PRFreshness` joins its own
+    /// clauses with, so a tooltip carrying both reads as one list rather than
+    /// two punctuations. It is a parameter because the sidebar row builds its
+    /// **spoken** label by joining with `", "` — VoiceOver reads an interpunct
+    /// as "middle dot" or as nothing at all, depending on the user's
+    /// punctuation setting, and either way a sentence that mixed `·` here with
+    /// `, ` around it announces as two styles in one breath. The words are
+    /// still the shared ones; only the joint differs.
     static func stateDescription(
         state: PRMergeableState,
         reason: String,
-        mergeQueuePosition: Int?
+        mergeQueuePosition: Int?,
+        separator: String = " · "
     ) -> String {
         guard let mergeQueuePosition else { return reason }
         let queued = "In merge queue, position \(mergeQueuePosition)"
         guard state != .pending else { return queued }
-        // Same separator `PRFreshness` joins its clauses with, so a tooltip
-        // that carries both reads as one list rather than two punctuations.
-        return "\(queued) · \(reason)"
+        return "\(queued)\(separator)\(reason)"
     }
 
     /// The same sentence for a caller holding a whole `PRStatus`. `reason`
     /// falls back to the state's generic words exactly as each render site did
     /// before this was shared, so nothing changes for an unqueued PR.
-    static func stateDescription(for status: PRStatus) -> String {
+    static func stateDescription(for status: PRStatus, separator: String = " · ") -> String {
         stateDescription(
             state: status.state,
             reason: status.reason ?? status.state.displayReason,
-            mergeQueuePosition: status.mergeQueuePosition
+            mergeQueuePosition: status.mergeQueuePosition,
+            separator: separator
         )
     }
 

--- a/Sources/TBDApp/PRStatusPresentation.swift
+++ b/Sources/TBDApp/PRStatusPresentation.swift
@@ -220,6 +220,60 @@ struct PRStatusPresentation: Equatable {
         return image
     }
 
+    /// The one sentence every surface uses to describe a single request's
+    /// state: the status-bar chip's headline, tooltip and VoiceOver hint, the
+    /// sidebar row's tooltip, and the rows of both the toolbar dropdown and the
+    /// `+N` overflow menu. It lives beside `busImage` for exactly the reason
+    /// that image is shared — a bar and a sidebar drawing one queued PR must
+    /// not describe it differently, and on a multi-PR worktree the chip and the
+    /// menu row for the *same* PR can be on screen at once.
+    ///
+    /// A queue position **adds** a leading clause. It replaces `reason` for
+    /// exactly one state, `.pending`, and that exception is mechanical rather
+    /// than stylistic: a queued PR reports its merge state as UNKNOWN, which
+    /// `PRStatusManager.mapGitHubStateAndReason` maps to
+    /// `(.pending, "Checks pending")` — a decay artifact claiming the PR waits
+    /// on its author when it plainly does not. Every other state is computed
+    /// independently of queue membership and is live news: a PR at position 2
+    /// whose required check just went red is `(.checksFailed, "Checks failing")`
+    /// *and* queued, and it is about to be evicted from that queue. Dropping
+    /// those words would hide the one fact worth acting on.
+    ///
+    /// The position is printed in full even though the bus glyph beside it
+    /// clamps at `maxQueueBadgeValue` — a chip reading `99+` can sit next to a
+    /// tooltip saying "position 150". The divergence is deliberate: the glyph
+    /// is a dozen points wide and must fit its number in three glyphs, the
+    /// sentence has a whole tooltip and no such budget.
+    ///
+    /// Capitalized, and the one casing serves every caller. The chip renders it
+    /// in a parenthetical (`PR#412 (In merge queue…)`) and the sidebar splices
+    /// it between interpuncts — but there it sits beside `reason`, which is
+    /// capitalized too ("Checks failing"), so a lowercase queue clause was the
+    /// odd one out rather than the sidebar's house style.
+    static func stateDescription(
+        state: PRMergeableState,
+        reason: String,
+        mergeQueuePosition: Int?
+    ) -> String {
+        guard let mergeQueuePosition else { return reason }
+        let queued = "In merge queue, position \(mergeQueuePosition)"
+        guard state != .pending else { return queued }
+        // Same separator `PRFreshness` joins its clauses with, so a tooltip
+        // that carries both reads as one list rather than two punctuations.
+        return "\(queued) · \(reason)"
+    }
+
+    /// The same sentence for a caller holding a whole `PRStatus`. `reason`
+    /// falls back to the state's generic words exactly as each render site did
+    /// before this was shared, so nothing changes for an unqueued PR.
+    static func stateDescription(for status: PRStatus) -> String {
+        stateDescription(
+            state: status.state,
+            reason: status.reason ?? status.state.displayReason,
+            mergeQueuePosition: status.mergeQueuePosition
+        )
+    }
+
     /// Draws `emoji` centered within `rect` at a font size matching the square.
     private static func drawEmoji(_ emoji: String, in rect: NSRect) {
         let font = NSFont.systemFont(ofSize: rect.height)

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -419,10 +419,14 @@ struct WorktreeRowView: View {
             // this cannot select a different request.
             if let presentation = prPresentation, let binding = indicatorBinding,
                let status = binding.status {
-                // A queued PR describes itself by its queue position, not its
-                // underlying (UNKNOWN→pending) check reason.
-                let detail = presentation.badge.map { "in merge queue, position \($0)" }
-                    ?? (status.reason ?? status.state.displayReason)
+                // Composed where the bus glyph is, not spelled out here, so the
+                // row's words cannot drift from the status-bar chip's or the
+                // dropdown row's for the same request — the three had already
+                // started to. A queued PR leads with its position and drops
+                // only the `.pending` reason it decayed from UNKNOWN into; a
+                // queued PR that is also failing keeps "Checks failing", which
+                // is the fact that says it is about to be evicted.
+                let detail = PRStatusPresentation.stateDescription(for: status)
                 // The cache never speaks without saying how old it is, and
                 // never hides that its last re-read failed.
                 let freshness = PRFreshness.clauses(

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -427,6 +427,13 @@ struct WorktreeRowView: View {
                 // queued PR that is also failing keeps "Checks failing", which
                 // is the fact that says it is about to be evicted.
                 let detail = PRStatusPresentation.stateDescription(for: status)
+                // The same words, joined the way the spoken label joins
+                // everything else. A queued-and-failing PR's sentence carries a
+                // separator of its own, so taking `detail` verbatim would
+                // announce "…position 2 · Checks failing, checked just now" —
+                // two punctuation styles in one utterance.
+                let spokenDetail = PRStatusPresentation.stateDescription(
+                    for: status, separator: ", ")
                 // The cache never speaks without saying how old it is, and
                 // never hides that its last re-read failed.
                 let freshness = PRFreshness.clauses(
@@ -441,7 +448,7 @@ struct WorktreeRowView: View {
                 .buttonStyle(.plain)
                 .onHover { isPRIconHovered = $0 }
                 .accessibilityLabel(
-                    "\(binding.refLabel): \(([detail] + freshness).joined(separator: ", "))")
+                    "\(binding.refLabel): \(([spokenDetail] + freshness).joined(separator: ", "))")
                 .anchorPreference(key: RowTooltipPreferenceKey.self, value: .bounds) { anchor in
                     isPRIconHovered ? RowTooltipPreference(text: tooltip, anchor: anchor) : nil
                 }
@@ -498,7 +505,8 @@ struct WorktreeRowView: View {
                     .foregroundStyle(presentation.color)
             }
         case .emoji:
-            Image(nsImage: PRStatusPresentation.busImage(position: presentation.badge, side: 12))
+            Image(nsImage: PRStatusPresentation.busImage(
+                position: presentation.badge, side: PRStatusPresentation.busSide))
                 .renderingMode(.original)
                 .resizable()
                 .scaledToFit()

--- a/Tests/TBDAppTests/PRBindingPresentationTests.swift
+++ b/Tests/TBDAppTests/PRBindingPresentationTests.swift
@@ -255,4 +255,57 @@ struct PRBindingPresentationTests {
         #expect(PRBindingPresentation.menuRows([queued(.pending, position: nil)])[0].title
             == "PR #412  Checks pending")
     }
+
+    // MARK: - The overflow menu's refresh key
+
+    /// AppKit materializes an `NSMenu` ONCE, so the `+N` menu carries an `.id`
+    /// keyed on its rendered rows. This is the tripwire on that key, and it has
+    /// to fail on the field that moves fastest: a queue position counting down
+    /// 3 → 2 → 1 under an unchanged `state` would otherwise leave the menu row
+    /// contradicting the bus badge on the chip two pixels away.
+    @Test("the overflow menu's id moves when anything its rows render moves")
+    func menuRowsIDTracksTheRenderedRows() {
+        let bindingID = UUID()
+        let defaultURL = "https://github.com/acme/acme-prod/pull/412"
+        func bound(state: PRMergeableState = .checksFailed,
+                   reason: String? = "Checks failing",
+                   position: Int? = nil,
+                   branch: String? = "fix-login-timeout",
+                   prURL: String? = nil) -> [MenuRow] {
+            let url = prURL ?? defaultURL
+            return PRBindingPresentation.menuRows([
+                PRBinding(id: bindingID, worktreeID: UUID(), owner: "acme", repo: "acme-prod",
+                          number: 412, url: url, headBranch: branch,
+                          status: PRStatus(number: 412, url: url, state: state,
+                                           reason: reason, mergeQueuePosition: position),
+                          source: .hook)
+            ])
+        }
+        let base = PRBindingPresentation.menuRowsID(bound())
+        #expect(PRBindingPresentation.menuRowsID(bound()) == base)
+        // The fast-moving field: same state, same reason, one place nearer the
+        // front of the queue.
+        #expect(PRBindingPresentation.menuRowsID(bound(position: 3))
+            != PRBindingPresentation.menuRowsID(bound(position: 2)))
+        // Everything else a row renders. The state reaches the title only
+        // through the words it falls back to, so it moves the key exactly when
+        // the status brought none of its own.
+        #expect(PRBindingPresentation.menuRowsID(bound(reason: "1 check failing")) != base)
+        #expect(PRBindingPresentation.menuRowsID(bound(state: .blocked, reason: nil))
+            != PRBindingPresentation.menuRowsID(bound(state: .checksFailed, reason: nil)))
+        #expect(PRBindingPresentation.menuRowsID(bound(branch: "fix-login-timeout-2")) != base)
+        // Identical text, re-pointed target — the row title carries the number
+        // and the branch, not the url. The row's action captures that url and
+        // `disabled` reads it, so the item still has to be rebuilt.
+        let repointed = bound(prURL: "https://github.com/acme/acme-prod/pull/999")
+        #expect(repointed[0].title == bound()[0].title)
+        #expect(PRBindingPresentation.menuRowsID(repointed) != base)
+        // A reason is whatever the forge wrote, and both of the key's own
+        // separators are legal in it. They go through
+        // `PRButtonLabel.escapedIDField`, so a value carrying either keys
+        // distinctly rather than reading as a field boundary.
+        #expect(PRBindingPresentation.menuRowsID(bound(reason: "a|b-c")) != base)
+        #expect(PRBindingPresentation.menuRowsID(bound(reason: "a|b-c"))
+            != PRBindingPresentation.menuRowsID(bound(reason: "abc")))
+    }
 }

--- a/Tests/TBDAppTests/PRBindingPresentationTests.swift
+++ b/Tests/TBDAppTests/PRBindingPresentationTests.swift
@@ -225,4 +225,34 @@ struct PRBindingPresentationTests {
         #expect(row.title.contains("Checks failing"))
         #expect(row.title.contains("fix-login-timeout"))
     }
+
+    /// These rows share a screen with the status-bar chips: the `+N` menu is
+    /// opened from beside them, and on a multi-PR worktree the chip and the row
+    /// for one PR can be visible at once. So a row for a queued PR has to say
+    /// the same thing the bus glyph beside it does — it used to render the
+    /// literal "Checks pending" for the very PR whose chip read "In merge
+    /// queue".
+    @Test("a menu row for a queued PR leads with its queue position")
+    func menuRowSpeaksTheQueue() {
+        let url = "https://github.com/acme/acme-prod/pull/412"
+        func queued(_ state: PRMergeableState, position: Int?) -> PRBinding {
+            PRBinding(worktreeID: UUID(), owner: "acme", repo: "acme-prod",
+                      number: 412, url: url,
+                      status: PRStatus(number: 412, url: url, state: state,
+                                       mergeQueuePosition: position),
+                      source: .hook)
+        }
+        // The pending reason is the UNKNOWN decay artifact, so it goes.
+        #expect(PRBindingPresentation.menuRows([queued(.pending, position: 3)])[0].title
+            == "PR #412  In merge queue, position 3")
+        // A failing check on a queued PR is live news — it says the PR is about
+        // to be evicted — so it rides along.
+        #expect(PRBindingPresentation.menuRows([queued(.checksFailed, position: 2)])[0].title
+            == "PR #412  In merge queue, position 2 · Checks failing")
+        // Unqueued rows are untouched by any of it.
+        #expect(PRBindingPresentation.menuRows([queued(.checksFailed, position: nil)])[0].title
+            == "PR #412  Checks failing")
+        #expect(PRBindingPresentation.menuRows([queued(.pending, position: nil)])[0].title
+            == "PR #412  Checks pending")
+    }
 }

--- a/Tests/TBDAppTests/PRButtonLabelTests.swift
+++ b/Tests/TBDAppTests/PRButtonLabelTests.swift
@@ -256,6 +256,7 @@ struct PRButtonLabelTests {
         #expect(open != otherURL)
 
         // reason IS keyed: `PRBindingPresentation.menuRows` renders
+        // `PRStatusPresentation.stateDescription`, which carries
         // `status.reason ?? state.displayReason` into every menu row title, so
         // a reason-only change ("1 check failing" → "3 checks failing") under an
         // unchanged state would leave the materialized NSMenu showing stale text.

--- a/Tests/TBDAppTests/PRSplitButtonIDTests.swift
+++ b/Tests/TBDAppTests/PRSplitButtonIDTests.swift
@@ -119,8 +119,9 @@ struct PRSplitButtonIDTests {
     @Test("the id changes when only a status REASON changes")
     func idCoversReason() {
         let wt = UUID()
-        // `menuRows` renders `status.reason ?? state.displayReason` into every
-        // row title, so "1 check failing" → "3 checks failing" under an
+        // `menuRows` renders `PRStatusPresentation.stateDescription`, whose
+        // `status.reason ?? state.displayReason` reaches every row title, so
+        // "1 check failing" → "3 checks failing" under an
         // unchanged `.checksFailed` must still recreate the materialized menu.
         // Two bindings, because that is when rows are rendered at all.
         let other = Self.binding(413, .mergeable, worktreeID: wt)

--- a/Tests/TBDAppTests/PRStatusPresentationTests.swift
+++ b/Tests/TBDAppTests/PRStatusPresentationTests.swift
@@ -162,4 +162,79 @@ struct PRStatusPresentationTests {
         #expect(ten != ninetyNine)
         #expect(one != ninetyNine)
     }
+
+    // MARK: - The shared state sentence
+
+    /// The rule in one place: a queue position ADDS a leading clause, and
+    /// replaces `reason` for exactly one state. `.pending` on a queued PR is
+    /// decay, not observation — the forge reports a queued PR's merge state as
+    /// UNKNOWN and `PRStatusManager.mapGitHubStateAndReason` maps that to
+    /// `(.pending, "Checks pending")` — so it is the one reason worth dropping.
+    @Test("a queued PR's pending reason is dropped, because it is the UNKNOWN decay artifact")
+    func queuedPendingReasonIsSuperseded() {
+        #expect(PRStatusPresentation.stateDescription(
+            state: .pending, reason: "Checks pending", mergeQueuePosition: 2)
+            == "In merge queue, position 2")
+    }
+
+    /// Every other state is computed independently of queue membership, so it
+    /// is live news and must survive. A PR at position 2 whose required check
+    /// just went red is about to be evicted from that queue; an unconditional
+    /// supersession hid exactly that.
+    @Test("a queued PR keeps every reason but the pending one", arguments: [
+        (PRMergeableState.checksFailed, "Checks failing"),
+        (.blocked, "Blocked"),
+        (.changesRequested, "Changes requested"),
+        (.mergeable, "Ready to merge"),
+        (.draft, "Draft")
+    ])
+    func queuedNonPendingReasonSurvives(state: PRMergeableState, reason: String) {
+        let sentence = PRStatusPresentation.stateDescription(
+            state: state, reason: reason, mergeQueuePosition: 2)
+        #expect(sentence == "In merge queue, position 2 · \(reason)")
+    }
+
+    /// Not queued: the sentence is the reason, untouched. The queue clause is a
+    /// qualification on one PR, not a change to how every PR describes itself.
+    @Test("an unqueued PR's sentence is its reason and nothing else")
+    func unqueuedSentenceIsJustTheReason() {
+        #expect(PRStatusPresentation.stateDescription(
+            state: .checksFailed, reason: "Checks failing", mergeQueuePosition: nil)
+            == "Checks failing")
+        #expect(PRStatusPresentation.stateDescription(
+            state: .pending, reason: "Checks pending", mergeQueuePosition: nil)
+            == "Checks pending")
+    }
+
+    /// The `PRStatus` overload falls back to the state's generic words exactly
+    /// as each render site did before the sentence was shared, so nothing
+    /// changes for a status the forge gave no reason for.
+    @Test("a status with no reason of its own falls back to the state's generic words")
+    func statusOverloadFallsBackToDisplayReason() {
+        let url = "https://github.com/acme/acme-prod/pull/412"
+        #expect(PRStatusPresentation.stateDescription(
+            for: PRStatus(number: 412, url: url, state: .checksFailed))
+            == PRMergeableState.checksFailed.displayReason)
+        #expect(PRStatusPresentation.stateDescription(
+            for: PRStatus(number: 412, url: url, state: .checksFailed, mergeQueuePosition: 2))
+            == "In merge queue, position 2 · \(PRMergeableState.checksFailed.displayReason)")
+        // A status's own words win over the generic ones, queued or not.
+        #expect(PRStatusPresentation.stateDescription(
+            for: PRStatus(number: 412, url: url, state: .blocked,
+                          reason: "Changes requested by reviewer", mergeQueuePosition: 4))
+            == "In merge queue, position 4 · Changes requested by reviewer")
+    }
+
+    /// The glyph clamps at `maxQueueBadgeValue` and the sentence does not, and
+    /// the divergence is deliberate: the bus is a dozen points wide and must
+    /// fit its number in three glyphs, while a tooltip has room to be exact.
+    @MainActor
+    @Test("the sentence prints a position the badge would have clamped to 99+")
+    func sentenceKeepsThePrecisePositionTheBadgeClamps() {
+        let iconRect = NSRect(x: 0, y: 0, width: 12, height: 12)
+        #expect(PRStatusPresentation.queueBadgeLayout(position: 150, in: iconRect).text == "99+")
+        #expect(PRStatusPresentation.stateDescription(
+            state: .pending, reason: "Checks pending", mergeQueuePosition: 150)
+            == "In merge queue, position 150")
+    }
 }

--- a/Tests/TBDAppTests/PRStatusPresentationTests.swift
+++ b/Tests/TBDAppTests/PRStatusPresentationTests.swift
@@ -225,6 +225,32 @@ struct PRStatusPresentationTests {
             == "In merge queue, position 4 · Changes requested by reviewer")
     }
 
+    /// The separator is a parameter so a spoken label can join with commas —
+    /// the sidebar row splices this sentence into a `", "`-joined list, and an
+    /// interpunct inside it makes VoiceOver announce two punctuation styles in
+    /// one breath. Only the joint moves; the words are the shared ones.
+    @Test("the shared sentence joins with the caller's separator")
+    func sentenceHonorsTheCallersSeparator() {
+        let url = "https://github.com/acme/acme-prod/pull/412"
+        let queuedAndFailing = PRStatus(number: 412, url: url, state: .checksFailed,
+                                        reason: "Checks failing", mergeQueuePosition: 2)
+        #expect(PRStatusPresentation.stateDescription(for: queuedAndFailing)
+            == "In merge queue, position 2 · Checks failing")
+        #expect(PRStatusPresentation.stateDescription(for: queuedAndFailing, separator: ", ")
+            == "In merge queue, position 2, Checks failing")
+        // The separator only ever joins two clauses — it cannot leak into a
+        // sentence that has just one, queued or not.
+        #expect(PRStatusPresentation.stateDescription(
+            for: PRStatus(number: 412, url: url, state: .pending,
+                          reason: "Checks pending", mergeQueuePosition: 2),
+            separator: ", ")
+            == "In merge queue, position 2")
+        #expect(PRStatusPresentation.stateDescription(
+            for: PRStatus(number: 412, url: url, state: .checksFailed, reason: "Checks failing"),
+            separator: ", ")
+            == "Checks failing")
+    }
+
     /// The glyph clamps at `maxQueueBadgeValue` and the sentence does not, and
     /// the divergence is deliberate: the bus is a dozen points wide and must
     /// fit its number in three glyphs, while a tooltip has room to be exact.

--- a/Tests/TBDAppTests/StatusBarViewChipsTests.swift
+++ b/Tests/TBDAppTests/StatusBarViewChipsTests.swift
@@ -422,30 +422,57 @@ struct StatusBarViewChipsTests {
         #expect(StatusBarView.prChips([binding(412, nil)]).chips[0].mergeQueuePosition == nil)
     }
 
-    /// The queue clause SUPERSEDES the state's words rather than joining them —
-    /// the same short-circuit `PRStatusPresentation.make(for:)` makes before it
-    /// ever reads `state`. A queued PR's reason is the pending wording its
-    /// UNKNOWN check status decayed into, so a headline carrying both would say
+    /// The queue clause supersedes the state's words for EXACTLY ONE state.
+    /// `.pending` on a queued PR is not an observation, it is decay: the forge
+    /// reports a queued PR's merge state as UNKNOWN and the daemon maps that to
+    /// `(.pending, "Checks pending")`, so a headline carrying both would say
     /// the PR is waiting on its author and sitting in the queue at once.
-    @Test("a queued chip's headline says the queue position instead of the state's reason")
-    func headlineSupersedesTheReasonWhenQueued() {
+    @Test("a queued chip's headline drops the pending reason the UNKNOWN state decayed into")
+    func headlineSupersedesOnlyThePendingReasonWhenQueued() {
         let queued = chip(state: .pending, mergeQueuePosition: 3)
         #expect(StatusBarView.chipHeadline(queued) == "PR#412 (In merge queue, position 3)")
         // Not appended: neither the generic pending label nor a second clause
         // survives beside the queue sentence.
         #expect(StatusBarView.chipHeadline(queued)
             .contains(PRMergeableState.pending.displayReason) == false)
-        // …and the same holds for the state that would otherwise read as the
-        // most confident thing a chip can say.
-        let ready = chip(state: .mergeable, mergeQueuePosition: 1)
-        #expect(StatusBarView.chipHeadline(ready) == "PR#412 (In merge queue, position 1)")
-        #expect(StatusBarView.chipHeadline(ready)
-            .contains(PRMergeableState.mergeable.displayReason) == false)
         // The title still follows the clause, so the queue does not cost the
         // headline its third fact.
         #expect(StatusBarView.chipHeadline(
             chip(state: .pending, title: "Fix the login timeout", mergeQueuePosition: 3))
             == "PR#412 (In merge queue, position 3) - Fix the login timeout")
+    }
+
+    /// Every state other than `.pending` is computed independently of queue
+    /// membership, so it is live news and rides along. A PR at position 2 whose
+    /// required check just went red is about to be evicted from that queue —
+    /// the one fact worth acting on, and the one an unconditional supersession
+    /// swallowed on every chip surface at once.
+    @Test("a queued chip that is also failing keeps the failure beside its position")
+    func queuedChipKeepsANonPendingReason() {
+        let failing = chip(state: .checksFailed, mergeQueuePosition: 2)
+        #expect(StatusBarView.chipHeadline(failing)
+            == "PR#412 (In merge queue, position 2 · Checks failing)")
+        #expect(StatusBarView.openLabel(failing)
+            == "Open PR #412 — In merge queue, position 2 · Checks failing")
+        // The queue clause leads, because it is the mode the PR is in; the
+        // reason qualifies it rather than replacing it.
+        #expect(failing.stateDescription?.hasPrefix("In merge queue, position 2") == true)
+        #expect(failing.stateDescription?.contains(PRMergeableState.checksFailed.displayReason)
+            == true)
+        // A queued PR the forge still calls ready keeps that reading too — the
+        // exception is `.pending`, not "any state a queued PR might report".
+        #expect(StatusBarView.chipHeadline(chip(state: .mergeable, mergeQueuePosition: 1))
+            == "PR#412 (In merge queue, position 1 · Ready to merge)")
+        // A status's own words, not just the generic state label, survive.
+        let url = "https://github.com/acme/acme-prod/pull/412"
+        let reviewed = StatusBarView.prChips([PRBinding(
+            worktreeID: UUID(), owner: "acme", repo: "acme-prod", number: 412, url: url,
+            status: PRStatus(number: 412, url: url, state: .blocked,
+                             reason: "Changes requested by reviewer",
+                             mergeQueuePosition: 4),
+            source: .hook)]).chips[0]
+        #expect(StatusBarView.chipHeadline(reviewed)
+            == "PR#412 (In merge queue, position 4 · Changes requested by reviewer)")
     }
 
     /// The tooltip and the VoiceOver hint read the same sentence the card does.
@@ -461,6 +488,56 @@ struct StatusBarViewChipsTests {
         // on the drawn bus opens the PR exactly as a click on a dot does.
         #expect(StatusBarView.iconSlotLabel(queued, isHovering: false)
             == StatusBarView.openLabel(queued))
+    }
+
+    /// The anti-drift claim made in three doc comments, asserted rather than
+    /// asserted-about: the chip does not compose its own sentence, it calls the
+    /// same `PRStatusPresentation.stateDescription` the sidebar row's tooltip
+    /// and the dropdown's menu rows call. So the test names the shared function
+    /// instead of repeating its literals — a change to the wording that reached
+    /// only some surfaces would break this even though every literal here still
+    /// matched.
+    @Test("the chip's sentence is the one shared with the sidebar and the menu rows")
+    func chipSentenceComesFromTheSharedHelper() {
+        let states: [PRMergeableState] = [.pending, .checksFailed, .mergeable, .blocked,
+                                          .changesRequested, .draft, .merged, .closed]
+        let positions: [Int?] = [nil, 1, 150]
+        for state in states {
+            for position in positions {
+                let url = "https://github.com/acme/acme-prod/pull/412"
+                let status = PRStatus(number: 412, url: url, state: state,
+                                      mergeQueuePosition: position)
+                let binding = PRBinding(
+                    worktreeID: UUID(), owner: "acme", repo: "acme-prod",
+                    number: 412, url: url, status: status, source: .hook)
+                let shared = PRStatusPresentation.stateDescription(for: status)
+                // The chip surface…
+                #expect(StatusBarView.prChips([binding]).chips[0].stateDescription == shared)
+                // …and the menu-row surface, which the `+N` overflow menu and
+                // the toolbar dropdown both render.
+                #expect(PRBindingPresentation.menuRows([binding])[0].title.contains(shared))
+            }
+        }
+    }
+
+    // MARK: - The icon slot's width
+
+    /// The invariant the hover geometry rests on: the slot's side is a function
+    /// of WHICH CHIP it is, never of hover state. A slot that grew under the
+    /// pointer would shove every chip to its right and slide the xmark out from
+    /// under the cursor that summoned it. It lives on `StatusBarView` rather
+    /// than inside `PRChipView` precisely so this can be asserted at all.
+    @Test("a queued chip's icon slot is bus-sized, and every other chip's is dot-sized")
+    func iconSlotSideDependsOnTheChipNotTheHover() {
+        #expect(StatusBarView.iconSlotSide(for: chip(state: .pending, mergeQueuePosition: 3))
+            == StatusBarView.prChipBusSide)
+        #expect(StatusBarView.iconSlotSide(for: chip(state: .pending)) == 9)
+        #expect(StatusBarView.iconSlotSide(for: chip(state: .checksFailed)) == 9)
+        // A never-polled binding has no position, so it draws a dot.
+        #expect(StatusBarView.iconSlotSide(for: chip(state: nil)) == 9)
+        // The bus is drawn at the size the sidebar row draws it at, so the two
+        // surfaces render one image rather than two.
+        #expect(StatusBarView.prChipBusSide == 12)
     }
 
     /// The queue clause is a replacement for one chip's state sentence, not a

--- a/Tests/TBDAppTests/StatusBarViewChipsTests.swift
+++ b/Tests/TBDAppTests/StatusBarViewChipsTests.swift
@@ -19,7 +19,8 @@ struct StatusBarViewChipsTests {
         _ state: PRMergeableState?,
         worktreeID: UUID = UUID(),
         title: String? = nil,
-        observedAt: Date? = nil
+        observedAt: Date? = nil,
+        mergeQueuePosition: Int? = nil
     ) -> PRBinding {
         let url = "https://github.com/acme/acme-prod/pull/\(number)"
         return PRBinding(
@@ -27,7 +28,8 @@ struct StatusBarViewChipsTests {
             number: number, url: url,
             title: title,
             status: state.map {
-                PRStatus(number: number, url: url, state: $0, observedAt: observedAt)
+                PRStatus(number: number, url: url, state: $0,
+                         mergeQueuePosition: mergeQueuePosition, observedAt: observedAt)
             },
             source: .hook
         )
@@ -127,10 +129,12 @@ struct StatusBarViewChipsTests {
         number: Int = 412,
         state: PRMergeableState? = .mergeable,
         title: String? = nil,
-        observedAt: Date? = nil
+        observedAt: Date? = nil,
+        mergeQueuePosition: Int? = nil
     ) -> StatusBarView.PRChip {
         StatusBarView.prChips([
-            binding(number, state, title: title, observedAt: observedAt)
+            binding(number, state, title: title, observedAt: observedAt,
+                    mergeQueuePosition: mergeQueuePosition)
         ]).chips[0]
     }
 
@@ -400,6 +404,79 @@ struct StatusBarViewChipsTests {
         #expect(unobserved.rows.last?.value == StatusBarView.chipOpenActionValue(.github))
         #expect(unobserved.rows.last?.alternateValue
                 == StatusBarView.chipUntrackActionValue(.github))
+    }
+
+    // MARK: - The merge queue
+
+    /// The chip cannot derive the queue from `state`: a queued PR reports
+    /// UNKNOWN, which decays to the ordinary pending state. So the position has
+    /// to ride on the chip, which is what the leading slot swaps its dot for a
+    /// bus on.
+    @Test("a chip carries the merge-queue position, and nil when the PR is not queued")
+    func chipCarriesTheQueuePosition() {
+        #expect(StatusBarView.prChips([binding(412, .pending, mergeQueuePosition: 3)])
+            .chips[0].mergeQueuePosition == 3)
+        #expect(StatusBarView.prChips([binding(412, .pending)])
+            .chips[0].mergeQueuePosition == nil)
+        // A binding nothing has polled has no status to read a position from.
+        #expect(StatusBarView.prChips([binding(412, nil)]).chips[0].mergeQueuePosition == nil)
+    }
+
+    /// The queue clause SUPERSEDES the state's words rather than joining them —
+    /// the same short-circuit `PRStatusPresentation.make(for:)` makes before it
+    /// ever reads `state`. A queued PR's reason is the pending wording its
+    /// UNKNOWN check status decayed into, so a headline carrying both would say
+    /// the PR is waiting on its author and sitting in the queue at once.
+    @Test("a queued chip's headline says the queue position instead of the state's reason")
+    func headlineSupersedesTheReasonWhenQueued() {
+        let queued = chip(state: .pending, mergeQueuePosition: 3)
+        #expect(StatusBarView.chipHeadline(queued) == "PR#412 (In merge queue, position 3)")
+        // Not appended: neither the generic pending label nor a second clause
+        // survives beside the queue sentence.
+        #expect(StatusBarView.chipHeadline(queued)
+            .contains(PRMergeableState.pending.displayReason) == false)
+        // …and the same holds for the state that would otherwise read as the
+        // most confident thing a chip can say.
+        let ready = chip(state: .mergeable, mergeQueuePosition: 1)
+        #expect(StatusBarView.chipHeadline(ready) == "PR#412 (In merge queue, position 1)")
+        #expect(StatusBarView.chipHeadline(ready)
+            .contains(PRMergeableState.mergeable.displayReason) == false)
+        // The title still follows the clause, so the queue does not cost the
+        // headline its third fact.
+        #expect(StatusBarView.chipHeadline(
+            chip(state: .pending, title: "Fix the login timeout", mergeQueuePosition: 3))
+            == "PR#412 (In merge queue, position 3) - Fix the login timeout")
+    }
+
+    /// The tooltip and the VoiceOver hint read the same sentence the card does.
+    /// A chip whose glyph is a bus and whose hint says "Checks pending" would
+    /// have the words under the pointer contradict the glyph the pointer is on.
+    @Test("the open target says the queue position too")
+    func openLabelSpeaksTheQueue() {
+        let queued = chip(state: .pending, mergeQueuePosition: 3)
+        #expect(StatusBarView.openLabel(queued) == "Open PR #412 — In merge queue, position 3")
+        #expect(StatusBarView.openLabel(queued)
+            .contains(PRMergeableState.pending.displayReason) == false)
+        // The icon slot's resting meaning is that same sentence, since a click
+        // on the drawn bus opens the PR exactly as a click on a dot does.
+        #expect(StatusBarView.iconSlotLabel(queued, isHovering: false)
+            == StatusBarView.openLabel(queued))
+    }
+
+    /// The queue clause is a replacement for one chip's state sentence, not a
+    /// change to how every chip describes itself.
+    @Test("an unqueued chip's headline and open label are untouched")
+    func unqueuedChipIsUnchanged() {
+        let plain = chip(state: .checksFailed, title: "Fix the login timeout")
+        #expect(StatusBarView.chipHeadline(plain)
+            == "PR#412 (\(PRMergeableState.checksFailed.displayReason)) - Fix the login timeout")
+        #expect(StatusBarView.openLabel(plain)
+            == "Open PR #412 — \(PRMergeableState.checksFailed.displayReason)")
+        #expect(StatusBarView.chipHeadline(plain).contains("merge queue") == false)
+        #expect(StatusBarView.openLabel(plain).contains("merge queue") == false)
+        // A chip with no status at all still says only what it observed.
+        #expect(StatusBarView.chipHeadline(chip(state: nil)) == "PR#412")
+        #expect(StatusBarView.openLabel(chip(state: nil)) == "Open PR #412")
     }
 
     // MARK: - Forge vocabulary

--- a/Tests/TBDAppTests/StatusBarViewChipsTests.swift
+++ b/Tests/TBDAppTests/StatusBarViewChipsTests.swift
@@ -493,29 +493,43 @@ struct StatusBarViewChipsTests {
     /// The anti-drift claim made in three doc comments, asserted rather than
     /// asserted-about: the chip does not compose its own sentence, it calls the
     /// same `PRStatusPresentation.stateDescription` the sidebar row's tooltip
-    /// and the dropdown's menu rows call. So the test names the shared function
-    /// instead of repeating its literals — a change to the wording that reached
-    /// only some surfaces would break this even though every literal here still
-    /// matched.
+    /// and the dropdown's menu rows call.
+    ///
+    /// It is worth being precise about what this can and cannot catch. Both
+    /// sides route through the shared helper, so a change to the *wording*
+    /// moves both and this stays green — that is the point, not a gap. What it
+    /// does catch is a surface that stops calling the helper and starts
+    /// composing its own words, and — because the chip carries `reason` while
+    /// the `for:` overload derives `reason ?? state.displayReason` — a chip
+    /// whose fallback drifts from the overload's. The custom-`reason` case
+    /// below exercises exactly that seam: with `reason: nil` on every status,
+    /// both paths would agree through `displayReason` alone and a divergence in
+    /// how the chip picks its words would never show.
     @Test("the chip's sentence is the one shared with the sidebar and the menu rows")
     func chipSentenceComesFromTheSharedHelper() {
         let states: [PRMergeableState] = [.pending, .checksFailed, .mergeable, .blocked,
                                           .changesRequested, .draft, .merged, .closed]
         let positions: [Int?] = [nil, 1, 150]
+        // nil = the state's generic words; the custom string = a status that
+        // brought its own, which is the only case where the chip's `reason` and
+        // the overload's `reason ?? displayReason` can disagree.
+        let reasons: [String?] = [nil, "Changes requested by reviewer"]
         for state in states {
             for position in positions {
-                let url = "https://github.com/acme/acme-prod/pull/412"
-                let status = PRStatus(number: 412, url: url, state: state,
-                                      mergeQueuePosition: position)
-                let binding = PRBinding(
-                    worktreeID: UUID(), owner: "acme", repo: "acme-prod",
-                    number: 412, url: url, status: status, source: .hook)
-                let shared = PRStatusPresentation.stateDescription(for: status)
-                // The chip surface…
-                #expect(StatusBarView.prChips([binding]).chips[0].stateDescription == shared)
-                // …and the menu-row surface, which the `+N` overflow menu and
-                // the toolbar dropdown both render.
-                #expect(PRBindingPresentation.menuRows([binding])[0].title.contains(shared))
+                for reason in reasons {
+                    let url = "https://github.com/acme/acme-prod/pull/412"
+                    let status = PRStatus(number: 412, url: url, state: state,
+                                          reason: reason, mergeQueuePosition: position)
+                    let binding = PRBinding(
+                        worktreeID: UUID(), owner: "acme", repo: "acme-prod",
+                        number: 412, url: url, status: status, source: .hook)
+                    let shared = PRStatusPresentation.stateDescription(for: status)
+                    // The chip surface…
+                    #expect(StatusBarView.prChips([binding]).chips[0].stateDescription == shared)
+                    // …and the menu-row surface, which the `+N` overflow menu and
+                    // the toolbar dropdown both render.
+                    #expect(PRBindingPresentation.menuRows([binding])[0].title.contains(shared))
+                }
             }
         }
     }
@@ -529,15 +543,18 @@ struct StatusBarViewChipsTests {
     /// than inside `PRChipView` precisely so this can be asserted at all.
     @Test("a queued chip's icon slot is bus-sized, and every other chip's is dot-sized")
     func iconSlotSideDependsOnTheChipNotTheHover() {
+        // The slot is sized by the ONE constant both surfaces draw the bus at,
+        // so a chip cannot be sized for a bus the sidebar renders at some other
+        // side — and `busImage` cannot be asked for a second cached bitmap.
         #expect(StatusBarView.iconSlotSide(for: chip(state: .pending, mergeQueuePosition: 3))
-            == StatusBarView.prChipBusSide)
+            == PRStatusPresentation.busSide)
         #expect(StatusBarView.iconSlotSide(for: chip(state: .pending)) == 9)
         #expect(StatusBarView.iconSlotSide(for: chip(state: .checksFailed)) == 9)
         // A never-polled binding has no position, so it draws a dot.
         #expect(StatusBarView.iconSlotSide(for: chip(state: nil)) == 9)
-        // The bus is drawn at the size the sidebar row draws it at, so the two
-        // surfaces render one image rather than two.
-        #expect(StatusBarView.prChipBusSide == 12)
+        // Pinned as a value too: the bus slot has to stay bigger than the 9pt
+        // dot slot, or a queued chip would clip its own glyph.
+        #expect(PRStatusPresentation.busSide == 12)
     }
 
     /// The queue clause is a replacement for one chip's state sentence, not a


### PR DESCRIPTION
## Summary

A pull request sitting in a merge queue is in a mode of its own: it is no longer waiting on its author, and the only thing worth knowing about it is how many PRs are ahead of it. GitHub cannot express that through `mergeStateStatus` — a queued PR reports `UNKNOWN`, which the daemon maps to the ordinary "Checks pending". The sidebar worktree row has drawn a 🚌 with its 1-indexed queue position badged into the corner for a while; the status bar's PR chips did not, so a queued PR showed the same olive dot as one genuinely waiting on its author.

The chips now draw the same bus, from the same image, and say "In merge queue, position 3" wherever they previously said "Checks pending".

## Why this shape

**No spec.** This is a minor UI change on an existing surface — it revises no theory of the system, adds no flag, and introduces no durable resource. It borrows a glyph the sidebar already ships.

**One image, not a second bus.** `PRStatusPresentation.busImage` already existed and already caches per `(position, side)`. Both surfaces call it at the same side, so they share one `NSImage` rather than two that could drift.

**One sentence, not three literals.** Writing the chip's wording inline would have made a third copy — the sidebar had its own literal, already drifting in capitalization, and the two menu surfaces had none at all. `PRStatusPresentation.stateDescription` composes it once for all three.

**The queue clause supersedes only the decayed reason.** `mapGitHubStateAndReason` computes state independently of queue membership, so `(.checksFailed, "Checks failing")` and a non-nil position arrive together in one GraphQL response. Dropping the reason unconditionally would erase the one fact that says the PR is about to be *evicted* from the queue. Only `.pending` — the `UNKNOWN` artifact — is dropped; everything else rides alongside: `In merge queue, position 2 · Checks failing`.

**The slot width depends on which chip, never on hover.** A queued chip's icon slot is 12pt against a dot chip's 9pt. That preserves the invariant the surrounding code is built on: hovering a chip cannot change its width, so it cannot shove its neighbours or slide the xmark out from under the cursor that summoned it.

## What this PR does

- `StatusBarView.PRChip` carries `mergeQueuePosition`; the chip's icon slot draws the badged bus at rest and the untrack xmark on hover, unchanged.
- `PRStatusPresentation.stateDescription(state:reason:mergeQueuePosition:separator:)` is the single composer, used by the chip, the sidebar row, and `PRBindingPresentation.menuRows`. `separator` exists because the sidebar's spoken accessibility label joins with `", "` — an interpunct reads badly aloud.
- `PRStatusPresentation.busSide` replaces the drawn-size literal in both render sites.
- The `+N` overflow menu gains an `.id` keyed on its composed rows. That file's own comment cites the absence of one as the reason PR titles are kept out of these rows: AppKit materializes an NSMenu once, so a changed field reads stale for as long as the menu lives — and the queue position is precisely the field that ticks 3 → 2 → 1.
- `StatusBarView.iconSlotSide(for:)` is lifted out of the private `View` member so the width invariant is assertable.

## Scope note

The two menu surfaces — the status bar's `+N` overflow menu and the toolbar dropdown — had never been taught about the merge queue, so they rendered the literal "Checks pending" for the very PR whose chip beside them said "In merge queue"; on a multi-PR worktree both are on screen at once. That is past the chip this PR was asked for, but it is the same defect, and the alternative was leaving a third dialect of one sentence. The sidebar row carried the unconditional-supersession bug too and is fixed by the same change.

## Assumptions

- Only GitHub reports a queue position. `GitLabQueries` hardcodes `mergeQueuePosition: nil`, so the forge-neutral wording is safe today — but GitLab's concept is a **merge train**, and wiring it up later needs a forge branch here and in the sidebar.
- `.pending` is dropped by a **state whitelist**, not by matching the `UNKNOWN` artifact. An earlier `requiredChecksPending` branch reaches the same state with a real observation; it produces the identical string today, so nothing distinguishable is swallowed. Adding a second `.pending` reason would need that guard narrowed — noted in the code.

## Evidence & verification

- `scripts/swift-safe build --build-tests` clean; `swiftlint --strict` clean (0 violations, 914 files).
- Discriminating test: `queuedChipKeepsANonPendingReason` expects `PR#412 (In merge queue, position 2 · Checks failing)` and **fails** against the first commit's unconditional supersession, which yielded `PR#412 (In merge queue, position 2)`.
- `chipSentenceComesFromTheSharedHelper` compares each surface's output against the shared helper across 48 state × position × reason combinations, so a surface that stops calling it reddens.
- `menuRowsIDTracksTheRenderedRows` tripwires the overflow menu's refresh key; `iconSlotSideDependsOnTheChipNotTheHover` pins 12/9.
- `sentenceKeepsThePrecisePositionTheBadgeClamps` records a deliberate divergence: the badge clamps to `99+` because it is width-constrained, the sentence prints the literal position because it is not.
- **Not live-verified in the queued state** — that needs a PR actually sitting in a merge queue, which I could not stage. The unqueued paths are byte-identical to before (verified by reading each call site and by regression tests), and the queued glyph goes through the same `busImage` the sidebar has been shipping.

Three review passes ran over this branch; the second caught the supersession defect described above, which the first commit had introduced.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=B88A79EC-068D-4580-8C63-B1A90B81EE04)

https://claude.ai/code/session_0183e1N6ybrBpZSJu2Hi39UM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Pull requests in the merge queue now display their queue position and pending status consistently across status-bar chips, menus, accessibility labels, and related views.
  * Queued items use a shared bus indicator and queue-aware sizing.
  * Status descriptions now preserve relevant failure reasons and support queue positions beyond the `99+` badge limit.
  * Overflow menus refresh when displayed pull request details change.
* **Tests**
  * Added coverage for queued pull request presentation, accessibility text, menu updates, sizing, and status descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->