### PR TITLE
DX: Make a stalled quiet pass name its test and hand over a stack instead of 15 silent minutes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -712,6 +712,29 @@ jobs:
                 kill -KILL "$pid" 2>/dev/null || true
               done
             fi
+            # The sampled targets were SIGKILLed the moment their stacks were
+            # captured — they are wedged, and the graceful pass below is for the
+            # plumbing that can still clean up after itself — so drop them from
+            # the list before the order is built. Signalling a pid that is
+            # already gone is inert at best and reaches whatever reused the
+            # number at worst.
+            is_target() {
+              local needle="$1" candidate
+              for candidate in $targets; do
+                if [ "$candidate" = "$needle" ]; then
+                  return 0
+                fi
+              done
+              return 1
+            }
+            remaining=""
+            for pid in $kids; do
+              if is_target "$pid"; then
+                continue
+              fi
+              remaining="$remaining $pid"
+            done
+            kids="$remaining"
             # Take the pipeline down within a bounded 30 s instead of leaving
             # `wait` to block until `timeout-minutes` fires — the very outcome
             # this budget exists to avoid. Killing the sampled targets is not

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -739,17 +739,12 @@ jobs:
                 kill -KILL "$pid" 2>/dev/null || true
               done
             fi
-            # Re-walk the tree now that sampling is done. The `$kids` above is
-            # the snapshot taken before the samples were captured, and sampling
-            # several targets takes 20 s or more, so anything the pipeline
-            # spawned in the meantime would never be signalled by the sweep
-            # below. The sampled targets are then dropped from that fresh list:
-            # they were SIGKILLed the moment their stacks were captured, since
-            # they are wedged and the graceful pass below is for the plumbing
-            # that can still clean up after itself. Signalling a pid that is
-            # already gone is inert at best and reaches whatever reused the
-            # number at worst.
-            kids=$(descendants "$pipeline" || true)
+            # The sampled targets were SIGKILLed the moment their stacks were
+            # captured — they are wedged, and the sweep below is the graceful
+            # pass, for the plumbing that can still clean up after itself — so
+            # they are filtered out of every order built from here on. Even
+            # though `kill` on a dead pid is harmless, signalling one is inert at
+            # best and reaches whatever reused the number at worst.
             is_target() {
               local needle="$1" candidate
               for candidate in $targets; do
@@ -759,32 +754,6 @@ jobs:
               done
               return 1
             }
-            remaining=""
-            for pid in $kids; do
-              if is_target "$pid"; then
-                continue
-              fi
-              remaining="$remaining $pid"
-            done
-            kids="$remaining"
-            # Take the pipeline down within a bounded 30 s instead of leaving
-            # `wait` to block until `timeout-minutes` fires — the very outcome
-            # this budget exists to avoid. Killing the sampled targets is not
-            # enough on its own: with no targets found nothing has been killed
-            # at all, and even when the helper dies its parents (`script`,
-            # `swift-test`, `scripts/test.sh`) can outlive it. SIGTERM goes
-            # first so `scripts/test.sh`'s EXIT trap still runs its tmux and
-            # fence cleanup, and that trap's output has to have somewhere to go:
-            # `tee` is a direct child of the subshell and owns the far end of
-            # the log pipe, so anything still writing when `tee` dies writes to
-            # a closed pipe. The order is therefore built explicitly rather than
-            # by reversing the walk. The walk is preorder — `script`, then all
-            # of script's subtree, then the sibling `tee` — so a plain reversal
-            # would signal `tee` first, precisely backwards. Instead: everything
-            # below the direct children goes first (that subset reversed, so
-            # deepest-first), then the direct children other than `tee`, then
-            # `tee`.
-            direct_children=$(pgrep -P "$pipeline" || true)
             is_direct_child() {
               local needle="$1" child
               for child in $direct_children; do
@@ -794,23 +763,57 @@ jobs:
               done
               return 1
             }
-            deeper_first=""
-            for pid in $kids; do
-              if is_direct_child "$pid"; then
-                continue
-              fi
-              deeper_first="$pid $deeper_first"
-            done
-            direct_others=""
-            tee_pids=""
-            for pid in $direct_children; do
-              comm=$(ps -o comm= -p "$pid" 2>/dev/null || true)
-              case "${comm##*/}" in
-                tee) tee_pids="$tee_pids $pid" ;;
-                *) direct_others="$direct_others $pid" ;;
-              esac
-            done
-            kill_order="$deeper_first $direct_others $tee_pids"
+            # The order is built from a walk taken at the moment it is needed
+            # rather than from any earlier snapshot: sampling several targets
+            # takes 20 s or more and the grace window below is another 30 s, so
+            # a list captured before either would miss whatever the pipeline
+            # spawned in the meantime.
+            #
+            # `tee` is a direct child of the subshell and owns the far end of
+            # the log pipe, so anything still writing when `tee` dies writes to
+            # a closed pipe — and the EXIT trap's cleanup output is exactly what
+            # the log wants. The order is therefore built explicitly rather than
+            # by reversing the walk. The walk is preorder — `script`, then all
+            # of script's subtree, then the sibling `tee` — so a plain reversal
+            # would signal `tee` first, precisely backwards. Instead: everything
+            # below the direct children goes first (that subset reversed, so
+            # deepest-first), then the direct children other than `tee`, then
+            # `tee`.
+            build_kill_order() {
+              local pid comm remaining="" deeper_first="" direct_others="" tee_pids=""
+              kids=$(descendants "$pipeline" || true)
+              for pid in $kids; do
+                if is_target "$pid"; then
+                  continue
+                fi
+                remaining="$remaining $pid"
+              done
+              kids="$remaining"
+              direct_children=$(pgrep -P "$pipeline" || true)
+              for pid in $kids; do
+                if is_direct_child "$pid"; then
+                  continue
+                fi
+                deeper_first="$pid $deeper_first"
+              done
+              for pid in $direct_children; do
+                comm=$(ps -o comm= -p "$pid" 2>/dev/null || true)
+                case "${comm##*/}" in
+                  tee) tee_pids="$tee_pids $pid" ;;
+                  *) direct_others="$direct_others $pid" ;;
+                esac
+              done
+              kill_order="$deeper_first $direct_others $tee_pids"
+            }
+            # Take the pipeline down within a bounded 30 s instead of leaving
+            # `wait` to block until `timeout-minutes` fires — the very outcome
+            # this budget exists to avoid. Killing the sampled targets is not
+            # enough on its own: with no targets found nothing has been killed
+            # at all, and even when the helper dies its parents (`script`,
+            # `swift-test`, `scripts/test.sh`) can outlive it. SIGTERM goes
+            # first so `scripts/test.sh`'s EXIT trap still runs its tmux and
+            # fence cleanup.
+            build_kill_order
             for pid in $kill_order; do
               kill -TERM "$pid" 2>/dev/null || true
             done
@@ -820,6 +823,11 @@ jobs:
               teardown_waited=$((teardown_waited + 1))
             done
             if kill -0 "$pipeline" 2>/dev/null; then
+              # The escalation rebuilds the order instead of reusing the one the
+              # SIGTERM sweep signalled: that grace window is exactly when the
+              # EXIT trap runs, and its tmux and fence cleanup spawns processes
+              # of its own that the earlier order knows nothing about.
+              build_kill_order
               for pid in $kill_order; do
                 kill -KILL "$pid" 2>/dev/null || true
               done

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -710,11 +710,44 @@ jobs:
             # at all, and even when the helper dies its parents (`script`,
             # `swift-test`, `scripts/test.sh`) can outlive it. SIGTERM goes
             # first so `scripts/test.sh`'s EXIT trap still runs its tmux and
-            # fence cleanup, and the list is walked deepest-first (descendants
-            # were recorded parents-before-children) so `tee` and `script` —
-            # the direct children that carry the log — are the last to go.
-            kids_reversed=$(printf '%s\n' "$kids" | tail -r)
-            for pid in $kids_reversed; do
+            # fence cleanup, and that trap's output has to have somewhere to go:
+            # `tee` is a direct child of the subshell and owns the far end of
+            # the log pipe, so anything still writing when `tee` dies writes to
+            # a closed pipe. The order is therefore built explicitly rather than
+            # by reversing the walk. The walk is preorder — `script`, then all
+            # of script's subtree, then the sibling `tee` — so a plain reversal
+            # would signal `tee` first, precisely backwards. Instead: everything
+            # below the direct children goes first (that subset reversed, so
+            # deepest-first), then the direct children other than `tee`, then
+            # `tee`.
+            direct_children=$(pgrep -P "$pipeline" || true)
+            is_direct_child() {
+              local needle="$1" child
+              for child in $direct_children; do
+                if [ "$child" = "$needle" ]; then
+                  return 0
+                fi
+              done
+              return 1
+            }
+            deeper_first=""
+            for pid in $kids; do
+              if is_direct_child "$pid"; then
+                continue
+              fi
+              deeper_first="$pid $deeper_first"
+            done
+            direct_others=""
+            tee_pids=""
+            for pid in $direct_children; do
+              comm=$(ps -o comm= -p "$pid" 2>/dev/null || true)
+              case "${comm##*/}" in
+                tee) tee_pids="$tee_pids $pid" ;;
+                *) direct_others="$direct_others $pid" ;;
+              esac
+            done
+            kill_order="$deeper_first $direct_others $tee_pids"
+            for pid in $kill_order; do
               kill -TERM "$pid" 2>/dev/null || true
             done
             teardown_waited=0
@@ -723,7 +756,7 @@ jobs:
               teardown_waited=$((teardown_waited + 1))
             done
             if kill -0 "$pipeline" 2>/dev/null; then
-              for pid in $kids_reversed; do
+              for pid in $kill_order; do
                 kill -KILL "$pid" 2>/dev/null || true
               done
               kill -KILL "$pipeline" 2>/dev/null || true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -630,6 +630,11 @@ jobs:
           stall_budget_seconds=720
           rm -f /tmp/quiet-pass.rc
           (
+            # This subshell's only job is to run the pipeline and record its
+            # status, so errexit is wrong here: on a red run it would abort the
+            # subshell before the `echo` below and discard the very status we
+            # came to capture (a real failure, or swift-safe's 75/76).
+            set +e
             TERM=dumb script -q /dev/null scripts/test.sh --fingerprint --filter '^TBDDaemonLiveTests\.' --no-parallel \
               --xunit-output /tmp/xunit-quiet.xml --experimental-xunit-message-failure \
               < /dev/null 2>&1 | tee /tmp/quiet-pass.log
@@ -662,7 +667,7 @@ jobs:
               echo "=== descendants of the pipeline subshell (pid $pipeline) ==="
             } >> /tmp/quiet-pass-stall-ps.txt
             if [ -n "$kids" ]; then
-              kid_list=$(echo $kids | tr ' ' ',')
+              kid_list=$(printf '%s\n' "$kids" | paste -sd, -)
               ps -ww -o pid,ppid,pgid,stat,%cpu,etime,comm,command -p "$kid_list" >> /tmp/quiet-pass-stall-ps.txt || true
             else
               echo "(none)" >> /tmp/quiet-pass-stall-ps.txt
@@ -697,6 +702,31 @@ jobs:
               for pid in $targets; do
                 kill -KILL "$pid" 2>/dev/null || true
               done
+            fi
+            # Take the pipeline down within a bounded 30 s instead of leaving
+            # `wait` to block until `timeout-minutes` fires — the very outcome
+            # this budget exists to avoid. Killing the sampled targets is not
+            # enough on its own: with no targets found nothing has been killed
+            # at all, and even when the helper dies its parents (`script`,
+            # `swift-test`, `scripts/test.sh`) can outlive it. SIGTERM goes
+            # first so `scripts/test.sh`'s EXIT trap still runs its tmux and
+            # fence cleanup, and the list is walked deepest-first (descendants
+            # were recorded parents-before-children) so `tee` and `script` —
+            # the direct children that carry the log — are the last to go.
+            kids_reversed=$(printf '%s\n' "$kids" | tail -r)
+            for pid in $kids_reversed; do
+              kill -TERM "$pid" 2>/dev/null || true
+            done
+            teardown_waited=0
+            while kill -0 "$pipeline" 2>/dev/null && [ "$teardown_waited" -lt 30 ]; do
+              sleep 1
+              teardown_waited=$((teardown_waited + 1))
+            done
+            if kill -0 "$pipeline" 2>/dev/null; then
+              for pid in $kids_reversed; do
+                kill -KILL "$pid" 2>/dev/null || true
+              done
+              kill -KILL "$pipeline" 2>/dev/null || true
             fi
             wait "$pipeline" || true
             exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -560,13 +560,149 @@ jobs:
         # the step is not quiet at all, defeating its entire purpose. With the
         # flag they run strictly one at a time (24 s). Serial execution on an
         # idle machine IS this step; do not "optimize" the flag away.
+        #
+        # The pty (`script -q /dev/null`) is what makes this step's log arrive
+        # in real time. On the serial path SwiftPM relays the test binary's
+        # output through `print($0, terminator: "")` on its own stdout
+        # (`SwiftTestCommand.runTestProducts`). `scripts/test.sh` runs
+        # `scripts/swift-safe` with no pipe of its own and `swift-safe`
+        # `os.execv`s `swift`, so whatever this step hands the script becomes
+        # SwiftPM's stdout directly. Piping into `tee` makes that stdout a pipe,
+        # and C stdio then fully buffers it in 16 KB blocks (a pipe's
+        # `st_blksize` on macOS). This pass emits roughly 16 KB per minute, so
+        # the log lagged the run by about a minute and was cut at an arbitrary
+        # byte boundary: runs 33797806278 (stalled) and 33787142345 (green) both
+        # stopped at exactly byte 16384, mid-way through the same
+        # `keepsTheReaderForAJobThatIsStillRunning()` line. The last line a
+        # wedged step showed was the buffer boundary, not the hung test. The
+        # fast passes only look real-time because they emit 16 KB a second.
+        # A pty makes SwiftPM's stdout a terminal, so C stdio line-buffers it
+        # and every line lands as it is produced. The pty translates `\n` to
+        # `\r\n`, which is harmless both to the runner log and to the
+        # `grep -oE 'Test run with [0-9]+ tests?'` floor check below. `script`
+        # propagates the child's exit status, `< /dev/null` guarantees nothing
+        # ever waits on the pty for input, and `TERM=dumb` keeps SwiftPM's build
+        # progress line-oriented instead of cursor-rewriting animations.
+        #
+        # The watchdog exists because GitHub's step timeout leaves no evidence.
+        # A stall here is a thread blocked somewhere no Swift Testing time limit
+        # can reach, so the step timeout is the only bound, and being killed by
+        # it records nothing about which test or which frame. So the pipeline
+        # runs in the background and a loop watches it: a healthy pass takes
+        # about 2 minutes (`Test run with 179 tests in 37 suites passed after
+        # 116.847 seconds`), the budget is six times that, and it lands three
+        # minutes short of `timeout-minutes` so sampling and artifact upload
+        # have room.
+        #
+        # On expiry the whole machine's process listing is written first and
+        # unconditionally. The runner is single-tenant, so that listing is both
+        # the record of the fixture's holder, tmux and job processes and the way
+        # we learn what anything is really called. The processes to sample are
+        # then found structurally, by descending the pipeline subshell's own
+        # tree with `pgrep -P`, and never by name: a CI probe of this watchdog
+        # matched `pgrep -x TBDPackageTests` against a live pass and
+        # found nothing, because the swift-testing binary does not run under its
+        # bundle name. A name match fails silently — it samples nothing and
+        # reports success at having collected nothing — whereas a tree walk
+        # finds whatever the pipeline actually spawned. The test binary is
+        # picked out of those descendants by matching `swiftpm-testing`,
+        # `xctest` or `TBDPackageTests` anywhere in the full argv from
+        # `ps -o command=`, not against a name: SwiftPM's
+        # `TestRunner.args(forTestAt:)` runs a swift-testing bundle as
+        # `<toolchain>/swiftpm-testing-helper --test-bundle-path <bundle> …
+        # --testing-library swift-testing` and an XCTest bundle as
+        # `<toolchain>/xctest <bundle>`, so the process executing the tests is
+        # the helper and never carries the bundle's own name — and the kernel
+        # truncates `p_comm` to 15 characters, which would render the helper as
+        # `swiftpm-testing` anyway. Matching unanchored against argv — read
+        # with `-ww` so ps never clips the long toolchain path — sidesteps both
+        # the truncation and the path prefix. When no descendant matches, every
+        # descendant that is not known plumbing
+        # (`script`, the shells, `tee`, `sleep`, python, `swift-safe`) is worth
+        # a stack, and the list is short enough that sampling all of them costs
+        # nothing. `/usr/bin/sample` — part of macOS, present on the runner
+        # image — captures every thread's stack of each target, and only then
+        # are those pids killed, by the pid we captured.
         # timeout-minutes so a wedged tmux test can't eat the job's 6 h default.
         timeout-minutes: 15
         run: |
           set -o pipefail
-          scripts/test.sh --fingerprint --filter '^TBDDaemonLiveTests\.' --no-parallel \
-            --xunit-output /tmp/xunit-quiet.xml --experimental-xunit-message-failure \
-            2>&1 | tee /tmp/quiet-pass.log
+          stall_budget_seconds=720
+          rm -f /tmp/quiet-pass.rc
+          (
+            TERM=dumb script -q /dev/null scripts/test.sh --fingerprint --filter '^TBDDaemonLiveTests\.' --no-parallel \
+              --xunit-output /tmp/xunit-quiet.xml --experimental-xunit-message-failure \
+              < /dev/null 2>&1 | tee /tmp/quiet-pass.log
+            echo "${PIPESTATUS[0]}" > /tmp/quiet-pass.rc
+          ) &
+          pipeline=$!
+          waited=0
+          while kill -0 "$pipeline" 2>/dev/null && [ "$waited" -lt "$stall_budget_seconds" ]; do
+            sleep 5
+            waited=$((waited + 5))
+          done
+          # Collect a process tree by parent pid, so targets are found by
+          # lineage from the pipeline rather than by executable name.
+          descendants() {
+            local parent="$1" child
+            for child in $(pgrep -P "$parent" || true); do
+              echo "$child"
+              descendants "$child"
+            done
+          }
+          if kill -0 "$pipeline" 2>/dev/null; then
+            echo "::error::Quiet pass has been running for ${stall_budget_seconds}s and is being sampled before it is killed."
+            {
+              echo "=== whole-machine process listing at stall (budget ${stall_budget_seconds}s) ==="
+              ps -ww -axo pid,ppid,pgid,stat,%cpu,etime,comm,command || true
+            } > /tmp/quiet-pass-stall-ps.txt
+            kids=$(descendants "$pipeline" || true)
+            {
+              echo
+              echo "=== descendants of the pipeline subshell (pid $pipeline) ==="
+            } >> /tmp/quiet-pass-stall-ps.txt
+            if [ -n "$kids" ]; then
+              kid_list=$(echo $kids | tr ' ' ',')
+              ps -ww -o pid,ppid,pgid,stat,%cpu,etime,comm,command -p "$kid_list" >> /tmp/quiet-pass-stall-ps.txt || true
+            else
+              echo "(none)" >> /tmp/quiet-pass-stall-ps.txt
+            fi
+            targets=""
+            for pid in $kids; do
+              argv=$(ps -ww -o command= -p "$pid" 2>/dev/null || true)
+              case "$argv" in
+                *swiftpm-testing*|*xctest*|*TBDPackageTests*) targets="$targets $pid" ;;
+              esac
+            done
+            if [ -z "$targets" ]; then
+              for pid in $kids; do
+                comm=$(ps -o comm= -p "$pid" 2>/dev/null || true)
+                case "${comm##*/}" in
+                  ""|script|bash|sh|tee|sleep|Python|python3|swift-safe) ;;
+                  *) targets="$targets $pid" ;;
+                esac
+              done
+            fi
+            if [ -z "$targets" ]; then
+              echo "The pipeline has no sampleable descendants — /tmp/quiet-pass-stall-ps.txt carries the whole-machine listing instead."
+            else
+              {
+                echo
+                echo "=== sampled processes ==="
+              } >> /tmp/quiet-pass-stall-ps.txt
+              for pid in $targets; do
+                ps -ww -o pid,comm,command -p "$pid" >> /tmp/quiet-pass-stall-ps.txt || true
+                sample "$pid" 5 -mayDie -file "/tmp/quiet-pass-stall-sample-$pid.txt" || echo "sample $pid failed"
+              done
+              for pid in $targets; do
+                kill -KILL "$pid" 2>/dev/null || true
+              done
+            fi
+            wait "$pipeline" || true
+            exit 1
+          fi
+          wait "$pipeline" || true
+          rc=$(cat /tmp/quiet-pass.rc 2>/dev/null || echo 1)
           # `|| true`: with `set -o pipefail` (and GitHub's `bash -e`), a log
           # with no summary line makes the first `grep` exit 1 and a failing
           # command substitution in an assignment kills the shell — so the
@@ -577,7 +713,23 @@ jobs:
             echo "::error::Quiet pass ran ${count:-no} tests (floor 35) — the --filter regex matched nothing or the target was renamed."
             exit 1
           fi
+          if [ "$rc" -ne 0 ]; then
+            echo "::error::Quiet pass exited $rc"
+            exit "$rc"
+          fi
           echo "Quiet pass executed $count tests."
+
+      # `ignore`, not the `warn` its neighbours use: a green run deliberately
+      # produces no stall files, so absence here is the normal case rather than
+      # a sign that the wiring broke.
+      - name: Upload quiet-pass stall diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: quiet-pass-stall-diagnostics
+          path: /tmp/quiet-pass-stall-*.txt
+          if-no-files-found: ignore
+          retention-days: 14
 
       # `warn`, not `ignore`: an absent file means the metrics wiring broke, and
       # that must be visible rather than silently producing an empty dashboard.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -691,9 +691,15 @@ jobs:
             if [ -z "$targets" ]; then
               # The fallback takes at most four targets, in walk order (parents
               # before children, so SwiftPM's driver processes come before the
-              # compiler processes they spawn): four serial 5 s samples plus
-              # symbolication stay well inside the three-minute margin, while an
-              # uncapped list — every non-plumbing process alive mid-compile —
+              # compiler processes they spawn). Measured on a probe of this path
+              # with the argv match disabled (run 33902144920): three of the
+              # four slots were used — SwiftPM's `swift-test` driver at 87 KB,
+              # `swiftpm-testing-helper` at 796 KB symbolicated, and a fixture
+              # `TBDHolder` that exited mid-sample and was reported as failed —
+              # and the whole expiry path, from the whole-machine ps through the
+              # tree walk, the three serial samples and the SIGTERM sweep to the
+              # step exiting, took 42 s against the 180 s margin. An uncapped
+              # list — every non-plumbing process alive mid-compile — is what
               # could eat that margin and leave the step to be killed by
               # `timeout-minutes` after all. Whatever the cap drops is recorded
               # in the ps file, so the omission is visible in the artifact. The

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -622,7 +622,16 @@ jobs:
         # a stack, and the list is short enough that sampling all of them costs
         # nothing. `/usr/bin/sample` — part of macOS, present on the runner
         # image — captures every thread's stack of each target, and only then
-        # are those pids killed, by the pid we captured.
+        # are those pids killed, by the pid we captured. Five seconds of it, at
+        # sample's 1 ms interval, is what it takes to show a blocked thread's
+        # stack unambiguously: a parked thread looks identical in every sample
+        # so a longer capture buys nothing, while a shorter one risks reading a
+        # scheduler blip as the stall — and symbolicating the ~200 MB debug
+        # helper still finishes well inside the three-minute margin. The 30 s
+        # between SIGTERM and SIGKILL is likewise sized to a job: it is what
+        # `scripts/test.sh`'s EXIT trap gets to run its tmux `kill-server` sweep
+        # and fence checks, generous against the few seconds those take and
+        # still inside that same margin.
         # timeout-minutes so a wedged tmux test can't eat the job's 6 h default.
         timeout-minutes: 15
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -733,12 +733,17 @@ jobs:
                 kill -KILL "$pid" 2>/dev/null || true
               done
             fi
-            # The sampled targets were SIGKILLed the moment their stacks were
-            # captured — they are wedged, and the graceful pass below is for the
-            # plumbing that can still clean up after itself — so drop them from
-            # the list before the order is built. Signalling a pid that is
+            # Re-walk the tree now that sampling is done. The `$kids` above is
+            # the snapshot taken before the samples were captured, and sampling
+            # several targets takes 20 s or more, so anything the pipeline
+            # spawned in the meantime would never be signalled by the sweep
+            # below. The sampled targets are then dropped from that fresh list:
+            # they were SIGKILLed the moment their stacks were captured, since
+            # they are wedged and the graceful pass below is for the plumbing
+            # that can still clean up after itself. Signalling a pid that is
             # already gone is inert at best and reaches whatever reused the
             # number at worst.
+            kids=$(descendants "$pipeline" || true)
             is_target() {
               local needle="$1" candidate
               for candidate in $targets; do

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -689,13 +689,34 @@ jobs:
               esac
             done
             if [ -z "$targets" ]; then
+              # The fallback takes at most four targets, in walk order (parents
+              # before children, so SwiftPM's driver processes come before the
+              # compiler processes they spawn): four serial 5 s samples plus
+              # symbolication stay well inside the three-minute margin, while an
+              # uncapped list — every non-plumbing process alive mid-compile —
+              # could eat that margin and leave the step to be killed by
+              # `timeout-minutes` after all. Whatever the cap drops is recorded
+              # in the ps file, so the omission is visible in the artifact. The
+              # argv-matched path above stays uncapped: it normally yields
+              # exactly one process.
+              fallback_cap=4
+              fallback_taken=0
+              fallback_skipped=0
               for pid in $kids; do
                 comm=$(ps -o comm= -p "$pid" 2>/dev/null || true)
                 case "${comm##*/}" in
-                  ""|script|bash|sh|tee|sleep|Python|python3|swift-safe) ;;
-                  *) targets="$targets $pid" ;;
+                  ""|script|bash|sh|tee|sleep|Python|python3|swift-safe) continue ;;
                 esac
+                if [ "$fallback_taken" -lt "$fallback_cap" ]; then
+                  targets="$targets $pid"
+                  fallback_taken=$((fallback_taken + 1))
+                else
+                  fallback_skipped=$((fallback_skipped + 1))
+                fi
               done
+              if [ "$fallback_skipped" -gt 0 ]; then
+                echo "(fallback sampling capped at $fallback_cap targets; $fallback_skipped further candidates skipped)" >> /tmp/quiet-pass-stall-ps.txt
+              fi
             fi
             if [ -z "$targets" ]; then
               echo "The pipeline has no sampleable descendants — /tmp/quiet-pass-stall-ps.txt carries the whole-machine listing instead."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -681,31 +681,48 @@ jobs:
             else
               echo "(none)" >> /tmp/quiet-pass-stall-ps.txt
             fi
+            # Both selection paths below take at most `sample_target_cap`
+            # processes, in walk order (parents before children, so SwiftPM's
+            # driver comes ahead of the compiler processes it spawns — in a stall
+            # during compilation the driver's own stack is the more informative
+            # one). A match count is not a process count: during compilation the
+            # bundle path `.build/<triple>/debug/TBDPackageTests.build/…` appears
+            # in the argv of every concurrent compiler process, so the argv match
+            # can select a dozen at once, and at ~5 s of serial sampling each
+            # that would eat the 180 s margin and leave the step to be killed by
+            # `timeout-minutes` after all. Whatever a cap drops is recorded in
+            # the ps file, and the whole-machine listing written above still
+            # names every matching process, so nothing disappears from the
+            # artifact — only from the sampling.
+            #
+            # Measured on a probe of the fallback path with the argv match
+            # disabled (run 33902144920): three of the four slots used —
+            # SwiftPM's `swift-test` driver at 87 KB, `swiftpm-testing-helper` at
+            # 796 KB symbolicated, and a fixture `TBDHolder` that exited
+            # mid-sample and was reported as failed — and the whole expiry path,
+            # from the whole-machine ps through the tree walk, the three serial
+            # samples and the SIGTERM sweep to the step exiting, took 42 s.
+            sample_target_cap=4
             targets=""
+            primary_taken=0
+            primary_skipped=0
             for pid in $kids; do
               argv=$(ps -ww -o command= -p "$pid" 2>/dev/null || true)
               case "$argv" in
-                *swiftpm-testing*|*xctest*|*TBDPackageTests*) targets="$targets $pid" ;;
+                *swiftpm-testing*|*xctest*|*TBDPackageTests*) ;;
+                *) continue ;;
               esac
+              if [ "$primary_taken" -lt "$sample_target_cap" ]; then
+                targets="$targets $pid"
+                primary_taken=$((primary_taken + 1))
+              else
+                primary_skipped=$((primary_skipped + 1))
+              fi
             done
+            if [ "$primary_skipped" -gt 0 ]; then
+              echo "(primary sampling capped at $sample_target_cap targets; $primary_skipped further candidates skipped)" >> /tmp/quiet-pass-stall-ps.txt
+            fi
             if [ -z "$targets" ]; then
-              # The fallback takes at most four targets, in walk order (parents
-              # before children, so SwiftPM's driver processes come before the
-              # compiler processes they spawn). Measured on a probe of this path
-              # with the argv match disabled (run 33902144920): three of the
-              # four slots were used — SwiftPM's `swift-test` driver at 87 KB,
-              # `swiftpm-testing-helper` at 796 KB symbolicated, and a fixture
-              # `TBDHolder` that exited mid-sample and was reported as failed —
-              # and the whole expiry path, from the whole-machine ps through the
-              # tree walk, the three serial samples and the SIGTERM sweep to the
-              # step exiting, took 42 s against the 180 s margin. An uncapped
-              # list — every non-plumbing process alive mid-compile — is what
-              # could eat that margin and leave the step to be killed by
-              # `timeout-minutes` after all. Whatever the cap drops is recorded
-              # in the ps file, so the omission is visible in the artifact. The
-              # argv-matched path above stays uncapped: it normally yields
-              # exactly one process.
-              fallback_cap=4
               fallback_taken=0
               fallback_skipped=0
               for pid in $kids; do
@@ -713,7 +730,7 @@ jobs:
                 case "${comm##*/}" in
                   ""|script|bash|sh|tee|sleep|Python|python3|swift-safe) continue ;;
                 esac
-                if [ "$fallback_taken" -lt "$fallback_cap" ]; then
+                if [ "$fallback_taken" -lt "$sample_target_cap" ]; then
                   targets="$targets $pid"
                   fallback_taken=$((fallback_taken + 1))
                 else
@@ -721,7 +738,7 @@ jobs:
                 fi
               done
               if [ "$fallback_skipped" -gt 0 ]; then
-                echo "(fallback sampling capped at $fallback_cap targets; $fallback_skipped further candidates skipped)" >> /tmp/quiet-pass-stall-ps.txt
+                echo "(fallback sampling capped at $sample_target_cap targets; $fallback_skipped further candidates skipped)" >> /tmp/quiet-pass-stall-ps.txt
               fi
             fi
             if [ -z "$targets" ]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -798,6 +798,17 @@ jobs:
           fi
           wait "$pipeline" || true
           rc=$(cat /tmp/quiet-pass.rc 2>/dev/null || echo 1)
+          # An unreadable status fails closed, the same way the floor below
+          # guards its own empty `count`: the `|| echo 1` covers only a missing
+          # file, and a writer that died mid-write leaves an empty or
+          # non-numeric one, on which `[ "$rc" -ne 0 ]` errors — and an erroring
+          # `if` condition reads as false, letting a failed run walk on to the
+          # floor check as though it had succeeded.
+          case "$rc" in
+            ''|*[!0-9]*)
+              echo "::error::Quiet pass left no readable exit status (got '$rc'); treating the run as failed."
+              exit 1 ;;
+          esac
           # The status comes first: it is the pipeline's own verdict and has to
           # reach the job untouched — a build error, an early crash, or
           # swift-safe's 75 and 76 all log fewer than 35 tests, and reporting

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -775,6 +775,16 @@ jobs:
           fi
           wait "$pipeline" || true
           rc=$(cat /tmp/quiet-pass.rc 2>/dev/null || echo 1)
+          # The status comes first: it is the pipeline's own verdict and has to
+          # reach the job untouched — a build error, an early crash, or
+          # swift-safe's 75 and 76 all log fewer than 35 tests, and reporting
+          # them through the floor's message would both misdiagnose them and
+          # flatten them to a generic 1. The floor only means anything for a run
+          # that claims to have succeeded.
+          if [ "$rc" -ne 0 ]; then
+            echo "::error::Quiet pass exited $rc"
+            exit "$rc"
+          fi
           # `|| true`: with `set -o pipefail` (and GitHub's `bash -e`), a log
           # with no summary line makes the first `grep` exit 1 and a failing
           # command substitution in an assignment kills the shell — so the
@@ -784,10 +794,6 @@ jobs:
           if [ -z "$count" ] || [ "$count" -lt 35 ]; then
             echo "::error::Quiet pass ran ${count:-no} tests (floor 35) — the --filter regex matched nothing or the target was renamed."
             exit 1
-          fi
-          if [ "$rc" -ne 0 ]; then
-            echo "::error::Quiet pass exited $rc"
-            exit "$rc"
           fi
           echo "Quiet pass executed $count tests."
 

--- a/docs/specs/2026-09-04-quiet-pass-stall-watchdog-design.md
+++ b/docs/specs/2026-09-04-quiet-pass-stall-watchdog-design.md
@@ -105,9 +105,19 @@ unanchored against argv sidesteps both the truncation and the toolchain path.
 
 When no descendant matches, every descendant that is not known plumbing — the
 pty wrapper, the shells, `tee`, `sleep`, python, `swift-safe` — is worth a
-stack, capped at four in walk order so parents come before the children they
-spawned. The count the cap skips is written into the ps file, so the omission is
-visible in the artifact rather than silent.
+stack.
+
+Both paths take at most four processes, in walk order so parents come before the
+children they spawned. A match count is not a process count: while the package is
+compiling, the bundle path `.build/<triple>/debug/TBDPackageTests.build/…`
+appears in the argv of every concurrent compiler process, so the argv match can
+select a dozen at once, and at five seconds of serial sampling each that would
+consume the margin the budget leaves. Walk order decides which four survive the
+cap, which puts SwiftPM's driver ahead of the compiler processes it spawned — in
+a stall during compilation the driver's stack is the more informative one. The
+count each cap skips is written into the ps file, and the whole-machine listing
+still names every matching process, so a capped candidate disappears from the
+sampling and not from the artifact.
 
 Each target gets `sample <pid> 5 -mayDie`, written to its own file, and is then
 SIGKILLed immediately: it is wedged, and it has already given up everything it
@@ -165,7 +175,7 @@ files, so absence is the normal case rather than evidence of broken wiring.
 | margin left after the budget | 180 s | 42 s used at worst measurement |
 | `sample` duration per target | 5 s | ~5000 stacks at 1 ms |
 | SIGTERM → SIGKILL grace | 30 s | cleanup takes a few seconds |
-| fallback target cap | 4 | 3 used in the measured probe |
+| sample-target cap (both paths) | 4 | 3 used in the measured probe |
 
 The healthy pass reports `Test run with 179 tests in 37 suites passed after
 116.847 seconds`, so the budget is six times a normal run and still three

--- a/docs/specs/2026-09-04-quiet-pass-stall-watchdog-design.md
+++ b/docs/specs/2026-09-04-quiet-pass-stall-watchdog-design.md
@@ -1,0 +1,267 @@
+# Quiet-pass stall watchdog: making a wedged CI test run name its test
+
+The `test` workflow runs the tier-3 live suites in their own step — serially,
+on an otherwise idle runner, because those suites drive real tmux servers and
+real child processes and contend with each other if run in parallel. That step
+sometimes stalls. GitHub kills it at its 15-minute `timeout-minutes`, and what
+lands in the run log is a truncated list of test names, no failing assertion,
+and nothing that identifies where the run stopped. Each occurrence costs fifteen
+minutes of a rationed macOS runner and reddens a pull request that has nothing
+to do with the defect.
+
+Three stalls are on record. Two sit on trees that predate the
+`Process.waitUntilExit()` cross-thread hang fixed in #789 and are consistent
+with it. The third is on a tree that carries that fix, so it is a different
+site, and no one can say which — the evidence to locate it was never captured.
+
+This design does not fix the stall. It makes the next one hand over the stacks
+of every thread in the process running the tests, plus a picture of the machine
+around it, and fail the step before the platform timeout can destroy the
+evidence.
+
+## What the log actually shows
+
+The truncated log is not truncated where the run stopped. On the serial
+(`--no-parallel`) path SwiftPM relays the test binary's output through
+`print(_:terminator:)` on its own stdout. In CI that stdout is a pipe into
+`tee`, and C stdio fully buffers a pipe in blocks the size of the pipe's
+`st_blksize` — 16 KB on macOS. The quiet pass emits roughly 16 KB of test lines
+per minute, so the log lags the run by about a minute and a wedged step shows
+whatever line the last complete block happened to end on.
+
+Two runs prove it rather than suggest it. A stalled run (33797806278, attempt 2)
+and a green run of the main branch (33787142345) both cut at exactly byte 16384,
+mid-way through the same test name, about 63 seconds in. Every one of the 227
+test lines in the stalled log carries a single runner timestamp — they were all
+written to the log at the same instant, when the block flushed. In the green run
+the second block arrives about 50 seconds later, after a particular teardown
+suite; in the stalled run it never arrives. That bounds the stall to the ~26
+suites between the two flush points, and no tighter.
+
+The method generalises and is worth keeping: to find what a buffered CI log can
+and cannot tell you, take a green run of the same step, accumulate the byte
+lengths of its lines, and mark the 16 KB boundaries. Every boundary is a point
+at which a stalled run's log would stop. A line adjacent to one of those
+boundaries is evidence of nothing; the natural reading — "the last line names
+the hung test" — is wrong by construction.
+
+## Requirements
+
+- **The log streams as the run produces it.** A stalled step's last line must
+  mean something.
+- **A stall fails the step before the platform timeout**, leaving every thread's
+  stack of the process executing the tests and a listing of the processes around
+  it.
+- **A green run is unchanged** — same verdict, same output, no new failure mode.
+- **A red run's exit status survives untouched.** `scripts/swift-safe` returns 75
+  for an abandoned queue wait and 76 for "verify remotely"; conflating them, or
+  flattening either to 1, is a silent wrong answer.
+- **Any doubt fails closed.** An unreadable status, an unattributable stall, a
+  sampling failure — none of them may pass for success.
+- **Nothing is killed by name.** Signals go to pids the step itself observed.
+
+## The mechanism
+
+### Streaming the log
+
+The step hands `scripts/test.sh` a pty: `TERM=dumb script -q /dev/null …
+< /dev/null`. C stdio line-buffers a terminal, so each line lands as it is
+produced. Nothing between the pty and SwiftPM re-pipes the stream —
+`scripts/test.sh` invokes `scripts/swift-safe` without a pipe of its own, and
+`swift-safe` `exec`s into SwiftPM — so the pty the step creates is SwiftPM's
+stdout.
+
+Each part earns its place. `script` propagates the child's exit status, so the
+verdict still reaches the step. `< /dev/null` guarantees nothing ever blocks
+waiting for input on the pty. `TERM=dumb` keeps SwiftPM's progress output
+line-oriented instead of cursor-rewriting animations, which would be unreadable
+in a log. The pty translates `\n` to `\r\n`, which affects neither the runner log
+nor the step's own `grep` over the summary line.
+
+### Watching the pipeline
+
+The pipeline runs in a background subshell that begins with `set +e` — its only
+job is to run the pipeline and record `PIPESTATUS[0]` to a status file, and
+errexit would abort it before the `echo` on exactly the runs whose status
+matters most. The step's foreground shell polls the subshell with `kill -0` in
+5-second steps up to `stall_budget_seconds`.
+
+### Finding what to sample
+
+On expiry the step writes a whole-machine `ps` listing first and
+unconditionally. The runner is single-tenant, so that listing is both the record
+of the fixture's holder, tmux and job processes and the way a reader learns what
+anything is really called.
+
+Targets are then found by lineage: a recursive walk of `pgrep -P` from the
+subshell's own pid. Among those descendants, the process executing the tests is
+the one whose full argv (`ps -ww -o command=`) contains `swiftpm-testing`,
+`xctest` or `TBDPackageTests`. SwiftPM runs a swift-testing bundle as
+`<toolchain>/swiftpm-testing-helper --test-bundle-path <bundle> … --testing-library
+swift-testing` and an XCTest bundle as `<toolchain>/xctest <bundle>`, so the
+process executing the tests never carries the bundle's own name, and the
+kernel's 15-character `p_comm` would truncate the helper regardless. Matching
+unanchored against argv sidesteps both the truncation and the toolchain path.
+
+When no descendant matches, every descendant that is not known plumbing — the
+pty wrapper, the shells, `tee`, `sleep`, python, `swift-safe` — is worth a
+stack, capped at four in walk order so parents come before the children they
+spawned. The count the cap skips is written into the ps file, so the omission is
+visible in the artifact rather than silent.
+
+Each target gets `sample <pid> 5 -mayDie`, written to its own file, and is then
+SIGKILLed immediately: it is wedged, and it has already given up everything it
+has to give.
+
+### Taking the pipeline down
+
+The remaining processes get a graceful pass, because `scripts/test.sh` has an
+EXIT trap that sweeps tmux servers and checks its filesystem fence, and that
+cleanup is worth running. The order is built explicitly and rebuilt before each
+sweep from a fresh walk: everything below the direct children first (that subset
+reversed, so deepest-first), then the direct children other than `tee`, then
+`tee`.
+
+The ordering is not cosmetic. `tee` is a direct child of the subshell and owns
+the far end of the log pipe, so anything still writing when `tee` dies writes to
+a closed pipe — and the EXIT trap's output is precisely what the log wants.
+Reversing the walk would achieve the opposite of the intent: the walk is
+preorder, so the sibling `tee` is last in it and first in any reversal.
+
+SIGTERM goes to that order, then a 30-second grace, then — if the subshell is
+still alive — a fresh walk, a rebuilt order, SIGKILL to each pid, and SIGKILL to
+the subshell itself. Both sweeps rebuild rather than reuse, because sampling and
+the grace window are each long enough for the tree to change underneath a
+snapshot; the EXIT trap's own cleanup spawns processes during exactly that
+window. The step then waits for the subshell and exits 1.
+
+### The verdict path
+
+On a run that completes, the recorded status is read and validated as a
+non-empty run of digits before it is compared — a writer that died mid-write
+leaves an empty or non-numeric file, and an erroring `if` condition reads as
+false, which would let a failed run walk on as though it had succeeded. Anything
+unreadable exits 1 with its own message.
+
+The status check comes before the floor check on `Test run with N tests`. A
+build error, an early crash, or swift-safe's 75 and 76 all log fewer than 35
+tests; reporting them through the floor's message would both misdiagnose them
+and flatten them to a generic 1. The floor keeps its own job — catching a run
+that claims success while having executed nothing — for runs that claim success.
+
+### The artifact
+
+An `if: always()` step uploads `/tmp/quiet-pass-stall-*.txt` as
+`quiet-pass-stall-diagnostics` with `if-no-files-found: ignore`. `ignore` rather
+than the `warn` its neighbours use: a green run deliberately produces no stall
+files, so absence is the normal case rather than evidence of broken wiring.
+
+## Numbers, and what each rests on
+
+| Constant | Value | Basis |
+| --- | --- | --- |
+| `stall_budget_seconds` | 720 s | 6 × the 117 s healthy pass |
+| step `timeout-minutes` | 15 min | platform bound |
+| margin left after the budget | 180 s | 42 s used at worst measurement |
+| `sample` duration per target | 5 s | ~5000 stacks at 1 ms |
+| SIGTERM → SIGKILL grace | 30 s | cleanup takes a few seconds |
+| fallback target cap | 4 | 3 used in the measured probe |
+
+The healthy pass reports `Test run with 179 tests in 37 suites passed after
+116.847 seconds`, so the budget is six times a normal run and still three
+minutes short of the step timeout.
+
+Five seconds of sampling is what it takes to show a blocked thread
+unambiguously: a parked thread looks identical in every sample, so more buys
+nothing, while less risks reading a scheduler blip as the stall.
+
+The margin is measured, not assumed. A probe with the argv match disabled, so
+the fallback path ran (run 33902144920), spent 42 seconds on the entire expiry
+path — whole-machine listing, tree walk, three targets sampled serially
+including a 796 KB symbolicated testing helper, SIGTERM sweep, exit — against
+the 180 seconds available. Two earlier probes at a shortened budget established
+the other two facts the design rests on: that the pty makes every test line
+arrive with its own runner timestamp (33803510307), and that a name match finds
+nothing against a live pass, which is what moved target selection to lineage and
+argv (33803510307, then 33805317227 sampling the helper by pid and uploading the
+artifact).
+
+## Scope
+
+Only the quiet pass gets the pty and the watchdog. The two fast passes run the
+parallel, in-process suites; they have never stalled, and they emit output fast
+enough that buffering is invisible. Every stall on record is in the serial live
+target. A fast-pass stall would be a different defect and earns its own
+instrumentation on its own evidence.
+
+## Who reclaims the orphans
+
+Nothing here creates a durable resource, so no reconciler is needed. The files
+are under `/tmp` on an ephemeral single-tenant runner that is destroyed when the
+job ends, and the only processes signalled are descendants of the step's own
+background subshell, enumerated seconds earlier. No resource can outlive the job
+that made it.
+
+## Assumptions, and how they fail
+
+- **`/usr/bin/sample` is on the runner image.** It ships with macOS and is
+  confirmed present by the probe runs. If it vanished, each target would log
+  `sample <pid> failed` and the ps listings would still upload.
+- **SwiftPM keeps executing tests in a descendant of its test command.** If it
+  ever daemonised the runner, the tree walk would find nothing sampleable, the
+  step would say so, and the whole-machine listing would still show where the
+  process went.
+- **`script(1)` propagates the child's non-zero exit status on macOS.** Verified
+  locally (`script -q /dev/null /bin/sh -c 'exit 3'` returns 3) and in Apple's
+  `shell_cmds` source; the success direction is confirmed by a green CI run. The
+  failure direction can be confirmed on demand with a throwaway commit that makes
+  `scripts/test.sh` exit non-zero. If it ever stopped holding, a red run would
+  surface as an unreadable or zero status — and the validation above fails
+  closed, so the failure mode is a spurious red, not a false green.
+
+## Reading a stall report
+
+Download the `quiet-pass-stall-diagnostics` artifact from the failed run.
+`quiet-pass-stall-sample-<pid>.txt` carries every thread's stack of the process
+that was executing tests; the parked thread's frames name the file and line the
+run is blocked in. `quiet-pass-stall-ps.txt` carries the machine listing, the
+pipeline's descendants and the sampled processes, which is where the fixture's
+holder, tmux and job processes appear and where the cap's skipped-candidate line
+would be. The step log names the budget it waited and the pids it sampled.
+
+## Rejected alternatives
+
+- **Matching processes by name.** `pgrep -x` on the bundle name found nothing
+  against a live, wedged pass, because the tests execute inside
+  `swiftpm-testing-helper`. A name match fails silently: it samples nothing while
+  reporting success at having collected nothing. Lineage cannot fail that way.
+- **Anchoring the argv match to an exact toolchain path.** The path is a
+  toolchain detail that changes with the runner image. An unanchored match
+  against argv survives both that and `p_comm` truncation.
+- **Unbuffering by other means.** macOS ships no `stdbuf`, and SwiftPM exposes no
+  flush knob. A pty is the mechanism the platform actually offers.
+- **Lowering `timeout-minutes`.** It would end the stall sooner and record
+  exactly as much as it does today, which is nothing.
+- **Changing the eight blocking `waitpid(…, 0)` sites in the fixtures.** The
+  leading hypothesis was the holder fixture's teardown, and it does not hold on
+  the merits: the holder detaches with its own `setsid()`, keeps no controlling
+  terminal, ignores only `SIGHUP` and `SIGPIPE`, and nothing in the test process
+  ignores or waits on `SIGCHLD` for it, so a killed holder becomes a zombie
+  promptly and the wait returns. Raw `waitpid` also carries none of the
+  per-thread state that makes `waitUntilExit()` hazardous. Converting those sites
+  without a stack would be a guess wearing the shape of the previous fix.
+- **Re-verifying process identity before signalling.** `AgentReaper` compares
+  start time and executable against a persisted row because it acts on processes
+  recorded minutes or hours earlier, on a machine shared with a live fleet. This
+  watchdog enumerates live descendants of its own subshell seconds before it
+  signals them, on a single-tenant runner. The check would guard against nothing
+  and could only add a way to skip a real target.
+- **A default-off feature flag.** The flag convention exists for behavior that
+  acts without a gesture on user sessions or persisted state. This acts only on
+  the processes of one CI step's own pipeline, in a run that has already failed,
+  on a machine that is discarded minutes later. A flag would mean the
+  instrumentation is absent on the runs that need it.
+- **Excluding SwiftPM's driver from the fallback.** It is included deliberately:
+  when no descendant looks like a test runner, the driver's own stack is evidence
+  about what it was waiting on, which is exactly the question a stall with no
+  identifiable test process poses.


### PR DESCRIPTION
## Summary

The tier-3 quiet pass has now stalled three times in two days, each time killed by GitHub's 15-minute step timeout with no failing assertion and no useful log. Two of those stalls were on trees that predate the `Process.waitUntilExit()` fix (#789) and are consistent with it. The third (run 33797806278) was on a tree that carries that fix, so it is a different site — and the log cannot say which, because the step's output is not what it looks like.

This PR does not fix the stall. It makes the next occurrence name its test and hand over a stack, which is the evidence the last two investigations had to work without.

## Why this shape

**The log is cut at a buffer boundary, not at the hung test.** On the serial (`--no-parallel`) path SwiftPM relays the test binary's output through `print` on its own stdout. In CI that stdout is a pipe into `tee`, so C stdio flushes it in 16 KB blocks. The quiet pass emits roughly 16 KB per minute, so the log lags the run by about a minute and a wedged step shows whatever line the last full block ended on. The stalled run and a green run of `main` (33787142345) both cut at exactly byte 16384, mid-way through the same `keepsTheReaderForAJobThatIsStillRunning()` line, about 63 seconds into the run — every one of the 227 test lines in the stalled log carries a single runner timestamp. That test was about to be blamed; it is simply where the buffer filled. In a green run the second block flushes ~50 seconds later, after the `TmuxControlSupervisor` teardown suite; it never came in the stalled run, which bounds the stall to the ~26 suites between those two points and no tighter. Handing `scripts/test.sh` a pty (`script -q /dev/null`) makes SwiftPM's stdout a terminal, and C stdio line-buffers a terminal. Nothing in between re-pipes it: `test.sh` runs `swift-safe` without a pipe and `swift-safe` `exec`s `swift`.

**A step timeout records nothing.** Whatever the site is, it is a thread blocked where no Swift Testing time limit reaches, and the only bound is `timeout-minutes`. So the pipeline now runs in the background under a watchdog: at 720 s (six times a healthy 2-minute pass, three minutes short of the step timeout) it writes a whole-machine process listing (so the fixture's holder, tmux and job processes are on record), walks the pipeline's own process tree by parent pid, runs `sample` on the process executing the tests, kills it by the pid it captured, and exits 1. Targets are found by lineage, not by name: SwiftPM runs swift-testing inside its `swiftpm-testing-helper`, so the bundle name `TBDPackageTests` never appears as a process name, and the first probe's `pgrep -x` on it silently found nothing. A new `if: always()` step uploads those files as the `quiet-pass-stall-diagnostics` artifact.

**What was checked and not changed.** The blocking `waitpid(holderPID, 0)` in `HolderProcessFixture.tearDown()` was the leading hypothesis. It does not hold on the merits: the holder detaches with its own `setsid()`, keeps no pty slave and no controlling terminal, ignores only `SIGHUP`/`SIGPIPE`, and nothing else in the test process waits on or ignores `SIGCHLD` for it — so a SIGKILLed holder becomes a zombie promptly and the wait returns. Raw `waitpid` also has none of the per-thread state that makes `waitUntilExit()` hazardous. The eight `waitpid(…, 0)` sites are left alone because there is no evidence against them; converting them without a stack would be a guess wearing the shape of the previous fix. Alternatives rejected: running the quiet pass unbuffered by other means (no `stdbuf` on macOS; SwiftPM has no flush knob), and lowering the step timeout (would still record nothing).

**Spec.** [`docs/specs/2026-09-04-quiet-pass-stall-watchdog-design.md`](docs/specs/2026-09-04-quiet-pass-stall-watchdog-design.md) records the requirements, the design as built, every threshold with the measurement behind it, the rejected alternatives, the reconciler answer, and the assumptions with how to check them. It is a transcription of decisions that were made on evidence during this PR, not a new design round: the numbers were measured on CI probes, and the alternatives were rejected on the record in this thread.

## What this PR does

- `.github/workflows/test.yml`, quiet-pass step: wraps the run in `TERM=dumb script -q /dev/null … < /dev/null` so the log streams line by line; runs the pipeline in a background subshell, captures its exit status through `PIPESTATUS` to a file, and watches it with a 720 s budget (`stall_budget_seconds`); on expiry dumps `ps` for the machine and for the pipeline's descendants, samples the descendants whose argv names `swiftpm-testing`, `xctest` or `TBDPackageTests` (falling back to every non-plumbing descendant), kills those pids, and fails the step. A non-zero pipeline status is checked first and propagated untouched (so swift-safe's 75/76 and a build failure keep their real status), then the unchanged floor check on `Test run with N tests` catches a green run of nothing.
- Scope: only the quiet pass gets the pty and the watchdog. The two fast passes are deliberately left alone: they run the parallel, in-process suites that have never stalled, they emit output fast enough that buffering is invisible, and every stall on record is in the serial live target. A fast-pass stall would be a different defect and would get its own instrumentation on its own evidence.
- New step `Upload quiet-pass stall diagnostics` (`if: always()`, `if-no-files-found: ignore`, 14-day retention) for `/tmp/quiet-pass-stall-*.txt`.

## Assumptions

- `/usr/bin/sample` is present on the `macos-26-arm64` runner image (it ships with macOS; verified on the probe run below).
- SwiftPM keeps executing tests in a descendant of the `swift test` process (today `swiftpm-testing-helper`); if it ever daemonised the test runner, the tree walk would miss it, the step would log that nothing was sampleable, and the whole-machine `ps` would still show where it went.
- `script(1)` propagates the child's exit status on macOS (verified locally: `script -q /dev/null /bin/sh -c 'exit 3'` returns 3).

## Evidence & verification

- **Forensics**: stalled run 33797806278 (attempt 2) versus green run 33787142345, both quiet-pass logs: identical 16 KB cut at the same line; one timestamp for all 227 lines in the stalled log; second flush absent. Runs 33709083585 (both attempts) stalled with zero test output on trees without #789.
- **Watchdog mutation check on CI**: a throwaway commit set the budget to 60 s and dispatched the workflow on this branch (runs 33803510307 and 33805317227). The first probe proved the pty: every test line arrived with its own runner timestamp instead of 227 lines sharing one. It also proved a name match is worthless — `pgrep -x TBDPackageTests` found nothing against a live pass, because SwiftPM runs swift-testing inside `swiftpm-testing-helper` — so the watchdog was reworked to walk the pipeline's own process tree. The second probe fired at 60 s, dumped the machine and the pipeline's descendants, sampled the helper (271 KB, fully symbolicated: frames like `PeerLinkSupervisorTests.swift:1473`), killed it by pid, and the `quiet-pass-stall-diagnostics` artifact was uploaded. The probe commit was then dropped; this PR carries only the 720 s budget. A third probe on a separate throwaway branch (run 33902144920) disabled the argv match so the fallback path ran at a 60 s budget: the whole expiry path — machine listing, tree walk, three fallback targets sampled serially (SwiftPM's driver, the 796 KB symbolicated testing helper, and a fixture holder that exited mid-sample), SIGTERM sweep, exit — took 42 s from watchdog fire to step end, against the 180 s margin before `timeout-minutes`.
- **Green check**: this PR's own CI run (33807574872) on the final head: the quiet pass passed with `Test run with 179 tests in 37 suites`, its lines arrived with individual timestamps, the `quiet-pass-stall-diagnostics` step uploaded nothing, and the floor and exit-status checks ran as before.

https://claude.ai/code/session_012G9Lm4gpTe5JJ4VGdWZN2m
[live-test-teardown-hang](https://cheapsteak.github.io/tbd/open/?worktree=D337E240-13CC-47FB-BB99-08C09FB664C1)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the quiet live-test pass by detecting stalls and enforcing a 720-second timeout.
  * Reports test failures based on process exit status before applying test-count checks.
  * Preserves retry metrics and test result artifacts when failures occur.

* **Diagnostics**
  * Captures process and stack information when a test pass times out.
  * Cleans up stalled test processes and uploads diagnostic artifacts.

* **Documentation**
  * Added documentation describing watchdog behavior and timeout handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->