### PR TITLE
Feat: Let a remote session be deleted without destroying its conversation

### DIFF
--- a/Sources/TBDApp/AppState+Remote.swift
+++ b/Sources/TBDApp/AppState+Remote.swift
@@ -50,6 +50,16 @@ extension AppState {
                 self.selectedRemoteProvider = nil
             }
             pruneRemoteSessionState(toKnownSessions: sessions.sessions)
+            // Best-effort and last, deliberately. The receipts only decide
+            // whether an archived lane's Revive means reseeding, so a failure
+            // here must not clear the roster and the mirror that did arrive —
+            // and the previous answer is a better one to keep than none.
+            do {
+                retainedTranscripts = try await retainedTranscriptsFetcher()
+            } catch {
+                remoteLogger.error(
+                    "Failed to refresh retained transcripts: \(error, privacy: .public)")
+            }
         } catch {
             switch AppState.classifyRemoteRefreshFailure(error) {
             case .unavailable:
@@ -60,6 +70,10 @@ extension AppState {
                 // rename overrides or unread bookkeeping.
                 remoteProviders = []
                 remoteSessions = []
+                // Safe to clear outright, unlike the two maps above: this is a
+                // cache of daemon rows, not user state, and the same refusal
+                // covers the verb that reads it.
+                retainedTranscripts = []
             case .error:
                 remoteLogger.error("Failed to refresh remote backends: \(error, privacy: .public)")
             }

--- a/Sources/TBDApp/AppState+Remote.swift
+++ b/Sources/TBDApp/AppState+Remote.swift
@@ -308,9 +308,14 @@ extension AppState {
     }
 
     /// Present the destructive confirm. Modal, mirroring
-    /// `confirmDefaultAccountFallback`; the destructive verb is the first
-    /// button and Cancel is the second, so Return does not destroy anything by
-    /// itself.
+    /// `confirmDefaultAccountFallback` for structure. "Delete" is still the
+    /// first button added — on macOS that's the rightmost, conventional
+    /// position for the confirming action, and `.alertFirstButtonReturn`
+    /// keeps meaning "the user chose to delete." But AppKit also makes the
+    /// first button the Return-key default, and this action is irreversible,
+    /// so the key equivalents are reassigned explicitly: Delete loses Return,
+    /// Cancel gets it (Escape already cancels). No keystroke by itself
+    /// destroys a session.
     @MainActor
     func confirmRemoteDelete(message: String) -> Bool {
         let alert = NSAlert()
@@ -319,6 +324,11 @@ extension AppState {
         alert.informativeText = message
         alert.addButton(withTitle: "Delete")
         alert.addButton(withTitle: "Cancel")
+        // HIG: destructive action shouldn't be the Return-key default (same
+        // pattern as AppState.noteCloseConfirmer / LegacyHooksCoordinator's
+        // migrate dialog).
+        alert.buttons[0].keyEquivalent = ""
+        alert.buttons[1].keyEquivalent = "\r"
         return alert.runModal() == .alertFirstButtonReturn
     }
 

--- a/Sources/TBDApp/AppState+Remote.swift
+++ b/Sources/TBDApp/AppState+Remote.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import TBDShared
 import os
@@ -233,6 +234,78 @@ extension AppState {
     /// offers the correct Pin/Unpin verb.
     func remoteSessionIsPinned(provider: String, sessionID: String) -> Bool {
         remoteSessions.first { $0.provider == provider && $0.payload.id == sessionID }?.pinnedAt != nil
+    }
+
+    // MARK: - Destroying a session
+
+    /// Whether the daemon currently permits `remote.delete`
+    /// (`remote_delete_enabled`). Read from the capability payload rather than
+    /// assumed, so with the flag off the menus compose no Delete at all instead
+    /// of offering a destructive action the daemon would refuse.
+    var remoteDeleteEnabled: Bool {
+        daemonCapabilities?.remoteDeleteEnabled ?? Config.remoteDeleteEnabledDefault
+    }
+
+    /// Destroy a remote session, confirming first unless nothing is at stake.
+    ///
+    /// **TBD asks for a receipt whenever the provider can give one.** The
+    /// contract forbids a *provider* from implying retention, not a caller from
+    /// requesting it, and the request is what this whole design is for:
+    /// destroying a session should not destroy the conversation. The receipt is
+    /// also what a later Revive-as-reseed reads. When the provider does not
+    /// declare `retain` no receipt is possible, and the confirmation says so in
+    /// as many words — that is the branch a user most needs to see.
+    ///
+    /// The confirmation itself is `RemoteDeleteConfirmation.decide`, which is
+    /// pure; this method supplies the facts and runs the alert. `expiresAt` is
+    /// nil at this point on purpose: no receipt exists yet, and the contract
+    /// makes stating an expiry TBD does not know a MUST NOT.
+    func deleteRemoteSession(provider: String, sessionID: String) async {
+        let session = remoteSessions.first {
+            $0.provider == provider && $0.payload.id == sessionID
+        }
+        let capabilities = remoteProviders.first { $0.config.name == provider }?
+            .describe?.capabilities ?? []
+        let willRetain = capabilities.contains("retain")
+        let decision = RemoteDeleteConfirmation.decide(
+            state: session?.payload.state ?? .unknown,
+            workspaceDirty: session?.payload.reportsDirtyWorkspace ?? false,
+            willRetain: willRetain,
+            sessionTitle: session?.payload.title ?? "",
+            expiresAt: nil)
+        if case .confirm(let message) = decision, !remoteDeleteConfirmer(message) {
+            return
+        }
+        do {
+            let outcome = try await remoteSessionDeleter(provider, sessionID, willRetain)
+            if !outcome.deleted {
+                // Not a failure: the contract has `delete` succeed on an id the
+                // provider no longer has. Say so rather than reporting nothing,
+                // because a gesture that appears to do nothing is
+                // indistinguishable from one that missed.
+                showAlert("That session was already gone on \(provider).")
+            }
+            await refreshRemote()
+        } catch {
+            remoteLogger.error(
+                "remoteDelete failed for \(provider, privacy: .public)/\(sessionID, privacy: .public): \(error, privacy: .public)")
+            showAlert("Couldn't delete the session: \(error.localizedDescription)", isError: true)
+        }
+    }
+
+    /// Present the destructive confirm. Modal, mirroring
+    /// `confirmDefaultAccountFallback`; the destructive verb is the first
+    /// button and Cancel is the second, so Return does not destroy anything by
+    /// itself.
+    @MainActor
+    func confirmRemoteDelete(message: String) -> Bool {
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = "Delete this remote session?"
+        alert.informativeText = message
+        alert.addButton(withTitle: "Delete")
+        alert.addButton(withTitle: "Cancel")
+        return alert.runModal() == .alertFirstButtonReturn
     }
 
     // MARK: - Creating a session

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -1594,6 +1594,26 @@ final class AppState {
                 provider: provider, sessionID: sessionID, pinned: pinned)
         }
 
+    /// How `deleteRemoteSession` destroys a provider session — injectable for
+    /// the same reason as `remoteSessionPinSetter` (`DaemonClient` is concrete,
+    /// no protocol), so both outcomes of a delete are testable without a real
+    /// daemon and without anything actually being destroyed. Arguments are
+    /// `(provider, sessionID, retain)`.
+    @ObservationIgnored lazy var remoteSessionDeleter: @MainActor (String, String, Bool) async throws -> RemoteDeleteResult =
+        { [daemonClient] provider, sessionID, retain in
+            try await daemonClient.remoteDelete(
+                provider: provider, sessionID: sessionID, retain: retain)
+        }
+
+    /// How `deleteRemoteSession` asks the user before destroying something.
+    /// A seam rather than a direct `NSAlert` call for two reasons: the success
+    /// path is otherwise untestable, and a headless test that reached
+    /// `runModal()` would not fail — it would hang the whole suite waiting for
+    /// a click nobody is there to make. Returns whether the user confirmed;
+    /// a state that has gone away confirms nothing.
+    @ObservationIgnored lazy var remoteDeleteConfirmer: @MainActor (String) -> Bool =
+        { [weak self] message in self?.confirmRemoteDelete(message: message) ?? false }
+
     /// How `createRemoteLane` starts a provider session — injectable for the
     /// same reason as `remoteRenamePusher` (`DaemonClient` is concrete, no
     /// protocol), so the optimistic-placeholder paths are testable without a

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -509,6 +509,15 @@ final class AppState {
     /// The daemon's remote-session mirror across all providers, fetched by
     /// `refreshRemote()`. See `AppState+Remote.swift`.
     var remoteSessions: [RemoteSessionInfo] = []
+    /// Every retain/import receipt the daemon holds, fetched by
+    /// `refreshRemote()`.
+    ///
+    /// Read by the archived list, where a lane whose remote session was
+    /// destroyed is revived by reseeding from its receipt rather than by
+    /// unarchiving a session that no longer exists — so the Revive button has
+    /// to know whether the transcript behind it is still good. Small by
+    /// construction: one row per key a human deliberately created.
+    var retainedTranscripts: [RetainedTranscript] = []
     /// TBD-owned display-name overrides for remote sessions, keyed by
     /// `AppState.remoteSessionKey(provider:sessionID:)`. Mirrors the
     /// worktree pattern (`Worktree.displayName` living in TBD's own DB
@@ -1570,6 +1579,10 @@ final class AppState {
     /// same reason as `remoteProvidersFetcher`.
     @ObservationIgnored lazy var remoteSessionsFetcher: @MainActor () async throws -> RemoteSessionsResult =
         { [daemonClient] in try await daemonClient.remoteSessions() }
+    /// How `refreshRemote()` fetches the retained-transcript receipts —
+    /// injectable for the same reason as `remoteProvidersFetcher`.
+    @ObservationIgnored lazy var retainedTranscriptsFetcher: @MainActor () async throws -> [RetainedTranscript] =
+        { [daemonClient] in try await daemonClient.remoteRetainedList() }
     /// How `pushRemoteRenameIfSupported` pushes a rename to the provider —
     /// injectable for the same reason as `remoteProvidersFetcher` (`DaemonClient`
     /// is concrete, no protocol), so tests can assert whether it fires per

--- a/Sources/TBDApp/ArchivedWorktreesView.swift
+++ b/Sources/TBDApp/ArchivedWorktreesView.swift
@@ -402,9 +402,12 @@ struct ArchivedWorktreesView: View {
                             .listRowSeparator(.hidden)
                             .contextMenu {
                                 if row.reviveState == nil {
+                                    let availability = reviveAvailability(for: row.worktree)
                                     Button("Revive") {
                                         Task { await appState.reviveWorktree(id: row.worktree.id) }
                                     }
+                                    .disabled(availability != .enabled)
+                                    .help(reviveHelp(availability))
                                 }
                                 // The status bar covers live worktrees, but an
                                 // archived one is never the selection it reads
@@ -643,6 +646,25 @@ struct ArchivedWorktreesView: View {
         }
     }
 
+    /// Whether this archived row's Revive is still good, and why not when it
+    /// is not. A remote lane whose session was destroyed is revived by
+    /// reseeding from its retained transcript, and past the provider's stated
+    /// expiry there is nothing left to reseed from — see
+    /// `RemoteLaneReviveAvailability`, which owns the rule, and
+    /// `RemoteLaneLifecycle.reseedPlan`, which enforces it daemon-side whether
+    /// or not this button was disabled first.
+    private func reviveAvailability(for worktree: Worktree) -> RemoteLaneReviveAvailability.Decision {
+        RemoteLaneReviveAvailability.decide(
+            worktree: worktree, receipts: appState.retainedTranscripts, now: Date())
+    }
+
+    private func reviveHelp(_ decision: RemoteLaneReviveAvailability.Decision) -> String {
+        switch decision {
+        case .enabled: return ""
+        case .expired(let reason): return reason
+        }
+    }
+
     private func noSessionsState(for worktree: Worktree) -> some View {
         VStack(spacing: 12) {
             Image(systemName: "bubble.left.and.bubble.right")
@@ -651,10 +673,21 @@ struct ArchivedWorktreesView: View {
             Text("No archived sessions")
                 .foregroundStyle(.secondary)
                 .font(.callout)
+            let availability = reviveAvailability(for: worktree)
             Button("Revive") {
                 Task { await appState.reviveWorktree(id: worktree.id) }
             }
             .buttonStyle(.borderedProminent)
+            .disabled(availability != .enabled)
+            .help(reviveHelp(availability))
+            if case .expired(let reason) = availability {
+                Text(reason)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.horizontal, 24)
+            }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -1281,6 +1281,22 @@ actor DaemonClient {
         )
     }
 
+    /// The retain and import receipts TBD holds, newest first, optionally
+    /// filtered to one provider.
+    ///
+    /// Local-only: it reads the daemon's own rows and invokes no provider verb,
+    /// so it needs no capability and works for a provider that has gone
+    /// unhealthy. Nothing in the contract lets a caller enumerate the keys a
+    /// provider issued, which is why TBD's record is the only enumeration
+    /// there is.
+    func remoteRetainedList(provider: String? = nil) async throws -> [RetainedTranscript] {
+        try await callAsync(
+            method: RPCMethod.remoteRetainedList,
+            params: RemoteRetainedListParams(provider: provider),
+            resultType: RemoteRetainedListResult.self
+        ).transcripts
+    }
+
     /// Destroy a provider-hosted session
     /// (`docs/remote-provider-contract.md` § `delete <id> [--retain]`).
     ///

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -1242,6 +1242,45 @@ actor DaemonClient {
         )
     }
 
+    /// Ask a provider to retain one of its own sessions' transcripts
+    /// (`docs/remote-provider-contract.md` § `retain <id>`), and record the
+    /// receipt daemon-side. Unlike `remoteRename`, the capability check is the
+    /// DAEMON's here — the handler refuses before invoking anything — so a
+    /// caller need not pre-check, and gets a refusal naming the capability
+    /// rather than a raw provider error.
+    func remoteRetain(provider: String, sessionID: String) async throws -> RetainReceipt {
+        try await callAsync(
+            method: RPCMethod.remoteRetain,
+            params: RemoteRetainParams(provider: provider, sessionID: sessionID),
+            resultType: RetainReceipt.self
+        )
+    }
+
+    /// Put a transcript from anywhere — including this machine — into a
+    /// provider's durable store (`docs/remote-provider-contract.md` §
+    /// `import`). `jsonl` is Claude Code transcript JSONL.
+    func remoteImport(provider: String, jsonl: String) async throws -> RetainReceipt {
+        try await callAsync(
+            method: RPCMethod.remoteImport,
+            params: RemoteImportParams(provider: provider, jsonl: jsonl),
+            resultType: RetainReceipt.self
+        )
+    }
+
+    /// Read a retained transcript back (`docs/remote-provider-contract.md` §
+    /// `recall <key>`). With `saveLocally`, the daemon also writes it under
+    /// `~/tbd/transcripts/` and returns that path; the records come back in
+    /// `jsonl` either way.
+    func remoteRecall(
+        provider: String, key: String, saveLocally: Bool = false
+    ) async throws -> RemoteRecallResult {
+        try await callAsync(
+            method: RPCMethod.remoteRecall,
+            params: RemoteRecallParams(provider: provider, key: key, saveLocally: saveLocally),
+            resultType: RemoteRecallResult.self
+        )
+    }
+
     /// Dismiss a gone/errored remote session from the mirror.
     func remoteDismiss(provider: String, sessionID: String) async throws {
         try await callVoidAsync(

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -1281,6 +1281,29 @@ actor DaemonClient {
         )
     }
 
+    /// Destroy a provider-hosted session
+    /// (`docs/remote-provider-contract.md` § `delete <id> [--retain]`).
+    ///
+    /// Gated daemon-side by `config.remoteDeleteEnabled` and by the provider's
+    /// `delete` capability — both refuse before anything is spawned, so a
+    /// caller that has not checked gets a refusal naming what is missing rather
+    /// than a destroyed session.
+    ///
+    /// `retain` asks the provider to keep the transcript first, and needs the
+    /// `retain` capability as well. The returned `RemoteDeleteResult` carries a
+    /// receipt exactly when it was asked for, and `deleted: false` — nothing
+    /// was there to destroy — is a success, not an error.
+    func remoteDelete(
+        provider: String, sessionID: String, retain: Bool = false
+    ) async throws -> RemoteDeleteResult {
+        try await callAsync(
+            method: RPCMethod.remoteDelete,
+            params: RemoteDeleteParams(
+                provider: provider, sessionID: sessionID, retain: retain),
+            resultType: RemoteDeleteResult.self
+        )
+    }
+
     /// Dismiss a gone/errored remote session from the mirror.
     func remoteDismiss(provider: String, sessionID: String) async throws {
         try await callVoidAsync(

--- a/Sources/TBDApp/Helpers/RowActionMenu.swift
+++ b/Sources/TBDApp/Helpers/RowActionMenu.swift
@@ -37,6 +37,10 @@ enum RowActionMenu {
         /// Create a child worktree based on THIS worktree's current branch.
         case newWorktreeFromBranch
         case archive
+        /// Destroy the remote session behind this lane
+        /// (`docs/remote-provider-contract.md` § `delete <id>`), behind the
+        /// default-off `remote_delete_enabled` flag. Local rows never offer it.
+        case deleteRemoteSession
         /// Pin this worktree to the sidebar dock.
         case pin
         /// Remove this worktree from the sidebar dock.
@@ -166,6 +170,11 @@ enum RowActionMenu {
         /// gesture the daemon will still perform. Always `false` for a local
         /// row.
         var isGone: Bool
+        /// The daemon's `remote_delete_enabled` gate, read from
+        /// `DaemonCapabilitiesResult`. Off — the shipped default — Delete is
+        /// not composed at all, so a destructive action is never offered that
+        /// the daemon would refuse. Always irrelevant for a local row.
+        var remoteDeleteEnabled: Bool
 
         init(hasHibernatableClaude: Bool = false,
              hasHibernatedClaude: Bool = false,
@@ -186,7 +195,8 @@ enum RowActionMenu {
              location: WorktreeLocation = .local,
              provider: String? = nil,
              providerCapabilities: Set<String> = [],
-             isGone: Bool = false) {
+             isGone: Bool = false,
+             remoteDeleteEnabled: Bool = false) {
             self.hasHibernatableClaude = hasHibernatableClaude
             self.hasHibernatedClaude = hasHibernatedClaude
             self.hasUnpinnedClaude = hasUnpinnedClaude
@@ -207,6 +217,7 @@ enum RowActionMenu {
             self.provider = provider
             self.providerCapabilities = providerCapabilities
             self.isGone = isGone
+            self.remoteDeleteEnabled = remoteDeleteEnabled
         }
     }
 
@@ -227,6 +238,19 @@ enum RowActionMenu {
     /// Disabled-help paired with `archiveProviderCannotArchiveLabel`: names the
     /// capability that would need to exist, not an action for the user to take.
     static let archiveNeedsProviderCapabilityHelp = "This provider hasn't implemented the archive capability yet"
+    /// Delete title for a remote lane whose provider declares `delete`.
+    static let deleteRemoteSessionLabel = "Delete Remote Session"
+    /// Delete title for a remote lane whose provider has not declared
+    /// `delete`: the same visible-but-disabled treatment
+    /// `archiveProviderCannotArchiveLabel` gets, and for the same reason —
+    /// naming what is missing rather than implying anything about the user or
+    /// the session's own state.
+    static let deleteProviderCannotDeleteLabel = "Delete Remote Session (provider can't delete)"
+    /// Disabled-help paired with `deleteProviderCannotDeleteLabel`. Wording
+    /// mirrors `archiveNeedsProviderCapabilityHelp`, not re-invented, so the
+    /// same absence reads the same wherever it shows up.
+    static let deleteNeedsProviderCapabilityHelp =
+        "This provider hasn't implemented the delete capability yet"
     static let forkSessionLabel = "Fork session"
     static let newWorktreeFromBranchLabel = "New worktree from this branch…"
     static let hibernateNowLabel = "Hibernate now"
@@ -405,6 +429,31 @@ enum RowActionMenu {
         return filesystemActions(context: context)
     }
 
+    /// Delete for a remote lane, beside Archive — retiring the lane and
+    /// destroying the session it points at, offered next to each other because
+    /// they are the two ways a lane leaves the working set and a user choosing
+    /// between them should see both.
+    ///
+    /// Empty for a local row (there is no remote session to destroy) and while
+    /// `remoteDeleteEnabled` is off, so the shipped default composes nothing at
+    /// all. When the provider has not declared `delete` the item is
+    /// **present but disabled**, exactly as an unarchivable lane's Archive is:
+    /// a user looking for the way to reclaim a lane must be told the way exists
+    /// and this provider has not built it, which an omitted item cannot say,
+    /// and the disabled item is the hook a later design uses to offer
+    /// implementing the capability. Do not "simplify" it into omission.
+    private static func deleteRemoteSessionActions(context: Context) -> [Item] {
+        guard context.remoteDeleteEnabled, !context.location.isLocal else { return [] }
+        let declared = context.providerCapabilities.contains("delete")
+        return [.action(Action(
+            kind: .deleteRemoteSession,
+            title: declared ? deleteRemoteSessionLabel : deleteProviderCannotDeleteLabel,
+            role: .destructive,
+            isEnabled: declared,
+            disabledHelp: declared ? nil : deleteNeedsProviderCapabilityHelp
+        ))]
+    }
+
     private static func regularItems(context: Context) -> [Item] {
         // A remote lane whose provider has not declared `archive` cannot be
         // retired on the backend (docs/specs/2026-08-16-remote-lane-archive-design.md
@@ -463,7 +512,7 @@ enum RowActionMenu {
                     isEnabled: !archiveBlocked,
                     disabledHelp: archiveHelp
                 )),
-            ],
+            ] + deleteRemoteSessionActions(context: context),
             pinActions(context: context).map(Item.action),
             hibernationActions(context: context).map(Item.action),
             spawning,

--- a/Sources/TBDApp/Panes/CodeViewerPaneView.swift
+++ b/Sources/TBDApp/Panes/CodeViewerPaneView.swift
@@ -581,7 +581,7 @@ private struct ImagePreviewView: View {
             if let image {
                 Image(nsImage: image)
                     .resizable()
-                    .aspectRatio(contentMode: .fit)
+                    .scaledToFit()
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .padding(12)
             } else {

--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -399,7 +399,7 @@ struct PanePlaceholder: View {
                     if let screenshot = appState.suspendingSnapshots[terminal.id] {
                         Image(nsImage: screenshot)
                             .resizable()
-                            .aspectRatio(contentMode: .fill)
+                            .scaledToFill()
                     } else {
                         Color.black
                     }

--- a/Sources/TBDApp/Panes/Transcript/TranscriptImageAttachmentView.swift
+++ b/Sources/TBDApp/Panes/Transcript/TranscriptImageAttachmentView.swift
@@ -101,7 +101,7 @@ struct TranscriptImageAttachmentView: View {
             if let image {
                 Image(nsImage: image)
                     .resizable()
-                    .aspectRatio(contentMode: .fit)
+                    .scaledToFit()
                     .clipShape(RoundedRectangle(cornerRadius: 6))
                     .opacity(hovering ? 0.85 : 1)
             } else {

--- a/Sources/TBDApp/Remote/RemoteDeleteConfirmation.swift
+++ b/Sources/TBDApp/Remote/RemoteDeleteConfirmation.swift
@@ -1,0 +1,117 @@
+import Foundation
+import TBDShared
+
+/// Whether deleting a remote session should ask first, and what to say when it
+/// does (`docs/specs/2026-09-02-remote-session-delete-and-transcript-exchange-design.md`,
+/// "App").
+///
+/// **Confirmation fires unless nothing is at stake.** It is skipped in exactly
+/// one situation: the session has exited, it claims no uncommitted work, and a
+/// receipt is coming. Anything running is compute a user may still want;
+/// anything claiming `meta.workspace_dirty` has work on another machine that
+/// goes with the session; and any delete keeping no record leaves nothing to
+/// recover, which is why an exited, clean session still confirms when no
+/// transcript is being retained. That last one is the branch a reader skips
+/// past — "it already exited and the workspace is clean, what is there to
+/// warn about" — and it is the branch where the whole conversation is lost.
+///
+/// A pure function with no AppKit or SwiftUI, mirroring the split
+/// `RemoteSessionActionMenu` keeps, so every branch is unit-testable without an
+/// `AppState`.
+enum RemoteDeleteConfirmation {
+    enum Decision: Equatable {
+        case proceed
+        case confirm(message: String)
+    }
+
+    /// - Parameters:
+    ///   - state: the provider's process-liveness axis for this session. Only
+    ///     `.exited` earns the skip: `.starting` and `.unknown` are not
+    ///     statements that the session is finished, and a state TBD could not
+    ///     read is the last one to wave a destruction through.
+    ///   - workspaceDirty: whether the session's `meta` claims uncommitted work.
+    ///   - willRetain: whether this delete is passing `--retain`, so a
+    ///     transcript survives it.
+    ///   - sessionTitle: what the human calls this conversation. Blank titles
+    ///     are common on providers that do not name sessions, so an empty one
+    ///     reads as a phrase rather than as empty quotes.
+    ///   - expiresAt: the expiry that can be stated in advance, if any. **Nil
+    ///     means the provider has made no claim, never that the transcript is
+    ///     kept forever** — the contract makes rendering absence as permanence
+    ///     a MUST NOT, so the wording says the provider stated nothing.
+    static func decide(
+        state: RemoteProcessState,
+        workspaceDirty: Bool,
+        willRetain: Bool,
+        sessionTitle: String,
+        expiresAt: Date?
+    ) -> Decision {
+        let live = state != .exited
+        guard live || workspaceDirty || !willRetain else { return .proceed }
+
+        let name = displayName(sessionTitle)
+        var sentences: [String] = []
+        if live {
+            sentences.append(
+                "Delete \(name)? It is \(liveDescription(state)), and deleting it ends its "
+                + "compute and removes it from the provider permanently.")
+        } else {
+            sentences.append(
+                "Delete \(name)? This removes it from the provider permanently.")
+        }
+        if workspaceDirty {
+            sentences.append(
+                "It reports uncommitted work, which lives on the provider's machine and goes "
+                + "with it.")
+        }
+        sentences.append(retentionClause(willRetain: willRetain, expiresAt: expiresAt))
+        return .confirm(message: sentences.joined(separator: " "))
+    }
+
+    /// What the dialog says about the conversation itself — the half a user
+    /// weighs the gesture against.
+    ///
+    /// The `expiresAt` value is used **only** on the retaining branch: an
+    /// expiry is meaningless when nothing is being kept, and printing one there
+    /// would suggest a record exists.
+    private static func retentionClause(willRetain: Bool, expiresAt: Date?) -> String {
+        guard willRetain else {
+            return "No transcript will be kept: once this is gone there is nothing to recall."
+        }
+        guard let expiresAt else {
+            // Deliberately not "kept forever", "never expires", or
+            // "indefinitely". The provider said nothing, and saying nothing is
+            // not a promise.
+            return "Its transcript will be kept, and the provider states no expiry for it."
+        }
+        return "Its transcript will be kept, and the provider says it expires "
+            + "\(expiryDescription(expiresAt))."
+    }
+
+    /// The stated expiry, rendered for a human. A `FormatStyle` rather than a
+    /// shared `DateFormatter`, so there is no mutable static to reason about
+    /// from several actors.
+    static func expiryDescription(_ date: Date) -> String {
+        date.formatted(date: .abbreviated, time: .omitted)
+    }
+
+    /// A session with no title still has to be named in a sentence, and empty
+    /// quotation marks name nothing.
+    private static func displayName(_ title: String) -> String {
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "this remote session" }
+        return "\u{201C}\(trimmed)\u{201D}"
+    }
+
+    /// How a non-exited state reads in the sentence. `.exited` never reaches
+    /// here — it is the branch that took the other sentence — so it falls
+    /// through to the same cautious wording `.unknown` gets rather than
+    /// claiming a liveness this function was not asked about.
+    private static func liveDescription(_ state: RemoteProcessState) -> String {
+        switch state {
+        case .running: return "still running"
+        case .starting: return "still starting up"
+        case .unknown, .exited: return "in a state the provider did not describe"
+        }
+    }
+}

--- a/Sources/TBDApp/Remote/RemoteLaneReviveAvailability.swift
+++ b/Sources/TBDApp/Remote/RemoteLaneReviveAvailability.swift
@@ -1,0 +1,56 @@
+import Foundation
+import TBDShared
+
+/// Whether an archived remote lane can still be revived, and what to say when
+/// it cannot
+/// (`docs/specs/2026-09-02-remote-session-delete-and-transcript-exchange-design.md`,
+/// "A deleted lane keeps its place").
+///
+/// A lane whose remote session was destroyed keeps its row, and Revive on that
+/// row means creating a new session seeded from the transcript the delete
+/// retained. Past the provider's stated expiry there is nothing to seed from,
+/// so Revive is disabled and names the date — and the row stays, because a lane
+/// whose conversation lapsed is still a record of work that happened.
+///
+/// Pure, with no AppKit or SwiftUI and no `AppState`, so every branch is
+/// testable directly — the same split `RemoteSessionActionMenu` and
+/// `RemoteDeleteConfirmation` use. The daemon makes the same decision
+/// authoritatively in `RemoteLaneLifecycle.reseedPlan`; this exists so the
+/// button is disabled before it is pressed rather than only refused after.
+enum RemoteLaneReviveAvailability {
+    enum Decision: Equatable {
+        case enabled
+        /// Disabled, with the sentence to show as help text.
+        case expired(String)
+    }
+
+    /// - Parameters:
+    ///   - worktree: the archived row the Revive button belongs to.
+    ///   - receipts: every receipt the daemon holds (`AppState.retainedTranscripts`).
+    ///   - now: the date seam. `expiresAt` is a persisted timestamp compared
+    ///     against the present, never a duration.
+    ///
+    /// A local lane, a remote lane with no receipt, and a remote lane whose
+    /// receipt states no expiry are all `.enabled`. **An absent `expiresAt` is
+    /// never read as permanence** — the contract makes that a MUST NOT for
+    /// callers — but it is equally not a reason to disable anything: the
+    /// provider has made no claim, and the provider is the last word on whether
+    /// the seed still works.
+    static func decide(
+        worktree: Worktree, receipts: [RetainedTranscript], now: Date
+    ) -> Decision {
+        guard !worktree.location.isLocal else { return .enabled }
+        // Newest first, matching the daemon's own choice: a lane retained more
+        // than once wants the last word on its conversation.
+        let receipt = receipts
+            .filter { $0.originWorktreeID == worktree.id }
+            .max { $0.createdAt < $1.createdAt }
+        guard let receipt, receipt.hasExpired(asOf: now), let expiresAt = receipt.expiresAt else {
+            return .enabled
+        }
+        return .expired(
+            "The transcript retained from this lane's session expired on " +
+            "\(RetainReceipt.formatTimestamp(expiresAt)), so there is nothing left to " +
+            "recreate the conversation from. The row stays as a record of the work.")
+    }
+}

--- a/Sources/TBDApp/Remote/RemoteSessionActionMenu.swift
+++ b/Sources/TBDApp/Remote/RemoteSessionActionMenu.swift
@@ -97,8 +97,22 @@ enum RemoteSessionActionMenu {
     /// provider mutations are omitted. A pinned
     /// session that goes `gone` must stay unpinnable without the user having
     /// to dismiss it, which is why the collapsed branch carries it too.
+    ///
+    /// Dismiss is offered for an `exited` row as well as a `gone` one, and
+    /// that is the whole of `exited`'s job here. The contract asks providers
+    /// to keep exited sessions listable for at least 24 hours so a
+    /// disappearance can be told apart from transport drift, and a provider
+    /// may keep one indefinitely — so an exited row is not `gone`, and on a
+    /// provider that never implements `delete` there would otherwise be no
+    /// gesture at all that removes a session the agent has finished with.
+    /// Dismiss stays exactly what it already is: a LOCAL tombstone on TBD's
+    /// mirror row that changes nothing on the provider, which is why it is
+    /// safe to offer on a row the provider still reports. It is composed
+    /// immediately after the pin toggle and before the divider, so Stop
+    /// remains the last, destructive item.
     static func items(
-        capabilities: [String], gone: Bool, snapshotFresh: Bool = true, isPinned: Bool
+        capabilities: [String], gone: Bool, snapshotFresh: Bool = true,
+        isPinned: Bool, exited: Bool = false
     ) -> [Item] {
         let pinAction = isPinned
             ? Action(kind: .unpin, title: unpinLabel)
@@ -127,6 +141,9 @@ enum RemoteSessionActionMenu {
         }
         actions.append(Action(kind: .copySessionID, title: copySessionIDLabel))
         actions.append(pinAction)
+        if exited {
+            actions.append(Action(kind: .dismiss, title: dismissLabel))
+        }
 
         var items = actions.map(Item.action)
         if snapshotFresh {

--- a/Sources/TBDApp/Remote/RemoteSessionActionMenu.swift
+++ b/Sources/TBDApp/Remote/RemoteSessionActionMenu.swift
@@ -22,6 +22,10 @@ enum RemoteSessionActionMenu {
         case sendText
         case copySessionID
         case stop
+        /// Destroy the session on the provider
+        /// (`docs/remote-provider-contract.md` § `delete <id>`). Behind the
+        /// default-off `remote_delete_enabled` flag.
+        case delete
         case dismiss
         case pin
         case unpin
@@ -38,11 +42,20 @@ enum RemoteSessionActionMenu {
         let kind: Kind
         let title: String
         let role: ActionRole
+        /// Whether the item can be chosen. Everything in this menu except
+        /// Delete is either offered or omitted; see `deleteItem` for why that
+        /// one action departs.
+        let isEnabled: Bool
+        /// Tooltip shown while `isEnabled` is false, naming what is missing.
+        let disabledHelp: String?
 
-        init(kind: Kind, title: String, role: ActionRole = .normal) {
+        init(kind: Kind, title: String, role: ActionRole = .normal,
+             isEnabled: Bool = true, disabledHelp: String? = nil) {
             self.kind = kind
             self.title = title
             self.role = role
+            self.isEnabled = isEnabled
+            self.disabledHelp = disabledHelp
         }
     }
 
@@ -59,6 +72,15 @@ enum RemoteSessionActionMenu {
     static let sendTextLabel = "Send Text…"
     static let copySessionIDLabel = "Copy Session ID"
     static let stopLabel = "Stop"
+    static let deleteLabel = "Delete"
+    /// Delete's title when the provider has not declared `delete`. Wording and
+    /// treatment taken from `RowActionMenu.archiveProviderCannotArchiveLabel`,
+    /// not re-invented, so the same absence reads the same on both surfaces.
+    static let deleteProviderCannotDeleteLabel = "Delete (provider can't delete)"
+    /// Disabled-help paired with `deleteProviderCannotDeleteLabel`: names the
+    /// capability that would need to exist, not an action for the user to take.
+    static let deleteNeedsProviderCapabilityHelp =
+        "This provider hasn't implemented the delete capability yet"
     static let dismissLabel = "Dismiss"
     /// Pin wording is taken from `RowActionMenu`, not re-typed, so a remote
     /// row and a worktree row can never drift into two different names for
@@ -72,6 +94,7 @@ enum RemoteSessionActionMenu {
     private static let attachCapability = "attach"
     private static let logCapability = "log"
     private static let sendCapability = "send"
+    private static let deleteCapability = "delete"
 
     // MARK: - Composition
 
@@ -98,6 +121,17 @@ enum RemoteSessionActionMenu {
     /// session that goes `gone` must stay unpinnable without the user having
     /// to dismiss it, which is why the collapsed branch carries it too.
     ///
+    /// Delete, when `deleteEnabled` (the `remote_delete_enabled` flag), is
+    /// composed after Stop as the last and strongest destructive item — and
+    /// unlike every other capability-gated item here it is present-but-disabled
+    /// rather than omitted when the provider has not declared `delete`. See
+    /// `deleteItem` for why that departure is deliberate. It is not offered in
+    /// the `gone` branch: the provider has stopped enumerating that session, so
+    /// there is nothing left there to destroy, and Dismiss is that row's
+    /// removal gesture. It is also omitted while the snapshot is stale, with
+    /// Stop and for the same reason — provider mutations wait for a trustworthy
+    /// inventory.
+    ///
     /// Dismiss is offered for an `exited` row as well as a `gone` one, and
     /// that is the whole of `exited`'s job here. The contract asks providers
     /// to keep exited sessions listable for at least 24 hours so a
@@ -112,7 +146,7 @@ enum RemoteSessionActionMenu {
     /// remains the last, destructive item.
     static func items(
         capabilities: [String], gone: Bool, snapshotFresh: Bool = true,
-        isPinned: Bool, exited: Bool = false
+        isPinned: Bool, exited: Bool = false, deleteEnabled: Bool = false
     ) -> [Item] {
         let pinAction = isPinned
             ? Action(kind: .unpin, title: unpinLabel)
@@ -149,7 +183,36 @@ enum RemoteSessionActionMenu {
         if snapshotFresh {
             items.append(.divider)
             items.append(.action(Action(kind: .stop, title: stopLabel, role: .destructive)))
+            if deleteEnabled {
+                items.append(.action(deleteItem(capabilities: capabilities)))
+            }
         }
         return items
+    }
+
+    /// Delete, composed last — after Stop, which it strictly outranks: Stop
+    /// ends compute, Delete ends compute *and* removes the record.
+    ///
+    /// **This one action is present-but-disabled when its capability is
+    /// absent, and that departure from this menu's omit-when-absent convention
+    /// is deliberate.** Attach, View Log and Send Text vanish when undeclared,
+    /// because a user who cannot attach has nothing to learn from a grey
+    /// "Attach" — the session simply works differently there. Delete is not
+    /// like that: a fleet with no reclaim path is the problem this whole design
+    /// exists to fix, and a user looking for the way to remove a session needs
+    /// to be told that the way exists and this provider has not built it yet.
+    /// The disabled item is also the hook a later design uses to offer
+    /// implementing the capability, which an omitted item could not be.
+    /// `RowActionMenu.archiveProviderCannotArchiveLabel` already gives an
+    /// unarchivable lane exactly this treatment; this follows it rather than
+    /// inventing a second idiom. Please do not "fix" it into consistency.
+    private static func deleteItem(capabilities: [String]) -> Action {
+        let declared = capabilities.contains(deleteCapability)
+        return Action(
+            kind: .delete,
+            title: declared ? deleteLabel : deleteProviderCannotDeleteLabel,
+            role: .destructive,
+            isEnabled: declared,
+            disabledHelp: declared ? nil : deleteNeedsProviderCapabilityHelp)
     }
 }

--- a/Sources/TBDApp/Sidebar/RemoteSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RemoteSectionView.swift
@@ -636,7 +636,8 @@ struct RemoteSessionRowView: View {
                 // session always offer the same verb.
                 isPinned: appState.remoteSessionIsPinned(
                     provider: session.provider, sessionID: session.payload.id),
-                exited: session.payload.state == .exited
+                exited: session.payload.state == .exited,
+                deleteEnabled: appState.remoteDeleteEnabled
             )
             ForEach(Array(items.enumerated()), id: \.offset) { _, item in
                 switch item {
@@ -656,6 +657,8 @@ struct RemoteSessionRowView: View {
         } label: {
             Text(action.title)
         }
+        .disabled(!action.isEnabled)
+        .help(action.disabledHelp ?? "")
     }
 
     /// Dispatches a `RemoteSessionActionMenu.Kind` to its side effect. Kept
@@ -696,6 +699,15 @@ struct RemoteSessionRowView: View {
                     remoteRowLogger.error(
                         "remoteDismiss failed for \(session.provider, privacy: .public)/\(session.payload.id, privacy: .public): \(error, privacy: .public)")
                 }
+            }
+        case .delete:
+            // The confirmation, the retain decision and the error toast all
+            // live in `AppState.deleteRemoteSession` — the lane row's menu
+            // reaches the same method, so the two surfaces cannot come to
+            // different conclusions about the same session.
+            Task {
+                await appState.deleteRemoteSession(
+                    provider: session.provider, sessionID: session.payload.id)
             }
         case .pin, .unpin:
             let pinned = kind == .pin

--- a/Sources/TBDApp/Sidebar/RemoteSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RemoteSectionView.swift
@@ -122,11 +122,17 @@ struct RemoteSectionView: View {
     /// (including this one) — calling that inferred isolation from a plain
     /// (non-`@MainActor`) test context traps at runtime instead of failing
     /// to compile.
+    ///
+    /// Sessions the provider reports as `archived` are excluded too, for the
+    /// same reason `RepoSectionView.matchedRemoteSessions` excludes them: the
+    /// contract keeps archived sessions in `list` and assigns the caller the
+    /// display policy for them, and these two filters are where TBD applies
+    /// it. They stay reachable in the Provider Desk's session ledger.
     nonisolated static func sessions(
         in all: [RemoteSessionInfo], forProvider provider: String, knownRepoIDs: Set<UUID>
     ) -> [RemoteSessionInfo] {
         all.filter {
-            $0.provider == provider && !$0.dismissed
+            $0.provider == provider && !$0.dismissed && !$0.payload.isArchived
                 && ($0.resolvedRepoID == nil || !knownRepoIDs.contains($0.resolvedRepoID!))
         }
     }

--- a/Sources/TBDApp/Sidebar/RemoteSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RemoteSectionView.swift
@@ -635,7 +635,8 @@ struct RemoteSessionRowView: View {
                 // `session`, so a dock copy and a section copy of the same
                 // session always offer the same verb.
                 isPinned: appState.remoteSessionIsPinned(
-                    provider: session.provider, sessionID: session.payload.id)
+                    provider: session.provider, sessionID: session.payload.id),
+                exited: session.payload.state == .exited
             )
             ForEach(Array(items.enumerated()), id: \.offset) { _, item in
                 switch item {

--- a/Sources/TBDApp/Sidebar/RepoSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RepoSectionView.swift
@@ -454,13 +454,21 @@ struct RepoSectionView: View {
     /// than defaulted so a new call site cannot silently reintroduce the
     /// duplicate.
     ///
-    /// An adopted lane therefore has exactly one surface, never two. It cannot
-    /// yet have zero either, because there is currently no way to retire an
-    /// adopted row: archiving a remote lane is refused (stopping the provider's
-    /// session is unimplemented), so the row simply persists. When remote
-    /// archive does land, this filter needs no change to stay correct —
-    /// `AppState.visibleWorktrees` drops archived rows from `worktrees`, so the
-    /// session would fall back to rendering as a plain session row.
+    /// An adopted lane therefore has exactly one surface, never two.
+    ///
+    /// A session the provider reports as `archived` gets NO surface here: it is
+    /// filtered out outright. The contract requires a provider to keep archived
+    /// sessions in `list` (`docs/remote-provider-contract.md` § "Archived
+    /// sessions stay in the inventory") and assigns the CALLER the display
+    /// policy for them — showing active sessions and hiding archived ones is a
+    /// decision applied to a complete inventory, and this filter is where TBD
+    /// makes it. Without it, archiving an adopted lane creates a row nothing
+    /// can remove: `AppState.visibleWorktrees` drops the archived worktree row,
+    /// the session falls back to rendering as a plain session row underneath
+    /// it, and no gesture retires that row while the provider keeps reporting
+    /// the session. Archived sessions stay reachable in the repo's Archived tab
+    /// (for an adopted lane) and in the Provider Desk's session ledger, which
+    /// lists every non-dismissed session the provider reports.
     nonisolated static func matchedRemoteSessions(
         _ all: [RemoteSessionInfo],
         repoID: UUID,
@@ -468,7 +476,7 @@ struct RepoSectionView: View {
     ) -> [RemoteSessionInfo] {
         let adopted = Set(worktrees.map(\.location).filter { !$0.isLocal })
         return all
-            .filter { $0.resolvedRepoID == repoID && !$0.dismissed }
+            .filter { $0.resolvedRepoID == repoID && !$0.dismissed && !$0.payload.isArchived }
             .filter { !adopted.contains(.remote(provider: $0.provider, sessionID: $0.payload.id)) }
             .sorted(by: RepoSectionView.isOrderedByCreation)
     }

--- a/Sources/TBDApp/Sidebar/RowActionMenuActions.swift
+++ b/Sources/TBDApp/Sidebar/RowActionMenuActions.swift
@@ -122,7 +122,8 @@ struct RowActionMenuActions {
             location: worktree.location,
             provider: worktree.providerBinding?.provider,
             providerCapabilities: providerCapabilities,
-            isGone: isGone
+            isGone: isGone,
+            remoteDeleteEnabled: appState.remoteDeleteEnabled
         )
     }
 
@@ -216,6 +217,16 @@ struct RowActionMenuActions {
         case .archive:
             let wtID = worktree.id
             Task { await appState.archiveWorktree(id: wtID) }
+
+        case .deleteRemoteSession:
+            // Only a remote lane composes this item, so a local row cannot
+            // reach it; a row whose binding has gone missing returns rather
+            // than guessing at a session id.
+            guard let binding = worktree.providerBinding else { return }
+            Task {
+                await appState.deleteRemoteSession(
+                    provider: binding.provider, sessionID: binding.sessionID)
+            }
 
         case .pin:
             let wtID = worktree.id

--- a/Sources/TBDCLI/Commands/GCCommands.swift
+++ b/Sources/TBDCLI/Commands/GCCommands.swift
@@ -174,7 +174,7 @@ struct GCRetainedTranscripts: AsyncParsableCommand {
         }
         try SocketClient().callVoid(
             method: RPCMethod.configSetGCRetainedTranscriptsEnabled,
-            params: ConfigSetGCRetainedTranscriptsEnabledParams(enabled: enabled))
+            params: ConfigSetGCRetainedTranscriptsParams(enabled: enabled))
         print("Retained-transcript GC \(enabled ? "enabled" : "disabled").")
     }
 }

--- a/Sources/TBDCLI/Commands/GCCommands.swift
+++ b/Sources/TBDCLI/Commands/GCCommands.swift
@@ -9,7 +9,7 @@ struct GCCommand: ParsableCommand {
         subcommands: [
             GCList.self, GCRestore.self, GCSweep.self, GCProfileDirs.self,
             GCOrphanProcesses.self, GCHolders.self, GCRowlessHolders.self,
-            GCHolderChildren.self,
+            GCHolderChildren.self, GCRetainedTranscripts.self,
         ]
     )
 }
@@ -132,6 +132,50 @@ struct GCHolderChildren: AsyncParsableCommand {
             method: RPCMethod.configSetReapHolderChildrenEnabled,
             params: ConfigSetReapHolderChildrenEnabledParams(enabled: enabled))
         print("Holder-child reaping \(enabled ? "enabled" : "disabled").")
+    }
+}
+
+/// The soak switch for the retained-transcript collector. It reclaims the
+/// residue of the transcript exchange on this machine: JSONL files under
+/// `~/tbd/transcripts/` that no `retained_transcript` row references, and rows
+/// whose stated expiry has passed. Read on top of the GC master switch, so both
+/// must be on for the leg to run.
+///
+/// A separate opt-in from `tbd remote allow-delete`: that gate destroys a
+/// session on a provider, this one only unlinks TBD's own local copies, and
+/// opting into either must never opt into the other. It ships off and is opted
+/// into by hand — here rather than by editing `state.db`, which the project's
+/// own rules put out of bounds.
+struct GCRetainedTranscripts: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "retained-transcripts",
+        abstract: "Enable or disable reclaiming unreferenced retained transcripts (default off)",
+        discussion: """
+            The soak switch for the orphan-GC leg that unlinks retained \
+            transcript files nobody references and drops receipts whose expiry \
+            has passed. Off — the shipped default — the leg reads nothing and \
+            unlinks nothing.
+
+            It is read on top of `gcEnabled`, so both must be on for the leg to \
+            run, and `tbd gc sweep --dry-run` prints the candidates either way — \
+            so the decision to turn it on can be made against real ones.
+
+            Turning it off stops the next sweep. It cannot restore a file an \
+            earlier one unlinked.
+            """
+    )
+    @Argument(help: "on | off") var state: String
+    mutating func run() async throws {
+        let enabled: Bool
+        switch state.lowercased() {
+        case "on", "true", "enable": enabled = true
+        case "off", "false", "disable": enabled = false
+        default: throw ValidationError("Expected 'on' or 'off', got: \(state)")
+        }
+        try SocketClient().callVoid(
+            method: RPCMethod.configSetGCRetainedTranscriptsEnabled,
+            params: ConfigSetGCRetainedTranscriptsEnabledParams(enabled: enabled))
+        print("Retained-transcript GC \(enabled ? "enabled" : "disabled").")
     }
 }
 

--- a/Sources/TBDCLI/Commands/RemoteCommands.swift
+++ b/Sources/TBDCLI/Commands/RemoteCommands.swift
@@ -451,9 +451,19 @@ enum RemoteDeletePrecondition {
         // Named separately rather than collapsed into one message, because the
         // two have different remedies: one waits or stops the session, the
         // other commits or pushes on the provider's machine.
+        //
+        // `.unknown` is refused alongside `.running` and `.starting`, matching
+        // the app's `RemoteDeleteConfirmation.decide` (`live = state != .exited`):
+        // a state TBD could not read is not a statement that the session is
+        // finished, and delete is irreversible, so it must not be the
+        // frictionless path.
         if let state, state == .running || state == .starting {
             return "Error: \(address) is still running. "
                 + "Stop it first, or re-run with --force to destroy it anyway."
+        }
+        if state == .unknown {
+            return "Error: \(address) is in a state the provider did not describe. "
+                + "Re-run with --force to destroy it anyway."
         }
         if workspaceDirty {
             return "Error: \(address) reports uncommitted work in its workspace "

--- a/Sources/TBDCLI/Commands/RemoteCommands.swift
+++ b/Sources/TBDCLI/Commands/RemoteCommands.swift
@@ -1,0 +1,423 @@
+import ArgumentParser
+import Foundation
+import TBDShared
+
+struct RemoteCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "remote",
+        // The first three words name the thing, because in a worktree manager
+        // "remote" reads as a git remote first and a reader who guesses wrong
+        // never reads the fourth word.
+        abstract: "Provider-hosted agent sessions: sessions running on a cloud backend",
+        discussion: """
+            A **remote session** is an agent session a registered provider runs \
+            somewhere TBD does not otherwise reach (docs/remote-provider-contract.md). \
+            It is unrelated to a git remote.
+
+            What each subcommand can do depends on what the provider declared. A \
+            missing capability is refused here, by name, before the provider is \
+            ever invoked — the contract forbids a caller from invoking a verb the \
+            provider has not declared.
+            """,
+        subcommands: [
+            RemoteRetain.self, RemoteImport.self, RemoteRecall.self, RemoteRetained.self,
+        ]
+    )
+}
+
+// MARK: - Addressing a session
+
+/// Resolves the `<session>` operand every session-addressed `tbd remote`
+/// subcommand takes.
+///
+/// Three forms, tried in this order:
+///
+/// 1. **`<provider>/<provider-session-id>`** — the compound a human reads off
+///    `tbd remote list`. Authoritative and never checked against the inventory:
+///    it is an address, so it must keep working against a session TBD has not
+///    mirrored (or a provider whose snapshot is stale). Split at the *first*
+///    slash, because a provider name cannot contain one and a session id can.
+/// 2. **A TBD UUID** — a worktree row's id, or the synthetic id of a mirror row.
+/// 3. **A worktree name or display name** — resolved only when exactly one row
+///    matches and that row is bound to a provider session. Two matches is
+///    ambiguous and resolves to nothing rather than to a guess: acting on the
+///    wrong session is worse than being asked to say which.
+enum RemoteSessionRef {
+    static func resolve(
+        _ raw: String, sessions: [RemoteSessionInfo], worktrees: [Worktree]
+    ) -> (provider: String, sessionID: String)? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        if let slash = trimmed.firstIndex(of: "/") {
+            let provider = String(trimmed[trimmed.startIndex..<slash])
+            let sessionID = String(trimmed[trimmed.index(after: slash)...])
+            if !provider.isEmpty, !sessionID.isEmpty {
+                return (provider, sessionID)
+            }
+            return nil
+        }
+
+        if let uuid = UUID(uuidString: trimmed) {
+            if let worktree = worktrees.first(where: { $0.id == uuid }),
+               let binding = worktree.providerBinding {
+                return binding
+            }
+            if let session = sessions.first(where: { $0.id == uuid }) {
+                return (session.provider, session.payload.id)
+            }
+            return nil
+        }
+
+        let named = worktrees.filter {
+            ($0.name == trimmed || $0.displayName == trimmed) && $0.providerBinding != nil
+        }
+        guard named.count == 1, let binding = named[0].providerBinding else { return nil }
+        return binding
+    }
+}
+
+// MARK: - Shared plumbing
+
+/// The daemon-side facts a `tbd remote` subcommand needs before it calls
+/// anything: which providers exist and what they declared, which sessions are
+/// mirrored, and which worktrees are bound to one.
+struct RemoteFleetSnapshot {
+    let providers: [RemoteProviderStatus]
+    let sessions: [RemoteSessionInfo]
+    let worktrees: [Worktree]
+
+    func capabilities(of provider: String) -> Set<String> {
+        Set(providers.first { $0.config.name == provider }?.describe?.capabilities ?? [])
+    }
+
+    func isKnown(provider: String) -> Bool {
+        providers.contains { $0.config.name == provider }
+    }
+}
+
+func readRemoteFleet(client: SocketClient) throws -> RemoteFleetSnapshot {
+    let providers = try client.call(
+        method: RPCMethod.remoteProviders, resultType: RemoteProvidersResult.self)
+    let sessions = try client.call(
+        method: RPCMethod.remoteSessions, resultType: RemoteSessionsResult.self)
+    // Archived rows are included on purpose: a lane that was retired is exactly
+    // the one whose transcript somebody wants to keep.
+    let worktrees = try client.call(
+        method: RPCMethod.worktreeList,
+        params: WorktreeListParams(excludeArchived: false, includeSessionCounts: false),
+        resultType: [Worktree].self)
+    return RemoteFleetSnapshot(
+        providers: providers.providers, sessions: sessions.sessions, worktrees: worktrees)
+}
+
+/// Write one line to stderr. Everything a key-returning command says that is
+/// not the key goes here, so `KEY=$(tbd remote retain my-lane)` captures the
+/// key and nothing else.
+func remoteNote(_ text: String) {
+    FileHandle.standardError.write(Data((text + "\n").utf8))
+}
+
+/// The refusal a missing capability gets: one line, on stderr, naming the
+/// capability, decided before any provider call. Never a raw provider error —
+/// a provider that does not implement a verb fails in whatever way it likes,
+/// and "unknown command" tells a reader nothing about what to do next.
+func remoteMissingCapability(_ capability: String, provider: String) -> String {
+    "Error: provider '\(provider)' has not declared the '\(capability)' capability"
+}
+
+/// The `--json` shape every key-returning command prints, per the design's CLI
+/// section: `{"provider", "key", "expires_at", "bytes"}`.
+///
+/// `expires_at` is omitted when the provider stated nothing — its absence means
+/// the provider makes no claim, and emitting `null` would invite a reader to
+/// treat it as an answer.
+struct RetainReceiptOutput: Encodable {
+    let provider: String
+    let key: String
+    let expiresAt: Date?
+    let bytes: Int
+
+    enum CodingKeys: String, CodingKey {
+        case provider, key, bytes
+        case expiresAt = "expires_at"
+    }
+
+    init(provider: String, receipt: RetainReceipt) {
+        self.provider = provider
+        self.key = receipt.key
+        self.expiresAt = receipt.expiresAt
+        self.bytes = receipt.bytes
+    }
+}
+
+/// The human sentence a key-returning command writes to stderr.
+///
+/// Pure, so the wording can be read and tested against the branch actually
+/// taken. **An absent expiry is never rendered as permanence** — the contract
+/// makes that a MUST NOT for callers, so it says the provider stated nothing.
+func retainConfirmation(provider: String, receipt: RetainReceipt) -> String {
+    let expiry: String
+    if let expiresAt = receipt.expiresAt {
+        expiry = "expires \(RetainReceipt.formatTimestamp(expiresAt))"
+    } else {
+        expiry = "no expiry stated by the provider"
+    }
+    return "retained \(receipt.bytes) bytes on \(provider) (\(expiry))"
+}
+
+// MARK: - remote retain
+
+struct RemoteRetain: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "retain",
+        abstract: "Store a provider session's transcript in the provider's own durable store",
+        discussion: """
+            Prints the bare key on stdout and everything else on stderr, so \
+            `KEY=$(tbd remote retain my-lane)` composes.
+
+            The key is opaque and provider-scoped: never parse one, never present \
+            one to a different provider. TBD records it, so `tbd remote retained \
+            list` can find it again.
+
+            <session> accepts a worktree name, a TBD UUID, or <provider>/<session-id>.
+            """
+    )
+
+    @Argument(help: "Worktree name, TBD UUID, or <provider>/<session-id>")
+    var session: String
+
+    @Flag(name: .long, help: "Output JSON")
+    var json = false
+
+    mutating func run() async throws {
+        let client = SocketClient()
+        let fleet = try readRemoteFleet(client: client)
+        guard let target = RemoteSessionRef.resolve(
+            session, sessions: fleet.sessions, worktrees: fleet.worktrees) else {
+            remoteNote("Error: could not resolve '\(session)' to a remote session")
+            throw ExitCode.failure
+        }
+        guard fleet.capabilities(of: target.provider).contains("retain") else {
+            remoteNote(remoteMissingCapability("retain", provider: target.provider))
+            throw ExitCode.failure
+        }
+        let receipt = try client.call(
+            method: RPCMethod.remoteRetain,
+            params: RemoteRetainParams(provider: target.provider, sessionID: target.sessionID),
+            resultType: RetainReceipt.self)
+        emitReceipt(receipt, provider: target.provider, json: json)
+    }
+}
+
+/// Shared by `retain` and `import`, because the contract gives them one receipt
+/// and a caller that read two different renderings of it would have to learn
+/// two.
+func emitReceipt(_ receipt: RetainReceipt, provider: String, json: Bool) {
+    if json {
+        printJSON(RetainReceiptOutput(provider: provider, receipt: receipt))
+        return
+    }
+    remoteNote(retainConfirmation(provider: provider, receipt: receipt))
+    print(receipt.key)
+}
+
+// MARK: - remote import
+
+struct RemoteImport: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "import",
+        abstract: "Store a transcript from anywhere in a provider's durable store",
+        discussion: """
+            Reads Claude Code transcript JSONL from <path>, or from stdin when \
+            <path> is `-`, and hands it to the provider. No session on the \
+            provider is involved — this is how a conversation from somewhere \
+            else, including one that ran on this machine, enters the store.
+
+            Prints the bare key on stdout and everything else on stderr.
+            """
+    )
+
+    @Option(name: .long, help: "Provider name")
+    var provider: String
+
+    @Argument(help: "Path to a transcript JSONL file, or - for stdin")
+    var path: String
+
+    @Flag(name: .long, help: "Output JSON")
+    var json = false
+
+    mutating func run() async throws {
+        let client = SocketClient()
+        let fleet = try readRemoteFleet(client: client)
+        guard fleet.isKnown(provider: provider) else {
+            remoteNote("Error: no provider named '\(provider)' is registered")
+            throw ExitCode.failure
+        }
+        guard fleet.capabilities(of: provider).contains("import") else {
+            remoteNote(remoteMissingCapability("import", provider: provider))
+            throw ExitCode.failure
+        }
+        let jsonl = try readTranscriptOperand(path)
+        let receipt = try client.call(
+            method: RPCMethod.remoteImport,
+            params: RemoteImportParams(provider: provider, jsonl: jsonl),
+            resultType: RetainReceipt.self)
+        emitReceipt(receipt, provider: provider, json: json)
+    }
+}
+
+/// Reads the transcript operand: a file, or stdin for `-`.
+///
+/// Never prompts. Agents drive this CLI and cannot answer a prompt, so `-`
+/// with a terminal on stdin is refused with an explanation rather than left to
+/// block forever on a read nobody will satisfy.
+func readTranscriptOperand(_ path: String) throws -> String {
+    if path == "-" {
+        guard isatty(STDIN_FILENO) == 0 else {
+            throw CLIError.invalidArgument(
+                "reading the transcript from - requires piped input (e.g. < transcript.jsonl)")
+        }
+        return String(decoding: FileHandle.standardInput.readDataToEndOfFile(), as: UTF8.self)
+    }
+    let resolved = resolvePath(path)
+    guard FileManager.default.fileExists(atPath: resolved) else {
+        throw CLIError.invalidArgument("Transcript file not found: \(path)")
+    }
+    return try String(contentsOfFile: resolved, encoding: .utf8)
+}
+
+// MARK: - remote recall
+
+struct RemoteRecall: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "recall",
+        abstract: "Read back a transcript a provider retained",
+        discussion: """
+            Writes Claude Code transcript JSONL to stdout, or to <path> with -o. \
+            There is no --json flag: the output is already machine format.
+
+            Works whether or not the session that produced the transcript still \
+            exists — that is the point of retaining one. A key TBD has never \
+            seen is fine to pass; keys are the provider's, not TBD's.
+
+            An unknown key and one the provider has aged out are reported \
+            differently, so a lapsed record is not reported as one that never \
+            existed.
+            """
+    )
+
+    @Option(name: .long, help: "Provider name (keys are provider-scoped)")
+    var provider: String
+
+    @Argument(help: "The opaque key from a retain or import receipt")
+    var key: String
+
+    @Option(name: .shortAndLong, help: "Write the JSONL to this file instead of stdout")
+    var output: String?
+
+    mutating func run() async throws {
+        let client = SocketClient()
+        let fleet = try readRemoteFleet(client: client)
+        guard fleet.isKnown(provider: provider) else {
+            remoteNote("Error: no provider named '\(provider)' is registered")
+            throw ExitCode.failure
+        }
+        guard fleet.capabilities(of: provider).contains("recall") else {
+            remoteNote(remoteMissingCapability("recall", provider: provider))
+            throw ExitCode.failure
+        }
+        let result = try client.call(
+            method: RPCMethod.remoteRecall,
+            // The daemon's own `~/tbd/transcripts` copy is a different gesture
+            // from `-o`, which writes where the user asked. Asking for both
+            // would leave two copies and no way to say which is authoritative.
+            params: RemoteRecallParams(provider: provider, key: key, saveLocally: false),
+            resultType: RemoteRecallResult.self)
+        let jsonl = result.jsonl ?? ""
+        guard let output else {
+            print(jsonl, terminator: "")
+            return
+        }
+        let resolved = resolvePath(output)
+        try jsonl.write(toFile: resolved, atomically: true, encoding: .utf8)
+        remoteNote("wrote \(jsonl.utf8.count) bytes to \(resolved)")
+    }
+}
+
+// MARK: - remote retained
+
+struct RemoteRetained: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "retained",
+        abstract: "Transcripts a provider has retained, as TBD recorded them",
+        subcommands: [RemoteRetainedList.self]
+    )
+}
+
+struct RemoteRetainedList: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "list",
+        abstract: "List the retain and import receipts TBD holds",
+        discussion: """
+            Nothing in the provider contract lets a caller enumerate the keys a \
+            provider issued, so this lists TBD's own record of them. A key \
+            obtained on another machine is not here.
+
+            A blank EXPIRES column means the provider stated nothing. That is \
+            not a promise the transcript is kept forever.
+            """
+    )
+
+    @Option(name: .long, help: "Only this provider's receipts")
+    var provider: String?
+
+    @Flag(name: .long, help: "Output JSON")
+    var json = false
+
+    mutating func run() async throws {
+        let result = try SocketClient().call(
+            method: RPCMethod.remoteRetainedList,
+            params: RemoteRetainedListParams(provider: provider),
+            resultType: RemoteRetainedListResult.self)
+        if json {
+            guard let output = jsonString(result.transcripts) else {
+                remoteNote("Error: could not encode the retained-transcript listing as JSON")
+                throw ExitCode.failure
+            }
+            print(output)
+            return
+        }
+        print(renderRetainedListing(result.transcripts))
+    }
+}
+
+/// The plain-text table `tbd remote retained list` prints.
+///
+/// Separated from the call so the rendering can be read and tested without a
+/// daemon. An empty listing says so rather than printing a bare header, because
+/// a header with no rows reads as a failure to fetch.
+func renderRetainedListing(_ transcripts: [RetainedTranscript]) -> String {
+    guard !transcripts.isEmpty else {
+        return "No retained transcripts recorded."
+    }
+    var lines = [tableRow([
+        (value: "PROVIDER", width: 16), (value: "KEY", width: 30),
+        (value: "BYTES", width: 10), (value: "EXPIRES", width: 22),
+        (value: "SOURCE", width: 0),
+    ])]
+    for transcript in transcripts {
+        // Blank rather than a word: an absent expiry is the provider declining
+        // to say, and any word here would be read as an answer.
+        let expires = transcript.expiresAt.map(RetainReceipt.formatTimestamp) ?? ""
+        let source = transcript.sourceTitle ?? transcript.sourceSessionID ?? "imported"
+        lines.append(tableRow([
+            (value: transcript.provider, width: 16),
+            (value: transcript.key, width: 30),
+            (value: String(transcript.bytes), width: 10),
+            (value: expires, width: 22),
+            (value: source, width: 0),
+        ]))
+    }
+    return lines.joined(separator: "\n")
+}

--- a/Sources/TBDCLI/Commands/RemoteCommands.swift
+++ b/Sources/TBDCLI/Commands/RemoteCommands.swift
@@ -20,7 +20,9 @@ struct RemoteCommand: ParsableCommand {
             provider has not declared.
             """,
         subcommands: [
-            RemoteCreate.self,
+            RemoteList.self, RemoteCreate.self,
+            RemoteStop.self, RemoteArchive.self, RemoteUnarchive.self,
+            RemoteTranscript.self,
             RemoteRetain.self, RemoteImport.self, RemoteRecall.self, RemoteRetained.self,
             RemoteDelete.self, RemoteDismiss.self, RemoteAllowDelete.self,
         ]
@@ -1010,3 +1012,297 @@ func remoteCreateConfirmation(
         : "created \(provider)/\(name)"
 }
 
+// MARK: - remote list
+
+/// The rows `tbd remote list` shows, decided as a pure function so the display
+/// policy can be read next to the sidebar's.
+///
+/// **Archived sessions are hidden by default, and that is a caller decision
+/// rather than a provider one.** The contract requires a provider to keep
+/// archived sessions in `list` and assigns the caller the policy about which a
+/// human sees; the sidebar drops them, and this drops them too, so the two
+/// surfaces cannot disagree about what "the working set" means. `--archived`
+/// asks for the complete inventory.
+///
+/// Dismissed rows are always hidden: dismiss is TBD's own local tombstone, and
+/// a row a user removed from their lists reappearing here would make the
+/// gesture look broken.
+func remoteListRows(
+    _ sessions: [RemoteSessionInfo], provider: String?, includeArchived: Bool
+) -> [RemoteSessionInfo] {
+    sessions
+        .filter { !$0.dismissed }
+        .filter { includeArchived || !$0.payload.isArchived }
+        .filter { provider == nil || $0.provider == provider }
+        .sorted {
+            $0.provider == $1.provider ? $0.payload.id < $1.payload.id : $0.provider < $1.provider
+        }
+}
+
+/// The plain-text table `tbd remote list` prints. Separated from the call so
+/// the rendering is readable without a daemon.
+func renderRemoteListing(_ sessions: [RemoteSessionInfo]) -> String {
+    guard !sessions.isEmpty else {
+        return "No remote sessions."
+    }
+    var lines = [tableRow([
+        (value: "PROVIDER", width: 16), (value: "SESSION", width: 30),
+        (value: "STATE", width: 12), (value: "AGENT", width: 14),
+        (value: "TITLE", width: 0),
+    ])]
+    for session in sessions {
+        // `gone` is a TBD-side drift conclusion rather than a provider state,
+        // so it is shown in the STATE column instead of being folded into it:
+        // a session TBD has stopped seeing is a different fact from one the
+        // provider reports as exited.
+        let state = session.gone ? "gone" : session.payload.state.rawValue
+        lines.append(tableRow([
+            (value: session.provider, width: 16),
+            (value: session.payload.id, width: 30),
+            (value: state, width: 12),
+            (value: session.payload.agentState.rawValue, width: 14),
+            (value: session.payload.title ?? "", width: 0),
+        ]))
+    }
+    return lines.joined(separator: "\n")
+}
+
+struct RemoteList: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "list",
+        abstract: "List the provider-hosted sessions TBD is mirroring",
+        discussion: """
+            Archived sessions are hidden unless --archived is passed, matching \
+            what the sidebar shows: the provider keeps them in its inventory by \
+            contract, and which of them a human sees is TBD's decision.
+
+            Sessions you have dismissed are always hidden — dismiss is a local \
+            tombstone, and this is one of the lists it removes them from.
+
+            The SESSION column is the provider's own id: `<provider>/<session>` \
+            is what every other subcommand here takes as an address.
+            """
+    )
+
+    @Option(name: .long, help: "Only this provider's sessions")
+    var provider: String?
+
+    @Flag(name: .long, help: "Include sessions the provider reports as archived")
+    var archived = false
+
+    @Flag(name: .long, help: "Output JSON")
+    var json = false
+
+    mutating func run() async throws {
+        let sessions = try SocketClient().call(
+            method: RPCMethod.remoteSessions, resultType: RemoteSessionsResult.self).sessions
+        let rows = remoteListRows(sessions, provider: provider, includeArchived: archived)
+        if json {
+            guard let output = jsonString(rows) else {
+                remoteNote("Error: could not encode the remote session list as JSON")
+                throw ExitCode.failure
+            }
+            print(output)
+            return
+        }
+        print(renderRemoteListing(rows))
+    }
+}
+
+// MARK: - remote stop / archive / unarchive
+
+/// The three session-addressed verbs whose whole body is "resolve, check the
+/// capability, call the RPC, say what happened".
+///
+/// One enum and one runner rather than three near-identical command bodies:
+/// they differ only in the verb, the RPC and the past-tense word they print,
+/// and three copies of the resolution and refusal logic would be three places
+/// for it to drift.
+///
+/// The raw value is the capability string, which is not a coincidence to be
+/// tidied away later — the contract states that every capability except
+/// `profile` and `seed` names the verb of the same name.
+enum RemoteSessionVerb: String {
+    case stop, archive, unarchive
+
+    /// The past-tense word the success line uses.
+    var pastTense: String {
+        switch self {
+        case .stop: return "stopped"
+        case .archive: return "archived"
+        case .unarchive: return "unarchived"
+        }
+    }
+}
+
+/// Runs one session-addressed verb. The capability is refused here, by name,
+/// before the daemon is asked to invoke anything — the contract forbids a
+/// caller from invoking a verb the provider has not declared, and a refusal
+/// that arrived as a raw provider error would tell a reader nothing about what
+/// to do next.
+///
+/// The three params types are structurally identical today, so one would encode
+/// perfectly well as another. They are still named individually, because "it
+/// happens to encode the same" is exactly the coincidence a later field on one
+/// of them breaks silently.
+func runRemoteSessionVerb(
+    _ verb: RemoteSessionVerb, session: String, json: Bool
+) throws {
+    let client = SocketClient()
+    let fleet = try readRemoteFleet(client: client)
+    guard let target = RemoteSessionRef.resolve(
+        session, sessions: fleet.sessions, worktrees: fleet.worktrees) else {
+        remoteNote("Error: could not resolve '\(session)' to a remote session")
+        throw ExitCode.failure
+    }
+    guard fleet.capabilities(of: target.provider).contains(verb.rawValue) else {
+        remoteNote(remoteMissingCapability(verb.rawValue, provider: target.provider))
+        throw ExitCode.failure
+    }
+    switch verb {
+    case .stop:
+        try client.callVoid(
+            method: RPCMethod.remoteStop,
+            params: RemoteStopParams(provider: target.provider, sessionID: target.sessionID))
+    case .archive:
+        try client.callVoid(
+            method: RPCMethod.remoteArchive,
+            params: RemoteArchiveParams(provider: target.provider, sessionID: target.sessionID))
+    case .unarchive:
+        try client.callVoid(
+            method: RPCMethod.remoteUnarchive,
+            params: RemoteUnarchiveParams(provider: target.provider, sessionID: target.sessionID))
+    }
+    let address = "\(target.provider)/\(target.sessionID)"
+    if json {
+        printJSON([
+            "provider": target.provider, "session": target.sessionID, "verb": verb.rawValue,
+        ])
+        return
+    }
+    print("\(verb.pastTense) \(address)")
+}
+
+struct RemoteStop: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "stop",
+        abstract: "End a session's compute, leaving its record in the provider's inventory",
+        discussion: """
+            Stop is not archive and not delete. It ends the compute and leaves \
+            the session listed; `tbd remote archive` retires the record without \
+            ending compute; `tbd remote delete` does both and removes it for good.
+
+            <session> accepts a worktree name, a TBD UUID, or <provider>/<session-id>.
+            """
+    )
+
+    @Argument(help: "Worktree name, TBD UUID, or <provider>/<session-id>")
+    var session: String
+
+    @Flag(name: .long, help: "Output JSON")
+    var json = false
+
+    mutating func run() async throws {
+        try runRemoteSessionVerb(.stop, session: session, json: json)
+    }
+}
+
+struct RemoteArchive: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "archive",
+        abstract: "Retire a session from the provider's working set, leaving its compute alone",
+        discussion: """
+            Archiving does not stop anything. A session still running keeps \
+            running; it simply stops appearing in `tbd remote list` and in the \
+            sidebar. Stop it first if that is what you meant.
+
+            <session> accepts a worktree name, a TBD UUID, or <provider>/<session-id>.
+            """
+    )
+
+    @Argument(help: "Worktree name, TBD UUID, or <provider>/<session-id>")
+    var session: String
+
+    @Flag(name: .long, help: "Output JSON")
+    var json = false
+
+    mutating func run() async throws {
+        try runRemoteSessionVerb(.archive, session: session, json: json)
+    }
+}
+
+struct RemoteUnarchive: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "unarchive",
+        abstract: "Return a retired session to the provider's working set",
+        discussion: """
+            The reverse of `tbd remote archive`. Address a retired session by \
+            `<provider>/<session-id>` — `tbd remote list --archived` prints it.
+            """
+    )
+
+    @Argument(help: "Worktree name, TBD UUID, or <provider>/<session-id>")
+    var session: String
+
+    @Flag(name: .long, help: "Output JSON")
+    var json = false
+
+    mutating func run() async throws {
+        try runRemoteSessionVerb(.unarchive, session: session, json: json)
+    }
+}
+
+// MARK: - remote transcript
+
+struct RemoteTranscript: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "transcript",
+        abstract: "Read a live session's conversation as Claude Code transcript JSONL",
+        discussion: """
+            Writes JSONL to stdout, or to <path> with -o. There is no --json \
+            flag: the output is already machine format.
+
+            This is the conversation, not the terminal. `transcript` returns \
+            structured records — user turns, agent responses, tool activity — \
+            while a scrollback recording is different data entirely, and the \
+            contract forbids substituting one for the other.
+
+            For a session that no longer exists, use `tbd remote recall` with \
+            the key its retention produced.
+
+            <session> accepts a worktree name, a TBD UUID, or <provider>/<session-id>.
+            """
+    )
+
+    @Argument(help: "Worktree name, TBD UUID, or <provider>/<session-id>")
+    var session: String
+
+    @Option(name: .shortAndLong, help: "Write the JSONL to this file instead of stdout")
+    var output: String?
+
+    mutating func run() async throws {
+        let client = SocketClient()
+        let fleet = try readRemoteFleet(client: client)
+        guard let target = RemoteSessionRef.resolve(
+            session, sessions: fleet.sessions, worktrees: fleet.worktrees) else {
+            remoteNote("Error: could not resolve '\(session)' to a remote session")
+            throw ExitCode.failure
+        }
+        guard fleet.capabilities(of: target.provider).contains("transcript") else {
+            remoteNote(remoteMissingCapability("transcript", provider: target.provider))
+            throw ExitCode.failure
+        }
+        let result = try client.call(
+            method: RPCMethod.remoteTranscript,
+            params: RemoteTranscriptParams(
+                provider: target.provider, sessionID: target.sessionID),
+            resultType: RemoteTranscriptResult.self)
+        guard let output else {
+            print(result.jsonl, terminator: "")
+            return
+        }
+        let resolved = resolvePath(output)
+        try result.jsonl.write(toFile: resolved, atomically: true, encoding: .utf8)
+        remoteNote("wrote \(result.jsonl.utf8.count) bytes to \(resolved)")
+    }
+}

--- a/Sources/TBDCLI/Commands/RemoteCommands.swift
+++ b/Sources/TBDCLI/Commands/RemoteCommands.swift
@@ -979,14 +979,19 @@ struct RemoteCreate: AsyncParsableCommand {
         // would leave a retained blob nobody will ever use.
         if let worktree = fleet.worktrees.first(where: { $0.id == terminal.worktreeID }),
            worktree.location.isLocal, !worktree.localPath.isEmpty {
-            guard let summary = readTeleportSummary(worktreePath: worktree.localPath) else {
+            if let summary = readTeleportSummary(worktreePath: worktree.localPath) {
+                if let refusal = TeleportPrecondition.refusal(summary, force: force) {
+                    remoteNote(refusal)
+                    throw ExitCode.failure
+                }
+            } else if !force {
+                // Unknown is refused rather than assumed clean: guessing zero
+                // would carry a conversation away from work the user believed
+                // was coming with it. --force still gets through, on the same
+                // terms as every other teleport refusal.
                 throw CLIError.invalidArgument(
                     "Could not read the git state of \(worktree.localPath), so what would be "
                     + "left behind is unknown. Re-run with --force to move the conversation anyway.")
-            }
-            if let refusal = TeleportPrecondition.refusal(summary, force: force) {
-                remoteNote(refusal)
-                throw ExitCode.failure
             }
         }
         guard let jsonl = try? String(contentsOfFile: transcriptPath, encoding: .utf8) else {

--- a/Sources/TBDCLI/Commands/RemoteCommands.swift
+++ b/Sources/TBDCLI/Commands/RemoteCommands.swift
@@ -20,6 +20,7 @@ struct RemoteCommand: ParsableCommand {
             provider has not declared.
             """,
         subcommands: [
+            RemoteCreate.self,
             RemoteRetain.self, RemoteImport.self, RemoteRecall.self, RemoteRetained.self,
             RemoteDelete.self, RemoteDismiss.self, RemoteAllowDelete.self,
         ]
@@ -675,3 +676,337 @@ struct RemoteAllowDelete: AsyncParsableCommand {
         print("Remote session delete \(enabled ? "enabled" : "disabled").")
     }
 }
+
+// MARK: - remote create
+
+/// A worktree's git state, reduced to the three facts teleport cares about.
+///
+/// A struct rather than three loose arguments because the precondition below is
+/// pure and this is the whole of its input: reading git is I/O, deciding what
+/// to refuse is not, and the split is what makes the decision testable without
+/// a repository.
+struct TeleportWorkspaceSummary: Equatable {
+    /// Paths `git status --porcelain` reports as changed — staged, unstaged or
+    /// untracked, deliberately not distinguished. All three stay on this
+    /// machine, which is the only thing the refusal is about.
+    let uncommittedFiles: Int
+    /// Commits on this branch the upstream does not have. Meaningless when
+    /// `hasUpstream` is false, where the answer is "all of them".
+    let unpushedCommits: Int
+    /// Whether the branch tracks anything at all. A branch with no upstream has
+    /// nothing on a remote for the new session to check out, which is a
+    /// different sentence from "you are two commits ahead".
+    let hasUpstream: Bool
+
+    init(uncommittedFiles: Int, unpushedCommits: Int, hasUpstream: Bool) {
+        self.uncommittedFiles = uncommittedFiles
+        self.unpushedCommits = unpushedCommits
+        self.hasUpstream = hasUpstream
+    }
+}
+
+/// The gate in front of `create --continue`.
+///
+/// **Teleport moves a branch, never files.** The new session is a checkout on
+/// another machine, made from what the remote has; nothing in this repository's
+/// working tree travels with the conversation. Carrying the files instead would
+/// mean shipping the untracked and ignored ones that make a checkout work —
+/// `.env`, local databases, credentials — which is a per-repo policy question
+/// and not a transport one, and shipping them by default exfiltrates secrets.
+///
+/// So the refusal's job is to name what would be left behind, in counts a user
+/// can check, rather than to say "the worktree is dirty". `--force` carries the
+/// conversation anyway, which is a perfectly reasonable thing to want.
+///
+/// Pure, mirroring `RemoteDeletePrecondition.refusal`: returns the message to
+/// print, or nil to proceed.
+enum TeleportPrecondition {
+    static func refusal(_ summary: TeleportWorkspaceSummary, force: Bool) -> String? {
+        guard !force else { return nil }
+        var leftBehind: [String] = []
+        if summary.uncommittedFiles > 0 {
+            leftBehind.append(
+                "\(summary.uncommittedFiles) uncommitted "
+                + (summary.uncommittedFiles == 1 ? "file" : "files"))
+        }
+        if !summary.hasUpstream {
+            leftBehind.append("every commit on this branch, which has no upstream")
+        } else if summary.unpushedCommits > 0 {
+            leftBehind.append(
+                "\(summary.unpushedCommits) unpushed "
+                + (summary.unpushedCommits == 1 ? "commit" : "commits"))
+        }
+        guard !leftBehind.isEmpty else { return nil }
+        let subject = leftBehind.joined(separator: " and ")
+        var message = "Error: \(subject) will stay on this machine. "
+            + "A remote session checks the branch out from the remote, so only what is "
+            + "pushed travels with the conversation.\n"
+        // Named separately because the two have different remedies, and the
+        // push one is an offer rather than an instruction to go and read git's
+        // manual.
+        if summary.uncommittedFiles > 0 {
+            message += "Commit or stash the changes first.\n"
+        }
+        if !summary.hasUpstream || summary.unpushedCommits > 0 {
+            message += "Push the branch first (`git push -u origin HEAD`).\n"
+        }
+        message += "Or re-run with --force to move the conversation and leave them behind."
+        return message
+    }
+}
+
+/// Reads the three facts `TeleportPrecondition` decides on out of a real
+/// checkout.
+///
+/// Every failure degrades toward *refusing*, never toward proceeding: a
+/// `git status` that will not run leaves `uncommittedFiles` unknown, and
+/// guessing zero there would carry a conversation away from work the user
+/// thought was coming with it. `hasUpstream` is false when `@{u}` does not
+/// resolve, which is exactly the "never pushed" case.
+func readTeleportSummary(worktreePath: String) -> TeleportWorkspaceSummary? {
+    guard let status = runGit(["status", "--porcelain"], at: worktreePath) else { return nil }
+    let changed = status
+        .split(separator: "\n")
+        .filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
+        .count
+    guard runGit(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
+                 at: worktreePath) != nil else {
+        return TeleportWorkspaceSummary(
+            uncommittedFiles: changed, unpushedCommits: 0, hasUpstream: false)
+    }
+    let ahead = runGit(["rev-list", "--count", "@{u}..HEAD"], at: worktreePath)
+        .flatMap { Int($0.trimmingCharacters(in: .whitespacesAndNewlines)) } ?? 0
+    return TeleportWorkspaceSummary(
+        uncommittedFiles: changed, unpushedCommits: ahead, hasUpstream: true)
+}
+
+/// Runs one git command in `path` and returns its stdout, or nil when git
+/// exited nonzero. Callers read a nonzero exit as a fact ("no upstream"), never
+/// as a reason to carry on regardless.
+private func runGit(_ arguments: [String], at path: String) -> String? {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+    process.arguments = ["git", "-C", path] + arguments
+    let out = Pipe()
+    let err = Pipe()
+    process.standardOutput = out
+    process.standardError = err
+    do {
+        try process.run()
+    } catch {
+        return nil
+    }
+    let data = out.fileHandleForReading.readDataToEndOfFile()
+    _ = err.fileHandleForReading.readDataToEndOfFile()
+    process.waitUntilExit()
+    guard process.terminationStatus == 0 else { return nil }
+    return String(bytes: data, encoding: .utf8) ?? ""
+}
+
+/// Turns repeated `--param key=value` into the JSON object `create` sends.
+///
+/// The values are the provider's own `create_params` fields and TBD does not
+/// interpret them, so everything is carried as a string: the contract's field
+/// types are the provider's business, and a CLI that guessed a number from
+/// `--param count=3` would be inventing a type the user never wrote.
+func remoteCreateParamsJSON(_ pairs: [String]) throws -> String {
+    var values: [String: String] = [:]
+    for pair in pairs {
+        guard let separator = pair.firstIndex(of: "=") else {
+            throw CLIError.invalidArgument(
+                "--param expects key=value, got: \(pair)")
+        }
+        let key = String(pair[pair.startIndex..<separator])
+        guard !key.isEmpty else {
+            throw CLIError.invalidArgument("--param expects key=value, got: \(pair)")
+        }
+        values[key] = String(pair[pair.index(after: separator)...])
+    }
+    guard let data = try? JSONSerialization.data(withJSONObject: values, options: [.sortedKeys]),
+          let json = String(bytes: data, encoding: .utf8) else {
+        throw CLIError.invalidArgument("could not encode --param values as JSON")
+    }
+    return json
+}
+
+struct RemoteCreate: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "create",
+        abstract: "Start a provider-hosted agent session, optionally carrying a conversation",
+        discussion: """
+            --param takes the provider's own create fields, repeated once per \
+            field; `tbd remote list` names the provider, and the provider's \
+            `describe` names the fields.
+
+            Three ways to give the new session a conversation to begin from, \
+            and they are mutually exclusive:
+
+              --continue <terminal-id>  carry a conversation running on THIS \
+            machine to the provider. TBD reads that terminal's Claude \
+            transcript, stores it on the provider, and creates a session \
+            seeded from it.
+              --from-key <key>          seed from a transcript already stored \
+            on this provider (see `tbd remote retain` and `tbd remote import`).
+              --from-file <path|->      seed from a transcript JSONL file.
+
+            **--continue moves the branch, never the files.** The new session \
+            checks the branch out from the remote, so anything uncommitted or \
+            unpushed stays here. TBD refuses and says what would be left \
+            behind; --force moves the conversation anyway.
+
+            Seeding needs the provider to declare `seed`, and the two \
+            file-bearing sources need `import` as well. Both are refused here, \
+            by name, before anything is created.
+            """
+    )
+
+    @Option(name: .long, help: "Provider name")
+    var provider: String
+
+    @Option(name: .long, parsing: .unconditionalSingleValue,
+            help: "A provider create field, as key=value. Repeat for more.")
+    var param: [String] = []
+
+    @Option(name: .customLong("continue"),
+            help: "Carry this terminal's conversation to the provider (terminal UUID)")
+    var continueTerminal: String?
+
+    @Option(name: .customLong("from-key"),
+            help: "Seed from a transcript this provider already holds")
+    var fromKey: String?
+
+    @Option(name: .customLong("from-file"),
+            help: "Seed from a transcript JSONL file, or - for stdin")
+    var fromFile: String?
+
+    @Flag(name: .long, help: "Move the conversation even though work would be left behind")
+    var force = false
+
+    @Flag(name: .long, help: "Output JSON")
+    var json = false
+
+    mutating func run() async throws {
+        let sources = [continueTerminal, fromKey, fromFile].compactMap { $0 }
+        guard sources.count <= 1 else {
+            throw ValidationError(
+                "--continue, --from-key and --from-file are mutually exclusive: "
+                + "a session begins from one conversation or from none.")
+        }
+        let paramsJSON = try remoteCreateParamsJSON(param)
+
+        let client = SocketClient()
+        let fleet = try readRemoteFleet(client: client)
+        guard fleet.isKnown(provider: provider) else {
+            remoteNote("Error: no provider named '\(provider)' is registered")
+            throw ExitCode.failure
+        }
+        let capabilities = fleet.capabilities(of: provider)
+        // Both capability checks happen before anything is read, imported or
+        // created. A `seed` a provider never declared is silently ignored by
+        // the contract's own ignore-unknown-fields rule, which would leave the
+        // user with an empty session they believed carried their conversation.
+        if !sources.isEmpty, !capabilities.contains("seed") {
+            remoteNote(remoteMissingCapability("seed", provider: provider))
+            throw ExitCode.failure
+        }
+        if continueTerminal != nil || fromFile != nil, !capabilities.contains("import") {
+            remoteNote(remoteMissingCapability("import", provider: provider))
+            throw ExitCode.failure
+        }
+
+        var seedKey: String?
+        if let fromKey {
+            seedKey = fromKey
+        } else if let fromFile {
+            seedKey = try importTranscript(readTranscriptOperand(fromFile), client: client)
+        } else if let continueTerminal {
+            seedKey = try carryLocalConversation(
+                terminalRef: continueTerminal, client: client, fleet: fleet)
+        }
+
+        let session = try client.call(
+            method: RPCMethod.remoteCreate,
+            params: RemoteCreateParams(
+                provider: provider, paramsJSON: paramsJSON, seedRetainedKey: seedKey),
+            resultType: RemoteSessionPayload.self)
+        if json {
+            printJSON(session)
+            return
+        }
+        remoteNote(remoteCreateConfirmation(
+            provider: provider, session: session, seeded: seedKey != nil))
+        print(session.id)
+    }
+
+    /// Stores a transcript on the provider and returns its key, noting the
+    /// receipt on stderr so a `create` that later fails still leaves the user
+    /// holding the key their conversation is under.
+    private func importTranscript(_ jsonl: String, client: SocketClient) throws -> String {
+        let receipt = try client.call(
+            method: RPCMethod.remoteImport,
+            params: RemoteImportParams(provider: provider, jsonl: jsonl),
+            resultType: RetainReceipt.self)
+        remoteNote(retainConfirmation(provider: provider, receipt: receipt))
+        remoteNote("seed key: \(receipt.key)")
+        return receipt.key
+    }
+
+    /// The teleport: read a local terminal's Claude transcript, check what
+    /// would be left behind, and store the conversation on the provider.
+    private func carryLocalConversation(
+        terminalRef: String, client: SocketClient, fleet: RemoteFleetSnapshot
+    ) throws -> String {
+        guard let terminalID = UUID(uuidString: terminalRef) else {
+            throw CLIError.invalidArgument(
+                "--continue takes a terminal UUID; `tbd terminal list <worktree>` prints them.")
+        }
+        let terminals: [Terminal] = try client.call(
+            method: RPCMethod.terminalList,
+            params: TerminalListParams(),
+            resultType: [Terminal].self)
+        guard let terminal = terminals.first(where: { $0.id == terminalID }) else {
+            throw CLIError.invalidArgument("No terminal found with ID: \(terminalRef)")
+        }
+        guard let transcriptPath = terminal.transcriptPath else {
+            throw CLIError.invalidArgument(
+                "Terminal \(terminalRef) has no Claude transcript on record yet — "
+                + "nothing has been said in it, or it is not a Claude session.")
+        }
+        // The precondition runs before the import, so a refusal costs nothing
+        // on the provider. An import that succeeded and was then abandoned
+        // would leave a retained blob nobody will ever use.
+        if let worktree = fleet.worktrees.first(where: { $0.id == terminal.worktreeID }),
+           worktree.location.isLocal, !worktree.localPath.isEmpty {
+            guard let summary = readTeleportSummary(worktreePath: worktree.localPath) else {
+                throw CLIError.invalidArgument(
+                    "Could not read the git state of \(worktree.localPath), so what would be "
+                    + "left behind is unknown. Re-run with --force to move the conversation anyway.")
+            }
+            if let refusal = TeleportPrecondition.refusal(summary, force: force) {
+                remoteNote(refusal)
+                throw ExitCode.failure
+            }
+        }
+        guard let jsonl = try? String(contentsOfFile: transcriptPath, encoding: .utf8) else {
+            throw CLIError.invalidArgument(
+                "Could not read the transcript at \(transcriptPath)")
+        }
+        return try importTranscript(jsonl, client: client)
+    }
+}
+
+/// The human sentence a create prints to stderr, pure so the seeded and
+/// unseeded wordings can be read side by side.
+///
+/// The seeded one says so explicitly: a session that silently began with
+/// somebody's whole conversation, and one that began empty, look identical from
+/// the outside, and the whole point of the flag is which of those happened.
+func remoteCreateConfirmation(
+    provider: String, session: RemoteSessionPayload, seeded: Bool
+) -> String {
+    let name = session.title.map { "\($0) (\(session.id))" } ?? session.id
+    return seeded
+        ? "created \(provider)/\(name), seeded from the retained conversation"
+        : "created \(provider)/\(name)"
+}
+

--- a/Sources/TBDCLI/Commands/RemoteCommands.swift
+++ b/Sources/TBDCLI/Commands/RemoteCommands.swift
@@ -21,6 +21,7 @@ struct RemoteCommand: ParsableCommand {
             """,
         subcommands: [
             RemoteRetain.self, RemoteImport.self, RemoteRecall.self, RemoteRetained.self,
+            RemoteDelete.self, RemoteDismiss.self, RemoteAllowDelete.self,
         ]
     )
 }
@@ -420,4 +421,257 @@ func renderRetainedListing(_ transcripts: [RetainedTranscript]) -> String {
         ]))
     }
     return lines.joined(separator: "\n")
+}
+
+// MARK: - remote delete
+
+/// The caller-side policy in front of `delete`, as a pure function.
+///
+/// The contract has no `--force` and deliberately so: "refusing to destroy live
+/// or dirty work is caller policy", and a provider that second-guessed an
+/// explicit delete would leave the caller no way through. This is that policy,
+/// and it lives here rather than in the daemon for the same reason — the daemon
+/// serves the app too, and the app asks its own question with a dialog.
+///
+/// Returns the refusal to print, or nil to proceed.
+///
+/// **An unmirrored session is not refused.** `<provider>/<session-id>` is an
+/// address that must keep working against a session TBD has never listed, and
+/// there is then no `state` and no `meta` to read: refusing on absent
+/// information would make the address form useless exactly when it is most
+/// needed. The provider is still the last word on whether the delete happens.
+enum RemoteDeletePrecondition {
+    static func refusal(
+        state: RemoteProcessState?, workspaceDirty: Bool, force: Bool, address: String
+    ) -> String? {
+        guard !force else { return nil }
+        // Named separately rather than collapsed into one message, because the
+        // two have different remedies: one waits or stops the session, the
+        // other commits or pushes on the provider's machine.
+        if let state, state == .running || state == .starting {
+            return "Error: \(address) is still running. "
+                + "Stop it first, or re-run with --force to destroy it anyway."
+        }
+        if workspaceDirty {
+            return "Error: \(address) reports uncommitted work in its workspace "
+                + "(meta.workspace_dirty), which lives on the provider's machine. "
+                + "Re-run with --force to destroy it anyway."
+        }
+        return nil
+    }
+}
+
+/// What `--json` prints for a delete: the provider's own response shape with
+/// the provider name added, rather than a second shape a reader has to learn.
+///
+/// `retained` is present exactly when a receipt came back, and carries no
+/// `provider` of its own — the enclosing object already names it once, and a
+/// key repeated at two nesting levels invites a reader to wonder whether they
+/// can differ.
+struct RemoteDeleteOutput: Encodable {
+    struct Receipt: Encodable {
+        let key: String
+        let expiresAt: Date?
+        let bytes: Int
+
+        enum CodingKeys: String, CodingKey {
+            case key, bytes
+            case expiresAt = "expires_at"
+        }
+    }
+
+    let provider: String
+    let id: String
+    let deleted: Bool
+    let retained: Receipt?
+
+    init(provider: String, result: RemoteDeleteResult) {
+        self.provider = provider
+        self.id = result.id
+        self.deleted = result.deleted
+        self.retained = result.retained.map {
+            Receipt(key: $0.key, expiresAt: $0.expiresAt, bytes: $0.bytes)
+        }
+    }
+}
+
+/// The human sentence a delete prints, pure so the two outcomes can be read
+/// side by side.
+///
+/// They are worded differently on purpose. `deleted: false` means there was
+/// nothing to destroy — a success per the contract, and the same answer `rm -f`
+/// gives — and reporting it as a deletion would tell the user something
+/// happened that did not.
+func remoteDeleteConfirmation(address: String, result: RemoteDeleteResult) -> String {
+    guard result.deleted else {
+        return "\(address) was already gone"
+    }
+    guard let receipt = result.retained else {
+        return "deleted \(address)"
+    }
+    // An absent expiry is never rendered as permanence — the contract makes
+    // that a MUST NOT for callers.
+    let expiry = receipt.expiresAt.map { ", expires \(RetainReceipt.formatTimestamp($0))" }
+        ?? ", no expiry stated"
+    return "deleted \(address) (retained: \(receipt.key)\(expiry))"
+}
+
+struct RemoteDelete: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "delete",
+        abstract: "Destroy a provider-hosted session: end its compute and remove it permanently",
+        discussion: """
+            Unlike `dismiss`, this acts on the provider. The session's compute \
+            ends and its record is removed from the provider's inventory for \
+            good; nothing on this machine can put it back.
+
+            Gated by the daemon's `remote_delete_enabled` flag, which ships off. \
+            Turn it on with `tbd remote allow-delete on`.
+
+            With --retain the provider stores the transcript first and the key is \
+            printed, so the conversation survives the session. Without it, \
+            nothing survives. --retain needs the provider to declare `retain` as \
+            well as `delete`.
+
+            Refuses without --force when the session is running or reports \
+            uncommitted work, naming which.
+
+            <session> accepts a worktree name, a TBD UUID, or <provider>/<session-id>.
+            """
+    )
+
+    @Argument(help: "Worktree name, TBD UUID, or <provider>/<session-id>")
+    var session: String
+
+    @Flag(name: .long, help: "Retain the transcript before destroying the session")
+    var retain = false
+
+    @Flag(name: .long, help: "Destroy a running session, or one with uncommitted work")
+    var force = false
+
+    @Flag(name: .long, help: "Output JSON")
+    var json = false
+
+    mutating func run() async throws {
+        let client = SocketClient()
+        let fleet = try readRemoteFleet(client: client)
+        guard let target = RemoteSessionRef.resolve(
+            session, sessions: fleet.sessions, worktrees: fleet.worktrees) else {
+            remoteNote("Error: could not resolve '\(session)' to a remote session")
+            throw ExitCode.failure
+        }
+        let address = "\(target.provider)/\(target.sessionID)"
+        let capabilities = fleet.capabilities(of: target.provider)
+        guard capabilities.contains("delete") else {
+            remoteNote(remoteMissingCapability("delete", provider: target.provider))
+            throw ExitCode.failure
+        }
+        // The contract makes --retain valid only where `retain` is declared, so
+        // this is refused here rather than sent and hoped for: a provider that
+        // ignored the flag would destroy a session the caller believed was
+        // being preserved.
+        if retain, !capabilities.contains("retain") {
+            remoteNote(remoteMissingCapability("retain", provider: target.provider))
+            throw ExitCode.failure
+        }
+        let mirrored = fleet.sessions.first {
+            $0.provider == target.provider && $0.payload.id == target.sessionID
+        }
+        if let refusal = RemoteDeletePrecondition.refusal(
+            state: mirrored?.payload.state,
+            workspaceDirty: mirrored?.payload.reportsDirtyWorkspace ?? false,
+            force: force, address: address) {
+            remoteNote(refusal)
+            throw ExitCode.failure
+        }
+        let result = try client.call(
+            method: RPCMethod.remoteDelete,
+            params: RemoteDeleteParams(
+                provider: target.provider, sessionID: target.sessionID, retain: retain),
+            resultType: RemoteDeleteResult.self)
+        if json {
+            printJSON(RemoteDeleteOutput(provider: target.provider, result: result))
+            return
+        }
+        // The key goes to stdout on its own, as it does for `retain`, so
+        // `KEY=$(tbd remote delete my-lane --retain)` composes; everything else
+        // is stderr.
+        remoteNote(remoteDeleteConfirmation(address: address, result: result))
+        if let key = result.retained?.key { print(key) }
+    }
+}
+
+// MARK: - remote dismiss
+
+struct RemoteDismiss: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "dismiss",
+        abstract: "Hide a session from TBD's own lists, changing nothing on the provider",
+        discussion: """
+            Dismiss is local. It marks TBD's mirror row so the session stops \
+            appearing in the sidebar and in `tbd remote list`, and that is all \
+            it does: the session, its compute and its record are untouched on \
+            the provider, and another machine running TBD still sees it.
+
+            **This is not `delete`.** `tbd remote delete` ends the session's \
+            compute and removes it from the provider permanently. Reach for \
+            dismiss when a finished session is in your way; reach for delete \
+            when you want it gone.
+
+            <session> accepts a worktree name, a TBD UUID, or <provider>/<session-id>.
+            """
+    )
+
+    @Argument(help: "Worktree name, TBD UUID, or <provider>/<session-id>")
+    var session: String
+
+    mutating func run() async throws {
+        let client = SocketClient()
+        let fleet = try readRemoteFleet(client: client)
+        guard let target = RemoteSessionRef.resolve(
+            session, sessions: fleet.sessions, worktrees: fleet.worktrees) else {
+            remoteNote("Error: could not resolve '\(session)' to a remote session")
+            throw ExitCode.failure
+        }
+        // No capability check: dismiss invokes no provider verb. It is the one
+        // removal gesture that works on every provider, which is exactly why
+        // its help has to say what it does not do.
+        try client.callVoid(
+            method: RPCMethod.remoteDismiss,
+            params: RemoteDismissParams(provider: target.provider, sessionID: target.sessionID))
+        print("Dismissed \(target.provider)/\(target.sessionID) from TBD's lists.")
+    }
+}
+
+// MARK: - the delete gate
+
+struct RemoteAllowDelete: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "allow-delete",
+        abstract: "Enable or disable `tbd remote delete` (default off)",
+        discussion: """
+            The soak switch for the one verb whose effect nothing on this \
+            machine can undo. Off — the shipped default — every delete is \
+            refused, on both the CLI and the app's menus.
+
+            Turning it off refuses the next delete. It cannot recall one already \
+            made.
+            """
+    )
+
+    @Argument(help: "on | off")
+    var state: String
+
+    mutating func run() async throws {
+        let enabled: Bool
+        switch state.lowercased() {
+        case "on", "true", "enable": enabled = true
+        case "off", "false", "disable": enabled = false
+        default: throw ValidationError("Expected 'on' or 'off', got: \(state)")
+        }
+        try SocketClient().callVoid(
+            method: RPCMethod.configSetRemoteDeleteEnabled,
+            params: ConfigSetRemoteDeleteEnabledParams(enabled: enabled))
+        print("Remote session delete \(enabled ? "enabled" : "disabled").")
+    }
 }

--- a/Sources/TBDCLI/TBD.swift
+++ b/Sources/TBDCLI/TBD.swift
@@ -15,6 +15,7 @@ struct TBDCommand: AsyncParsableCommand {
             ProfileCommand.self,
             TerminalCommand.self,
             PeerCommand.self,
+            RemoteCommand.self,
             PanelCommand.self,
             NotifyCommand.self,
             SessionEventCommand.self,

--- a/Sources/TBDDaemon/Actuation/ActuationSurface.swift
+++ b/Sources/TBDDaemon/Actuation/ActuationSurface.swift
@@ -115,6 +115,14 @@ enum ActuationSurface: CaseIterable, Sendable {
     /// matching `worktreeRevive`'s kind for the same reason: it brings a
     /// retired lane back into use.
     case remoteUnarchive
+    /// Destroys a remote session outright
+    /// (`docs/remote-provider-contract.md` § `delete <id>`) — `dispose`, like
+    /// `remoteStop` and `remoteArchive`, and the strongest of the three: it
+    /// ends compute AND removes the record. When an adopted lane is deleted
+    /// its worktree row is archived underneath this row rather than earning a
+    /// second one, for the same reason `remoteArchive` sits under
+    /// `worktreeArchive`: one intent, one row.
+    case remoteDelete
 
     /// The exact public method name that carries this surface's requests.
     var method: String {
@@ -147,6 +155,7 @@ enum ActuationSurface: CaseIterable, Sendable {
         case .remoteSend: return RPCMethod.remoteSend
         case .remoteArchive: return RPCMethod.remoteArchive
         case .remoteUnarchive: return RPCMethod.remoteUnarchive
+        case .remoteDelete: return RPCMethod.remoteDelete
         }
     }
 
@@ -161,7 +170,8 @@ enum ActuationSurface: CaseIterable, Sendable {
              .scratchCreate, .worktreeRevive, .worktreeReviveConversationFresh,
              .worktreeRerunPreSession, .remoteCreate, .remoteUnarchive: return .spawn
         case .terminalDelete, .worktreeArchive, .worktreeForget, .repoRemove,
-             .scratchDelete, .scratchArchive, .remoteStop, .remoteArchive: return .dispose
+             .scratchDelete, .scratchArchive, .remoteStop, .remoteArchive,
+             .remoteDelete: return .dispose
         case .terminalHibernate, .terminalSuspend, .worktreeSuspend: return .hibernate
         case .terminalWake, .terminalResume, .worktreeResume: return .wake
         }

--- a/Sources/TBDDaemon/Database/ConfigStore.swift
+++ b/Sources/TBDDaemon/Database/ConfigStore.swift
@@ -123,6 +123,14 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     /// so `nil` here means "never chose" rather than "off". Resolve it through
     /// `Config.remoteDeleteEnabledDefault`, never through `?? false`.
     var remote_delete_enabled: Bool?
+    /// Gate for the orphan-GC leg that reclaims retained transcripts nobody
+    /// references. **Genuinely tri-state**, same shape as
+    /// `remote_delete_enabled`: the
+    /// `20260902140000_config_gc_retained_transcripts` migration carries no SQL
+    /// default, so `nil` here means "never chose" rather than "off". Resolve it
+    /// through `Config.gcRetainedTranscriptsEnabledDefault`, never through
+    /// `?? false`.
+    var gc_retained_transcripts_enabled: Bool?
     /// This installation's holder owner token, minted once by the first daemon
     /// that needs one and read forever after. **Not a flag**: NULL means "not
     /// yet minted", and the mint is the conditional UPDATE in
@@ -175,6 +183,9 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     ///   `remote_delete_enabled` — the gate on destroying a provider-hosted
     ///   session, whose soak is the one that matters most, because what it
     ///   permits cannot be undone from this machine.
+    /// - Parameter gcRetainedTranscriptsDefault: and truly the last, for
+    ///   `gc_retained_transcripts_enabled` — the retained-transcript GC leg's
+    ///   soak gate.
     func toModel(
         queuedPromptDefault: Bool = Config.queuedPromptDefault,
         autoCreateNotesDefault: Bool = Config.autoCreateNotesDefault,
@@ -187,7 +198,8 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         gcHolderRendezvousDefault: Bool = Config.gcHolderRendezvousEnabledDefault,
         gcRowlessHoldersDefault: Bool = Config.gcRowlessHoldersEnabledDefault,
         reapHolderChildrenDefault: Bool = Config.reapHolderChildrenEnabledDefault,
-        remoteDeleteDefault: Bool = Config.remoteDeleteEnabledDefault
+        remoteDeleteDefault: Bool = Config.remoteDeleteEnabledDefault,
+        gcRetainedTranscriptsDefault: Bool = Config.gcRetainedTranscriptsEnabledDefault
     ) -> Config {
         Config(
             defaultProfileID: default_profile_id.flatMap(UUID.init(uuidString:)),
@@ -259,6 +271,10 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             // And truly the last of them, for the remote-delete gate —
             // NOT `?? false`.
             remoteDeleteEnabled: remote_delete_enabled ?? remoteDeleteDefault,
+            // And truly the last of them, for the retained-transcript GC leg's
+            // gate — NOT `?? false`.
+            gcRetainedTranscriptsEnabled:
+                gc_retained_transcripts_enabled ?? gcRetainedTranscriptsDefault,
             remoteCreateDefaults: EnvOverridesCoding.decode(remote_create_defaults),
             // Passed straight through, NULL included: "not yet minted" is a
             // real state and has no default to resolve to.
@@ -740,6 +756,22 @@ public struct ConfigStore: Sendable {
         try await writer.write { db in
             try db.execute(
                 sql: "UPDATE config SET remote_delete_enabled = ? WHERE id = ?",
+                arguments: [enabled, Self.singletonID]
+            )
+        }
+    }
+
+    /// Persist the retained-transcript GC leg's gate (default OFF, soaking) —
+    /// read on top of the GC master switch, so both must be on for the leg to
+    /// run. Separate from `setRemoteDeleteEnabled` on purpose: that gate
+    /// destroys a session on a provider, this one reclaims TBD's own local
+    /// residue, and opting into either must never opt into the other. The
+    /// column is written on every call, because writing either value is the
+    /// explicit gesture that lifts it out of NULL forever after.
+    public func setGCRetainedTranscriptsEnabled(_ enabled: Bool) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE config SET gc_retained_transcripts_enabled = ? WHERE id = ?",
                 arguments: [enabled, Self.singletonID]
             )
         }

--- a/Sources/TBDDaemon/Database/ConfigStore.swift
+++ b/Sources/TBDDaemon/Database/ConfigStore.swift
@@ -116,6 +116,13 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     /// through `Config.reapHolderChildrenEnabledDefault`, never through
     /// `?? false`.
     var reap_holder_children_enabled: Bool?
+    /// Gate for `remote.delete`, the verb that destroys a provider-hosted agent
+    /// session. **Genuinely tri-state**, same shape as
+    /// `reap_holder_children_enabled`: the
+    /// `20260902130000_config_remote_delete` migration carries no SQL default,
+    /// so `nil` here means "never chose" rather than "off". Resolve it through
+    /// `Config.remoteDeleteEnabledDefault`, never through `?? false`.
+    var remote_delete_enabled: Bool?
     /// This installation's holder owner token, minted once by the first daemon
     /// that needs one and read forever after. **Not a flag**: NULL means "not
     /// yet minted", and the mint is the conditional UPDATE in
@@ -161,9 +168,13 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     ///   `gc_rowless_holders_enabled` — the row-less holder sweep's soak gate,
     ///   which is a separate opt-in because it kills processes rather than
     ///   unlinking files.
-    /// - Parameter reapHolderChildrenDefault: and the last of them, for
+    /// - Parameter reapHolderChildrenDefault: same shape once more, for
     ///   `reap_holder_children_enabled` — the `AgentReaper` holder leg's soak
     ///   gate.
+    /// - Parameter remoteDeleteDefault: and the last of them, for
+    ///   `remote_delete_enabled` — the gate on destroying a provider-hosted
+    ///   session, whose soak is the one that matters most, because what it
+    ///   permits cannot be undone from this machine.
     func toModel(
         queuedPromptDefault: Bool = Config.queuedPromptDefault,
         autoCreateNotesDefault: Bool = Config.autoCreateNotesDefault,
@@ -175,7 +186,8 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         ptyHolderDefault: Bool = Config.ptyHolderDefault,
         gcHolderRendezvousDefault: Bool = Config.gcHolderRendezvousEnabledDefault,
         gcRowlessHoldersDefault: Bool = Config.gcRowlessHoldersEnabledDefault,
-        reapHolderChildrenDefault: Bool = Config.reapHolderChildrenEnabledDefault
+        reapHolderChildrenDefault: Bool = Config.reapHolderChildrenEnabledDefault,
+        remoteDeleteDefault: Bool = Config.remoteDeleteEnabledDefault
     ) -> Config {
         Config(
             defaultProfileID: default_profile_id.flatMap(UUID.init(uuidString:)),
@@ -244,6 +256,9 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             // And truly the last of them, for the `AgentReaper` holder leg's
             // gate — NOT `?? false`.
             reapHolderChildrenEnabled: reap_holder_children_enabled ?? reapHolderChildrenDefault,
+            // And truly the last of them, for the remote-delete gate —
+            // NOT `?? false`.
+            remoteDeleteEnabled: remote_delete_enabled ?? remoteDeleteDefault,
             remoteCreateDefaults: EnvOverridesCoding.decode(remote_create_defaults),
             // Passed straight through, NULL included: "not yet minted" is a
             // real state and has no default to resolve to.
@@ -712,6 +727,19 @@ public struct ConfigStore: Sendable {
         try await writer.write { db in
             try db.execute(
                 sql: "UPDATE config SET reap_holder_children_enabled = ? WHERE id = ?",
+                arguments: [enabled, Self.singletonID]
+            )
+        }
+    }
+
+    /// Persist the remote-delete gate (default OFF, soaking) — the single
+    /// opt-in for destroying a provider-hosted agent session. The column is
+    /// written on every call, because writing either value is the explicit
+    /// gesture that lifts it out of NULL forever after.
+    public func setRemoteDeleteEnabled(_ enabled: Bool) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE config SET remote_delete_enabled = ? WHERE id = ?",
                 arguments: [enabled, Self.singletonID]
             )
         }

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -35,6 +35,11 @@ public final class TBDDatabase: Sendable {
     /// and detection"). Durable because a shadow's record carries no marker of
     /// TBD's own, so a row that is lost is a shadow nothing can recognise.
     public let shadowPeerArtifacts: ShadowPeerArtifactStore
+    /// TBD's record of the transcripts a provider has retained
+    /// (`docs/remote-provider-contract.md` § `retain <id>` / `import`). The
+    /// provider contract gives no way to enumerate the keys a provider issued,
+    /// so these rows are the only listing a caller has.
+    public let retainedTranscripts: RetainedTranscriptStore
 
     private static let logger = Logger(subsystem: "com.tbd.daemon", category: "migrations")
 
@@ -78,6 +83,7 @@ public final class TBDDatabase: Sendable {
         self.prBindings = PRBindingStore(writer: pool)
         self.claudeCloudSessions = ClaudeCloudSessionStore(writer: pool)
         self.shadowPeerArtifacts = ShadowPeerArtifactStore(writer: pool)
+        self.retainedTranscripts = RetainedTranscriptStore(writer: pool)
 
         let migrator = Self.buildMigrator()
         // Both refusal gates before touching the database: rethrow a
@@ -126,6 +132,7 @@ public final class TBDDatabase: Sendable {
         self.prBindings = PRBindingStore(writer: queue)
         self.claudeCloudSessions = ClaudeCloudSessionStore(writer: queue)
         self.shadowPeerArtifacts = ShadowPeerArtifactStore(writer: queue)
+        self.retainedTranscripts = RetainedTranscriptStore(writer: queue)
         // The same gates `init(path:)` runs. `migrationsForRegistration()`
         // cannot throw, so without this a resource bundle that failed to
         // resolve under `scripts/test.sh` would surface as scattered "no such

--- a/Sources/TBDDaemon/Database/Migrations/20260902120000_retained_transcript.sql
+++ b/Sources/TBDDaemon/Database/Migrations/20260902120000_retained_transcript.sql
@@ -1,0 +1,36 @@
+-- Receipts for transcripts a provider has retained in its own durable store
+-- (`docs/remote-provider-contract.md` § `retain <id>` / `import`, and
+-- `docs/specs/2026-09-02-remote-session-delete-and-transcript-exchange-design.md`).
+--
+-- A key is opaque and provider-scoped, so (provider, key) is the identity;
+-- everything else is what makes a key findable again by a human. Without this
+-- table a key printed once is unrecoverable: nothing in the provider contract
+-- lets a caller enumerate the keys it holds, so TBD's own row is the only
+-- record that a retained transcript exists at all.
+--
+-- `expires_at` is nullable and carries no DEFAULT, because an absent value is
+-- the contract's "the provider makes no claim" and must never be confused with
+-- an instant somebody chose. It is likewise never read as "kept forever".
+--
+-- `bytes` is NOT NULL: it is how a caller detects a truncated `recall`, and a
+-- row without it cannot do that job.
+--
+-- `origin_worktree_id` links an adopted lane, so a deleted lane's archived row
+-- can offer Revive-as-reseed. `local_path` is filled in when a `recall` writes
+-- the JSONL under `~/tbd/transcripts/`; it is what the GC leg reconciles files
+-- against.
+CREATE TABLE IF NOT EXISTS retained_transcript (
+    id TEXT PRIMARY KEY NOT NULL,
+    provider TEXT NOT NULL,
+    key TEXT NOT NULL,
+    expires_at DATETIME,
+    bytes INTEGER NOT NULL,
+    source_session_id TEXT,
+    source_title TEXT,
+    resolved_repo_id TEXT,
+    origin_worktree_id TEXT,
+    local_path TEXT,
+    created_at DATETIME NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_retained_transcript_provider_key
+    ON retained_transcript (provider, key);

--- a/Sources/TBDDaemon/Database/Migrations/20260902130000_config_remote_delete.sql
+++ b/Sources/TBDDaemon/Database/Migrations/20260902130000_config_remote_delete.sql
@@ -1,0 +1,12 @@
+-- Gate for `remote.delete`, the verb that destroys a provider-hosted agent
+-- session (docs/specs/2026-09-02-remote-session-delete-and-transcript-exchange-design.md).
+-- It gates the destructive verb only: `retain`, `import` and `recall` are
+-- non-destructive and are gated by the provider's declared capabilities alone.
+--
+-- No DEFAULT clause, deliberately. ADD COLUMN ... DEFAULT would backfill every
+-- existing row, destroying the distinction between "nobody has chosen" (NULL)
+-- and "chose off" (0) — which is what made auto_hibernate_enabled impossible to
+-- graduate without a forcing UPDATE that also reset deliberate opt-ins.
+-- The shipped default lives in exactly one place:
+-- Config.remoteDeleteEnabledDefault.
+ALTER TABLE config ADD COLUMN remote_delete_enabled INTEGER;

--- a/Sources/TBDDaemon/Database/Migrations/20260902140000_config_gc_retained_transcripts.sql
+++ b/Sources/TBDDaemon/Database/Migrations/20260902140000_config_gc_retained_transcripts.sql
@@ -1,0 +1,13 @@
+-- Gate for the orphan-GC leg that reclaims retained transcripts nobody
+-- references — JSONL files under ~/tbd/transcripts/ that no retained_transcript
+-- row points at, and rows whose provider-stated expiry has passed
+-- (docs/specs/2026-09-02-remote-session-delete-and-transcript-exchange-design.md,
+-- "Reclamation").
+--
+-- No DEFAULT clause, deliberately. ADD COLUMN ... DEFAULT would backfill every
+-- existing row, destroying the distinction between "nobody has chosen" (NULL)
+-- and "chose off" (0) — which is what made auto_hibernate_enabled impossible to
+-- graduate without a forcing UPDATE that also reset deliberate opt-ins.
+-- The shipped default lives in exactly one place:
+-- Config.gcRetainedTranscriptsEnabledDefault.
+ALTER TABLE config ADD COLUMN gc_retained_transcripts_enabled INTEGER;

--- a/Sources/TBDDaemon/Database/RemoteSessionStore.swift
+++ b/Sources/TBDDaemon/Database/RemoteSessionStore.swift
@@ -305,6 +305,14 @@ public struct RemoteSessionStore: Sendable {
     /// to the drift rule, a session the user just deleted would render as live,
     /// then stale, then gone, across two poll intervals.
     ///
+    /// **On its own this write is not enough**, and the missing half lives in
+    /// `RemoteProviderManager.noteDeletion`: a `list` whose snapshot was
+    /// captured before the provider committed the deletion still names the
+    /// session, and applying it after this DELETE would silently insert the row
+    /// back with `gone` false. The caller stamps a deletion watermark that the
+    /// snapshot-apply path checks, so such a snapshot is dropped rather than
+    /// applied.
+    ///
     /// Returns whether a row actually went away, mirroring `markGone` and
     /// `dismiss` so the handler can skip a pointless UI broadcast. Deleting a
     /// session TBD never mirrored changes nothing, which is a normal outcome:

--- a/Sources/TBDDaemon/Database/RemoteSessionStore.swift
+++ b/Sources/TBDDaemon/Database/RemoteSessionStore.swift
@@ -292,6 +292,33 @@ public struct RemoteSessionStore: Sendable {
         }
     }
 
+    /// Removes the mirror row outright, for a session THIS daemon just
+    /// destroyed through `remote.delete`.
+    ///
+    /// **This is deliberately not `markGone`, and the difference is the whole
+    /// point.** `gone` is what an *observed* disappearance produces: the drift
+    /// rule needs two consecutive complete absences before it will believe a
+    /// session is missing, because one absence is as likely to be transport
+    /// trouble as death. A delete is a *requested* disappearance — the caller
+    /// has positive knowledge that the record is gone, from the provider's own
+    /// answer — so there is nothing to disambiguate and no reason to wait. Left
+    /// to the drift rule, a session the user just deleted would render as live,
+    /// then stale, then gone, across two poll intervals.
+    ///
+    /// Returns whether a row actually went away, mirroring `markGone` and
+    /// `dismiss` so the handler can skip a pointless UI broadcast. Deleting a
+    /// session TBD never mirrored changes nothing, which is a normal outcome:
+    /// the contract has `delete` succeed on an unknown id.
+    @discardableResult
+    public func deleteRow(provider: String, sessionID: String) async throws -> Bool {
+        try await writer.write { db in
+            try db.execute(
+                sql: "DELETE FROM remote_session WHERE provider = ? AND sessionID = ?",
+                arguments: [provider, sessionID])
+            return db.changesCount > 0
+        }
+    }
+
     /// One provider's mirror rows. Adoption reads these straight after a
     /// snapshot to learn the repo association this store just PINNED, rather
     /// than resolving `meta["repo"]` a second time — a second resolution could

--- a/Sources/TBDDaemon/Database/RetainedTranscriptStore.swift
+++ b/Sources/TBDDaemon/Database/RetainedTranscriptStore.swift
@@ -142,6 +142,25 @@ public struct RetainedTranscriptStore: Sendable {
         }
     }
 
+    /// The newest receipt taken from a session that belonged to this lane, or
+    /// nil when the lane has none.
+    ///
+    /// This is what makes Revive-as-reseed possible: an archived lane whose
+    /// remote session was destroyed has no session left to unarchive, and the
+    /// receipt is the only thing that says its conversation survived somewhere.
+    /// Newest first, because a lane retained more than once — say a manual
+    /// `tbd remote retain` and then a `delete --retain` — wants the last word
+    /// on the conversation rather than the first.
+    public func latest(originWorktreeID: UUID) async throws -> RetainedTranscript? {
+        try await writer.read { db in
+            try RetainedTranscriptRecord
+                .filter(Column("origin_worktree_id") == originWorktreeID.uuidString)
+                .order(Column("created_at").desc)
+                .fetchOne(db)?
+                .toModel()
+        }
+    }
+
     /// Record where a `recall` wrote this receipt's JSONL on this machine.
     ///
     /// Returns whether a row actually changed, mirroring

--- a/Sources/TBDDaemon/Database/RetainedTranscriptStore.swift
+++ b/Sources/TBDDaemon/Database/RetainedTranscriptStore.swift
@@ -1,0 +1,192 @@
+import Foundation
+import GRDB
+import TBDShared
+
+/// GRDB row for the `retained_transcript` table
+/// (`20260902120000_retained_transcript`).
+///
+/// Snake-case property names because the columns are snake-case, matching
+/// `ShadowPeerArtifactRecord`'s convention rather than `RemoteSessionRow`'s
+/// camel-case one — the table is new, so it follows the newer of the two.
+struct RetainedTranscriptRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
+    static let databaseTableName = "retained_transcript"
+
+    var id: String
+    var provider: String
+    var key: String
+    var expires_at: Date?
+    var bytes: Int
+    var source_session_id: String?
+    var source_title: String?
+    var resolved_repo_id: String?
+    var origin_worktree_id: String?
+    var local_path: String?
+    var created_at: Date
+
+    init(from model: RetainedTranscript) {
+        self.id = model.id.uuidString
+        self.provider = model.provider
+        self.key = model.key
+        self.expires_at = model.expiresAt
+        self.bytes = model.bytes
+        self.source_session_id = model.sourceSessionID
+        self.source_title = model.sourceTitle
+        self.resolved_repo_id = model.resolvedRepoID?.uuidString
+        self.origin_worktree_id = model.originWorktreeID?.uuidString
+        self.local_path = model.localPath
+        self.created_at = model.createdAt
+    }
+
+    /// Nil when `id` is not a UUID — a row nothing this daemon wrote could
+    /// have produced. Dropped rather than crashed, on the same terms every
+    /// other record type in this directory degrades: one unreadable row costs
+    /// its own key and never the listing.
+    func toModel() -> RetainedTranscript? {
+        guard let uuid = UUID(uuidString: id) else { return nil }
+        return RetainedTranscript(
+            id: uuid,
+            provider: provider,
+            key: key,
+            expiresAt: expires_at,
+            bytes: bytes,
+            sourceSessionID: source_session_id,
+            sourceTitle: source_title,
+            resolvedRepoID: resolved_repo_id.flatMap(UUID.init(uuidString:)),
+            originWorktreeID: origin_worktree_id.flatMap(UUID.init(uuidString:)),
+            localPath: local_path,
+            createdAt: created_at)
+    }
+}
+
+/// Reads and writes TBD's record of the transcripts a provider has retained.
+///
+/// The rows are the only enumeration a caller has: the provider contract gives
+/// no way to list the keys a provider issued, so a key that never reaches this
+/// table is a retained transcript nobody can ever recall.
+public struct RetainedTranscriptStore: Sendable {
+    let writer: any DatabaseWriter
+
+    init(writer: any DatabaseWriter) {
+        self.writer = writer
+    }
+
+    /// Record one receipt.
+    ///
+    /// `(provider, key)` is unique, and re-recording the same pair replaces the
+    /// row rather than failing. That is correct rather than lossy: a provider
+    /// that hands back a key it has already issued is describing the same
+    /// stored blob, and the newer receipt carries the newer `bytes` and
+    /// `expires_at`. The existing row's `local_path` is deliberately preserved
+    /// — a file already on this disk is still there, and a re-`retain` is not
+    /// a reason to forget where it landed.
+    public func insert(_ transcript: RetainedTranscript) async throws {
+        let row = RetainedTranscriptRecord(from: transcript)
+        try await writer.write { db in
+            try db.execute(
+                sql: """
+                    INSERT INTO retained_transcript
+                        (id, provider, key, expires_at, bytes, source_session_id,
+                         source_title, resolved_repo_id, origin_worktree_id,
+                         local_path, created_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(provider, key) DO UPDATE SET
+                        expires_at = excluded.expires_at,
+                        bytes = excluded.bytes,
+                        source_session_id = COALESCE(excluded.source_session_id, source_session_id),
+                        source_title = COALESCE(excluded.source_title, source_title),
+                        resolved_repo_id = COALESCE(excluded.resolved_repo_id, resolved_repo_id),
+                        origin_worktree_id = COALESCE(excluded.origin_worktree_id, origin_worktree_id),
+                        local_path = COALESCE(excluded.local_path, local_path)
+                    """,
+                arguments: [
+                    row.id, row.provider, row.key, row.expires_at, row.bytes,
+                    row.source_session_id, row.source_title, row.resolved_repo_id,
+                    row.origin_worktree_id, row.local_path, row.created_at,
+                ])
+        }
+    }
+
+    /// One provider's receipts, newest first — the order a human wants when
+    /// hunting for the key they made a moment ago.
+    public func all(provider: String) async throws -> [RetainedTranscript] {
+        try await writer.read { db in
+            try RetainedTranscriptRecord
+                .filter(Column("provider") == provider)
+                .order(Column("created_at").desc)
+                .fetchAll(db)
+                .compactMap { $0.toModel() }
+        }
+    }
+
+    /// Every receipt across every provider, newest first.
+    public func all() async throws -> [RetainedTranscript] {
+        try await writer.read { db in
+            try RetainedTranscriptRecord
+                .order(Column("created_at").desc)
+                .fetchAll(db)
+                .compactMap { $0.toModel() }
+        }
+    }
+
+    /// The one row filed under `(provider, key)`, which is the identity a key
+    /// has. A key is never looked up without its provider: keys are
+    /// provider-scoped and two providers may legitimately issue the same
+    /// string.
+    public func find(provider: String, key: String) async throws -> RetainedTranscript? {
+        try await writer.read { db in
+            try RetainedTranscriptRecord
+                .filter(Column("provider") == provider)
+                .filter(Column("key") == key)
+                .fetchOne(db)?
+                .toModel()
+        }
+    }
+
+    /// Record where a `recall` wrote this receipt's JSONL on this machine.
+    ///
+    /// Returns whether a row actually changed, mirroring
+    /// `RemoteSessionStore.dismiss`'s contract — an unknown `(provider, key)`
+    /// changes nothing, and a caller can tell that from a write it made.
+    @discardableResult
+    public func setLocalPath(provider: String, key: String, localPath: String?) async throws -> Bool {
+        try await writer.write { db in
+            try db.execute(
+                sql: """
+                    UPDATE retained_transcript SET local_path = ?
+                    WHERE provider = ? AND key = ?
+                    """,
+                arguments: [localPath, provider, key])
+            return db.changesCount > 0
+        }
+    }
+
+    /// Drop every row whose provider-stated expiry has passed as of `date`.
+    ///
+    /// **`date` is passed, never read here.** Expiry is a persisted timestamp
+    /// compared against now, which is the date seam rather than the clock seam
+    /// (`Duration` is behavior; `Date` is data), and a store that read its own
+    /// clock could not be tested without one.
+    ///
+    /// Rows with no stated expiry are never touched: an absent `expires_at`
+    /// means the provider made no claim, and deleting on that would discard
+    /// records the provider may still be holding. Returns the number of rows
+    /// removed so a sweep can report what it reclaimed.
+    @discardableResult
+    public func deleteExpired(asOf date: Date) async throws -> Int {
+        try await writer.write { db in
+            try db.execute(
+                sql: "DELETE FROM retained_transcript WHERE expires_at IS NOT NULL AND expires_at <= ?",
+                arguments: [date])
+            return db.changesCount
+        }
+    }
+
+    /// Forget one receipt outright.
+    public func delete(provider: String, key: String) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: "DELETE FROM retained_transcript WHERE provider = ? AND key = ?",
+                arguments: [provider, key])
+        }
+    }
+}

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -756,6 +756,39 @@ public struct WorktreeStore: Sendable {
         }
     }
 
+    /// Point a remote lane row at a different provider session.
+    ///
+    /// Written for Revive-as-reseed and used nowhere else: a lane whose remote
+    /// session was destroyed keeps its row — its branch, its PR context, its
+    /// place in the repo's Archived tab — and Revive gives that row a freshly
+    /// created session seeded from the retained transcript. Rebinding is what
+    /// keeps the history and the new session the same lane instead of two.
+    ///
+    /// **`path` moves with the binding, and that is not bookkeeping.** A remote
+    /// row's `path` is `WorktreeLocation.storagePath`, a pure function of
+    /// `(provider, sessionID)`, and `worktree.path` is NOT NULL UNIQUE — it is
+    /// the constraint that stops two rows claiming one session. Leaving the old
+    /// path behind would leave the row occupying the destroyed session's
+    /// address, so the next lane to be created for that id would collide with a
+    /// row that no longer means anything.
+    ///
+    /// The caller rebinds **before** mirroring the new session, so adoption
+    /// finds this row by `findRemote(provider:sessionID:)` and nests nothing
+    /// new; rebinding afterwards would let adoption mint a second lane first.
+    public func rebindRemote(id: UUID, provider: String, sessionID: String) async throws {
+        let location = WorktreeLocation.remote(provider: provider, sessionID: sessionID)
+        try await writer.write { db in
+            guard var record = try WorktreeRecord.fetchOne(db, key: id.uuidString) else {
+                throw DatabaseError(message: "Worktree not found")
+            }
+            record.location = "remote"
+            record.providerName = provider
+            record.providerSessionID = sessionID
+            if let path = location.storagePath { record.path = path }
+            try record.update(db)
+        }
+    }
+
     /// Update a worktree's hasConflicts flag.
     public func updateHasConflicts(id: UUID, hasConflicts: Bool) async throws {
         try await writer.write { db in

--- a/Sources/TBDDaemon/GC/OrphanGC.swift
+++ b/Sources/TBDDaemon/GC/OrphanGC.swift
@@ -292,6 +292,10 @@ public actor OrphanGC {
             config: config, dryRun: dryRun, planned: &planned, reaped: &reaped
         )
 
+        await reclaimRetainedTranscripts(
+            config: config, dryRun: dryRun, planned: &planned, reaped: &reaped
+        )
+
         // Snapshot retention never runs in dryRun; the outer guard already
         // establishes gcEnabled for any non-dry run.
         if !dryRun {
@@ -750,6 +754,216 @@ public actor OrphanGC {
                 reaped += 1
             }
         }
+    }
+
+    // MARK: - Retained transcripts
+
+    /// Reclaims the local half of the retained-transcript exchange — the JSONL
+    /// files under `~/tbd/transcripts/` that no `retained_transcript` row
+    /// references, and the rows whose provider-stated expiry has passed. The
+    /// named reconciler for that resource class
+    /// (`docs/specs/2026-09-02-remote-session-delete-and-transcript-exchange-design.md`,
+    /// "Reclamation").
+    ///
+    /// **Load-bearing, not tidiness.** The teleport flow calls `import` and
+    /// then `create`: a `create` that fails after a successful `import` leaves
+    /// a retained blob on the provider and a row here that nothing will ever
+    /// use, because the session it was going to seed was never made. No
+    /// creation path can close that window — the provider commits its side
+    /// before TBD learns whether the second call will succeed — so the standing
+    /// guarantee is this sweep rather than any rollback, which is precisely
+    /// what the named-reconciler doctrine exists for.
+    ///
+    /// Gated by `gcRetainedTranscriptsEnabled` on top of `gcEnabled`, both
+    /// because every new background sweep that unlinks files and deletes rows
+    /// soaks behind its own switch, and because the exchange whose residue it
+    /// reclaims only exists on a provider declaring `retain`, `import` or
+    /// `recall` — a machine with no such provider has nothing here for this leg
+    /// to be right or wrong about.
+    ///
+    /// `dryRun` bypasses the flag exactly as `sweep` lets it bypass `gcEnabled`:
+    /// planning is read-only, and someone deciding whether to enable a
+    /// default-off flag needs to see what enabling it would reclaim before
+    /// flipping it. A NON-dry run still requires the flag.
+    ///
+    /// Three directions all fail toward keeping:
+    ///
+    ///   - **A row with no stated expiry is never dropped.** An absent
+    ///     `expires_at` means the provider made no claim, not that the claim
+    ///     lapsed, and the key lives in that row and nowhere else — the
+    ///     contract gives no way to enumerate a provider's keys, so a dropped
+    ///     row is a blob nobody can ever recall again.
+    ///   - **A file younger than `gcGraceSeconds` is kept**, and so is one
+    ///     whose age cannot be read. `recall` writes the file before it records
+    ///     the path on the row, so a sweep landing inside that window would
+    ///     otherwise unlink a transcript that was arriving as it looked.
+    ///   - **An unreadable row list skips the whole leg**, rather than reading
+    ///     an empty list as "no file is referenced" and unlinking the lot.
+    ///
+    /// Only `<base>/<provider>/<key>.jsonl` is a candidate — a whitelist, so
+    /// anything else a human or a future feature puts in that tree is left
+    /// alone rather than classified by a rule that never considered it. Emptied
+    /// provider directories are left behind too: there is one per provider ever
+    /// used, which is bounded by hand-registered providers, and removing a
+    /// directory a concurrent `recall` is writing into buys nothing.
+    ///
+    /// No `ReapRecord` is written. The record type is directory-shaped and
+    /// keyed by the worktree a reap removed, and neither half here has one;
+    /// there is nothing a `tbd gc restore` could put back, since the transcript
+    /// this file held still lives on the provider until its own expiry.
+    private func reclaimRetainedTranscripts(
+        config: Config, dryRun: Bool, planned: inout [String], reaped: inout Int
+    ) async {
+        guard config.gcRetainedTranscriptsEnabled || dryRun else { return }
+
+        let rows: [RetainedTranscript]
+        do {
+            rows = try await db.retainedTranscripts.all()
+        } catch {
+            logger.error("""
+            gc: retained-transcript rows unreadable this sweep \
+            (\(error.localizedDescription, privacy: .public)) — skipping the phase
+            """)
+            planned.append("KEEP rows-unreadable retained-transcripts")
+            return
+        }
+
+        // One reading of now for both halves, through the date seam: expiry is
+        // a persisted timestamp compared against a time, which is data rather
+        // than behavior, so it never comes from a clock read inside here.
+        let asOf = now()
+        // `hasExpired(asOf:)` rather than an inline comparison, so this leg and
+        // `RetainedTranscriptStore.deleteExpired(asOf:)` cannot drift on what
+        // "expired" means — and so the no-claim reading above has one home.
+        let expired = rows.filter { $0.hasExpired(asOf: asOf) }
+        for row in expired {
+            planned.append("REAP retained-transcript-row \(row.provider)/\(row.key)")
+        }
+
+        // Whether those rows actually went is what decides if their files count
+        // as referenced below. A dry run deletes nothing and a failed delete
+        // leaves them in place; in both cases the files stay referenced, so a
+        // row and its file are never split apart by a half-completed pass.
+        var expiredRowsRemoved = false
+        if !dryRun && !expired.isEmpty {
+            do {
+                let removed = try await db.retainedTranscripts.deleteExpired(asOf: asOf)
+                expiredRowsRemoved = true
+                reaped += removed
+                logger.info("""
+                gc: dropped \(removed, privacy: .public) expired retained-transcript row(s)
+                """)
+            } catch {
+                planned.append("KEEP row-delete-failed retained-transcripts")
+                logger.warning("""
+                gc: could not drop expired retained-transcript rows \
+                (\(error.localizedDescription, privacy: .public)) — their files are kept too
+                """)
+            }
+        }
+
+        let expiredIdentities = Set(expired.map { Self.transcriptIdentity($0) })
+        let liveRows = expiredRowsRemoved
+            ? rows.filter { !expiredIdentities.contains(Self.transcriptIdentity($0)) }
+            : rows
+
+        // Both the canonical path a `recall` writes to AND whatever path the
+        // row actually records. They are the same today, and a row written by
+        // another build (or a file moved by hand and re-recorded) would make
+        // them differ — in which case both are referenced, never one.
+        var referenced = Set<String>()
+        for row in liveRows {
+            referenced.insert(deletionQueueCollector.resolvedPath(
+                TBDConstants.retainedTranscriptPath(provider: row.provider, key: row.key).path))
+            if let localPath = row.localPath {
+                referenced.insert(deletionQueueCollector.resolvedPath(localPath))
+            }
+        }
+
+        for file in Self.retainedTranscriptFiles(in: TBDConstants.retainedTranscriptsDir) {
+            guard !referenced.contains(deletionQueueCollector.resolvedPath(file.path)) else {
+                continue
+            }
+            if let reason = Self.youngTranscriptKeepReason(
+                path: file.path, asOf: asOf, graceSeconds: config.gcGraceSeconds
+            ) {
+                planned.append("KEEP \(reason) \(file.path)")
+                logger.debug("""
+                gc: keep \(reason, privacy: .public) \(file.path, privacy: .public)
+                """)
+                continue
+            }
+            planned.append("REAP retained-transcript \(file.path)")
+            // This leg's guard is `gcRetainedTranscriptsEnabled || dryRun`, so
+            // every line below runs only with the flag actually on.
+            guard !dryRun else { continue }
+            do {
+                try FileManager.default.removeItem(at: file)
+                reaped += 1
+                logger.info("""
+                gc: unlinked unreferenced retained transcript \(file.path, privacy: .public)
+                """)
+            } catch {
+                planned.append("KEEP unlink-failed \(file.path)")
+                logger.warning("""
+                gc: could not unlink \(file.path, privacy: .public): \
+                \(error.localizedDescription, privacy: .public)
+                """)
+            }
+        }
+    }
+
+    /// `(provider, key)` as one comparable value — the identity a receipt has,
+    /// with a separator no path component can contain.
+    private static func transcriptIdentity(_ row: RetainedTranscript) -> String {
+        "\(row.provider)\u{0}\(row.key)"
+    }
+
+    /// Every `<base>/<provider>/<key>.jsonl` file, and nothing else in the
+    /// tree: not a stray file at the top level, not a deeper nesting, not a
+    /// file with another extension. An unreadable (or absent) directory yields
+    /// nothing, which classifies nothing.
+    private static func retainedTranscriptFiles(in base: URL) -> [URL] {
+        let fm = FileManager.default
+        guard let providerDirectories = try? fm.contentsOfDirectory(
+            at: base, includingPropertiesForKeys: [.isDirectoryKey], options: [.skipsHiddenFiles])
+        else { return [] }
+
+        var files: [URL] = []
+        for directory in providerDirectories {
+            var isDirectory: ObjCBool = false
+            guard fm.fileExists(atPath: directory.path, isDirectory: &isDirectory),
+                  isDirectory.boolValue,
+                  let entries = try? fm.contentsOfDirectory(
+                    at: directory, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles])
+            else { continue }
+            for entry in entries where entry.pathExtension == "jsonl" {
+                var entryIsDirectory: ObjCBool = false
+                guard fm.fileExists(atPath: entry.path, isDirectory: &entryIsDirectory),
+                      !entryIsDirectory.boolValue
+                else { continue }
+                files.append(entry)
+            }
+        }
+        return files.sorted { $0.path < $1.path }
+    }
+
+    /// A keep reason when the file is too young to judge, `nil` when it is old
+    /// enough to reclaim. The newer of creation and modification is used, which
+    /// is the reading that keeps longest; a file whose dates cannot be read at
+    /// all keeps as `unknown-age` rather than being guessed at.
+    private static func youngTranscriptKeepReason(
+        path: String, asOf: Date, graceSeconds: Int
+    ) -> String? {
+        guard let attributes = try? FileManager.default.attributesOfItem(atPath: path) else {
+            return "unknown-age"
+        }
+        let dates = [
+            attributes[.creationDate] as? Date,
+            attributes[.modificationDate] as? Date,
+        ].compactMap { $0 }
+        guard let newest = dates.max() else { return "unknown-age" }
+        return asOf.timeIntervalSince(newest) < Double(graceSeconds) ? "grace" : nil
     }
 
     // MARK: - Row-less holders

--- a/Sources/TBDDaemon/Remote/ProviderCreateBody.swift
+++ b/Sources/TBDDaemon/Remote/ProviderCreateBody.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+/// Composes the JSON body TBD writes to a provider's `create` stdin
+/// (`docs/remote-provider-contract.md` § `create`).
+///
+/// One composer, two callers: `remote.create` and the seeded create behind
+/// Revive-as-reseed (`RemoteLaneLifecycle+Actuate`). They must agree about
+/// where `seed` sits and about how an opaque key is escaped, and the way to
+/// make two callers agree is to give them one function rather than two
+/// implementations that look alike today.
+///
+/// The body is assembled as **text rather than encoded**, deliberately.
+/// `paramsJSON` is a caller-supplied JSON object that the contract has TBD pass
+/// through verbatim: decoding and re-encoding it would rewrite the caller's own
+/// object — key order, number spelling, whitespace — for no gain, and would
+/// give TBD an opinion about a structure it is explicitly not supposed to
+/// interpret. Everything else in the body is escaped properly on the way in.
+enum ProviderCreateBody {
+    /// `create`'s stdin.
+    ///
+    /// - Parameters:
+    ///   - paramsJSON: the provider-defined `params` object, already validated
+    ///     as a JSON object by the caller and spliced through untouched.
+    ///   - seedRetainedKey: the retained transcript the new session begins
+    ///     with, or nil to send no `seed` field at all. **Nil omits the key
+    ///     rather than emitting `null`** — a provider reading `"seed": null`
+    ///     would have to decide what an explicit nothing means, and the
+    ///     contract never asks it to.
+    ///   - idempotencyKey: the dedupe token, minted by the caller so a retry
+    ///     can reuse the same one.
+    ///
+    /// `seed` is a top-level sibling of `params` and `idempotency_key`, never a
+    /// member of `params` — `params` is the provider's own free-form set, where
+    /// a contract field would be indistinguishable from a provider-defined one.
+    static func compose(
+        paramsJSON: String, seedRetainedKey: String?, idempotencyKey: String
+    ) -> String {
+        var seedField = ""
+        if let seedRetainedKey {
+            seedField = #", "seed": {"retained_key": \#(jsonStringLiteral(seedRetainedKey))}"#
+        }
+        return #"{"params": \#(paramsJSON)\#(seedField), "idempotency_key": \#(jsonStringLiteral(idempotencyKey))}"#
+    }
+
+    /// A JSON string literal — quotes and escaping included — for a value
+    /// spliced into the hand-composed body above.
+    ///
+    /// Load-bearing for the seed key specifically. A retained key is opaque:
+    /// the contract forbids a caller from parsing, constructing or
+    /// pattern-matching one, so it may perfectly well contain a quote, a
+    /// backslash or a newline. Interpolated raw, such a key produces a
+    /// malformed request the provider rejects with no indication of why.
+    ///
+    /// `JSONSerialization` needs a top-level container, so the value goes in as
+    /// a one-element array and the brackets come off. The fallback is an empty
+    /// literal, which the provider rejects as an unknown key — a failure a
+    /// caller can act on, rather than a broken body.
+    static func jsonStringLiteral(_ value: String) -> String {
+        guard let data = try? JSONSerialization.data(withJSONObject: [value]),
+              let text = String(bytes: data, encoding: .utf8),
+              text.count >= 2 else {
+            return "\"\""
+        }
+        return String(text.dropFirst().dropLast())
+    }
+
+    /// A `params` object built from a `[String: String]` map of provider field
+    /// names to values — the shape TBD's stored create-param defaults take
+    /// (`Config.remoteCreateDefaults`, `Repo.remoteCreateDefaults`).
+    ///
+    /// Blank values are dropped rather than sent as empty strings: an omitted
+    /// optional field lets the provider apply its own answer, while an empty
+    /// string is a value, and a provider that validates its fields would
+    /// reject one. Keys are sorted so the same map always composes the same
+    /// body, which is what makes a composed body assertable in a test.
+    static func paramsJSON(from values: [String: String]) -> String {
+        let filtered = values.filter {
+            !$0.value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+        guard let data = try? JSONSerialization.data(
+                withJSONObject: filtered, options: [.sortedKeys]),
+              let text = String(bytes: data, encoding: .utf8) else {
+            return "{}"
+        }
+        return text
+    }
+}

--- a/Sources/TBDDaemon/Remote/ProviderEventsSupervisor.swift
+++ b/Sources/TBDDaemon/Remote/ProviderEventsSupervisor.swift
@@ -424,7 +424,13 @@ actor ProviderEventsSupervisor {
                 snapshot: sessions, provider: config.name, complete: complete,
                 requestStartedAt: connectionOpenedAt)
         case .session(let session):
-            await manager.applyUpsert(session, provider: config.name)
+            // `composedSince` for the same reason `snapshot` above passes
+            // `requestStartedAt`: a line pushed over this connection may have
+            // been composed at any point since it opened, so a delete this
+            // daemon issued in the meantime is newer than the line and the
+            // mirror row must not come back.
+            await manager.applyUpsert(
+                session, provider: config.name, composedSince: connectionOpenedAt)
         case .removed(let id):
             await manager.applyRemoval(sessionID: id, provider: config.name)
         }

--- a/Sources/TBDDaemon/Remote/RemoteLaneLifecycle+Actuate.swift
+++ b/Sources/TBDDaemon/Remote/RemoteLaneLifecycle+Actuate.swift
@@ -261,6 +261,34 @@ extension RemoteLaneLifecycle {
         return nil
     }
 
+    /// Files an adopted lane whose remote session has just been **destroyed**
+    /// by `remote.delete`.
+    ///
+    /// A deleted lane keeps its place: the worktree row goes to the repo's
+    /// Archived tab with its branch and PR context intact, which is where a
+    /// human looks for work they finished with, and where Revive-as-reseed
+    /// later finds the receipt. Losing the row would lose that context along
+    /// with the session.
+    ///
+    /// It reuses `performArchive` rather than writing a second archive path —
+    /// the watermark ordering, the row write and the broadcast are all the same
+    /// obligations — with `.rowOnly` as the step, and only `.rowOnly`. The
+    /// session no longer exists on the provider, so there is no `archive <id>`
+    /// left to invoke: a verb call here would address an id the provider has
+    /// just been told to forget, and the `gone` exemption `.rowOnly` was built
+    /// for describes exactly this situation — nothing live to misdescribe, and
+    /// no verb that could reach it.
+    ///
+    /// Returns `nil` on success, or the message to surface. The `.rowOnly` step
+    /// invokes nothing, so the only failure it can report is a row write that
+    /// threw — and that throws rather than returning a message, as it does for
+    /// every other caller of `performArchive`.
+    func archiveLaneAfterDelete(
+        _ worktree: Worktree, now: @Sendable () -> Date = { Date() }
+    ) async throws -> String? {
+        try await performArchive(.rowOnly, worktree: worktree, now: now)
+    }
+
     /// What a retirement verb came back with.
     ///
     /// The Session object travels out rather than being mirrored here, so the

--- a/Sources/TBDDaemon/Remote/RemoteLaneLifecycle+Actuate.swift
+++ b/Sources/TBDDaemon/Remote/RemoteLaneLifecycle+Actuate.swift
@@ -49,8 +49,21 @@ extension RemoteLaneLifecycle {
 
     enum ReviveStep: Equatable {
         case invokeUnarchive(provider: String, sessionID: String)
+        /// Create a new session seeded from a retained transcript and rebind
+        /// this row to it — Revive on a lane whose session was destroyed. See
+        /// `RemoteLaneLifecycle.reseedPlan`.
+        case reseed(provider: String, key: String)
         case rowOnly
     }
+
+    /// The budget for the seeded `create` behind a reseed. The same 60 seconds
+    /// `remote.create` gets, because it is the same verb doing the same work
+    /// with one more field on its stdin.
+    ///
+    /// Stated here rather than reached for on `RPCRouter`: the lifecycle does
+    /// not depend on the router, and inverting that to share a number would be
+    /// the wrong dependency for the smaller gain.
+    static let reseedCreateTimeout: TimeInterval = 60
 
     /// Routes an archive of `worktree`, applying the verb path's two guards.
     ///
@@ -102,12 +115,46 @@ extension RemoteLaneLifecycle {
     /// reads as `false` here (`isArchived`, the contract's display reading):
     /// a provider that made no claim is not one asserting a retirement this
     /// flip would fight with.
-    func reviveDecision(for worktree: Worktree) async throws -> ReviveDecision {
+    ///
+    /// **The reseed question is asked first, and it is asked of the mirror
+    /// row's absence.** `remote.delete` drops the mirror row the moment the
+    /// provider confirms the destruction, so an archived lane with a receipt
+    /// and no row is one whose session no longer exists — and `unarchive` on a
+    /// destroyed id would degrade to a row-only filing, quietly returning a
+    /// lane bound to nothing to the active list. See
+    /// `RemoteLaneLifecycle.reseedPlan` for why a receipt alone is not the
+    /// discriminator.
+    ///
+    /// The reseed path is deliberately **not** behind the stale-snapshot gate,
+    /// for the same reason `.rowOnly` is not: that gate exists because the
+    /// guards read `agentState` and `meta.workspace_dirty` out of a mirror a
+    /// stale inventory makes untrustworthy, and this path reads no mirror at
+    /// all — there is none to read. Gating it would make a deleted lane
+    /// unrevivable for as long as its provider stayed unhealthy.
+    ///
+    /// `now` is the date seam: `expiresAt` is a persisted timestamp compared
+    /// against the present, never a duration (`Tests/CLAUDE.md`, "Clock and
+    /// date seams"). Defaulted, so no call site changes.
+    func reviveDecision(
+        for worktree: Worktree, now: @Sendable () -> Date = { Date() }
+    ) async throws -> ReviveDecision {
         guard case .remote(let provider, let sessionID) = worktree.location else {
             return .refused("Cannot revive \(worktree.name) through the remote path: it is a local worktree.")
         }
         let row = try await db.remoteSessions.row(provider: provider, sessionID: sessionID)
         let capabilities = await manager.declaredCapabilities(provider: provider)
+        let receipt = try? await db.retainedTranscripts.latest(originWorktreeID: worktree.id)
+        switch Self.reseedPlan(
+            receipt: receipt, sessionStillListed: row != nil,
+            capabilities: capabilities, now: now()
+        ) {
+        case .reseed(let key):
+            return .proceed(.reseed(provider: provider, key: key))
+        case .expired(let message), .refusedNoSeed(let message):
+            return .refused("Cannot revive \(worktree.name): \(message)")
+        case .unarchive:
+            break
+        }
         switch Self.revivePlan(
             capabilities: capabilities,
             providerReportsArchived: row?.decodedPayload?.isArchived ?? false
@@ -232,7 +279,10 @@ extension RemoteLaneLifecycle {
         let decidedAt = now()
         let prior = await manager.noteFilingDecision(worktreeID: worktree.id, at: decidedAt)
         var mirrored: (session: RemoteSessionPayload, provider: String)?
-        if case .invokeUnarchive(let provider, let sessionID) = step {
+        switch step {
+        case .rowOnly:
+            break
+        case .invokeUnarchive(let provider, let sessionID):
             switch await invokeRetirementVerb(
                 "unarchive", provider: provider, sessionID: sessionID) {
             case .failed(let message):
@@ -241,6 +291,37 @@ extension RemoteLaneLifecycle {
                 return message
             case .succeeded(let session):
                 mirrored = session.map { ($0, provider) }
+            }
+        case .reseed(let provider, let key):
+            switch await invokeSeededCreate(provider: provider, key: key, worktree: worktree) {
+            case .failed(let message):
+                await manager.withdrawFilingDecision(
+                    worktreeID: worktree.id, restoring: prior, ifStillAt: decidedAt)
+                return message
+            case .succeeded(let session):
+                guard let session else {
+                    // A create that answers with nothing readable has failed at
+                    // the transport however healthy its exit code looked, and
+                    // there is no session id to rebind the row to. Reporting
+                    // success would leave a revived lane pointing at a session
+                    // that was destroyed.
+                    await manager.withdrawFilingDecision(
+                        worktreeID: worktree.id, restoring: prior, ifStillAt: decidedAt)
+                    return "provider '\(provider)' returned an unreadable session from a seeded create"
+                }
+                do {
+                    // Before the row write and before any mirror: adoption keys
+                    // off `findRemote(provider:sessionID:)`, so rebinding first
+                    // is what makes the new session land on THIS lane instead
+                    // of minting a second one beside it.
+                    try await db.worktrees.rebindRemote(
+                        id: worktree.id, provider: provider, sessionID: session.id)
+                } catch {
+                    await manager.withdrawFilingDecision(
+                        worktreeID: worktree.id, restoring: prior, ifStillAt: decidedAt)
+                    throw error
+                }
+                mirrored = (session, provider)
             }
         }
         do {
@@ -287,6 +368,81 @@ extension RemoteLaneLifecycle {
         _ worktree: Worktree, now: @Sendable () -> Date = { Date() }
     ) async throws -> String? {
         try await performArchive(.rowOnly, worktree: worktree, now: now)
+    }
+
+    /// Runs the seeded `create` behind a reseed and decodes the session it
+    /// returns.
+    ///
+    /// Shares `VerbOutcome` with `invokeRetirementVerb` because the caller
+    /// wants the same two answers — a message to surface, or a session to
+    /// mirror — but deliberately does **not** share its `not_found`
+    /// degradation: `create` addresses no existing id, so it has nothing to
+    /// report missing, and treating a failure here as "file the row anyway"
+    /// would return a lane to the active list with no session behind it.
+    ///
+    /// This creates a provider session, which is a durable external resource —
+    /// but through the same `create` verb `remote.create` uses, so the same
+    /// reconcilers cover it: the provider's own `list` poll is ground truth,
+    /// adoption binds a session to a row, and the drift rule retires a row
+    /// whose session stops being enumerated. It is a routine call site on an
+    /// existing creation path, not a new kind of resource.
+    private func invokeSeededCreate(
+        provider: String, key: String, worktree: Worktree
+    ) async -> VerbOutcome {
+        let body = ProviderCreateBody.compose(
+            paramsJSON: ProviderCreateBody.paramsJSON(from: await reseedParams(for: worktree)),
+            seedRetainedKey: key,
+            idempotencyKey: "tbd-\(UUID().uuidString.lowercased())")
+        let result: ProviderResult
+        do {
+            result = try await manager.invoke(
+                providerName: provider, verb: ["create"], stdin: Data(body.utf8),
+                timeout: Self.reseedCreateTimeout)
+        } catch let error as ProviderRunError {
+            remoteLaneLogger.error(
+                "seeded create provider=\(provider, privacy: .public) timed out")
+            switch error {
+            case .timeout(let timedOutVerb):
+                return .failed("provider '\(provider)' timed out running '\(timedOutVerb)'")
+            }
+        } catch {
+            remoteLaneLogger.error(
+                "seeded create provider=\(provider, privacy: .public) failed: \(String(describing: error), privacy: .public)")
+            return .failed("\(error)")
+        }
+        if result.failureClass != nil {
+            let message = result.decodedError?.message ?? "create failed (exit \(result.exitCode))"
+            remoteLaneLogger.error(
+                "seeded create provider=\(provider, privacy: .public) failed: \(message, privacy: .public)")
+            return .failed(message)
+        }
+        return .succeeded(try? result.decoded(RemoteSessionPayload.self, provider: provider))
+    }
+
+    /// The `params` object a reseed's `create` carries.
+    ///
+    /// **TBD replays its stored create-param defaults and invents nothing
+    /// else.** `Repo.remoteCreateDefaults` over `Config.remoteCreateDefaults`
+    /// is the same fall-through the create form uses, and the maps are keyed by
+    /// the provider's own field names precisely so TBD can store and replay
+    /// them without interpreting them. The form's other levels — the ambient
+    /// repo prefill, a freshly generated slug — belong to a human filling in a
+    /// sheet, and re-deriving them here would be a second implementation of
+    /// rules that already have one.
+    ///
+    /// The consequence is worth stating rather than hiding: a provider with a
+    /// required field neither map supplies rejects the create with its own
+    /// `invalid_params` naming that field. That is an actionable failure with a
+    /// remedy the user already has — set the repo's remote create defaults —
+    /// and it is a great deal better than TBD guessing a value for a field
+    /// whose meaning is the provider's alone.
+    private func reseedParams(for worktree: Worktree) async -> [String: String] {
+        var values = (try? await db.config.get().remoteCreateDefaults) ?? [:]
+        if let repoID = worktree.repoID,
+           let repo = try? await db.repos.get(id: repoID) {
+            for (field, value) in repo.remoteCreateDefaults { values[field] = value }
+        }
+        return values
     }
 
     /// What a retirement verb came back with.

--- a/Sources/TBDDaemon/Remote/RemoteLaneLifecycle.swift
+++ b/Sources/TBDDaemon/Remote/RemoteLaneLifecycle.swift
@@ -1,4 +1,5 @@
 import Foundation
+import TBDShared
 
 /// The remote half of retiring and reviving a lane
 /// (`docs/specs/2026-08-16-remote-lane-archive-design.md`, "Archive",
@@ -112,23 +113,16 @@ struct RemoteLaneLifecycle: Sendable {
     /// here; one that says nothing degrades to the `working` guard alone.
     /// **The guard is therefore inert until a provider adopts the key, and
     /// TBD never fabricates the fact.**
-    static let dirtyWorkspaceMetaKey = "workspace_dirty"
+    static let dirtyWorkspaceMetaKey = RemoteSessionPayload.dirtyWorkspaceMetaKey
 
     /// Reads the dirty-checkout claim out of a session's `meta`.
     ///
-    /// `meta` is a flat string-to-string map, so the claim arrives as text.
-    /// Only `"true"` and `"1"` (trimmed, case-insensitively) are read as a
-    /// claim; an absent key, an empty value, and anything unrecognized all
-    /// mean "no claim was made" and leave the guard inert. Deliberately not
-    /// a permissive truthiness test: this value decides whether a user's
-    /// archive is refused, and inventing a claim out of a value a provider
-    /// meant for display would refuse a gesture nobody asked to block.
+    /// The reading itself lives on `RemoteSessionPayload` in `TBDShared`,
+    /// because the app's delete confirmation asks the same question of the same
+    /// key and two copies of a rule this sharp would drift. This name stays as
+    /// the daemon's way in.
     static func metaReportsDirtyWorkspace(_ meta: [String: String]?) -> Bool {
-        guard let raw = meta?[dirtyWorkspaceMetaKey] else { return false }
-        switch raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
-        case "true", "1": return true
-        default: return false
-        }
+        RemoteSessionPayload.metaReportsDirtyWorkspace(meta)
     }
 
     /// The refusal for a lane whose agent is mid-task. Parallels how local

--- a/Sources/TBDDaemon/Remote/RemoteLaneLifecycle.swift
+++ b/Sources/TBDDaemon/Remote/RemoteLaneLifecycle.swift
@@ -61,6 +61,75 @@ struct RemoteLaneLifecycle: Sendable {
         case refusedNoUnarchive(String)
     }
 
+    /// What Revive means for an archived remote lane once the question "is
+    /// there still a session to unarchive?" has been asked
+    /// (`docs/specs/2026-09-02-remote-session-delete-and-transcript-exchange-design.md`,
+    /// "A deleted lane keeps its place").
+    ///
+    /// A deleted lane is archived like any other, and the row is deliberately
+    /// kept — with its branch, its PR context, and its place in the repo's
+    /// Archived tab. What it no longer has is a session: `delete` destroyed it
+    /// and the mirror row went with it. So Revive on such a row cannot mean
+    /// `unarchive`; it means creating a new session seeded from the transcript
+    /// the delete retained. The gesture, the place and the word already mean
+    /// this, which is why it is not a second button.
+    enum RemoteLaneReseedPlan: Equatable {
+        /// Create a new session seeded from this key, and rebind the row to it.
+        case reseed(key: String)
+        /// The provider's stated expiry has passed. Refuse, naming the date.
+        /// The row stays as history — a lane whose conversation lapsed is
+        /// still a record of work that happened.
+        case expired(String)
+        /// A receipt survives, but this provider cannot begin a session from
+        /// one. Refuse naming `seed` rather than sending it and hoping: the
+        /// contract has providers ignore stdin fields they do not recognize,
+        /// so an unchecked reseed would produce an empty session wearing a
+        /// revived lane's name.
+        case refusedNoSeed(String)
+        /// Nothing about this lane calls for a reseed — take the ordinary
+        /// archive/unarchive path, unchanged.
+        case unarchive
+    }
+
+    /// Decides whether `worktree.revive` on a remote lane means reseeding.
+    ///
+    /// `sessionStillListed` is the discriminator, and it is the mirror row's
+    /// existence rather than anything about the receipt. A receipt on its own
+    /// proves only that somebody retained a transcript — `tbd remote retain`
+    /// is an ordinary thing to do to a session that is alive and well, and
+    /// reviving *that* lane must still be an `unarchive`. `remote.delete` drops
+    /// the mirror row the instant the provider confirms the destruction, so an
+    /// archived lane with a receipt and no row is the deleted one.
+    ///
+    /// `now` is passed rather than read: `expiresAt` is a persisted timestamp
+    /// compared against the present, which is the date seam and not the clock
+    /// seam (`Duration` is behavior; `Date` is data).
+    ///
+    /// Messages come back bare, as `archivePlan`'s and `revivePlan`'s do, and
+    /// the caller prefixes them with the lane's name.
+    static func reseedPlan(
+        receipt: RetainedTranscript?, sessionStillListed: Bool,
+        capabilities: Set<String>, now: Date
+    ) -> RemoteLaneReseedPlan {
+        guard !sessionStillListed else { return .unarchive }
+        guard let receipt else { return .unarchive }
+        if receipt.hasExpired(asOf: now), let expiresAt = receipt.expiresAt {
+            return .expired(
+                "the transcript retained from its session expired on " +
+                "\(RetainReceipt.formatTimestamp(expiresAt)), so there is nothing left to " +
+                "recreate the conversation from. The row stays as a record of the work."
+            )
+        }
+        guard capabilities.contains("seed") else {
+            return .refusedNoSeed(
+                "its session was destroyed, so reviving it means creating a new one seeded " +
+                "from the retained transcript — and this provider does not declare the " +
+                "\"seed\" capability. See docs/remote-provider-contract.md"
+            )
+        }
+        return .reseed(key: receipt.key)
+    }
+
     /// Decides how `worktree.archive` should treat a remote row.
     ///
     /// Order matters: a provider that declares `archive` takes the verb

--- a/Sources/TBDDaemon/Remote/RemoteProviderManager.swift
+++ b/Sources/TBDDaemon/Remote/RemoteProviderManager.swift
@@ -148,6 +148,46 @@ public actor RemoteProviderManager {
     /// (`docs/specs/2026-08-16-remote-lane-archive-design.md` §"Stale
     /// snapshots"). Swept on every apply so it cannot grow without bound.
     private var filingDecisions: [UUID: Date] = [:]
+
+    /// The identity a remote session is addressed by everywhere except the
+    /// worktree table. `delete` names one of these, and so does every mirror
+    /// row — whether or not a lane was ever adopted for it.
+    private struct DeletedSessionKey: Hashable {
+        let provider: String
+        let sessionID: String
+    }
+
+    /// `(provider, session id)` → the moment TBD destroyed that session through
+    /// `remote.delete`. The deletion watermark: a response whose request began
+    /// before one of these entries composed its answer without knowing about
+    /// the delete, so a sighting it carries of that session is dropped instead
+    /// of being allowed to re-insert the mirror row the delete removed.
+    ///
+    /// **Keyed by the session, not by a worktree.** `filingDecisions` above is
+    /// keyed by worktree id because archive and revive are acts upon a lane.
+    /// Delete is not: most deletable sessions were never adopted and have no
+    /// worktree at all — they are the bare rows in the sidebar — so a
+    /// worktree-keyed watermark would leave the common case unprotected. This
+    /// key is the one `remote.delete` itself is addressed by, so an adopted
+    /// lane and a bare row take exactly the same path.
+    ///
+    /// **In memory, and a watermark rather than a tombstone row.** The
+    /// alternative — a `deletedAt` column on `remote_session` that the
+    /// snapshot-apply path refuses to resurrect — costs a migration, a GRDB
+    /// record field and a `TBDShared` model field, and then leaves a row in a
+    /// table whose entire meaning is "sessions the provider enumerates", so
+    /// every reader of it (both sidebar filters, adoption, `remote.list`, the
+    /// pin dock) would have to learn to skip a state it has no other reason to
+    /// know about — and a tombstone that outlives the daemon needs a reconciler
+    /// to reclaim it. None of that buys anything here, because the window this
+    /// defends is open only while a provider request is outstanding and no such
+    /// request survives a restart: afterwards every request start is later than
+    /// every prior delete, so there is nothing left to suppress. That is the
+    /// same argument `filingDecisions` makes, and this map is bounded the same
+    /// way — swept to two poll intervals on every apply (`sweepDeletions`), so
+    /// a session legitimately re-created under a deleted id is mirrored again
+    /// by the first poll whose request began after the delete returned.
+    private var deletions: [DeletedSessionKey: Date] = [:]
     /// True once `loadRegistryAndDescribe()` has swept the registry. It is
     /// the line between "boot will describe this provider" and "nothing ever
     /// will" — see `enrollIfNeeded`, which is a no-op before it flips.
@@ -510,8 +550,14 @@ public actor RemoteProviderManager {
         complete: Bool = true, now: Date = Date(),
         requestStartedAt: Date? = nil
     ) async throws {
+        // Dropped before any of the three writers below sees them: the mirror,
+        // adoption and the filing sync each hold something a sighting of an
+        // already-deleted session would resurrect.
+        let sightedSince = requestStartedAt ?? now
+        let sightings = suppressingDeleted(
+            sessions, provider: provider, sightedSince: sightedSince, now: now)
         let outcome = try await db.remoteSessions.applySnapshot(
-            provider: provider, sessions: sessions, complete: complete, now: now)
+            provider: provider, sessions: sightings, complete: complete, now: now)
         // After the mirror, never before: adoption reads the repo association
         // `applySnapshot` just pinned rather than resolving `meta["repo"]` a
         // second time. Unconditional on `outcome.changed` — a session can
@@ -520,7 +566,7 @@ public actor RemoteProviderManager {
         // and the poll after the user registers the repo is exactly that case.
         // Also unconditional on `complete`: an incomplete snapshot is
         // authoritative about presence, so a session it sighted is adopted.
-        broadcastAdoptions(await adopter.adopt(sessions: sessions, provider: provider))
+        broadcastAdoptions(await adopter.adopt(sessions: sightings, provider: provider))
         // After adoption, never before: a session first sighted in this very
         // snapshot already reporting `archived: true` must be filed on the
         // row adoption just minted, not skipped for lack of one.
@@ -531,8 +577,8 @@ public actor RemoteProviderManager {
         // here as a complete one. Completeness gates only the absence-derived
         // and inventory-freshness conclusions below.
         await syncFilingDecisions(
-            sessions: sessions, provider: provider,
-            requestStartedAt: requestStartedAt ?? now, now: now)
+            sessions: sightings, provider: provider,
+            requestStartedAt: sightedSince, now: now)
         if complete {
             lastSuccessfulSnapshotAt[provider] = now
             // A live COMPLETE snapshot supersedes whatever the persisted row
@@ -575,11 +621,23 @@ public actor RemoteProviderManager {
     /// user started the lane from a worktree's nested `+`: it is the parent
     /// they asked for, handed to adoption as an override of whatever the
     /// provider stamped. See `RemoteSessionAdopter.adopt(session:provider:parentOverride:)`.
+    ///
+    /// `composedSince` is the earliest moment the provider could have written
+    /// this line. It is nil — meaning "arrival" — for every response to a verb
+    /// this daemon just issued, which is fresh by construction. The events
+    /// stream supplies the moment it opened the connection instead, because a
+    /// line pushed over a long-lived connection may have been composed at any
+    /// point since. Only the deletion watermark reads it; the filing sync keeps
+    /// taking a pushed line as fresh, which is what it has always done.
     func applyUpsert(
         _ session: RemoteSessionPayload, provider: String, parentWorktreeID: UUID? = nil,
-        date: Date = Date()
+        date: Date = Date(), composedSince: Date? = nil
     ) async {
         let arrivedAt = date
+        guard !suppressingDeleted(
+            [session], provider: provider,
+            sightedSince: composedSince ?? arrivedAt, now: arrivedAt).isEmpty
+        else { return }
         let outcome: SnapshotOutcome
         do {
             outcome = try await db.remoteSessions.upsertOne(
@@ -725,6 +783,97 @@ public actor RemoteProviderManager {
     /// none survived the sweep). Nothing in production reads this.
     func filingDecision(for worktreeID: UUID) -> Date? {
         filingDecisions[worktreeID]
+    }
+
+    /// Records that TBD itself just destroyed `(provider, sessionID)` through
+    /// `remote.delete`, so a provider response composed before `at` cannot put
+    /// its mirror row back.
+    ///
+    /// Stamped twice by the handler, for the reason the retirement verbs stamp
+    /// twice (`RPCRouter.retire`): once before the verb, so a `list` already in
+    /// flight cannot act on the session while the delete runs, and again once
+    /// the verb has returned, because a poll launched *after* the first stamp
+    /// but before the provider committed the destruction still carries the
+    /// pre-delete inventory. A poll whose request begins after the second stamp
+    /// cannot see the session at all — the provider destroyed it before
+    /// answering.
+    ///
+    /// **The map only ever moves forward**, and for the same reason
+    /// `noteFilingDecision` does: the instants arriving here are not ordered by
+    /// the order of the calls, and a blind assignment could hand a
+    /// still-outstanding response a watermark it predates. Returns whatever was
+    /// on file before, so a delete that then fails can put it back through
+    /// `withdrawDeletion`.
+    @discardableResult
+    func noteDeletion(provider: String, sessionID: String, at date: Date) -> Date? {
+        let key = DeletedSessionKey(provider: provider, sessionID: sessionID)
+        let prior = deletions[key]
+        if let prior, prior >= date { return prior }
+        deletions[key] = date
+        return prior
+    }
+
+    /// Takes back a watermark recorded in anticipation of a delete that then
+    /// did not happen — the verb failed, or answered something TBD could not
+    /// read — leaving the session where it was. Keeping it would hide a live
+    /// session from the mirror for up to two poll intervals over a destruction
+    /// that never occurred.
+    ///
+    /// Restores rather than deletes, and only while the map still holds what
+    /// this caller wrote: `withdrawFilingDecision` documents both conditions,
+    /// and they hold here for the same reasons.
+    func withdrawDeletion(
+        provider: String, sessionID: String, restoring prior: Date?, ifStillAt written: Date
+    ) {
+        let key = DeletedSessionKey(provider: provider, sessionID: sessionID)
+        guard deletions[key] == written else { return }
+        if let prior {
+            deletions[key] = prior
+        } else {
+            deletions.removeValue(forKey: key)
+        }
+    }
+
+    /// Test seam: the deletion watermark on file for one session, or nil when
+    /// none is (or none survived the sweep). Nothing in production reads this.
+    func deletionWatermark(provider: String, sessionID: String) -> Date? {
+        deletions[DeletedSessionKey(provider: provider, sessionID: sessionID)]
+    }
+
+    /// Drops the sightings a `remote.delete` this daemon issued has already
+    /// answered: a session is suppressed when its watermark is *later* than the
+    /// moment the response carrying it could first have been composed.
+    ///
+    /// The boundary belongs to the response, exactly as in
+    /// `filingDecisionAllowsFlip`: a delete recorded at the very instant the
+    /// request began is one that request could have accounted for. Everything
+    /// else passes through untouched, so a provider whose sessions nobody has
+    /// deleted pays one empty-dictionary check per poll.
+    private func suppressingDeleted(
+        _ sessions: [RemoteSessionPayload], provider: String,
+        sightedSince: Date, now: Date
+    ) -> [RemoteSessionPayload] {
+        defer { sweepDeletions(now: now) }
+        guard !deletions.isEmpty else { return sessions }
+        return sessions.filter { session in
+            let key = DeletedSessionKey(provider: provider, sessionID: session.id)
+            guard let deletedAt = deletions[key], deletedAt > sightedSince else { return true }
+            remoteLogger.debug(
+                "dropped \(provider, privacy: .public)/\(session.id, privacy: .public) from a response that predates its delete"
+            )
+            return false
+        }
+    }
+
+    /// Drops deletion watermarks older than two poll intervals, on the same
+    /// reasoning and the same cutoff as `sweepFilingDecisions`: a provider
+    /// request outstanding for longer has already timed out (`list` is bounded
+    /// at 30s), so no response can still be in flight from before them. Past
+    /// that the entry can only do harm — it would hide a session somebody
+    /// legitimately re-created under the same id.
+    private func sweepDeletions(now: Date) {
+        let cutoff = now.addingTimeInterval(-2 * Self.pollInterval)
+        deletions = deletions.filter { $0.value >= cutoff }
     }
 
     /// Test seam: awaited inside the check-then-act window, immediately before

--- a/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
@@ -255,6 +255,25 @@ extension RPCRouter {
         return .ok()
     }
 
+    /// Persist the retained-transcript GC gate — the default-off soak switch
+    /// for the `OrphanGC` leg that unlinks retained transcripts nobody
+    /// references and drops receipts whose expiry has passed, read on top of
+    /// the GC master switch.
+    ///
+    /// This is how the soak is turned on. Deliberately a different verb from
+    /// the remote-delete gate below: enabling a local reclaimer must never
+    /// enable the one verb that destroys a session on a provider. Like the
+    /// master switch, flipping it off does not cancel an in-progress sweep:
+    /// `OrphanGC.sweep` re-reads the flag on its next pass.
+    func handleConfigSetGCRetainedTranscriptsEnabled(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(
+            ConfigSetGCRetainedTranscriptsEnabledParams.self, from: paramsData)
+        try await db.config.setGCRetainedTranscriptsEnabled(params.enabled)
+        // Reuse the existing config-change channel so the app reloads Config.
+        subscriptions.broadcast(delta: .modelProfilesChanged)
+        return .ok()
+    }
+
     /// Persist the remote-delete gate — the default-off soak switch for
     /// `remote.delete`, the verb that destroys a provider-hosted session.
     ///

--- a/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
@@ -255,6 +255,24 @@ extension RPCRouter {
         return .ok()
     }
 
+    /// Persist the remote-delete gate — the default-off soak switch for
+    /// `remote.delete`, the verb that destroys a provider-hosted session.
+    ///
+    /// This is how the soak is turned on. Every other flag in this file gates
+    /// something a reconciler could undo; this one gates the single act that
+    /// nothing on this machine can reverse, which is exactly why it must have a
+    /// supported switch rather than being reachable only by hand-editing the
+    /// database. Flipping it off refuses the next delete; it cannot recall one
+    /// already made.
+    func handleConfigSetRemoteDeleteEnabled(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(
+            ConfigSetRemoteDeleteEnabledParams.self, from: paramsData)
+        try await db.config.setRemoteDeleteEnabled(params.enabled)
+        // Reuse the existing config-change channel so the app reloads Config.
+        subscriptions.broadcast(delta: .modelProfilesChanged)
+        return .ok()
+    }
+
     /// Persist the orphaned-process collector gate — the default-off soak
     /// switch for reclaiming processes that outlived the worktree they were
     /// rooted in, read on top of the GC master switch.

--- a/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
@@ -267,7 +267,7 @@ extension RPCRouter {
     /// `OrphanGC.sweep` re-reads the flag on its next pass.
     func handleConfigSetGCRetainedTranscriptsEnabled(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(
-            ConfigSetGCRetainedTranscriptsEnabledParams.self, from: paramsData)
+            ConfigSetGCRetainedTranscriptsParams.self, from: paramsData)
         try await db.config.setGCRetainedTranscriptsEnabled(params.enabled)
         // Reuse the existing config-change channel so the app reloads Config.
         subscriptions.broadcast(delta: .modelProfilesChanged)

--- a/Sources/TBDDaemon/Server/RPCRouter+RemoteHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+RemoteHandlers.swift
@@ -734,6 +734,27 @@ extension RPCRouter {
         return try RPCResponse(result: RemoteRecallResult(jsonl: jsonl, localPath: localPath))
     }
 
+    /// Lists the receipts TBD holds, optionally filtered to one provider.
+    ///
+    /// Local-only — it reads TBD's own rows and never invokes a provider verb,
+    /// so unlike the three verbs above it needs no `RemoteProviderManager`, no
+    /// cloud gate, and no capability. It still passes through `remoteGate()`
+    /// because the whole feature hides behind `config.remoteBackendsEnabled`,
+    /// which is the same reason `handleRemoteSetPin` does.
+    func handleRemoteRetainedList(_ paramsData: Data) async throws -> RPCResponse {
+        guard try await remoteGate() != nil else {
+            return Self.remoteBackendsDisabledResponse
+        }
+        let params = try decoder.decode(RemoteRetainedListParams.self, from: paramsData)
+        let transcripts: [RetainedTranscript]
+        if let provider = params.provider {
+            transcripts = try await db.retainedTranscripts.all(provider: provider)
+        } else {
+            transcripts = try await db.retainedTranscripts.all()
+        }
+        return try RPCResponse(result: RemoteRetainedListResult(transcripts: transcripts))
+    }
+
     /// Writes one receipt into `retained_transcript`, filling in whatever TBD
     /// already knows about the session it came from.
     ///

--- a/Sources/TBDDaemon/Server/RPCRouter+RemoteHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+RemoteHandlers.swift
@@ -57,6 +57,18 @@ extension RPCRouter {
     /// off entirely, this says the compiled cloud provider is.
     private static let claudeCloudDisabledResponse = RPCResponse(error: "claude cloud sessions disabled")
 
+    /// `remote.delete`'s own refusal, and the only feature-flag refusal in this
+    /// file. It names the flag and how to lift it, because a refusal that only
+    /// says "disabled" leaves a soak participant guessing which of three gates
+    /// stopped them — the subsystem, the cloud gate, or this one.
+    ///
+    /// Kept as a shared value for the same reason
+    /// `remoteBackendsDisabledResponse` is: tests assert equality against the
+    /// exact string.
+    static let remoteDeleteDisabledResponse = RPCResponse(error:
+        "remote delete is disabled (config remote_delete_enabled); " +
+        "turn it on with `tbd remote allow-delete on`")
+
     /// The per-invocation timeout for the `create` verb, applied to both the
     /// initial call and its one same-key retry below. Provider-agnostic at
     /// this layer — every `remote.*` backend's `create` gets this budget —
@@ -845,6 +857,161 @@ extension RPCRouter {
                 """)
         }
         return url.path
+    }
+
+    /// The contract's budget for `delete`. Shorter than the exchange verbs'
+    /// 60 seconds because a delete moves no transcript — with `--retain` the
+    /// provider is doing both, and the contract still says 30, so this follows
+    /// the contract rather than second-guessing it.
+    private static let deleteTimeout: TimeInterval = 30
+
+    /// Destroys a provider-hosted session (`docs/remote-provider-contract.md` §
+    /// `delete <id> [--retain]`). Mirrors `handleRemoteStop`'s shape — same
+    /// outer gate, same cloud gate, same `ProviderRunError` timeout branch,
+    /// same `failureClass` branch surfacing `decodedError?.message` — with
+    /// three additions the other verbs do not carry.
+    ///
+    /// **The feature flag is checked before the capability, and after the two
+    /// subsystem gates.** The subsystem gates answer whether the request is
+    /// admissible at all, and every provider-named `remote.*` method must
+    /// refuse identically when they are shut; the flag is this feature's own
+    /// policy and belongs after them. It sits before the capability check and
+    /// before anything is spawned, so a daemon with the flag off never runs a
+    /// provider's `delete` for any reason.
+    ///
+    /// **`--retain` needs the `retain` capability too.** The contract makes the
+    /// flag valid only where the provider declares `retain`; sending it to a
+    /// provider that does not would either be ignored — destroying a session
+    /// the caller believed was being preserved — or fail after the fact.
+    ///
+    /// **A successful delete drops the mirror row at once.** See
+    /// `RemoteSessionStore.deleteRow` for why this must not wait for the drift
+    /// rule; it is the piece of this handler most likely to read as redundant
+    /// and be removed.
+    ///
+    /// `deleted: false` is a success, not an error: the contract has deleting
+    /// an unknown or already-deleted id exit 0 saying so, and the caller's
+    /// intent — that this session not exist — holds either way. The row is
+    /// dropped and the lane filed on that reading too, because the provider has
+    /// just stated the session is not there.
+    func handleRemoteDelete(
+        _ paramsData: Data, actor: ActuationActor? = nil,
+        now: @Sendable () -> Date = { Date() }
+    ) async throws -> RPCResponse {
+        guard let manager = try await remoteGate() else {
+            return Self.remoteBackendsDisabledResponse
+        }
+        let params = try decoder.decode(RemoteDeleteParams.self, from: paramsData)
+        if let refusal = try await cloudGate(provider: params.provider) { return refusal }
+        guard try await db.config.get().remoteDeleteEnabled else {
+            return Self.remoteDeleteDisabledResponse
+        }
+        let capabilities = await declaredCapabilities(manager, provider: params.provider)
+        guard capabilities.contains("delete") else {
+            return Self.missingCapabilityResponse(
+                provider: params.provider, capability: "delete",
+                section: "delete <id> [--retain]")
+        }
+        if params.retain, !capabilities.contains("retain") {
+            return Self.missingCapabilityResponse(
+                provider: params.provider, capability: "retain",
+                section: "delete <id> [--retain]")
+        }
+        let actuationID = try await beginActuation(
+            .remoteDelete, actor: actor,
+            target: .remote(provider: params.provider, session: params.sessionID))
+        var verb = ["delete", params.sessionID]
+        if params.retain { verb.append("--retain") }
+        let result: ProviderResult
+        do {
+            result = try await manager.invoke(
+                providerName: params.provider, verb: verb, stdin: nil,
+                timeout: Self.deleteTimeout)
+        } catch let error as ProviderRunError {
+            remoteHandlerLogger.error(
+                "remote.delete provider=\(params.provider, privacy: .public) timed out")
+            let message = Self.friendlyMessage(for: error, provider: params.provider)
+            await finishActuation(actuationID, .transportFailed, error: message)
+            return RPCResponse(error: message)
+        }
+        if result.failureClass != nil {
+            let message = result.decodedError?.message ?? "delete failed (exit \(result.exitCode))"
+            remoteHandlerLogger.error(
+                "remote.delete provider=\(params.provider, privacy: .public) failed: \(message, privacy: .public)")
+            await finishActuation(actuationID, .transportFailed, error: message)
+            return RPCResponse(error: message)
+        }
+        let outcome: RemoteDeleteResult
+        do {
+            outcome = try result.decoded(RemoteDeleteResult.self, provider: params.provider)
+        } catch {
+            // The session may well be destroyed — the provider exited 0 — but
+            // TBD cannot say so from an unreadable answer, and must not drop
+            // the row on a guess. A contract bug is reported as one.
+            let message = "provider '\(params.provider)' returned an unreadable delete result"
+            remoteHandlerLogger.error(
+                "remote.delete provider=\(params.provider, privacy: .public): \(message, privacy: .public)")
+            await finishActuation(actuationID, .transportFailed, error: message)
+            return RPCResponse(error: message)
+        }
+        await recordDeleteAftermath(outcome, params: params, now: now)
+        await finishActuation(actuationID, .dispatched)
+        return try RPCResponse(result: outcome)
+    }
+
+    /// Everything TBD writes down once a `delete` has come back successfully,
+    /// in the one order that works.
+    ///
+    /// 1. **Record the receipt first**, while the mirror row and the lane are
+    ///    still there to be read: `recordReceipt` fills the row's title, repo
+    ///    and originating lane from them, and those are what make a key
+    ///    findable by a human months later. After step 2 they are gone.
+    /// 2. **Drop the mirror row**, immediately — see
+    ///    `RemoteSessionStore.deleteRow`.
+    /// 3. **File the adopted lane**, so a deleted lane keeps its place in the
+    ///    repo's Archived tab with its branch and PR context.
+    ///
+    /// Nothing here can fail the delete. The provider has already destroyed the
+    /// session; a bookkeeping write that throws is logged and the caller still
+    /// hears that the destruction happened, because reporting failure would
+    /// invite a retry of an act that cannot be repeated.
+    private func recordDeleteAftermath(
+        _ outcome: RemoteDeleteResult, params: RemoteDeleteParams,
+        now: @Sendable () -> Date
+    ) async {
+        if let receipt = outcome.retained {
+            await recordReceipt(
+                receipt, provider: params.provider, sessionID: params.sessionID)
+        }
+        let lane = try? await db.worktrees.findRemote(
+            provider: params.provider, sessionID: params.sessionID)
+        do {
+            if try await db.remoteSessions.deleteRow(
+                provider: params.provider, sessionID: params.sessionID) {
+                subscriptions.broadcast(delta: .remoteSessionsChanged)
+            }
+        } catch {
+            remoteHandlerLogger.error("""
+                deleted \(params.provider, privacy: .public)/\(params.sessionID, privacy: .public) \
+                but could not drop its mirror row: \(error.localizedDescription, privacy: .public). \
+                The drift rule will reach the same answer two polls from now
+                """)
+        }
+        guard let lane, let manager = remoteManager else { return }
+        let lanes = RemoteLaneLifecycle(db: db, subscriptions: subscriptions, manager: manager)
+        do {
+            if let message = try await lanes.archiveLaneAfterDelete(lane, now: now) {
+                remoteHandlerLogger.error("""
+                    deleted \(params.provider, privacy: .public)/\(params.sessionID, privacy: .public) \
+                    but could not file its lane: \(message, privacy: .public)
+                    """)
+            }
+        } catch {
+            remoteHandlerLogger.error("""
+                deleted \(params.provider, privacy: .public)/\(params.sessionID, privacy: .public) \
+                but could not file its lane: \(error.localizedDescription, privacy: .public)
+                """)
+        }
     }
 
     func handleRemoteDismiss(_ paramsData: Data) async throws -> RPCResponse {

--- a/Sources/TBDDaemon/Server/RPCRouter+RemoteHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+RemoteHandlers.swift
@@ -136,31 +136,6 @@ extension RPCRouter {
         return trimmed
     }
 
-    /// A JSON string literal — quotes and escaping included — for a value TBD
-    /// must splice into a hand-composed request body.
-    ///
-    /// `create`'s body is assembled as text rather than encoded, because
-    /// `paramsJSON` is a caller-supplied JSON object spliced through verbatim
-    /// and re-encoding it would rewrite the caller's own formatting. Everything
-    /// else in that body has so far been a value TBD minted itself. A retained
-    /// key is not: it is an opaque provider-issued string that MUST NOT be
-    /// parsed or pattern-matched, so it may contain a quote, a backslash, or a
-    /// newline, and interpolating one raw would produce a malformed request the
-    /// provider rejects with no indication of why.
-    ///
-    /// `JSONSerialization` needs a top-level container, so the value is encoded
-    /// as a one-element array and the brackets are dropped. The fallback is an
-    /// empty literal, which the provider will reject as an unknown key —
-    /// the failure a caller can act on, rather than a broken body.
-    private static func jsonStringLiteral(_ value: String) -> String {
-        guard let data = try? JSONSerialization.data(withJSONObject: [value]),
-              let text = String(bytes: data, encoding: .utf8),
-              text.count >= 2 else {
-            return "\"\""
-        }
-        return String(text.dropFirst().dropLast())
-    }
-
     /// Turns a provider timeout into a message the app can show, instead of
     /// letting `ProviderRunError.timeout`'s raw enum description
     /// (`timeout(verb: "stop")`) leak through the router's catch-all.
@@ -227,17 +202,12 @@ extension RPCRouter {
         // the capability gate exists to prevent. That is also why the check
         // sits here and not at a caller: nothing upstream is trusted to have
         // made it (the same rule `handleRemoteRetain` follows).
-        var seedField = ""
-        if let seedKey = params.seedRetainedKey {
-            guard await declaredCapabilities(manager, provider: params.provider).contains("seed") else {
+        if params.seedRetainedKey != nil {
+            let capabilities = await declaredCapabilities(manager, provider: params.provider)
+            guard capabilities.contains("seed") else {
                 return Self.missingCapabilityResponse(
                     provider: params.provider, capability: "seed", section: "create")
             }
-            // A top-level sibling of `params` and `idempotency_key`, never a
-            // member of `params` — `params` is the provider's own free-form
-            // set, and burying a contract field inside it would make `seed`
-            // indistinguishable from a provider-defined one.
-            seedField = #", "seed": {"retained_key": \#(Self.jsonStringLiteral(seedKey))}"#
         }
         // The session ID is the provider's return value, so the request row
         // carries the provider alone; the resolved ID lands with the observed
@@ -251,7 +221,9 @@ extension RPCRouter {
         // the retry surfaces via the next snapshot poll's adoption anyway,
         // so there's nothing a persisted key would add.
         let key = "tbd-\(UUID().uuidString.lowercased())"
-        let body = #"{"params": \#(paramsJSON)\#(seedField), "idempotency_key": "\#(key)"}"#
+        let body = ProviderCreateBody.compose(
+            paramsJSON: paramsJSON, seedRetainedKey: params.seedRetainedKey,
+            idempotencyKey: key)
         let stdin = Data(body.utf8)
         let result: ProviderResult
         do {

--- a/Sources/TBDDaemon/Server/RPCRouter+RemoteHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+RemoteHandlers.swift
@@ -764,6 +764,56 @@ extension RPCRouter {
         return try RPCResponse(result: RemoteRecallResult(jsonl: jsonl, localPath: localPath))
     }
 
+    /// The conversation of a session the provider still has
+    /// (`docs/remote-provider-contract.md` § `transcript <id>`). See
+    /// `handleRemoteRetain` for the shared shape and for why the capability is
+    /// checked before anything is invoked.
+    ///
+    /// **stderr is dropped on the floor, deliberately.** `transcript` is the
+    /// contract's one stderr exception: it may write a continuation-cursor
+    /// envelope there. This RPC reads the whole transcript in one call and has
+    /// nowhere to keep a cursor between calls, so carrying it across the RPC
+    /// boundary would hand every caller a token none of them could use. A
+    /// caller that wants what accumulated since refetches.
+    ///
+    /// It is emphatically not `log`. The contract states the two are different
+    /// data rather than two encodings of one — structured conversation records
+    /// against raw ANSI scrollback — and that a caller MUST NOT substitute one
+    /// for the other, so this verb exists rather than `remote.log` being reused.
+    func handleRemoteTranscript(_ paramsData: Data) async throws -> RPCResponse {
+        guard let manager = try await remoteGate() else {
+            return Self.remoteBackendsDisabledResponse
+        }
+        let params = try decoder.decode(RemoteTranscriptParams.self, from: paramsData)
+        if let refusal = try await cloudGate(provider: params.provider) { return refusal }
+        guard await declaredCapabilities(manager, provider: params.provider).contains("transcript") else {
+            return Self.missingCapabilityResponse(
+                provider: params.provider, capability: "transcript",
+                section: "transcript <id> [--since <cursor>]")
+        }
+        let result: ProviderResult
+        do {
+            result = try await manager.invoke(
+                providerName: params.provider, verb: ["transcript", params.sessionID],
+                stdin: nil, timeout: Self.exchangeTimeout)
+        } catch let error as ProviderRunError {
+            remoteHandlerLogger.error(
+                "remote.transcript provider=\(params.provider, privacy: .public) timed out")
+            return RPCResponse(error: Self.friendlyMessage(for: error, provider: params.provider))
+        }
+        if result.failureClass != nil {
+            let message = result.decodedError?.message ?? "transcript failed (exit \(result.exitCode))"
+            remoteHandlerLogger.error(
+                "remote.transcript provider=\(params.provider, privacy: .public) failed: \(message, privacy: .public)")
+            return RPCResponse(error: message)
+        }
+        // JSONL records by contract — lossy UTF-8 decode, never sanitized or
+        // re-encoded, on the same terms as `remote.recall`'s bytes.
+        // swiftlint:disable:next optional_data_string_conversion
+        let jsonl = String(decoding: result.stdout, as: UTF8.self)
+        return try RPCResponse(result: RemoteTranscriptResult(jsonl: jsonl))
+    }
+
     /// Lists the receipts TBD holds, optionally filtered to one provider.
     ///
     /// Local-only — it reads TBD's own rows and never invokes a provider verb,

--- a/Sources/TBDDaemon/Server/RPCRouter+RemoteHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+RemoteHandlers.swift
@@ -136,6 +136,31 @@ extension RPCRouter {
         return trimmed
     }
 
+    /// A JSON string literal — quotes and escaping included — for a value TBD
+    /// must splice into a hand-composed request body.
+    ///
+    /// `create`'s body is assembled as text rather than encoded, because
+    /// `paramsJSON` is a caller-supplied JSON object spliced through verbatim
+    /// and re-encoding it would rewrite the caller's own formatting. Everything
+    /// else in that body has so far been a value TBD minted itself. A retained
+    /// key is not: it is an opaque provider-issued string that MUST NOT be
+    /// parsed or pattern-matched, so it may contain a quote, a backslash, or a
+    /// newline, and interpolating one raw would produce a malformed request the
+    /// provider rejects with no indication of why.
+    ///
+    /// `JSONSerialization` needs a top-level container, so the value is encoded
+    /// as a one-element array and the brackets are dropped. The fallback is an
+    /// empty literal, which the provider will reject as an unknown key —
+    /// the failure a caller can act on, rather than a broken body.
+    private static func jsonStringLiteral(_ value: String) -> String {
+        guard let data = try? JSONSerialization.data(withJSONObject: [value]),
+              let text = String(bytes: data, encoding: .utf8),
+              text.count >= 2 else {
+            return "\"\""
+        }
+        return String(text.dropFirst().dropLast())
+    }
+
     /// Turns a provider timeout into a message the app can show, instead of
     /// letting `ProviderRunError.timeout`'s raw enum description
     /// (`timeout(verb: "stop")`) leak through the router's catch-all.
@@ -193,6 +218,27 @@ extension RPCRouter {
         guard let paramsJSON = Self.normalizedParamsJSON(params.paramsJSON) else {
             return RPCResponse(error: "remote.create paramsJSON must be a JSON object; got: \(params.paramsJSON)")
         }
+        // `seed` is refused here rather than sent and hoped for, and refused
+        // BEFORE the actuation row and before anything is spawned. The contract
+        // requires a provider to ignore stdin fields it does not recognize, so
+        // an unchecked send to a provider that never declared `seed` would exit
+        // 0 with a brand-new empty session while the caller believed its
+        // conversation had been carried over — the exact silent wrong answer
+        // the capability gate exists to prevent. That is also why the check
+        // sits here and not at a caller: nothing upstream is trusted to have
+        // made it (the same rule `handleRemoteRetain` follows).
+        var seedField = ""
+        if let seedKey = params.seedRetainedKey {
+            guard await declaredCapabilities(manager, provider: params.provider).contains("seed") else {
+                return Self.missingCapabilityResponse(
+                    provider: params.provider, capability: "seed", section: "create")
+            }
+            // A top-level sibling of `params` and `idempotency_key`, never a
+            // member of `params` — `params` is the provider's own free-form
+            // set, and burying a contract field inside it would make `seed`
+            // indistinguishable from a provider-defined one.
+            seedField = #", "seed": {"retained_key": \#(Self.jsonStringLiteral(seedKey))}"#
+        }
         // The session ID is the provider's return value, so the request row
         // carries the provider alone; the resolved ID lands with the observed
         // rung, not here.
@@ -205,7 +251,7 @@ extension RPCRouter {
         // the retry surfaces via the next snapshot poll's adoption anyway,
         // so there's nothing a persisted key would add.
         let key = "tbd-\(UUID().uuidString.lowercased())"
-        let body = #"{"params": \#(paramsJSON), "idempotency_key": "\#(key)"}"#
+        let body = #"{"params": \#(paramsJSON)\#(seedField), "idempotency_key": "\#(key)"}"#
         let stdin = Data(body.utf8)
         let result: ProviderResult
         do {

--- a/Sources/TBDDaemon/Server/RPCRouter+RemoteHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+RemoteHandlers.swift
@@ -35,6 +35,39 @@ struct RemoteFilingWatermark {
     }
 }
 
+/// A deletion recorded in anticipation of `delete`, held across the call so it
+/// can be re-stamped when the verb returns or taken back when it fails.
+///
+/// The session-shaped twin of `RemoteFilingWatermark`, and it is keyed by
+/// `(provider, sessionID)` rather than by a worktree for the reason
+/// `RemoteProviderManager.deletions` gives: most deletable sessions were never
+/// adopted, so a worktree-keyed watermark would protect only the rare case.
+/// It carries `prior` and `decidedAt` for exactly the reasons the filing twin
+/// documents above.
+struct RemoteDeletionWatermark {
+    let manager: RemoteProviderManager
+    let provider: String
+    let sessionID: String
+    /// The instant written before the verb was invoked.
+    let decidedAt: Date
+    /// Whatever the map held before `decidedAt` was written, if anything.
+    let prior: Date?
+
+    /// The delete did not happen: put back what was there before, so a session
+    /// that is still alive is not hidden from the mirror over a destruction
+    /// that never occurred.
+    func withdraw() async {
+        await manager.withdrawDeletion(
+            provider: provider, sessionID: sessionID, restoring: prior, ifStillAt: decidedAt)
+    }
+
+    /// The verb returned: move the watermark forward past every poll that could
+    /// have been launched while it ran.
+    func restamp(at date: Date) async {
+        await manager.noteDeletion(provider: provider, sessionID: sessionID, at: date)
+    }
+}
+
 /// RPC handlers for remote agent backends (`docs/remote-provider-contract.md`).
 /// Every `remote.*` verb gates on `config.remoteBackendsEnabled` AND on the
 /// `remoteManager` actor existing — the daemon only constructs it at boot
@@ -957,6 +990,15 @@ extension RPCRouter {
     /// rule; it is the piece of this handler most likely to read as redundant
     /// and be removed.
     ///
+    /// **And the drop is interlocked against polls in flight.** Dropping a row
+    /// races the `list` loop: a poll that captured its snapshot before the
+    /// provider committed the deletion applies it afterwards and re-inserts the
+    /// row with `gone` false, which is the two-poll limbo the immediate drop
+    /// exists to prevent, arrived at by a different route. So the delete stamps
+    /// a deletion watermark before the verb and again after it returns, and
+    /// withdraws it on every failure exit —
+    /// `RemoteProviderManager.noteDeletion`.
+    ///
     /// `deleted: false` is a success, not an error: the contract has deleting
     /// an unknown or already-deleted id exit 0 saying so, and the caller's
     /// intent — that this session not exist — holds either way. The row is
@@ -988,6 +1030,18 @@ extension RPCRouter {
         let actuationID = try await beginActuation(
             .remoteDelete, actor: actor,
             target: .remote(provider: params.provider, session: params.sessionID))
+        // Stamped BEFORE the verb, and again after it returns. See
+        // `RemoteProviderManager.noteDeletion` for what each stamp covers;
+        // without them the row this handler drops below is re-inserted, with
+        // `gone` false, by the next `list` whose snapshot predates the delete —
+        // reproducing exactly the two-poll limbo the immediate drop exists to
+        // prevent.
+        let decidedAt = now()
+        let deletion = RemoteDeletionWatermark(
+            manager: manager, provider: params.provider, sessionID: params.sessionID,
+            decidedAt: decidedAt,
+            prior: await manager.noteDeletion(
+                provider: params.provider, sessionID: params.sessionID, at: decidedAt))
         var verb = ["delete", params.sessionID]
         if params.retain { verb.append("--retain") }
         let result: ProviderResult
@@ -999,6 +1053,7 @@ extension RPCRouter {
             remoteHandlerLogger.error(
                 "remote.delete provider=\(params.provider, privacy: .public) timed out")
             let message = Self.friendlyMessage(for: error, provider: params.provider)
+            await deletion.withdraw()
             await finishActuation(actuationID, .transportFailed, error: message)
             return RPCResponse(error: message)
         }
@@ -1006,6 +1061,7 @@ extension RPCRouter {
             let message = result.decodedError?.message ?? "delete failed (exit \(result.exitCode))"
             remoteHandlerLogger.error(
                 "remote.delete provider=\(params.provider, privacy: .public) failed: \(message, privacy: .public)")
+            await deletion.withdraw()
             await finishActuation(actuationID, .transportFailed, error: message)
             return RPCResponse(error: message)
         }
@@ -1019,9 +1075,15 @@ extension RPCRouter {
             let message = "provider '\(params.provider)' returned an unreadable delete result"
             remoteHandlerLogger.error(
                 "remote.delete provider=\(params.provider, privacy: .public): \(message, privacy: .public)")
+            await deletion.withdraw()
             await finishActuation(actuationID, .transportFailed, error: message)
             return RPCResponse(error: message)
         }
+        // The session is destroyed, whether this call did it or found it
+        // already gone. Either way a poll launched while the verb ran carries
+        // the pre-delete inventory, so the watermark moves past it before the
+        // row is dropped.
+        await deletion.restamp(at: now())
         await recordDeleteAftermath(outcome, params: params, now: now)
         await finishActuation(actuationID, .dispatched)
         return try RPCResponse(result: outcome)

--- a/Sources/TBDDaemon/Server/RPCRouter+RemoteHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+RemoteHandlers.swift
@@ -300,10 +300,17 @@ extension RPCRouter {
         await manager.declaredCapabilities(provider: provider)
     }
 
-    private static func missingCapabilityResponse(provider: String, capability: String) -> RPCResponse {
+    /// The refusal a handler returns instead of invoking a verb the provider
+    /// has not declared. `section` names the contract heading to read, and
+    /// defaults to the `<verb> <id>` shape the session-addressed verbs use;
+    /// the exchange verbs pass their own, because `import` takes no id and
+    /// `recall` takes a key rather than one.
+    private static func missingCapabilityResponse(
+        provider: String, capability: String, section: String? = nil
+    ) -> RPCResponse {
         RPCResponse(error:
             "provider '\(provider)' has not declared capability '\(capability)' " +
-            "(docs/remote-provider-contract.md § \(capability) <id>)")
+            "(docs/remote-provider-contract.md § \(section ?? "\(capability) <id>"))")
     }
 
     /// Retires a session from the working inventory
@@ -573,6 +580,250 @@ extension RPCRouter {
             await manager.applyUpsert(session, provider: params.provider)
         }
         return .ok()
+    }
+
+    // MARK: - The transcript exchange
+
+    /// The budget for all three exchange verbs, matching the contract's
+    /// 60-second timeout for `retain`, `import`, and `recall` — a transcript is
+    /// a whole conversation, and the two store-writing verbs may be moving it
+    /// across a network.
+    private static let exchangeTimeout: TimeInterval = 60
+
+    /// Retains one of the provider's own sessions' transcripts
+    /// (`docs/remote-provider-contract.md` § `retain <id>`). Mirrors
+    /// `handleRemoteLog`'s shape — same outer gate, same cloud gate, same
+    /// timeout and `failureClass` branches — with two additions.
+    ///
+    /// **The capability is checked before anything is invoked.** The contract
+    /// states a caller "MUST NOT invoke a verb whose capability the provider
+    /// has not declared", and nothing upstream of this handler is trusted to
+    /// have checked, so a missing capability is a refusal naming it rather than
+    /// an opaque provider failure — the same rule `retire` follows for
+    /// `archive`/`unarchive`.
+    ///
+    /// **The receipt is recorded before the response is returned.** A key is
+    /// opaque and the contract gives no way to enumerate the keys a provider
+    /// issued, so a key that does not reach `retained_transcript` is a
+    /// retained transcript nobody can ever recall. Recording it is therefore
+    /// part of the verb, not bookkeeping around it — but a row that fails to
+    /// write must not fail a retention the provider already performed, so the
+    /// failure is logged and the receipt is still returned.
+    func handleRemoteRetain(_ paramsData: Data) async throws -> RPCResponse {
+        guard let manager = try await remoteGate() else {
+            return Self.remoteBackendsDisabledResponse
+        }
+        let params = try decoder.decode(RemoteRetainParams.self, from: paramsData)
+        if let refusal = try await cloudGate(provider: params.provider) { return refusal }
+        guard await declaredCapabilities(manager, provider: params.provider).contains("retain") else {
+            return Self.missingCapabilityResponse(
+                provider: params.provider, capability: "retain", section: "retain <id> / import")
+        }
+        let result: ProviderResult
+        do {
+            result = try await manager.invoke(
+                providerName: params.provider, verb: ["retain", params.sessionID],
+                stdin: nil, timeout: Self.exchangeTimeout)
+        } catch let error as ProviderRunError {
+            remoteHandlerLogger.error("remote.retain provider=\(params.provider, privacy: .public) timed out")
+            return RPCResponse(error: Self.friendlyMessage(for: error, provider: params.provider))
+        }
+        if result.failureClass != nil {
+            let message = result.decodedError?.message ?? "retain failed (exit \(result.exitCode))"
+            remoteHandlerLogger.error(
+                "remote.retain provider=\(params.provider, privacy: .public) failed: \(message, privacy: .public)")
+            return RPCResponse(error: message)
+        }
+        let receipt = try result.decoded(RetainReceipt.self, provider: params.provider)
+        await recordReceipt(receipt, provider: params.provider, sessionID: params.sessionID)
+        return try RPCResponse(result: receipt)
+    }
+
+    /// Puts a transcript from anywhere — including this machine — into a
+    /// provider's durable store (`docs/remote-provider-contract.md` §
+    /// `import`). See `handleRemoteRetain` for the shared shape and for why the
+    /// capability check and the receipt row are both part of the verb.
+    ///
+    /// Unlike `retain` there is no session on this provider, so the recorded
+    /// row carries no source session id and no origin lane. Malformed JSONL is
+    /// the provider's `invalid_params`, surfaced through the ordinary
+    /// `failureClass` branch rather than pre-validated here: the contract makes
+    /// the provider the validator of record, and a caller that parsed the
+    /// records first would be a second, divergent one.
+    func handleRemoteImport(_ paramsData: Data) async throws -> RPCResponse {
+        guard let manager = try await remoteGate() else {
+            return Self.remoteBackendsDisabledResponse
+        }
+        let params = try decoder.decode(RemoteImportParams.self, from: paramsData)
+        if let refusal = try await cloudGate(provider: params.provider) { return refusal }
+        guard await declaredCapabilities(manager, provider: params.provider).contains("import") else {
+            return Self.missingCapabilityResponse(
+                provider: params.provider, capability: "import", section: "retain <id> / import")
+        }
+        let result: ProviderResult
+        do {
+            result = try await manager.invoke(
+                providerName: params.provider, verb: ["import"],
+                stdin: Data(params.jsonl.utf8), timeout: Self.exchangeTimeout)
+        } catch let error as ProviderRunError {
+            remoteHandlerLogger.error("remote.import provider=\(params.provider, privacy: .public) timed out")
+            return RPCResponse(error: Self.friendlyMessage(for: error, provider: params.provider))
+        }
+        if result.failureClass != nil {
+            let message = result.decodedError?.message ?? "import failed (exit \(result.exitCode))"
+            remoteHandlerLogger.error(
+                "remote.import provider=\(params.provider, privacy: .public) failed: \(message, privacy: .public)")
+            return RPCResponse(error: message)
+        }
+        let receipt = try result.decoded(RetainReceipt.self, provider: params.provider)
+        await recordReceipt(receipt, provider: params.provider, sessionID: nil)
+        return try RPCResponse(result: receipt)
+    }
+
+    /// Reads a retained transcript back (`docs/remote-provider-contract.md` §
+    /// `recall <key>`). See `handleRemoteRetain` for the shared shape.
+    ///
+    /// **stdout is the whole response.** `recall` writes nothing to stderr —
+    /// the contract keeps exactly one stderr exception, `transcript`'s cursor
+    /// envelope, and a retained transcript is immutable so a cursor would have
+    /// nothing to mean. Truncation is detected against the receipt's `bytes`
+    /// instead, which is why a short read is logged here naming both counts.
+    ///
+    /// A short read is **not** an error: the records that did arrive are real,
+    /// and refusing them would turn a partial transcript into no transcript.
+    /// The caller gets the bytes and the log says what was missing.
+    func handleRemoteRecall(_ paramsData: Data) async throws -> RPCResponse {
+        guard let manager = try await remoteGate() else {
+            return Self.remoteBackendsDisabledResponse
+        }
+        let params = try decoder.decode(RemoteRecallParams.self, from: paramsData)
+        if let refusal = try await cloudGate(provider: params.provider) { return refusal }
+        guard await declaredCapabilities(manager, provider: params.provider).contains("recall") else {
+            return Self.missingCapabilityResponse(
+                provider: params.provider, capability: "recall", section: "recall <key>")
+        }
+        let result: ProviderResult
+        do {
+            result = try await manager.invoke(
+                providerName: params.provider, verb: ["recall", params.key],
+                stdin: nil, timeout: Self.exchangeTimeout)
+        } catch let error as ProviderRunError {
+            remoteHandlerLogger.error("remote.recall provider=\(params.provider, privacy: .public) timed out")
+            return RPCResponse(error: Self.friendlyMessage(for: error, provider: params.provider))
+        }
+        if result.failureClass != nil {
+            // Carries `not_found` and `expired` — the two codes this verb
+            // defines — through unchanged, so a caller can say a record lapsed
+            // rather than claim it never existed.
+            let message = result.decodedError?.message ?? "recall failed (exit \(result.exitCode))"
+            remoteHandlerLogger.error(
+                "remote.recall provider=\(params.provider, privacy: .public) failed: \(message, privacy: .public)")
+            return RPCResponse(error: message)
+        }
+        await warnOnShortRecall(
+            provider: params.provider, key: params.key, received: result.stdout.count)
+        // JSONL records by contract — lossy UTF-8 decode, never sanitized or
+        // re-encoded, on the same terms as `remote.log`'s raw bytes.
+        // swiftlint:disable:next optional_data_string_conversion
+        let jsonl = String(decoding: result.stdout, as: UTF8.self)
+        var localPath: String?
+        if params.saveLocally {
+            localPath = await saveRecalledTranscript(
+                result.stdout, provider: params.provider, key: params.key)
+        }
+        return try RPCResponse(result: RemoteRecallResult(jsonl: jsonl, localPath: localPath))
+    }
+
+    /// Writes one receipt into `retained_transcript`, filling in whatever TBD
+    /// already knows about the session it came from.
+    ///
+    /// Never throws. A retention the provider already performed must not be
+    /// reported as a failure because a local row would not write — the key
+    /// would then be lost twice over, since the response the caller never saw
+    /// carried it. The error is logged loudly instead, naming the key, because
+    /// that log line is the last place the key exists.
+    private func recordReceipt(
+        _ receipt: RetainReceipt, provider: String, sessionID: String?
+    ) async {
+        var sourceTitle: String?
+        var resolvedRepoID: UUID?
+        var originWorktreeID: UUID?
+        if let sessionID {
+            let row = try? await db.remoteSessions.row(provider: provider, sessionID: sessionID)
+            sourceTitle = row?.decodedPayload?.title
+            resolvedRepoID = row?.resolvedRepoIDUUID
+            originWorktreeID = try? await db.worktrees
+                .findRemote(provider: provider, sessionID: sessionID)?.id
+        }
+        do {
+            try await db.retainedTranscripts.insert(RetainedTranscript(
+                provider: provider, key: receipt.key, expiresAt: receipt.expiresAt,
+                bytes: receipt.bytes, sourceSessionID: sessionID, sourceTitle: sourceTitle,
+                resolvedRepoID: resolvedRepoID, originWorktreeID: originWorktreeID,
+                localPath: nil))
+        } catch {
+            remoteHandlerLogger.error("""
+                could not record the retained-transcript receipt for \
+                \(provider, privacy: .public) key \(receipt.key, privacy: .public): \
+                \(error.localizedDescription, privacy: .public). The key is in this log line \
+                and nowhere else — nothing enumerates a provider's keys
+                """)
+        }
+    }
+
+    /// Compares what `recall` returned against the byte count the receipt
+    /// claimed, and logs at `.error` when it falls short.
+    ///
+    /// Silent when TBD holds no receipt for this key — a key recalled from
+    /// another machine, or one recorded before this table existed, gives
+    /// nothing to compare against, and a comparison against zero would report
+    /// every such recall as short.
+    private func warnOnShortRecall(provider: String, key: String, received: Int) async {
+        guard let receipt = try? await db.retainedTranscripts.find(provider: provider, key: key),
+              received < receipt.bytes else { return }
+        remoteHandlerLogger.error("""
+            remote.recall provider=\(provider, privacy: .public) returned \
+            \(received, privacy: .public) bytes for a receipt claiming \
+            \(receipt.bytes, privacy: .public); the transcript is truncated
+            """)
+    }
+
+    /// Writes the recalled records under `~/tbd/transcripts/<provider>/<key>.jsonl`
+    /// and records that path on the receipt row. Returns the path written, or
+    /// nil when nothing was written.
+    ///
+    /// The path comes from `TBDConstants`, never composed from `$HOME`, so the
+    /// test fence covers it.
+    ///
+    /// A failed write is nil rather than an error: the records arrived, and the
+    /// caller has them in the response regardless of whether this disk would
+    /// take a copy.
+    private func saveRecalledTranscript(_ data: Data, provider: String, key: String) async -> String? {
+        let url = TBDConstants.retainedTranscriptPath(provider: provider, key: key)
+        do {
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try data.write(to: url, options: .atomic)
+        } catch {
+            remoteHandlerLogger.error("""
+                could not write the recalled transcript for \(provider, privacy: .public) \
+                key \(key, privacy: .public) to \(url.path, privacy: .public): \
+                \(error.localizedDescription, privacy: .public)
+                """)
+            return nil
+        }
+        do {
+            try await db.retainedTranscripts.setLocalPath(
+                provider: provider, key: key, localPath: url.path)
+        } catch {
+            // The file is on disk either way; only the row's pointer to it is
+            // lost, and the GC leg reconciles files against rows.
+            remoteHandlerLogger.warning("""
+                wrote \(url.path, privacy: .public) but could not record it on the receipt row: \
+                \(error.localizedDescription, privacy: .public)
+                """)
+        }
+        return url.path
     }
 
     func handleRemoteDismiss(_ paramsData: Data) async throws -> RPCResponse {

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -815,7 +815,8 @@ public final class RPCRouter: Sendable {
             remoteBackendsLive: remoteManager != nil,
             queuedPromptEnabled: config.queuedPromptEnabled,
             claudeCloudEnabled: config.claudeCloudEnabled,
-            claudeCloudLive: claudeCloudLive))
+            claudeCloudLive: claudeCloudLive,
+            remoteDeleteEnabled: config.remoteDeleteEnabled))
     }
 
     // MARK: - PR Status

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -692,6 +692,8 @@ public final class RPCRouter: Sendable {
                 return try await handleConfigSetGCRowlessHoldersEnabled(request.paramsData)
             case RPCMethod.configSetReapHolderChildrenEnabled:
                 return try await handleConfigSetReapHolderChildrenEnabled(request.paramsData)
+            case RPCMethod.configSetGCRetainedTranscriptsEnabled:
+                return try await handleConfigSetGCRetainedTranscriptsEnabled(request.paramsData)
             case RPCMethod.configSetRemoteDeleteEnabled:
                 return try await handleConfigSetRemoteDeleteEnabled(request.paramsData)
             case RPCMethod.configSetSupervisionEnabled:

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -692,6 +692,8 @@ public final class RPCRouter: Sendable {
                 return try await handleConfigSetGCRowlessHoldersEnabled(request.paramsData)
             case RPCMethod.configSetReapHolderChildrenEnabled:
                 return try await handleConfigSetReapHolderChildrenEnabled(request.paramsData)
+            case RPCMethod.configSetRemoteDeleteEnabled:
+                return try await handleConfigSetRemoteDeleteEnabled(request.paramsData)
             case RPCMethod.configSetSupervisionEnabled:
                 return try await handleConfigSetSupervisionEnabled(request.paramsData)
             case RPCMethod.remoteProviders:
@@ -722,6 +724,8 @@ public final class RPCRouter: Sendable {
                 return try await handleRemoteRecall(request.paramsData)
             case RPCMethod.remoteRetainedList:
                 return try await handleRemoteRetainedList(request.paramsData)
+            case RPCMethod.remoteDelete:
+                return try await handleRemoteDelete(request.paramsData, actor: request.actor)
             case RPCMethod.remoteSetPin:
                 return try await handleRemoteSetPin(request.paramsData)
             case RPCMethod.remoteReportAttachExit:

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -720,6 +720,8 @@ public final class RPCRouter: Sendable {
                 return try await handleRemoteImport(request.paramsData)
             case RPCMethod.remoteRecall:
                 return try await handleRemoteRecall(request.paramsData)
+            case RPCMethod.remoteRetainedList:
+                return try await handleRemoteRetainedList(request.paramsData)
             case RPCMethod.remoteSetPin:
                 return try await handleRemoteSetPin(request.paramsData)
             case RPCMethod.remoteReportAttachExit:

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -714,6 +714,12 @@ public final class RPCRouter: Sendable {
                 return try await handleRemoteRename(request.paramsData)
             case RPCMethod.remoteDismiss:
                 return try await handleRemoteDismiss(request.paramsData)
+            case RPCMethod.remoteRetain:
+                return try await handleRemoteRetain(request.paramsData)
+            case RPCMethod.remoteImport:
+                return try await handleRemoteImport(request.paramsData)
+            case RPCMethod.remoteRecall:
+                return try await handleRemoteRecall(request.paramsData)
             case RPCMethod.remoteSetPin:
                 return try await handleRemoteSetPin(request.paramsData)
             case RPCMethod.remoteReportAttachExit:

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -722,6 +722,8 @@ public final class RPCRouter: Sendable {
                 return try await handleRemoteImport(request.paramsData)
             case RPCMethod.remoteRecall:
                 return try await handleRemoteRecall(request.paramsData)
+            case RPCMethod.remoteTranscript:
+                return try await handleRemoteTranscript(request.paramsData)
             case RPCMethod.remoteRetainedList:
                 return try await handleRemoteRetainedList(request.paramsData)
             case RPCMethod.remoteDelete:

--- a/Sources/TBDShared/Constants.swift
+++ b/Sources/TBDShared/Constants.swift
@@ -230,6 +230,69 @@ public enum TBDConstants {
         terminalHistoryPath(worktreeID: worktreeID, terminalID: terminalID, environment: ProcessInfo.processInfo.environment)
     }
 
+    /// Base directory for transcripts recalled from a provider's retained
+    /// store: `~/tbd/transcripts`. Honors TBD_HOME.
+    ///
+    /// Derived from `configDir` rather than composed from `$HOME`, which is
+    /// the mistake `WorktreeLayout.basePath` made and which defeated the test
+    /// fence outright — every TBD-owned path comes from here.
+    public static func retainedTranscriptsDir(environment: [String: String]) -> URL {
+        configDir(environment: environment).appendingPathComponent("transcripts")
+    }
+    public static var retainedTranscriptsDir: URL {
+        retainedTranscriptsDir(environment: ProcessInfo.processInfo.environment)
+    }
+
+    /// Path to one recalled transcript:
+    /// `~/tbd/transcripts/<provider>/<key>.jsonl`. Honors TBD_HOME.
+    ///
+    /// **Both components are percent-encoded, and the mapping is injective.**
+    /// A key is opaque by contract — a caller may not parse or construct one,
+    /// and a provider may issue any bytes it likes — so neither component may
+    /// be trusted to be a safe filename. Everything outside RFC 3986's
+    /// unreserved set *minus `.`* is percent-encoded, which gives three
+    /// properties at once:
+    ///
+    /// - **Injective.** `%` is itself escaped, so no two distinct inputs can
+    ///   produce the same output, and two different keys can never collide on
+    ///   one file.
+    /// - **No traversal.** `/` becomes `%2F`, so a key containing a separator
+    ///   stays a single path component, and `.` is escaped too, so a key of
+    ///   `.` or `..` can never name a relative directory.
+    /// - **Reversible by eye.** A human reading the directory can still
+    ///   recognise an ordinary key, which matters because this directory is
+    ///   the recovery surface when a key is lost.
+    ///
+    /// Composed as a filesystem path string and handed to
+    /// `URL(fileURLWithPath:)`, rather than built with `appendingPathComponent`.
+    /// The escaped components contain `%`, and `appendingPathComponent` decides
+    /// for itself whether a component needs further URL encoding — so a
+    /// component that already reads as a percent escape could survive into the
+    /// URL and decode back to the very separator the escaping removed.
+    /// `URL(fileURLWithPath:)` treats its argument as a path and round-trips
+    /// through `.path` unchanged, which is the property this needs.
+    public static func retainedTranscriptPath(
+        provider: String, key: String, environment: [String: String]
+    ) -> URL {
+        let directory = retainedTranscriptsDir(environment: environment).path
+        return URL(fileURLWithPath:
+            "\(directory)/\(filenameEscaped(provider))/\(filenameEscaped(key)).jsonl")
+    }
+    public static func retainedTranscriptPath(provider: String, key: String) -> URL {
+        retainedTranscriptPath(
+            provider: provider, key: key, environment: ProcessInfo.processInfo.environment)
+    }
+
+    /// RFC 3986's unreserved set less `.`, so no encoded component can be `.`
+    /// or `..`. See `retainedTranscriptPath` for why each exclusion is
+    /// load-bearing.
+    private static let filenameSafe = CharacterSet(
+        charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_~")
+
+    private static func filenameEscaped(_ component: String) -> String {
+        component.addingPercentEncoding(withAllowedCharacters: filenameSafe) ?? component
+    }
+
     /// Path to a scratch worktree's notepad file:
     /// `~/tbd/worktrees/<worktreeID>/notes.md`. Honors TBD_HOME.
     public static func notesPath(worktreeID: UUID, environment: [String: String]) -> String {

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -2566,3 +2566,78 @@ public struct TabState: Codable, Sendable, Equatable, Identifiable {
         self.createdAt = createdAt
     }
 }
+
+// MARK: - Retained transcripts
+
+/// TBD's own record of one transcript a provider has retained in its own
+/// durable store (`docs/remote-provider-contract.md` § `retain <id>` /
+/// `import`).
+///
+/// A key is opaque and provider-scoped, so `(provider, key)` is the identity.
+/// Everything else on the row exists to make a key findable again by a human:
+/// a key printed once and written down nowhere is a retained transcript nobody
+/// can ever recall.
+///
+/// Written by every path that obtains a key — `retain`, `import`, and
+/// `delete --retain`.
+public struct RetainedTranscript: Codable, Sendable, Equatable, Identifiable {
+    public let id: UUID
+    /// The provider that issued `key`. A key means nothing to any other
+    /// provider and MUST NOT be presented to one.
+    public let provider: String
+    /// The opaque handle `recall` and `create`'s `seed` field take. Never
+    /// parsed, ordered, compared, or constructed.
+    public let key: String
+    /// When the provider said it intends to drop the record, or nil when it
+    /// stated nothing. **Nil is not permanence** — no surface may render it
+    /// as such.
+    public let expiresAt: Date?
+    /// The byte count the receipt carried. The only way a short `recall` is
+    /// detectable.
+    public let bytes: Int
+    /// The provider session the transcript came from, or nil for an `import`
+    /// of a conversation that never ran on this provider.
+    public let sourceSessionID: String?
+    /// The session's display title at retention time, kept because a title is
+    /// what a human recognises a conversation by and the session it names may
+    /// no longer exist.
+    public let sourceTitle: String?
+    public let resolvedRepoID: UUID?
+    /// The lane this transcript belongs to, when one was adopted — what lets a
+    /// deleted lane's Archived row offer Revive-as-reseed.
+    public let originWorktreeID: UUID?
+    /// Where a `recall` wrote the JSONL on this machine, or nil when nothing
+    /// has been recalled locally yet.
+    public let localPath: String?
+    public let createdAt: Date
+
+    public init(
+        id: UUID = UUID(), provider: String, key: String, expiresAt: Date? = nil,
+        bytes: Int, sourceSessionID: String? = nil, sourceTitle: String? = nil,
+        resolvedRepoID: UUID? = nil, originWorktreeID: UUID? = nil,
+        localPath: String? = nil, createdAt: Date = Date()
+    ) {
+        self.id = id
+        self.provider = provider
+        self.key = key
+        self.expiresAt = expiresAt
+        self.bytes = bytes
+        self.sourceSessionID = sourceSessionID
+        self.sourceTitle = sourceTitle
+        self.resolvedRepoID = resolvedRepoID
+        self.originWorktreeID = originWorktreeID
+        self.localPath = localPath
+        self.createdAt = createdAt
+    }
+
+    /// Whether the provider's stated expiry has passed as of `date`.
+    ///
+    /// A row with no stated expiry is never expired here — absence is "no
+    /// claim", and treating it as expired would discard records the provider
+    /// may still hold. Takes the instant rather than reading a clock, so
+    /// expiry stays data (`Date`) rather than behavior (`Duration`).
+    public func hasExpired(asOf date: Date) -> Bool {
+        guard let expiresAt else { return false }
+        return expiresAt <= date
+    }
+}

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -1553,6 +1553,25 @@ public struct Config: Codable, Sendable, Equatable {
     /// "never chose" and follows the shipped default wherever it goes; `0`/`1`
     /// is an explicit gesture and is honored forever.
     public var remoteDeleteEnabled: Bool
+    /// Gate for the orphan-GC leg that reclaims retained transcripts nobody
+    /// references — the JSONL files under `~/tbd/transcripts/` that no
+    /// `retained_transcript` row points at, and the rows whose provider-stated
+    /// expiry has passed
+    /// (`docs/specs/2026-09-02-remote-session-delete-and-transcript-exchange-design.md`,
+    /// "Reclamation"). Read on top of `gcEnabled`: both must be on for the leg
+    /// to run. It ships OFF because it is a brand-new background sweep that
+    /// unlinks files and deletes rows, and because the exchange whose residue
+    /// it reclaims is itself only reachable on a provider that declares
+    /// `retain`, `import` or `recall` — so a machine with no such provider has
+    /// nothing here for this leg to be right or wrong about.
+    ///
+    /// **Resolved, not stored**, like `gcHolderRendezvousEnabled`: the backing
+    /// column carries no SQL default and stays NULL until somebody touches the
+    /// toggle, so this property is
+    /// `gc_retained_transcripts_enabled ?? Config.gcRetainedTranscriptsEnabledDefault`.
+    /// NULL means "never chose" and follows the shipped default wherever it
+    /// goes; `0`/`1` is an explicit gesture and is honored forever.
+    public var gcRetainedTranscriptsEnabled: Bool
     /// The single opt-in for remote peer messaging
     /// (`docs/specs/2026-08-29-remote-peer-messaging-design.md`, "Flag and
     /// rollout"): publishing a shadow peer for each remote session and carrying
@@ -1681,6 +1700,13 @@ public struct Config: Codable, Sendable, Equatable {
     /// asked for a receipt got one — is a change to this constant, with no
     /// forcing `UPDATE` migration and every explicit opt-out left alone.
     public static let remoteDeleteEnabledDefault = false
+    /// The shipped default for `gcRetainedTranscriptsEnabled`, and the single
+    /// place it lives. The retained-transcript leg ships off; graduation —
+    /// after a soak in which it never unlinked a transcript a row still
+    /// referenced, and never dropped a row whose provider had made no expiry
+    /// claim — is a change to this constant, with no forcing `UPDATE` migration
+    /// and every explicit opt-out left alone.
+    public static let gcRetainedTranscriptsEnabledDefault = false
 
     public init(defaultProfileID: UUID? = nil,
                 primaryAgentPreference: PrimaryAgentPreference = .defaultValue,
@@ -1719,6 +1745,8 @@ public struct Config: Codable, Sendable, Equatable {
                 gcRowlessHoldersEnabled: Bool = Config.gcRowlessHoldersEnabledDefault,
                 reapHolderChildrenEnabled: Bool = Config.reapHolderChildrenEnabledDefault,
                 remoteDeleteEnabled: Bool = Config.remoteDeleteEnabledDefault,
+                gcRetainedTranscriptsEnabled: Bool =
+                    Config.gcRetainedTranscriptsEnabledDefault,
                 remoteCreateDefaults: [String: String] = [:],
                 holderOwnerToken: String? = nil) {
         self.defaultProfileID = defaultProfileID
@@ -1758,6 +1786,7 @@ public struct Config: Codable, Sendable, Equatable {
         self.gcRowlessHoldersEnabled = gcRowlessHoldersEnabled
         self.reapHolderChildrenEnabled = reapHolderChildrenEnabled
         self.remoteDeleteEnabled = remoteDeleteEnabled
+        self.gcRetainedTranscriptsEnabled = gcRetainedTranscriptsEnabled
         self.remoteCreateDefaults = remoteCreateDefaults
         self.holderOwnerToken = holderOwnerToken
     }
@@ -1869,6 +1898,12 @@ public struct Config: Codable, Sendable, Equatable {
         remoteDeleteEnabled = try c.decodeIfPresent(
             Bool.self, forKey: .remoteDeleteEnabled)
             ?? Config.remoteDeleteEnabledDefault
+        // Same shape for the retained-transcript GC leg's gate: absent means
+        // the sender knew nothing about the flag, which is the NULL column's
+        // situation — follow the shipped default, never a hardcoded `false`.
+        gcRetainedTranscriptsEnabled = try c.decodeIfPresent(
+            Bool.self, forKey: .gcRetainedTranscriptsEnabled)
+            ?? Config.gcRetainedTranscriptsEnabledDefault
         // Absent means the sender knew nothing about global create defaults —
         // the same state as an empty map: no opinion at this level, so every
         // field falls through to its provider-declared `default`.

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -1534,6 +1534,25 @@ public struct Config: Codable, Sendable, Equatable {
     /// NULL means "never chose" and follows the shipped default wherever it
     /// goes; `0`/`1` is an explicit gesture and is honored forever.
     public var reapHolderChildrenEnabled: Bool
+    /// The single opt-in for `remote.delete` — destroying a provider-hosted
+    /// agent session outright
+    /// (`docs/specs/2026-09-02-remote-session-delete-and-transcript-exchange-design.md`,
+    /// "Daemon"). It ships OFF because delete is irreversible on the far side:
+    /// a successful delete ends the session's compute and removes it from the
+    /// provider's inventory permanently, and no reconciler on this machine can
+    /// put back what another machine destroyed.
+    ///
+    /// It gates the destructive verb **only**. `retain`, `import` and `recall`
+    /// add records rather than removing them, so the provider's declared
+    /// capabilities are their whole gate and this flag says nothing about them.
+    ///
+    /// **Resolved, not stored**, like `reapHolderChildrenEnabled`: the backing
+    /// column carries no SQL default and stays NULL until somebody touches the
+    /// toggle, so this property is
+    /// `remote_delete_enabled ?? Config.remoteDeleteEnabledDefault`. NULL means
+    /// "never chose" and follows the shipped default wherever it goes; `0`/`1`
+    /// is an explicit gesture and is honored forever.
+    public var remoteDeleteEnabled: Bool
     /// The single opt-in for remote peer messaging
     /// (`docs/specs/2026-08-29-remote-peer-messaging-design.md`, "Flag and
     /// rollout"): publishing a shadow peer for each remote session and carrying
@@ -1656,6 +1675,12 @@ public struct Config: Codable, Sendable, Equatable {
     /// dead holder — is a change to this constant, with no forcing `UPDATE`
     /// migration and every explicit opt-out left alone.
     public static let reapHolderChildrenEnabledDefault = false
+    /// The shipped default for `remoteDeleteEnabled`, and the single place it
+    /// lives. Delete ships off; graduation — after a soak in which no delete
+    /// destroyed a session its user had not confirmed, and every delete that
+    /// asked for a receipt got one — is a change to this constant, with no
+    /// forcing `UPDATE` migration and every explicit opt-out left alone.
+    public static let remoteDeleteEnabledDefault = false
 
     public init(defaultProfileID: UUID? = nil,
                 primaryAgentPreference: PrimaryAgentPreference = .defaultValue,
@@ -1693,6 +1718,7 @@ public struct Config: Codable, Sendable, Equatable {
                 gcHolderRendezvousEnabled: Bool = Config.gcHolderRendezvousEnabledDefault,
                 gcRowlessHoldersEnabled: Bool = Config.gcRowlessHoldersEnabledDefault,
                 reapHolderChildrenEnabled: Bool = Config.reapHolderChildrenEnabledDefault,
+                remoteDeleteEnabled: Bool = Config.remoteDeleteEnabledDefault,
                 remoteCreateDefaults: [String: String] = [:],
                 holderOwnerToken: String? = nil) {
         self.defaultProfileID = defaultProfileID
@@ -1731,6 +1757,7 @@ public struct Config: Codable, Sendable, Equatable {
         self.gcHolderRendezvousEnabled = gcHolderRendezvousEnabled
         self.gcRowlessHoldersEnabled = gcRowlessHoldersEnabled
         self.reapHolderChildrenEnabled = reapHolderChildrenEnabled
+        self.remoteDeleteEnabled = remoteDeleteEnabled
         self.remoteCreateDefaults = remoteCreateDefaults
         self.holderOwnerToken = holderOwnerToken
     }
@@ -1836,6 +1863,12 @@ public struct Config: Codable, Sendable, Equatable {
         reapHolderChildrenEnabled = try c.decodeIfPresent(
             Bool.self, forKey: .reapHolderChildrenEnabled)
             ?? Config.reapHolderChildrenEnabledDefault
+        // And the same shape for the remote-delete gate: absent means the sender
+        // knew nothing about the flag, which is the NULL column's situation —
+        // follow the shipped default, never a hardcoded `false`.
+        remoteDeleteEnabled = try c.decodeIfPresent(
+            Bool.self, forKey: .remoteDeleteEnabled)
+            ?? Config.remoteDeleteEnabledDefault
         // Absent means the sender knew nothing about global create defaults —
         // the same state as an empty map: no opinion at this level, so every
         // field falls through to its provider-declared `default`.

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -293,6 +293,13 @@ public enum RPCMethod {
     public static let configSetGCHolderRendezvousEnabled = "config.setGCHolderRendezvousEnabled"
     public static let configSetGCRowlessHoldersEnabled = "config.setGCRowlessHoldersEnabled"
     public static let configSetReapHolderChildrenEnabled = "config.setReapHolderChildrenEnabled"
+    /// The retained-transcript GC gate (`gc_retained_transcripts_enabled`) —
+    /// the soak switch on the `OrphanGC` leg that unlinks retained transcripts
+    /// nobody references and drops receipts whose expiry has passed. Reading
+    /// needs no method of its own: `config.get` already carries the resolved
+    /// value.
+    public static let configSetGCRetainedTranscriptsEnabled =
+        "config.setGCRetainedTranscriptsEnabled"
     /// The remote-delete gate (`remote_delete_enabled`) — the feature's only
     /// opt-in, and the supported way to turn the soak on. Reading needs no
     /// method of its own: `config.get` already carries the resolved value.
@@ -3198,6 +3205,19 @@ public struct ConfigSetGCRowlessHoldersEnabledParams: Codable, Sendable {
 /// the database by hand would make it un-soakable. Design:
 /// `docs/specs/2026-08-30-pty-holder-session-transport-design.md`.
 public struct ConfigSetReapHolderChildrenEnabledParams: Codable, Sendable {
+    public var enabled: Bool
+    public init(enabled: Bool) { self.enabled = enabled }
+}
+
+/// Params for `config.setGCRetainedTranscriptsEnabled` — the gate on the
+/// `OrphanGC` leg that reclaims retained-transcript residue: files under
+/// `~/tbd/transcripts/` that no row references, and rows whose `expires_at` has
+/// passed (default OFF during soak, on top of the GC master switch). This is
+/// how the soak is turned on. A separate opt-in from `remote_delete_enabled`:
+/// that gate destroys a session on a provider, this one reclaims TBD's own
+/// local residue, and opting into either must never opt into the other. Design:
+/// `docs/specs/2026-09-02-remote-session-delete-and-transcript-exchange-design.md`.
+public struct ConfigSetGCRetainedTranscriptsEnabledParams: Codable, Sendable {
     public var enabled: Bool
     public init(enabled: Bool) { self.enabled = enabled }
 }

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -1542,9 +1542,32 @@ public struct RemoteCreateParams: Codable, Sendable {
     ///
     /// Optional and defaulted: params encoded by an older app still decode.
     public let parentWorktreeID: UUID?
-    public init(provider: String, paramsJSON: String, parentWorktreeID: UUID? = nil) {
+    /// The retained transcript the new session should begin with as its
+    /// history — the key from a `retain` or `import` receipt **this same
+    /// provider** issued (`docs/remote-provider-contract.md` § `create`,
+    /// § Keys).
+    ///
+    /// It rides as a bare key rather than as the contract's `{"retained_key":
+    /// ...}` object because the object exists to leave room for a future
+    /// inline source, and inventing that shape on this protocol before the
+    /// contract has one would be two guesses instead of one. The daemon builds
+    /// the object when it composes `create`'s stdin.
+    ///
+    /// **Nil is not "no opinion" — it is "do not send the field".** The daemon
+    /// refuses to send `seed` to a provider that has not declared the
+    /// capability rather than sending it and hoping: the contract requires
+    /// providers to ignore stdin fields they do not recognize, so an ungated
+    /// send would silently produce an unseeded session the caller believed
+    /// carried its conversation.
+    ///
+    /// Optional, so params encoded by a client that predates the field still
+    /// decode (Optional properties synthesize `decodeIfPresent`).
+    public let seedRetainedKey: String?
+    public init(provider: String, paramsJSON: String, parentWorktreeID: UUID? = nil,
+                seedRetainedKey: String? = nil) {
         self.provider = provider
         self.paramsJSON = paramsJSON
+        self.seedRetainedKey = seedRetainedKey
         self.parentWorktreeID = parentWorktreeID
     }
 }

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -310,6 +310,12 @@ public enum RPCMethod {
     public static let remoteRetain = "remote.retain"
     public static let remoteImport = "remote.import"
     public static let remoteRecall = "remote.recall"
+    /// Lists the receipts TBD holds. Deliberately absent from
+    /// `providerNamedRemoteMethods` below: it invokes no provider verb, and its
+    /// `provider` field is an optional *filter* rather than an address, so
+    /// there is nothing for the cloud gate to refuse and no provider name to
+    /// refuse it by.
+    public static let remoteRetainedList = "remote.retainedList"
     public static let remoteSetPin = "remote.setPin"
     public static let remoteReportAttachExit = "remote.reportAttachExit"
 
@@ -1666,6 +1672,21 @@ public struct RemoteRecallResult: Codable, Sendable {
     public init(jsonl: String?, localPath: String?) {
         self.jsonl = jsonl; self.localPath = localPath
     }
+}
+
+/// Params for `remote.retainedList` — the receipts TBD holds.
+///
+/// `provider` is an optional filter, not an address: nil lists every provider's
+/// receipts. Nothing here reaches a provider, which is why this verb needs no
+/// capability and appears in no capability check.
+public struct RemoteRetainedListParams: Codable, Sendable {
+    public let provider: String?
+    public init(provider: String? = nil) { self.provider = provider }
+}
+
+public struct RemoteRetainedListResult: Codable, Sendable {
+    public let transcripts: [RetainedTranscript]
+    public init(transcripts: [RetainedTranscript]) { self.transcripts = transcripts }
 }
 
 /// Pin or unpin a remote session for the sidebar dock. Purely local — no

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -3217,7 +3217,7 @@ public struct ConfigSetReapHolderChildrenEnabledParams: Codable, Sendable {
 /// that gate destroys a session on a provider, this one reclaims TBD's own
 /// local residue, and opting into either must never opt into the other. Design:
 /// `docs/specs/2026-09-02-remote-session-delete-and-transcript-exchange-design.md`.
-public struct ConfigSetGCRetainedTranscriptsEnabledParams: Codable, Sendable {
+public struct ConfigSetGCRetainedTranscriptsParams: Codable, Sendable {
     public var enabled: Bool
     public init(enabled: Bool) { self.enabled = enabled }
 }

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -3377,6 +3377,13 @@ public struct DaemonCapabilitiesResult: Codable, Sendable {
     /// verb and parsing its error string, exactly as `remoteBackendsLive` does
     /// for the outer flag.
     public let claudeCloudLive: Bool
+    /// Whether `remote.delete` is permitted (`remote_delete_enabled`). Default
+    /// OFF while it soaks. The app gates the Delete item on this, so with it
+    /// false the destructive action is not offered at all rather than offered
+    /// and refused — resolved through `Config.remoteDeleteEnabledDefault`, so
+    /// an install that never touched the toggle reports whatever the shipped
+    /// default currently is.
+    public let remoteDeleteEnabled: Bool
 
     public init(controlModeEnabled: Bool,
                 tmuxVersion: String? = nil,
@@ -3390,7 +3397,8 @@ public struct DaemonCapabilitiesResult: Codable, Sendable {
                 remoteBackendsLive: Bool = false,
                 queuedPromptEnabled: Bool = Config.queuedPromptDefault,
                 claudeCloudEnabled: Bool = Config.claudeCloudEnabledDefault,
-                claudeCloudLive: Bool = false) {
+                claudeCloudLive: Bool = false,
+                remoteDeleteEnabled: Bool = Config.remoteDeleteEnabledDefault) {
         self.controlModeEnabled = controlModeEnabled
         self.tmuxVersion = tmuxVersion
         self.controlModeSupported = controlModeSupported
@@ -3404,6 +3412,7 @@ public struct DaemonCapabilitiesResult: Codable, Sendable {
         self.queuedPromptEnabled = queuedPromptEnabled
         self.claudeCloudEnabled = claudeCloudEnabled
         self.claudeCloudLive = claudeCloudLive
+        self.remoteDeleteEnabled = remoteDeleteEnabled
     }
 
     public init(from decoder: Decoder) throws {
@@ -3440,6 +3449,11 @@ public struct DaemonCapabilitiesResult: Codable, Sendable {
         claudeCloudEnabled = try c.decodeIfPresent(
             Bool.self, forKey: .claudeCloudEnabled) ?? Config.claudeCloudEnabledDefault
         claudeCloudLive = try c.decodeIfPresent(Bool.self, forKey: .claudeCloudLive) ?? false
+        // New field for the remote-delete gate. A daemon that does not send it
+        // would refuse the verb anyway, so fall through to the shipped default
+        // rather than offering a destructive action nothing can carry out.
+        remoteDeleteEnabled = try c.decodeIfPresent(
+            Bool.self, forKey: .remoteDeleteEnabled) ?? Config.remoteDeleteEnabledDefault
     }
 }
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -293,6 +293,10 @@ public enum RPCMethod {
     public static let configSetGCHolderRendezvousEnabled = "config.setGCHolderRendezvousEnabled"
     public static let configSetGCRowlessHoldersEnabled = "config.setGCRowlessHoldersEnabled"
     public static let configSetReapHolderChildrenEnabled = "config.setReapHolderChildrenEnabled"
+    /// The remote-delete gate (`remote_delete_enabled`) — the feature's only
+    /// opt-in, and the supported way to turn the soak on. Reading needs no
+    /// method of its own: `config.get` already carries the resolved value.
+    public static let configSetRemoteDeleteEnabled = "config.setRemoteDeleteEnabled"
     public static let remoteProviders = "remote.providers"
     public static let remoteSessions = "remote.sessions"
     public static let remoteCreate = "remote.create"
@@ -316,6 +320,12 @@ public enum RPCMethod {
     /// there is nothing for the cloud gate to refuse and no provider name to
     /// refuse it by.
     public static let remoteRetainedList = "remote.retainedList"
+    /// Destroys a provider-hosted session outright
+    /// (`docs/remote-provider-contract.md` § `delete <id> [--retain]`).
+    /// The one `remote.*` verb behind a feature flag of its own
+    /// (`config.remoteDeleteEnabled`), because it is the one whose effect no
+    /// reconciler on this machine can undo.
+    public static let remoteDelete = "remote.delete"
     public static let remoteSetPin = "remote.setPin"
     public static let remoteReportAttachExit = "remote.reportAttachExit"
 
@@ -338,7 +348,7 @@ public enum RPCMethod {
     public static let providerNamedRemoteMethods: [String] = [
         remoteCreate, remoteStop, remoteArchive, remoteUnarchive,
         remoteSend, remoteLog, remoteRename, remoteDismiss,
-        remoteRetain, remoteImport, remoteRecall,
+        remoteRetain, remoteImport, remoteRecall, remoteDelete,
         remoteSetPin, remoteReportAttachExit,
     ]
 
@@ -1671,6 +1681,38 @@ public struct RemoteRecallResult: Codable, Sendable {
     public let localPath: String?
     public init(jsonl: String?, localPath: String?) {
         self.jsonl = jsonl; self.localPath = localPath
+    }
+}
+
+/// Params for `remote.delete` — destroy a provider-hosted session
+/// (`docs/remote-provider-contract.md` § `delete <id> [--retain]`). The result
+/// is a `RemoteDeleteResult`.
+///
+/// `retain` maps to the verb's `--retain` flag, and is a request rather than a
+/// preference: the contract makes retention something a caller asks for
+/// explicitly, never something implied by the provider declaring `retain`. So
+/// an absent field decodes as `false` — a caller that said nothing did not ask
+/// for storage, and allocating it anyway would put a copy of a conversation on
+/// a remote store nobody asked to write to. The hand-written decoder exists for
+/// that default, and so params from a client that predates the field still
+/// decode.
+public struct RemoteDeleteParams: Codable, Sendable {
+    public let provider: String
+    public let sessionID: String
+    public let retain: Bool
+    public init(provider: String, sessionID: String, retain: Bool = false) {
+        self.provider = provider; self.sessionID = sessionID; self.retain = retain
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case provider, sessionID, retain
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        provider = try c.decode(String.self, forKey: .provider)
+        sessionID = try c.decode(String.self, forKey: .sessionID)
+        retain = try c.decodeIfPresent(Bool.self, forKey: .retain) ?? false
     }
 }
 
@@ -3102,6 +3144,16 @@ public struct ConfigSetGCRowlessHoldersEnabledParams: Codable, Sendable {
 /// the database by hand would make it un-soakable. Design:
 /// `docs/specs/2026-08-30-pty-holder-session-transport-design.md`.
 public struct ConfigSetReapHolderChildrenEnabledParams: Codable, Sendable {
+    public var enabled: Bool
+    public init(enabled: Bool) { self.enabled = enabled }
+}
+
+/// Params for `config.setRemoteDeleteEnabled` — the gate on `remote.delete`,
+/// the verb that destroys a provider-hosted session (default OFF during soak).
+/// This is how the soak is turned on: without it the one irreversible verb
+/// would be the one reachable only by hand-editing `~/tbd/state.db`. Design:
+/// `docs/specs/2026-09-02-remote-session-delete-and-transcript-exchange-design.md`.
+public struct ConfigSetRemoteDeleteEnabledParams: Codable, Sendable {
     public var enabled: Bool
     public init(enabled: Bool) { self.enabled = enabled }
 }

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -314,6 +314,14 @@ public enum RPCMethod {
     public static let remoteRetain = "remote.retain"
     public static let remoteImport = "remote.import"
     public static let remoteRecall = "remote.recall"
+    /// The live transcript of a session the provider still has
+    /// (`docs/remote-provider-contract.md` § `transcript <id>`). A sibling of
+    /// the exchange verbs rather than one of them: `recall` reads an immutable
+    /// blob out of the provider's store by key, this reads a growing
+    /// conversation out of a live session by id, and the contract keeps the two
+    /// capabilities separate so `transcript` never becomes ambiguous about
+    /// which of the two a provider implements.
+    public static let remoteTranscript = "remote.transcript"
     /// Lists the receipts TBD holds. Deliberately absent from
     /// `providerNamedRemoteMethods` below: it invokes no provider verb, and its
     /// `provider` field is an optional *filter* rather than an address, so
@@ -348,7 +356,7 @@ public enum RPCMethod {
     public static let providerNamedRemoteMethods: [String] = [
         remoteCreate, remoteStop, remoteArchive, remoteUnarchive,
         remoteSend, remoteLog, remoteRename, remoteDismiss,
-        remoteRetain, remoteImport, remoteRecall, remoteDelete,
+        remoteRetain, remoteImport, remoteRecall, remoteTranscript, remoteDelete,
         remoteSetPin, remoteReportAttachExit,
     ]
 
@@ -1705,6 +1713,29 @@ public struct RemoteRecallResult: Codable, Sendable {
     public init(jsonl: String?, localPath: String?) {
         self.jsonl = jsonl; self.localPath = localPath
     }
+}
+
+/// Params for `remote.transcript` — the conversation of a session the provider
+/// still has (`docs/remote-provider-contract.md` § `transcript <id>`).
+///
+/// No cursor. The verb's `--since` exists so a *live* view can fetch a growing
+/// transcript incrementally, and this RPC serves a one-shot read of the whole
+/// thing; adding a cursor would mean carrying the contract's one stderr
+/// exception — the continuation envelope — across the RPC boundary for a caller
+/// that has nowhere to keep it. A caller that wants the tail refetches.
+public struct RemoteTranscriptParams: Codable, Sendable {
+    public let provider: String
+    public let sessionID: String
+    public init(provider: String, sessionID: String) {
+        self.provider = provider; self.sessionID = sessionID
+    }
+}
+
+/// Result of `remote.transcript` — Claude Code transcript JSONL, one record per
+/// line, exactly as the provider wrote it.
+public struct RemoteTranscriptResult: Codable, Sendable {
+    public let jsonl: String
+    public init(jsonl: String) { self.jsonl = jsonl }
 }
 
 /// Params for `remote.delete` — destroy a provider-hosted session

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -303,6 +303,13 @@ public enum RPCMethod {
     public static let remoteLog = "remote.log"
     public static let remoteRename = "remote.rename"
     public static let remoteDismiss = "remote.dismiss"
+    /// The transcript exchange (`docs/remote-provider-contract.md` §
+    /// `retain <id>` / `import`, § `recall <key>`). All three are
+    /// non-destructive and gated by their capabilities alone — no feature flag
+    /// stands in front of them.
+    public static let remoteRetain = "remote.retain"
+    public static let remoteImport = "remote.import"
+    public static let remoteRecall = "remote.recall"
     public static let remoteSetPin = "remote.setPin"
     public static let remoteReportAttachExit = "remote.reportAttachExit"
 
@@ -325,6 +332,7 @@ public enum RPCMethod {
     public static let providerNamedRemoteMethods: [String] = [
         remoteCreate, remoteStop, remoteArchive, remoteUnarchive,
         remoteSend, remoteLog, remoteRename, remoteDismiss,
+        remoteRetain, remoteImport, remoteRecall,
         remoteSetPin, remoteReportAttachExit,
     ]
 
@@ -1577,6 +1585,86 @@ public struct RemoteDismissParams: Codable, Sendable {
     public let sessionID: String
     public init(provider: String, sessionID: String) {
         self.provider = provider; self.sessionID = sessionID
+    }
+}
+
+// MARK: - The transcript exchange
+
+/// Params for `remote.retain` — ask a provider to put one of its own sessions'
+/// transcripts into its durable store (`docs/remote-provider-contract.md` §
+/// `retain <id>`). The result is a `RetainReceipt`.
+public struct RemoteRetainParams: Codable, Sendable {
+    public let provider: String
+    public let sessionID: String
+    public init(provider: String, sessionID: String) {
+        self.provider = provider; self.sessionID = sessionID
+    }
+}
+
+/// Params for `remote.import` — put a transcript from somewhere else, including
+/// this machine, into a provider's durable store with no session of the
+/// provider's involved (`docs/remote-provider-contract.md` § `import`). The
+/// result is a `RetainReceipt`.
+///
+/// `jsonl` is Claude Code transcript JSONL, which the contract's format-scope
+/// paragraph fixes for this verb. It rides as a `String` rather than `Data`
+/// because that is what every other text-bearing param on this protocol does
+/// (`RemoteSendParams.text`), and because the daemon hands it straight to the
+/// provider's stdin without interpreting it.
+public struct RemoteImportParams: Codable, Sendable {
+    public let provider: String
+    public let jsonl: String
+    public init(provider: String, jsonl: String) {
+        self.provider = provider; self.jsonl = jsonl
+    }
+}
+
+/// Params for `remote.recall` — read back a transcript the provider retained
+/// (`docs/remote-provider-contract.md` § `recall <key>`).
+///
+/// `key` is opaque and provider-scoped, so the provider travels with it: the
+/// same string may mean different things to two providers, and a caller MUST
+/// NOT present one to a provider that did not issue it.
+public struct RemoteRecallParams: Codable, Sendable {
+    public let provider: String
+    public let key: String
+    /// Whether the daemon also writes the JSONL to
+    /// `TBDConstants.retainedTranscriptPath(provider:key:)` and records that
+    /// path on the receipt row.
+    ///
+    /// Decoded with a `false` default so params from a client that predates
+    /// the field still decode — and `false` is the right default besides:
+    /// reading a transcript should not put a file on disk unless asked.
+    public let saveLocally: Bool
+    public init(provider: String, key: String, saveLocally: Bool = false) {
+        self.provider = provider; self.key = key; self.saveLocally = saveLocally
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case provider, key, saveLocally
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        provider = try c.decode(String.self, forKey: .provider)
+        key = try c.decode(String.self, forKey: .key)
+        saveLocally = try c.decodeIfPresent(Bool.self, forKey: .saveLocally) ?? false
+    }
+}
+
+/// Result of `remote.recall`.
+///
+/// `jsonl` carries the records whether or not they were also written to disk —
+/// a caller that asked to save still gets the bytes, so a short read is
+/// detectable at the caller as well as logged by the daemon. `localPath` is
+/// non-nil only when `saveLocally` was set and the write succeeded; a failed
+/// write leaves it nil rather than failing the recall, because the records
+/// themselves arrived.
+public struct RemoteRecallResult: Codable, Sendable {
+    public let jsonl: String?
+    public let localPath: String?
+    public init(jsonl: String?, localPath: String?) {
+        self.jsonl = jsonl; self.localPath = localPath
     }
 }
 

--- a/Sources/TBDShared/RemoteProvider.swift
+++ b/Sources/TBDShared/RemoteProvider.swift
@@ -715,3 +715,121 @@ public enum RemoteProviderRegistry {
         }
     }
 }
+
+// MARK: - The transcript exchange (docs/remote-provider-contract.md § retain / import / recall)
+
+/// The receipt `retain` and `import` both return, and the object `delete
+/// --retain` nests under `retained`.
+///
+/// One shape for all three paths, because the contract defines one: a key the
+/// provider issued, the byte count it stored, and — optionally — when it
+/// intends to drop the record.
+///
+/// **An absent `expiresAt` means the provider makes no claim, never "kept
+/// forever".** The contract states that as a MUST NOT for callers, so nothing
+/// downstream of this type may render `nil` as permanence; it renders as
+/// "no expiry stated".
+///
+/// `bytes` is REQUIRED and deliberately non-optional: it is the only way a
+/// caller detects a truncated `recall`, and a receipt without it cannot do the
+/// one job the field exists for. A payload missing it fails to decode rather
+/// than defaulting to zero, which would read as "nothing was stored" and make
+/// every later short-read check pass vacuously.
+public struct RetainReceipt: Codable, Sendable, Equatable {
+    public let key: String
+    /// Decoded from `expires_at`. Nil means the provider stated nothing.
+    public let expiresAt: Date?
+    public let bytes: Int
+
+    public init(key: String, expiresAt: Date? = nil, bytes: Int) {
+        self.key = key
+        self.expiresAt = expiresAt
+        self.bytes = bytes
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case key, bytes
+        case expiresAt = "expires_at"
+    }
+
+    /// Hand-written because `expires_at` arrives as an RFC 3339 string on the
+    /// wire while `JSONDecoder`'s default date strategy reads a number of
+    /// seconds. Every other contract type sidesteps this by keeping its
+    /// timestamps as `String` (`RemoteSessionPayload.createdAt`); this one
+    /// cannot, because expiry is compared against now rather than displayed.
+    public init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        key = try c.decode(String.self, forKey: .key)
+        bytes = try c.decode(Int.self, forKey: .bytes)
+        if let raw = try c.decodeIfPresent(String.self, forKey: .expiresAt) {
+            // A value that is present but unparseable reads as no claim — the
+            // same degradation rule the Session object applies to a wrong-typed
+            // field, and strictly safer than inventing an instant: a bogus
+            // expiry in the past would disable Revive on a live record.
+            expiresAt = Self.parseTimestamp(raw)
+        } else {
+            expiresAt = nil
+        }
+    }
+
+    /// Re-emits `expires_at` as RFC 3339, so a receipt survives a round trip
+    /// through this type unchanged in meaning.
+    public func encode(to encoder: any Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(key, forKey: .key)
+        try c.encode(bytes, forKey: .bytes)
+        if let expiresAt {
+            try c.encode(Self.formatTimestamp(expiresAt), forKey: .expiresAt)
+        }
+    }
+
+    /// Fractional seconds first, then plain: `ISO8601DateFormatter` accepts one
+    /// or the other, never both, and providers emit both spellings.
+    /// `nonisolated(unsafe)` on read-only formatters follows
+    /// `TranscriptParser`'s precedent — the class is documented thread-safe
+    /// once configured.
+    nonisolated(unsafe) private static let fractionalFormatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+
+    nonisolated(unsafe) private static let plainFormatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f
+    }()
+
+    public static func parseTimestamp(_ raw: String) -> Date? {
+        fractionalFormatter.date(from: raw) ?? plainFormatter.date(from: raw)
+    }
+
+    public static func formatTimestamp(_ date: Date) -> String {
+        plainFormatter.string(from: date)
+    }
+}
+
+/// The response `delete` returns (`docs/remote-provider-contract.md` §
+/// `delete <id> [--retain]`).
+///
+/// **Deliberately not a Session object.** Every other verb that changes a
+/// session returns one; this one must not, because the adoption path reads a
+/// session object as a session to track and would re-adopt the very session
+/// this response declares gone.
+///
+/// `deleted: false` is a success, not a failure: deleting an unknown or
+/// already-deleted id is idempotent and exits 0.
+public struct RemoteDeleteResult: Codable, Sendable, Equatable {
+    public let id: String
+    public let deleted: Bool
+    /// Present exactly when `--retain` was passed. Retention is never implied
+    /// by capability presence, so a caller that did not ask for storage must
+    /// never find a receipt here.
+    public let retained: RetainReceipt?
+
+    public init(id: String, deleted: Bool, retained: RetainReceipt? = nil) {
+        self.id = id
+        self.deleted = deleted
+        self.retained = retained
+    }
+}

--- a/Sources/TBDShared/RemoteProvider.swift
+++ b/Sources/TBDShared/RemoteProvider.swift
@@ -819,6 +819,39 @@ public struct RetainReceipt: Codable, Sendable, Equatable {
 ///
 /// `deleted: false` is a success, not a failure: deleting an unknown or
 /// already-deleted id is idempotent and exits 0.
+public extension RemoteSessionPayload {
+    /// The `meta` key by which a provider claims its checkout has uncommitted
+    /// work. TBD never fabricates the fact: a provider that says nothing leaves
+    /// every guard reading this inert.
+    static let dirtyWorkspaceMetaKey = "workspace_dirty"
+
+    /// Reads the dirty-checkout claim out of a session's `meta`.
+    ///
+    /// `meta` is a flat string-to-string map, so the claim arrives as text.
+    /// Only `"true"` and `"1"` (trimmed, case-insensitively) are read as a
+    /// claim; an absent key, an empty value, and anything unrecognized all mean
+    /// "no claim was made". Deliberately not a permissive truthiness test: this
+    /// value decides whether a user's archive is refused and whether a delete
+    /// stops to confirm, and inventing a claim out of a value a provider meant
+    /// for display would block a gesture nobody asked to block.
+    ///
+    /// It lives here, beside the payload, because both sides of the wire read
+    /// it: the daemon's archive guard and the app's delete confirmation. Two
+    /// copies of a rule this sharp would drift.
+    static func metaReportsDirtyWorkspace(_ meta: [String: String]?) -> Bool {
+        guard let raw = meta?[dirtyWorkspaceMetaKey] else { return false }
+        switch raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "true", "1": return true
+        default: return false
+        }
+    }
+
+    /// This session's own dirty-checkout claim.
+    var reportsDirtyWorkspace: Bool {
+        Self.metaReportsDirtyWorkspace(meta)
+    }
+}
+
 public struct RemoteDeleteResult: Codable, Sendable, Equatable {
     public let id: String
     public let deleted: Bool

--- a/Tests/TBDAppTests/AppStateEmissionCounter.swift
+++ b/Tests/TBDAppTests/AppStateEmissionCounter.swift
@@ -114,6 +114,7 @@ final class AppStateEmissionTracker {
         _ = state.reapRecords
         _ = state.remoteProviders
         _ = state.remoteSessions
+        _ = state.retainedTranscripts
         _ = state.remoteSessionDisplayNames
         _ = state.highlightedArchivedWorktreeID
         _ = state.activeToast
@@ -223,6 +224,7 @@ final class AppStateEmissionTracker {
         "reapRecords",
         "remoteProviders",
         "remoteSessions",
+        "retainedTranscripts",
         "remoteSessionDisplayNames",
         "highlightedArchivedWorktreeID",
         "activeToast",

--- a/Tests/TBDAppTests/RemoteAppStateTests.swift
+++ b/Tests/TBDAppTests/RemoteAppStateTests.swift
@@ -27,6 +27,18 @@ private final class Recorder {
 
 private enum TestPinError: Error { case boom }
 
+/// What a `deleteRemoteSession` run did, recorded through the injected seams.
+/// A reference type for the same reason `Recorder` is one: the seams are
+/// escaping closures, and a captured local `var` cannot be mutated from one.
+@MainActor
+private final class DeleteProbe {
+    var confirmAnswer = false
+    var confirmed = false
+    var confirmMessage: String?
+    var deleteCalls: [(provider: String, sessionID: String, retain: Bool)] = []
+    var deletedFlag = true
+}
+
 @MainActor
 @Suite("Remote backends — app state")
 struct RemoteAppStateTests {
@@ -548,6 +560,124 @@ struct RemoteAppStateTests {
 
     // Helper: run an async body against a freshly-isolated AppState with
     // proper UserDefaults suite teardown (async variant of `withState`).
+    // MARK: - deleteRemoteSession
+
+    private func seedForDelete(
+        _ state: AppState, capabilities: [String],
+        sessionState: RemoteProcessState, meta: [String: String]? = nil
+    ) {
+        state.remoteProviders = [RemoteProviderStatus(
+            config: RemoteProviderConfig(name: "acme", exec: "/bin/acme"),
+            describe: ProviderDescribe(name: "acme", capabilities: capabilities),
+            health: .ok, errorMessage: nil, remediationLabel: nil, remediationCommand: nil)]
+        state.remoteSessions = [RemoteSessionInfo(
+            provider: "acme",
+            payload: RemoteSessionPayload(
+                id: "s1", title: "fix flaky CI", state: sessionState, meta: meta),
+            gone: false, dismissed: false, lastSeen: Date())]
+    }
+
+    /// Wires both seams at a probe and makes the refresh that follows a delete
+    /// a no-op, so no test here reaches a daemon — and, crucially, none reaches
+    /// `NSAlert.runModal()`, which in a headless run would hang rather than
+    /// fail.
+    private func attachDeleteProbe(_ state: AppState, _ probe: DeleteProbe) {
+        state.remoteDeleteConfirmer = { message in
+            probe.confirmed = true
+            probe.confirmMessage = message
+            return probe.confirmAnswer
+        }
+        state.remoteSessionDeleter = { provider, sessionID, retain in
+            probe.deleteCalls.append((provider, sessionID, retain))
+            return RemoteDeleteResult(id: sessionID, deleted: probe.deletedFlag)
+        }
+        state.remoteProvidersFetcher = { RemoteProvidersResult(providers: []) }
+        state.remoteSessionsFetcher = { RemoteSessionsResult(sessions: []) }
+    }
+
+    /// Exited, clean, and the provider can retain: nothing is at stake, so the
+    /// gesture goes straight through without asking.
+    @Test func deleteSkipsTheConfirmWhenNothingIsAtStake() async {
+        await withStateAsync { state in
+            seedForDelete(state, capabilities: ["delete", "retain"], sessionState: .exited)
+            let probe = DeleteProbe()
+            attachDeleteProbe(state, probe)
+
+            await state.deleteRemoteSession(provider: "acme", sessionID: "s1")
+
+            #expect(!probe.confirmed)
+            #expect(probe.deleteCalls.count == 1)
+            #expect(probe.deleteCalls.first?.provider == "acme")
+            #expect(probe.deleteCalls.first?.sessionID == "s1")
+            #expect(probe.deleteCalls.first?.retain == true,
+                    "TBD asks for a receipt whenever the provider can give one")
+        }
+    }
+
+    /// A running session confirms, and declining destroys nothing. The
+    /// discriminating half is the deleter never being called.
+    @Test func decliningTheConfirmDeletesNothing() async {
+        await withStateAsync { state in
+            seedForDelete(state, capabilities: ["delete", "retain"], sessionState: .running)
+            let probe = DeleteProbe()
+            probe.confirmAnswer = false
+            attachDeleteProbe(state, probe)
+
+            await state.deleteRemoteSession(provider: "acme", sessionID: "s1")
+
+            #expect(probe.confirmed)
+            #expect(probe.deleteCalls.isEmpty)
+        }
+    }
+
+    /// A provider that cannot retain gets `retain: false` — TBD requests a
+    /// receipt, it never assumes one — and the delete still confirms, because
+    /// no record will survive it.
+    @Test func aProviderWithoutRetainIsNotAskedToRetain() async {
+        await withStateAsync { state in
+            seedForDelete(state, capabilities: ["delete"], sessionState: .exited)
+            let probe = DeleteProbe()
+            probe.confirmAnswer = true
+            attachDeleteProbe(state, probe)
+
+            await state.deleteRemoteSession(provider: "acme", sessionID: "s1")
+
+            #expect(probe.confirmed, "a delete that keeps no record always confirms")
+            #expect(probe.deleteCalls.first?.retain == false)
+        }
+    }
+
+    /// A session claiming `workspace_dirty` confirms even though it has exited
+    /// and a receipt is coming — the uncommitted work is on the provider's
+    /// machine and goes with the session.
+    @Test func aDirtyWorkspaceConfirmsEvenWhenExitedAndRetaining() async {
+        await withStateAsync { state in
+            seedForDelete(
+                state, capabilities: ["delete", "retain"], sessionState: .exited,
+                meta: [RemoteSessionPayload.dirtyWorkspaceMetaKey: "true"])
+            let probe = DeleteProbe()
+            probe.confirmAnswer = false
+            attachDeleteProbe(state, probe)
+
+            await state.deleteRemoteSession(provider: "acme", sessionID: "s1")
+
+            #expect(probe.confirmed)
+            #expect(probe.confirmMessage?.contains("uncommitted") == true)
+            #expect(probe.deleteCalls.isEmpty)
+        }
+    }
+
+    /// The flag the menus read comes from the daemon, and falls back to the
+    /// shipped default when the daemon has not answered.
+    @Test func remoteDeleteEnabledFollowsTheDaemon() async {
+        await withStateAsync { state in
+            #expect(state.remoteDeleteEnabled == Config.remoteDeleteEnabledDefault)
+            state.daemonCapabilities = DaemonCapabilitiesResult(
+                controlModeEnabled: false, remoteDeleteEnabled: true)
+            #expect(state.remoteDeleteEnabled)
+        }
+    }
+
     private func withStateAsync(_ body: (AppState) async -> Void) async {
         let suiteName = "TBDAppTests.Remote.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!

--- a/Tests/TBDAppTests/RemoteDeleteConfirmationTests.swift
+++ b/Tests/TBDAppTests/RemoteDeleteConfirmationTests.swift
@@ -1,0 +1,142 @@
+import Foundation
+import Testing
+@testable import TBDApp
+import TBDShared
+
+/// The rule that decides whether deleting a remote session asks first
+/// (`docs/specs/2026-09-02-remote-session-delete-and-transcript-exchange-design.md`,
+/// "App"): confirmation is skipped only when nothing is at stake — the session
+/// has exited, claims no uncommitted work, and a record of the conversation is
+/// coming back. Everything else confirms.
+///
+/// A pure function, so every branch is testable without an `AppState` — the
+/// same split `RemoteSessionActionMenu` keeps.
+@Suite("Remote delete confirmation")
+struct RemoteDeleteConfirmationTests {
+    private typealias Decision = RemoteDeleteConfirmation.Decision
+
+    private let expiry = ISO8601DateFormatter().date(from: "2026-10-01T00:00:00Z")!
+
+    private func message(_ decision: Decision) -> String? {
+        if case .confirm(let message) = decision { return message }
+        return nil
+    }
+
+    // MARK: - The one branch that proceeds
+
+    /// Exited, clean, and a receipt is coming: nothing is destroyed that
+    /// anybody can miss, so the gesture goes straight through.
+    @Test func exitedAndCleanWithARetainProceeds() {
+        let decision = RemoteDeleteConfirmation.decide(
+            state: .exited, workspaceDirty: false, willRetain: true,
+            sessionTitle: "fix flaky CI", expiresAt: expiry)
+        #expect(decision == .proceed)
+    }
+
+    // MARK: - Every branch that confirms
+
+    /// Still running: deleting ends compute that is doing something right now.
+    @Test func runningConfirms() {
+        let decision = RemoteDeleteConfirmation.decide(
+            state: .running, workspaceDirty: false, willRetain: true,
+            sessionTitle: "fix flaky CI", expiresAt: expiry)
+        #expect(decision != .proceed)
+    }
+
+    /// `starting` and `unknown` are not `exited`, and the skip is granted only
+    /// to `exited`. A state TBD cannot read is the last one to wave through.
+    @Test func startingAndUnknownStatesConfirm() {
+        for state in [RemoteProcessState.starting, .unknown] {
+            let decision = RemoteDeleteConfirmation.decide(
+                state: state, workspaceDirty: false, willRetain: true,
+                sessionTitle: "fix flaky CI", expiresAt: expiry)
+            #expect(decision != .proceed, "\(state) must confirm")
+        }
+    }
+
+    /// `meta.workspace_dirty`: uncommitted work lives on the provider's machine
+    /// and goes with the session.
+    @Test func dirtyWorkspaceConfirms() {
+        let decision = RemoteDeleteConfirmation.decide(
+            state: .exited, workspaceDirty: true, willRetain: true,
+            sessionTitle: "fix flaky CI", expiresAt: expiry)
+        #expect(decision != .proceed)
+        #expect(message(decision)?.contains("uncommitted") == true)
+    }
+
+    /// **The branch that is easy to miss.** An exited, clean session still
+    /// confirms when no record is being kept, because there is then nothing
+    /// left to recover afterwards.
+    @Test func keepingNoRecordConfirmsEvenWhenExitedAndClean() {
+        let decision = RemoteDeleteConfirmation.decide(
+            state: .exited, workspaceDirty: false, willRetain: false,
+            sessionTitle: "fix flaky CI", expiresAt: nil)
+        #expect(decision != .proceed)
+        let text = try? #require(message(decision))
+        #expect(text?.contains("No transcript") == true)
+    }
+
+    // MARK: - What the message must say
+
+    /// The dialog names the session, so a user with several open knows which
+    /// one is about to go.
+    @Test func theMessageNamesTheSession() {
+        let decision = RemoteDeleteConfirmation.decide(
+            state: .running, workspaceDirty: false, willRetain: true,
+            sessionTitle: "fix flaky CI", expiresAt: expiry)
+        #expect(message(decision)?.contains("fix flaky CI") == true)
+    }
+
+    /// A session the provider never titled still reads as a sentence rather
+    /// than as empty quotes.
+    @Test func anUntitledSessionStillReadsAsASentence() {
+        let decision = RemoteDeleteConfirmation.decide(
+            state: .running, workspaceDirty: false, willRetain: false,
+            sessionTitle: "   ", expiresAt: nil)
+        let text = try? #require(message(decision))
+        #expect(text?.contains("\u{201C}\u{201D}") != true, "no empty quotes")
+        #expect(text?.contains("this remote session") == true)
+    }
+
+    /// A kept transcript is stated as kept, and the stated expiry is shown.
+    @Test func theMessageStatesTheExpiryWhenTheProviderGaveOne() {
+        let decision = RemoteDeleteConfirmation.decide(
+            state: .running, workspaceDirty: false, willRetain: true,
+            sessionTitle: "fix flaky CI", expiresAt: expiry)
+        let text = try? #require(message(decision))
+        #expect(text?.contains("transcript") == true)
+        #expect(text?.contains("expires") == true)
+        #expect(text?.contains(RemoteDeleteConfirmation.expiryDescription(expiry)) == true)
+    }
+
+    /// **An absent expiry is never permanence.** The contract makes rendering
+    /// absence as a guarantee a MUST NOT, so the message says the provider
+    /// stated nothing rather than "never expires" or "kept forever".
+    @Test func anAbsentExpiryIsNeverRenderedAsPermanence() {
+        let decision = RemoteDeleteConfirmation.decide(
+            state: .running, workspaceDirty: false, willRetain: true,
+            sessionTitle: "fix flaky CI", expiresAt: nil)
+        let text = try? #require(message(decision))
+        #expect(text?.contains("transcript") == true)
+        let lowered = text?.lowercased() ?? ""
+        #expect(!lowered.contains("never"))
+        #expect(!lowered.contains("forever"))
+        #expect(!lowered.contains("indefinitely"))
+        #expect(text?.contains("states no expiry") == true)
+    }
+
+    /// The retention clause is one or the other, never both, whichever branch
+    /// produced the confirmation.
+    @Test func theRetentionClauseIsExactlyOneOfTheTwo() {
+        let kept = RemoteDeleteConfirmation.decide(
+            state: .running, workspaceDirty: false, willRetain: true,
+            sessionTitle: "t", expiresAt: expiry)
+        let notKept = RemoteDeleteConfirmation.decide(
+            state: .running, workspaceDirty: false, willRetain: false,
+            sessionTitle: "t", expiresAt: expiry)
+        #expect(message(kept)?.contains("No transcript") != true)
+        #expect(message(notKept)?.contains("No transcript") == true)
+        #expect(message(notKept)?.contains("expires") != true,
+                "an expiry is meaningless when nothing is being kept")
+    }
+}

--- a/Tests/TBDAppTests/RemoteLaneReviveAvailabilityTests.swift
+++ b/Tests/TBDAppTests/RemoteLaneReviveAvailabilityTests.swift
@@ -1,0 +1,103 @@
+import Testing
+import Foundation
+@testable import TBDApp
+@testable import TBDShared
+
+/// `RemoteLaneReviveAvailability` — whether the archived list's Revive button
+/// is still good for a remote lane whose session was destroyed.
+///
+/// Tier 1: a pure function over a worktree, a receipt list and a `Date`. The
+/// daemon decides the same thing authoritatively
+/// (`RemoteLaneLifecycle.reseedPlan`); this is what disables the button before
+/// it is pressed rather than only refusing afterwards.
+@Suite("RemoteLaneReviveAvailability")
+struct RemoteLaneReviveAvailabilityTests {
+    private let now = Date(timeIntervalSince1970: 1_800_000_000)
+    private let laneID = UUID()
+
+    private func lane(location: WorktreeLocation) -> Worktree {
+        Worktree(
+            id: laneID, repoID: UUID(), name: "agentbox-probe",
+            displayName: "probe", branch: "acme-branch", path: "",
+            status: .archived, tmuxServer: "", location: location)
+    }
+
+    private var remoteLane: Worktree {
+        lane(location: .remote(provider: "agentbox", sessionID: "probe"))
+    }
+
+    private func receipt(
+        expiresAt: Date?, lane: UUID?, createdAt: Date = Date(timeIntervalSince1970: 1)
+    ) -> RetainedTranscript {
+        RetainedTranscript(
+            provider: "agentbox", key: "opaque-key", expiresAt: expiresAt, bytes: 7,
+            originWorktreeID: lane, createdAt: createdAt)
+    }
+
+    @Test func aLaneWithNoReceiptStaysRevivable() {
+        let decision = RemoteLaneReviveAvailability.decide(
+            worktree: remoteLane, receipts: [], now: now)
+        #expect(decision == .enabled)
+    }
+
+    /// An absent `expires_at` is the provider declining to say. It is never
+    /// rendered as permanence, and it is never a reason to disable anything.
+    @Test func anUnstatedExpiryStaysRevivable() {
+        let decision = RemoteLaneReviveAvailability.decide(
+            worktree: remoteLane, receipts: [receipt(expiresAt: nil, lane: laneID)], now: now)
+        #expect(decision == .enabled)
+    }
+
+    @Test func anUnexpiredReceiptStaysRevivable() {
+        let decision = RemoteLaneReviveAvailability.decide(
+            worktree: remoteLane,
+            receipts: [receipt(expiresAt: now.addingTimeInterval(60), lane: laneID)],
+            now: now)
+        #expect(decision == .enabled)
+    }
+
+    @Test func aLapsedReceiptDisablesReviveAndNamesTheDate() {
+        let expiresAt = now.addingTimeInterval(-60)
+        let decision = RemoteLaneReviveAvailability.decide(
+            worktree: remoteLane, receipts: [receipt(expiresAt: expiresAt, lane: laneID)],
+            now: now)
+        guard case .expired(let reason) = decision else {
+            Issue.record("expected .expired, got \(decision)")
+            return
+        }
+        #expect(reason.contains(RetainReceipt.formatTimestamp(expiresAt)))
+    }
+
+    /// Another lane's lapsed receipt must not disable this one — the receipts
+    /// arrive as one flat list across every provider and every lane.
+    @Test func someoneElsesLapsedReceiptDoesNotDisableThisLane() {
+        let decision = RemoteLaneReviveAvailability.decide(
+            worktree: remoteLane,
+            receipts: [receipt(expiresAt: now.addingTimeInterval(-60), lane: UUID())],
+            now: now)
+        #expect(decision == .enabled)
+    }
+
+    /// A lane retained twice takes the newest word: an early receipt that has
+    /// since lapsed must not disable a lane whose later retention is still good.
+    @Test func theNewestReceiptWins() {
+        let receipts = [
+            receipt(expiresAt: now.addingTimeInterval(-600), lane: laneID,
+                    createdAt: Date(timeIntervalSince1970: 1)),
+            receipt(expiresAt: now.addingTimeInterval(600), lane: laneID,
+                    createdAt: Date(timeIntervalSince1970: 100)),
+        ]
+        #expect(RemoteLaneReviveAvailability.decide(
+            worktree: remoteLane, receipts: receipts, now: now) == .enabled)
+    }
+
+    /// A local worktree never consults a receipt at all — its revive is a git
+    /// worktree being recreated, and nothing about a transcript bears on it.
+    @Test func aLocalWorktreeIsNeverGatedByAReceipt() {
+        let decision = RemoteLaneReviveAvailability.decide(
+            worktree: lane(location: .local),
+            receipts: [receipt(expiresAt: now.addingTimeInterval(-60), lane: laneID)],
+            now: now)
+        #expect(decision == .enabled)
+    }
+}

--- a/Tests/TBDAppTests/RemoteSectionViewTests.swift
+++ b/Tests/TBDAppTests/RemoteSectionViewTests.swift
@@ -109,6 +109,45 @@ struct RemoteSectionViewTests {
         #expect(RemoteSectionView.shouldShowHeader(provider: status(health: .ok), sessions: sessions, knownRepoIDs: []))
     }
 
+    // MARK: - archived sessions are display policy, applied here
+
+    /// Built through the PRODUCTION decode path — the payload is decoded from
+    /// provider-shaped JSON, so the absent-reads-as-false semantics of
+    /// `archived` are the real ones and not a hand-assembled stand-in.
+    private func decodedSession(
+        provider: String = "acme", id: String, archivedJSON: String? = nil
+    ) throws -> RemoteSessionInfo {
+        var fields = ["\"id\": \"\(id)\"", "\"state\": \"running\""]
+        if let archivedJSON { fields.append("\"archived\": \(archivedJSON)") }
+        let json = "{ \(fields.joined(separator: ", ")) }"
+        let payload = try JSONDecoder().decode(RemoteSessionPayload.self, from: Data(json.utf8))
+        return RemoteSessionInfo(
+            provider: provider, payload: payload,
+            gone: false, dismissed: false, lastSeen: Date())
+    }
+
+    /// Same display policy as `RepoSectionView.matchedRemoteSessions`: the
+    /// provider keeps archived sessions in `list`, and the caller decides
+    /// which of them a human sees.
+    @Test func providerSectionExcludesArchivedSessions() throws {
+        let sessions = [
+            try decodedSession(id: "archived", archivedJSON: "true"),
+            try decodedSession(id: "active"),
+        ]
+        let result = RemoteSectionView.sessions(in: sessions, forProvider: "acme", knownRepoIDs: [])
+        #expect(result.map(\.payload.id) == ["active"])
+    }
+
+    /// The other arm — an explicit `false` and an omitted key both stay.
+    @Test func providerSectionIncludesUnarchivedSessions() throws {
+        let sessions = [
+            try decodedSession(id: "explicit-false", archivedJSON: "false"),
+            try decodedSession(id: "absent"),
+        ]
+        let result = RemoteSectionView.sessions(in: sessions, forProvider: "acme", knownRepoIDs: [])
+        #expect(Set(result.map(\.payload.id)) == ["explicit-false", "absent"])
+    }
+
     // MARK: - knownRepoIDs(repos:repoFilter:) — final review item 3
 
     private func repo(id: UUID = UUID(), hidden: Bool = false) -> Repo {

--- a/Tests/TBDAppTests/RemoteSessionActionMenuTests.swift
+++ b/Tests/TBDAppTests/RemoteSessionActionMenuTests.swift
@@ -109,6 +109,54 @@ struct RemoteSessionActionMenuTests {
         #expect(RemoteSessionActionMenu.items(capabilities: ["attach", "log", "send"], gone: false, isPinned: false).count == 8)
     }
 
+    // MARK: - Dismiss: offered for gone OR exited, never for a live running row
+
+    /// The gate this parameter opens. A provider may keep an exited session
+    /// listed indefinitely, so the row is not `gone`; on a provider that
+    /// never implements `delete`, Dismiss is the only thing that removes it.
+    @Test func dismissOfferedForExitedSession() {
+        let items = RemoteSessionActionMenu.items(
+            capabilities: [], gone: false, isPinned: false, exited: true)
+        #expect(kinds(items).contains(.dismiss))
+        // Immediately after the pin toggle and before the divider, so Stop
+        // stays the last destructive item.
+        #expect(kinds(items) == [.rename, .copySessionID, .pin, .dismiss, nil, .stop])
+    }
+
+    /// The pre-existing branch is untouched: a `gone` row still collapses to
+    /// Copy + pin + Dismiss, whatever `exited` says.
+    @Test func dismissOfferedForGoneSession() {
+        for exited in [true, false] {
+            let items = RemoteSessionActionMenu.items(
+                capabilities: [], gone: true, isPinned: false, exited: exited)
+            #expect(kinds(items) == [.copySessionID, .pin, .dismiss])
+        }
+    }
+
+    /// The discriminating arm: a live, running row must NOT offer Dismiss —
+    /// tombstoning a session the agent is still working in would hide live
+    /// work behind a local-only gesture with no undo in the menu.
+    @Test func dismissNotOfferedForLiveRunningSession() {
+        let items = RemoteSessionActionMenu.items(
+            capabilities: ["attach", "log", "send"], gone: false, isPinned: false, exited: false)
+        #expect(!kinds(items).contains(.dismiss))
+        // And the default keeps every existing call site on that branch.
+        #expect(!kinds(RemoteSessionActionMenu.items(
+            capabilities: [], gone: false, isPinned: false)).contains(.dismiss))
+    }
+
+    /// An exited row takes the LIVE branch, not the collapsed `gone` one: it
+    /// keeps every inspection action plus Stop, and merely gains Dismiss.
+    @Test func exitedSessionKeepsInspectionActions() {
+        let items = RemoteSessionActionMenu.items(
+            capabilities: ["attach", "log", "send"], gone: false, isPinned: false, exited: true)
+        #expect(kinds(items) == [
+            .rename, .attach, .viewLog, .sendText, .copySessionID, .pin, .dismiss, nil, .stop,
+        ])
+        #expect(items.last == .action(RemoteSessionActionMenu.Action(
+            kind: .stop, title: RemoteSessionActionMenu.stopLabel, role: .destructive)))
+    }
+
     // MARK: - unrecognized capability strings are ignored, not erroring
 
     @Test func unrecognizedCapabilityStringsAreIgnored() {

--- a/Tests/TBDAppTests/RemoteSessionActionMenuTests.swift
+++ b/Tests/TBDAppTests/RemoteSessionActionMenuTests.swift
@@ -213,4 +213,86 @@ struct RemoteSessionActionMenuTests {
         #expect(RemoteSessionActionMenu.pinLabel == RowActionMenu.pinLabel)
         #expect(RemoteSessionActionMenu.unpinLabel == RowActionMenu.unpinLabel)
     }
+
+    // MARK: - Delete, behind the default-off flag
+
+    private func deleteAction(_ items: [Item]) -> RemoteSessionActionMenu.Action? {
+        items.compactMap { item -> RemoteSessionActionMenu.Action? in
+            if case let .action(action) = item, action.kind == .delete { return action }
+            return nil
+        }.first
+    }
+
+    /// The flag's off branch — the shipped default, and the default of the
+    /// parameter, so every pre-existing call site in this suite composes no
+    /// Delete at all.
+    @Test func deleteOmittedWhenFlagOff() {
+        let items = RemoteSessionActionMenu.items(
+            capabilities: ["delete"], gone: false, isPinned: false, deleteEnabled: false)
+        #expect(!kinds(items).contains(.delete))
+    }
+
+    /// The flag's on branch, with the capability: present, enabled, destructive.
+    @Test func deletePresentAndEnabledWithTheCapability() {
+        let items = RemoteSessionActionMenu.items(
+            capabilities: ["delete"], gone: false, isPinned: false, deleteEnabled: true)
+        let delete = deleteAction(items)
+        #expect(delete?.title == RemoteSessionActionMenu.deleteLabel)
+        #expect(delete?.isEnabled == true)
+        #expect(delete?.role == .destructive)
+        #expect(delete?.disabledHelp == nil)
+    }
+
+    /// **Present but disabled**, not omitted — the one deliberate departure
+    /// from this menu's omit-when-absent convention. Attach, View Log and Send
+    /// Text vanish when undeclared; Delete stays and says why, because a user
+    /// looking for the way to reclaim a session needs to be told the way exists
+    /// and this provider has not built it yet.
+    @Test func deletePresentButDisabledWithoutTheCapability() {
+        let items = RemoteSessionActionMenu.items(
+            capabilities: ["attach", "log"], gone: false, isPinned: false, deleteEnabled: true)
+        let delete = deleteAction(items)
+        #expect(delete?.title == RemoteSessionActionMenu.deleteProviderCannotDeleteLabel)
+        #expect(delete?.title == "Delete (provider can't delete)")
+        #expect(delete?.isEnabled == false)
+        #expect(delete?.role == .destructive)
+        #expect(delete?.disabledHelp == RemoteSessionActionMenu.deleteNeedsProviderCapabilityHelp)
+    }
+
+    /// The discriminating pair for the departure: an absent `attach` is
+    /// omitted while an absent `delete` is present-and-disabled, in the very
+    /// same menu. If someone "fixed" Delete into consistency, this goes red.
+    @Test func anAbsentDeleteIsShownWhileAnAbsentAttachIsNot() {
+        let items = RemoteSessionActionMenu.items(
+            capabilities: [], gone: false, isPinned: false, deleteEnabled: true)
+        #expect(!kinds(items).contains(.attach))
+        #expect(kinds(items).contains(.delete))
+    }
+
+    /// Delete is last: it strictly outranks Stop, which ends compute without
+    /// removing the record.
+    @Test func deleteIsTheLastItemAfterStop() {
+        let items = RemoteSessionActionMenu.items(
+            capabilities: ["delete"], gone: false, isPinned: false, deleteEnabled: true)
+        #expect(kinds(items) == [.rename, .copySessionID, .pin, nil, .stop, .delete])
+    }
+
+    /// A `gone` row keeps its collapsed shape: the provider has stopped
+    /// enumerating that session, so there is nothing left there to destroy and
+    /// Dismiss is the row's removal gesture.
+    @Test func deleteNotOfferedForAGoneRow() {
+        let items = RemoteSessionActionMenu.items(
+            capabilities: ["delete"], gone: true, isPinned: false, deleteEnabled: true)
+        #expect(kinds(items) == [.copySessionID, .pin, .dismiss])
+    }
+
+    /// A stale inventory omits Delete with Stop, for the same reason: provider
+    /// mutations wait for an inventory worth trusting.
+    @Test func deleteOmittedWhileTheSnapshotIsStale() {
+        let items = RemoteSessionActionMenu.items(
+            capabilities: ["delete"], gone: false, snapshotFresh: false,
+            isPinned: false, deleteEnabled: true)
+        #expect(!kinds(items).contains(.delete))
+        #expect(!kinds(items).contains(.stop))
+    }
 }

--- a/Tests/TBDAppTests/RepoSectionRemoteSessionsTests.swift
+++ b/Tests/TBDAppTests/RepoSectionRemoteSessionsTests.swift
@@ -69,6 +69,54 @@ struct RepoSectionRemoteSessionsTests {
         #expect(RepoSectionView.matchedRemoteSessions(sessions, repoID: UUID(), worktrees: []).isEmpty)
     }
 
+    // MARK: - archived sessions are display policy, applied here
+
+    /// A session built through the PRODUCTION decode path: the payload comes
+    /// from provider-shaped JSON, so these tests exercise the real
+    /// `archived` decoding — including the absent-reads-as-false case a
+    /// hand-assembled struct would never reach. `archivedJSON` is the raw
+    /// JSON value (or nil to omit the key entirely, as a provider that has
+    /// never heard of `archived` does).
+    private func decodedSession(
+        id: String, resolvedRepoID: UUID?, archivedJSON: String? = nil
+    ) throws -> RemoteSessionInfo {
+        var fields = ["\"id\": \"\(id)\"", "\"state\": \"running\""]
+        if let archivedJSON { fields.append("\"archived\": \(archivedJSON)") }
+        let json = "{ \(fields.joined(separator: ", ")) }"
+        let payload = try JSONDecoder().decode(RemoteSessionPayload.self, from: Data(json.utf8))
+        return RemoteSessionInfo(
+            provider: "acme", payload: payload,
+            gone: false, dismissed: false, lastSeen: Date(), resolvedRepoID: resolvedRepoID)
+    }
+
+    /// The contract keeps archived sessions in `list` and leaves the display
+    /// policy to the caller — this filter is where TBD writes it. Without
+    /// the exclusion, archiving an adopted lane retires its worktree row and
+    /// the session reappears immediately underneath as a bare session row
+    /// nothing can remove.
+    @Test func matchedRemoteSessionsExcludesArchivedSessions() throws {
+        let repoID = UUID()
+        let sessions = [
+            try decodedSession(id: "archived", resolvedRepoID: repoID, archivedJSON: "true"),
+            try decodedSession(id: "active", resolvedRepoID: repoID),
+        ]
+        let result = RepoSectionView.matchedRemoteSessions(sessions, repoID: repoID, worktrees: [])
+        #expect(result.map(\.payload.id) == ["active"])
+    }
+
+    /// The other arm: the exclusion must not swallow ordinary sessions. Both
+    /// non-archived spellings are covered — an explicit `false`, and the key
+    /// omitted altogether, which the contract reads as `false`.
+    @Test func matchedRemoteSessionsIncludesUnarchivedSessions() throws {
+        let repoID = UUID()
+        let sessions = [
+            try decodedSession(id: "explicit-false", resolvedRepoID: repoID, archivedJSON: "false"),
+            try decodedSession(id: "absent", resolvedRepoID: repoID),
+        ]
+        let result = RepoSectionView.matchedRemoteSessions(sessions, repoID: repoID, worktrees: [])
+        #expect(Set(result.map(\.payload.id)) == ["explicit-false", "absent"])
+    }
+
     // MARK: - dedup against adopted worktree rows
 
     /// The defect this filter closes: a session adopted into a worktree row

--- a/Tests/TBDAppTests/RowActionMenuTests.swift
+++ b/Tests/TBDAppTests/RowActionMenuTests.swift
@@ -343,6 +343,88 @@ struct RowActionMenuRemoteArchiveTests {
     }
 }
 
+/// Delete on a remote lane, behind the default-off `remote_delete_enabled`
+/// flag. Both branches of the flag, and both branches of the capability.
+@Suite("RowActionMenu — remote delete")
+struct RowActionMenuRemoteDeleteTests {
+    private static let remoteLocation = WorktreeLocation.remote(provider: "acme", sessionID: "s1")
+
+    private func deleteAction(_ ctx: RowActionMenu.Context) -> RowActionMenu.Action? {
+        RowActionMenu.items(context: ctx)
+            .compactMap(\.action).first { $0.kind == .deleteRemoteSession }
+    }
+
+    /// The flag's off branch — the shipped default. Nothing is composed, so a
+    /// destructive action is never offered that the daemon would refuse.
+    @Test func deleteOmittedWhenFlagOff() {
+        let ctx = RowActionMenu.Context(hasRepoID: true, branch: "b",
+                                        location: Self.remoteLocation,
+                                        provider: "acme",
+                                        providerCapabilities: ["delete"],
+                                        remoteDeleteEnabled: false)
+        #expect(deleteAction(ctx) == nil)
+    }
+
+    /// The flag's on branch, with the capability: present, enabled, destructive.
+    @Test func deletePresentAndEnabledWithTheCapability() {
+        let ctx = RowActionMenu.Context(hasRepoID: true, branch: "b",
+                                        location: Self.remoteLocation,
+                                        provider: "acme",
+                                        providerCapabilities: ["delete", "archive"],
+                                        remoteDeleteEnabled: true)
+        let delete = deleteAction(ctx)
+        #expect(delete?.title == RowActionMenu.deleteRemoteSessionLabel)
+        #expect(delete?.isEnabled == true)
+        #expect(delete?.role == .destructive)
+        #expect(delete?.disabledHelp == nil)
+    }
+
+    /// **Present but disabled**, not omitted — the treatment an unarchivable
+    /// lane's Archive already gets, and a deliberate departure from omitting an
+    /// undeclared capability. A user looking for the way to reclaim a lane is
+    /// told the way exists and this provider has not built it yet.
+    @Test func deletePresentButDisabledWithoutTheCapability() {
+        let ctx = RowActionMenu.Context(hasRepoID: true, branch: "b",
+                                        location: Self.remoteLocation,
+                                        provider: "acme",
+                                        providerCapabilities: ["archive"],
+                                        remoteDeleteEnabled: true)
+        let delete = deleteAction(ctx)
+        #expect(delete?.title == RowActionMenu.deleteProviderCannotDeleteLabel)
+        #expect(delete?.title == "Delete Remote Session (provider can't delete)")
+        #expect(delete?.isEnabled == false)
+        #expect(delete?.role == .destructive)
+        #expect(delete?.disabledHelp == RowActionMenu.deleteNeedsProviderCapabilityHelp)
+    }
+
+    /// A local row has no remote session to destroy, flag or no flag.
+    @Test func localRowNeverOffersDelete() {
+        let ctx = RowActionMenu.Context(hasRepoID: true, branch: "b",
+                                        providerCapabilities: ["delete"],
+                                        remoteDeleteEnabled: true)
+        #expect(ctx.location.isLocal)
+        #expect(deleteAction(ctx) == nil)
+    }
+
+    /// Delete sits beside Archive: the two ways a lane leaves the working set,
+    /// shown together so a user choosing between them sees both.
+    @Test func deleteIsComposedImmediatelyAfterArchive() {
+        let ctx = RowActionMenu.Context(hasRepoID: true, branch: "b",
+                                        location: Self.remoteLocation,
+                                        provider: "acme",
+                                        providerCapabilities: ["delete", "archive"],
+                                        remoteDeleteEnabled: true)
+        let kinds = RowActionMenu.items(context: ctx).compactMap(\.action).map(\.kind)
+        let archiveIndex = kinds.firstIndex(of: .archive)
+        let deleteIndex = kinds.firstIndex(of: .deleteRemoteSession)
+        #expect(archiveIndex != nil)
+        #expect(deleteIndex != nil)
+        if let archiveIndex, let deleteIndex {
+            #expect(deleteIndex == archiveIndex + 1)
+        }
+    }
+}
+
 // MARK: - Scratch branch
 
 @Suite("RowActionMenu — scratch")

--- a/Tests/TBDCLITests/RemoteCommandsTests.swift
+++ b/Tests/TBDCLITests/RemoteCommandsTests.swift
@@ -219,4 +219,113 @@ struct RemoteCommandsTests {
         #expect(text.contains("recall"))
         #expect(text.contains("agentbox"))
     }
+
+    // MARK: - delete: the caller-side policy
+
+    private let address = "agentbox/acme-app/probe"
+
+    /// Exited and clean: nothing to refuse.
+    @Test func deleteProceedsForAnExitedCleanSession() {
+        #expect(RemoteDeletePrecondition.refusal(
+            state: .exited, workspaceDirty: false, force: false, address: address) == nil)
+    }
+
+    /// The two refusals are named separately because they have different
+    /// remedies: one waits or stops the session, the other commits or pushes on
+    /// the provider's machine.
+    @Test func deleteRefusesARunningSessionByName() {
+        let refusal = RemoteDeletePrecondition.refusal(
+            state: .running, workspaceDirty: false, force: false, address: address)
+        #expect(refusal?.contains("still running") == true)
+        #expect(refusal?.contains(address) == true)
+        #expect(refusal?.contains("--force") == true)
+    }
+
+    @Test func deleteRefusesAStartingSession() {
+        #expect(RemoteDeletePrecondition.refusal(
+            state: .starting, workspaceDirty: false, force: false, address: address) != nil)
+    }
+
+    @Test func deleteRefusesADirtyWorkspaceByName() {
+        let refusal = RemoteDeletePrecondition.refusal(
+            state: .exited, workspaceDirty: true, force: false, address: address)
+        #expect(refusal?.contains("workspace_dirty") == true)
+        #expect(refusal?.contains("--force") == true)
+    }
+
+    /// `--force` overrides both, which is the whole reason the contract leaves
+    /// this policy to the caller.
+    @Test func forceOverridesBothRefusals() {
+        #expect(RemoteDeletePrecondition.refusal(
+            state: .running, workspaceDirty: true, force: true, address: address) == nil)
+    }
+
+    /// A session TBD has never mirrored has no state and no meta to read, and
+    /// `<provider>/<session-id>` must keep working against exactly that. The
+    /// provider is still the last word on whether the delete happens.
+    @Test func anUnmirroredSessionIsNotRefusedOnAbsentInformation() {
+        #expect(RemoteDeletePrecondition.refusal(
+            state: nil, workspaceDirty: false, force: false, address: address) == nil)
+    }
+
+    // MARK: - delete: the two outcomes
+
+    /// `deleted: false` is a success — there was nothing to destroy — and is
+    /// worded so nobody reads it as a deletion that happened.
+    @Test func anAlreadyGoneSessionIsNotReportedAsDeleted() {
+        let text = remoteDeleteConfirmation(
+            address: address, result: RemoteDeleteResult(id: "probe", deleted: false))
+        #expect(text.contains("already gone"))
+        #expect(!text.contains("deleted \(address)"))
+    }
+
+    @Test func aDeleteWithNoReceiptSaysOnlyThat() {
+        let text = remoteDeleteConfirmation(
+            address: address, result: RemoteDeleteResult(id: "probe", deleted: true))
+        #expect(text.contains("deleted \(address)"))
+        #expect(!text.contains("retained"))
+    }
+
+    @Test func aRetainingDeletePrintsTheKeyAndTheStatedExpiry() {
+        let expiry = ISO8601DateFormatter().date(from: "2026-10-01T00:00:00Z")!
+        let text = remoteDeleteConfirmation(
+            address: address,
+            result: RemoteDeleteResult(
+                id: "probe", deleted: true,
+                retained: RetainReceipt(key: "opaque", expiresAt: expiry, bytes: 12)))
+        #expect(text.contains("retained: opaque"))
+        #expect(text.contains("2026-10-01T00:00:00Z"))
+    }
+
+    /// An absent expiry is never rendered as permanence.
+    @Test func aRetainingDeleteWithNoStatedExpirySaysSo() {
+        let text = remoteDeleteConfirmation(
+            address: address,
+            result: RemoteDeleteResult(
+                id: "probe", deleted: true,
+                retained: RetainReceipt(key: "opaque", bytes: 12)))
+        #expect(text.contains("no expiry stated"))
+        #expect(!text.lowercased().contains("never"))
+        #expect(!text.lowercased().contains("forever"))
+    }
+
+    // MARK: - dismiss contrasts itself with delete
+
+    /// Without the contrast users reach for whichever they find first, and the
+    /// two are not interchangeable in either direction: one is a local tidy-up,
+    /// the other is irreversible.
+    @Test func dismissHelpSaysWhatItDoesNotDo() {
+        let discussion = RemoteDismiss.configuration.discussion
+        #expect(discussion.contains("delete"))
+        #expect(discussion.contains("local"))
+        #expect(RemoteDismiss.configuration.abstract.contains("changing nothing on the provider"))
+    }
+
+    /// And delete's own help points at the gate, since a refusal naming a flag
+    /// the user cannot find is not much of a refusal.
+    @Test func deleteHelpNamesTheFlagAndHowToLiftIt() {
+        let discussion = RemoteDelete.configuration.discussion
+        #expect(discussion.contains("remote_delete_enabled"))
+        #expect(discussion.contains("tbd remote allow-delete on"))
+    }
 }

--- a/Tests/TBDCLITests/RemoteCommandsTests.swift
+++ b/Tests/TBDCLITests/RemoteCommandsTests.swift
@@ -246,6 +246,23 @@ struct RemoteCommandsTests {
             state: .starting, workspaceDirty: false, force: false, address: address) != nil)
     }
 
+    /// The app's `RemoteDeleteConfirmation.decide` treats `.unknown` as live
+    /// (`live = state != .exited`) because a state TBD could not read is not a
+    /// statement the session is finished. The CLI must agree: `.unknown` is not
+    /// the frictionless path.
+    @Test func deleteRefusesASessionInUnknownState() {
+        let refusal = RemoteDeletePrecondition.refusal(
+            state: .unknown, workspaceDirty: false, force: false, address: address)
+        #expect(refusal != nil)
+        #expect(refusal?.contains(address) == true)
+        #expect(refusal?.contains("--force") == true)
+    }
+
+    @Test func forceOverridesAnUnknownStateRefusal() {
+        #expect(RemoteDeletePrecondition.refusal(
+            state: .unknown, workspaceDirty: false, force: true, address: address) == nil)
+    }
+
     @Test func deleteRefusesADirtyWorkspaceByName() {
         let refusal = RemoteDeletePrecondition.refusal(
             state: .exited, workspaceDirty: true, force: false, address: address)

--- a/Tests/TBDCLITests/RemoteCommandsTests.swift
+++ b/Tests/TBDCLITests/RemoteCommandsTests.swift
@@ -1,0 +1,222 @@
+import Foundation
+import Testing
+import TBDShared
+
+@testable import TBDCLI
+
+/// The pure halves of the `tbd remote` group: address resolution, the receipt
+/// wording, and the retained-transcript table.
+///
+/// The commands themselves need a live daemon, so the last hop — `run()` — is
+/// out of reach here; everything it decides before the socket opens is not.
+@Suite("tbd remote")
+struct RemoteCommandsTests {
+    private func session(provider: String, id: String) -> RemoteSessionInfo {
+        RemoteSessionInfo(
+            provider: provider,
+            payload: RemoteSessionPayload(id: id, title: id, state: .running),
+            gone: false, dismissed: false, lastSeen: Date())
+    }
+
+    /// Built through `Worktree`'s own initializer with a real
+    /// `WorktreeLocation`, so `providerBinding` is derived the way production
+    /// derives it rather than stamped by hand.
+    private func remoteWorktree(
+        id: UUID = UUID(), name: String, displayName: String? = nil,
+        provider: String?, sessionID: String?
+    ) -> Worktree {
+        let location: WorktreeLocation = provider.flatMap { p in
+            sessionID.map { WorktreeLocation.remote(provider: p, sessionID: $0) }
+        } ?? .local
+        return Worktree(
+            id: id, repoID: UUID(), name: name, displayName: displayName ?? name,
+            branch: "b", path: location.storagePath ?? "/tmp/acme/\(name)",
+            tmuxServer: "tbd-test", location: location)
+    }
+
+    // MARK: - RemoteSessionRef.resolve
+
+    /// The compound is an address, so it resolves without consulting the
+    /// inventory at all — a session TBD has not mirrored, or a provider whose
+    /// snapshot is stale, must still be addressable.
+    @Test func resolvesTheProviderSlashSessionCompound() {
+        let resolved = RemoteSessionRef.resolve(
+            "agentbox/fix-flaky-ci", sessions: [], worktrees: [])
+        #expect(resolved?.provider == "agentbox")
+        #expect(resolved?.sessionID == "fix-flaky-ci")
+    }
+
+    /// A provider name cannot contain a slash and a session id can, so the
+    /// split is at the FIRST one.
+    @Test func splitsTheCompoundAtTheFirstSlashOnly() {
+        let resolved = RemoteSessionRef.resolve(
+            "agentbox/acme-app/probe", sessions: [], worktrees: [])
+        #expect(resolved?.provider == "agentbox")
+        #expect(resolved?.sessionID == "acme-app/probe")
+    }
+
+    @Test func refusesACompoundWithAnEmptyHalf() {
+        #expect(RemoteSessionRef.resolve("/probe", sessions: [], worktrees: []) == nil)
+        #expect(RemoteSessionRef.resolve("agentbox/", sessions: [], worktrees: []) == nil)
+    }
+
+    @Test func resolvesAWorktreeUUIDThroughItsProviderBinding() {
+        let id = UUID()
+        let worktree = remoteWorktree(
+            id: id, name: "acme-lane", provider: "agentbox", sessionID: "fix-flaky-ci")
+        let resolved = RemoteSessionRef.resolve(
+            id.uuidString, sessions: [], worktrees: [worktree])
+        #expect(resolved?.provider == "agentbox")
+        #expect(resolved?.sessionID == "fix-flaky-ci")
+    }
+
+    /// A session nobody adopted has no worktree row, so its synthetic mirror id
+    /// is the only UUID that names it.
+    @Test func resolvesAMirrorRowsSyntheticUUID() {
+        let info = session(provider: "agentbox", id: "unadopted")
+        let resolved = RemoteSessionRef.resolve(
+            info.id.uuidString, sessions: [info], worktrees: [])
+        #expect(resolved?.provider == "agentbox")
+        #expect(resolved?.sessionID == "unadopted")
+    }
+
+    @Test func resolvesAWorktreeName() {
+        let worktree = remoteWorktree(
+            name: "acme-lane", provider: "agentbox", sessionID: "fix-flaky-ci")
+        let resolved = RemoteSessionRef.resolve(
+            "acme-lane", sessions: [], worktrees: [worktree])
+        #expect(resolved?.sessionID == "fix-flaky-ci")
+    }
+
+    @Test func resolvesAWorktreeDisplayName() {
+        let worktree = remoteWorktree(
+            name: "acme-lane", displayName: "fix flaky CI",
+            provider: "agentbox", sessionID: "fix-flaky-ci")
+        let resolved = RemoteSessionRef.resolve(
+            "fix flaky CI", sessions: [], worktrees: [worktree])
+        #expect(resolved?.sessionID == "fix-flaky-ci")
+    }
+
+    /// Two rows answering to one name resolve to nothing rather than to a
+    /// guess: acting on the wrong session is worse than being asked which.
+    @Test func refusesAnAmbiguousName() {
+        let first = remoteWorktree(
+            name: "probe", provider: "agentbox", sessionID: "one")
+        let second = remoteWorktree(
+            name: "probe", provider: "acme-cloud", sessionID: "two")
+        #expect(RemoteSessionRef.resolve(
+            "probe", sessions: [], worktrees: [first, second]) == nil)
+    }
+
+    /// A local worktree carries no provider binding, so its name names no
+    /// remote session.
+    @Test func refusesANameThatIsALocalWorktree() {
+        let local = remoteWorktree(name: "local-lane", provider: nil, sessionID: nil)
+        #expect(RemoteSessionRef.resolve(
+            "local-lane", sessions: [], worktrees: [local]) == nil)
+    }
+
+    @Test func refusesAnUnknownName() {
+        #expect(RemoteSessionRef.resolve("nothing", sessions: [], worktrees: []) == nil)
+    }
+
+    @Test func refusesBlankInput() {
+        #expect(RemoteSessionRef.resolve("   ", sessions: [], worktrees: []) == nil)
+    }
+
+    // MARK: - The receipt's human wording
+
+    @Test func confirmationNamesTheExpiryWhenTheProviderStatedOne() {
+        let expiry = ISO8601DateFormatter().date(from: "2026-10-01T00:00:00Z")!
+        let text = retainConfirmation(
+            provider: "agentbox",
+            receipt: RetainReceipt(key: "k", expiresAt: expiry, bytes: 148_213))
+        #expect(text.contains("148213"))
+        #expect(text.contains("2026-10-01T00:00:00Z"))
+    }
+
+    /// The contract makes rendering an absent expiry as permanence a MUST NOT,
+    /// so the sentence says the provider stated nothing.
+    @Test func confirmationNeverRendersAnAbsentExpiryAsPermanence() {
+        let text = retainConfirmation(
+            provider: "agentbox", receipt: RetainReceipt(key: "k", bytes: 10))
+        #expect(text.contains("no expiry stated"))
+        #expect(text.lowercased().contains("forever") == false)
+        #expect(text.lowercased().contains("never expires") == false)
+    }
+
+    // MARK: - The --json receipt shape
+
+    @Test func receiptJSONCarriesTheFourDocumentedFields() throws {
+        let expiry = ISO8601DateFormatter().date(from: "2026-10-01T00:00:00Z")!
+        let text = try #require(jsonString(RetainReceiptOutput(
+            provider: "agentbox",
+            receipt: RetainReceipt(key: "opaque", expiresAt: expiry, bytes: 12))))
+        let parsed = try JSONSerialization.jsonObject(with: Data(text.utf8))
+        let object = try #require(parsed as? [String: Any])
+        #expect(object["provider"] as? String == "agentbox")
+        #expect(object["key"] as? String == "opaque")
+        #expect(object["bytes"] as? Int == 12)
+        #expect(object["expires_at"] != nil)
+    }
+
+    /// Omitted, not null: `null` would read as an answer, and the answer the
+    /// provider gave is that it has no claim to make.
+    @Test func receiptJSONOmitsExpiresAtWhenThereIsNoClaim() throws {
+        let text = try #require(jsonString(RetainReceiptOutput(
+            provider: "agentbox", receipt: RetainReceipt(key: "opaque", bytes: 12))))
+        #expect(text.contains("expires_at") == false)
+    }
+
+    // MARK: - retained list rendering
+
+    @Test func retainedListingSaysSoWhenEmpty() {
+        #expect(renderRetainedListing([]) == "No retained transcripts recorded.")
+    }
+
+    @Test func retainedListingNamesProviderKeyBytesAndSource() {
+        let rows = [RetainedTranscript(
+            provider: "agentbox", key: "opaque", expiresAt: nil, bytes: 12,
+            sourceSessionID: "fix-flaky-ci", sourceTitle: "fix flaky CI")]
+        let text = renderRetainedListing(rows)
+        #expect(text.contains("agentbox"))
+        #expect(text.contains("opaque"))
+        #expect(text.contains("12"))
+        #expect(text.contains("fix flaky CI"))
+    }
+
+    /// A blank EXPIRES cell is the honest rendering of "no claim". Any word
+    /// there would be read as an answer.
+    @Test func retainedListingLeavesExpiresBlankWhenThereIsNoClaim() {
+        let text = renderRetainedListing([
+            RetainedTranscript(provider: "agentbox", key: "k", expiresAt: nil, bytes: 1),
+        ])
+        #expect(text.lowercased().contains("never") == false)
+        #expect(text.lowercased().contains("forever") == false)
+    }
+
+    @Test func retainedListingShowsAStatedExpiry() {
+        let expiry = ISO8601DateFormatter().date(from: "2026-10-01T00:00:00Z")!
+        let text = renderRetainedListing([
+            RetainedTranscript(provider: "agentbox", key: "k", expiresAt: expiry, bytes: 1),
+        ])
+        #expect(text.contains("2026-10-01T00:00:00Z"))
+    }
+
+    /// An `import` names no session on the provider, so the source column says
+    /// where it came from instead of leaving a hole.
+    @Test func retainedListingLabelsAnImportedTranscript() {
+        let text = renderRetainedListing([
+            RetainedTranscript(provider: "agentbox", key: "k", bytes: 1),
+        ])
+        #expect(text.contains("imported"))
+    }
+
+    // MARK: - The missing-capability refusal
+
+    @Test func missingCapabilityRefusalNamesTheCapabilityAndProvider() {
+        let text = remoteMissingCapability("recall", provider: "agentbox")
+        #expect(text.contains("recall"))
+        #expect(text.contains("agentbox"))
+    }
+}

--- a/Tests/TBDCLITests/RemoteCreateCommandTests.swift
+++ b/Tests/TBDCLITests/RemoteCreateCommandTests.swift
@@ -4,12 +4,13 @@ import TBDShared
 
 @testable import TBDCLI
 
-/// The pure halves of `tbd remote create`: the teleport precondition,
-/// `--param` parsing, and the composed confirmation.
+/// The pure halves of `tbd remote create` and of the listing commands: the
+/// teleport precondition, `--param` parsing, the display policy, and the two
+/// composed sentences.
 ///
 /// The commands themselves need a live daemon, so `run()` is out of reach; every
 /// decision they make before the socket opens is not.
-@Suite("tbd remote create")
+@Suite("tbd remote create and list")
 struct RemoteCreateCommandTests {
     // MARK: - Teleport preconditions
 
@@ -153,5 +154,84 @@ struct RemoteCreateCommandTests {
             seeded: false)
         #expect(line.contains("seeded") == false)
         #expect(line.contains("agentbox/probe"))
+    }
+
+    // MARK: - list display policy
+
+    private func session(
+        id: String, provider: String = "agentbox",
+        archived: Bool? = nil, dismissed: Bool = false
+    ) -> RemoteSessionInfo {
+        RemoteSessionInfo(
+            provider: provider,
+            payload: RemoteSessionPayload(
+                id: id, title: id, state: .running, archived: archived),
+            gone: false, dismissed: dismissed, lastSeen: Date())
+    }
+
+    /// The contract keeps archived sessions in `list` and assigns the caller
+    /// the policy about which a human sees. The sidebar hides them; so does this.
+    @Test func listHidesArchivedSessionsByDefault() {
+        let rows = remoteListRows(
+            [session(id: "live"), session(id: "retired", archived: true)],
+            provider: nil, includeArchived: false)
+        #expect(rows.map(\.payload.id) == ["live"])
+    }
+
+    @Test func listShowsArchivedSessionsOnRequest() {
+        let rows = remoteListRows(
+            [session(id: "live"), session(id: "retired", archived: true)],
+            provider: nil, includeArchived: true)
+        #expect(rows.map(\.payload.id).sorted() == ["live", "retired"])
+    }
+
+    /// An absent `archived` is "no claim", which the contract reads as not
+    /// archived for display — so a provider that never mentions the field keeps
+    /// every session visible.
+    @Test func aSessionWithNoArchivedClaimStaysVisible() {
+        let rows = remoteListRows(
+            [session(id: "live", archived: nil)], provider: nil, includeArchived: false)
+        #expect(rows.map(\.payload.id) == ["live"])
+    }
+
+    /// Dismiss is TBD's own local tombstone, and this is one of the lists it
+    /// removes a row from — including under `--archived`, which asks for the
+    /// provider's inventory rather than for rows the user has put away.
+    @Test func listAlwaysHidesDismissedSessions() {
+        let all = [session(id: "live"), session(id: "put-away", dismissed: true)]
+        #expect(remoteListRows(all, provider: nil, includeArchived: false)
+            .map(\.payload.id) == ["live"])
+        #expect(remoteListRows(all, provider: nil, includeArchived: true)
+            .map(\.payload.id) == ["live"])
+    }
+
+    @Test func listFiltersByProvider() {
+        let rows = remoteListRows(
+            [session(id: "a", provider: "agentbox"), session(id: "b", provider: "other")],
+            provider: "other", includeArchived: false)
+        #expect(rows.map(\.payload.id) == ["b"])
+    }
+
+    /// An empty listing says so rather than printing a bare header, which reads
+    /// as a failure to fetch.
+    @Test func anEmptyListingSaysSo() {
+        #expect(renderRemoteListing([]) == "No remote sessions.")
+    }
+
+    @Test func theListingNamesProviderSessionStateAndTitle() {
+        let rendered = renderRemoteListing([session(id: "probe")])
+        #expect(rendered.contains("agentbox"))
+        #expect(rendered.contains("probe"))
+        #expect(rendered.contains("running"))
+    }
+
+    /// `gone` is TBD's drift conclusion, not a provider state, and showing it
+    /// as one would tell the user the provider said something it never said.
+    @Test func aGoneSessionRendersAsGone() {
+        let row = RemoteSessionInfo(
+            provider: "agentbox",
+            payload: RemoteSessionPayload(id: "probe", state: .running),
+            gone: true, dismissed: false, lastSeen: Date())
+        #expect(renderRemoteListing([row]).contains("gone"))
     }
 }

--- a/Tests/TBDCLITests/RemoteCreateCommandTests.swift
+++ b/Tests/TBDCLITests/RemoteCreateCommandTests.swift
@@ -1,0 +1,157 @@
+import Foundation
+import Testing
+import TBDShared
+
+@testable import TBDCLI
+
+/// The pure halves of `tbd remote create`: the teleport precondition,
+/// `--param` parsing, and the composed confirmation.
+///
+/// The commands themselves need a live daemon, so `run()` is out of reach; every
+/// decision they make before the socket opens is not.
+@Suite("tbd remote create")
+struct RemoteCreateCommandTests {
+    // MARK: - Teleport preconditions
+
+    private func summary(
+        uncommitted: Int = 0, unpushed: Int = 0, upstream: Bool = true
+    ) -> TeleportWorkspaceSummary {
+        TeleportWorkspaceSummary(
+            uncommittedFiles: uncommitted, unpushedCommits: unpushed, hasUpstream: upstream)
+    }
+
+    @Test func aCleanPushedWorktreeTeleportsWithoutARefusal() {
+        #expect(TeleportPrecondition.refusal(summary(), force: false) == nil)
+    }
+
+    /// The refusal has to say what would be left behind, in counts the user can
+    /// check — "the worktree is dirty" tells them nothing about whether they
+    /// mind.
+    @Test func uncommittedFilesAreRefusedByCount() throws {
+        let refusal = try #require(
+            TeleportPrecondition.refusal(summary(uncommitted: 3), force: false))
+        #expect(refusal.contains("3 uncommitted files"))
+        #expect(refusal.contains("stay on this machine"))
+    }
+
+    @Test func unpushedCommitsAreRefusedByCount() throws {
+        let refusal = try #require(
+            TeleportPrecondition.refusal(summary(unpushed: 2), force: false))
+        #expect(refusal.contains("2 unpushed commits"))
+    }
+
+    /// Both at once name both, in the sentence the design asks for.
+    @Test func bothRefusalsAreNamedTogether() throws {
+        let refusal = try #require(
+            TeleportPrecondition.refusal(summary(uncommitted: 3, unpushed: 2), force: false))
+        #expect(refusal.contains("3 uncommitted files and 2 unpushed commits will stay on this machine"))
+    }
+
+    @Test func singularCountsReadAsSingular() throws {
+        let refusal = try #require(
+            TeleportPrecondition.refusal(summary(uncommitted: 1, unpushed: 1), force: false))
+        #expect(refusal.contains("1 uncommitted file and 1 unpushed commit will stay"))
+    }
+
+    /// A branch with no upstream is a different sentence from "you are two
+    /// commits ahead": there is nothing on a remote for the new session to
+    /// check out at all.
+    @Test func aBranchWithNoUpstreamIsRefusedInItsOwnWords() throws {
+        let refusal = try #require(
+            TeleportPrecondition.refusal(summary(unpushed: 0, upstream: false), force: false))
+        #expect(refusal.contains("no upstream"))
+    }
+
+    /// Pushing is offered, not left to the reader to remember.
+    @Test func theUnpushedRefusalOffersThePush() throws {
+        let refusal = try #require(
+            TeleportPrecondition.refusal(summary(unpushed: 2), force: false))
+        #expect(refusal.contains("git push"))
+    }
+
+    @Test func theUncommittedRefusalDoesNotOfferAPushForCommittedWork() throws {
+        let refusal = try #require(
+            TeleportPrecondition.refusal(summary(uncommitted: 2), force: false))
+        #expect(refusal.contains("Commit or stash"))
+    }
+
+    @Test func forceOverridesEveryRefusal() {
+        #expect(TeleportPrecondition.refusal(
+            summary(uncommitted: 3, unpushed: 2, upstream: false), force: true) == nil)
+        #expect(TeleportPrecondition.refusal(summary(uncommitted: 3), force: true) == nil)
+        #expect(TeleportPrecondition.refusal(summary(unpushed: 2), force: true) == nil)
+    }
+
+    /// Every refusal says how to get through it. A gate with no stated override
+    /// reads as a wall.
+    @Test func everyRefusalNamesForce() throws {
+        for candidate in [summary(uncommitted: 1), summary(unpushed: 1),
+                          summary(upstream: false)] {
+            let refusal = try #require(TeleportPrecondition.refusal(candidate, force: false))
+            #expect(refusal.contains("--force"))
+        }
+    }
+
+    // MARK: - --param parsing
+
+    @Test func paramsBecomeAJSONObject() throws {
+        let json = try remoteCreateParamsJSON(["repo=acme/api", "slug=probe"])
+        let decoded = try #require(
+            try JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any])
+        #expect(decoded["repo"] as? String == "acme/api")
+        #expect(decoded["slug"] as? String == "probe")
+    }
+
+    @Test func noParamsIsAnEmptyObject() throws {
+        let json = try remoteCreateParamsJSON([])
+        #expect(json == "{}")
+    }
+
+    /// A value may contain `=` — a prompt, a URL, a base64 blob — so the split
+    /// is at the FIRST one only.
+    @Test func aValueMayContainEqualsSigns() throws {
+        let json = try remoteCreateParamsJSON(["prompt=a=b=c"])
+        let decoded = try #require(
+            try JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any])
+        #expect(decoded["prompt"] as? String == "a=b=c")
+    }
+
+    /// Values stay strings. The field types belong to the provider, and a CLI
+    /// that read `count=3` as a number would be inventing a type nobody wrote.
+    @Test func valuesAreCarriedAsStrings() throws {
+        let json = try remoteCreateParamsJSON(["count=3"])
+        let decoded = try #require(
+            try JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any])
+        #expect(decoded["count"] as? String == "3")
+    }
+
+    @Test func aParamWithNoEqualsIsRefused() {
+        #expect(throws: (any Error).self) { try remoteCreateParamsJSON(["repo"]) }
+    }
+
+    @Test func aParamWithAnEmptyKeyIsRefused() {
+        #expect(throws: (any Error).self) { try remoteCreateParamsJSON(["=acme/api"]) }
+    }
+
+    // MARK: - The create confirmation
+
+    /// A session that silently began with somebody's whole conversation and one
+    /// that began empty look identical from outside, so the line says which.
+    @Test func aSeededCreateSaysSo() {
+        let line = remoteCreateConfirmation(
+            provider: "agentbox",
+            session: RemoteSessionPayload(id: "probe", title: "fix flaky CI", state: .starting),
+            seeded: true)
+        #expect(line.contains("seeded"))
+        #expect(line.contains("probe"))
+    }
+
+    @Test func anUnseededCreateDoesNotClaimASeed() {
+        let line = remoteCreateConfirmation(
+            provider: "agentbox",
+            session: RemoteSessionPayload(id: "probe", state: .starting),
+            seeded: false)
+        #expect(line.contains("seeded") == false)
+        #expect(line.contains("agentbox/probe"))
+    }
+}

--- a/Tests/TBDDaemonTests/ClaudeCloudGateTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeCloudGateTests.swift
@@ -53,8 +53,13 @@ struct ClaudeCloudGateTests: ~Copyable {
         await router.handle(RPCRequest(method: method, params: params))
     }
 
-    private let cloudParams = #"{"provider": "claude-cloud", "sessionID": "s", "text": "t", "title": "t", "paramsJSON": "{}", "pinned": true, "exitCode": 1}"#
-    private let otherParams = #"{"provider": "fake", "sessionID": "s", "text": "t", "title": "t", "paramsJSON": "{}", "pinned": true, "exitCode": 1}"#
+    /// One params object wide enough for every method in `gatedMethods`: the
+    /// gate runs after each handler decodes, so a method whose required field
+    /// is missing here would refuse for the wrong reason and quietly stop
+    /// testing the gate. `jsonl` / `key` / `saveLocally` are the exchange
+    /// verbs' share of that.
+    private let cloudParams = #"{"provider": "claude-cloud", "sessionID": "s", "text": "t", "title": "t", "paramsJSON": "{}", "pinned": true, "exitCode": 1, "jsonl": "{}", "key": "k", "saveLocally": false}"#
+    private let otherParams = #"{"provider": "fake", "sessionID": "s", "text": "t", "title": "t", "paramsJSON": "{}", "pinned": true, "exitCode": 1, "jsonl": "{}", "key": "k", "saveLocally": false}"#
 
     /// Drawn from `RPCMethod.providerNamedRemoteMethods` — the production
     /// list of every `remote.*` verb addressed by a provider — rather than

--- a/Tests/TBDDaemonTests/Config/GCRetainedTranscriptsFlagTests.swift
+++ b/Tests/TBDDaemonTests/Config/GCRetainedTranscriptsFlagTests.swift
@@ -1,0 +1,190 @@
+import Foundation
+import GRDB
+import Testing
+
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Schema and resolution guards for `config.gc_retained_transcripts_enabled`,
+/// the soak gate on the orphan-GC leg that unlinks retained transcripts nobody
+/// references and drops receipts whose expiry has passed.
+///
+/// The column is added by `20260902140000_config_gc_retained_transcripts` with
+/// **no SQL default**, so "never chose" (NULL) stays distinguishable from
+/// "explicitly off" (0). If someone adds a `DEFAULT` clause to that migration,
+/// `nullBeforeAnyGesture` and `rowWrittenBeforeTheMigrationStillReadsNull` go
+/// red — that is their only job. The distinction earns its keep because this
+/// leg unlinks files and deletes rows: somebody who turned it off did so
+/// deliberately and must stay opted out through graduation.
+@Suite("GCRetainedTranscriptsFlag")
+struct GCRetainedTranscriptsFlagTests {
+
+    /// The last migration identifier that predates the flag's column. Migrating
+    /// only this far reproduces the schema a real pre-flag daemon ran on.
+    private static let lastIdentifierBeforeTheFlag = "20260902130000_config_remote_delete"
+
+    private func fetchConfigRecord(_ db: TBDDatabase) async throws -> ConfigRecord? {
+        try await db.writerForTests.read { conn in
+            try ConfigRecord.fetchOne(conn, key: ConfigStore.singletonID)
+        }
+    }
+
+    // MARK: - Storage: the column is genuinely NULL until somebody chooses
+
+    /// **The load-bearing test.** The `config` singleton row is inserted by v1,
+    /// so every install has a row that predates this column. After the
+    /// migration that row must read NULL, not `0`.
+    @Test func nullBeforeAnyGesture() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let record = try #require(try await fetchConfigRecord(db))
+        #expect(
+            record.gc_retained_transcripts_enabled == nil,
+            """
+            config.gc_retained_transcripts_enabled must be NULL until the toggle \
+            is touched — read back \
+            \(String(describing: record.gc_retained_transcripts_enabled)). A non-nil \
+            value here means 20260902140000_config_gc_retained_transcripts grew a \
+            DEFAULT clause; remove it.
+            """)
+    }
+
+    /// The same guard against a row written by a real pre-flag daemon: migrate
+    /// only as far as the last identifier that predates the column, write to the
+    /// config row, then finish migrating.
+    @Test func rowWrittenBeforeTheMigrationStillReadsNull() throws {
+        let queue = try DatabaseQueue()
+        let migrator = TBDDatabase.buildMigratorForTests()
+        try migrator.migrate(queue, upTo: Self.lastIdentifierBeforeTheFlag)
+
+        try queue.write { db in
+            try db.execute(
+                sql: "UPDATE config SET auto_create_notes_enabled = 1 WHERE id = ?",
+                arguments: [ConfigStore.singletonID])
+        }
+
+        try migrator.migrate(queue)
+
+        try queue.read { db in
+            let row = try #require(try Row.fetchOne(
+                db, sql: "SELECT * FROM config WHERE id = ?",
+                arguments: [ConfigStore.singletonID]))
+            let raw: DatabaseValue = row["gc_retained_transcripts_enabled"]
+            #expect(
+                raw.isNull,
+                "a config row written before the migration must read NULL, not \(raw)")
+            // The pre-existing write survived — the migration is purely additive.
+            #expect(row["auto_create_notes_enabled"] == true)
+        }
+    }
+
+    // MARK: - Resolution: the three states are distinguishable
+
+    /// NULL follows `Config.gcRetainedTranscriptsEnabledDefault` wherever it
+    /// goes; an explicit `false` does not. That property is what makes
+    /// graduation a one-line constant change with no forcing `UPDATE`
+    /// migration. Exercised against BOTH possible default values, so it fails
+    /// if the resolution is ever wired as `?? false`.
+    @Test func explicitFalseSurvivesADefaultFlipWhileNullFollowsIt() async throws {
+        let db = try TBDDatabase(inMemory: true)
+
+        let untouched = try #require(try await fetchConfigRecord(db))
+        #expect(untouched.gc_retained_transcripts_enabled == nil)
+        #expect(
+            untouched.toModel(gcRetainedTranscriptsDefault: false)
+                .gcRetainedTranscriptsEnabled == false)
+        #expect(
+            untouched.toModel(gcRetainedTranscriptsDefault: true)
+                .gcRetainedTranscriptsEnabled == true,
+            "a never-chosen row must pick up a changed shipped default")
+
+        try await db.config.setGCRetainedTranscriptsEnabled(false)
+        let explicitlyOff = try #require(try await fetchConfigRecord(db))
+        #expect(explicitlyOff.gc_retained_transcripts_enabled == false)
+        #expect(
+            explicitlyOff.toModel(gcRetainedTranscriptsDefault: false)
+                .gcRetainedTranscriptsEnabled == false)
+        #expect(
+            explicitlyOff.toModel(gcRetainedTranscriptsDefault: true)
+                .gcRetainedTranscriptsEnabled == false,
+            "an explicit opt-out must be honored forever, whatever the shipped default becomes")
+    }
+
+    /// Mirrored for an explicit `true`: an operator who opted into the soak
+    /// stays opted in even if the shipped default never moves.
+    @Test func explicitTrueSticks() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCRetainedTranscriptsEnabled(true)
+        let explicitlyOn = try #require(try await fetchConfigRecord(db))
+        #expect(explicitlyOn.gc_retained_transcripts_enabled == true)
+        #expect(
+            explicitlyOn.toModel(gcRetainedTranscriptsDefault: false)
+                .gcRetainedTranscriptsEnabled == true)
+        #expect(
+            explicitlyOn.toModel(gcRetainedTranscriptsDefault: true)
+                .gcRetainedTranscriptsEnabled == true)
+    }
+
+    /// Isolates the RESOLUTION guard (`toModel()`'s
+    /// `?? gcRetainedTranscriptsDefault`) from the STORAGE guard (the
+    /// migration's missing SQL default) by constructing a `ConfigRecord`
+    /// directly — no database, no migration.
+    @Test func toModelResolvesNullThroughTheInjectedDefault() {
+        let record = ConfigRecord(id: "unstored", gc_retained_transcripts_enabled: nil)
+        #expect(
+            record.toModel(gcRetainedTranscriptsDefault: false)
+                .gcRetainedTranscriptsEnabled == false)
+        #expect(
+            record.toModel(gcRetainedTranscriptsDefault: true)
+                .gcRetainedTranscriptsEnabled == true,
+            "a NULL record must pick up whatever default is injected, not a hardcoded false")
+    }
+
+    // MARK: - The shipped default, and the wire
+
+    /// The shipped default today: OFF. A background sweep that unlinks files
+    /// and deletes rows soaks behind its own switch. Graduation edits this
+    /// constant and nothing else.
+    @Test func shippedDefaultIsOff() async throws {
+        #expect(Config.gcRetainedTranscriptsEnabledDefault == false)
+        let db = try TBDDatabase(inMemory: true)
+        #expect(try await db.config.get().gcRetainedTranscriptsEnabled == false)
+    }
+
+    @Test func setterRoundtrips() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCRetainedTranscriptsEnabled(true)
+        #expect(try await db.config.get().gcRetainedTranscriptsEnabled == true)
+        try await db.config.setGCRetainedTranscriptsEnabled(false)
+        #expect(try await db.config.get().gcRetainedTranscriptsEnabled == false)
+    }
+
+    /// The gate is its own opt-in: turning on the sibling remote-delete flag
+    /// must not enable a sweep that unlinks files, and vice versa.
+    @Test func theRemoteDeleteFlagDoesNotEnableThisLeg() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setRemoteDeleteEnabled(true)
+        let config = try await db.config.get()
+        #expect(config.remoteDeleteEnabled == true)
+        #expect(config.gcRetainedTranscriptsEnabled == false)
+    }
+
+    /// JSON from a daemon that predates the flag still decodes, and the absent
+    /// key means the sender knew nothing about it — the NULL column's situation,
+    /// so it follows the shipped default rather than a hardcoded `false`.
+    @Test func configJSONWithoutTheKeyFollowsTheShippedDefault() throws {
+        let json = #"{"primaryAgentPreference":"claude"}"#
+        let config = try JSONDecoder().decode(Config.self, from: Data(json.utf8))
+        #expect(
+            config.gcRetainedTranscriptsEnabled == Config.gcRetainedTranscriptsEnabledDefault)
+    }
+
+    /// An explicit `true` on the wire is carried, so the app and the CLI see the
+    /// same state the daemon resolved rather than re-deriving it.
+    @Test func configJSONRoundTripsAnExplicitChoice() throws {
+        var config = Config()
+        config.gcRetainedTranscriptsEnabled = true
+        let decoded = try JSONDecoder().decode(
+            Config.self, from: JSONEncoder().encode(config))
+        #expect(decoded.gcRetainedTranscriptsEnabled == true)
+    }
+}

--- a/Tests/TBDDaemonTests/Config/RemoteDeleteFlagTests.swift
+++ b/Tests/TBDDaemonTests/Config/RemoteDeleteFlagTests.swift
@@ -1,0 +1,177 @@
+import Foundation
+import GRDB
+import Testing
+
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Schema and resolution guards for `config.remote_delete_enabled`, the soak
+/// gate on `remote.delete` — the verb that destroys a provider-hosted agent
+/// session outright.
+///
+/// The column is added by `20260902130000_config_remote_delete` with **no SQL
+/// default**, so "never chose" (NULL) stays distinguishable from "explicitly
+/// off" (0). If someone adds a `DEFAULT` clause to that migration,
+/// `nullBeforeAnyGesture` and `rowWrittenBeforeTheMigrationStillReadsNull` go
+/// red — that is their only job. The distinction earns its keep because this
+/// flag permits an irreversible act on another machine: somebody who turned it
+/// off did so deliberately and must stay opted out through graduation.
+@Suite("RemoteDeleteFlag")
+struct RemoteDeleteFlagTests {
+
+    /// The last migration identifier that predates the flag's column. Migrating
+    /// only this far reproduces the schema a real pre-flag daemon ran on.
+    private static let lastIdentifierBeforeTheFlag = "20260902120000_retained_transcript"
+
+    private func fetchConfigRecord(_ db: TBDDatabase) async throws -> ConfigRecord? {
+        try await db.writerForTests.read { conn in
+            try ConfigRecord.fetchOne(conn, key: ConfigStore.singletonID)
+        }
+    }
+
+    // MARK: - Storage: the column is genuinely NULL until somebody chooses
+
+    /// **The load-bearing test.** The `config` singleton row is inserted by v1,
+    /// so every install has a row that predates this column. After the
+    /// migration that row must read NULL, not `0`.
+    @Test func nullBeforeAnyGesture() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let record = try #require(try await fetchConfigRecord(db))
+        #expect(
+            record.remote_delete_enabled == nil,
+            """
+            config.remote_delete_enabled must be NULL until the toggle is \
+            touched — read back \(String(describing: record.remote_delete_enabled)). \
+            A non-nil value here means 20260902130000_config_remote_delete grew a \
+            DEFAULT clause; remove it.
+            """)
+    }
+
+    /// The same guard against a row written by a real pre-flag daemon: migrate
+    /// only as far as the last identifier that predates the column, write to the
+    /// config row, then finish migrating.
+    @Test func rowWrittenBeforeTheMigrationStillReadsNull() throws {
+        let queue = try DatabaseQueue()
+        let migrator = TBDDatabase.buildMigratorForTests()
+        try migrator.migrate(queue, upTo: Self.lastIdentifierBeforeTheFlag)
+
+        try queue.write { db in
+            try db.execute(
+                sql: "UPDATE config SET auto_create_notes_enabled = 1 WHERE id = ?",
+                arguments: [ConfigStore.singletonID])
+        }
+
+        try migrator.migrate(queue)
+
+        try queue.read { db in
+            let row = try #require(try Row.fetchOne(
+                db, sql: "SELECT * FROM config WHERE id = ?",
+                arguments: [ConfigStore.singletonID]))
+            let raw: DatabaseValue = row["remote_delete_enabled"]
+            #expect(
+                raw.isNull,
+                "a config row written before the migration must read NULL, not \(raw)")
+            // The pre-existing write survived — the migration is purely additive.
+            #expect(row["auto_create_notes_enabled"] == true)
+        }
+    }
+
+    // MARK: - Resolution: the three states are distinguishable
+
+    /// NULL follows `Config.remoteDeleteEnabledDefault` wherever it goes; an
+    /// explicit `false` does not. That property is what makes graduation a
+    /// one-line constant change with no forcing `UPDATE` migration. Exercised
+    /// against BOTH possible default values, so it fails if the resolution is
+    /// ever wired as `?? false`.
+    @Test func explicitFalseSurvivesADefaultFlipWhileNullFollowsIt() async throws {
+        let db = try TBDDatabase(inMemory: true)
+
+        let untouched = try #require(try await fetchConfigRecord(db))
+        #expect(untouched.remote_delete_enabled == nil)
+        #expect(untouched.toModel(remoteDeleteDefault: false).remoteDeleteEnabled == false)
+        #expect(
+            untouched.toModel(remoteDeleteDefault: true).remoteDeleteEnabled == true,
+            "a never-chosen row must pick up a changed shipped default")
+
+        try await db.config.setRemoteDeleteEnabled(false)
+        let explicitlyOff = try #require(try await fetchConfigRecord(db))
+        #expect(explicitlyOff.remote_delete_enabled == false)
+        #expect(explicitlyOff.toModel(remoteDeleteDefault: false).remoteDeleteEnabled == false)
+        #expect(
+            explicitlyOff.toModel(remoteDeleteDefault: true).remoteDeleteEnabled == false,
+            "an explicit opt-out must be honored forever, whatever the shipped default becomes")
+    }
+
+    /// Mirrored for an explicit `true`: an operator who opted into the soak
+    /// stays opted in even if the shipped default never moves.
+    @Test func explicitTrueSticks() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setRemoteDeleteEnabled(true)
+        let explicitlyOn = try #require(try await fetchConfigRecord(db))
+        #expect(explicitlyOn.remote_delete_enabled == true)
+        #expect(explicitlyOn.toModel(remoteDeleteDefault: false).remoteDeleteEnabled == true)
+        #expect(explicitlyOn.toModel(remoteDeleteDefault: true).remoteDeleteEnabled == true)
+    }
+
+    /// Isolates the RESOLUTION guard (`toModel()`'s `?? remoteDeleteDefault`)
+    /// from the STORAGE guard (the migration's missing SQL default) by
+    /// constructing a `ConfigRecord` directly — no database, no migration.
+    @Test func toModelResolvesNullThroughTheInjectedDefault() {
+        let record = ConfigRecord(id: "unstored", remote_delete_enabled: nil)
+        #expect(record.toModel(remoteDeleteDefault: false).remoteDeleteEnabled == false)
+        #expect(
+            record.toModel(remoteDeleteDefault: true).remoteDeleteEnabled == true,
+            "a NULL record must pick up whatever default is injected, not a hardcoded false")
+    }
+
+    // MARK: - The shipped default, and the wire
+
+    /// The shipped default today: OFF. Delete is irreversible on the far side —
+    /// it ends compute and removes the session from the provider's inventory
+    /// permanently — so it soaks behind its own switch. Graduation edits this
+    /// constant and nothing else.
+    @Test func shippedDefaultIsOff() async throws {
+        #expect(Config.remoteDeleteEnabledDefault == false)
+        let db = try TBDDatabase(inMemory: true)
+        #expect(try await db.config.get().remoteDeleteEnabled == false)
+    }
+
+    @Test func setterRoundtrips() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setRemoteDeleteEnabled(true)
+        #expect(try await db.config.get().remoteDeleteEnabled == true)
+        try await db.config.setRemoteDeleteEnabled(false)
+        #expect(try await db.config.get().remoteDeleteEnabled == false)
+    }
+
+    /// The gate is delete's alone. Turning it on must not turn on anything
+    /// else, and the non-destructive exchange verbs have no flag at all — their
+    /// gate is the provider's declared capabilities.
+    @Test func theGateIsIndependentOfTheOtherFlags() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setRemoteDeleteEnabled(true)
+        let config = try await db.config.get()
+        #expect(config.remoteDeleteEnabled == true)
+        #expect(config.remoteBackendsEnabled == false)
+        #expect(config.reapHolderChildrenEnabled == Config.reapHolderChildrenEnabledDefault)
+    }
+
+    /// JSON from a daemon that predates the flag still decodes, and the absent
+    /// key means the sender knew nothing about it — the NULL column's situation,
+    /// so it follows the shipped default rather than a hardcoded `false`.
+    @Test func configJSONWithoutTheKeyFollowsTheShippedDefault() throws {
+        let json = #"{"primaryAgentPreference":"claude"}"#
+        let config = try JSONDecoder().decode(Config.self, from: Data(json.utf8))
+        #expect(config.remoteDeleteEnabled == Config.remoteDeleteEnabledDefault)
+    }
+
+    /// An explicit `true` on the wire is carried, so the app and the CLI see the
+    /// same state the daemon resolved rather than re-deriving it.
+    @Test func configJSONRoundTripsAnExplicitChoice() throws {
+        var config = Config()
+        config.remoteDeleteEnabled = true
+        let decoded = try JSONDecoder().decode(
+            Config.self, from: JSONEncoder().encode(config))
+        #expect(decoded.remoteDeleteEnabled == true)
+    }
+}

--- a/Tests/TBDDaemonTests/GCRetainedTranscriptsRPCTests.swift
+++ b/Tests/TBDDaemonTests/GCRetainedTranscriptsRPCTests.swift
@@ -1,0 +1,148 @@
+import Foundation
+import Testing
+
+@testable import TBDDaemonLib
+@testable import TBDShared
+import TestSupport
+
+/// The RPC surface for `gc_retained_transcripts_enabled` — the soak gate on the
+/// `OrphanGC` leg that unlinks retained transcripts nobody references and drops
+/// receipts whose expiry has passed.
+///
+/// The verb exists so the soak can be entered and left through a supported
+/// path. Without it the only way to lift the gate is a hand-written `UPDATE`
+/// against `~/tbd/state.db`, which this project's own rules put out of bounds —
+/// the same reasoning that gave every sibling soak gate an RPC of its own.
+@Suite("GC retained transcripts RPC")
+struct GCRetainedTranscriptsRPCTests {
+
+    private func makeRouterAndDB() throws -> (RPCRouter, TBDDatabase) {
+        let db = try TBDDatabase(inMemory: true)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db,
+                git: GitManager(),
+                tmux: TmuxManager(dryRun: true),
+                hooks: HookResolver()
+            ),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date(),
+            actuationLog: makeTestActuationLog()
+        )
+        return (router, db)
+    }
+
+    private func setFlag(_ router: RPCRouter, enabled: Bool) async throws {
+        let request = try RPCRequest(
+            method: RPCMethod.configSetGCRetainedTranscriptsEnabled,
+            params: ConfigSetGCRetainedTranscriptsEnabledParams(enabled: enabled))
+        let response = await router.handle(request)
+        #expect(response.success, "\(String(describing: response.error))")
+    }
+
+    // MARK: - The method reaches a handler at all
+
+    /// The wire name, pinned. A rename would leave every shipped CLI calling a
+    /// method the router answers with `unknown method`, and the failure would
+    /// only show up at runtime.
+    @Test("the method name is config.setGCRetainedTranscriptsEnabled")
+    func methodName() {
+        #expect(
+            RPCMethod.configSetGCRetainedTranscriptsEnabled
+                == "config.setGCRetainedTranscriptsEnabled")
+    }
+
+    /// The gate is off before anybody calls the verb — so a passing "on" test
+    /// below cannot be passing because the flag was already on.
+    @Test("the gate is off before the verb is called")
+    func offBeforeAnyCall() async throws {
+        let (_, db) = try makeRouterAndDB()
+        #expect(try await db.config.get().gcRetainedTranscriptsEnabled == false)
+    }
+
+    // MARK: - Round trip
+
+    @Test("the verb lifts the gate")
+    func setEnabledPersists() async throws {
+        let (router, db) = try makeRouterAndDB()
+        try await setFlag(router, enabled: true)
+        #expect(try await db.config.get().gcRetainedTranscriptsEnabled == true)
+    }
+
+    /// An explicit opt-out is stored as a real `0`, not left as the NULL that
+    /// merely resolves to today's default — that is what keeps it honored
+    /// through graduation, when the shipped default flips.
+    @Test("the verb records an explicit opt-out, not a NULL")
+    func setDisabledPersistsAsAnExplicitFalse() async throws {
+        let (router, db) = try makeRouterAndDB()
+        try await setFlag(router, enabled: false)
+        #expect(try await db.config.get().gcRetainedTranscriptsEnabled == false)
+        let stored = try await db.writerForTests.read { conn in
+            try ConfigRecord.fetchOne(conn, key: ConfigStore.singletonID)?
+                .gc_retained_transcripts_enabled
+        }
+        #expect(stored == false)
+    }
+
+    @Test("the verb round-trips on and back off")
+    func roundTrip() async throws {
+        let (router, db) = try makeRouterAndDB()
+        try await setFlag(router, enabled: true)
+        #expect(try await db.config.get().gcRetainedTranscriptsEnabled == true)
+        try await setFlag(router, enabled: false)
+        #expect(try await db.config.get().gcRetainedTranscriptsEnabled == false)
+    }
+
+    // MARK: - It gates one leg and no other
+
+    /// Lifting this gate must not lift any sibling. The one that matters most
+    /// is `remoteDeleteEnabled`: this verb reclaims TBD's own local residue,
+    /// that one destroys a session on a provider, and no operator opting into
+    /// a local sweep is asking for the irreversible verb.
+    @Test("lifting this gate lifts no sibling flag")
+    func doesNotDisturbSiblingFlags() async throws {
+        let (router, db) = try makeRouterAndDB()
+        let before = try await db.config.get()
+        try await setFlag(router, enabled: true)
+        let config = try await db.config.get()
+        #expect(config.gcRetainedTranscriptsEnabled == true)
+        #expect(config.remoteDeleteEnabled == false)
+        #expect(config.gcProfileDirsEnabled == false)
+        #expect(config.gcOrphanProcessesEnabled == false)
+        #expect(config.gcHolderRendezvousEnabled == false)
+        #expect(config.gcRowlessHoldersEnabled == false)
+        #expect(config.reapHolderChildrenEnabled == false)
+        // The master switch is untouched in the other direction: this verb
+        // neither turns GC on nor off.
+        #expect(config.gcEnabled == before.gcEnabled)
+    }
+
+    /// …and the reverse. `tbd remote allow-delete on` must leave this sweep
+    /// disabled, so the two opt-ins stay genuinely separate gestures.
+    @Test("the remote-delete verb does not lift this gate")
+    func theRemoteDeleteVerbDoesNotLiftThisGate() async throws {
+        let (router, db) = try makeRouterAndDB()
+        let request = try RPCRequest(
+            method: RPCMethod.configSetRemoteDeleteEnabled,
+            params: ConfigSetRemoteDeleteEnabledParams(enabled: true))
+        let response = await router.handle(request)
+        #expect(response.success)
+        let config = try await db.config.get()
+        #expect(config.remoteDeleteEnabled == true)
+        #expect(config.gcRetainedTranscriptsEnabled == false)
+    }
+
+    // MARK: - Wire type
+
+    @Test("the params type round-trips")
+    func paramsRoundTrip() throws {
+        for enabled in [true, false] {
+            let decoded = try JSONDecoder().decode(
+                ConfigSetGCRetainedTranscriptsEnabledParams.self,
+                from: try JSONEncoder().encode(
+                    ConfigSetGCRetainedTranscriptsEnabledParams(enabled: enabled)))
+            #expect(decoded.enabled == enabled)
+        }
+    }
+}

--- a/Tests/TBDDaemonTests/GCRetainedTranscriptsRPCTests.swift
+++ b/Tests/TBDDaemonTests/GCRetainedTranscriptsRPCTests.swift
@@ -36,7 +36,7 @@ struct GCRetainedTranscriptsRPCTests {
     private func setFlag(_ router: RPCRouter, enabled: Bool) async throws {
         let request = try RPCRequest(
             method: RPCMethod.configSetGCRetainedTranscriptsEnabled,
-            params: ConfigSetGCRetainedTranscriptsEnabledParams(enabled: enabled))
+            params: ConfigSetGCRetainedTranscriptsParams(enabled: enabled))
         let response = await router.handle(request)
         #expect(response.success, "\(String(describing: response.error))")
     }
@@ -139,9 +139,9 @@ struct GCRetainedTranscriptsRPCTests {
     func paramsRoundTrip() throws {
         for enabled in [true, false] {
             let decoded = try JSONDecoder().decode(
-                ConfigSetGCRetainedTranscriptsEnabledParams.self,
+                ConfigSetGCRetainedTranscriptsParams.self,
                 from: try JSONEncoder().encode(
-                    ConfigSetGCRetainedTranscriptsEnabledParams(enabled: enabled)))
+                    ConfigSetGCRetainedTranscriptsParams(enabled: enabled)))
             #expect(decoded.enabled == enabled)
         }
     }

--- a/Tests/TBDDaemonTests/OrphanGCRetainedTranscriptTests.swift
+++ b/Tests/TBDDaemonTests/OrphanGCRetainedTranscriptTests.swift
@@ -1,0 +1,320 @@
+import Foundation
+import Testing
+import TestSupport
+@testable import TBDDaemonLib
+import TBDShared
+
+// Nested under TBDHomeSerialized: the retained-transcript leg walks
+// `TBDConstants.retainedTranscriptsDir`, which resolves from the process-global
+// TBD_HOME and has no injection seam of its own — the path helper that names a
+// receipt's file resolves the same variable, and the two must agree. See
+// TBDHomeSerializedSuites.swift.
+extension TBDHomeSerialized {
+
+/// Tier 2: a real `~/tbd/transcripts` tree under a temp `TBD_HOME`, plus an
+/// in-memory database. The scratchpad base, the profile base, the holders base
+/// and the clock are all injected; no process is spawned and no production path
+/// outside the temp home is touched.
+@Suite("OrphanGC reclaims retained transcripts")
+struct OrphanGCRetainedTranscriptTests {
+    private let fm = FileManager.default
+    /// The sweep's fixed reading of now. Every fixture's age is expressed
+    /// against it, so nothing here depends on wall-clock time.
+    private let clock = Date(timeIntervalSince1970: 1_800_000_000)
+    private let provider = "agentbox"
+
+    /// Restores the displaced `TBD_HOME` rather than unsetting it —
+    /// `scripts/test.sh` exports one for the whole run, and `unsetenv` would
+    /// hand every concurrently running suite the developer's real `~/tbd`.
+    private func isolateTBDHome() -> (URL, () -> Void) {
+        let home = fm.temporaryDirectory
+            .appendingPathComponent("tbd-gc-rt-\(UUID().uuidString.prefix(8))")
+        try? fm.createDirectory(at: home, withIntermediateDirectories: true)
+        let prior = setTBDHome(home.path)
+        // `FileManager.default` rather than the suite's `fm`, so the returned
+        // closure captures two locals and never `self`.
+        return (home, {
+            restoreTBDHome(prior)
+            try? FileManager.default.removeItem(at: home)
+        })
+    }
+
+    private func makeGC(db: TBDDatabase, home: URL) -> OrphanGC {
+        let fixed = clock
+        return OrphanGC(
+            db: db, git: GitManager(),
+            broadcast: { _ in },
+            liveCWDsProvider: { [] },
+            scratchpadBase: home.appendingPathComponent("s", isDirectory: true),
+            now: { fixed },
+            profileDirBase: home.appendingPathComponent("p", isDirectory: true),
+            holdersBase: home.appendingPathComponent("h", isDirectory: true)
+        )
+    }
+
+    /// Writes a JSONL file at the canonical path for `(provider, key)` and
+    /// backdates it, so the grace window has elapsed against this suite's fixed
+    /// clock unless the caller asks otherwise.
+    @discardableResult
+    private func writeTranscript(key: String, age: TimeInterval = 86_400) -> String {
+        let url = TBDConstants.retainedTranscriptPath(provider: provider, key: key)
+        try? fm.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        fm.createFile(atPath: url.path, contents: Data(#"{"type":"user"}"#.utf8))
+        backdate(url.path, age: age)
+        return url.path
+    }
+
+    private func backdate(_ path: String, age: TimeInterval) {
+        let stamp = clock.addingTimeInterval(-age)
+        try? fm.setAttributes(
+            [.creationDate: stamp, .modificationDate: stamp], ofItemAtPath: path)
+    }
+
+    private func receipt(
+        key: String, expiresAt: Date? = nil, localPath: String? = nil
+    ) -> RetainedTranscript {
+        RetainedTranscript(
+            provider: provider, key: key, expiresAt: expiresAt, bytes: 15,
+            localPath: localPath, createdAt: clock.addingTimeInterval(-86_400))
+    }
+
+    // MARK: - The gate
+
+    /// **The discriminating sweep test.** A transcript file no row references —
+    /// the residue of an `import` whose `create` then failed — is gone from disk
+    /// after one sweep with the flag on.
+    @Test func aSweepWithTheFlagOnUnlinksAnUnreferencedTranscript() async throws {
+        let (home, cleanUp) = isolateTBDHome()
+        defer { cleanUp() }
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCRetainedTranscriptsEnabled(true)
+        let path = writeTranscript(key: "orphaned-key")
+
+        let result = await makeGC(db: db, home: home).sweep()
+
+        #expect(fm.fileExists(atPath: path) == false, "\(path) survived the sweep")
+        #expect(result.planned.contains("REAP retained-transcript \(path)"))
+        #expect(result.reaped >= 1)
+    }
+
+    /// The off branch of the gate — the state every install ships in. The same
+    /// fixture the test above reaps is left completely alone, and the sweep does
+    /// not even plan it.
+    @Test func aSweepWithTheFlagOffTouchesNothing() async throws {
+        let (home, cleanUp) = isolateTBDHome()
+        defer { cleanUp() }
+        let db = try TBDDatabase(inMemory: true)
+        #expect(try await db.config.get().gcRetainedTranscriptsEnabled == false,
+                "the shipped default must be off")
+        let path = writeTranscript(key: "orphaned-key")
+        try await db.retainedTranscripts.insert(
+            receipt(key: "stale-key", expiresAt: clock.addingTimeInterval(-3_600)))
+
+        let result = await makeGC(db: db, home: home).sweep()
+
+        #expect(fm.fileExists(atPath: path), "\(path) was swept with the flag off")
+        #expect(try await db.retainedTranscripts.find(provider: provider, key: "stale-key") != nil,
+                "an expired row was dropped with the flag off")
+        #expect(result.planned.contains { $0.contains("retained-transcript") } == false)
+    }
+
+    /// An explicit `false` is the same as never having chosen, for behavior.
+    @Test func anExplicitOptOutTouchesNothing() async throws {
+        let (home, cleanUp) = isolateTBDHome()
+        defer { cleanUp() }
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCRetainedTranscriptsEnabled(false)
+        let path = writeTranscript(key: "orphaned-key")
+
+        _ = await makeGC(db: db, home: home).sweep()
+
+        #expect(fm.fileExists(atPath: path))
+    }
+
+    /// The GC master switch is read on top of the leg's flag: both must be on.
+    @Test func theMasterSwitchStillGovernsTheLeg() async throws {
+        let (home, cleanUp) = isolateTBDHome()
+        defer { cleanUp() }
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCRetainedTranscriptsEnabled(true)
+        try await db.config.setGCEnabled(false)
+        let path = writeTranscript(key: "orphaned-key")
+        try await db.retainedTranscripts.insert(
+            receipt(key: "stale-key", expiresAt: clock.addingTimeInterval(-3_600)))
+
+        _ = await makeGC(db: db, home: home).sweep()
+
+        #expect(fm.fileExists(atPath: path))
+        #expect(try await db.retainedTranscripts.find(provider: provider, key: "stale-key") != nil)
+    }
+
+    /// `dryRun` bypasses the flag, exactly as it bypasses `gcEnabled`: someone
+    /// deciding whether to turn a default-off flag on needs to see what it would
+    /// reclaim first. It plans both halves and changes neither.
+    @Test func aDryRunPlansWithTheFlagOffAndChangesNothing() async throws {
+        let (home, cleanUp) = isolateTBDHome()
+        defer { cleanUp() }
+        let db = try TBDDatabase(inMemory: true)
+        let path = writeTranscript(key: "orphaned-key")
+        try await db.retainedTranscripts.insert(
+            receipt(key: "stale-key", expiresAt: clock.addingTimeInterval(-3_600)))
+
+        let result = await makeGC(db: db, home: home).sweep(dryRun: true)
+
+        #expect(result.planned.contains("REAP retained-transcript \(path)"))
+        #expect(result.planned.contains("REAP retained-transcript-row \(provider)/stale-key"))
+        #expect(result.reaped == 0)
+        #expect(fm.fileExists(atPath: path), "a dry run must never touch disk")
+        #expect(try await db.retainedTranscripts.find(provider: provider, key: "stale-key") != nil,
+                "a dry run must never touch the database")
+    }
+
+    // MARK: - What it must never reclaim
+
+    /// The keep case that matters most: a file a live row references is not
+    /// residue, and unlinking it would destroy the only local copy of a
+    /// conversation.
+    @Test func aReferencedTranscriptSurvivesTheSweep() async throws {
+        let (home, cleanUp) = isolateTBDHome()
+        defer { cleanUp() }
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCRetainedTranscriptsEnabled(true)
+        let kept = writeTranscript(key: "referenced-key")
+        let orphan = writeTranscript(key: "orphaned-key")
+        try await db.retainedTranscripts.insert(
+            receipt(key: "referenced-key", expiresAt: clock.addingTimeInterval(86_400)))
+
+        let result = await makeGC(db: db, home: home).sweep()
+
+        #expect(fm.fileExists(atPath: kept), "a referenced transcript was unlinked")
+        #expect(result.planned.contains("REAP retained-transcript \(kept)") == false)
+        #expect(fm.fileExists(atPath: orphan) == false,
+                "the unreferenced sibling proves the sweep ran at all")
+    }
+
+    /// A row that records a local path outside the canonical layout still
+    /// protects that file: both readings are referenced, never just one.
+    @Test func aRowThatRecordsItsOwnLocalPathKeepsThatFile() async throws {
+        let (home, cleanUp) = isolateTBDHome()
+        defer { cleanUp() }
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCRetainedTranscriptsEnabled(true)
+        // A file filed under one key, recorded as the local path of another.
+        let moved = writeTranscript(key: "moved-file")
+        try await db.retainedTranscripts.insert(
+            receipt(key: "other-key", localPath: moved))
+
+        _ = await makeGC(db: db, home: home).sweep()
+
+        #expect(fm.fileExists(atPath: moved),
+                "a file named by a row's local_path must never be unlinked")
+    }
+
+    /// **A row with no stated expiry is never reclaimed.** Absence means the
+    /// provider made no claim, not that a claim lapsed — and the key lives in
+    /// that row and nowhere else, so dropping it strands the blob forever.
+    @Test func aRowWithNoStatedExpiryIsNeverDropped() async throws {
+        let (home, cleanUp) = isolateTBDHome()
+        defer { cleanUp() }
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCRetainedTranscriptsEnabled(true)
+        try await db.retainedTranscripts.insert(receipt(key: "no-claim-key"))
+        try await db.retainedTranscripts.insert(
+            receipt(key: "stale-key", expiresAt: clock.addingTimeInterval(-3_600)))
+
+        let result = await makeGC(db: db, home: home).sweep()
+
+        #expect(
+            try await db.retainedTranscripts.find(provider: provider, key: "no-claim-key") != nil,
+            "an absent expires_at is no claim, never a lapsed one")
+        #expect(
+            result.planned.contains("REAP retained-transcript-row \(provider)/no-claim-key")
+                == false)
+        #expect(
+            try await db.retainedTranscripts.find(provider: provider, key: "stale-key") == nil,
+            "the expired sibling proves the leg ran at all")
+    }
+
+    /// A file younger than `gcGraceSeconds` is kept even with no row pointing at
+    /// it: `recall` writes the file before it records the path, so a sweep
+    /// landing inside that window would otherwise unlink an arriving transcript.
+    @Test func aYoungUnreferencedFileIsKeptByTheGraceWindow() async throws {
+        let (home, cleanUp) = isolateTBDHome()
+        defer { cleanUp() }
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCRetainedTranscriptsEnabled(true)
+        let young = writeTranscript(key: "just-arrived", age: 5)
+
+        let result = await makeGC(db: db, home: home).sweep()
+
+        #expect(fm.fileExists(atPath: young))
+        #expect(result.planned.contains("KEEP grace \(young)"))
+    }
+
+    /// Only `<base>/<provider>/<key>.jsonl` is a candidate. Anything else in the
+    /// tree is left alone rather than judged by a rule that never considered it.
+    @Test func aFileThatIsNotATranscriptIsLeftAlone() async throws {
+        let (home, cleanUp) = isolateTBDHome()
+        defer { cleanUp() }
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCRetainedTranscriptsEnabled(true)
+        let orphan = writeTranscript(key: "orphaned-key")
+        let notes = URL(fileURLWithPath: orphan)
+            .deletingLastPathComponent().appendingPathComponent("notes.txt").path
+        fm.createFile(atPath: notes, contents: Data("hand-written\n".utf8))
+        backdate(notes, age: 86_400)
+        let topLevel = TBDConstants.retainedTranscriptsDir
+            .appendingPathComponent("README.md").path
+        fm.createFile(atPath: topLevel, contents: Data("hand-written\n".utf8))
+        backdate(topLevel, age: 86_400)
+
+        let result = await makeGC(db: db, home: home).sweep()
+
+        #expect(fm.fileExists(atPath: notes))
+        #expect(fm.fileExists(atPath: topLevel))
+        #expect(result.planned.contains { $0.contains(notes) } == false)
+        #expect(result.planned.contains { $0.contains(topLevel) } == false)
+        #expect(fm.fileExists(atPath: orphan) == false,
+                "the real candidate proves the sweep ran at all")
+    }
+
+    // MARK: - Expiry
+
+    /// One pass reclaims both halves: the expired row goes, and the file it had
+    /// been protecting goes with it.
+    @Test func anExpiredRowIsDroppedAndItsFileWithIt() async throws {
+        let (home, cleanUp) = isolateTBDHome()
+        defer { cleanUp() }
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCRetainedTranscriptsEnabled(true)
+        let path = writeTranscript(key: "stale-key")
+        try await db.retainedTranscripts.insert(
+            receipt(key: "stale-key", expiresAt: clock.addingTimeInterval(-3_600)))
+
+        let result = await makeGC(db: db, home: home).sweep()
+
+        #expect(try await db.retainedTranscripts.find(provider: provider, key: "stale-key") == nil)
+        #expect(fm.fileExists(atPath: path) == false)
+        #expect(result.planned.contains("REAP retained-transcript-row \(provider)/stale-key"))
+        #expect(result.planned.contains("REAP retained-transcript \(path)"))
+        #expect(result.reaped >= 2, "the row and the file are both reclaimed")
+    }
+
+    /// A receipt whose expiry is still ahead keeps both its row and its file.
+    @Test func anUnexpiredRowKeepsItsRowAndItsFile() async throws {
+        let (home, cleanUp) = isolateTBDHome()
+        defer { cleanUp() }
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCRetainedTranscriptsEnabled(true)
+        let path = writeTranscript(key: "fresh-key")
+        try await db.retainedTranscripts.insert(
+            receipt(key: "fresh-key", expiresAt: clock.addingTimeInterval(3_600)))
+
+        _ = await makeGC(db: db, home: home).sweep()
+
+        #expect(try await db.retainedTranscripts.find(provider: provider, key: "fresh-key") != nil)
+        #expect(fm.fileExists(atPath: path))
+    }
+}
+}

--- a/Tests/TBDDaemonTests/OrphanGCRetainedTranscriptTests.swift
+++ b/Tests/TBDDaemonTests/OrphanGCRetainedTranscriptTests.swift
@@ -71,6 +71,21 @@ struct OrphanGCRetainedTranscriptTests {
             [.creationDate: stamp, .modificationDate: stamp], ofItemAtPath: path)
     }
 
+    /// Canonicalizes a path exactly as the retained-transcript leg's own
+    /// `REAP`/`KEEP` lines do, through the same `DeletionQueueCollector`
+    /// helper `OrphanGC` reports paths through. On macOS, `NSTemporaryDirectory()`
+    /// (and everything derived from it, including `TBD_HOME` here) reads
+    /// `/var/...`, but `/var` is itself a symlink to `/private/var` — so a
+    /// path built from raw string composition and the equivalent path as it
+    /// comes back out of a filesystem walk disagree on that prefix unless
+    /// both go through the same resolver. Comparing a hand-built expectation
+    /// against `result.planned` without this would either fail outright, or
+    /// — worse — silently never match and pass a negative assertion for the
+    /// wrong reason.
+    private func canonical(_ path: String) -> String {
+        DeletionQueueCollector(git: GitManager()).resolvedPath(path)
+    }
+
     private func receipt(
         key: String, expiresAt: Date? = nil, localPath: String? = nil
     ) -> RetainedTranscript {
@@ -94,7 +109,7 @@ struct OrphanGCRetainedTranscriptTests {
         let result = await makeGC(db: db, home: home).sweep()
 
         #expect(fm.fileExists(atPath: path) == false, "\(path) survived the sweep")
-        #expect(result.planned.contains("REAP retained-transcript \(path)"))
+        #expect(result.planned.contains("REAP retained-transcript \(canonical(path))"))
         #expect(result.reaped >= 1)
     }
 
@@ -162,7 +177,7 @@ struct OrphanGCRetainedTranscriptTests {
 
         let result = await makeGC(db: db, home: home).sweep(dryRun: true)
 
-        #expect(result.planned.contains("REAP retained-transcript \(path)"))
+        #expect(result.planned.contains("REAP retained-transcript \(canonical(path))"))
         #expect(result.planned.contains("REAP retained-transcript-row \(provider)/stale-key"))
         #expect(result.reaped == 0)
         #expect(fm.fileExists(atPath: path), "a dry run must never touch disk")
@@ -188,7 +203,7 @@ struct OrphanGCRetainedTranscriptTests {
         let result = await makeGC(db: db, home: home).sweep()
 
         #expect(fm.fileExists(atPath: kept), "a referenced transcript was unlinked")
-        #expect(result.planned.contains("REAP retained-transcript \(kept)") == false)
+        #expect(result.planned.contains("REAP retained-transcript \(canonical(kept))") == false)
         #expect(fm.fileExists(atPath: orphan) == false,
                 "the unreferenced sibling proves the sweep ran at all")
     }
@@ -249,7 +264,7 @@ struct OrphanGCRetainedTranscriptTests {
         let result = await makeGC(db: db, home: home).sweep()
 
         #expect(fm.fileExists(atPath: young))
-        #expect(result.planned.contains("KEEP grace \(young)"))
+        #expect(result.planned.contains("KEEP grace \(canonical(young))"))
     }
 
     /// Only `<base>/<provider>/<key>.jsonl` is a candidate. Anything else in the
@@ -297,7 +312,7 @@ struct OrphanGCRetainedTranscriptTests {
         #expect(try await db.retainedTranscripts.find(provider: provider, key: "stale-key") == nil)
         #expect(fm.fileExists(atPath: path) == false)
         #expect(result.planned.contains("REAP retained-transcript-row \(provider)/stale-key"))
-        #expect(result.planned.contains("REAP retained-transcript \(path)"))
+        #expect(result.planned.contains("REAP retained-transcript \(canonical(path))"))
         #expect(result.reaped >= 2, "the row and the file are both reclaimed")
     }
 

--- a/Tests/TBDDaemonTests/RPCRouterRemoteDeleteTests.swift
+++ b/Tests/TBDDaemonTests/RPCRouterRemoteDeleteTests.swift
@@ -330,4 +330,104 @@ struct RPCRouterRemoteDeleteTests: ~Copyable {
         #expect(response.error?.contains("unreadable") == true)
         #expect(try await db.remoteSessions.row(provider: "agentbox", sessionID: sessionID) != nil)
     }
+
+    // MARK: - A poll in flight across the delete
+
+    /// The manager the router is built on, so a test can drive a poll through
+    /// it directly — `router(invoker:)` keeps its own to itself.
+    private func managerAndRouter(
+        invoker: FakeProviderInvoker
+    ) async -> (RemoteProviderManager, RPCRouter) {
+        let manager = RemoteProviderManager(
+            db: db, subscriptions: subs, runner: invoker, registryURL: registryURL,
+            actuationLog: makeTestActuationLog())
+        await manager.loadRegistryAndDescribe()
+        return (manager, router(manager: manager))
+    }
+
+    private func staleSighting() -> [RemoteSessionPayload] {
+        [RemoteSessionPayload(id: sessionID, title: "fix flaky CI", state: .running, agentState: .idle)]
+    }
+
+    /// The interlock, and the reason `remote.delete` is not just "call the verb
+    /// then DELETE the row". A `list` that captured its snapshot before the
+    /// provider committed the destruction lands *after* the row is dropped and
+    /// re-inserts it with `gone` false — the two-poll limbo the immediate drop
+    /// exists to prevent, arrived at from the other side. Without the deletion
+    /// watermark this test finds the row back in the mirror.
+    @Test func aSnapshotCapturedBeforeTheDeleteCannotResurrectTheRow() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        try await db.config.setRemoteDeleteEnabled(true)
+        try await mirrorSession()
+        let invoker = FakeProviderInvoker(script: [
+            describeDeclaring(["delete"]),
+            providerOK(deletedJSON),
+        ])
+        let (manager, r) = await managerAndRouter(invoker: invoker)
+        // The poll went out a second before the delete, so nothing in its
+        // answer can have accounted for one.
+        let pollStartedAt = Date().addingTimeInterval(-1)
+        let inFlight = staleSighting()
+
+        #expect(await call(r, "remote.delete", deleteParams()).success)
+        #expect(try await db.remoteSessions.row(provider: "agentbox", sessionID: sessionID) == nil)
+
+        try await manager.apply(
+            snapshot: inFlight, provider: "agentbox", now: Date(),
+            requestStartedAt: pollStartedAt)
+        #expect(
+            try await db.remoteSessions.row(provider: "agentbox", sessionID: sessionID) == nil,
+            "a snapshot captured before the delete must not put the row back")
+    }
+
+    /// The other branch, and what keeps the watermark from being a permanent
+    /// blocklist: it suppresses stale answers, not the id. A poll whose request
+    /// began after the delete returned is reporting something it learned
+    /// afterwards — a session genuinely re-created under the same id — and it
+    /// mirrors exactly as it always did.
+    @Test func aSnapshotTakenAfterTheDeleteMirrorsTheSessionAgain() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        try await db.config.setRemoteDeleteEnabled(true)
+        try await mirrorSession()
+        let invoker = FakeProviderInvoker(script: [
+            describeDeclaring(["delete"]),
+            providerOK(deletedJSON),
+        ])
+        let (manager, r) = await managerAndRouter(invoker: invoker)
+
+        #expect(await call(r, "remote.delete", deleteParams()).success)
+        #expect(try await db.remoteSessions.row(provider: "agentbox", sessionID: sessionID) == nil)
+
+        try await manager.apply(
+            snapshot: staleSighting(), provider: "agentbox", now: Date(),
+            requestStartedAt: Date())
+        #expect(
+            try await db.remoteSessions.row(provider: "agentbox", sessionID: sessionID) != nil,
+            "the watermark must not hide a session the provider reports after the delete")
+    }
+
+    /// A delete that failed destroyed nothing, so its watermark is taken back
+    /// rather than left to hide a session that is still alive. No mirror row is
+    /// seeded here on purpose: a watermark left standing would suppress the
+    /// INSERT, which is the observable this asserts.
+    @Test func aFailedDeleteWithdrawsItsWatermark() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        try await db.config.setRemoteDeleteEnabled(true)
+        let invoker = FakeProviderInvoker(script: [
+            describeDeclaring(["delete"]),
+            providerError("permission_denied", "cannot end compute for this session"),
+        ])
+        let (manager, r) = await managerAndRouter(invoker: invoker)
+        let pollStartedAt = Date().addingTimeInterval(-1)
+
+        #expect(await call(r, "remote.delete", deleteParams()).success == false)
+        #expect(await manager.deletionWatermark(provider: "agentbox", sessionID: sessionID) == nil)
+
+        try await manager.apply(
+            snapshot: staleSighting(), provider: "agentbox", now: Date(),
+            requestStartedAt: pollStartedAt)
+        #expect(
+            try await db.remoteSessions.row(provider: "agentbox", sessionID: sessionID) != nil,
+            "a session nothing destroyed must keep being mirrored")
+    }
 }

--- a/Tests/TBDDaemonTests/RPCRouterRemoteDeleteTests.swift
+++ b/Tests/TBDDaemonTests/RPCRouterRemoteDeleteTests.swift
@@ -1,0 +1,333 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+import TestSupport
+
+/// `remote.delete` — the destructive verb, behind the default-off
+/// `remote_delete_enabled` flag. Tier 2: in-memory GRDB plus a fake provider
+/// invoker, no real subprocess.
+///
+/// Wiring mirrors `RPCRouterRemoteExchangeTests`. The observable that matters
+/// most here is `invoker.calls`: every refusal in this suite must be decided
+/// *before* the provider is spawned, because a refusal that still ran `delete`
+/// would pass a message assertion while having destroyed the session.
+@Suite("RPCRouter remote delete")
+struct RPCRouterRemoteDeleteTests: ~Copyable {
+    let db: TBDDatabase
+    let subs: StateSubscriptionManager
+    let dir: URL
+    let registryURL: URL
+
+    init() throws {
+        let localDB = try TBDDatabase(inMemory: true)
+        let localDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rpc-remote-delete-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: localDir, withIntermediateDirectories: true)
+        let localRegistryURL = localDir.appendingPathComponent("agent-providers.json")
+        try #"[{"name": "agentbox", "exec": "/nonexistent"}]"#
+            .write(to: localRegistryURL, atomically: true, encoding: .utf8)
+        db = localDB
+        subs = StateSubscriptionManager()
+        dir = localDir
+        registryURL = localRegistryURL
+    }
+
+    deinit { try? FileManager.default.removeItem(at: dir) }
+
+    private func router(manager: RemoteProviderManager?) -> RPCRouter {
+        RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver(),
+                subscriptions: subs),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date(),
+            subscriptions: subs,
+            remoteManager: manager, actuationLog: makeTestActuationLog())
+    }
+
+    /// `describe` is popped FIRST — `loadRegistryAndDescribe` runs before the
+    /// verb under test — so scripts read `[describe, verb...]`.
+    private func router(invoker: FakeProviderInvoker) async -> RPCRouter {
+        let manager = RemoteProviderManager(
+            db: db, subscriptions: subs, runner: invoker, registryURL: registryURL,
+            actuationLog: makeTestActuationLog())
+        await manager.loadRegistryAndDescribe()
+        return router(manager: manager)
+    }
+
+    private func call(_ router: RPCRouter, _ method: String, _ params: String) async -> RPCResponse {
+        await router.handle(RPCRequest(method: method, params: params))
+    }
+
+    private func describeDeclaring(_ capabilities: [String]) -> ProviderResult {
+        let caps = capabilities.map { "\"\($0)\"" }.joined(separator: ", ")
+        return providerOK(#"{"contract_versions": [1], "name": "agentbox", "capabilities": [\#(caps)]}"#)
+    }
+
+    private func providerError(_ code: String, _ message: String, exitCode: Int32 = 1) -> ProviderResult {
+        ProviderResult(
+            exitCode: exitCode,
+            stdout: Data(#"{"error": {"code": "\#(code)", "message": "\#(message)"}}"#.utf8),
+            stderr: "")
+    }
+
+    private let sessionID = "fix-flaky-ci"
+    private func deleteParams(retain: Bool = false) -> String {
+        #"{"provider": "agentbox", "sessionID": "\#(sessionID)", "retain": \#(retain)}"#
+    }
+
+    private let deletedJSON = #"{"id": "fix-flaky-ci", "deleted": true}"#
+    // One line on purpose: inside a `#"""` raw literal a trailing backslash is
+    // a literal backslash, not a line continuation, and the JSON would be
+    // malformed in a way that reads as valid Swift.
+    private let deletedWithReceiptJSON = #"{"id": "fix-flaky-ci", "deleted": true, "retained": {"key": "opaque-provider-string", "expires_at": "2026-10-01T00:00:00Z", "bytes": 148213}}"#
+
+    /// Puts a mirror row in place, so "the row is gone afterwards" is a real
+    /// observation rather than a vacuous one.
+    @discardableResult
+    private func mirrorSession(title: String = "fix flaky CI") async throws -> Bool {
+        _ = try await db.remoteSessions.applySnapshot(
+            provider: "agentbox",
+            sessions: [RemoteSessionPayload(
+                id: sessionID, title: title, state: .running, agentState: .idle)],
+            now: Date())
+        return try await db.remoteSessions.row(provider: "agentbox", sessionID: sessionID) != nil
+    }
+
+    private func adoptLane() async throws -> Worktree {
+        let repo = try await db.repos.create(
+            path: "/tmp/acme-\(UUID().uuidString)", displayName: "acme", defaultBranch: "main")
+        return try await db.worktrees.createRemote(
+            repoID: repo.id, name: "acme-remote", branch: "acme-branch",
+            provider: "agentbox", sessionID: sessionID, status: .active)
+    }
+
+    // MARK: - The gates, in order, none of which may spawn the provider
+
+    /// The subsystem gate is outermost: with remote backends off, the answer is
+    /// the subsystem's, not the feature flag's.
+    @Test func deleteErrorsWhenTheSubsystemFlagIsOff() async throws {
+        try await db.config.setRemoteDeleteEnabled(true)
+        let invoker = FakeProviderInvoker(script: [])
+        let manager = RemoteProviderManager(
+            db: db, subscriptions: subs, runner: invoker, registryURL: registryURL)
+        let r = router(manager: manager)
+        let response = await call(r, "remote.delete", deleteParams())
+        #expect(response.success == false)
+        #expect(response.error == "remote backends disabled")
+        #expect(invoker.callsSnapshot().isEmpty)
+    }
+
+    /// **The flag's off branch.** The provider declares `delete` and would
+    /// happily run it; the flag alone stops it, and the refusal names the flag
+    /// so a soak participant knows which of three gates closed.
+    @Test func deleteRefusesNamingTheFlagAndNeverSpawnsWhenFlagOff() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let invoker = FakeProviderInvoker(script: [describeDeclaring(["delete", "retain"])])
+        let r = await router(invoker: invoker)
+        try await mirrorSession()
+
+        let response = await call(r, "remote.delete", deleteParams())
+        #expect(response.success == false)
+        #expect(response.error?.contains("remote_delete_enabled") == true)
+        #expect(invoker.calls == [["describe"]], "the flag must be read before anything is spawned")
+        #expect(
+            try await db.remoteSessions.row(provider: "agentbox", sessionID: sessionID) != nil,
+            "a refused delete must not drop the mirror row")
+    }
+
+    /// The flag's on branch, isolated: the same request the previous test
+    /// refused now reaches the provider. Without this pair the flag could be
+    /// wired to refuse unconditionally and both branches would look right.
+    @Test func deleteProceedsWhenFlagOn() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        try await db.config.setRemoteDeleteEnabled(true)
+        let invoker = FakeProviderInvoker(script: [
+            describeDeclaring(["delete"]),
+            providerOK(deletedJSON),
+        ])
+        let r = await router(invoker: invoker)
+        let response = await call(r, "remote.delete", deleteParams())
+        #expect(response.success)
+        #expect(invoker.calls == [["describe"], ["delete", sessionID]])
+    }
+
+    /// Flag on, capability absent: refused before anything is spawned, naming
+    /// the capability.
+    @Test func deleteRefusesWhenCapabilityUndeclared() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        try await db.config.setRemoteDeleteEnabled(true)
+        let invoker = FakeProviderInvoker(script: [describeDeclaring(["retain", "recall"])])
+        let r = await router(invoker: invoker)
+        let response = await call(r, "remote.delete", deleteParams())
+        #expect(response.success == false)
+        #expect(response.error?.contains("delete") == true)
+        #expect(invoker.calls == [["describe"]])
+    }
+
+    /// `--retain` is valid only where `retain` is also declared. A provider
+    /// that declares `delete` alone must not be sent the flag: it would either
+    /// ignore it and destroy a session the caller believed was being kept, or
+    /// fail after the fact.
+    @Test func retainRequestRequiresTheRetainCapability() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        try await db.config.setRemoteDeleteEnabled(true)
+        let invoker = FakeProviderInvoker(script: [describeDeclaring(["delete"])])
+        let r = await router(invoker: invoker)
+        let response = await call(r, "remote.delete", deleteParams(retain: true))
+        #expect(response.success == false)
+        #expect(response.error?.contains("retain") == true)
+        #expect(invoker.calls == [["describe"]], "nothing may be destroyed on the way to this refusal")
+    }
+
+    // MARK: - The successful delete
+
+    /// **The immediate row drop.** The caller has positive knowledge that the
+    /// session is gone, so the row goes at once rather than waiting for the
+    /// drift rule's two absences.
+    @Test func deleteDropsTheMirrorRowImmediately() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        try await db.config.setRemoteDeleteEnabled(true)
+        #expect(try await mirrorSession())
+        let invoker = FakeProviderInvoker(script: [
+            describeDeclaring(["delete"]),
+            providerOK(deletedJSON),
+        ])
+        let r = await router(invoker: invoker)
+
+        let response = await call(r, "remote.delete", deleteParams())
+        #expect(response.success)
+        let outcome = try response.decodeResult(RemoteDeleteResult.self)
+        #expect(outcome.deleted == true)
+        #expect(outcome.retained == nil)
+        #expect(
+            try await db.remoteSessions.row(provider: "agentbox", sessionID: sessionID) == nil,
+            "the row must be gone now, not two polls from now")
+    }
+
+    /// Without `--retain` nothing is stored, and no receipt row is written —
+    /// retention is never implied by the provider declaring `retain`.
+    @Test func deleteWithoutRetainStoresNoReceipt() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        try await db.config.setRemoteDeleteEnabled(true)
+        let invoker = FakeProviderInvoker(script: [
+            describeDeclaring(["delete", "retain"]),
+            providerOK(deletedJSON),
+        ])
+        let r = await router(invoker: invoker)
+        #expect(await call(r, "remote.delete", deleteParams()).success)
+        #expect(invoker.calls == [["describe"], ["delete", sessionID]])
+        #expect(try await db.retainedTranscripts.all().isEmpty)
+    }
+
+    /// With `--retain` the flag reaches the provider and the receipt is
+    /// recorded — a key TBD does not write down is a retained transcript nobody
+    /// can ever recall.
+    @Test func deleteWithRetainPassesTheFlagAndStoresTheReceipt() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        try await db.config.setRemoteDeleteEnabled(true)
+        try await mirrorSession()
+        let invoker = FakeProviderInvoker(script: [
+            describeDeclaring(["delete", "retain"]),
+            providerOK(deletedWithReceiptJSON),
+        ])
+        let r = await router(invoker: invoker)
+
+        let response = await call(r, "remote.delete", deleteParams(retain: true))
+        #expect(response.success)
+        #expect(invoker.calls == [["describe"], ["delete", sessionID, "--retain"]])
+
+        let outcome = try response.decodeResult(RemoteDeleteResult.self)
+        #expect(outcome.retained?.key == "opaque-provider-string")
+        #expect(outcome.retained?.bytes == 148213)
+
+        let stored = try await db.retainedTranscripts.find(
+            provider: "agentbox", key: "opaque-provider-string")
+        #expect(stored?.bytes == 148213)
+        #expect(stored?.sourceSessionID == sessionID)
+        #expect(stored?.sourceTitle == "fix flaky CI",
+                "the receipt must be written before the mirror row it reads from is dropped")
+    }
+
+    /// The receipt links the lane, which is what makes Revive-as-reseed
+    /// possible later — and the lane is filed rather than lost, so a deleted
+    /// lane keeps its place in the repo's Archived tab.
+    @Test func deleteLinksAndArchivesTheAdoptedLane() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        try await db.config.setRemoteDeleteEnabled(true)
+        let lane = try await adoptLane()
+        try await mirrorSession()
+        let invoker = FakeProviderInvoker(script: [
+            describeDeclaring(["delete", "retain"]),
+            providerOK(deletedWithReceiptJSON),
+        ])
+        let r = await router(invoker: invoker)
+
+        #expect(await call(r, "remote.delete", deleteParams(retain: true)).success)
+        let stored = try await db.retainedTranscripts.find(
+            provider: "agentbox", key: "opaque-provider-string")
+        #expect(stored?.originWorktreeID == lane.id)
+        #expect(try await db.worktrees.get(id: lane.id)?.status == .archived)
+        // Filing a deleted lane calls nothing on the provider: the session it
+        // named no longer exists there.
+        #expect(invoker.calls == [["describe"], ["delete", sessionID, "--retain"]])
+    }
+
+    /// `deleted: false` — an unknown or already-deleted id — is a success per
+    /// the contract, matching `rm -f`. The row goes too: the provider has just
+    /// stated the session is not there.
+    @Test func deletedFalseForAnUnknownIDIsSuccess() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        try await db.config.setRemoteDeleteEnabled(true)
+        try await mirrorSession()
+        let invoker = FakeProviderInvoker(script: [
+            describeDeclaring(["delete"]),
+            providerOK(#"{"id": "fix-flaky-ci", "deleted": false}"#),
+        ])
+        let r = await router(invoker: invoker)
+
+        let response = await call(r, "remote.delete", deleteParams())
+        #expect(response.success, "asking for a state the session is already in is not an error")
+        #expect(response.error == nil)
+        #expect(try response.decodeResult(RemoteDeleteResult.self).deleted == false)
+        #expect(try await db.remoteSessions.row(provider: "agentbox", sessionID: sessionID) == nil)
+    }
+
+    // MARK: - Failures keep the row
+
+    @Test func deleteSurfacesTheProvidersErrorMessageAndKeepsTheRow() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        try await db.config.setRemoteDeleteEnabled(true)
+        try await mirrorSession()
+        let invoker = FakeProviderInvoker(script: [
+            describeDeclaring(["delete"]),
+            providerError("permission_denied", "cannot end compute for this session"),
+        ])
+        let r = await router(invoker: invoker)
+
+        let response = await call(r, "remote.delete", deleteParams())
+        #expect(response.success == false)
+        #expect(response.error == "cannot end compute for this session")
+        #expect(try await db.remoteSessions.row(provider: "agentbox", sessionID: sessionID) != nil)
+    }
+
+    /// Exit 0 with an unreadable body: TBD cannot say the session is gone, so
+    /// it does not drop the row on a guess.
+    @Test func unreadableDeleteResultIsReportedAndKeepsTheRow() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        try await db.config.setRemoteDeleteEnabled(true)
+        try await mirrorSession()
+        let invoker = FakeProviderInvoker(script: [
+            describeDeclaring(["delete"]),
+            providerOK(#"{"nonsense": true}"#),
+        ])
+        let r = await router(invoker: invoker)
+
+        let response = await call(r, "remote.delete", deleteParams())
+        #expect(response.success == false)
+        #expect(response.error?.contains("unreadable") == true)
+        #expect(try await db.remoteSessions.row(provider: "agentbox", sessionID: sessionID) != nil)
+    }
+}

--- a/Tests/TBDDaemonTests/RPCRouterRemoteExchangeTests.swift
+++ b/Tests/TBDDaemonTests/RPCRouterRemoteExchangeTests.swift
@@ -1,0 +1,415 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+import TestSupport
+
+/// Paths the daemon wrote during a test, so `deinit` can take them away again.
+/// A reference type because the suite is `~Copyable` and `deinit` must see what
+/// the test body recorded.
+private final class WrittenPathBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var paths: [String] = []
+    func add(_ path: String) {
+        lock.lock(); defer { lock.unlock() }
+        paths.append(path)
+    }
+    func drain() -> [String] {
+        lock.lock(); defer { lock.unlock() }
+        let out = paths
+        paths = []
+        return out
+    }
+}
+
+/// `remote.retain` / `remote.import` / `remote.recall` — the transcript
+/// exchange. Tier 2: in-memory GRDB plus a fake provider invoker, no real
+/// subprocess.
+///
+/// Mirrors `RPCRouterRemoteArchiveTests`'s wiring exactly; the interesting
+/// difference is that these verbs write a `retained_transcript` row, so almost
+/// every test has two observables — what the provider was asked, and what TBD
+/// wrote down about the answer. A key TBD does not write down is a retained
+/// transcript nobody can recall, so the second observable is not decoration.
+@Suite("RPCRouter transcript exchange")
+struct RPCRouterRemoteExchangeTests: ~Copyable {
+    let db: TBDDatabase
+    let subs: StateSubscriptionManager
+    let dir: URL
+    let registryURL: URL
+    /// Files this suite let the daemon write under `TBD_HOME`, removed in
+    /// `deinit`. `scripts/test.sh` already points `TBD_HOME` at a scratch dir,
+    /// so nothing here can reach the developer's real `~/tbd`; this only keeps
+    /// the scratch tidy across a long run.
+    private let writtenPaths: WrittenPathBox
+
+    init() throws {
+        let localDB = try TBDDatabase(inMemory: true)
+        let localDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rpc-remote-exchange-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: localDir, withIntermediateDirectories: true)
+        let localRegistryURL = localDir.appendingPathComponent("agent-providers.json")
+        try #"[{"name": "agentbox", "exec": "/nonexistent"}]"#
+            .write(to: localRegistryURL, atomically: true, encoding: .utf8)
+        db = localDB
+        subs = StateSubscriptionManager()
+        dir = localDir
+        registryURL = localRegistryURL
+        writtenPaths = WrittenPathBox()
+    }
+
+    deinit {
+        try? FileManager.default.removeItem(at: dir)
+        for path in writtenPaths.drain() {
+            try? FileManager.default.removeItem(atPath: path)
+        }
+    }
+
+    private func router(manager: RemoteProviderManager?) -> RPCRouter {
+        RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver(),
+                subscriptions: subs),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date(),
+            subscriptions: subs,
+            remoteManager: manager, actuationLog: makeTestActuationLog())
+    }
+
+    /// `describe` is popped FIRST — `loadRegistryAndDescribe` runs before the
+    /// verb under test — so scripts read `[describe, verb...]`.
+    private func router(invoker: FakeProviderInvoker) async -> RPCRouter {
+        let manager = RemoteProviderManager(
+            db: db, subscriptions: subs, runner: invoker, registryURL: registryURL,
+            actuationLog: makeTestActuationLog())
+        await manager.loadRegistryAndDescribe()
+        return router(manager: manager)
+    }
+
+    private func call(_ router: RPCRouter, _ method: String, _ params: String) async -> RPCResponse {
+        await router.handle(RPCRequest(method: method, params: params))
+    }
+
+    private func describeDeclaring(_ capabilities: [String]) -> ProviderResult {
+        let caps = capabilities.map { "\"\($0)\"" }.joined(separator: ", ")
+        return providerOK(#"{"contract_versions": [1], "name": "agentbox", "capabilities": [\#(caps)]}"#)
+    }
+
+    private func providerError(_ code: String, _ message: String, exitCode: Int32 = 1) -> ProviderResult {
+        ProviderResult(
+            exitCode: exitCode,
+            stdout: Data(#"{"error": {"code": "\#(code)", "message": "\#(message)"}}"#.utf8),
+            stderr: "")
+    }
+
+    private let retainParams = #"{"provider": "agentbox", "sessionID": "fix-flaky-ci"}"#
+    private let importParams = #"{"provider": "agentbox", "jsonl": "{\"type\":\"user\"}\n"}"#
+    private func recallParams(key: String, saveLocally: Bool = false) -> String {
+        #"{"provider": "agentbox", "key": "\#(key)", "saveLocally": \#(saveLocally)}"#
+    }
+
+    private let receiptJSON = #"""
+        {"key": "opaque-provider-string", "expires_at": "2026-10-01T00:00:00Z", "bytes": 12}
+        """#
+
+    // MARK: - The subsystem gate
+
+    @Test func exchangeVerbsErrorWhenFlagOff() async throws {
+        let invoker = FakeProviderInvoker(script: [])
+        let manager = RemoteProviderManager(
+            db: db, subscriptions: subs, runner: invoker, registryURL: registryURL)
+        let r = router(manager: manager)
+        for (method, params) in [
+            ("remote.retain", retainParams),
+            ("remote.import", importParams),
+            ("remote.recall", recallParams(key: "k")),
+        ] {
+            let response = await call(r, method, params)
+            #expect(response.success == false, "expected \(method) to be gated")
+            #expect(response.error == "remote backends disabled")
+        }
+        #expect(invoker.callsSnapshot().isEmpty)
+    }
+
+    // MARK: - Undeclared capability: refused, provider never spawned
+
+    /// The contract forbids invoking a verb whose capability the provider has
+    /// not declared. The discriminating half of each of these is
+    /// `invoker.calls`: a refusal that still spawned the provider would pass a
+    /// message assertion and fail the contract.
+    @Test func retainRefusesAndNeverSpawnsWhenCapabilityUndeclared() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let invoker = FakeProviderInvoker(script: [describeDeclaring(["import", "recall"])])
+        let r = await router(invoker: invoker)
+        let response = await call(r, "remote.retain", retainParams)
+        #expect(response.success == false)
+        #expect(response.error?.contains("retain") == true)
+        #expect(invoker.calls == [["describe"]])
+    }
+
+    @Test func importRefusesAndNeverSpawnsWhenCapabilityUndeclared() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let invoker = FakeProviderInvoker(script: [describeDeclaring(["retain", "recall"])])
+        let r = await router(invoker: invoker)
+        let response = await call(r, "remote.import", importParams)
+        #expect(response.success == false)
+        #expect(response.error?.contains("import") == true)
+        #expect(invoker.calls == [["describe"]])
+    }
+
+    @Test func recallRefusesAndNeverSpawnsWhenCapabilityUndeclared() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let invoker = FakeProviderInvoker(script: [describeDeclaring(["retain", "import"])])
+        let r = await router(invoker: invoker)
+        let response = await call(r, "remote.recall", recallParams(key: "k"))
+        #expect(response.success == false)
+        #expect(response.error?.contains("recall") == true)
+        #expect(invoker.calls == [["describe"]])
+    }
+
+    /// `retain` and `import` are two capabilities precisely because a backend
+    /// may be able to snapshot its own sessions and not accept a foreign blob.
+    /// Declaring one must never admit the other.
+    @Test func declaringRetainDoesNotAdmitImport() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let invoker = FakeProviderInvoker(script: [describeDeclaring(["retain"])])
+        let r = await router(invoker: invoker)
+        let response = await call(r, "remote.import", importParams)
+        #expect(response.success == false)
+        #expect(invoker.calls == [["describe"]])
+    }
+
+    /// No cached `describe` at all — capabilities read as empty, so every
+    /// exchange verb refuses rather than failing open.
+    @Test func exchangeVerbsRefuseWhenProviderHasNoCachedDescribe() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let invoker = FakeProviderInvoker(script: [
+            ProviderResult(exitCode: 1, stdout: Data(), stderr: "describe failed"),
+        ])
+        let r = await router(invoker: invoker)
+        let response = await call(r, "remote.retain", retainParams)
+        #expect(response.success == false)
+        #expect(invoker.calls == [["describe"]])
+    }
+
+    // MARK: - retain
+
+    @Test func retainInvokesTheVerbAndStoresTheReceiptRow() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let invoker = FakeProviderInvoker(script: [
+            describeDeclaring(["retain"]),
+            providerOK(receiptJSON),
+        ])
+        let r = await router(invoker: invoker)
+        let response = await call(r, "remote.retain", retainParams)
+        #expect(response.success)
+        #expect(invoker.calls == [["describe"], ["retain", "fix-flaky-ci"]])
+
+        let receipt = try response.decodeResult(RetainReceipt.self)
+        #expect(receipt.key == "opaque-provider-string")
+        #expect(receipt.bytes == 12)
+
+        let stored = try await db.retainedTranscripts.find(
+            provider: "agentbox", key: "opaque-provider-string")
+        #expect(stored?.bytes == 12)
+        #expect(stored?.sourceSessionID == "fix-flaky-ci")
+        #expect(stored?.expiresAt == ISO8601DateFormatter().date(from: "2026-10-01T00:00:00Z"))
+    }
+
+    /// A receipt with no stated expiry stores a NULL — "the provider makes no
+    /// claim", never "kept forever".
+    @Test func retainStoresAnAbsentExpiryAsNoClaim() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let invoker = FakeProviderInvoker(script: [
+            describeDeclaring(["retain"]),
+            providerOK(#"{"key": "k", "bytes": 5}"#),
+        ])
+        let r = await router(invoker: invoker)
+        #expect(await call(r, "remote.retain", retainParams).success)
+        let stored = try await db.retainedTranscripts.find(provider: "agentbox", key: "k")
+        #expect(stored != nil)
+        #expect(stored?.expiresAt == nil)
+    }
+
+    /// The receipt row is what makes a deleted lane's Revive-as-reseed
+    /// possible, so `retain` on an adopted session must link the lane and keep
+    /// the title the human recognises the conversation by.
+    @Test func retainLinksTheAdoptedLaneAndItsTitle() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let repo = try await db.repos.create(
+            path: "/tmp/acme-\(UUID().uuidString)", displayName: "acme", defaultBranch: "main")
+        let lane = try await db.worktrees.createRemote(
+            repoID: repo.id, name: "acme-remote", branch: "acme-branch",
+            provider: "agentbox", sessionID: "fix-flaky-ci", status: .active)
+        _ = try await db.remoteSessions.applySnapshot(
+            provider: "agentbox",
+            sessions: [RemoteSessionPayload(
+                id: "fix-flaky-ci", title: "fix flaky CI", state: .running, agentState: .idle)],
+            now: Date())
+
+        let invoker = FakeProviderInvoker(script: [
+            describeDeclaring(["retain"]),
+            providerOK(receiptJSON),
+        ])
+        let r = await router(invoker: invoker)
+        #expect(await call(r, "remote.retain", retainParams).success)
+
+        let stored = try await db.retainedTranscripts.find(
+            provider: "agentbox", key: "opaque-provider-string")
+        #expect(stored?.originWorktreeID == lane.id)
+        #expect(stored?.sourceTitle == "fix flaky CI")
+    }
+
+    @Test func retainSurfacesTheProvidersErrorMessage() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let invoker = FakeProviderInvoker(script: [
+            describeDeclaring(["retain"]),
+            providerError("not_found", "no such session"),
+        ])
+        let r = await router(invoker: invoker)
+        let response = await call(r, "remote.retain", retainParams)
+        #expect(response.success == false)
+        #expect(response.error == "no such session")
+        #expect(try await db.retainedTranscripts.all().isEmpty)
+    }
+
+    @Test func retainReportsATimeoutInWords() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let invoker = FakeProviderInvoker(outcomes: [
+            .result(describeDeclaring(["retain"])),
+            .timeout,
+        ])
+        let r = await router(invoker: invoker)
+        let response = await call(r, "remote.retain", retainParams)
+        #expect(response.success == false)
+        #expect(response.error == "provider 'agentbox' timed out running 'retain'")
+    }
+
+    // MARK: - import
+
+    @Test func importFeedsJSONLOnStdinAndStoresTheReceipt() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let invoker = FakeProviderInvoker(script: [
+            describeDeclaring(["import"]),
+            providerOK(receiptJSON),
+        ])
+        let r = await router(invoker: invoker)
+        let response = await call(r, "remote.import", importParams)
+        #expect(response.success)
+        #expect(invoker.calls == [["describe"], ["import"]])
+        let sent = invoker.stdinsSnapshot().last ?? nil
+        #expect(sent.map { String(decoding: $0, as: UTF8.self) } == "{\"type\":\"user\"}\n")
+
+        let stored = try await db.retainedTranscripts.find(
+            provider: "agentbox", key: "opaque-provider-string")
+        #expect(stored != nil)
+        // No session on this provider was involved, so there is none to name.
+        #expect(stored?.sourceSessionID == nil)
+        #expect(stored?.originWorktreeID == nil)
+    }
+
+    /// Malformed JSONL is the provider's `invalid_params`, surfaced as an
+    /// ordinary failure — TBD does not pre-validate, because the contract makes
+    /// the provider the validator of record.
+    @Test func importSurfacesInvalidParams() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let invoker = FakeProviderInvoker(script: [
+            describeDeclaring(["import"]),
+            providerError("invalid_params", "line 3 is not JSON"),
+        ])
+        let r = await router(invoker: invoker)
+        let response = await call(r, "remote.import", importParams)
+        #expect(response.success == false)
+        #expect(response.error == "line 3 is not JSON")
+        #expect(try await db.retainedTranscripts.all().isEmpty)
+    }
+
+    // MARK: - recall
+
+    @Test func recallReturnsJSONLAndWritesNoFileByDefault() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let invoker = FakeProviderInvoker(script: [
+            describeDeclaring(["recall"]),
+            providerOK("{\"type\":\"user\"}\n"),
+        ])
+        let r = await router(invoker: invoker)
+        let response = await call(r, "remote.recall", recallParams(key: "opaque-key"))
+        #expect(response.success)
+        #expect(invoker.calls == [["describe"], ["recall", "opaque-key"]])
+        let result = try response.decodeResult(RemoteRecallResult.self)
+        #expect(result.jsonl == "{\"type\":\"user\"}\n")
+        #expect(result.localPath == nil)
+        let expected = TBDConstants.retainedTranscriptPath(provider: "agentbox", key: "opaque-key")
+        #expect(FileManager.default.fileExists(atPath: expected.path) == false)
+    }
+
+    @Test func recallWithSaveLocallyWritesTheFileAndRecordsThePath() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let key = "saved-\(UUID().uuidString)"
+        try await db.retainedTranscripts.insert(
+            RetainedTranscript(provider: "agentbox", key: key, bytes: 16))
+        let body = "{\"type\":\"user\"}\n"
+        let invoker = FakeProviderInvoker(script: [
+            describeDeclaring(["recall"]),
+            providerOK(body),
+        ])
+        let r = await router(invoker: invoker)
+        let response = await call(r, "remote.recall", recallParams(key: key, saveLocally: true))
+        #expect(response.success)
+        let result = try response.decodeResult(RemoteRecallResult.self)
+
+        let expected = TBDConstants.retainedTranscriptPath(provider: "agentbox", key: key)
+        writtenPaths.add(expected.path)
+        #expect(result.localPath == expected.path)
+        #expect(result.jsonl == body, "the records come back whether or not they were saved")
+        #expect(try String(contentsOf: expected, encoding: .utf8) == body)
+
+        let stored = try await db.retainedTranscripts.find(provider: "agentbox", key: key)
+        #expect(stored?.localPath == expected.path)
+    }
+
+    /// Truncation is detected against the receipt's `bytes` and reported in the
+    /// log, never by failing the call: the records that arrived are real, and
+    /// refusing them would turn a partial transcript into no transcript.
+    @Test func aShortRecallStillReturnsTheBytesItGot() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        try await db.retainedTranscripts.insert(
+            RetainedTranscript(provider: "agentbox", key: "short", bytes: 148_213))
+        let invoker = FakeProviderInvoker(script: [
+            describeDeclaring(["recall"]),
+            providerOK("{\"type\":\"user\"}\n"),
+        ])
+        let r = await router(invoker: invoker)
+        let response = await call(r, "remote.recall", recallParams(key: "short"))
+        #expect(response.success)
+        let result = try response.decodeResult(RemoteRecallResult.self)
+        #expect(result.jsonl == "{\"type\":\"user\"}\n")
+    }
+
+    /// An aged-out key must say the record lapsed rather than claim it never
+    /// existed, so `expired`'s message reaches the caller intact.
+    @Test func recallSurfacesTheExpiredCode() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let invoker = FakeProviderInvoker(script: [
+            describeDeclaring(["recall"]),
+            providerError("expired", "that transcript has aged out"),
+        ])
+        let r = await router(invoker: invoker)
+        let response = await call(r, "remote.recall", recallParams(key: "old"))
+        #expect(response.success == false)
+        #expect(response.error == "that transcript has aged out")
+    }
+
+    @Test func recallSurfacesTheNotFoundCode() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let invoker = FakeProviderInvoker(script: [
+            describeDeclaring(["recall"]),
+            providerError("not_found", "unknown key"),
+        ])
+        let r = await router(invoker: invoker)
+        let response = await call(r, "remote.recall", recallParams(key: "nope"))
+        #expect(response.success == false)
+        #expect(response.error == "unknown key")
+    }
+}

--- a/Tests/TBDDaemonTests/RPCRouterRemoteSeedTests.swift
+++ b/Tests/TBDDaemonTests/RPCRouterRemoteSeedTests.swift
@@ -1,0 +1,195 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+import TestSupport
+
+/// `remote.create`'s `seed` field — the capability-gated way a new session
+/// begins with a retained conversation as its history
+/// (`docs/remote-provider-contract.md` § `create`).
+///
+/// Every test here reads the composed stdin rather than the response, because
+/// the whole of `seed` is what reaches the provider: a body missing the field,
+/// or carrying it in the wrong place, produces a perfectly healthy-looking
+/// session with none of the caller's conversation in it.
+///
+/// Tier 2: in-memory GRDB plus a fake provider invoker, no real subprocess.
+/// Wiring mirrors `RPCRouterRemoteExchangeTests` — `describe` is popped first,
+/// so scripts read `[describe, create, list]`.
+@Suite("RPCRouter remote.create seed")
+struct RPCRouterRemoteSeedTests: ~Copyable {
+    let db: TBDDatabase
+    let subs: StateSubscriptionManager
+    let dir: URL
+    let registryURL: URL
+
+    init() throws {
+        let localDB = try TBDDatabase(inMemory: true)
+        let localDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rpc-remote-seed-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: localDir, withIntermediateDirectories: true)
+        let localRegistryURL = localDir.appendingPathComponent("agent-providers.json")
+        try #"[{"name": "agentbox", "exec": "/nonexistent"}]"#
+            .write(to: localRegistryURL, atomically: true, encoding: .utf8)
+        db = localDB
+        subs = StateSubscriptionManager()
+        dir = localDir
+        registryURL = localRegistryURL
+    }
+
+    deinit {
+        try? FileManager.default.removeItem(at: dir)
+    }
+
+    private func router(invoker: FakeProviderInvoker) async -> RPCRouter {
+        let manager = RemoteProviderManager(
+            db: db, subscriptions: subs, runner: invoker, registryURL: registryURL,
+            actuationLog: makeTestActuationLog())
+        await manager.loadRegistryAndDescribe()
+        return RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver(),
+                subscriptions: subs),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date(),
+            subscriptions: subs,
+            remoteManager: manager, actuationLog: makeTestActuationLog())
+    }
+
+    private func call(_ router: RPCRouter, _ method: String, _ params: String) async -> RPCResponse {
+        await router.handle(RPCRequest(method: method, params: params))
+    }
+
+    private func describeDeclaring(_ capabilities: [String]) -> ProviderResult {
+        let caps = capabilities.map { "\"\($0)\"" }.joined(separator: ", ")
+        return providerOK(#"{"contract_versions": [1], "name": "agentbox", "capabilities": [\#(caps)]}"#)
+    }
+
+    private let createdSession = #"{"id": "new-1", "state": "starting"}"#
+    private let emptyList = #"{"complete": true, "sessions": []}"#
+
+    /// The composed `create` stdin, decoded.
+    private func sentBody(_ invoker: FakeProviderInvoker) throws -> [String: Any] {
+        let stdin = try #require(invoker.stdinsSnapshot().compactMap { $0 }.first)
+        return try #require(try JSONSerialization.jsonObject(with: stdin) as? [String: Any])
+    }
+
+    // MARK: - Sent when declared
+
+    @Test func createSendsSeedWhenTheProviderDeclaresIt() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let invoker = FakeProviderInvoker(script: [
+            describeDeclaring(["seed"]), providerOK(createdSession), providerOK(emptyList),
+        ])
+        let r = await router(invoker: invoker)
+        let response = await call(r, "remote.create",
+            #"{"provider": "agentbox", "paramsJSON": "{}", "seedRetainedKey": "opaque-key"}"#)
+        #expect(response.success)
+        let body = try sentBody(invoker)
+        let seed = try #require(body["seed"] as? [String: Any])
+        #expect(seed["retained_key"] as? String == "opaque-key")
+    }
+
+    /// The field is a top-level sibling of `params` and `idempotency_key`, and
+    /// emphatically not a member of `params` — which is the provider's own
+    /// free-form set, where a contract field would be indistinguishable from a
+    /// provider-defined one.
+    @Test func seedIsATopLevelSiblingAndNeverAMemberOfParams() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let invoker = FakeProviderInvoker(script: [
+            describeDeclaring(["seed"]), providerOK(createdSession), providerOK(emptyList),
+        ])
+        let r = await router(invoker: invoker)
+        let request = #"{"provider": "agentbox", "paramsJSON": "{\"repo\": \"acme/api\"}", "seedRetainedKey": "opaque-key"}"#
+        #expect(await call(r, "remote.create", request).success)
+        let body = try sentBody(invoker)
+        #expect(body.keys.sorted() == ["idempotency_key", "params", "seed"])
+        let params = try #require(body["params"] as? [String: Any])
+        #expect(params.keys.contains("seed") == false)
+        #expect(params["repo"] as? String == "acme/api",
+                "the caller's own params must survive the seed field verbatim")
+    }
+
+    /// A key is opaque: a caller MUST NOT parse, construct or pattern-match
+    /// one, so it may hold a quote or a backslash. Interpolated raw, such a key
+    /// would produce a malformed body the provider rejects with no indication
+    /// of why.
+    @Test func createEscapesAnOpaqueSeedKey() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let invoker = FakeProviderInvoker(script: [
+            describeDeclaring(["seed"]), providerOK(createdSession), providerOK(emptyList),
+        ])
+        let r = await router(invoker: invoker)
+        // A key carrying a quote and a backslash, escaped once for the RPC
+        // params string and therefore twice here.
+        #expect(await call(r, "remote.create",
+            #"{"provider": "agentbox", "paramsJSON": "{}", "seedRetainedKey": "a\"b\\c"}"#).success)
+        let body = try sentBody(invoker)
+        let seed = try #require(body["seed"] as? [String: Any])
+        #expect(seed["retained_key"] as? String == #"a"b\c"#)
+    }
+
+    // MARK: - Refused when undeclared
+
+    /// The discriminating half is `invoker.calls`: the contract requires a
+    /// provider to ignore stdin fields it does not recognize, so a `seed` sent
+    /// to a provider that never declared it would exit 0 with an empty session
+    /// the caller believed carried its conversation. Nothing may be spawned.
+    @Test func createRefusesSeedWhenTheProviderHasNotDeclaredIt() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let invoker = FakeProviderInvoker(script: [describeDeclaring(["stop", "log"])])
+        let r = await router(invoker: invoker)
+        let response = await call(r, "remote.create",
+            #"{"provider": "agentbox", "paramsJSON": "{}", "seedRetainedKey": "opaque-key"}"#)
+        #expect(response.success == false)
+        #expect(response.error?.contains("seed") == true)
+        #expect(invoker.calls == [["describe"]])
+    }
+
+    /// A provider with no cached `describe` reads as declaring nothing, so a
+    /// seeded create refuses rather than failing open.
+    @Test func createRefusesSeedWhenTheProviderHasNoCachedDescribe() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let invoker = FakeProviderInvoker(script: [
+            ProviderResult(exitCode: 1, stdout: Data(), stderr: "describe failed"),
+        ])
+        let r = await router(invoker: invoker)
+        let response = await call(r, "remote.create",
+            #"{"provider": "agentbox", "paramsJSON": "{}", "seedRetainedKey": "opaque-key"}"#)
+        #expect(response.success == false)
+        #expect(response.error?.contains("seed") == true)
+        #expect(invoker.calls == [["describe"]])
+    }
+
+    // MARK: - Absent when nothing was asked for
+
+    /// An unseeded create is unchanged: no `seed` key at all, not a null one.
+    /// A provider reading `"seed": null` would have to decide what an explicit
+    /// nothing means.
+    @Test func createSendsNoSeedFieldWhenNoKeyWasSupplied() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let invoker = FakeProviderInvoker(script: [
+            describeDeclaring(["seed"]), providerOK(createdSession), providerOK(emptyList),
+        ])
+        let r = await router(invoker: invoker)
+        #expect(await call(r, "remote.create",
+                          #"{"provider": "agentbox", "paramsJSON": "{}"}"#).success)
+        let body = try sentBody(invoker)
+        #expect(body.keys.sorted() == ["idempotency_key", "params"])
+    }
+
+    /// And a provider that declares nothing is still perfectly able to take an
+    /// unseeded create — the gate is on the field, never on `create` itself.
+    @Test func createWithoutASeedKeyIsUngatedByTheCapability() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let invoker = FakeProviderInvoker(script: [
+            describeDeclaring([]), providerOK(createdSession), providerOK(emptyList),
+        ])
+        let r = await router(invoker: invoker)
+        let response = await call(r, "remote.create",
+                                  #"{"provider": "agentbox", "paramsJSON": "{}"}"#)
+        #expect(response.success)
+        #expect(invoker.calls == [["describe"], ["create"], ["list"]])
+    }
+}

--- a/Tests/TBDDaemonTests/RPCRouterRemoteTranscriptTests.swift
+++ b/Tests/TBDDaemonTests/RPCRouterRemoteTranscriptTests.swift
@@ -1,0 +1,167 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+import TestSupport
+
+/// `remote.transcript` — a live session's conversation, as Claude Code
+/// transcript JSONL (`docs/remote-provider-contract.md` § `transcript <id>`).
+///
+/// Tier 2: in-memory GRDB plus a fake provider invoker, no real subprocess.
+/// Wiring mirrors `RPCRouterRemoteExchangeTests` — `describe` is popped first,
+/// so scripts read `[describe, transcript]`.
+@Suite("RPCRouter remote.transcript")
+struct RPCRouterRemoteTranscriptTests: ~Copyable {
+    let db: TBDDatabase
+    let subs: StateSubscriptionManager
+    let dir: URL
+    let registryURL: URL
+
+    init() throws {
+        let localDB = try TBDDatabase(inMemory: true)
+        let localDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rpc-remote-transcript-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: localDir, withIntermediateDirectories: true)
+        let localRegistryURL = localDir.appendingPathComponent("agent-providers.json")
+        try #"[{"name": "agentbox", "exec": "/nonexistent"}]"#
+            .write(to: localRegistryURL, atomically: true, encoding: .utf8)
+        db = localDB
+        subs = StateSubscriptionManager()
+        dir = localDir
+        registryURL = localRegistryURL
+    }
+
+    deinit {
+        try? FileManager.default.removeItem(at: dir)
+    }
+
+    private func router(invoker: FakeProviderInvoker) async -> RPCRouter {
+        let manager = RemoteProviderManager(
+            db: db, subscriptions: subs, runner: invoker, registryURL: registryURL,
+            actuationLog: makeTestActuationLog())
+        await manager.loadRegistryAndDescribe()
+        return RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver(),
+                subscriptions: subs),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date(),
+            subscriptions: subs,
+            remoteManager: manager, actuationLog: makeTestActuationLog())
+    }
+
+    private func call(_ router: RPCRouter, _ params: String) async -> RPCResponse {
+        await router.handle(RPCRequest(method: "remote.transcript", params: params))
+    }
+
+    private func describeDeclaring(_ capabilities: [String]) -> ProviderResult {
+        let caps = capabilities.map { "\"\($0)\"" }.joined(separator: ", ")
+        return providerOK(#"{"contract_versions": [1], "name": "agentbox", "capabilities": [\#(caps)]}"#)
+    }
+
+    private let params = #"{"provider": "agentbox", "sessionID": "fix-flaky-ci"}"#
+
+    @Test func errorsWhenTheSubsystemIsOff() async throws {
+        let invoker = FakeProviderInvoker(script: [])
+        let manager = RemoteProviderManager(
+            db: db, subscriptions: subs, runner: invoker, registryURL: registryURL)
+        let r = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver(),
+                subscriptions: subs),
+            tmux: TmuxManager(dryRun: true), startTime: Date(), subscriptions: subs,
+            remoteManager: manager, actuationLog: makeTestActuationLog())
+        let response = await call(r, params)
+        #expect(response.success == false)
+        #expect(response.error == "remote backends disabled")
+        #expect(invoker.callsSnapshot().isEmpty)
+    }
+
+    /// The discriminating half is `invoker.calls`: the contract forbids
+    /// invoking a verb the provider has not declared, so a refusal that still
+    /// spawned the provider would pass a message assertion and fail the
+    /// contract.
+    @Test func refusesAndNeverSpawnsWhenCapabilityUndeclared() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let invoker = FakeProviderInvoker(script: [describeDeclaring(["log", "recall"])])
+        let r = await router(invoker: invoker)
+        let response = await call(r, params)
+        #expect(response.success == false)
+        #expect(response.error?.contains("transcript") == true)
+        #expect(invoker.calls == [["describe"]])
+    }
+
+    /// `log` is raw scrollback and `transcript` is structured records; the
+    /// contract states they are different data and a caller MUST NOT substitute
+    /// one for the other. Declaring `log` must therefore not admit this verb.
+    @Test func declaringLogDoesNotAdmitTranscript() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let invoker = FakeProviderInvoker(script: [describeDeclaring(["log"])])
+        let r = await router(invoker: invoker)
+        #expect(await call(r, params).success == false)
+        #expect(invoker.calls == [["describe"]])
+    }
+
+    @Test func returnsTheRecordsVerbatim() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let jsonl = "{\"type\":\"user\"}\n{\"type\":\"assistant\"}\n"
+        let invoker = FakeProviderInvoker(script: [
+            describeDeclaring(["transcript"]),
+            ProviderResult(exitCode: 0, stdout: Data(jsonl.utf8), stderr: ""),
+        ])
+        let r = await router(invoker: invoker)
+        let response = await call(r, params)
+        #expect(response.success)
+        #expect(invoker.calls == [["describe"], ["transcript", "fix-flaky-ci"]])
+        #expect(try response.decodeResult(RemoteTranscriptResult.self).jsonl == jsonl)
+    }
+
+    /// The cursor envelope on stderr is the contract's one stderr exception,
+    /// and this RPC reads the whole transcript in one call — so it is dropped
+    /// rather than carried to a caller with nowhere to keep it. The records
+    /// must arrive unaffected.
+    @Test func ignoresTheCursorEnvelopeOnStderr() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let invoker = FakeProviderInvoker(script: [
+            describeDeclaring(["transcript"]),
+            ProviderResult(
+                exitCode: 0, stdout: Data("{\"type\":\"user\"}\n".utf8),
+                stderr: #"{"cursor": "abc123"}"#),
+        ])
+        let r = await router(invoker: invoker)
+        let response = await call(r, params)
+        #expect(response.success)
+        let result = try response.decodeResult(RemoteTranscriptResult.self)
+        #expect(result.jsonl == "{\"type\":\"user\"}\n")
+        #expect(result.jsonl.contains("cursor") == false)
+    }
+
+    @Test func surfacesTheProvidersErrorMessage() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let invoker = FakeProviderInvoker(script: [
+            describeDeclaring(["transcript"]),
+            ProviderResult(
+                exitCode: 1,
+                stdout: Data(#"{"error": {"code": "not_found", "message": "no such session"}}"#.utf8),
+                stderr: ""),
+        ])
+        let r = await router(invoker: invoker)
+        let response = await call(r, params)
+        #expect(response.success == false)
+        #expect(response.error == "no such session")
+    }
+
+    @Test func reportsATimeoutInWords() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let invoker = FakeProviderInvoker(outcomes: [
+            .result(describeDeclaring(["transcript"])),
+            .timeout,
+        ])
+        let r = await router(invoker: invoker)
+        let response = await call(r, params)
+        #expect(response.success == false)
+        #expect(response.error == "provider 'agentbox' timed out running 'transcript'")
+    }
+}

--- a/Tests/TBDDaemonTests/RemoteLaneReseedTests.swift
+++ b/Tests/TBDDaemonTests/RemoteLaneReseedTests.swift
@@ -1,0 +1,180 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// `RemoteLaneLifecycle.reseedPlan` — what Revive means for an archived remote
+/// lane
+/// (`docs/specs/2026-09-02-remote-session-delete-and-transcript-exchange-design.md`,
+/// "A deleted lane keeps its place").
+///
+/// Tier 1: a pure function over a receipt, a boolean, a capability set and a
+/// date. No provider, no database, no clock — expiry is a persisted timestamp
+/// compared against a `Date` that is passed in, which is the date seam.
+@Suite("RemoteLaneLifecycle reseed")
+struct RemoteLaneReseedTests {
+    private let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+    private func receipt(
+        key: String = "opaque-key", expiresAt: Date? = nil, lane: UUID? = nil
+    ) -> RetainedTranscript {
+        RetainedTranscript(
+            provider: "agentbox", key: key, expiresAt: expiresAt, bytes: 42,
+            originWorktreeID: lane)
+    }
+
+    // MARK: - A receipt and no session: reseed
+
+    @Test("a receipt and no listed session reseeds from its key")
+    func receiptWithNoListedSessionReseeds() {
+        let plan = RemoteLaneLifecycle.reseedPlan(
+            receipt: receipt(), sessionStillListed: false,
+            capabilities: ["seed"], now: now)
+        #expect(plan == .reseed(key: "opaque-key"))
+    }
+
+    /// An absent `expires_at` is the provider declining to say, never a promise
+    /// of permanence — but it is equally not a reason to refuse. The provider
+    /// is the last word on whether the seed still works.
+    @Test("an unstated expiry does not stand in the way of a reseed")
+    func unstatedExpiryStillReseeds() {
+        let plan = RemoteLaneLifecycle.reseedPlan(
+            receipt: receipt(expiresAt: nil), sessionStillListed: false,
+            capabilities: ["seed"], now: now)
+        #expect(plan == .reseed(key: "opaque-key"))
+    }
+
+    @Test("an expiry still in the future reseeds")
+    func futureExpiryReseeds() {
+        let plan = RemoteLaneLifecycle.reseedPlan(
+            receipt: receipt(expiresAt: now.addingTimeInterval(3600)),
+            sessionStillListed: false, capabilities: ["seed"], now: now)
+        #expect(plan == .reseed(key: "opaque-key"))
+    }
+
+    // MARK: - Past the expiry: refused, naming the date
+
+    @Test("a lapsed receipt refuses and names the date")
+    func lapsedReceiptRefusesNamingTheDate() throws {
+        let expiresAt = now.addingTimeInterval(-3600)
+        let plan = RemoteLaneLifecycle.reseedPlan(
+            receipt: receipt(expiresAt: expiresAt), sessionStillListed: false,
+            capabilities: ["seed"], now: now)
+        guard case .expired(let message) = plan else {
+            Issue.record("expected .expired, got \(plan)")
+            return
+        }
+        // Asserted on the composed sentence rather than on the case alone: the
+        // date IS the finding, and a refusal that omitted it would leave the
+        // user with no way to tell a lapsed record from a broken one.
+        #expect(message.contains(RetainReceipt.formatTimestamp(expiresAt)))
+    }
+
+    /// The boundary is inclusive — a receipt expiring exactly now has expired,
+    /// matching `RetainedTranscript.hasExpired(asOf:)` and the store's own
+    /// `expires_at <= ?` sweep, so the three cannot disagree about one instant.
+    @Test("an expiry exactly at now has lapsed")
+    func expiryAtNowHasLapsed() {
+        let plan = RemoteLaneLifecycle.reseedPlan(
+            receipt: receipt(expiresAt: now), sessionStillListed: false,
+            capabilities: ["seed"], now: now)
+        #expect(plan != .reseed(key: "opaque-key"))
+    }
+
+    // MARK: - No seed capability
+
+    /// Refused by name rather than attempted: the contract has providers ignore
+    /// stdin fields they do not recognize, so an unchecked reseed would return
+    /// an empty session wearing a revived lane's name.
+    @Test("a provider that does not declare seed refuses, naming the capability")
+    func undeclaredSeedRefusesNamingIt() {
+        let plan = RemoteLaneLifecycle.reseedPlan(
+            receipt: receipt(), sessionStillListed: false,
+            capabilities: ["unarchive", "archive"], now: now)
+        guard case .refusedNoSeed(let message) = plan else {
+            Issue.record("expected .refusedNoSeed, got \(plan)")
+            return
+        }
+        #expect(message.contains("seed"))
+    }
+
+    /// Expiry is checked before the capability, so a lane whose transcript
+    /// lapsed is told the transcript lapsed — the fact that actually explains
+    /// why nothing can be done — rather than being sent to ask its provider for
+    /// a capability that would not help.
+    @Test("a lapsed receipt reports the expiry rather than the missing capability")
+    func lapsedReceiptBeatsMissingCapability() {
+        let plan = RemoteLaneLifecycle.reseedPlan(
+            receipt: receipt(expiresAt: now.addingTimeInterval(-1)),
+            sessionStillListed: false, capabilities: [], now: now)
+        guard case .expired = plan else {
+            Issue.record("expected .expired to win over .refusedNoSeed, got \(plan)")
+            return
+        }
+    }
+
+    // MARK: - Everything else keeps today's behavior
+
+    @Test("no receipt keeps the ordinary unarchive path")
+    func noReceiptKeepsUnarchive() {
+        let plan = RemoteLaneLifecycle.reseedPlan(
+            receipt: nil, sessionStillListed: false, capabilities: ["seed"], now: now)
+        #expect(plan == .unarchive)
+    }
+
+    /// The discriminating case, and the reason `sessionStillListed` exists.
+    /// `tbd remote retain` on a healthy session leaves a receipt behind, and
+    /// reviving *that* lane must still be an `unarchive` — a receipt alone
+    /// never means the session was destroyed.
+    @Test("a receipt on a session the provider still lists keeps unarchive")
+    func receiptOnALiveSessionKeepsUnarchive() {
+        let plan = RemoteLaneLifecycle.reseedPlan(
+            receipt: receipt(), sessionStillListed: true,
+            capabilities: ["seed"], now: now)
+        #expect(plan == .unarchive)
+    }
+
+    /// And a lapsed receipt on a live session is still just an unarchive: the
+    /// session is right there, so no transcript is needed to reach it.
+    @Test("a lapsed receipt on a listed session keeps unarchive")
+    func lapsedReceiptOnALiveSessionKeepsUnarchive() {
+        let plan = RemoteLaneLifecycle.reseedPlan(
+            receipt: receipt(expiresAt: now.addingTimeInterval(-3600)),
+            sessionStillListed: true, capabilities: ["seed"], now: now)
+        #expect(plan == .unarchive)
+    }
+}
+
+/// `RetainedTranscriptStore.latest(originWorktreeID:)` — the lookup Revive uses
+/// to find the transcript a deleted lane left behind.
+///
+/// Tier 2: in-memory GRDB, no provider.
+@Suite("RetainedTranscriptStore origin lookup")
+struct RetainedTranscriptOriginLookupTests {
+    @Test func findsTheNewestReceiptForALane() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let lane = UUID()
+        let other = UUID()
+        let base = Date(timeIntervalSince1970: 1_700_000_000)
+        try await db.retainedTranscripts.insert(RetainedTranscript(
+            provider: "agentbox", key: "older", bytes: 1,
+            originWorktreeID: lane, createdAt: base))
+        try await db.retainedTranscripts.insert(RetainedTranscript(
+            provider: "agentbox", key: "newer", bytes: 2,
+            originWorktreeID: lane, createdAt: base.addingTimeInterval(60)))
+        try await db.retainedTranscripts.insert(RetainedTranscript(
+            provider: "agentbox", key: "someone-elses", bytes: 3,
+            originWorktreeID: other, createdAt: base.addingTimeInterval(120)))
+
+        let found = try await db.retainedTranscripts.latest(originWorktreeID: lane)
+        #expect(found?.key == "newer")
+    }
+
+    @Test func findsNothingForALaneWithNoReceipt() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.retainedTranscripts.insert(RetainedTranscript(
+            provider: "agentbox", key: "unattached", bytes: 1))
+        let found = try await db.retainedTranscripts.latest(originWorktreeID: UUID())
+        #expect(found == nil)
+    }
+}

--- a/Tests/TBDDaemonTests/RetainedTranscriptStoreTests.swift
+++ b/Tests/TBDDaemonTests/RetainedTranscriptStoreTests.swift
@@ -1,0 +1,153 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Tier 2: in-memory GRDB only, no provider and no filesystem.
+///
+/// The store is where a key becomes recoverable, so what is under test is
+/// exactly that: a round trip, the `(provider, key)` identity, and an expiry
+/// sweep that reads the instant it was handed rather than a clock of its own.
+@Suite("RetainedTranscriptStore")
+struct RetainedTranscriptStoreTests {
+    let db: TBDDatabase
+    init() throws { db = try TBDDatabase(inMemory: true) }
+
+    private func receipt(
+        provider: String = "agentbox", key: String = "k-1", expiresAt: Date? = nil,
+        bytes: Int = 1234, sourceSessionID: String? = "sess-1",
+        sourceTitle: String? = "fix flaky CI", originWorktreeID: UUID? = nil,
+        localPath: String? = nil, createdAt: Date = Date()
+    ) -> RetainedTranscript {
+        RetainedTranscript(
+            provider: provider, key: key, expiresAt: expiresAt, bytes: bytes,
+            sourceSessionID: sourceSessionID, sourceTitle: sourceTitle,
+            originWorktreeID: originWorktreeID, localPath: localPath, createdAt: createdAt)
+    }
+
+    @Test func insertRoundTripsEveryField() async throws {
+        let expiry = Date(timeIntervalSince1970: 1_790_000_000)
+        let worktreeID = UUID()
+        let repoID = UUID()
+        let row = RetainedTranscript(
+            provider: "agentbox", key: "opaque/key with spaces", expiresAt: expiry,
+            bytes: 148_213, sourceSessionID: "fix-flaky-ci", sourceTitle: "fix flaky CI",
+            resolvedRepoID: repoID, originWorktreeID: worktreeID,
+            localPath: "/tmp/x.jsonl", createdAt: Date(timeIntervalSince1970: 1_780_000_000))
+        try await db.retainedTranscripts.insert(row)
+
+        let found = try await db.retainedTranscripts.find(provider: "agentbox", key: "opaque/key with spaces")
+        #expect(found?.id == row.id)
+        #expect(found?.key == "opaque/key with spaces")
+        #expect(found?.bytes == 148_213)
+        #expect(found?.expiresAt == expiry)
+        #expect(found?.sourceSessionID == "fix-flaky-ci")
+        #expect(found?.sourceTitle == "fix flaky CI")
+        #expect(found?.resolvedRepoID == repoID)
+        #expect(found?.originWorktreeID == worktreeID)
+        #expect(found?.localPath == "/tmp/x.jsonl")
+    }
+
+    @Test func absentExpiryRoundTripsAsNoClaim() async throws {
+        try await db.retainedTranscripts.insert(receipt(key: "no-expiry", expiresAt: nil))
+        let found = try await db.retainedTranscripts.find(provider: "agentbox", key: "no-expiry")
+        #expect(found != nil)
+        #expect(found?.expiresAt == nil)
+    }
+
+    /// A key is provider-scoped, so the same string under two providers is two
+    /// records — not a collision.
+    @Test func sameKeyUnderTwoProvidersAreTwoRows() async throws {
+        try await db.retainedTranscripts.insert(receipt(provider: "agentbox", key: "shared"))
+        try await db.retainedTranscripts.insert(receipt(provider: "acme-cloud", key: "shared"))
+        #expect(try await db.retainedTranscripts.all().count == 2)
+        #expect(try await db.retainedTranscripts.find(provider: "agentbox", key: "shared") != nil)
+        #expect(try await db.retainedTranscripts.find(provider: "acme-cloud", key: "shared") != nil)
+    }
+
+    /// `(provider, key)` is the identity: re-recording the pair updates the
+    /// receipt rather than growing a second row.
+    @Test func reinsertingTheSameProviderKeyReplacesTheReceipt() async throws {
+        try await db.retainedTranscripts.insert(receipt(key: "k", bytes: 10))
+        try await db.retainedTranscripts.insert(
+            receipt(key: "k", expiresAt: Date(timeIntervalSince1970: 99), bytes: 20))
+        let rows = try await db.retainedTranscripts.all(provider: "agentbox")
+        #expect(rows.count == 1)
+        #expect(rows.first?.bytes == 20)
+        #expect(rows.first?.expiresAt == Date(timeIntervalSince1970: 99))
+    }
+
+    /// A re-`retain` must not forget where an earlier `recall` put the file.
+    @Test func reinsertingPreservesAnExistingLocalPath() async throws {
+        try await db.retainedTranscripts.insert(receipt(key: "k", localPath: "/tmp/first.jsonl"))
+        try await db.retainedTranscripts.insert(receipt(key: "k", bytes: 77, localPath: nil))
+        let found = try await db.retainedTranscripts.find(provider: "agentbox", key: "k")
+        #expect(found?.localPath == "/tmp/first.jsonl")
+        #expect(found?.bytes == 77)
+    }
+
+    @Test func setLocalPathRecordsWhereRecallWrote() async throws {
+        try await db.retainedTranscripts.insert(receipt(key: "k"))
+        let changed = try await db.retainedTranscripts.setLocalPath(
+            provider: "agentbox", key: "k", localPath: "/tmp/tbd/transcripts/agentbox/k.jsonl")
+        #expect(changed)
+        let found = try await db.retainedTranscripts.find(provider: "agentbox", key: "k")
+        #expect(found?.localPath == "/tmp/tbd/transcripts/agentbox/k.jsonl")
+    }
+
+    @Test func setLocalPathOnAnUnknownKeyChangesNothing() async throws {
+        let changed = try await db.retainedTranscripts.setLocalPath(
+            provider: "agentbox", key: "nope", localPath: "/tmp/x")
+        #expect(changed == false)
+    }
+
+    /// The whole point of the date seam: the sweep acts on the instant it was
+    /// handed, so the same rows are expired or not depending only on that
+    /// argument.
+    @Test func deleteExpiredRemovesOnlyStatedExpiriesInThePast() async throws {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        try await db.retainedTranscripts.insert(
+            receipt(key: "past", expiresAt: now.addingTimeInterval(-60)))
+        try await db.retainedTranscripts.insert(
+            receipt(key: "future", expiresAt: now.addingTimeInterval(60)))
+        try await db.retainedTranscripts.insert(receipt(key: "no-claim", expiresAt: nil))
+
+        let removed = try await db.retainedTranscripts.deleteExpired(asOf: now)
+        #expect(removed == 1)
+        let remaining = Set(try await db.retainedTranscripts.all().map(\.key))
+        #expect(remaining == ["future", "no-claim"])
+    }
+
+    /// An absent `expires_at` is "the provider makes no claim", never "already
+    /// gone" — no instant may sweep it.
+    @Test func deleteExpiredNeverRemovesARowWithNoStatedExpiry() async throws {
+        try await db.retainedTranscripts.insert(receipt(key: "no-claim", expiresAt: nil))
+        let removed = try await db.retainedTranscripts.deleteExpired(
+            asOf: Date(timeIntervalSince1970: 4_000_000_000))
+        #expect(removed == 0)
+        #expect(try await db.retainedTranscripts.all().count == 1)
+    }
+
+    @Test func allByProviderIsScopedToThatProvider() async throws {
+        try await db.retainedTranscripts.insert(receipt(provider: "agentbox", key: "a"))
+        try await db.retainedTranscripts.insert(receipt(provider: "acme-cloud", key: "b"))
+        let rows = try await db.retainedTranscripts.all(provider: "agentbox")
+        #expect(rows.map(\.key) == ["a"])
+    }
+
+    @Test func deleteForgetsOneReceipt() async throws {
+        try await db.retainedTranscripts.insert(receipt(key: "a"))
+        try await db.retainedTranscripts.insert(receipt(key: "b"))
+        try await db.retainedTranscripts.delete(provider: "agentbox", key: "a")
+        #expect(try await db.retainedTranscripts.all().map(\.key) == ["b"])
+    }
+
+    /// `hasExpired` is the model's half of the same rule the store enforces in
+    /// SQL, and it must agree: no stated expiry is never expired.
+    @Test func hasExpiredReadsAbsenceAsNoClaim() {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        #expect(receipt(expiresAt: nil).hasExpired(asOf: now) == false)
+        #expect(receipt(expiresAt: now.addingTimeInterval(-1)).hasExpired(asOf: now))
+        #expect(receipt(expiresAt: now.addingTimeInterval(1)).hasExpired(asOf: now) == false)
+    }
+}

--- a/Tests/TBDDaemonTests/SQLMigrationLoaderTests.swift
+++ b/Tests/TBDDaemonTests/SQLMigrationLoaderTests.swift
@@ -499,6 +499,7 @@ import Testing
             "20260901135111_config_gc_holder_rendezvous",
             "20260901161500_config_gc_rowless_holders",
             "20260901180118_config_reap_holder_children",
+            "20260902120000_retained_transcript",
             "20260902130000_config_remote_delete",
         ]
         let found = try SQLMigrationLoader.bundled.get()

--- a/Tests/TBDDaemonTests/SQLMigrationLoaderTests.swift
+++ b/Tests/TBDDaemonTests/SQLMigrationLoaderTests.swift
@@ -499,6 +499,7 @@ import Testing
             "20260901135111_config_gc_holder_rendezvous",
             "20260901161500_config_gc_rowless_holders",
             "20260901180118_config_reap_holder_children",
+            "20260902130000_config_remote_delete",
         ]
         let found = try SQLMigrationLoader.bundled.get()
         #expect(found.files.map(\.identifier) == expected)

--- a/Tests/TBDDaemonTests/SQLMigrationLoaderTests.swift
+++ b/Tests/TBDDaemonTests/SQLMigrationLoaderTests.swift
@@ -501,6 +501,7 @@ import Testing
             "20260901180118_config_reap_holder_children",
             "20260902120000_retained_transcript",
             "20260902130000_config_remote_delete",
+            "20260902140000_config_gc_retained_transcripts",
         ]
         let found = try SQLMigrationLoader.bundled.get()
         #expect(found.files.map(\.identifier) == expected)

--- a/Tests/TBDSharedTests/ConstantsTests.swift
+++ b/Tests/TBDSharedTests/ConstantsTests.swift
@@ -195,3 +195,68 @@ import Foundation
     let path = TBDConstants.notesPath(worktreeID: wtID, environment: ["TBD_HOME": "/tmp/tbd-notes"])
     #expect(path == "/tmp/tbd-notes/worktrees/AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE/notes.md")
 }
+
+/// `~/tbd/transcripts/<provider>/<key>.jsonl` — where a `recall` lands.
+///
+/// Env dictionaries throughout, for the reason `ConfigDirEnvOverrideTests`
+/// gives: an unserialized `setenv` in this target races every concurrently
+/// running suite in the same process.
+@Suite struct RetainedTranscriptPathTests {
+    private let env = ["TBD_HOME": "/tmp/tbd-transcripts"]
+
+    @Test func transcriptsDirFollowsTBDHome() {
+        #expect(TBDConstants.retainedTranscriptsDir(environment: env).path
+            == "/tmp/tbd-transcripts/transcripts")
+    }
+
+    @Test func transcriptsDirFallsBackToHomeTbdWhenKeyAbsent() {
+        let path = TBDConstants.retainedTranscriptsDir(environment: [:]).path
+        #expect(path.contains(FileManager.default.homeDirectoryForCurrentUser.path))
+        #expect(path.hasSuffix("/tbd/transcripts"))
+    }
+
+    @Test func ordinaryKeyLandsUnderItsProvider() {
+        let url = TBDConstants.retainedTranscriptPath(
+            provider: "agentbox", key: "abc-123", environment: env)
+        #expect(url.path == "/tmp/tbd-transcripts/transcripts/agentbox/abc-123.jsonl")
+    }
+
+    /// A key is opaque and may contain anything, including a path separator.
+    /// It must stay one filename rather than becoming a directory tree.
+    @Test func aKeyWithSeparatorsStaysOneComponent() {
+        let url = TBDConstants.retainedTranscriptPath(
+            provider: "agentbox", key: "a/b/c", environment: env)
+        #expect(url.path == "/tmp/tbd-transcripts/transcripts/agentbox/a%2Fb%2Fc.jsonl")
+        #expect(url.deletingLastPathComponent().path == "/tmp/tbd-transcripts/transcripts/agentbox")
+        #expect(url.pathComponents.count
+            == TBDConstants.retainedTranscriptsDir(environment: env).pathComponents.count + 2)
+    }
+
+    /// The traversal case the escaping exists for: neither `.` nor `..` may
+    /// survive as a relative path component.
+    @Test func dotAndDotDotAreEscapedRatherThanTraversing() {
+        let dotdot = TBDConstants.retainedTranscriptPath(
+            provider: "..", key: "..", environment: env)
+        #expect(dotdot.path == "/tmp/tbd-transcripts/transcripts/%2E%2E/%2E%2E.jsonl")
+        let dot = TBDConstants.retainedTranscriptPath(
+            provider: "agentbox", key: ".", environment: env)
+        #expect(dot.path == "/tmp/tbd-transcripts/transcripts/agentbox/%2E.jsonl")
+    }
+
+    /// Injective: two distinct keys can never name one file. `%` is itself
+    /// escaped, which is what rules out the collision a naive escaper has.
+    @Test func escapingIsInjectiveAcrossPercentSequences() {
+        let literal = TBDConstants.retainedTranscriptPath(
+            provider: "p", key: "a%2Fb", environment: env)
+        let separator = TBDConstants.retainedTranscriptPath(
+            provider: "p", key: "a/b", environment: env)
+        #expect(literal.path != separator.path)
+        #expect(literal.path == "/tmp/tbd-transcripts/transcripts/p/a%252Fb.jsonl")
+    }
+
+    @Test func spacesAndUnicodeAreEncoded() {
+        let url = TBDConstants.retainedTranscriptPath(
+            provider: "agentbox", key: "fix flaky CI", environment: env)
+        #expect(url.path == "/tmp/tbd-transcripts/transcripts/agentbox/fix%20flaky%20CI.jsonl")
+    }
+}

--- a/Tests/TBDSharedTests/RetainReceiptTests.swift
+++ b/Tests/TBDSharedTests/RetainReceiptTests.swift
@@ -72,7 +72,7 @@ struct RetainReceiptTests {
         let original = RetainReceipt(
             key: "k", expiresAt: ISO8601DateFormatter().date(from: "2026-10-01T00:00:00Z"), bytes: 9)
         let data = try JSONEncoder().encode(original)
-        let text = String(decoding: data, as: UTF8.self)
+        let text = try #require(String(bytes: data, encoding: .utf8))
         #expect(text.contains("expires_at"))
         #expect(text.contains("2026-10-01T00:00:00Z"))
         let decoded = try JSONDecoder().decode(RetainReceipt.self, from: data)
@@ -81,7 +81,7 @@ struct RetainReceiptTests {
 
     @Test func encodesNoExpiresAtKeyWhenThereIsNoClaim() throws {
         let data = try JSONEncoder().encode(RetainReceipt(key: "k", bytes: 9))
-        let text = String(decoding: data, as: UTF8.self)
+        let text = try #require(String(bytes: data, encoding: .utf8))
         #expect(text.contains("expires_at") == false)
     }
 }

--- a/Tests/TBDSharedTests/RetainReceiptTests.swift
+++ b/Tests/TBDSharedTests/RetainReceiptTests.swift
@@ -1,0 +1,122 @@
+import Testing
+import Foundation
+@testable import TBDShared
+
+/// The receipt shape `retain`, `import`, and `delete --retain` all share
+/// (`docs/remote-provider-contract.md` § `retain <id>` / `import`).
+///
+/// Decoded through `JSONDecoder.forRemoteProvider`, which is the decoder the
+/// daemon actually hands provider stdout to — a bare `JSONDecoder()` would
+/// exercise a path no provider output ever takes.
+@Suite("RetainReceipt")
+struct RetainReceiptTests {
+    private func decode(_ json: String) throws -> RetainReceipt {
+        try JSONDecoder.forRemoteProvider("agentbox")
+            .decode(RetainReceipt.self, from: Data(json.utf8))
+    }
+
+    @Test func decodesKeyExpiryAndBytes() throws {
+        let receipt = try decode(#"""
+            {"key": "opaque-provider-string", "expires_at": "2026-10-01T00:00:00Z", "bytes": 148213}
+            """#)
+        #expect(receipt.key == "opaque-provider-string")
+        #expect(receipt.bytes == 148_213)
+        #expect(receipt.expiresAt == ISO8601DateFormatter().date(from: "2026-10-01T00:00:00Z"))
+    }
+
+    /// Absence is "the provider makes no claim". It decodes to nil, and nothing
+    /// downstream may read nil as permanence.
+    @Test func decodesWithoutExpiresAtAsNoClaim() throws {
+        let receipt = try decode(#"{"key": "k", "bytes": 12}"#)
+        #expect(receipt.expiresAt == nil)
+        #expect(receipt.key == "k")
+        #expect(receipt.bytes == 12)
+    }
+
+    /// `bytes` is how a truncated `recall` is detected, so a receipt without it
+    /// cannot do its job — it must fail rather than default to zero, which
+    /// would make every later short-read check pass vacuously.
+    @Test func missingBytesIsADecodeFailure() {
+        #expect(throws: (any Error).self) {
+            try decode(#"{"key": "k", "expires_at": "2026-10-01T00:00:00Z"}"#)
+        }
+    }
+
+    @Test func missingKeyIsADecodeFailure() {
+        #expect(throws: (any Error).self) {
+            try decode(#"{"bytes": 12}"#)
+        }
+    }
+
+    /// Providers emit both RFC 3339 spellings; both must land on the same
+    /// instant rather than one of them silently reading as "no claim".
+    @Test func decodesFractionalSecondTimestamps() throws {
+        let plain = try decode(#"{"key": "k", "expires_at": "2026-10-01T00:00:00Z", "bytes": 1}"#)
+        let fractional = try decode(#"{"key": "k", "expires_at": "2026-10-01T00:00:00.000Z", "bytes": 1}"#)
+        #expect(plain.expiresAt == fractional.expiresAt)
+        #expect(plain.expiresAt != nil)
+    }
+
+    /// A present-but-unparseable timestamp degrades to "no claim" rather than
+    /// to an invented instant. Inventing one in the past would disable Revive
+    /// on a record the provider still holds.
+    @Test func unparseableExpiresAtReadsAsNoClaim() throws {
+        let receipt = try decode(#"{"key": "k", "expires_at": "next tuesday", "bytes": 1}"#)
+        #expect(receipt.expiresAt == nil)
+        #expect(receipt.bytes == 1)
+    }
+
+    /// Round-tripping must not change what the receipt means: the encoder
+    /// re-emits RFC 3339, not a number of seconds.
+    @Test func encodesExpiresAtAsRFC3339AndRoundTrips() throws {
+        let original = RetainReceipt(
+            key: "k", expiresAt: ISO8601DateFormatter().date(from: "2026-10-01T00:00:00Z"), bytes: 9)
+        let data = try JSONEncoder().encode(original)
+        let text = String(decoding: data, as: UTF8.self)
+        #expect(text.contains("expires_at"))
+        #expect(text.contains("2026-10-01T00:00:00Z"))
+        let decoded = try JSONDecoder().decode(RetainReceipt.self, from: data)
+        #expect(decoded == original)
+    }
+
+    @Test func encodesNoExpiresAtKeyWhenThereIsNoClaim() throws {
+        let data = try JSONEncoder().encode(RetainReceipt(key: "k", bytes: 9))
+        let text = String(decoding: data, as: UTF8.self)
+        #expect(text.contains("expires_at") == false)
+    }
+}
+
+/// `delete`'s response shape (`docs/remote-provider-contract.md` §
+/// `delete <id> [--retain]`).
+@Suite("RemoteDeleteResult")
+struct RemoteDeleteResultTests {
+    private func decode(_ json: String) throws -> RemoteDeleteResult {
+        try JSONDecoder.forRemoteProvider("agentbox")
+            .decode(RemoteDeleteResult.self, from: Data(json.utf8))
+    }
+
+    @Test func decodesWithoutRetained() throws {
+        let result = try decode(#"{"id": "fix-flaky-ci", "deleted": true}"#)
+        #expect(result.id == "fix-flaky-ci")
+        #expect(result.deleted)
+        #expect(result.retained == nil)
+    }
+
+    @Test func decodesWithRetainedReceipt() throws {
+        let result = try decode(#"""
+            {"id": "fix-flaky-ci", "deleted": true,
+             "retained": {"key": "opaque", "expires_at": "2026-10-01T00:00:00Z", "bytes": 148213}}
+            """#)
+        #expect(result.retained?.key == "opaque")
+        #expect(result.retained?.bytes == 148_213)
+        #expect(result.retained?.expiresAt != nil)
+    }
+
+    /// Deleting an unknown or already-deleted id is idempotent: `deleted:
+    /// false` decodes as an ordinary result, not an error.
+    @Test func decodesDeletedFalseForAnUnknownID() throws {
+        let result = try decode(#"{"id": "gone-already", "deleted": false}"#)
+        #expect(result.deleted == false)
+        #expect(result.retained == nil)
+    }
+}

--- a/docs/orphan-gc.md
+++ b/docs/orphan-gc.md
@@ -18,7 +18,7 @@ auto-removes one if it ended unchanged — the moment an agent commits, the work
 Code's own 30-day sweep permanently exempts anything with unpushed commits. Nothing
 else ever cleans these up.
 
-Three things get reaped:
+These get reaped:
 - **Agent worktrees** — `<repo>/.claude/worktrees/agent-*` and `wf_*` whose run has
   ended (see gates below).
 - **Attributable scratchpads** — `/private/tmp/claude-<uid>/<slug>` directories TBD can
@@ -27,6 +27,9 @@ Three things get reaped:
   `model_profiles` row is gone; `ProfileDirCollector` is the named reconciler for that
   resource class, alongside the agent-worktree and scratchpad collectors, and it
   quarantines rather than deletes (see below).
+- **Unreferenced retained transcripts** — JSONL files under `~/tbd/transcripts/` that no
+  `retained_transcript` row points at, and receipt rows whose provider-stated expiry has
+  passed (see below).
 
 ## Philosophy: orphaned, not idle
 
@@ -235,6 +238,74 @@ profile and moves the directory into the new UUID. The app's Reclaimed section d
 surface these records — it is per-repo, and a profile directory belongs to no repo — so
 the CLI is where a quarantine path is read.
 
+## Retained transcripts
+
+A provider that declares `retain`, `import` or `recall` can hold a conversation in its
+own durable store and hand back an opaque key; TBD records the receipt in
+`retained_transcript` and a `recall` writes the JSONL under
+`~/tbd/transcripts/<provider>/<key>.jsonl`. Both halves are durable resources with no
+owner once the thing that motivated them is gone, so `OrphanGC` is their named
+reconciler — see
+[`docs/specs/2026-09-02-remote-session-delete-and-transcript-exchange-design.md`](specs/2026-09-02-remote-session-delete-and-transcript-exchange-design.md),
+"Reclamation".
+
+**Why it is load-bearing rather than tidiness.** The teleport flow calls `import` and
+then `create`. A `create` that fails after a successful `import` leaves a retained blob
+on the provider and a row here that nothing will ever use, because the session it was
+going to seed was never made. No creation path can close that window — the provider
+commits its side before TBD learns whether the second call will succeed — so the standing
+guarantee is this sweep rather than any rollback.
+
+**Flag: `gc_retained_transcripts_enabled`, default off**, read on top of `gcEnabled`, so
+both must be on for the leg to run. It ships off because it is a background sweep that
+unlinks files and deletes rows, and because the exchange whose residue it reclaims exists
+only on a provider declaring those capabilities. The column carries no SQL default, so an
+install nobody has touched reads NULL and resolves through
+`Config.gcRetainedTranscriptsEnabledDefault` — graduation is a one-line change to that
+constant, reaching everyone who never flipped the switch while preserving every explicit
+opt-out. A dry run bypasses the flag exactly as it bypasses `gcEnabled`:
+`tbd gc sweep --dry-run` prints the `REAP retained-transcript` and
+`REAP retained-transcript-row` lines the leg *would* act on, so the decision to enable it
+can be made against real candidates. There is no Settings toggle and no RPC yet; enable
+it for a soak by writing the column directly, the way `gcGraceSeconds` is set:
+
+```sh
+sqlite3 ~/tbd/state.db \
+  "UPDATE config SET gc_retained_transcripts_enabled = 1;"
+```
+
+**What it reclaims**, in this order, from one reading of the clock through the date seam:
+
+1. **Expired rows.** A row whose `expires_at` has passed is deleted. Whether that
+   delete actually landed decides whether its file counts as referenced in step 2, so a
+   dry run or a failed delete keeps both halves together rather than splitting them.
+2. **Unreferenced files.** A file at `<base>/<provider>/<key>.jsonl` that no surviving
+   row names — neither by its canonical `(provider, key)` path nor by the `local_path`
+   the row recorded — is unlinked.
+
+**Gates**, each failing toward keeping and each reported in the sweep plan with its
+reason:
+
+- **No stated expiry is never expiry** — an absent `expires_at` means the provider made
+  no claim, not that a claim lapsed, and the key lives in that row and nowhere else,
+  because the contract gives no way to enumerate a provider's keys. Dropping such a row
+  strands the blob forever.
+- **Grace window** (`grace`) — a file whose newer of creation and modification is younger
+  than `gcGraceSeconds` (default 3600s / 1h) is kept. `recall` writes the file before it
+  records the path on the row, and this is the window that covers it. A file whose dates
+  cannot be read keeps as `unknown-age`.
+- **Unreadable rows skip the leg** (`rows-unreadable`) — never read as "no file is
+  referenced".
+- **Whitelist, not blacklist** — only `<base>/<provider>/<key>.jsonl` is a candidate. A
+  stray file at the top level, another extension, or a deeper nesting is left alone
+  rather than judged by a rule that never considered it. Emptied provider directories are
+  left in place too: there is one per provider ever used.
+
+**No reap record, and no restore.** The `ReapRecord` type is directory-shaped and keyed
+by the worktree a reap removed, and neither half here has one. Nothing is lost that a
+restore could return either: the transcript still lives on the provider until its own
+expiry, and `tbd remote recall <key>` fetches it again.
+
 ## Cadence and the `gcEnabled` gate
 
 `gcEnabled` (config-table boolean, **default on**) is the single master switch — it
@@ -284,6 +355,7 @@ than the preceding dry run predicted.
 |---|---|---|
 | `gcEnabled` | `true` | Settings toggle + `config.setGCEnabled` RPC |
 | `gcProfileDirsEnabled` | `false` | `tbd gc profile-dirs on\|off` + `config.setGCProfileDirsEnabled` RPC, no UI |
+| `gcRetainedTranscriptsEnabled` | `false` | config table only, no UI |
 | `gcGraceSeconds` | `3600` (1h) | config table only, no UI |
 | `gcSnapshotRetentionDays` | `30` | config table only, no UI |
 

--- a/docs/orphan-gc.md
+++ b/docs/orphan-gc.md
@@ -266,13 +266,16 @@ constant, reaching everyone who never flipped the switch while preserving every 
 opt-out. A dry run bypasses the flag exactly as it bypasses `gcEnabled`:
 `tbd gc sweep --dry-run` prints the `REAP retained-transcript` and
 `REAP retained-transcript-row` lines the leg *would* act on, so the decision to enable it
-can be made against real candidates. There is no Settings toggle and no RPC yet; enable
-it for a soak by writing the column directly, the way `gcGraceSeconds` is set:
+can be made against real candidates. There is no Settings toggle; enable it for a soak
+from the CLI, which is the supported path:
 
 ```sh
-sqlite3 ~/tbd/state.db \
-  "UPDATE config SET gc_retained_transcripts_enabled = 1;"
+tbd gc retained-transcripts on
 ```
+
+That calls `config.setGCRetainedTranscriptsEnabled`, which writes the column and
+broadcasts the config change so a running app reloads. `off` writes an explicit `0`,
+which is honored through graduation rather than following the shipped default.
 
 **What it reclaims**, in this order, from one reading of the clock through the date seam:
 
@@ -355,7 +358,7 @@ than the preceding dry run predicted.
 |---|---|---|
 | `gcEnabled` | `true` | Settings toggle + `config.setGCEnabled` RPC |
 | `gcProfileDirsEnabled` | `false` | `tbd gc profile-dirs on\|off` + `config.setGCProfileDirsEnabled` RPC, no UI |
-| `gcRetainedTranscriptsEnabled` | `false` | config table only, no UI |
+| `gcRetainedTranscriptsEnabled` | `false` | `tbd gc retained-transcripts on\|off` + `config.setGCRetainedTranscriptsEnabled` RPC, no UI |
 | `gcGraceSeconds` | `3600` (1h) | config table only, no UI |
 | `gcSnapshotRetentionDays` | `30` | config table only, no UI |
 

--- a/docs/remote-provider-contract.md
+++ b/docs/remote-provider-contract.md
@@ -20,6 +20,10 @@ Three verbs are **required**: `describe`, `create`, and `list`. Every other verb
 | `stop` | capability `stop` | `<exec> stop <id>` | — | JSON session | 30s |
 | `archive` | capability `archive` | `<exec> archive <id>` | — | JSON session | 30s |
 | `unarchive` | capability `unarchive` | `<exec> unarchive <id>` | — | JSON session | 30s |
+| `delete` | capability `delete` | `<exec> delete <id> [--retain]` | — | JSON result | 30s |
+| `retain` | capability `retain` | `<exec> retain <id>` | — | JSON receipt | 60s |
+| `import` | capability `import` | `<exec> import` | JSONL | JSON receipt | 60s |
+| `recall` | capability `recall` | `<exec> recall <key>` | — | JSONL | 60s |
 | `log` | capability `log` | `<exec> log <id> [--lines N]` | — | raw bytes | 30s |
 | `transcript` | capability `transcript` | `<exec> transcript <id> [--since <cursor>]` | — | JSONL bytes | 60s |
 | `send` | capability `send` | `<exec> send <id>` | raw bytes | JSON `{}` | 30s |
@@ -219,7 +223,7 @@ Why credentials never travel, by kind:
   "contract_versions": [1, 2],
   "name": "example-provider",
   "provider_version": "0.4.2",
-  "capabilities": ["stop", "log", "transcript", "send", "attach", "events", "messages", "rename", "profile", "set-profile", "archive", "unarchive", "land"],
+  "capabilities": ["stop", "log", "transcript", "send", "attach", "events", "messages", "rename", "profile", "set-profile", "archive", "unarchive", "delete", "retain", "import", "recall", "seed", "land"],
   "create_params": [
     {"name": "repo",   "type": "string", "label": "Repository", "required": true},
     {"name": "branch", "type": "string", "label": "Branch", "default": "main"},
@@ -233,7 +237,7 @@ Why credentials never travel, by kind:
 
 - `contract_versions` — every contract major version this provider supports (see Versioning).
 - `name` — a stable machine identifier for the provider (used, along with each session id, as the caller's key for this provider's sessions).
-- `capabilities` — which optional verbs/features (`stop`, `log`, `transcript`, `send`, `attach`, `events`, `messages`, `rename`, `profile`, `set-profile`, `archive`, `unarchive`, `land`) this provider implements. Every capability string except `profile` names the verb of the same name: declaring it means the verb is implemented, and omitting it means the caller never invokes it and never offers the corresponding action. `profile` is the exception — it gates whether `create`'s `profile` field is honored (see `create` and the Profile object above), while `set-profile` gates the verb of the same name.
+- `capabilities` — which optional verbs/features (`stop`, `log`, `transcript`, `send`, `attach`, `events`, `messages`, `rename`, `profile`, `set-profile`, `archive`, `unarchive`, `delete`, `retain`, `import`, `recall`, `seed`, `land`) this provider implements. Every capability string except `profile` and `seed` names the verb of the same name: declaring it means the verb is implemented, and omitting it means the caller never invokes it and never offers the corresponding action. `profile` and `seed` are the two exceptions — each gates whether `create` honors the stdin field of the same name (see `create` and Format scope below, and the Profile object above) rather than admitting a verb — while `set-profile` gates the verb of the same name.
 - `create_params` — a flat field list, not a JSON Schema, describing the form for `create`. Supported `type` values: `string`, `text`, `bool`, `int`, `enum`. The caller renders this generically (the most complex widget is an enum dropdown) and only does required/type checks client-side — the provider is the validator of record, via the error model below. The field names `repo`, `slug`, `branch`, `prompt`, and `title` are well-known: a caller may prefill them from ambient context (e.g. a currently selected repository) when present, and for `slug` a caller may generate a lane identifier of its own choosing. Well-known is a caller-side prefill convention and nothing more: it obliges a provider to nothing, changes no validation, and a provider that declares any of these names is simply one whose form a caller can fill in without asking. A caller that can answer every `required` field this way may skip the form entirely and create straight away; one that cannot must ask rather than guess.
 - `profile_kinds` and `credential_ref_hint` are meaningful only when `capabilities` includes `profile`; a provider without that capability SHOULD omit both, and a caller MUST ignore them if present without it. `profile_kinds` lists which `kind` values (from the Profile object above) this provider can actually realize. `credential_ref_hint` is placeholder text — not validation — describing the shape of a `credential_ref` this provider expects; a caller shows it as placeholder text in its credential-reference input.
 
@@ -247,11 +251,18 @@ stdin:
 {
   "params": {"repo": "acme/api", "branch": "fix-ci", "prompt": "..."},
   "profile": {"name": "acme-default", "kind": "oauth", "credential_ref": "acme-vault://oauth/acme-default"},
+  "seed": {"retained_key": "opaque-provider-string"},
   "idempotency_key": "tbd-9a1c..."
 }
 ```
 
 `profile` (optional) is a Profile object (see above) selecting the identity the new session's agent should run as. It is meaningful only when the provider declares the `profile` capability; a provider that doesn't declare it MUST ignore the field — per the ignore-unknown-fields rule in Versioning — and create the session against its own default identity rather than error. An absent `profile` always means the provider's default identity, regardless of capability.
+
+`seed` (optional) names a retained transcript the new session begins with as its history: `{"retained_key": "<key>"}`, where the key came from a `retain` or `import` receipt this same provider issued (see Keys below). It is a top-level sibling of `profile` and `idempotency_key`, never a member of the provider-defined `params`, and the payload it names is Claude Code transcript JSONL (see Format scope below).
+
+`seed` is gated by the `seed` capability, which names the field it gates rather than a verb — the same shape `profile` has. A provider that has not declared `seed` MUST ignore the field, per the ignore-unknown-fields rule in Versioning, and a caller MUST NOT send it to such a provider. That obligation is the whole point of gating the field: because an unrecognized stdin field is dropped silently rather than refused, an ungated `seed` sent to a provider that does not implement it would produce an unseeded session the caller believed carried a conversation, with nothing on either side to say so. `idempotency_key` dedupe covers a seeded create unchanged — replaying a key that already produced a session returns that same session rather than seeding a second one.
+
+`seed` is an object rather than a bare key string so that a future inline source — `{"transcript": [...]}` — needs neither a new field nor a new capability.
 
 If `create_params` exposes the well-known `prompt` field, the provider owns clearing any agent startup or trust gate before delivering that prompt. Writing prompt bytes while another interactive gate owns the TTY does not count as delivery. Providers SHOULD use agent flags or machine interfaces to clear and verify such gates, and MUST NOT infer readiness by parsing cosmetic TUI output.
 
@@ -311,6 +322,89 @@ The verb is optional and declared via the `stop` capability. Not every backend e
 The two verbs are declared separately (`archive`, `unarchive`), because a backend may be able to retire a session without being able to bring it back. A provider that declares `archive` alone is conformant; a caller then offers archiving and simply has no unarchive action.
 
 Failure follows the standard error model below — for example, exit 1 with `code: "not_found"` if `<id>` no longer exists.
+
+## `delete <id> [--retain]` (optional)
+
+Destroys the session: ends its compute if it is still running, and removes it from the inventory permanently. It is the third act alongside the two above — `stop` ends compute without retiring the session, `archive` retires the session without ending compute, and `delete` leaves nothing behind.
+
+**A provider MUST NOT declare `delete` unless a successful delete of a running session also ends that session's compute.** A provider that cannot end compute for a given session MUST refuse that delete with exit 1 rather than remove the record. This contract already recognizes backends with no client-facing kill and forbids them from declaring `stop`; such a backend declaring `delete` would strand compute that nothing enumerates and no reconciler can reach.
+
+Response:
+
+```json
+{"id": "fix-flaky-ci", "deleted": true}
+```
+
+- `id` (required) — MUST be the same `<id>` passed on the invocation line.
+- `deleted` (required) — `true` when this call destroyed a session, `false` when there was nothing to destroy.
+
+**The response is deliberately not a Session object.** Every other verb that changes a session returns one; this verb must not, because a caller that has just been told a session no longer exists must not be handed inventory-shaped data about it. The caller's adoption path reads a session object as a session to track, so returning one here would re-adopt the very session the response declares gone.
+
+**`delete` is idempotent.** Deleting an unknown or already-deleted id exits 0 with `"deleted": false`, matching the idempotence `stop` and `archive` already have: asking for a state a session is already in is not an error.
+
+**Filing never gates destruction.** An archived session MAY be deleted, and a caller need not unarchive one first: `archived` is a filing decision and says nothing about whether a session may be destroyed.
+
+**`delete` overrides the exited-session retention SHOULD.** Providers SHOULD keep exited sessions listable for at least 24 hours (see `list` above) so that a disappearance can be told apart from transport drift. A deleted session is exempt, because its disappearance was requested by the caller rather than observed by it, and there is nothing to tell apart.
+
+**A provider that declares `events` MUST emit `{"event": "removed", "id": ...}` after a successful delete.** `removed` already means "stop tracking this at all", which is exactly the fact a delete establishes.
+
+**`--retain` retains the session's transcript before destroying it**, and is valid only where the provider also declares the `retain` capability. When the flag is passed — and only then — the response carries the same receipt `retain` returns:
+
+```json
+{"id": "fix-flaky-ci", "deleted": true, "retained": {"key": "opaque-provider-string", "expires_at": "2026-10-01T00:00:00Z", "bytes": 148213}}
+```
+
+Without the flag, nothing is retained and no `retained` object appears. **Retention is never implied by capability presence.** A caller that did not ask for storage MUST NOT have storage allocated on its behalf, and a response shape MUST NOT vary with which capabilities a provider happens to hold.
+
+There is no `--force` at this layer. Refusing to destroy live or dirty work is caller policy — the caller has `stop` to sequence and the `workspace_dirty` key to consult — and a provider that second-guesses an explicit delete leaves the caller no way through.
+
+Failure follows the standard error model below.
+
+## `retain <id>` / `import` (optional)
+
+Both verbs put a transcript into the provider's own durable store and return the same receipt:
+
+```json
+{"key": "opaque-provider-string", "expires_at": "2026-10-01T00:00:00Z", "bytes": 148213}
+```
+
+`retain <id>` stores the transcript of a session this provider owns. `import` reads Claude Code transcript JSONL on stdin and stores it, with no session on this provider involved at all — that is how a conversation from somewhere else, including one that ran on the caller's own machine, enters the store.
+
+- `key` (required) — the opaque handle `recall` and `create`'s `seed` field take. See Keys below.
+- `bytes` (required) — the count of transcript bytes stored. It is how a caller detects a truncated `recall`, so a provider MUST emit it.
+- `expires_at` (optional) — when the provider intends to drop the record. **An absent `expires_at` means the provider makes no claim, never "kept forever".** A caller MUST NOT render its absence as a guarantee of permanence.
+
+Malformed JSONL on `import` is a permanent error with `code: "invalid_params"`.
+
+Providers SHOULD expire retained transcripts nobody recalls. Retention is storage a caller asked for, and a store with no expiry policy grows without bound.
+
+**These are two verbs and two capabilities rather than one verb with an operand or a `--stdin` flag.** Every capability string but the two that gate a `create` field names the verb of the same name, and the two acts have genuinely different prerequisites: a backend may be able to snapshot its own sessions while being unable to accept a foreign blob, and one capability cannot say that. Separately, stdin is a property of a verb here — `create`, `send`, and `set-profile` read it unconditionally, and nothing else reads it at all — so a flag that switched it on would be the only one of its kind. Detecting a tty instead would be worse: TBD always invokes providers without one, so the heuristic would be constant-true in the caller that matters.
+
+Failure follows the standard error model below — for example, exit 1 with `code: "not_found"` if `retain`'s `<id>` no longer exists.
+
+## `recall <key>` (optional)
+
+Writes a retained transcript to stdout as Claude Code transcript JSONL, in the same format `transcript` returns (see `transcript` below). It works for any key the provider issued, whether or not the session that produced the transcript still exists — which is the point of retaining one.
+
+**`recall` writes nothing to stderr**, so this contract keeps exactly one stderr exception. `recall` does not inherit `transcript`'s cursor envelope: a cursor exists because a live transcript grows and is fetched incrementally, while a retained transcript is immutable, so `--since` would have nothing to mean. Truncation — the cursor's other job — is detected against the `bytes` the receipt carried.
+
+- Unknown key: exit 1 with `code: "not_found"`.
+- A key the provider issued and has since aged out: exit 1 with `code: "expired"` (see Error model below), so a caller can say that a record lapsed rather than claim it never existed.
+
+Both are permanent errors.
+
+**It is a separate verb rather than `transcript --key`.** The operand is a different identifier namespace — a key is not a session id — and the `transcript` capability must keep meaning "live transcripts work" rather than becoming ambiguous about which of two paths a provider implements.
+
+### Keys
+
+A key is an opaque provider-issued string, on the same terms as a `transcript` cursor or a `credential_ref`. A caller MUST NOT parse, order, compare, construct, or pattern-match one; it stores whatever a receipt gave it and passes that value back verbatim.
+
+- **Keys are provider-scoped.** A key is meaningful only to the provider that issued it, so a caller keys every key by the pair `(provider name, key)` and MUST NOT present one to a different provider.
+- **A key is an identifier, not an authorization.** `recall` authenticates exactly as every other verb does, and holding a key grants nothing on its own. A key is therefore not a bearer secret — which is what lets a caller log it, print it, and store it beside the rest of its inventory rather than treating it as credential material.
+
+### Format scope
+
+`import`, `recall`, and `create`'s `seed` field all fix the payload as Claude Code transcript JSONL, the same format `transcript` returns. The rest of this contract assumes no particular agent, so these three are a real narrowing of it: a provider whose sessions are not Claude Code sessions simply declines these capabilities and remains fully conformant, and other agents' transcript formats are out of scope.
 
 ## `log <id> [--lines N]`
 
@@ -560,7 +654,9 @@ On a nonzero exit, the provider SHOULD emit one JSON error object on stdout:
 }
 ```
 
-Well-known `code` values: `auth_expired`, `auth_missing`, `not_found`, `already_exists`, `unreachable`, `invalid_params`, `credential_unresolvable`. Providers may return other codes; callers should treat unrecognized codes as opaque strings and still show `message`.
+Well-known `code` values: `auth_expired`, `auth_missing`, `not_found`, `expired`, `already_exists`, `unreachable`, `invalid_params`, `credential_unresolvable`. Providers may return other codes; callers should treat unrecognized codes as opaque strings and still show `message`.
+
+`expired` means the thing named existed and has since lapsed — `recall` returns it for a key the provider issued and has since aged out (see `recall` above). It is distinct from `not_found` because the two say different things to a human: `not_found` claims the identifier was never issued, which for a key a caller is holding a receipt for is simply false, and hides the fact that the record lapsed on a schedule the provider declared.
 
 `credential_unresolvable` means a `credential_ref` in a `profile` object didn't resolve against the provider's own secret store. It's distinct from `invalid_params` because the remedy is provisioning — registering or fixing the secret on the provider side — not correcting the shape of the request. It carries the same `remediation` shape as any other code:
 
@@ -604,6 +700,8 @@ The one asymmetry runs the other way: a provider that **drops** `stop` altogethe
 Within a major version: providers may add new response fields at any time — a scalar or a structured object alike, such as `pending_question` on the Session object — and callers MUST ignore fields they don't recognize. This is symmetric: callers may send new optional fields in structured stdin (for example, `profile` on `create`) that an older provider doesn't recognize, and **providers MUST likewise ignore fields they don't recognize in structured stdin** rather than fail on them — the same forward-compatibility contract applies in both directions. Removing or renaming a field, or changing the semantics of a verb, requires a new major version.
 
 **A caller's silence is not confirmation.** That ignore-unknown-fields rule, read from the sending end, means an optional field a caller does not consume is dropped at decode rather than rejected: nothing is returned, nothing is logged on the sender's side, and a run in which a field was understood is indistinguishable from one in which it was never looked at. A provider therefore MUST NOT read the absence of an error, or the absence of any complaint at all, as evidence that a caller consumes a field it sends. Where this document states what TBD's own caller does with an optional field, that statement sits at the field; where it makes no such statement, a provider that needs to know has to ask the caller's implementers rather than infer it from a quiet run. Adding a new optional verb — gated behind a new entry in `capabilities`, as `rename`, `set-profile`, and `messages` were — is likewise additive within a major version: a caller that doesn't recognize the capability string simply never invokes the verb, so no version bump is needed for it either. **A provider declaring `contract_versions: [1]` may implement any capability-gated verb this document specifies, `messages` included.** The capability string is what admits a verb at either major — a caller invokes one because the provider declared it, never because a major was negotiated — and the optional response fields such a verb arrives with are readable at either major under the rule above. Declaring one therefore obliges nobody to add `2`, and adding `2` for a verb alone is the expensive mistake: it carries the `stop` pairing above with it. `messages` is the worked example of both halves at once: a capability-gated verb plus one optional response field (`peer_messaging`), added within major 2 and requiring no bump, no change to any existing verb, and nothing at all from a provider that declines it.
+
+**`delete`, `retain`, `import`, `recall`, and `seed` are additive within major 2 on exactly those terms, and require no bump.** Four are capability-gated verbs, admitted by their capability strings the way `rename` and `messages` are; `seed` is a capability-gated field on `create`, admitted the way `profile` is. No required verb changes, no existing field is removed or renamed, and no existing verb's semantics move, so a provider that declares none of the five behaves precisely as it always has. **None of this changes `stop`'s status.** `delete`'s obligation to end a running session's compute is a statement about `delete` alone: it neither requires nor implies the `stop` capability, and the pairing rule above — a provider that implements `stop` and declares major 2 MUST declare the `stop` capability — is untouched by it.
 
 ## Identity & drift
 

--- a/docs/specs/2026-08-16-remote-lane-archive-design.md
+++ b/docs/specs/2026-08-16-remote-lane-archive-design.md
@@ -548,7 +548,8 @@ exist without it.
 
 No recreation of a session for a lane whose session was terminated, so revive
 reaches only as far as `unarchive` does. No `delete` verb, and no mapping of any
-TBD gesture onto one — retiring and destroying are different acts and the
-contract names only the first. No per-repo policy for which providers may be
-archived automatically. No change to attach, log, send, stop, or the reconnect
-policy.
+TBD gesture onto one — retiring and destroying are different acts, and this
+design specifies only the first; destruction is specified in
+[`2026-09-02-remote-session-delete-and-transcript-exchange-design.md`](2026-09-02-remote-session-delete-and-transcript-exchange-design.md).
+No per-repo policy for which providers may be archived automatically. No change
+to attach, log, send, stop, or the reconnect policy.

--- a/docs/specs/2026-09-02-remote-session-delete-and-transcript-exchange-design.md
+++ b/docs/specs/2026-09-02-remote-session-delete-and-transcript-exchange-design.md
@@ -279,7 +279,7 @@ sessions — in a worktree manager "remote" reads as git remote first.
 
 ```
 tbd remote list [--provider <name>] [--archived] [--json]
-tbd remote create --provider <name> [--param key=value]... [--profile <name>]
+tbd remote create --provider <name> [--param key=value]...
                   [--continue <terminal-id> | --from-key <key> | --from-file <path|->] [--json]
 tbd remote stop <session> [--json]
 tbd remote archive <session> [--json]
@@ -297,6 +297,14 @@ tbd remote dismiss <session>
   the compound a human reads off `tbd remote list`. Key-addressed commands take
   `--provider` explicitly, because keys are provider-scoped and may contain any
   character.
+- **`create` names no identity.** TBD's `remote.create` composes the provider's
+  stdin as `{params, [seed], idempotency_key}` and never sends the contract's
+  optional `profile` object, so both an ordinary and a seeded create run under
+  the provider's default identity — which is exactly what an absent `profile`
+  means to a provider. Nothing on this path carries an identity to expose, so
+  there is no flag for one: sending `profile` is separate work, taking a profile
+  projection all the way from the app and the CLI through the RPC to the
+  composed body, and it belongs with `set-profile` rather than here.
 - **`create --continue <terminal-id>` is the teleport.** TBD reads that
   terminal's local Claude transcript, `import`s it on the chosen provider, then
   `create`s seeded from the returned key. `--from-key` and `--from-file` are the

--- a/docs/specs/2026-09-02-remote-session-delete-and-transcript-exchange-design.md
+++ b/docs/specs/2026-09-02-remote-session-delete-and-transcript-exchange-design.md
@@ -1,0 +1,414 @@
+# Deleting a remote session, and moving transcripts between machines
+
+**Date:** 2026-09-02
+**Status:** Approved, not yet built.
+**Depends on:** [`docs/remote-provider-contract.md`](../remote-provider-contract.md)
+(the verb/capability model, the Session object, the error model, and the
+`transcript` format), and
+[`2026-08-16-remote-lane-archive-design.md`](2026-08-16-remote-lane-archive-design.md)
+(archive and revive, whose deliberate cut this design reverses).
+
+## Summary
+
+A remote agent session cannot be destroyed. It can be stopped, which ends its
+compute, and archived, which retires it from the working set, but nothing
+removes it — so sessions accumulate forever, and the ones a user has finished
+with are the ones that accumulate fastest.
+
+Destroying a session would also destroy the only copy of its conversation,
+because a remote session's transcript lives on the remote machine and TBD keeps
+nothing. So this design adds two things at once, and they are one thing: a
+`delete` verb, and a transcript exchange that gives a conversation an identity
+independent of the machine that hosted it. A transcript can be retained on the
+provider's own store and read back by an opaque key long after its session is
+gone; a transcript from anywhere — including a local session on this Mac — can
+be put into that store and used to seed a new remote session.
+
+Delete is then destruction with a receipt, and the receipt is not a special
+form: it is an ordinary exchange key.
+
+## The gap
+
+Three separate absences meet here.
+
+**Nothing removes a session.** `stop` ends compute and explicitly does not
+retire the session; `archive` retires it from the working set and explicitly
+does not end compute. The contract names no third act, and
+[`2026-08-16-remote-lane-archive-design.md`](2026-08-16-remote-lane-archive-design.md)
+recorded that as a deliberate cut: retiring and destroying are different acts,
+and only the first was specified. That reading was right about the distinction
+and wrong about the consequence — a fleet with no reclaim path fills up.
+
+**Archived sessions render anyway.** The contract requires a provider to keep
+archived sessions in `list` and leaves it to the caller to decide which a human
+sees: display policy applied to a complete inventory. TBD never wrote that
+policy. `RepoSectionView.matchedRemoteSessions` and `RemoteSectionView.sessions`
+filter on `dismissed` alone, and `payload.isArchived` has exactly one consumer
+in the tree, in the daemon. So archiving a remote lane retires the worktree row
+and the session immediately reappears beneath it as a bare session row, which
+the only removal gesture — Dismiss, offered only for a `gone` session — cannot
+touch. Archiving a lane creates a row nothing can remove.
+
+**No transcript ever reaches this machine.** The contract defines a
+`transcript` verb returning Claude Code JSONL, and TBD has never invoked it:
+`"transcript"` as a capability string appears nowhere in `Sources/`. `log` is
+fetched on demand and rendered without being stored. TBD's `remote_session` row
+holds the last `list` payload — id, title, state, `meta`, `created_at` — and no
+conversation. A session destroyed today takes its history with it.
+
+## Contract additions
+
+All additive within contract major 2: four capability-gated verbs and one
+capability-gated field on an existing verb. No required verb changes, no field
+is removed or renamed, and no existing semantics move, so no major bump. None of
+this touches `stop`'s status; "delete ends compute" is a statement about
+`delete`, and a provider's `stop` declaration is unaffected.
+
+| Verb | Gate | Invocation | stdin | stdout | Timeout |
+|---|---|---|---|---|---|
+| `delete` | capability `delete` | `<exec> delete <id> [--retain]` | — | JSON result | 30s |
+| `retain` | capability `retain` | `<exec> retain <id>` | — | JSON receipt | 60s |
+| `import` | capability `import` | `<exec> import` | JSONL | JSON receipt | 60s |
+| `recall` | capability `recall` | `<exec> recall <key>` | — | JSONL | 60s |
+
+### `delete <id> [--retain]`
+
+Destroys the session: ends its compute if it is running, and removes it from the
+inventory permanently.
+
+- **A provider MUST NOT declare `delete` unless a successful `delete` of a
+  running session also ends that session's compute.** A provider that cannot end
+  compute for a given session MUST refuse with exit 1 rather than remove the
+  record. The contract already recognizes backends with no client-facing kill
+  and forbids them from declaring `stop`; such a backend declaring `delete`
+  would leave compute running that nothing enumerates and no reconciler can
+  reach.
+- **Response is `{"id": "<id>", "deleted": true|false}`** — `true` when this call
+  destroyed a session, `false` when there was nothing to destroy. Deliberately
+  **not** a Session object: a caller that has just been told a session no longer
+  exists must not be handed inventory-shaped data, which the adoption path would
+  read as a session to adopt.
+- **Idempotent.** Deleting an unknown or already-deleted id exits 0 with
+  `"deleted": false`, matching `stop` and `archive` and the `rm -f` convention.
+- **Filing is orthogonal.** An archived session may be deleted; archive state
+  never gates it.
+- **`delete` overrides the exited-session retention SHOULD.** Providers keep
+  exited sessions listable for at least 24 hours so a disappearance can be told
+  apart from transport drift; a deleted session is exempt, because its
+  disappearance was requested rather than observed.
+- **A provider declaring `events` MUST emit `{"event": "removed", "id": ...}`**
+  after a successful delete. `removed` already means "stop tracking this at
+  all", which is exactly the fact.
+- **`--retain` retains before destroying**, and is valid only where the provider
+  also declares `retain`. With the flag, the response carries
+  `"retained": {"key": ..., "expires_at"?: ..., "bytes": ...}`; without it, no
+  retention happens and no such object appears. Retention is never implied by
+  capability presence — a caller that did not ask for storage must not cause
+  storage to be allocated, and a response shape must not depend on which
+  capabilities the provider happens to hold.
+
+There is no `--force` at the contract layer. Refusing to destroy live or dirty
+work is a caller policy, and the caller already has `stop` to sequence.
+
+### `retain <id>` and `import`
+
+Both put a transcript into the provider's durable store and return a receipt:
+
+```json
+{"key": "opaque-provider-string", "expires_at": "2026-10-01T00:00:00Z", "bytes": 148213}
+```
+
+`retain <id>` stores the transcript of a session this provider owns. `import`
+reads Claude Code transcript JSONL on stdin and stores it, with no session on
+this provider involved at all — that is how a conversation from another machine,
+including a local one, enters the store.
+
+They are two verbs and two capabilities rather than one verb with an operand or
+a `--stdin` flag. Every capability string except `profile` names the verb of the
+same name, and the two acts have genuinely different prerequisites: a backend
+may be able to snapshot its own sessions while being unable to accept a foreign
+blob, and there is no way to say that with one capability. Separately, stdin is a
+property of a verb throughout this contract — `create`, `send`, and `set-profile`
+read it unconditionally and nothing else reads it at all — so a flag that
+switches it on would be the only one of its kind. Detecting a tty instead would
+be worse: TBD always invokes providers without one, so the heuristic would be
+constant-true in the only caller that matters.
+
+- **`bytes` is required** and is the count of transcript bytes stored. It is how
+  a caller detects a truncated `recall`.
+- **`expires_at` is optional, and absent means the provider makes no claim** —
+  never "this is kept forever". A caller MUST NOT render an absent value as a
+  guarantee of permanence.
+- Malformed JSONL on `import` is `invalid_params`.
+- Providers SHOULD expire retained transcripts nobody recalls. Retention is
+  storage the caller asked for, and a store with no expiry policy grows without
+  bound.
+
+### `recall <key>`
+
+Writes the retained transcript to stdout as JSONL, in `transcript`'s format,
+for any key — whether or not the session that produced it still exists.
+
+- **`recall` writes nothing to stderr.** It does not inherit `transcript`'s
+  cursor envelope: a cursor exists because a live transcript grows and is fetched
+  incrementally, and a retained transcript is immutable. `--since` would be
+  meaningless. Truncation, the cursor's other job, is detected against the
+  `bytes` in the receipt. The contract keeps exactly one stderr exception.
+- It is a separate verb rather than `transcript --key`, because the operand is a
+  different identifier namespace and because the `transcript` capability must
+  keep meaning "live transcripts work" rather than becoming ambiguous about
+  which of two paths a provider implements.
+- Unknown key: exit 1, `code: "not_found"`. A key the provider recognizes but has
+  aged out: exit 1, `code: "expired"` — a new well-known code, added so a caller
+  can say when a record lapsed instead of claiming it never existed. Both are
+  permanent errors. Callers treat unrecognized codes as opaque strings already,
+  so no caller breaks on it.
+
+### Keys
+
+A key is an opaque provider-issued string. Callers MUST NOT parse, construct, or
+pattern-match one, exactly as with a `transcript` cursor or a `credential_ref`.
+
+- **Keys are provider-scoped.** A key is meaningful only to the provider that
+  issued it. TBD stores every key against `(provider name, key)` and MUST NOT
+  present a key to a different provider.
+- **A key is an identifier, not an authorization.** `recall` authenticates the
+  way every other verb does; holding a key grants nothing on its own. This is
+  stated so that neither side treats keys as bearer secrets, which would make
+  them unloggable and unprintable and would put a credential in TBD's database.
+
+### `seed` on `create`
+
+`create`'s stdin gains an optional top-level field, a sibling of `profile` and
+`idempotency_key` rather than a member of the provider-defined `params`:
+
+```json
+{"params": {...}, "profile": {...}, "seed": {"retained_key": "..."}, "idempotency_key": "tbd-9a1c..."}
+```
+
+The new session begins with that retained conversation as its history. It is
+gated by a capability named `seed`, matching the field it gates — the same shape
+`profile` already has, and the only precedent for a capability that gates a
+field rather than a verb.
+
+The gate is not optional politeness. The contract requires providers to ignore
+stdin fields they do not recognize, so an ungated `seed` would be silently
+dropped by a provider that does not implement it, producing an empty session the
+caller believed was seeded. A caller MUST NOT send `seed` to a provider that has
+not declared it. `create`'s idempotency dedupe covers seeded creates unchanged.
+
+`seed` is an object rather than a bare key string so that a future inline source
+— `{"transcript": [...]}` — needs no new field and no new capability.
+
+### Format scope
+
+`import`, `recall`, and `seed` all fix the payload as Claude Code transcript
+JSONL, matching `transcript`. The contract otherwise assumes no particular
+agent, so this is a real narrowing: a provider whose sessions are not Claude
+Code sessions simply does not declare these capabilities. Other agents' formats
+are out of scope here.
+
+## Daemon
+
+**RPC.** `remote.delete`, `remote.retain`, `remote.import`, `remote.recall`,
+following the existing shape in `RPCRouter+RemoteHandlers`. `remote.create`
+gains an optional seed key.
+
+**A caller that issued the delete drops its row immediately.** The drift rule
+needs two consecutive complete absences before a session is `gone`, which is
+right for an observed disappearance and wrong for a requested one. On a
+successful `delete` the daemon removes the `remote_session` row at once. Without
+this the UI shows a session the user just deleted as live, then stale, then
+gone, over two poll intervals.
+
+**A new table, `retained_transcript`**: provider, key, `expiresAt`, `bytes`,
+source session id, source title, resolved repo, originating worktree, local
+path, `createdAt`. Rows are written by every path that obtains a key —
+`retain`, `import`, and `delete --retain`. Without it a key printed once is
+unrecoverable. Migration plus GRDB record plus the `TBDShared` Codable model
+land in one commit, with every new model field optional or defaulted.
+
+**Flag.** `remote_delete_enabled`, added by migration with no SQL `DEFAULT` so
+NULL remains a third state, shipped default-off, graduating by a one-line change
+to `Config.remoteDeleteDefault`. It gates the destructive verb only; `retain`,
+`import`, and `recall` are non-destructive and are gated by their capabilities
+alone.
+
+**Expiry uses the date seam, not the clock seam.** `expires_at` is a persisted
+timestamp compared against now, so the types that read it take
+`now: @Sendable () -> Date`. `Duration` is behavior; `Date` is data.
+
+## App
+
+**Delete is offered on both surfaces a remote session can wear.**
+`RemoteSessionActionMenu` gains a destructive `delete` after `stop`, and
+`RowActionMenu` gains the same for a remote-location lane, beside Archive. Where
+the provider has not declared `delete`, the item is present but disabled and
+reads `Delete (provider can't delete)` with help text naming the missing
+capability — the treatment `RowActionMenu` already gives an unarchivable lane,
+and the hook a later design will use to offer implementing the capability.
+
+**Confirmation fires unless nothing is at stake.** It is skipped only when the
+session is `exited`, does not claim `meta.workspace_dirty`, and a receipt is
+coming. Anything running, anything claiming uncommitted work, and any delete
+that will keep no record is confirmed, and the dialog states what is destroyed
+and whether a transcript is kept and until when.
+
+**A deleted lane keeps its place.** Deleting an adopted lane archives its
+worktree row and points the receipt at it, so the row stays in the repo's
+Archived tab with its branch and PR context. Revive on such a row means
+`create` with `seed` — the gesture, the place, and the word already mean this.
+Past `expires_at`, Revive is disabled and names the date; the row remains as
+history. A never-adopted session's receipt surfaces in the Provider Desk's
+session ledger, marked deleted.
+
+**Recalled transcripts land at `~/tbd/transcripts/<provider>/<key>.jsonl`**,
+derived from `TBDConstants` so the test fence covers it, and render read-only in
+the existing transcript pane.
+
+**The display fix.** Both sidebar filters drop sessions whose payload reports
+`archived`, which is the display policy the contract assigns the caller. Dismiss
+becomes available when a session is `gone` **or** `exited`, so a session the
+provider keeps enumerating after death is removable even from a provider that
+never implements `delete`.
+
+## CLI
+
+A `tbd remote` group, whose abstract opens by naming provider-hosted agent
+sessions — in a worktree manager "remote" reads as git remote first.
+
+```
+tbd remote list [--provider <name>] [--archived] [--json]
+tbd remote create --provider <name> [--param key=value]... [--profile <name>]
+                  [--continue <terminal-id> | --from-key <key> | --from-file <path|->] [--json]
+tbd remote stop <session> [--json]
+tbd remote archive <session> [--json]
+tbd remote unarchive <session> [--json]
+tbd remote delete <session> [--retain] [--force] [--json]
+tbd remote transcript <session> [-o <path>]
+tbd remote retain <session> [--json]
+tbd remote import --provider <name> [<path>|-] [--json]
+tbd remote recall --provider <name> <key> [-o <path>]
+tbd remote retained list [--provider <name>] [--json]
+tbd remote dismiss <session>
+```
+
+- **`<session>` accepts a worktree name, a TBD UUID, or `<provider>/<id>`** —
+  the compound a human reads off `tbd remote list`. Key-addressed commands take
+  `--provider` explicitly, because keys are provider-scoped and may contain any
+  character.
+- **`create --continue <terminal-id>` is the teleport.** TBD reads that
+  terminal's local Claude transcript, `import`s it on the chosen provider, then
+  `create`s seeded from the returned key. `--from-key` and `--from-file` are the
+  other two seed sources; the three are mutually exclusive. It is not named
+  `teleport`, because `claude --teleport` means cloud-to-local — the opposite
+  direction — and TBD already says `tbd terminal continue-in-codex` for "carry
+  this conversation elsewhere".
+- **Teleport moves a branch, never files.** TBD refuses when the worktree has
+  uncommitted changes or unpushed commits, naming what would be left behind, and
+  each refusal is overridable with `--force`; for unpushed commits it offers to
+  push. Carrying files would mean shipping the untracked and ignored ones that
+  make a checkout work — `.env`, local databases, credentials — which is a
+  per-repo policy question, not a transport question, and is out of scope.
+  `meta.workspace_dirty` is the same fact in the other direction.
+- **`delete` refuses without `--force`** when the session is running or claims
+  `workspace_dirty`. `--retain` prints the key.
+- **A missing capability is a one-line refusal naming it, exit 1**, decided
+  before any provider call — never a provider error surfaced raw.
+- **Key-returning commands print the bare key on stdout** and everything else on
+  stderr, so `KEY=$(tbd remote retain my-lane)` composes. `--json` returns
+  `{"provider", "key", "expires_at", "bytes"}`.
+- **`transcript` and `recall` write JSONL to stdout** with no `--json` flag —
+  the output is already machine format — and `-o` writes to a file. `import`
+  takes a path operand or `-` for stdin.
+- **`dismiss`'s help must contrast with `delete`**: dismiss changes nothing on
+  the provider. Without the contrast users reach for whichever they find first.
+- No interactive prompts anywhere: agents drive this CLI and cannot answer them.
+
+## Reclamation
+
+Retained transcripts are a new kind of durable resource on both sides.
+
+On the provider side, `expires_at` plus the SHOULD that providers expire what
+nobody recalls is the whole mechanism; TBD cannot reclaim another machine's
+storage.
+
+On TBD's side there are two: `retained_transcript` rows, and the JSONL files
+under `~/tbd/transcripts/`. **`OrphanGC` gains a leg** that deletes files no row
+references and rows whose `expiresAt` has passed, gated by
+`gcRetainedTranscriptsEnabled`, default-off during soak, following the
+profile-dir and holder-rendezvous legs. The teleport flow is what makes this
+load-bearing rather than tidy: `import` succeeding and `create` then failing
+leaves a retained blob and a row nobody will ever use.
+
+## Testing
+
+- Both branches of `remote_delete_enabled`, and the three-state config check: a
+  pre-migration row reads NULL, an explicit `false` survives a change to the
+  default constant, NULL follows it.
+- Both branches of `gcRetainedTranscriptsEnabled`.
+- Pure menu composition: `delete` present, disabled-with-reason, and omitted;
+  Dismiss offered for `gone`, for `exited`, and for neither.
+- Sidebar filters: an archived session renders in neither section, and an
+  unarchived one still does.
+- Decode: `delete`'s response with and without `retained`; a receipt with and
+  without `expires_at`; an `expired` error code round-tripping as a known code.
+- CLI: `<session>` resolution by all three forms; mutually exclusive seed
+  sources; the refusal path for a missing capability, asserted on composed
+  output rather than on absence.
+- A mock provider declaring each subset of the four capabilities. The built-in
+  claude-cloud provider declares none of them, so nothing here is end-to-end
+  testable against a real backend inside this repo; agentbox is the first
+  implementation.
+
+## Build order
+
+1. Contract document, and rewriting the archive spec's "Deliberate cuts"
+   paragraph to state the current design.
+2. Sidebar display fix and the Dismiss gate — independent of everything else,
+   and it clears the accumulated rows on its own.
+3. `retain`, `import`, `recall` end to end: RPC, table, migration, CLI.
+4. `delete`: RPC, flag, both menus, confirmation, immediate row drop.
+5. `seed` on create, Revive-as-reseed, and `create --continue`.
+6. The `OrphanGC` leg.
+
+## Rejected alternatives
+
+**One `retain` verb with `<id>` XOR `--stdin`.** Rejected on capability
+granularity: a provider able to snapshot its own sessions but not accept foreign
+blobs cannot be described. Also the only flag-switched stdin in the contract, and
+it needs error paths for neither-operand-nor-flag and for both that two verbs
+make unreachable.
+
+**Retention implied by capability rather than by `--retain`.** Rejected because
+it makes a response shape depend on capabilities rather than on the request, and
+allocates storage the caller never asked for.
+
+**The session id as the retrieval key.** Smallest possible addition — `transcript
+<id>` keeps answering after deletion — but it forbids id reuse forever and
+conflates "this session exists" with "this session's record exists".
+
+**A general `retain`-then-`delete` sequence with no atomic flag.** Kept as the
+composable form; `--retain` exists as well because a caller that means "destroy
+this but keep the record" should not have a state where the first call succeeded
+and the second did not.
+
+**`reseed` as the capability name.** It describes nothing — the session was
+never seeded before — and it breaks the one precedent for a field-gating
+capability, which names the field.
+
+**Naming the local-to-remote path `teleport`.** Collides head-on with
+`claude --teleport`, which moves a conversation cloud-to-local.
+
+**Capturing scrollback instead of transcripts.** `log` bytes are a terminal
+recording; poured into a transcript view they lose every tool card. The contract
+is explicit that `log` and `transcript` are different data, not two encodings of
+one.
+
+**Teleporting files.** See the CLI section: the files that make a checkout work
+are the ones git does not track, and shipping them by default exfiltrates
+secrets.
+
+**Hiding archived sessions behind a per-provider toggle.** More surface and a
+persisted preference for a state that already has two homes — the repo's
+Archived tab and the Provider Desk ledger.

--- a/docs/specs/2026-09-02-remote-session-delete-and-transcript-exchange-design.md
+++ b/docs/specs/2026-09-02-remote-session-delete-and-transcript-exchange-design.md
@@ -221,6 +221,19 @@ successful `delete` the daemon removes the `remote_session` row at once. Without
 this the UI shows a session the user just deleted as live, then stale, then
 gone, over two poll intervals.
 
+That drop races the poll loop, so it is interlocked the way archive and revive
+already are: a **deletion watermark**, stamped before the verb and again once it
+returns, and withdrawn if the verb fails. A `list` whose snapshot was captured
+before the provider committed the destruction still names the session, and
+applying it afterwards would silently re-insert the row — the same two-poll
+limbo, reached from the other side. The watermark is keyed by
+`(provider, session id)` rather than by worktree, because most deletable
+sessions were never adopted and have no worktree at all, and it is held in
+memory and swept to two poll intervals: the window it defends is open only while
+a provider request is outstanding, no such request survives a restart, and a
+session legitimately re-created under the same id is mirrored again by the first
+poll whose request began after the delete returned.
+
 **A new table, `retained_transcript`**: provider, key, `expiresAt`, `bytes`,
 source session id, source title, resolved repo, originating worktree, local
 path, `createdAt`. Rows are written by every path that obtains a key —

--- a/docs/specs/2026-09-02-remote-session-delete-and-transcript-exchange-design.md
+++ b/docs/specs/2026-09-02-remote-session-delete-and-transcript-exchange-design.md
@@ -1,7 +1,7 @@
 # Deleting a remote session, and moving transcripts between machines
 
 **Date:** 2026-09-02
-**Status:** Approved, not yet built.
+**Status:** Approved, built.
 **Depends on:** [`docs/remote-provider-contract.md`](../remote-provider-contract.md)
 (the verb/capability model, the Session object, the error model, and the
 `transcript` format), and


### PR DESCRIPTION
## Summary

A remote agent session could not be destroyed. It could be stopped, which ends its compute, and archived, which retires it from the working set — but nothing removed it, so sessions accumulated forever and the ones a person had finished with accumulated fastest.

Worse, archiving actively created litter. The contract requires a provider to keep archived sessions in `list` and leaves it to the caller to decide which a human sees; TBD never applied that policy. So archiving a remote lane retired the worktree row and the same session immediately reappeared beneath it as a bare session row — one that Dismiss, offered only for a session the provider had stopped enumerating, could not touch. A user watching their sidebar fill with `exited` rows had no gesture that removed any of them.

Destroying a session would also have destroyed its conversation, because a remote transcript lives on the remote machine and TBD kept none. So this adds both halves at once, and they are one idea: a `delete` verb, and a transcript exchange that gives a conversation an identity independent of the machine that hosted it. A transcript can be retained on the provider's own store and read back by an opaque key long after its session is gone; a transcript from anywhere — including a local session on this Mac — can be put into that store and used to seed a new remote session.

Delete becomes destruction with a receipt, and the receipt is not a special form: it is an ordinary exchange key.

## Why this shape

Spec: [`docs/specs/2026-09-02-remote-session-delete-and-transcript-exchange-design.md`](../blob/remote-delete-transcript-exchange/docs/specs/2026-09-02-remote-session-delete-and-transcript-exchange-design.md).

Four decisions carried the design, each with an alternative that looked reasonable first:

- **`retain` and `import` are two verbs, not one verb with a `--stdin` flag.** Capability strings are one-per-verb, and a backend may be able to snapshot its own sessions while being unable to accept a foreign blob — there is no way to say that with one capability. Separately, stdin is a property of a verb throughout this contract, and detecting a tty instead would be constant-true, since TBD always invokes providers without one.
- **`--retain` is an explicit flag, never implied by capability presence.** Implying it would make a response shape depend on which capabilities a provider happens to hold, and would allocate storage the caller never asked for.
- **`recall` writes nothing to stderr**, unlike `transcript`. A cursor exists because a live transcript grows and is fetched incrementally; a retained transcript is immutable, so `--since` would have nothing to mean. Truncation — the cursor's other job — is caught against the `bytes` the receipt carried. The contract keeps exactly one stderr exception.
- **`seed` is capability-gated rather than merely optional.** The contract requires providers to ignore stdin fields they don't recognize, so an ungated `seed` would be silently dropped by a provider that doesn't implement it, producing an empty session the caller believed carried a conversation.

Teleport moves a branch and never files. The files that make a checkout actually work are the ones git doesn't track — `.env`, local databases, credentials — so shipping them by default would exfiltrate secrets to another machine, and omitting them leaves a workspace that doesn't run anyway. That is a per-repo policy question, not a transport one.

This reverses a deliberate cut. [`2026-08-16-remote-lane-archive-design.md`](../blob/remote-delete-transcript-exchange/docs/specs/2026-08-16-remote-lane-archive-design.md) recorded "No `delete` verb" on the grounds that retiring and destroying are different acts. That distinction was right and stays; the consequence was wrong, because a fleet with no reclaim path fills up. That spec's cut now points at the design that specifies destruction.

## What this PR does

**Contract** (`docs/remote-provider-contract.md`) — four capability-gated verbs and one capability-gated `create` field, all additive within major 2, so no version bump and no existing provider is affected:

- `delete <id> [--retain]` — ends compute and removes the session. A provider **MUST NOT** declare `delete` unless deleting a running session also ends its compute, and must refuse with exit 1 rather than remove the record; the contract already forbids a backend with no client-facing kill from declaring `stop`, and such a backend declaring `delete` would strand compute nothing enumerates. Returns `{"id", "deleted": bool}` — deliberately not a Session object, which the adoption path would read as a session to re-adopt.
- `retain <id>` / `import` — put a transcript in the provider's durable store, returning `{"key", "expires_at"?, "bytes"}`. An absent `expires_at` means the provider makes no claim, never "kept forever".
- `recall <key>` — reads it back, whether or not the session still exists.
- `seed` on `create` — a top-level sibling of `profile` and `idempotency_key`, gated by a `seed` capability that names the field it gates, as `profile` does.
- One new well-known error code, `expired`, distinct from `not_found`: for a key the caller holds a receipt for, "never issued" is simply false.

**Sidebar** — both filters now honor `archived`, and Dismiss is offered for an `exited` session and not only a `gone` one. This is the half that fixes the reported symptom, and it stands alone.

**Daemon** — `remote.delete`, `remote.retain`, `remote.import`, `remote.recall`, `remote.retainedList`, `remote.transcript`; a `retained_transcript` table keyed `(provider, key)`; and an immediate mirror-row drop on a successful delete, because the caller has positive knowledge and letting the drift rule take two absences would show a just-deleted session as live, then stale, then gone across two poll intervals.

**App** — Delete on both surfaces a remote session can wear, present-but-disabled when the provider hasn't declared it; a confirmation skipped only when the session is exited, not `workspace_dirty`, **and** a receipt is coming; and Revive on a deleted lane meaning `create` with `seed`.

**CLI** — a `tbd remote` group: `list`, `create` (with `--continue` / `--from-key` / `--from-file`), `stop`, `archive`, `unarchive`, `delete`, `dismiss`, `retain`, `import`, `recall`, `transcript`, `retained list`, `allow-delete`.

**Reclamation** — retained transcripts are a new kind of durable resource on both sides. Provider-side, `expires_at` plus a SHOULD that providers expire what nobody recalls. TBD-side, **`OrphanGC` gains a leg** reclaiming rows past their expiry and files no row references. That leg is load-bearing rather than tidy: `import` succeeding and `create` then failing leaves a retained blob and a row nobody will ever use.

## Flag & rollout

Two flags, both added with no SQL `DEFAULT` so NULL stays a third state, both shipped **OFF**:

- **`remote_delete_enabled`** — gates the destructive verb. Enable for the soak with `tbd remote allow-delete on`.
- **`gc_retained_transcripts_enabled`** — gates the reclamation leg, on top of the `gcEnabled` master switch. Enable with `tbd gc retained-transcripts on`.

`retain`, `import`, and `recall` are non-destructive and ungated beyond their capabilities.

Graduation for each is a one-line change to `Config.remoteDeleteEnabledDefault` / `Config.gcRetainedTranscriptsEnabledDefault`, which reaches everyone who never touched the toggle while preserving every explicit opt-out. Both are worth soaking against a real backend before flipping — delete is irreversible, and the GC leg unlinks files.

## Assumptions

- **Assumes a provider that declares `delete` really does end compute.** TBD cannot verify it. If a provider declares the capability without honoring the obligation, deleting a running session leaves compute no reconciler can reach, because the row it would be found through is gone.
- **Assumes an opaque key is an identifier and not a bearer credential** — `recall` authenticates the way every other verb does. If a provider instead treats keys as capability tokens, they become secrets in TBD's database and in CLI output, which nothing here is designed for.
- **Assumes `meta.workspace_dirty` is truthful when present.** It gates whether a delete confirms. Absent it degrades to ordinary behavior, per contract.
- **Assumes a branch is the whole of what teleport must move.** Untracked and ignored files stay on the origin machine by design.

## Evidence & verification

- **CI run `33714651810` is green across all four jobs** on the merge tip, quiet pass included.
- **Both branches of both flags are tested**, plus the three config states each: a pre-migration row reads NULL rather than `0`, an explicit `false` survives a change to the default constant, and NULL follows it.
- Pure decision functions are tested directly, without a view hierarchy or an `AppState`: menu composition (Delete present / disabled / omitted, and that an absent `delete` is *shown* while an absent `attach` is not), the confirmation decision, the sidebar filters, the CLI's session-address resolution, and the teleport precondition.
- Sidebar-filter tests build their payloads **through the production decode path** from provider-shaped JSON, covering `"archived": true`, `"archived": false`, and the key omitted, so a filter written as `archived == nil` — collapsing "no claim" with "not archived" — reddens.
- The GC leg's keep-cases are tested individually: a row with no stated expiry is never dropped, a young file is kept by the grace window, a non-transcript file is left alone, and a referenced file survives.

**What is not verified, and should be read as the main risk:** nothing here has been exercised against a real backend. The built-in claude-cloud provider declares none of these capabilities and gains none in this PR, so every test runs against a mock provider, and until an external provider implements the verbs, these actions render as the disabled "provider can't delete" state. The first real implementation will be the first true test of the contract wording.

Per this repo's constraint on local builds during this work, all verification is from CI rather than a local run or a live app session.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=17A25F47-97A6-467C-B87D-FB9EBA63DA5C)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added remote session deletion with capability checks, confirmation prompts, optional transcript retention, and archived-session handling.
  * Added transcript retention, import, recall, listing, and retrieval across the app and CLI.
  * Added revival of deleted remote sessions using retained transcripts when supported.
  * Added controls for retained-transcript garbage collection.
* **Improvements**
  * Archived remote sessions are now hidden from active session views.
  * Updated image previews to scale consistently within available space.
* **Documentation**
  * Documented remote deletion, transcript exchange, retention, and cleanup settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->