### PR TITLE
Fix: Stop the CLI destroying a remote session's transcript by default

### DIFF
--- a/Sources/TBDCLI/Commands/RemoteCommands.swift
+++ b/Sources/TBDCLI/Commands/RemoteCommands.swift
@@ -472,6 +472,19 @@ enum RemoteDeletePrecondition {
         }
         return nil
     }
+
+    /// Resolves the tri-state `--retain`/`--no-retain` flag against what the
+    /// provider declares.
+    ///
+    /// `nil` (unspecified) retains wherever the provider can honor it and does
+    /// nothing otherwise — an absent `retain` capability is "no receipt
+    /// available", not a caller mistake, so this branch never errors. `true`
+    /// and `false` pass through unchanged: an explicit `--retain` against a
+    /// provider that cannot honor it is refused elsewhere, by name, and
+    /// `--no-retain` declines even when the provider could have retained.
+    static func resolveRetain(_ requested: Bool?, capabilities: Set<String>) -> Bool {
+        requested ?? capabilities.contains("retain")
+    }
 }
 
 /// What `--json` prints for a delete: the provider's own response shape with
@@ -541,10 +554,12 @@ struct RemoteDelete: AsyncParsableCommand {
             Gated by the daemon's `remote_delete_enabled` flag, which ships off. \
             Turn it on with `tbd remote allow-delete on`.
 
-            With --retain the provider stores the transcript first and the key is \
-            printed, so the conversation survives the session. Without it, \
-            nothing survives. --retain needs the provider to declare `retain` as \
-            well as `delete`.
+            The transcript is retained by default wherever the provider \
+            supports it: the provider stores it first and the key is printed, \
+            so the conversation survives the session. Pass --no-retain to \
+            destroy the transcript along with the session. Passing --retain \
+            explicitly against a provider that has not declared `retain` \
+            alongside `delete` is refused, naming the missing capability.
 
             Refuses without --force when the session is running or reports \
             uncommitted work, naming which.
@@ -556,8 +571,11 @@ struct RemoteDelete: AsyncParsableCommand {
     @Argument(help: "Worktree name, TBD UUID, or <provider>/<session-id>")
     var session: String
 
-    @Flag(name: .long, help: "Retain the transcript before destroying the session")
-    var retain = false
+    @Flag(
+        name: .long, inversion: .prefixedNo,
+        help: "Retain the transcript before destroying the session "
+            + "(default: on wherever the provider supports it; --no-retain destroys it too)")
+    var retain: Bool?
 
     @Flag(name: .long, help: "Destroy a running session, or one with uncommitted work")
     var force = false
@@ -580,13 +598,15 @@ struct RemoteDelete: AsyncParsableCommand {
             throw ExitCode.failure
         }
         // The contract makes --retain valid only where `retain` is declared, so
-        // this is refused here rather than sent and hoped for: a provider that
-        // ignored the flag would destroy a session the caller believed was
-        // being preserved.
-        if retain, !capabilities.contains("retain") {
+        // an explicit request is refused here rather than sent and hoped for: a
+        // provider that ignored the flag would destroy a session the caller
+        // believed was being preserved. Unspecified is not a request — it
+        // resolves below to "no receipt available" instead of an error.
+        if retain == true, !capabilities.contains("retain") {
             remoteNote(remoteMissingCapability("retain", provider: target.provider))
             throw ExitCode.failure
         }
+        let willRetain = RemoteDeletePrecondition.resolveRetain(retain, capabilities: capabilities)
         let mirrored = fleet.sessions.first {
             $0.provider == target.provider && $0.payload.id == target.sessionID
         }
@@ -600,7 +620,7 @@ struct RemoteDelete: AsyncParsableCommand {
         let result = try client.call(
             method: RPCMethod.remoteDelete,
             params: RemoteDeleteParams(
-                provider: target.provider, sessionID: target.sessionID, retain: retain),
+                provider: target.provider, sessionID: target.sessionID, retain: willRetain),
             resultType: RemoteDeleteResult.self)
         if json {
             printJSON(RemoteDeleteOutput(provider: target.provider, result: result))

--- a/Sources/TBDCLI/Commands/RemoteCommands.swift
+++ b/Sources/TBDCLI/Commands/RemoteCommands.swift
@@ -573,8 +573,7 @@ struct RemoteDelete: AsyncParsableCommand {
 
     @Flag(
         name: .long, inversion: .prefixedNo,
-        help: "Retain the transcript before destroying the session "
-            + "(default: on wherever the provider supports it; --no-retain destroys it too)")
+        help: "Retain the transcript before destroying the session (default: on wherever the provider supports it; --no-retain destroys it too)")
     var retain: Bool?
 
     @Flag(name: .long, help: "Destroy a running session, or one with uncommitted work")

--- a/Tests/TBDCLITests/RemoteCommandsTests.swift
+++ b/Tests/TBDCLITests/RemoteCommandsTests.swift
@@ -285,6 +285,27 @@ struct RemoteCommandsTests {
             state: nil, workspaceDirty: false, force: false, address: address) == nil)
     }
 
+    // MARK: - delete: resolving --retain
+
+    /// Unspecified is not "off" — it asks for a receipt whenever the provider
+    /// can give one, matching what the app already does.
+    @Test func unspecifiedRetainDefaultsOnWhenTheProviderDeclaresIt() {
+        #expect(RemoteDeletePrecondition.resolveRetain(nil, capabilities: ["delete", "retain"]))
+    }
+
+    /// A provider that never declared `retain` has no receipt to give, and
+    /// that is "no receipt available", not a caller mistake — this must not
+    /// be conflated with the explicit-`--retain` refusal, which errors.
+    @Test func unspecifiedRetainStaysOffWithoutTheCapabilityAndDoesNotError() {
+        #expect(!RemoteDeletePrecondition.resolveRetain(nil, capabilities: ["delete"]))
+    }
+
+    /// `--no-retain` declines even against a provider that could have
+    /// retained — the explicit opt-out always wins.
+    @Test func explicitNoRetainDeclinesEvenWhenTheProviderCanRetain() {
+        #expect(!RemoteDeletePrecondition.resolveRetain(false, capabilities: ["delete", "retain"]))
+    }
+
     // MARK: - delete: the two outcomes
 
     /// `deleted: false` is a success — there was nothing to destroy — and is

--- a/docs/specs/2026-09-02-remote-session-delete-and-transcript-exchange-design.md
+++ b/docs/specs/2026-09-02-remote-session-delete-and-transcript-exchange-design.md
@@ -297,7 +297,7 @@ tbd remote create --provider <name> [--param key=value]...
 tbd remote stop <session> [--json]
 tbd remote archive <session> [--json]
 tbd remote unarchive <session> [--json]
-tbd remote delete <session> [--retain] [--force] [--json]
+tbd remote delete <session> [--retain | --no-retain] [--force] [--json]
 tbd remote transcript <session> [-o <path>]
 tbd remote retain <session> [--json]
 tbd remote import --provider <name> [<path>|-] [--json]
@@ -333,7 +333,17 @@ tbd remote dismiss <session>
   per-repo policy question, not a transport question, and is out of scope.
   `meta.workspace_dirty` is the same fact in the other direction.
 - **`delete` refuses without `--force`** when the session is running or claims
-  `workspace_dirty`. `--retain` prints the key.
+  `workspace_dirty`.
+- **`delete` retains by default wherever the provider can**, matching what the
+  app already does: retention is what makes an irreversible action safe, so
+  the default must not be the lossy one. `--retain`/`--no-retain` is a tri-state
+  flag (unspecified, forced on, forced off) — leaving it unspecified retains
+  when the provider declares `retain` and does nothing otherwise, with no
+  error either way; `--no-retain` destroys the transcript along with the
+  session even where the provider could have kept it; `--retain` against a
+  provider that has not declared `retain` is refused, naming the missing
+  capability, the same as any other missing-capability refusal. Retention
+  succeeding prints the key.
 - **A missing capability is a one-line refusal naming it, exit 1**, decided
   before any provider call — never a provider error surfaced raw.
 - **Key-returning commands print the bare key on stdout** and everything else on


### PR DESCRIPTION
## What's broken

Deleting a remote agent session is irreversible, and TBD's two surfaces disagreed about whether the conversation survives it.

The app retains whenever it can — `AppState+Remote.swift` reads `willRetain = capabilities.contains("retain")` and passes it straight through, so deleting from the sidebar keeps the transcript wherever the provider supports retention. The CLI's flag defaulted to off, so `tbd remote delete <session>` with no flags destroyed the transcript along with the session.

Same gesture, opposite outcome, and the CLI's default was the lossy one — on the one action in this feature that cannot be undone, reached by the surface agents script.

## Why it happens

`--retain` is deliberately opt-in *at the provider contract layer*: a caller must ask, so that a response shape never depends on which capabilities a provider happens to hold and no caller silently allocates provider storage it did not request. That rule is correct and does not change here.

What was missing is that TBD, as the caller, then has to decide whether to ask. The app decided yes. The CLI inherited the contract flag's own default of "off" rather than making a decision, so the two surfaces diverged without anyone choosing that.

## What this PR does

`tbd remote delete` now retains by default wherever the provider declares `retain`, with `--no-retain` to opt out. The flag becomes tri-state (`Bool?` with `inversion: .prefixedNo`) so "unspecified" stays distinguishable from "explicitly off":

- **unspecified** — retains when the provider declares `retain`, and does nothing when it does not. This branch never errors: an absent capability is "no receipt available", not a caller mistake.
- **`--retain`** — unchanged, including the existing refusal that names the missing capability when the provider cannot honor it.
- **`--no-retain`** — declines even when the provider could have retained.

The resolution is a pure `RemoteDeletePrecondition.resolveRetain(_:capabilities:)` so all three cases are testable without going through argument parsing.

The provider-contract layer is untouched: `<exec> delete <id> [--retain]` still means exactly what it did, and retention is still never implied by capability presence. Only TBD's own default choice changed.

## Evidence & verification

Three tests covering the resolution, in the existing delete suite:

- `unspecifiedRetainDefaultsOnWhenTheProviderDeclaresIt`
- `unspecifiedRetainStaysOffWithoutTheCapabilityAndDoesNotError`
- `explicitNoRetainDeclinesEvenWhenTheProviderCanRetain`

Verification is from CI rather than a local run, per the constraint on local builds during this work.

## Assumptions

Assumes a provider that declares `retain` will honor `--retain` on a delete. If it declares the capability but ignores the flag, the CLI reports a delete with no receipt, which is the same outcome as not asking — no work is lost that would otherwise have survived.

[🗑 Remote Delete & Transcript Exchange](https://cheapsteak.github.io/tbd/open/?worktree=17A25F47-97A6-467C-B87D-FB9EBA63DA5C)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote deletion now retains transcripts by default when supported by the provider.
  * Use `--retain` to request transcript retention or `--no-retain` to disable it explicitly.
  * Successfully retained transcripts display the returned retrieval key.
  * Requests for retention on unsupported providers are rejected before deletion begins.

* **Documentation**
  * Updated remote deletion help and specifications to explain retention defaults and available options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->