### PR TITLE
Fix: A relative link in a rendered markdown file does nothing when you click it

### DIFF
--- a/Sources/TBDApp/Panes/CodeViewerPaneView.swift
+++ b/Sources/TBDApp/Panes/CodeViewerPaneView.swift
@@ -205,9 +205,12 @@ private extension Color {
 }
 
 /// Files that have a rich rendered view in addition to raw source code.
+///
+/// Reads the same set the navigation policy uses to decide that a link should
+/// navigate this pane, so the pane can always render what a click routes here.
 private func isRenderableFile(_ path: String) -> Bool {
     let ext = (path as NSString).pathExtension.lowercased()
-    return ["md", "markdown"].contains(ext)
+    return MarkdownWebViewConfiguration.renderableExtensions.contains(ext)
 }
 
 /// Decides whether a rendered markdown document owns the whole code-viewer
@@ -285,7 +288,8 @@ struct CodeViewerPaneView: View {
                     filePath: selectedFiles[0],
                     worktreePath: worktreePath,
                     showSourceCode: showSourceCode,
-                    useWebViewMarkdown: true
+                    useWebViewMarkdown: true,
+                    onOpenFile: { openLinkedFile($0) }
                 )
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
@@ -308,7 +312,8 @@ struct CodeViewerPaneView: View {
                                         filePath: filePath,
                                         worktreePath: worktreePath,
                                         showSourceCode: showSourceCode,
-                                        useWebViewMarkdown: false
+                                        useWebViewMarkdown: false,
+                                        onOpenFile: { openLinkedFile($0) }
                                     )
                                 }
                             }
@@ -330,6 +335,20 @@ struct CodeViewerPaneView: View {
                 selectedFiles = [newPath]
             }
         }
+    }
+
+    /// A relative link in a rendered markdown document that points at another
+    /// markdown file navigates this pane, the way picking the file in the
+    /// sidebar would.
+    ///
+    /// `onChange(of: path)` fires only when the OUTER path changes, so a
+    /// locally navigated selection survives until the pane is pointed
+    /// somewhere else. The existence check is the guard against selecting a
+    /// path that vanished between render and click.
+    private func openLinkedFile(_ url: URL) {
+        let target = url.standardizedFileURL.path
+        guard FileManager.default.fileExists(atPath: target) else { return }
+        selectedFiles = [target]
     }
 
     private var emptyState: some View {
@@ -396,6 +415,8 @@ private struct FilePreviewView: View {
     /// Decided by the pane, not read from `UserDefaults` here: only the pane
     /// knows whether this preview owns the full height the webview needs.
     let useWebViewMarkdown: Bool
+    /// Where a repo-local markdown link goes. Only the webview path raises it.
+    let onOpenFile: (URL) -> Void
 
     @State private var revision: Int = 0
     private let watcher = FileWatcher()
@@ -407,7 +428,8 @@ private struct FilePreviewView: View {
                     filePath: filePath,
                     worktreePath: worktreePath,
                     revision: revision,
-                    useWebView: useWebViewMarkdown
+                    useWebView: useWebViewMarkdown,
+                    onOpenFile: onOpenFile
                 )
             } else if isImageFile(filePath) {
                 ImagePreviewView(filePath: filePath, revision: revision)
@@ -439,6 +461,7 @@ private struct RenderedContentView: View {
     let worktreePath: String
     let revision: Int
     let useWebView: Bool
+    let onOpenFile: (URL) -> Void
     @State private var content: String?
     @State private var loadError: String?
     @State private var renderedHTML: String?
@@ -478,7 +501,7 @@ private struct RenderedContentView: View {
                     .padding(12)
             } else if useWebView {
                 if let renderedHTML {
-                    MarkdownWebView(html: renderedHTML)
+                    MarkdownWebView(html: renderedHTML, onOpenFile: onOpenFile)
                 } else {
                     ProgressView().controlSize(.small)
                 }

--- a/Sources/TBDApp/Panes/CodeViewerPaneView.swift
+++ b/Sources/TBDApp/Panes/CodeViewerPaneView.swift
@@ -241,6 +241,12 @@ struct CodeViewerPaneView: View {
     let path: String
     let worktreePath: String
     let showSourceCode: Bool
+    /// Points the ENCLOSING pane at another file. The pane's identity is its
+    /// `PaneContent.codeViewer(id:path:)`, so a navigation that only touched
+    /// this view's `selectedFiles` would leave the header title, the header
+    /// context menu, the slot's history and the persisted layout on the
+    /// previous document. Raised by `openLinkedFile`.
+    let onNavigate: (String) -> Void
 
     @State private var selectedFiles: [String] = []
     @AppStorage("codeViewer.showSidebar") private var showSidebar = false
@@ -341,14 +347,17 @@ struct CodeViewerPaneView: View {
     /// markdown file navigates this pane, the way picking the file in the
     /// sidebar would.
     ///
-    /// `onChange(of: path)` fires only when the OUTER path changes, so a
-    /// locally navigated selection survives until the pane is pointed
-    /// somewhere else. The existence check is the guard against selecting a
-    /// path that vanished between render and click.
+    /// The navigation goes UP rather than into `selectedFiles`: the enclosing
+    /// pane owns the path, and `onChange(of: path)` brings the selection along
+    /// once the new content arrives.
+    ///
+    /// `MarkdownLinkNavigation` re-judges worktree containment here, where the
+    /// root is known — the navigation policy is pure and cannot — and rejects
+    /// a path that vanished between render and click.
     private func openLinkedFile(_ url: URL) {
-        let target = url.standardizedFileURL.path
-        guard FileManager.default.fileExists(atPath: target) else { return }
-        selectedFiles = [target]
+        guard let target = MarkdownLinkNavigation.target(
+            for: url, worktreeRoot: worktreePath) else { return }
+        onNavigate(target)
     }
 
     private var emptyState: some View {

--- a/Sources/TBDApp/Panes/Markdown/MarkdownDocumentBuilder.swift
+++ b/Sources/TBDApp/Panes/Markdown/MarkdownDocumentBuilder.swift
@@ -10,7 +10,9 @@ enum MarkdownDocumentBuilder {
     /// - Parameters:
     ///   - documentDirectory: what relative image `src` and link `href` values
     ///     resolve against.
-    ///   - worktreeRoot: the containment boundary for those resolved paths.
+    ///   - worktreeRoot: the containment boundary for those resolved paths,
+    ///     and what a root-relative `href` (`/docs/setup.md`) resolves
+    ///     against.
     static func build(
         markdown: String, documentDirectory: URL, worktreeRoot: URL, css: String
     ) -> String? {

--- a/Sources/TBDApp/Panes/Markdown/MarkdownDocumentBuilder.swift
+++ b/Sources/TBDApp/Panes/Markdown/MarkdownDocumentBuilder.swift
@@ -8,16 +8,24 @@ import Foundation
 enum MarkdownDocumentBuilder {
 
     /// - Parameters:
-    ///   - documentDirectory: what relative image `src` values resolve against.
+    ///   - documentDirectory: what relative image `src` and link `href` values
+    ///     resolve against.
     ///   - worktreeRoot: the containment boundary for those resolved paths.
     static func build(
         markdown: String, documentDirectory: URL, worktreeRoot: URL, css: String
     ) -> String? {
         guard let body = MarkdownHTMLRenderer.renderBody(markdown) else { return nil }
+        // Links first, images second: the inliner's output carries multi-megabyte
+        // base64 `data:` URIs, and there is no reason to run a second regex pass
+        // over them.
+        let resolver = MarkdownLinkResolver(
+            documentDirectory: documentDirectory, worktreeRoot: worktreeRoot
+        )
+        let linked = resolver.resolve(html: body)
         var inliner = MarkdownImageInliner(
             documentDirectory: documentDirectory, worktreeRoot: worktreeRoot
         )
-        let inlined = inliner.inline(html: body)
+        let inlined = inliner.inline(html: linked)
         return """
         <!DOCTYPE html>
         <html>

--- a/Sources/TBDApp/Panes/Markdown/MarkdownLinkNavigation.swift
+++ b/Sources/TBDApp/Panes/Markdown/MarkdownLinkNavigation.swift
@@ -1,0 +1,80 @@
+import Foundation
+import os
+
+private let logger = Logger(subsystem: "com.tbd.app", category: "markdown")
+
+/// The containment rule every markdown surface applies before it turns an href
+/// into a path on disk.
+///
+/// Symlinks are resolved on BOTH sides. Resolving only the candidate breaks
+/// every repo that lives under a symlinked path; resolving neither lets a
+/// symlink inside the repo point anywhere on disk. The trailing separator on
+/// the root is what stops `/repo-secrets` passing as "inside `/repo`".
+enum MarkdownWorktreeContainment {
+
+    /// The form the rule compares against. Hoisted so a caller judging many
+    /// candidates against one root pays for the `realpath` once.
+    static func resolvedRoot(_ root: URL) -> String {
+        root.standardizedFileURL.resolvingSymlinksInPath().path
+    }
+
+    /// Both sides already symlink-resolved.
+    static func containsResolved(_ path: String, inResolvedRoot root: String) -> Bool {
+        path.hasPrefix(root + "/")
+    }
+
+    /// Convenience for a caller holding raw URLs.
+    static func contains(_ candidate: URL, in root: URL) -> Bool {
+        containsResolved(
+            candidate.standardizedFileURL.resolvingSymlinksInPath().path,
+            inResolvedRoot: resolvedRoot(root)
+        )
+    }
+}
+
+/// The consuming half of `MarkdownNavigationPolicy.openInPane`.
+///
+/// `MarkdownWebViewConfiguration.policy` is pure and knows no worktree, so the
+/// most it can say about a `file:` URL is "this is a markdown file". Whether
+/// that file is one this pane may render is a question only the pane can
+/// answer, because only the pane knows its worktree root — so containment is
+/// judged here, against the same symlink-resolved rule `MarkdownLinkResolver`
+/// applies when it rewrites the href in the first place.
+///
+/// Both halves are load-bearing. The resolver's check is what makes an
+/// in-repo link work at all; this one is what keeps anything else from
+/// arriving — a hand-written `file:` destination, a future markdown source
+/// that reaches the webview by some other path, a policy relaxation nobody
+/// re-examined. Neither is a substitute for the other.
+enum MarkdownLinkNavigation {
+
+    /// The path the pane should select, or nil to drop the click.
+    ///
+    /// The returned path is the UNRESOLVED one, so the pane's selection and
+    /// its header match what the sidebar shows; containment and the file
+    /// checks are judged against the symlink-resolved target.
+    static func target(
+        for url: URL,
+        worktreeRoot: String,
+        fileManager: FileManager = .default
+    ) -> String? {
+        guard url.isFileURL, !worktreeRoot.isEmpty else { return nil }
+        let candidate = url.standardizedFileURL
+        let resolved = candidate.resolvingSymlinksInPath()
+        let root = MarkdownWorktreeContainment.resolvedRoot(URL(fileURLWithPath: worktreeRoot))
+        guard MarkdownWorktreeContainment.containsResolved(resolved.path, inResolvedRoot: root)
+        else {
+            logger.debug(
+                "refused in-pane navigation outside worktree root: \(url.path, privacy: .public)")
+            return nil
+        }
+        // A regular file, not just an existing one: a directory named
+        // `notes.md` is not a document, and neither is a device node. Same
+        // check `MarkdownImageInliner` makes on the image side.
+        guard fileManager.fileExists(atPath: resolved.path),
+              let values = try? resolved.resourceValues(forKeys: [.isRegularFileKey]),
+              values.isRegularFile == true
+        else { return nil }
+        return candidate.path
+    }
+}

--- a/Sources/TBDApp/Panes/Markdown/MarkdownLinkResolver.swift
+++ b/Sources/TBDApp/Panes/Markdown/MarkdownLinkResolver.swift
@@ -1,0 +1,125 @@
+import Foundation
+import os
+
+private let logger = Logger(subsystem: "com.tbd.app", category: "markdown")
+
+/// Rewrites document-relative `<a href>` values into absolute `file://` URLs.
+///
+/// The document is loaded with `baseURL: nil`, i.e. `about:blank`, so a
+/// relative href has nothing to resolve against: `[log](./log.md)` arrives at
+/// the navigation policy as `about:blank`-relative junk and is dropped, so the
+/// click does nothing. Resolving at document-build time is deliberate in
+/// preference to emitting a `<base href="file:///…">`, which would change
+/// subresource resolution for the WHOLE document rather than just its links.
+///
+/// Resolution and containment mirror `MarkdownImageInliner` exactly: a
+/// relative href resolves against the document's own directory, the result
+/// must live under the symlink-resolved worktree root, and symlinks are
+/// resolved on both sides. What the two do with the result differs — an image
+/// is read and inlined, a link is only rewritten — but the trust boundary is
+/// the same one, for the same reason.
+struct MarkdownLinkResolver {
+
+    private let documentDirectory: URL
+    /// Symlink-resolved path the candidate must live under.
+    private let containmentRoot: String
+    private let fileManager: FileManager
+
+    /// - Parameters:
+    ///   - documentDirectory: what a relative `href` is *resolved against* —
+    ///     the markdown file's own directory.
+    ///   - worktreeRoot: the trust boundary the resolved candidate must stay
+    ///     inside. Deliberately NOT the document directory: `docs/guide.md`
+    ///     linking `../README.md` is a mainstream repo layout.
+    init(documentDirectory: URL, worktreeRoot: URL, fileManager: FileManager = .default) {
+        self.documentDirectory = documentDirectory.standardizedFileURL
+        // Resolve symlinks on BOTH sides. Resolving only the candidate breaks
+        // every repo that lives under a symlinked path; resolving neither lets
+        // a symlink inside the repo point anywhere on disk.
+        self.containmentRoot = worktreeRoot.standardizedFileURL.resolvingSymlinksInPath().path
+        self.fileManager = fileManager
+    }
+
+    func resolve(html: String) -> String {
+        // Matches href="..." on anchor tags. comrak emits double-quoted
+        // attributes, same as for `<img src>`. The leading `\s` is what keeps
+        // `<abbr …>` and any other `a`-initial tag out of the match.
+        let pattern = #"<a(\s[^>]*?)href="([^"]*)"([^>]*?)>"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return html }
+
+        var result = html
+        let matches = regex.matches(in: html, range: NSRange(html.startIndex..., in: html))
+
+        // Reversed so each replacement leaves the earlier ranges valid.
+        for match in matches.reversed() {
+            guard let full = Range(match.range, in: result),
+                  let hrefRange = Range(match.range(at: 2), in: result) else { continue }
+            let href = String(result[hrefRange])
+            guard let rewritten = rewritten(href: href) else { continue }
+            let prefix = Range(match.range(at: 1), in: result).map { String(result[$0]) } ?? " "
+            let suffix = Range(match.range(at: 3), in: result).map { String(result[$0]) } ?? ""
+            // Preserve the tag's other attributes (title, most often) —
+            // rebuilding it from scratch would drop every link's tooltip.
+            result.replaceSubrange(full, with: #"<a\#(prefix)href="\#(rewritten)"\#(suffix)>"#)
+        }
+        return result
+    }
+
+    /// The replacement href, or nil to leave the tag exactly as it was.
+    private func rewritten(href: String) -> String? {
+        // Anything that already names a scheme — http, mailto, data, an
+        // absolute file: URL — is somebody else's decision.
+        if hasScheme(href) { return nil }
+        // Protocol-relative `//host/path` carries no scheme but is remote.
+        if href.hasPrefix("//") { return nil }
+        // Fragment-only hrefs are same-document anchors. Every README table of
+        // contents depends on them reaching the webview untouched.
+        if href.hasPrefix("#") { return nil }
+
+        // comrak percent-encodes and entity-escapes destinations, so decode
+        // before doing anything else. This MUST precede the containment check:
+        // otherwise `%2e%2e%2fsecret.md` is a traversal vector that the
+        // lexical check never sees.
+        var decoded = (href.removingPercentEncoding ?? href)
+            .replacingOccurrences(of: "&amp;", with: "&")
+        // `./doc.md#section` navigates to the file. The fragment is dropped:
+        // the pane re-renders the linked document from the top and has no
+        // scroll-to-anchor plumbing across a document switch.
+        if let hash = decoded.firstIndex(of: "#") { decoded = String(decoded[..<hash]) }
+        // Re-check the decoded form: percent-encoding can hide both of the
+        // shapes rejected above.
+        guard !decoded.isEmpty, !decoded.hasPrefix("//"), !hasScheme(decoded) else { return nil }
+
+        // Resolved against the DOCUMENT directory (that is what `href` is
+        // relative to), contained against the WORKTREE ROOT.
+        let candidate = documentDirectory.appendingPathComponent(decoded).standardizedFileURL
+        let resolved = candidate.resolvingSymlinksInPath()
+        guard resolved.path.hasPrefix(containmentRoot + "/") else {
+            logger.debug("rejected link outside worktree root: \(href, privacy: .public)")
+            return nil
+        }
+        // A link to something that is not there stays unrewritten, so a broken
+        // link keeps doing what it does today — nothing — rather than opening a
+        // Finder window on a path that does not exist.
+        guard fileManager.fileExists(atPath: resolved.path) else { return nil }
+
+        // The UNRESOLVED path is what the href becomes: it is the path the
+        // sidebar shows and the pane selects, and containment has already been
+        // judged against the symlink-resolved target.
+        return Self.escapeAttribute(candidate.absoluteString)
+    }
+
+    /// Does this destination name a URL scheme?
+    private func hasScheme(_ value: String) -> Bool {
+        if let url = URL(string: value), url.scheme != nil { return true }
+        return false
+    }
+
+    private static func escapeAttribute(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+    }
+}

--- a/Sources/TBDApp/Panes/Markdown/MarkdownLinkResolver.swift
+++ b/Sources/TBDApp/Panes/Markdown/MarkdownLinkResolver.swift
@@ -12,15 +12,23 @@ private let logger = Logger(subsystem: "com.tbd.app", category: "markdown")
 /// preference to emitting a `<base href="file:///…">`, which would change
 /// subresource resolution for the WHOLE document rather than just its links.
 ///
-/// Resolution and containment mirror `MarkdownImageInliner` exactly: a
-/// relative href resolves against the document's own directory, the result
-/// must live under the symlink-resolved worktree root, and symlinks are
-/// resolved on both sides. What the two do with the result differs — an image
-/// is read and inlined, a link is only rewritten — but the trust boundary is
-/// the same one, for the same reason.
+/// Containment matches `MarkdownImageInliner`: the result must live under the
+/// symlink-resolved worktree root, symlinks are resolved on both sides, and
+/// the target must be a regular file. What the two do with the result differs
+/// — an image is read and inlined, a link is only rewritten — but the trust
+/// boundary is the same one, for the same reason.
+///
+/// Resolution differs in one place: a root-relative `/docs/setup.md` resolves
+/// against the worktree root rather than the document's directory, which is
+/// what a leading slash means to every forge that renders a repo's markdown.
+/// The image pass does not yet do this.
 struct MarkdownLinkResolver {
 
     private let documentDirectory: URL
+    /// What a ROOT-relative href (`/docs/setup.md`) resolves against. Kept
+    /// unresolved so a rewritten href names the path the user navigated
+    /// rather than its realpath — see the return of `rewritten(href:)`.
+    private let worktreeRoot: URL
     /// Symlink-resolved path the candidate must live under.
     private let containmentRoot: String
     private let fileManager: FileManager
@@ -29,14 +37,16 @@ struct MarkdownLinkResolver {
     ///   - documentDirectory: what a relative `href` is *resolved against* —
     ///     the markdown file's own directory.
     ///   - worktreeRoot: the trust boundary the resolved candidate must stay
-    ///     inside. Deliberately NOT the document directory: `docs/guide.md`
-    ///     linking `../README.md` is a mainstream repo layout.
+    ///     inside, and what a ROOT-relative `href` resolves against.
+    ///     Deliberately NOT the document directory for containment either:
+    ///     `docs/guide.md` linking `../README.md` is a mainstream repo layout.
     init(documentDirectory: URL, worktreeRoot: URL, fileManager: FileManager = .default) {
         self.documentDirectory = documentDirectory.standardizedFileURL
-        // Resolve symlinks on BOTH sides. Resolving only the candidate breaks
-        // every repo that lives under a symlinked path; resolving neither lets
-        // a symlink inside the repo point anywhere on disk.
-        self.containmentRoot = worktreeRoot.standardizedFileURL.resolvingSymlinksInPath().path
+        self.worktreeRoot = worktreeRoot.standardizedFileURL
+        // Symlinks are resolved on BOTH sides — see
+        // `MarkdownWorktreeContainment`, which is also what the pane applies
+        // to the URL this resolver hands it.
+        self.containmentRoot = MarkdownWorktreeContainment.resolvedRoot(worktreeRoot)
         self.fileManager = fileManager
     }
 
@@ -76,32 +86,56 @@ struct MarkdownLinkResolver {
         // contents depends on them reaching the webview untouched.
         if href.hasPrefix("#") { return nil }
 
-        // comrak percent-encodes and entity-escapes destinations, so decode
-        // before doing anything else. This MUST precede the containment check:
-        // otherwise `%2e%2e%2fsecret.md` is a traversal vector that the
-        // lexical check never sees.
-        var decoded = (href.removingPercentEncoding ?? href)
+        // Undo comrak's `escape_href`, the ONLY escaping a destination gets:
+        // it emits `&#x27;` for `'` and `&amp;` for `&`, and percent-encodes
+        // every other byte outside its HREF_SAFE set. `&#x27;` is undone
+        // BEFORE `&amp;`, or a filename holding the literal text `&#x27;` —
+        // which comrak wrote as `&amp;#x27;` — comes back as an apostrophe.
+        let unescaped = href
+            .replacingOccurrences(of: "&#x27;", with: "'")
             .replacingOccurrences(of: "&amp;", with: "&")
-        // `./doc.md#section` navigates to the file. The fragment is dropped:
-        // the pane re-renders the linked document from the top and has no
+
+        // `./doc.md#section` navigates to the file, dropping the fragment: the
+        // pane re-renders the linked document from the top and has no
         // scroll-to-anchor plumbing across a document switch.
-        if let hash = decoded.firstIndex(of: "#") { decoded = String(decoded[..<hash]) }
+        //
+        // The split sits between the two decodes, and neither side is
+        // arbitrary. AFTER unescaping, because `&#x27;` carries a literal `#`
+        // and splitting first would cut `user&#x27;s guide.md` down to
+        // `user&`. BEFORE percent-decoding, because `#` is in HREF_SAFE — a
+        // real fragment arrives literal while a `#` in a filename arrives as
+        // `%23`, so splitting afterwards would cut `a%23b.md`, a link to the
+        // real file `a#b.md`, down to `a`.
+        let beforeFragment = unescaped.firstIndex(of: "#")
+            .map { String(unescaped[..<$0]) } ?? unescaped
+
+        // Decoding MUST precede the containment check: otherwise
+        // `%2e%2e%2fsecret.md` is a traversal vector the lexical check never
+        // sees.
+        let decoded = beforeFragment.removingPercentEncoding ?? beforeFragment
+
         // Re-check the decoded form: percent-encoding can hide both of the
         // shapes rejected above.
         guard !decoded.isEmpty, !decoded.hasPrefix("//"), !hasScheme(decoded) else { return nil }
 
-        // Resolved against the DOCUMENT directory (that is what `href` is
-        // relative to), contained against the WORKTREE ROOT.
-        let candidate = documentDirectory.appendingPathComponent(decoded).standardizedFileURL
+        guard let candidate = resolvedCandidate(for: decoded) else { return nil }
         let resolved = candidate.resolvingSymlinksInPath()
-        guard resolved.path.hasPrefix(containmentRoot + "/") else {
+        guard MarkdownWorktreeContainment.containsResolved(
+            resolved.path, inResolvedRoot: containmentRoot
+        ) else {
             logger.debug("rejected link outside worktree root: \(href, privacy: .public)")
             return nil
         }
         // A link to something that is not there stays unrewritten, so a broken
         // link keeps doing what it does today — nothing — rather than opening a
-        // Finder window on a path that does not exist.
-        guard fileManager.fileExists(atPath: resolved.path) else { return nil }
+        // Finder window on a path that does not exist. A regular file, not
+        // merely an existing one: a directory named `notes.md` is not a
+        // document, and neither is a device node. Same check the image pass
+        // makes, for the same reason.
+        guard fileManager.fileExists(atPath: resolved.path),
+              let values = try? resolved.resourceValues(forKeys: [.isRegularFileKey]),
+              values.isRegularFile == true
+        else { return nil }
 
         // The UNRESOLVED path is what the href becomes: it is the path the
         // sidebar shows and the pane selects, and containment has already been
@@ -109,10 +143,64 @@ struct MarkdownLinkResolver {
         return Self.escapeAttribute(candidate.absoluteString)
     }
 
+    /// Where a decoded destination points, before containment is judged.
+    ///
+    /// A leading `/` addresses the WORKTREE ROOT — what a root-relative href
+    /// means to every forge that renders a repo's markdown — and everything
+    /// else the DOCUMENT directory, which is what an href is relative to.
+    ///
+    /// An absolute filesystem path is therefore reinterpreted as root-relative:
+    /// `/etc/passwd` becomes `<root>/etc/passwd`, which does not exist, so the
+    /// link is left alone. That is the intended outcome — there is no shape of
+    /// href that names a file outside the repo.
+    private func resolvedCandidate(for decoded: String) -> URL? {
+        guard decoded.hasPrefix("/") else {
+            return documentDirectory.appendingPathComponent(decoded).standardizedFileURL
+        }
+        let relative = String(decoded.drop(while: { $0 == "/" }))
+        guard !relative.isEmpty else { return nil }
+        return worktreeRoot.appendingPathComponent(relative).standardizedFileURL
+    }
+
+    /// Schemes that count even without an authority: they carry no path to
+    /// resolve, so a destination naming one is never a repo-relative file.
+    private static let opaqueSchemes: Set<String> = [
+        "about", "blob", "data", "file", "javascript", "mailto",
+        "sms", "tel", "urn", "vbscript",
+    ]
+
+    /// The non-alphanumeric half of RFC 3986's scheme grammar.
+    private static let schemePunctuation: Set<Character> = ["+", "-", "."]
+
     /// Does this destination name a URL scheme?
+    ///
+    /// Deliberately NOT `URL(string:)?.scheme != nil`. That reports `v1` for
+    /// `v1:changelog.md`, and `:` is in comrak's HREF_SAFE set, so an ordinary
+    /// repo-relative filename containing a colon reaches this function
+    /// unencoded and would be abandoned as remote — the exact dead link this
+    /// resolver exists to fix. A destination counts as scheme-bearing only
+    /// when it opens an authority (`scheme://…`) or names one of the opaque
+    /// schemes above.
+    ///
+    /// Erring permissive is safe: whatever gets through still has to resolve
+    /// inside the worktree root and name a regular file that exists. A remote
+    /// destination that slips past satisfies neither, so it comes out
+    /// unrewritten exactly as if it had been recognised here.
     private func hasScheme(_ value: String) -> Bool {
-        if let url = URL(string: value), url.scheme != nil { return true }
-        return false
+        guard let colon = value.firstIndex(of: ":") else { return false }
+        let scheme = value[value.startIndex..<colon].lowercased()
+        // RFC 3986 scheme grammar. A colon inside a path segment
+        // (`notes/rev:2.md`) fails it and is correctly read as a path.
+        let isSchemeCharacter: (Character) -> Bool = { character in
+            guard character.isASCII else { return false }
+            return character.isLetter || character.isNumber
+                || Self.schemePunctuation.contains(character)
+        }
+        guard let first = scheme.first, first.isASCII, first.isLetter,
+              scheme.allSatisfy(isSchemeCharacter)
+        else { return false }
+        if Self.opaqueSchemes.contains(scheme) { return true }
+        return value[value.index(after: colon)...].hasPrefix("//")
     }
 
     private static func escapeAttribute(_ value: String) -> String {

--- a/Sources/TBDApp/Panes/Markdown/MarkdownWebView.swift
+++ b/Sources/TBDApp/Panes/Markdown/MarkdownWebView.swift
@@ -98,9 +98,29 @@ enum MarkdownWebViewConfiguration {
         case "http", "https", "mailto":
             return .openExternally(url)
         case "file":
-            // A relative link that `MarkdownLinkResolver` rewrote, or an
-            // explicit file: URL in the source. Markdown navigates the pane —
-            // in-app, so no launch decision is involved at all.
+            // A relative link that `MarkdownLinkResolver` rewrote — the only
+            // way a file: URL reaches here. An explicit `file:` destination in
+            // the markdown source cannot: comrak's safe mode empties the href
+            // for `file:`, `data:`, `javascript:` and `vbscript:`, so the
+            // anchor arrives with nothing to navigate to. Markdown navigates
+            // the pane — in-app, so no launch decision is involved at all.
+            //
+            // This function is pure and knows no worktree, so it cannot judge
+            // WHICH file. Containment is re-judged on the consuming side, by
+            // `MarkdownLinkNavigation.target(for:worktreeRoot:)`, against the
+            // same rule the resolver applied — that check, not comrak's safe
+            // mode, is what keeps a file outside the worktree from rendering
+            // in the pane.
+            //
+            // `isLinkActivation` means "a real gesture" only while JavaScript
+            // is off on this path, which it unconditionally is today. Enabling
+            // it for `renderMermaidDiagrams` (see
+            // `docs/specs/2026-07-28-markdown-display-options-design.md`)
+            // ends that: `document.querySelector('a').click()` produces
+            // navigationType `.linkActivated`, so a script in the rendered
+            // document could drive this route — and `.openExternally` —
+            // without the user touching anything. Whoever lands mermaid needs
+            // a gesture signal that a script cannot forge.
             if isRenderableMarkdown(url) { return .openInPane(url) }
             // NEVER `NSWorkspace.open` a file: URL. `git clone` sets only
             // com.apple.provenance, not com.apple.quarantine (verified), so a

--- a/Sources/TBDApp/Panes/Markdown/MarkdownWebView.swift
+++ b/Sources/TBDApp/Panes/Markdown/MarkdownWebView.swift
@@ -1,6 +1,9 @@
 import AppKit
+import os
 import SwiftUI
 import WebKit
+
+private let logger = Logger(subsystem: "com.tbd.app", category: "markdown")
 
 /// What to do with a navigation the webview is about to perform.
 enum MarkdownNavigationPolicy: Equatable {
@@ -8,6 +11,9 @@ enum MarkdownNavigationPolicy: Equatable {
     case allowInPlace
     /// Hand to `NSWorkspace.open` and cancel in place.
     case openExternally(URL)
+    /// Render this local markdown file in the code-viewer pane itself, the way
+    /// selecting it in the sidebar would. Never leaves the app.
+    case openInPane(URL)
     /// Reveal in Finder WITHOUT launching. `file:` URLs never get `open`.
     case revealInFinder(URL)
     /// Drop silently.
@@ -26,6 +32,18 @@ enum MarkdownWebViewConfiguration {
         config.defaultWebpagePreferences.allowsContentJavaScript = false
         config.websiteDataStore = .nonPersistent()
         return config
+    }
+
+    /// Extensions the code-viewer pane can render in place.
+    ///
+    /// Single source of truth: `isRenderableFile` in `CodeViewerPaneView`
+    /// reads the same set, so the pane can always render whatever a link
+    /// routed to it.
+    static let renderableExtensions: Set<String> = ["md", "markdown"]
+
+    /// Is this a local file the pane itself renders?
+    static func isRenderableMarkdown(_ url: URL) -> Bool {
+        renderableExtensions.contains(url.pathExtension.lowercased())
     }
 
     /// Does this URL have the shape of a document we loaded ourselves?
@@ -80,6 +98,10 @@ enum MarkdownWebViewConfiguration {
         case "http", "https", "mailto":
             return .openExternally(url)
         case "file":
+            // A relative link that `MarkdownLinkResolver` rewrote, or an
+            // explicit file: URL in the source. Markdown navigates the pane —
+            // in-app, so no launch decision is involved at all.
+            if isRenderableMarkdown(url) { return .openInPane(url) }
             // NEVER `NSWorkspace.open` a file: URL. `git clone` sets only
             // com.apple.provenance, not com.apple.quarantine (verified), so a
             // .app/.command/.terminal inside a freshly cloned repo would
@@ -98,17 +120,22 @@ enum MarkdownWebViewConfiguration {
 ///
 /// JavaScript is disabled, no script message handlers are installed, the data
 /// store is non-persistent, and there is no URL scheme handler. Navigation is
-/// three-way: our own load and same-document anchors render in place, allowed
-/// schemes leave via `NSWorkspace` on a real click, everything else is
-/// dropped. See `MarkdownNavigationPolicy`.
+/// four-way: our own load and same-document anchors render in place, a link to
+/// a repo-local markdown file navigates the enclosing pane, allowed schemes
+/// leave via `NSWorkspace` on a real click, everything else is dropped. See
+/// `MarkdownNavigationPolicy`.
 struct MarkdownWebView: NSViewRepresentable {
     let html: String
+    /// Invoked when a link resolves to a repo-local markdown file. The pane
+    /// owns the selection, so it decides what "navigate" means.
+    let onOpenFile: (URL) -> Void
 
     func makeCoordinator() -> Coordinator { Coordinator() }
 
     func makeNSView(context: Context) -> WKWebView {
         let webView = WKWebView(frame: .zero, configuration: MarkdownWebViewConfiguration.make())
         webView.navigationDelegate = context.coordinator
+        context.coordinator.onOpenFile = onOpenFile
         // Supported API. `setValue(false, forKey: "drawsBackground")` is
         // private KVC; if the key ever disappears it raises an ObjC exception
         // that Swift cannot catch, crashing on the render path.
@@ -128,6 +155,9 @@ struct MarkdownWebView: NSViewRepresentable {
     }
 
     func updateNSView(_ webView: WKWebView, context: Context) {
+        // Refreshed BEFORE the equality guard: an unchanged document still
+        // needs the latest closure, which captures the current pane state.
+        context.coordinator.onOpenFile = onOpenFile
         guard context.coordinator.loadedHTML != html else { return }
         context.coordinator.load(html, into: webView)
     }
@@ -148,6 +178,10 @@ struct MarkdownWebView: NSViewRepresentable {
     @MainActor
     final class Coordinator: NSObject, WKNavigationDelegate {
         private(set) var loadedHTML: String?
+
+        /// Set by `makeNSView`/`updateNSView`. Optional so a `Coordinator` can
+        /// still be constructed bare in tests.
+        var onOpenFile: ((URL) -> Void)?
 
         /// Counter, not a Bool. WebKit delivers one policy callback per
         /// `loadHTMLString`, so two loads dispatched before the first callback
@@ -212,6 +246,14 @@ struct MarkdownWebView: NSViewRepresentable {
                 decisionHandler(.allow)
             case .openExternally(let target):
                 NSWorkspace.shared.open(target)
+                decisionHandler(.cancel)
+            case .openInPane(let target):
+                if let onOpenFile {
+                    onOpenFile(target)
+                } else {
+                    logger.debug(
+                        "no in-pane handler for \(target.path, privacy: .public)")
+                }
                 decisionHandler(.cancel)
             case .revealInFinder(let target):
                 NSWorkspace.shared.activateFileViewerSelecting([target])

--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -334,6 +334,22 @@ struct PanePlaceholder: View {
         layout = updated
     }
 
+    /// Point THIS pane at another file, keeping its pane UUID — raised by a
+    /// link click inside a rendered markdown document.
+    ///
+    /// Not `routeFileClick`: that one picks a destination slot, and the
+    /// destination here is already known. `routeInPaneFileNavigation` is the
+    /// same swap over the same primitives, aimed at one named pane, and its
+    /// result is consumed exactly like every other viewer route in this file.
+    private func navigateCodeViewer(to path: String) {
+        guard let result = routeInPaneFileNavigation(
+            into: layout, paneID: content.paneID, path: path) else { return }
+        if let replaced = result.replaced {
+            appState.recordPaneReplacement(replaced)
+        }
+        layout = result.layout
+    }
+
     // MARK: - Pane Body
 
     @ViewBuilder
@@ -344,7 +360,12 @@ struct PanePlaceholder: View {
         case .webview(_, let url):
             WebviewPaneView(url: url, state: webviewState)
         case .codeViewer(_, let path):
-            CodeViewerPaneView(path: path, worktreePath: worktree.path, showSourceCode: showSourceCode)
+            CodeViewerPaneView(
+                path: path,
+                worktreePath: worktree.path,
+                showSourceCode: showSourceCode,
+                onNavigate: { navigateCodeViewer(to: $0) }
+            )
         case .note(let noteID):
             NotePaneView(noteID: noteID, worktreeID: worktree.id)
         case .liveTranscript(_, let terminalID):

--- a/Sources/TBDShared/PanelSurface/ViewerRouting.swift
+++ b/Sources/TBDShared/PanelSurface/ViewerRouting.swift
@@ -74,3 +74,32 @@ public func routeFileClick(into layout: LayoutNode, terminalID: UUID, path: Stri
         newContent: .codeViewer(id: UUID(), path: path)
     ))
 }
+
+// MARK: - routeInPaneFileNavigation
+
+/// Points ONE named pane at a file, keeping its pane UUID.
+///
+/// Distinct from `routeFileClick`, which *chooses* a destination slot. Here
+/// the destination is fixed: a link clicked inside a rendered markdown
+/// document navigates the pane the document is in, and no other. Going
+/// through the layout rather than the pane's own private state is what keeps
+/// the pane header, its context menu, the slot's history and the persisted
+/// layout pointed at the document the user is actually looking at — every one
+/// of those reads the path from `PaneContent.codeViewer`.
+///
+/// Returns nil when the pane is not in the layout, or is already showing that
+/// file — a no-op must not push a duplicate history entry.
+public func routeInPaneFileNavigation(
+    into layout: LayoutNode, paneID: UUID, path: String
+) -> ViewerRouteResult? {
+    guard let outgoing = layout.firstPaneContent(where: { $0.paneID == paneID }) else { return nil }
+    if case .codeViewer(_, let current) = outgoing, current == path { return nil }
+    let incoming = PaneContent.codeViewer(id: paneID, path: path)
+    guard let updated = layout.replacingContent(at: paneID, with: incoming) else { return nil }
+    logger.debug(
+        "routeInPaneFileNavigation: paneID=\(paneID, privacy: .public) path=\(path, privacy: .public)")
+    return ViewerRouteResult(
+        layout: updated,
+        replaced: .init(paneID: paneID, outgoing: outgoing, incoming: incoming)
+    )
+}

--- a/Tests/TBDAppTests/MarkdownLinkNavigationTests.swift
+++ b/Tests/TBDAppTests/MarkdownLinkNavigationTests.swift
@@ -1,0 +1,144 @@
+import Foundation
+import Testing
+@testable import TBDApp
+
+@Suite("MarkdownLinkNavigation")
+struct MarkdownLinkNavigationTests {
+
+    private func makeTempDir() throws -> URL {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("md-nav-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    @discardableResult
+    private func write(_ name: String, in dir: URL) throws -> URL {
+        let url = dir.appendingPathComponent(name)
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try "# doc".write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    @Test("a repo-local markdown file is accepted")
+    func acceptsFileInsideRoot() throws {
+        let root = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let target = try write("docs/log.md", in: root)
+
+        #expect(MarkdownLinkNavigation.target(for: target, worktreeRoot: root.path)
+            == target.standardizedFileURL.path)
+    }
+
+    @Test("a file outside the worktree root is refused")
+    func refusesFileOutsideRoot() throws {
+        // The scenario: a README containing
+        // `[docs](file:///Users/me/.claude/CLAUDE.md)`. The navigation policy
+        // is pure and knows no worktree, so it can only say "markdown file" —
+        // this is the check that keeps it out of the pane.
+        let sandbox = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: sandbox) }
+        let root = sandbox.appendingPathComponent("repo")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let outside = try write("secret.md", in: sandbox)
+
+        // Guard against the false pass: the target must exist, so a nil result
+        // means "refused", not "not found".
+        #expect(FileManager.default.fileExists(atPath: outside.path))
+        #expect(MarkdownLinkNavigation.target(for: outside, worktreeRoot: root.path) == nil)
+    }
+
+    @Test("a symlink pointing out of the worktree root is refused")
+    func refusesEscapingSymlink() throws {
+        let sandbox = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: sandbox) }
+        let root = sandbox.appendingPathComponent("repo")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let outside = try write("secret.md", in: sandbox)
+        let innocent = root.appendingPathComponent("innocent.md")
+        try FileManager.default.createSymbolicLink(at: innocent, withDestinationURL: outside)
+
+        #expect(MarkdownLinkNavigation.target(for: innocent, worktreeRoot: root.path) == nil)
+    }
+
+    @Test("a repo reached through a symlinked root still works")
+    func acceptsSymlinkedRoot() throws {
+        // Both sides are symlink-resolved. Resolving only the candidate would
+        // refuse every repo that lives under a symlinked path.
+        let sandbox = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: sandbox) }
+        let real = sandbox.appendingPathComponent("real")
+        try FileManager.default.createDirectory(at: real, withIntermediateDirectories: true)
+        try write("log.md", in: real)
+        let link = sandbox.appendingPathComponent("link")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: real)
+
+        let viaLink = link.appendingPathComponent("log.md")
+        // The path handed back is the one the user navigated, not its
+        // realpath, so the pane's header and the sidebar agree.
+        #expect(MarkdownLinkNavigation.target(for: viaLink, worktreeRoot: link.path)
+            == viaLink.standardizedFileURL.path)
+    }
+
+    @Test("a directory named like a document is refused")
+    func refusesDirectory() throws {
+        let root = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let asDirectory = root.appendingPathComponent("notes.md")
+        try FileManager.default.createDirectory(at: asDirectory, withIntermediateDirectories: true)
+
+        #expect(FileManager.default.fileExists(atPath: asDirectory.path))
+        #expect(MarkdownLinkNavigation.target(for: asDirectory, worktreeRoot: root.path) == nil)
+    }
+
+    @Test("a file that vanished between render and click is refused")
+    func refusesMissingFile() throws {
+        let root = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        #expect(MarkdownLinkNavigation.target(
+            for: root.appendingPathComponent("gone.md"), worktreeRoot: root.path) == nil)
+    }
+
+    @Test("the worktree root itself is not a target")
+    func refusesTheRootItself() throws {
+        let root = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        #expect(MarkdownLinkNavigation.target(for: root, worktreeRoot: root.path) == nil)
+    }
+
+    @Test("a sibling directory sharing the root's name prefix is refused")
+    func refusesSiblingWithSharedPrefix() throws {
+        // The trailing separator on the root: `/tmp/x-secrets` must not read
+        // as inside `/tmp/x`.
+        let sandbox = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: sandbox) }
+        let root = sandbox.appendingPathComponent("repo")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let sibling = try write("repo-secrets/log.md", in: sandbox)
+
+        #expect(MarkdownLinkNavigation.target(for: sibling, worktreeRoot: root.path) == nil)
+    }
+
+    @Test("a non-file URL is refused")
+    func refusesNonFileURL() throws {
+        let root = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let url = try #require(URL(string: "https://example.com/a.md"))
+
+        #expect(MarkdownLinkNavigation.target(for: url, worktreeRoot: root.path) == nil)
+    }
+
+    @Test("an empty worktree root refuses everything")
+    func refusesEmptyRoot() throws {
+        // Without this, `"" + "/"` is a prefix of every absolute path and the
+        // containment check would wave the whole filesystem through.
+        let root = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let target = try write("log.md", in: root)
+
+        #expect(MarkdownLinkNavigation.target(for: target, worktreeRoot: "") == nil)
+    }
+}

--- a/Tests/TBDAppTests/MarkdownLinkResolverTests.swift
+++ b/Tests/TBDAppTests/MarkdownLinkResolverTests.swift
@@ -1,0 +1,296 @@
+import Foundation
+import Testing
+@testable import TBDApp
+
+@Suite("MarkdownLinkResolver")
+struct MarkdownLinkResolverTests {
+
+    private func makeTempDir() throws -> URL {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("md-links-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    @discardableResult
+    private func write(_ name: String, in dir: URL) throws -> URL {
+        let url = dir.appendingPathComponent(name)
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try "# doc".write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    // MARK: - Rewriting
+
+    @Test("rewrites a document-relative link to an absolute file URL")
+    func rewritesRelativeLink() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let target = try write("log.md", in: dir)
+
+        let resolver = MarkdownLinkResolver(documentDirectory: dir, worktreeRoot: dir)
+        let out = resolver.resolve(html: #"<a href="log.md">log</a>"#)
+
+        #expect(out == #"<a href="\#(target.standardizedFileURL.absoluteString)">log</a>"#)
+    }
+
+    @Test("rewrites a ./-prefixed link")
+    func rewritesDotSlashLink() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try write("log.md", in: dir)
+
+        let resolver = MarkdownLinkResolver(documentDirectory: dir, worktreeRoot: dir)
+        let out = resolver.resolve(html: #"<a href="./log.md">log</a>"#)
+
+        #expect(out.contains("file://"))
+        #expect(out.contains("log.md"))
+        #expect(!out.contains(#"href="./log.md""#))
+    }
+
+    @Test("preserves the anchor's other attributes")
+    func preservesAttributes() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try write("log.md", in: dir)
+
+        let resolver = MarkdownLinkResolver(documentDirectory: dir, worktreeRoot: dir)
+        let out = resolver.resolve(html: #"<a href="log.md" title="the log">log</a>"#)
+
+        #expect(out.contains(#"title="the log""#))
+        #expect(out.contains("file://"))
+    }
+
+    @Test("percent-encoded destinations are decoded before resolution")
+    func decodesPercentEncoding() throws {
+        // comrak percent-encodes destinations, so `[x](my log.md)` arrives as
+        // `my%20log.md` and a literal resolution would miss the file.
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try write("my log.md", in: dir)
+
+        let resolver = MarkdownLinkResolver(documentDirectory: dir, worktreeRoot: dir)
+        let out = resolver.resolve(html: #"<a href="my%20log.md">log</a>"#)
+
+        #expect(out.contains("file://"))
+        #expect(out.contains("my%20log.md"))
+    }
+
+    @Test("a fragment on a relative link is dropped, the file still resolves")
+    func dropsFragmentOnRelativeLink() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let target = try write("log.md", in: dir)
+
+        let resolver = MarkdownLinkResolver(documentDirectory: dir, worktreeRoot: dir)
+        let out = resolver.resolve(html: #"<a href="./log.md#results">log</a>"#)
+
+        #expect(out.contains(target.standardizedFileURL.absoluteString))
+        #expect(!out.contains("#results"))
+    }
+
+    @Test("rewrites every link in a document")
+    func rewritesMultipleLinks() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try write("a.md", in: dir)
+        try write("b.md", in: dir)
+
+        let resolver = MarkdownLinkResolver(documentDirectory: dir, worktreeRoot: dir)
+        let out = resolver.resolve(
+            html: #"<p><a href="a.md">a</a> and <a href="./b.md">b</a></p>"#)
+
+        #expect(out.components(separatedBy: "file://").count - 1 == 2)
+    }
+
+    // MARK: - Containment
+
+    @Test("a ../ link that stays inside the worktree root is rewritten")
+    func allowsParentRelativeInsideRoot() throws {
+        // `docs/guide.md` linking `../README.md` is a mainstream repo layout.
+        let root = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let docs = root.appendingPathComponent("docs")
+        try FileManager.default.createDirectory(at: docs, withIntermediateDirectories: true)
+        let target = try write("README.md", in: root)
+
+        let resolver = MarkdownLinkResolver(documentDirectory: docs, worktreeRoot: root)
+        let out = resolver.resolve(html: #"<a href="../README.md">readme</a>"#)
+
+        #expect(out.contains(target.standardizedFileURL.absoluteString))
+    }
+
+    @Test("a ../ link that escapes the worktree root is left unrewritten")
+    func rejectsTraversalOutsideRoot() throws {
+        // Per-test sandbox, not a fixed name in the shared temp root: a fixed
+        // name races concurrent suite runs in sibling worktrees and the loser's
+        // cleanup deletes the file, turning this into a FALSE PASS
+        // indistinguishable from "the target was missing".
+        let sandbox = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: sandbox) }
+        let root = sandbox.appendingPathComponent("repo")
+        let docs = root.appendingPathComponent("docs")
+        try FileManager.default.createDirectory(at: docs, withIntermediateDirectories: true)
+        let secret = try write("secret.md", in: sandbox)
+
+        // Guard against the false pass: the target must actually exist, so an
+        // unrewritten result means "rejected", not "not found".
+        #expect(FileManager.default.fileExists(atPath: secret.path))
+
+        let resolver = MarkdownLinkResolver(documentDirectory: docs, worktreeRoot: root)
+        let out = resolver.resolve(html: #"<a href="../../secret.md">oops</a>"#)
+
+        #expect(out == #"<a href="../../secret.md">oops</a>"#)
+        #expect(!out.contains("file://"))
+    }
+
+    @Test("percent-encoded traversal is rejected too")
+    func rejectsEncodedTraversal() throws {
+        // The decode MUST precede the containment check, or %2e%2e%2f walks
+        // straight past a lexical guard.
+        let sandbox = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: sandbox) }
+        let root = sandbox.appendingPathComponent("repo")
+        let docs = root.appendingPathComponent("docs")
+        try FileManager.default.createDirectory(at: docs, withIntermediateDirectories: true)
+        let secret = try write("secret.md", in: sandbox)
+        #expect(FileManager.default.fileExists(atPath: secret.path))
+
+        let resolver = MarkdownLinkResolver(documentDirectory: docs, worktreeRoot: root)
+        let out = resolver.resolve(html: #"<a href="%2e%2e%2f%2e%2e%2fsecret.md">oops</a>"#)
+
+        #expect(!out.contains("file://"))
+    }
+
+    @Test("a symlink that escapes the worktree root is rejected")
+    func rejectsEscapingSymlink() throws {
+        let sandbox = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: sandbox) }
+        let root = sandbox.appendingPathComponent("repo")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let secret = try write("secret.md", in: sandbox)
+        try FileManager.default.createSymbolicLink(
+            at: root.appendingPathComponent("innocent.md"), withDestinationURL: secret)
+        #expect(FileManager.default.fileExists(atPath: secret.path))
+
+        let resolver = MarkdownLinkResolver(documentDirectory: root, worktreeRoot: root)
+        let out = resolver.resolve(html: #"<a href="innocent.md">x</a>"#)
+
+        #expect(!out.contains("file://"))
+    }
+
+    @Test("works when the document is reached through a symlinked root")
+    func worksUnderSymlinkedRoot() throws {
+        // Pins the ROOT-side resolvingSymlinksInPath(). Dropping it makes every
+        // link in every repo under a symlinked path silently stop working, and
+        // no temp-path test would notice: NSTemporaryDirectory() already equals
+        // its own realpath, so only a user-created symlink exposes a one-sided
+        // resolution.
+        let sandbox = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: sandbox) }
+        let real = sandbox.appendingPathComponent("real/doc")
+        try FileManager.default.createDirectory(at: real, withIntermediateDirectories: true)
+        try write("log.md", in: real)
+        try FileManager.default.createSymbolicLink(
+            at: sandbox.appendingPathComponent("link"),
+            withDestinationURL: sandbox.appendingPathComponent("real"))
+
+        let viaLink = sandbox.appendingPathComponent("link/doc")
+        let resolver = MarkdownLinkResolver(
+            documentDirectory: viaLink, worktreeRoot: sandbox.appendingPathComponent("link"))
+        let out = resolver.resolve(html: #"<a href="log.md">log</a>"#)
+
+        #expect(out.contains("file://"))
+        // The href keeps the path the user navigated, not its realpath, so the
+        // pane's selection matches what the sidebar shows.
+        #expect(out.contains("/link/doc/log.md"))
+    }
+
+    // MARK: - Left alone
+
+    @Test("absolute http(s) hrefs are untouched")
+    func leavesRemoteAlone() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let resolver = MarkdownLinkResolver(documentDirectory: dir, worktreeRoot: dir)
+        for raw in ["https://example.com/docs", "http://example.com/x", "mailto:a@b.com"] {
+            let html = #"<a href="\#(raw)">x</a>"#
+            #expect(resolver.resolve(html: html) == html)
+        }
+    }
+
+    @Test("fragment-only hrefs are untouched")
+    func leavesFragmentAnchorsAlone() throws {
+        // Every README table of contents depends on these reaching the webview
+        // as same-document anchors.
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let resolver = MarkdownLinkResolver(documentDirectory: dir, worktreeRoot: dir)
+        let html = #"<a href="#installation">Installation</a>"#
+        #expect(resolver.resolve(html: html) == html)
+    }
+
+    @Test("protocol-relative hrefs are untouched")
+    func leavesProtocolRelativeAlone() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let resolver = MarkdownLinkResolver(documentDirectory: dir, worktreeRoot: dir)
+        let html = #"<a href="//evil.com/x">x</a>"#
+        #expect(resolver.resolve(html: html) == html)
+    }
+
+    @Test("an href pointing at nothing is left unrewritten")
+    func leavesMissingTargetAlone() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let resolver = MarkdownLinkResolver(documentDirectory: dir, worktreeRoot: dir)
+        let html = #"<a href="nope.md">nope</a>"#
+        #expect(resolver.resolve(html: html) == html)
+    }
+
+    @Test("image tags are not touched by the link pass")
+    func leavesImagesAlone() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try write("pic.png", in: dir)
+
+        let resolver = MarkdownLinkResolver(documentDirectory: dir, worktreeRoot: dir)
+        let html = #"<img src="pic.png" alt="x" />"#
+        #expect(resolver.resolve(html: html) == html)
+    }
+
+    @Test("a tag whose name merely starts with 'a' is not matched")
+    func leavesAbbrAlone() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try write("log.md", in: dir)
+
+        let resolver = MarkdownLinkResolver(documentDirectory: dir, worktreeRoot: dir)
+        let html = #"<abbr href="log.md">x</abbr>"#
+        #expect(resolver.resolve(html: html) == html)
+    }
+
+    // MARK: - Through the document builder
+
+    @Test("a relative markdown link survives the whole build pipeline")
+    func resolvesThroughDocumentBuilder() throws {
+        // Construct through the production path: the regex, the ordering
+        // against the image inliner, and the builder wiring all participate.
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let target = try write("for-adam-log.md", in: dir)
+
+        let doc = try #require(MarkdownDocumentBuilder.build(
+            markdown: "See [the log](./for-adam-log.md) and [the web](https://example.com).",
+            documentDirectory: dir, worktreeRoot: dir, css: ""
+        ))
+
+        #expect(doc.contains(target.standardizedFileURL.absoluteString))
+        #expect(doc.contains("https://example.com"))
+    }
+}

--- a/Tests/TBDAppTests/MarkdownLinkResolverTests.swift
+++ b/Tests/TBDAppTests/MarkdownLinkResolverTests.swift
@@ -387,7 +387,14 @@ struct MarkdownLinkResolverTests {
         let resolver = MarkdownLinkResolver(documentDirectory: dir, worktreeRoot: dir)
         let out = resolver.resolve(html: #"<a href="this%20&amp;%20that.md">both</a>"#)
 
-        #expect(out.contains(target.standardizedFileURL.absoluteString))
+        // The emitted attribute is HTML-escaped, so the `&` the entity decoded
+        // to comes back out as `&amp;` — the round trip, not a failure to
+        // decode. Asserting the raw `absoluteString` here would pin the wrong
+        // contract and would only pass if the attribute were left unescaped.
+        let escaped = target.standardizedFileURL.absoluteString
+            .replacingOccurrences(of: "&", with: "&amp;")
+        #expect(out.contains(escaped))
+        #expect(!out.contains("&amp;amp;"), "the entity is decoded once, not re-escaped twice")
     }
 
     @Test("an encoded # in a filename is not mistaken for a fragment")

--- a/Tests/TBDAppTests/MarkdownLinkResolverTests.swift
+++ b/Tests/TBDAppTests/MarkdownLinkResolverTests.swift
@@ -157,10 +157,20 @@ struct MarkdownLinkResolverTests {
         let secret = try write("secret.md", in: sandbox)
         #expect(FileManager.default.fileExists(atPath: secret.path))
 
+        // Positive control, in the same test: without it this passes green
+        // even with `removingPercentEncoding` deleted from the resolver, since
+        // the literal name `%2e%2e%2f%2e%2e%2fsecret.md` does not exist either
+        // and an unrewritten href is the same observation as a rejected one.
+        // This href decodes to a file that DOES exist inside the root, so the
+        // decode has to be happening for the test to pass at all.
+        let inside = try write("release notes.md", in: docs)
+
         let resolver = MarkdownLinkResolver(documentDirectory: docs, worktreeRoot: root)
         let out = resolver.resolve(html: #"<a href="%2e%2e%2f%2e%2e%2fsecret.md">oops</a>"#)
+        let control = resolver.resolve(html: #"<a href="release%20notes.md">notes</a>"#)
 
         #expect(!out.contains("file://"))
+        #expect(control.contains(inside.standardizedFileURL.absoluteString))
     }
 
     @Test("a symlink that escapes the worktree root is rejected")
@@ -229,7 +239,7 @@ struct MarkdownLinkResolverTests {
         defer { try? FileManager.default.removeItem(at: dir) }
 
         let resolver = MarkdownLinkResolver(documentDirectory: dir, worktreeRoot: dir)
-        let html = #"<a href="#installation">Installation</a>"#
+        let html = ##"<a href="#installation">Installation</a>"##
         #expect(resolver.resolve(html: html) == html)
     }
 
@@ -253,15 +263,24 @@ struct MarkdownLinkResolverTests {
         #expect(resolver.resolve(html: html) == html)
     }
 
-    @Test("image tags are not touched by the link pass")
-    func leavesImagesAlone() throws {
+    @Test("the link pass rewrites the anchor and leaves the image src alone")
+    func leavesImageSourcesAlone() throws {
+        // Feeding it an `<img>` alone proves nothing: the regex is anchored on
+        // `<a`, so a lone image could never have matched however broken the
+        // pass was. Both tags in one document is the discriminating shape —
+        // loosen the regex to `src=` and the image assertion fails, break the
+        // anchor half and the link assertion fails.
         let dir = try makeTempDir()
         defer { try? FileManager.default.removeItem(at: dir) }
         try write("pic.png", in: dir)
+        let target = try write("log.md", in: dir)
 
         let resolver = MarkdownLinkResolver(documentDirectory: dir, worktreeRoot: dir)
-        let html = #"<img src="pic.png" alt="x" />"#
-        #expect(resolver.resolve(html: html) == html)
+        let out = resolver.resolve(
+            html: #"<p><img src="pic.png" alt="x" /><a href="log.md">log</a></p>"#)
+
+        #expect(out.contains(#"<img src="pic.png" alt="x" />"#))
+        #expect(out.contains(target.standardizedFileURL.absoluteString))
     }
 
     @Test("a tag whose name merely starts with 'a' is not matched")
@@ -272,6 +291,174 @@ struct MarkdownLinkResolverTests {
 
         let resolver = MarkdownLinkResolver(documentDirectory: dir, worktreeRoot: dir)
         let html = #"<abbr href="log.md">x</abbr>"#
+        #expect(resolver.resolve(html: html) == html)
+    }
+
+    // MARK: - Root-relative hrefs
+
+    @Test("a root-relative href resolves against the worktree root, not the document")
+    func resolvesRootRelativeAgainstRoot() throws {
+        // GitHub semantics: a leading `/` addresses the repository root.
+        // Resolved against the document directory instead, this lands on the
+        // dead `<root>/docs/docs/setup.md`.
+        let root = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let docs = root.appendingPathComponent("docs")
+        try FileManager.default.createDirectory(at: docs, withIntermediateDirectories: true)
+        let target = try write("docs/setup.md", in: root)
+
+        let resolver = MarkdownLinkResolver(documentDirectory: docs, worktreeRoot: root)
+        let out = resolver.resolve(html: #"<a href="/docs/setup.md">setup</a>"#)
+
+        #expect(out.contains(target.standardizedFileURL.absoluteString))
+    }
+
+    @Test("a root-relative href does not silently pick the same-named sibling")
+    func rootRelativePrefersRootOverDocumentDirectory() throws {
+        // Both files exist. Resolving `/README.md` against the document
+        // directory finds `docs/README.md` and looks like it worked — the
+        // silent-wrong-file half of the defect, which the dead-link test
+        // above cannot see.
+        let root = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let docs = root.appendingPathComponent("docs")
+        try FileManager.default.createDirectory(at: docs, withIntermediateDirectories: true)
+        let atRoot = try write("README.md", in: root)
+        let decoy = try write("README.md", in: docs)
+
+        let resolver = MarkdownLinkResolver(documentDirectory: docs, worktreeRoot: root)
+        let out = resolver.resolve(html: #"<a href="/README.md">readme</a>"#)
+
+        #expect(out.contains(atRoot.standardizedFileURL.absoluteString))
+        #expect(!out.contains(decoy.standardizedFileURL.absoluteString))
+    }
+
+    @Test("an absolute system path is reinterpreted under the root, never escaping it")
+    func absoluteSystemPathStaysInsideRoot() throws {
+        // `/etc/passwd` becomes `<root>/etc/passwd`. The file is created here
+        // so the test discriminates: without the reinterpretation the href
+        // would have to name the real `/etc/passwd`, and with it the href
+        // names the in-root file. A missing target would have made both
+        // outcomes look identical.
+        let root = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let inRoot = try write("etc/passwd", in: root)
+
+        let resolver = MarkdownLinkResolver(documentDirectory: root, worktreeRoot: root)
+        let out = resolver.resolve(html: #"<a href="/etc/passwd">creds</a>"#)
+
+        #expect(out.contains(inRoot.standardizedFileURL.absoluteString))
+        #expect(!out.contains(#"file:///etc/passwd""#))
+    }
+
+    @Test("a bare / href is left alone")
+    func leavesBareRootHrefAlone() throws {
+        let root = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let resolver = MarkdownLinkResolver(documentDirectory: root, worktreeRoot: root)
+        let html = #"<a href="/">home</a>"#
+        #expect(resolver.resolve(html: html) == html)
+    }
+
+    // MARK: - Undoing comrak's escaping
+
+    @Test("an apostrophe entity is decoded")
+    func decodesApostropheEntity() throws {
+        // comrak's `escape_href` writes `'` as `&#x27;` — verified in its
+        // source, alongside `&amp;` for `&`. Leaving it undecoded makes every
+        // link to a file with an apostrophe in its name dead.
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let target = try write("user's guide.md", in: dir)
+
+        let resolver = MarkdownLinkResolver(documentDirectory: dir, worktreeRoot: dir)
+        let out = resolver.resolve(html: ##"<a href="user&#x27;s%20guide.md">guide</a>"##)
+
+        #expect(out.contains(target.standardizedFileURL.absoluteString))
+    }
+
+    @Test("an escaped ampersand entity is still decoded")
+    func decodesAmpersandEntity() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let target = try write("this & that.md", in: dir)
+
+        let resolver = MarkdownLinkResolver(documentDirectory: dir, worktreeRoot: dir)
+        let out = resolver.resolve(html: #"<a href="this%20&amp;%20that.md">both</a>"#)
+
+        #expect(out.contains(target.standardizedFileURL.absoluteString))
+    }
+
+    @Test("an encoded # in a filename is not mistaken for a fragment")
+    func doesNotTruncateAtAnEncodedHash() throws {
+        // `#` is in comrak's HREF_SAFE set, so a real fragment arrives
+        // literal and a `#` in a filename arrives as `%23`. Splitting after
+        // the percent-decode cuts this href down to `a`.
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let target = try write("a#b.md", in: dir)
+
+        let resolver = MarkdownLinkResolver(documentDirectory: dir, worktreeRoot: dir)
+        let out = resolver.resolve(html: #"<a href="a%23b.md">a</a>"#)
+
+        #expect(out.contains(target.standardizedFileURL.absoluteString))
+    }
+
+    // MARK: - Scheme detection
+
+    @Test("a colon inside a filename is not read as a scheme")
+    func colonInFilenameIsNotAScheme() throws {
+        // `:` is in comrak's HREF_SAFE set, so `[notes](v1:changelog.md)`
+        // reaches the resolver unencoded. `URL(string:)?.scheme` reports
+        // `v1` for it, which abandoned the link as if it were remote.
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let target = try write("v1:changelog.md", in: dir)
+
+        let resolver = MarkdownLinkResolver(documentDirectory: dir, worktreeRoot: dir)
+        let out = resolver.resolve(html: #"<a href="v1:changelog.md">notes</a>"#)
+
+        #expect(out.contains(target.standardizedFileURL.absoluteString))
+    }
+
+    @Test("authority-bearing and opaque schemes are still refused")
+    func stillRefusesRealSchemes() throws {
+        // The permissive half of the scheme check must not reach these.
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        // The opaque ones are the discriminating half: each names a file that
+        // really is sitting in the root, so a resolver that read them as
+        // relative paths would rewrite the href and redden this test.
+        let opaque = ["mailto:a@b.com", "data:text", "file:x.md", "javascript:x.md"]
+        for name in opaque {
+            try write(name, in: dir)
+        }
+
+        let resolver = MarkdownLinkResolver(documentDirectory: dir, worktreeRoot: dir)
+        let raws = opaque + [
+            "https://evil.com", "http://evil.com", "smb://evil.com", "tbd://evil.com",
+        ]
+        for raw in raws {
+            let html = #"<a href="\#(raw)">x</a>"#
+            #expect(resolver.resolve(html: html) == html, "\(raw) must be left alone")
+        }
+    }
+
+    // MARK: - What the target has to be
+
+    @Test("a directory named like a document is not a link target")
+    func rejectsDirectoryTarget() throws {
+        // Parity with `MarkdownImageInliner`, which requires a regular file.
+        // `fileExists` alone says yes to a directory named `notes.md`.
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let asDirectory = dir.appendingPathComponent("notes.md")
+        try FileManager.default.createDirectory(at: asDirectory, withIntermediateDirectories: true)
+        #expect(FileManager.default.fileExists(atPath: asDirectory.path))
+
+        let resolver = MarkdownLinkResolver(documentDirectory: dir, worktreeRoot: dir)
+        let html = #"<a href="notes.md">notes</a>"#
         #expect(resolver.resolve(html: html) == html)
     }
 

--- a/Tests/TBDAppTests/MarkdownWebViewConfigurationTests.swift
+++ b/Tests/TBDAppTests/MarkdownWebViewConfigurationTests.swift
@@ -155,12 +155,19 @@ struct MarkdownWebViewConfigurationTests {
         }
     }
 
-    @Test("extension sets agree between the policy and the pane")
-    func renderableExtensionsAreLowercased() {
-        // `isRenderableMarkdown` lowercases the candidate, so the set itself
-        // must hold lowercase entries or the comparison silently never matches.
-        for ext in MarkdownWebViewConfiguration.renderableExtensions {
-            #expect(ext == ext.lowercased())
+    @Test("the pane renders in place exactly what the policy routes to it")
+    func paneRendersWhatThePolicyRoutes() {
+        // The two read one set, and the pane collapses to zero height if it is
+        // handed something it will not render as a full-pane webview. Asserting
+        // the set against itself — every entry equals its own lowercasing —
+        // could not fail; comparing the two consumers can.
+        for ext in ["md", "markdown", "MD", "MarkDown", "txt", "png", "swift", ""] {
+            let url = URL(fileURLWithPath: "/repo/file.\(ext)")
+            let routesToPane = MarkdownWebViewConfiguration.policy(
+                for: url, isOwnLoad: false, isLinkActivation: true) == .openInPane(url)
+            let paneRendersIt = MarkdownPaneLayout.usesFullPaneWebView(
+                showSourceCode: false, selectedFiles: [url.path], useWebView: true)
+            #expect(routesToPane == paneRendersIt, "disagreement on .\(ext)")
         }
     }
 

--- a/Tests/TBDAppTests/MarkdownWebViewConfigurationTests.swift
+++ b/Tests/TBDAppTests/MarkdownWebViewConfigurationTests.swift
@@ -95,15 +95,73 @@ struct MarkdownWebViewConfigurationTests {
             for: url, isOwnLoad: false, isLinkActivation: true) == .openExternally(url))
     }
 
-    @Test("file links reveal in Finder and are never launched")
+    @Test("non-markdown file links reveal in Finder and are never launched")
     func fileRevealsRatherThanOpens() {
         // NSWorkspace.open on a file: URL launches it with its default app.
         // `git clone` sets only com.apple.provenance, NOT com.apple.quarantine
         // (verified), so a .app inside a freshly cloned repo would run with
         // Gatekeeper never consulted.
-        let url = URL(string: "file:///tmp/notes.md")!
+        let url = URL(string: "file:///tmp/install.command")!
         #expect(MarkdownWebViewConfiguration.policy(
             for: url, isOwnLoad: false, isLinkActivation: true) == .revealInFinder(url))
+    }
+
+    @Test("a link to a local markdown file navigates the pane")
+    func markdownFileOpensInPane() {
+        // `MarkdownLinkResolver` turns `[log](./log.md)` into this file: URL.
+        // Revealing it in Finder would be a worse answer than rendering it,
+        // and rendering happens entirely in-app.
+        let url = URL(string: "file:///repo/docs/log.md")!
+        #expect(MarkdownWebViewConfiguration.policy(
+            for: url, isOwnLoad: false, isLinkActivation: true) == .openInPane(url))
+    }
+
+    @Test("the .markdown extension and odd casing also navigate the pane")
+    func markdownExtensionVariants() {
+        for raw in ["file:///repo/a.markdown", "file:///repo/b.MD", "file:///repo/c.MarkDown"] {
+            let url = URL(string: raw)!
+            #expect(MarkdownWebViewConfiguration.policy(
+                for: url, isOwnLoad: false, isLinkActivation: true) == .openInPane(url))
+        }
+    }
+
+    @Test("a markdown file link still needs a real click")
+    func markdownFileNeedsLinkActivation() {
+        // The gesture gate covers the in-pane route too: a <meta refresh> must
+        // not be able to swap the pane's document out from under the user.
+        #expect(MarkdownWebViewConfiguration.policy(
+            for: URL(string: "file:///repo/docs/log.md"), isOwnLoad: false,
+            isLinkActivation: false) == .cancel)
+    }
+
+    @Test("no file: URL ever routes to openExternally")
+    func fileNeverOpensExternally() {
+        // The invariant the whole file: branch exists to hold. Whichever way a
+        // local file is routed, it is never handed to NSWorkspace.open.
+        let raws = [
+            "file:///repo/docs/log.md", "file:///repo/a.markdown",
+            "file:///repo/run.command", "file:///Applications/Evil.app",
+            "file:///repo/noextension", "file:///etc/passwd",
+        ]
+        for raw in raws {
+            let policy = MarkdownWebViewConfiguration.policy(
+                for: URL(string: raw), isOwnLoad: false, isLinkActivation: true)
+            switch policy {
+            case .openExternally:
+                Issue.record("file: URL \(raw) routed to openExternally")
+            case .openInPane, .revealInFinder, .cancel, .allowInPlace:
+                break
+            }
+        }
+    }
+
+    @Test("extension sets agree between the policy and the pane")
+    func renderableExtensionsAreLowercased() {
+        // `isRenderableMarkdown` lowercases the candidate, so the set itself
+        // must hold lowercase entries or the comparison silently never matches.
+        for ext in MarkdownWebViewConfiguration.renderableExtensions {
+            #expect(ext == ext.lowercased())
+        }
     }
 
     @Test("network-mount schemes are cancelled")
@@ -148,7 +206,7 @@ struct MarkdownWebViewConfigurationTests {
         let https = URL(string: "HTTPS://example.com/x")!
         #expect(MarkdownWebViewConfiguration.policy(
             for: https, isOwnLoad: false, isLinkActivation: true) == .openExternally(https))
-        let file = URL(string: "FILE:///tmp/x")!
+        let file = URL(string: "FILE:///tmp/x.command")!
         #expect(MarkdownWebViewConfiguration.policy(
             for: file, isOwnLoad: false, isLinkActivation: true) == .revealInFinder(file))
         #expect(MarkdownWebViewConfiguration.policy(

--- a/Tests/TBDSharedTests/ViewerRoutingTests.swift
+++ b/Tests/TBDSharedTests/ViewerRoutingTests.swift
@@ -181,4 +181,57 @@ struct ViewerRoutingTests {
         #expect(result.replaced == nil, "note panes are not viewer-class — must split instead")
         #expect(result.layout.allPaneIDs().count == 3)
     }
+
+    // MARK: - routeInPaneFileNavigation
+
+    @Test func routeInPaneFileNavigation_swapsThatPaneKeepingItsID() {
+        // The whole point of routing through the layout rather than the pane's
+        // own state: the pane's `path` is what the header title, the header
+        // context menu, the slot history and the persisted layout all read.
+        let viewerID = UUID()
+        let otherViewerID = UUID()
+        let layout = LayoutNode.split(
+            id: UUID(), direction: .horizontal,
+            children: [
+                .pane(.codeViewer(id: otherViewerID, path: "/other.md")),
+                .pane(.codeViewer(id: viewerID, path: "/old.md")),
+            ],
+            ratios: [0.5, 0.5]
+        )
+
+        let result = routeInPaneFileNavigation(into: layout, paneID: viewerID, path: "/new.md")
+
+        guard let result,
+              case .split(_, _, let children, let ratios) = result.layout,
+              case .pane(.codeViewer(let id, let path)) = children[1]
+        else {
+            Issue.record("Expected codeViewer in right child"); return
+        }
+        #expect(id == viewerID, "paneID must survive so the slot keeps its history and identity")
+        #expect(path == "/new.md")
+        #expect(ratios == [0.5, 0.5])
+        // The OTHER viewer must not be the one that moved — that is the
+        // difference from `routeFileClick`, which picks the first viewer it
+        // finds anywhere in the layout.
+        #expect(children[0] == .pane(.codeViewer(id: otherViewerID, path: "/other.md")))
+        #expect(result.replaced == .init(
+            paneID: viewerID,
+            outgoing: .codeViewer(id: viewerID, path: "/old.md"),
+            incoming: .codeViewer(id: viewerID, path: "/new.md")
+        ))
+    }
+
+    @Test func routeInPaneFileNavigation_isNilWhenAlreadyShowingThatFile() {
+        let viewerID = UUID()
+        let layout = LayoutNode.pane(.codeViewer(id: viewerID, path: "/same.md"))
+
+        #expect(routeInPaneFileNavigation(into: layout, paneID: viewerID, path: "/same.md") == nil,
+                "a no-op navigation must not push a duplicate history entry")
+    }
+
+    @Test func routeInPaneFileNavigation_isNilForAPaneNotInTheLayout() {
+        let layout = LayoutNode.pane(.codeViewer(id: UUID(), path: "/a.md"))
+
+        #expect(routeInPaneFileNavigation(into: layout, paneID: UUID(), path: "/b.md") == nil)
+    }
 }

--- a/docs/specs/2026-07-28-markdown-display-options-design.md
+++ b/docs/specs/2026-07-28-markdown-display-options-design.md
@@ -138,8 +138,30 @@ Scope is global. No per-repo override and no repo-local config file.
 > both designs.
 
 The display webview uses a `.nonPersistent()` data store, installs **no script message
-handlers**, and denies in-place navigation — link clicks route to `NSWorkspace`. JavaScript is
-disabled (`allowsContentJavaScript = false`) unless `renderMermaidDiagrams` is enabled.
+handlers**, and registers **no URL scheme handler**. JavaScript is disabled
+(`allowsContentJavaScript = false`) unless `renderMermaidDiagrams` is enabled.
+
+Navigation is decided four ways, and everything but the first two requires a real link
+activation — a `<meta http-equiv="refresh">` fires with JavaScript off, so a gesture gate is what
+stops a rendered document acting on its own:
+
+- **In place** — our own document load, and a same-document `about:blank#fragment` anchor. README
+  tables of contents depend on the second.
+- **In the pane** — a link to a repo-local markdown file navigates the enclosing code-viewer pane,
+  which renders it. Entirely in-app: no launch decision is involved. Relative hrefs are rewritten
+  to absolute `file://` URLs at document-build time, and the resolved target must be a regular
+  file inside the symlink-resolved worktree root; the pane re-checks that containment before it
+  accepts the navigation, because the policy function itself is pure and knows no worktree.
+- **Out to `NSWorkspace`** — `http`, `https` and `mailto` only, on a click. An allowlist, not a
+  blocklist: `smb:`/`afp:`/`nfs:` mount against an attacker-chosen host and prompt for
+  credentials, `tbd:` drives TBD's own deep-link handler, and any installed app can claim a
+  scheme.
+- **Dropped** — everything else, including every unrecognised scheme.
+
+A `file:` URL is **never** handed to `NSWorkspace.open`. One that is not renderable markdown is
+revealed in Finder instead: `git clone` sets `com.apple.provenance` but not
+`com.apple.quarantine`, so a `.app` or `.command` inside a freshly cloned repo would otherwise
+launch with Gatekeeper never consulted.
 
 **Remote subresources are allowed.** Badges and remote images load normally. The accepted
 consequence is that opening an unaudited README issues requests to whatever hosts it names,


### PR DESCRIPTION
## What's broken

In the code-viewer pane, with markdown rendered by the webview, a link to another
file in the same repo does nothing. You click `[full history](for-adam-log.md)`
and the pane sits there. No error, no Finder window, no navigation — the click is
swallowed.

It hits every relative link, in every markdown file, every time: the cross-linked
`.context/` note, a README pointing at `docs/setup.md`, a spec citing its sibling
proposal. External links (`https://…`) and same-page anchors (`#section`) work
fine, which makes the failure look arbitrary rather than systematic. The older
MarkdownUI rendering does not have this problem, so a reader who switches
renderers sees the same document lose its links.

## Why it happens

A relative link only means something relative to *somewhere*. The webview is
handed its document as a string, with no location attached — `loadHTMLString`
with a nil base URL — so the page's address is `about:blank`. Resolving
`for-adam-log.md` against `about:blank` yields nothing usable, and the pane's
navigation policy, which only recognises a small allowlist of schemes, drops what
comes out. The document never knew where on disk it came from, so its links had
nothing to point at.

The MarkdownUI path escapes this because it is given the file's own URL as a base
and resolves against that.

## What this PR does

The document is assembled from a markdown file whose directory we know, so the
links are resolved at assembly time rather than at click time. A new
`MarkdownLinkResolver` rewrites document-relative `href` values into absolute
`file://` URLs, and a click on one navigates the pane to that file.

- **Resolution happens during document assembly**, mirroring the existing
  `MarkdownImageInliner`: resolve against the document's directory, require the
  result to be a regular file contained under the symlink-resolved worktree root,
  leave anything else untouched. Preferred over emitting `<base href="file:///…">`,
  which would change subresource resolution for the whole document rather than
  just its links.
- **A markdown target navigates the pane**; every other local file still reveals
  in Finder. A `file:` URL is never handed to `NSWorkspace.open` — the existing
  reasoning holds, that a `.command` or `.app` inside a freshly cloned repo would
  launch with Gatekeeper never consulted.
- **Navigation goes through the layout, not the view's private state.** The pane's
  identity is its `PaneContent.codeViewer(id:path:)`, and the header title, the
  header context menu's Copy Path / Open With, the slot's history and the persisted
  layout all read the path from there. A new `routeInPaneFileNavigation` points one
  named pane at a file, keeping its pane UUID — the same primitives `routeFileClick`
  uses, minus the destination-picking, which would have been free to choose the
  wrong pane.
- **Containment is checked twice, on purpose.** The resolver's check is what makes
  an in-repo link work at all; the pane re-checks before accepting a navigation,
  because the navigation policy is pure and knows no worktree. That second check is
  what stands between a hand-written `file:` destination and an out-of-worktree file
  rendering in-app; today comrak's safe mode also empties `file:` hrefs, but nothing
  in this repo tested that, so the guarantee did not belong there alone.

Also folded in, since they were found while resolving the same href: root-relative
`/docs/setup.md` now resolves against the worktree root the way every forge renders
it (it was landing under the document's own directory, dead or occasionally on the
wrong file); comrak's `&#x27;` escape is decoded, so a filename with an apostrophe
resolves; the fragment split moved between the two decode steps, so `a%23b.md` finds
the real file `a#b.md`; and `v1:changelog.md` is no longer mistaken for a URL scheme.

## Assumptions

- **comrak's safe mode empties `javascript:`, `vbscript:`, `file:` and `data:`
  destinations.** The resolver leaves any href that already names a scheme alone, so
  a hand-written `file:` link reaching the page depends on comrak clobbering it. If
  that ever changes, the pane's own containment check is what still holds — which is
  why it is there.
- **`isLinkActivation` means a user gesture.** True while JavaScript is off on this
  path. Once `renderMermaidDiagrams` enables JS, `document.querySelector('a').click()`
  also reports `.linkActivated`, and a script in the document could drive both the
  in-pane navigation and the existing external-open route. Not reachable today; a
  code comment at the site records it for whoever lands mermaid.

## Evidence & verification

- **Repro:** a `.context/` note containing `[Full history](for-adam-log.md)` and
  `[draft](./draft-handback.md)`, opened in a code-viewer pane with
  `markdown.viewer.usewebview` on. Clicking either does nothing.
- **Discriminating tests.** The resolver tests assert the exact rewritten
  `file://` string, so they fail if resolution is absent; the traversal tests carry a
  positive in-root control alongside each refusal, so deleting the percent-decode or
  the containment check reddens them rather than passing on a missing file; the
  scheme test names files that actually exist, so a resolver reading `data:` as a
  path would rewrite and fail. The routing tests pin that the pane UUID survives, that
  a sibling viewer is untouched, and that re-navigating to the file already shown is a
  no-op rather than a duplicate history entry.
- **Suites:** the markdown and viewer-routing suites pass (198 tests, 14 suites).
  Full suite: 9,738 tests, failures confined to holder / tmux / control-mode / OSC-777
  suites that are unrelated to this diff and that shift between runs on this machine —
  a filtered re-run passed some of them and failed a different one. `swiftlint --strict`
  clean across 925 files.
- **Not yet verified live.** That WebKit delivers a policy callback at all for a
  `file:` navigation from an `about:blank` document is read-verified only; the
  pre-existing reveal-in-Finder branch rests on the same behaviour, and neither
  callback fires under unit tests.

## Notes

- A fragment on a link (`./doc.md#section`) navigates to the file and lands at the
  top; there is no scroll-to-anchor plumbing across a document switch.
- `MarkdownImageInliner` has the same root-relative defect for image `src` values.
  Left alone deliberately — out of scope here.
- The MarkdownUI path still calls `NSWorkspace.open` on file URLs, which is what
  every user sees while `markdown.viewer.usewebview` is off. Pre-existing and
  untouched.

https://claude.ai/code/session_01GPPvcUsKLJV9V1VWVGWLcZ

[🔗 Fix Web Relative Links](https://cheapsteak.github.io/tbd/open/?worktree=2E986C03-02D9-4331-8385-F8E9FDB6040B)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Markdown previews now support safe in-pane navigation for repository-local Markdown links.
  - Links to non-renderable local files open in Finder, while supported web and email links open externally.
  - Document-relative and root-relative links are resolved automatically, with fragment navigation preserved.
  - Navigating between documents keeps the existing pane and layout intact.

- **Bug Fixes**
  - Unsafe, missing, unsupported, or out-of-worktree links are rejected.

- **Documentation**
  - Updated Markdown display and link-navigation behavior specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->