### PR TITLE
Fix: Stop the shadow-peer sweep from unlinking a live session's socket when its accept queue is momentarily full

### DIFF
--- a/Sources/TBDDaemon/Remote/ShadowPeerAttribution.swift
+++ b/Sources/TBDDaemon/Remote/ShadowPeerAttribution.swift
@@ -232,11 +232,18 @@ public protocol LocalPeerDelivering: Sendable {
 /// (`docs/research/2026-08-29-cross-machine-messaging/findings.md` § T1).
 ///
 /// The syscalls run on a dedicated serial queue rather than on the caller's
-/// actor. A `connect(2)` to a Unix socket whose listener has a full backlog
-/// blocks, and blocking an actor's executor is the starvation class
-/// `ProviderEventsSupervisor` documents at length; hopping costs one context
-/// switch per message on a channel whose traffic is, by design, aggregate and
-/// small.
+/// actor. The `connect(2)` does not block — on darwin it refuses immediately
+/// when the listener's accept queue is full — but the `write(2)` after it can
+/// park for the whole of `SO_SNDTIMEO` against a receiver that has stopped
+/// draining, and blocking an actor's executor for two seconds is the starvation
+/// class `ProviderEventsSupervisor` documents at length. Hopping costs one
+/// context switch per message on a channel whose traffic is, by design,
+/// aggregate and small.
+///
+/// A corollary of that same refusal: a frame aimed at a saturated peer is
+/// refused at the connect and dropped, exactly as one aimed at a session that
+/// has exited is. That is the designed failure semantics of this channel — no
+/// buffering, no retry — not an incident.
 public struct UnixSocketLocalPeerDelivery: LocalPeerDelivering {
     /// How long a write may take before the frame is abandoned.
     ///

--- a/Sources/TBDDaemon/Remote/ShadowPeerAttribution.swift
+++ b/Sources/TBDDaemon/Remote/ShadowPeerAttribution.swift
@@ -311,9 +311,11 @@ public struct UnixSocketLocalPeerDelivery: LocalPeerDelivering {
             }
         }
         guard connected == 0 else {
-            // ECONNREFUSED here is the *designed* signal that a peer is gone:
-            // a listener that has been closed and unlinked is what makes a
-            // sender see the same failure as a session that exited.
+            // ECONNREFUSED here is what a gone peer produces — a listener that
+            // has been closed and unlinked — and equally what a live peer whose
+            // accept queue is full produces. This side does not try to tell the
+            // two apart: either way the frame is dropped, which is the designed
+            // failure semantics of this channel.
             throw LocalPeerDeliveryError.connectFailed(path: path, errno: errno)
         }
 

--- a/Sources/TBDDaemon/Remote/ShadowPeerReconciler.swift
+++ b/Sources/TBDDaemon/Remote/ShadowPeerReconciler.swift
@@ -80,11 +80,14 @@ public actor ShadowPeerBridgeRegistry: ShadowPeerBridgeInspecting {
 
 /// What a connect to a socket path found.
 public enum ShadowPeerListenerState: Sendable, Equatable {
-    /// Something accepted, or its backlog is full. Either way a listener
-    /// exists, so the file is not TBD's to unlink.
+    /// Something accepted the connect. A listener exists, so the file is not
+    /// TBD's to unlink.
     case listening
-    /// `ECONNREFUSED` — the file is there and nothing is behind it. This is the
-    /// designed signal that a peer is gone.
+    /// `ECONNREFUSED` — nothing accepted the connect. On darwin that is also
+    /// what a live listener whose accept queue is full reports, so this is
+    /// proof of absence only alongside a pid that is provably gone; see
+    /// `UnixSocketShadowPeerProbe` for the measurement and
+    /// `ShadowPeerReconciler.socketOutcome` for the gate that follows from it.
     case refused
     /// No such file. Already reclaimed, by the helper's own exit or by an
     /// earlier sweep.
@@ -102,11 +105,21 @@ public protocol ShadowPeerSocketProbing: Sendable {
 /// `SOCK_STREAM`, which is the same connect-and-drop `ListAgents` uses to
 /// delist a peer whose socket no longer answers.
 ///
-/// Non-blocking deliberately. A `connect` to a Unix socket whose listener has a
-/// full backlog blocks, and blocking the reconciler's actor executor is the
-/// starvation class the rest of this subsystem avoids everywhere. `EAGAIN` /
-/// `EINPROGRESS` from a non-blocking connect means a listener exists and is
-/// merely busy, which is exactly the answer the sweep needs.
+/// **A refused connect is not proof that nothing is listening.** On darwin, a
+/// `connect(2)` to an `AF_UNIX` socket whose listener's accept queue is full
+/// returns `ECONNREFUSED` immediately: the queue limit is exactly the backlog
+/// value passed to `listen(2)`, the call never blocks, and a non-blocking
+/// connect never comes back `EINPROGRESS` or `EAGAIN` (measured). So at this
+/// syscall "a listener is alive and saturated" and "nothing is behind the path"
+/// are the same answer, and no amount of probing separates them. What separates
+/// them is the pid the socket file is named after, which is why
+/// `ShadowPeerReconciler` unlinks only once that pid is gone.
+///
+/// Non-blocking is kept even though nothing here blocks. It costs nothing, it
+/// bounds how long one probe can hold an executor whatever a kernel does with
+/// this call later, and it makes an unexpected in-progress result fall through
+/// to `.inconclusive` — an answer the sweep refuses to act on — rather than be
+/// read as an answer.
 public struct UnixSocketShadowPeerProbe: ShadowPeerSocketProbing {
     public init() {}
 
@@ -145,7 +158,6 @@ public struct UnixSocketShadowPeerProbe: ShadowPeerSocketProbing {
         switch errno {
         case ECONNREFUSED: return .refused
         case ENOENT: return .absent
-        case EAGAIN, EINPROGRESS: return .listening
         default: return .inconclusive("connect(2): \(String(cString: strerror(errno)))")
         }
     }
@@ -220,7 +232,8 @@ public struct ShadowPeerSweepResult: Sendable, Equatable {
 /// - a record with no live helper — including the **recycled-pid ghost**, which
 ///   Claude Code's own reaper provably will not collect, because it checks pid
 ///   liveness and nothing else (measured),
-/// - a socket TBD created with nothing listening,
+/// - a socket TBD created, at a pid that no longer exists, that refuses a
+///   connect,
 /// - anything TBD published under a previous daemon generation.
 ///
 /// A fourth artifact rides along with the record: `ShadowPeerRecordStore.write`
@@ -230,12 +243,17 @@ public struct ShadowPeerSweepResult: Sendable, Equatable {
 /// reclaimed here — see `unlinkStrandedRecordTemporaries` for why that is still
 /// ledger-derived rather than the forbidden inference.
 ///
-/// **Ownership is proved before every unlink.** A pid outlives the process TBD
-/// filed under it: `<pid>.json` and `<pid>.sock` can be re-created by a real
-/// Claude Code session that inherited the number. So a record is unlinked only
-/// when the `sessionId` inside it is the one TBD published, and a socket only
-/// when a connect gets `ECONNREFUSED`. Anything else is somebody's live peer
-/// and is left exactly where it is.
+/// **Ownership is proved before every unlink, and the pid is what proves it.**
+/// A pid outlives the process TBD filed under it: `<pid>.json` and `<pid>.sock`
+/// can be re-created by a real Claude Code session that inherited the number. A
+/// record carries a session id, so it proves its own ownership and is unlinked
+/// only when that id is the one TBD published. A socket carries nothing, and a
+/// connect cannot supply the missing proof — on darwin a saturated listener
+/// refuses exactly like an empty path — so the socket is unlinked only when the
+/// pid it is named after is provably gone *and* a connect refuses. While that
+/// pid belongs to somebody else the socket is never even probed, and its row is
+/// kept so a later sweep can reclaim the file once the pid dies. Anything else
+/// is somebody's live peer and is left exactly where it is.
 public actor ShadowPeerReconciler {
     private let artifacts: ShadowPeerArtifactStore
     private let bridges: any ShadowPeerBridgeInspecting
@@ -461,11 +479,14 @@ public actor ShadowPeerReconciler {
             // nothing else, so this record would survive it forever. Its pid
             // now belongs to an unrelated process, which must never be
             // signalled — that is somebody's editor, or a session of their own.
+            // Only the record can be judged while that process lives, because
+            // only the record says who wrote it; the socket waits for the pid
+            // to go (`socketOutcome`).
             reconcilerLogger.info("""
                 recycled-pid ghost for shadow \(row.name, privacy: .public) \
                 (\(row.handle, privacy: .public)): pid \(row.pid, privacy: .public) is alive but \
-                is not the helper TBD recorded, so it is left running and only the artifacts are \
-                reclaimed
+                is not the helper TBD recorded, so it is left running and only the artifacts TBD \
+                can prove are its own are reclaimed
                 """)
 
         case .undecided:
@@ -489,8 +510,10 @@ public actor ShadowPeerReconciler {
             return
         }
 
+        var recordOutcome = ArtifactOutcome.absent
         if settled {
-            switch unlinkRecordIfOurs(row) {
+            recordOutcome = unlinkRecordIfOurs(row)
+            switch recordOutcome {
             case .unlinked:
                 result.recordsUnlinked += 1
             case .absent:
@@ -503,21 +526,26 @@ public actor ShadowPeerReconciler {
             }
         }
 
-        // The record's write-temps, and **only when the pid is provably gone**.
-        // A dead pid cannot be halfway through a `rename(2)`, which is the one
-        // thing that would make a temp at this name somebody's live business
-        // rather than an orphan.
+        // **The pid is re-read here, and both steps below turn on it.** A dead
+        // pid cannot be halfway through a `rename(2)`, which is the one thing
+        // that would make a write-temp at this name somebody's live business
+        // rather than an orphan; and a dead pid is the only thing that makes a
+        // refused connect mean the socket is unowned rather than merely busy.
         //
-        // Liveness is re-read rather than reused from the top of this call: a
-        // helper this pass has just killed leaves exactly the stranded temp
-        // this reclaims, and reusing the earlier `alive` would skip its own
-        // kill's leavings and then retire the row that named them.
-        if !signaller.isAlive(row.pid) {
+        // Re-read rather than reused from the top of this call: a helper this
+        // pass has just killed leaves exactly the stranded temp and the
+        // unanswered socket these two steps reclaim, and reusing the earlier
+        // `alive` would skip its own kill's leavings and then retire the row
+        // that named them.
+        let pidIsGone = !signaller.isAlive(row.pid)
+        if pidIsGone {
             result.recordTemporariesUnlinked += unlinkStrandedRecordTemporaries(row)
         }
 
         if settled {
-            switch unlinkSocketIfUnclaimed(row) {
+            switch socketOutcome(
+                row, recordProvedForeign: recordOutcome == .foreign, pidIsGone: pidIsGone
+            ) {
             case .unlinked:
                 result.socketsUnlinked += 1
             case .absent:
@@ -572,7 +600,7 @@ public actor ShadowPeerReconciler {
         return current == recorded ? .ourHelper : .stranger
     }
 
-    private enum ArtifactOutcome {
+    private enum ArtifactOutcome: Equatable {
         case unlinked
         case absent
         /// At the recorded path, but demonstrably not TBD's any more.
@@ -689,12 +717,86 @@ public actor ShadowPeerReconciler {
         return unlinked
     }
 
-    /// Unlink the socket only when a connect proves nothing is behind it.
+    /// Decide the socket half of one row — and decide it from the **pid**,
+    /// with the connect as corroboration rather than as the proof.
     ///
-    /// This is the narrow version of the rule the design forbids in general:
-    /// not "any socket with nothing listening", which races a real session
-    /// between `bind()` and `listen()`, but "this socket, which TBD's own
-    /// bookkeeping says TBD created, and which now refuses a connect".
+    /// A Claude Code session, and TBD's helper, each bind exactly one socket,
+    /// named after their own pid. So the only process that can legitimately be
+    /// listening at `<pid>.sock` is the one holding that pid, and the pid is
+    /// the honest primitive here. The connect is not: on darwin a connect to a
+    /// socket whose listener's accept queue is full refuses immediately and is
+    /// indistinguishable from a connect to a path nobody is behind
+    /// (`UnixSocketShadowPeerProbe`). Three answers follow, ordered by what TBD
+    /// can prove:
+    ///
+    /// - **The record proved a foreign owner.** `unlinkRecordIfOurs` read a
+    ///   record at this row's path carrying a session id TBD never published,
+    ///   which is proof the pid was recycled and that whatever sits at
+    ///   `<pid>.sock` was bound by that session. The socket is not probed at
+    ///   all: the proof is already in hand, and a probe could only return a
+    ///   refusal that invites an unlink. Counted as a foreign artifact when the
+    ///   file is there, and the row retires, because nothing of TBD's is left
+    ///   for it to name.
+    /// - **The pid is alive and is not TBD's helper.** A live stranger may be
+    ///   listening on that socket right now, and a saturated listener refuses
+    ///   exactly like an empty path, so there is nothing here to tell the two
+    ///   apart and the file is left untouched. The row is **deferred rather
+    ///   than retired**: if the stranger never bound it, the file is TBD's own
+    ///   orphan, and the row is the only entry that names it. The sweep that
+    ///   finds the pid gone takes it back — which is this resource's answer to
+    ///   "who reclaims the orphan", instead of leaking one forever.
+    /// - **The pid is gone.** Now a refusal means something. No process holds
+    ///   the number, so nothing can legitimately be listening at a path named
+    ///   after it, and the file is TBD's to take back. This is the narrow
+    ///   version of the rule the design forbids in general: not "any socket
+    ///   with nothing listening", which races a real session between `bind()`
+    ///   and `listen()`, but "this socket, which TBD's own bookkeeping says TBD
+    ///   created, whose pid no longer exists, and which now refuses a connect".
+    ///
+    /// **No retries, deliberately.** Probing again narrows the window in which
+    /// a busy listener looks empty; it cannot make an indistinguishable signal
+    /// distinguishable, and a listener whose accept loop is wedged rather than
+    /// merely busy refuses every attempt for as long as it lives. Only the pid
+    /// separates the two cases, so the pid is what this gates on.
+    ///
+    /// One residual race is accepted rather than solved: the pid could be
+    /// recycled between the liveness read in `reclaim` and the `unlink(2)`
+    /// below. The window is microseconds wide, and losing it needs the new
+    /// occupant to reach `bind()` inside it *and* to have a full accept queue
+    /// at the instant of the probe — with any room in the queue the probe reads
+    /// `.listening` and the file is left where it is.
+    private func socketOutcome(
+        _ row: ShadowPeerArtifact, recordProvedForeign: Bool, pidIsGone: Bool
+    ) -> ArtifactOutcome {
+        let socketExists = FileManager.default.fileExists(atPath: row.socketPath)
+        if recordProvedForeign {
+            guard socketExists else { return .absent }
+            reconcilerLogger.info("""
+                left the socket at \(row.socketPath, privacy: .public) alone without probing it: \
+                the record beside it proved pid \(row.pid, privacy: .public) was recycled, so this \
+                file belongs to the session that wrote that record and not to TBD's helper for \
+                shadow \(row.handle, privacy: .public)
+                """)
+            return .foreign
+        }
+        guard pidIsGone else {
+            guard socketExists else { return .absent }
+            reconcilerLogger.info("""
+                left the socket at \(row.socketPath, privacy: .public) unjudged: pid \
+                \(row.pid, privacy: .public) is alive and is not the helper TBD recorded, and a \
+                connect cannot tell a saturated listener from an empty path, so the row for shadow \
+                \(row.handle, privacy: .public) is kept for the sweep that finds the pid gone
+                """)
+            return .undecided
+        }
+        return unlinkSocketIfUnclaimed(row)
+    }
+
+    /// Probe the socket and unlink it when the connect refuses.
+    ///
+    /// **Only `socketOutcome` may call this**, and only once the recorded pid
+    /// is proved gone: a refused connect is not by itself proof that nothing is
+    /// behind the path (see `UnixSocketShadowPeerProbe`).
     private func unlinkSocketIfUnclaimed(_ row: ShadowPeerArtifact) -> ArtifactOutcome {
         switch probe.listenerState(atPath: row.socketPath) {
         case .absent:

--- a/Sources/TBDDaemon/Remote/ShadowPeerReconciler.swift
+++ b/Sources/TBDDaemon/Remote/ShadowPeerReconciler.swift
@@ -194,9 +194,17 @@ public struct ShadowPeerSweepResult: Sendable, Equatable {
     /// Artifacts at a recorded path that proved to belong to somebody else —
     /// the recycled-pid case, where a real session now owns `<pid>.json` or
     /// `<pid>.sock`. Left on disk, always.
+    ///
+    /// Two proofs count here. A record proves its own author, because it
+    /// carries a session id. A socket carries nothing, so it is counted foreign
+    /// on the strength of the record beside it: while the pid is alive, a
+    /// record written by another session vouches for the socket named after the
+    /// same pid, since a session binds exactly one socket under its own pid.
     public var foreignArtifactsLeftAlone = 0
     /// Rows kept for a later pass because something was undecided: a probe that
-    /// could not answer, or a process that outlived `SIGKILL`.
+    /// could not answer, or a process that outlived `SIGKILL`. It also counts a
+    /// row parked behind a live stranger's pid, which stays parked until that
+    /// pid dies rather than clearing on the next tick.
     public var deferred = 0
 
     public init() {}
@@ -251,9 +259,11 @@ public struct ShadowPeerSweepResult: Sendable, Equatable {
 /// connect cannot supply the missing proof — on darwin a saturated listener
 /// refuses exactly like an empty path — so the socket is unlinked only when the
 /// pid it is named after is provably gone *and* a connect refuses. While that
-/// pid belongs to somebody else the socket is never even probed, and its row is
-/// kept so a later sweep can reclaim the file once the pid dies. Anything else
-/// is somebody's live peer and is left exactly where it is.
+/// pid belongs to somebody else the socket is never even probed: its row is
+/// kept, so the sweep that finds the pid gone can reclaim the file, unless the
+/// record beside it names the live session that bound it, which leaves nothing
+/// for the row to name. Anything else is somebody's live peer and is left
+/// exactly where it is.
 public actor ShadowPeerReconciler {
     private let artifacts: ShadowPeerArtifactStore
     private let bridges: any ShadowPeerBridgeInspecting
@@ -726,17 +736,30 @@ public actor ShadowPeerReconciler {
     /// the honest primitive here. The connect is not: on darwin a connect to a
     /// socket whose listener's accept queue is full refuses immediately and is
     /// indistinguishable from a connect to a path nobody is behind
-    /// (`UnixSocketShadowPeerProbe`). Three answers follow, ordered by what TBD
-    /// can prove:
+    /// (`UnixSocketShadowPeerProbe`). Three answers follow, and the pid asks
+    /// first because it is the strongest thing TBD holds:
     ///
-    /// - **The record proved a foreign owner.** `unlinkRecordIfOurs` read a
-    ///   record at this row's path carrying a session id TBD never published,
-    ///   which is proof the pid was recycled and that whatever sits at
-    ///   `<pid>.sock` was bound by that session. The socket is not probed at
-    ///   all: the proof is already in hand, and a probe could only return a
-    ///   refusal that invites an unlink. Counted as a foreign artifact when the
-    ///   file is there, and the row retires, because nothing of TBD's is left
-    ///   for it to name.
+    /// - **The pid is gone.** The socket is always probed, whoever wrote the
+    ///   record beside it. No process holds the number, so nothing can
+    ///   legitimately be listening at a path named after it — a record a
+    ///   recycled pid's owner left behind says who wrote *that file*, and says
+    ///   nothing about a socket whose only possible listener has since exited.
+    ///   A refusal therefore means the file is TBD's to take back, `.listening`
+    ///   leaves it as somebody's, and an undecided probe defers the row. This
+    ///   is the narrow version of the rule the design forbids in general: not
+    ///   "any socket with nothing listening", which races a real session
+    ///   between `bind()` and `listen()`, but "this socket, which TBD's own
+    ///   bookkeeping says TBD created, whose pid no longer exists, and which
+    ///   now refuses a connect". Answering `.foreign` here instead would retire
+    ///   the row and strand the file with nothing left able to recognise it.
+    /// - **The pid is alive, and the record proved a foreign owner.**
+    ///   `unlinkRecordIfOurs` read a record at this row's path carrying a
+    ///   session id TBD never published, which is proof the pid was recycled
+    ///   and that whatever sits at `<pid>.sock` was bound by the live session
+    ///   that wrote that record. The socket is not probed at all: the proof is
+    ///   already in hand, and a probe could only return a refusal that invites
+    ///   an unlink. Counted as a foreign artifact when the file is there, and
+    ///   the row retires, because nothing of TBD's is left for it to name.
     /// - **The pid is alive and is not TBD's helper.** A live stranger may be
     ///   listening on that socket right now, and a saturated listener refuses
     ///   exactly like an empty path, so there is nothing here to tell the two
@@ -745,13 +768,6 @@ public actor ShadowPeerReconciler {
     ///   orphan, and the row is the only entry that names it. The sweep that
     ///   finds the pid gone takes it back — which is this resource's answer to
     ///   "who reclaims the orphan", instead of leaking one forever.
-    /// - **The pid is gone.** Now a refusal means something. No process holds
-    ///   the number, so nothing can legitimately be listening at a path named
-    ///   after it, and the file is TBD's to take back. This is the narrow
-    ///   version of the rule the design forbids in general: not "any socket
-    ///   with nothing listening", which races a real session between `bind()`
-    ///   and `listen()`, but "this socket, which TBD's own bookkeeping says TBD
-    ///   created, whose pid no longer exists, and which now refuses a connect".
     ///
     /// **No retries, deliberately.** Probing again narrows the window in which
     /// a busy listener looks empty; it cannot make an indistinguishable signal
@@ -761,16 +777,22 @@ public actor ShadowPeerReconciler {
     ///
     /// One residual race is accepted rather than solved: the pid could be
     /// recycled between the liveness read in `reclaim` and the `unlink(2)`
-    /// below. The window is microseconds wide, and losing it needs the new
-    /// occupant to reach `bind()` inside it *and* to have a full accept queue
-    /// at the instant of the probe — with any room in the queue the probe reads
-    /// `.listening` and the file is left where it is.
+    /// below. Losing it needs the number to be handed to a new occupant, and
+    /// that occupant to reach `bind()`, inside a window microseconds wide —
+    /// whether or not it has reached `listen(2)` by then, and whether or not
+    /// its queue has room, since a socket that is bound and not yet listening
+    /// refuses a connect exactly as a saturated one does. It is accepted
+    /// because of that width, and because the same bind-before-listen race is
+    /// the reason this design forbids reclaiming "any socket with nothing
+    /// listening" in the first place: the pid gate narrows the exposure from
+    /// every session on the machine to one number for a few microseconds.
     private func socketOutcome(
         _ row: ShadowPeerArtifact, recordProvedForeign: Bool, pidIsGone: Bool
     ) -> ArtifactOutcome {
-        let socketExists = FileManager.default.fileExists(atPath: row.socketPath)
+        if pidIsGone { return unlinkSocketIfUnclaimed(row) }
+
+        guard FileManager.default.fileExists(atPath: row.socketPath) else { return .absent }
         if recordProvedForeign {
-            guard socketExists else { return .absent }
             reconcilerLogger.info("""
                 left the socket at \(row.socketPath, privacy: .public) alone without probing it: \
                 the record beside it proved pid \(row.pid, privacy: .public) was recycled, so this \
@@ -779,17 +801,16 @@ public actor ShadowPeerReconciler {
                 """)
             return .foreign
         }
-        guard pidIsGone else {
-            guard socketExists else { return .absent }
-            reconcilerLogger.info("""
-                left the socket at \(row.socketPath, privacy: .public) unjudged: pid \
-                \(row.pid, privacy: .public) is alive and is not the helper TBD recorded, and a \
-                connect cannot tell a saturated listener from an empty path, so the row for shadow \
-                \(row.handle, privacy: .public) is kept for the sweep that finds the pid gone
-                """)
-            return .undecided
-        }
-        return unlinkSocketIfUnclaimed(row)
+        // Debug rather than info: this is a steady state, repeated every tick
+        // for as long as the stranger holds the pid, and an info line per tick
+        // would bury the counts that matter.
+        reconcilerLogger.debug("""
+            left the socket at \(row.socketPath, privacy: .public) unjudged: pid \
+            \(row.pid, privacy: .public) is alive and is not the helper TBD recorded, and a \
+            connect cannot tell a saturated listener from an empty path, so the row for shadow \
+            \(row.handle, privacy: .public) is kept for the sweep that finds the pid gone
+            """)
+        return .undecided
     }
 
     /// Probe the socket and unlink it when the connect refuses.

--- a/Tests/TBDDaemonTests/ShadowPeerReconcilerTests.swift
+++ b/Tests/TBDDaemonTests/ShadowPeerReconcilerTests.swift
@@ -117,10 +117,13 @@ private struct FakeProbe: ShadowPeerSocketProbing {
 /// (`docs/specs/2026-08-29-remote-peer-messaging-design.md`, "Reclamation and
 /// detection").
 ///
-/// Tier 1: no process is signalled, no socket is bound, and every path the
-/// sweep touches is one the test itself planted under the process temp
-/// directory. The registry the real thing sweeps is shared with every Claude
-/// Code session on the machine, which is exactly why nothing here goes near it.
+/// Tier 1: no process is signalled, and every path the sweep touches is one the
+/// test itself planted and removes. Most tests plant plain files under the
+/// process temp directory; the two that drive the real probe bind their own
+/// listeners, in a directory created directly under `/tmp` so the socket path
+/// fits inside `sun_path`. The registry the real thing sweeps is shared with
+/// every Claude Code session on the machine, which is exactly why nothing here
+/// goes near it.
 @Suite("ShadowPeerReconciler")
 struct ShadowPeerReconcilerTests {
 
@@ -664,6 +667,55 @@ struct ShadowPeerReconcilerTests {
         // stranger's file forever.
         let remaining = try await store.all()
         #expect(remaining.isEmpty)
+    }
+
+    /// The record that vouches for a socket stops vouching once the pid dies,
+    /// and this is the sweep that has to notice.
+    ///
+    /// The sequence is one TBD can produce on its own: TBD's helper at pid N is
+    /// `SIGKILL`ed and leaves `N.sock` behind, the kernel hands N to a real
+    /// Claude Code session that writes its own `N.json`, and that session then
+    /// exits too. What is left is a stranger's record — never TBD's to unlink —
+    /// beside a socket that is TBD's own orphan. Reading the record as proof
+    /// about the socket here would leave the file on disk *and* retire the row
+    /// that names it, which is a leak nothing can recognise afterwards. With
+    /// the pid gone, no process can legitimately be listening at a path named
+    /// after it, so the socket is probed and reclaimed on the refusal.
+    @Test func aDeadPIDsSocketIsReclaimedEvenBesideAStrangersRecord() async throws {
+        let directory = try Self.makeScratchDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let db = try TBDDatabase(inMemory: true)
+        let store = db.shadowPeerArtifacts
+
+        let ghost = try await Self.plant(
+            directory: directory, store: store, pid: 954, handle: "remote-recycled-and-gone",
+            sessionID: "ours", recordSessionID: "someone-elses")
+
+        let signaller = FakeSignaller(alive: [])
+        let bridge = FakeBridge(inventories: [
+            ShadowPeerBridgeInventory(provider: "cloud", pidsByHandle: [:]),
+        ])
+        let reconciler = Self.makeReconciler(
+            store: store, bridge: bridge, signaller: signaller)
+
+        let result = await reconciler.sweep()
+
+        // The record is somebody else's whatever the pid is doing.
+        #expect(result.recordsUnlinked == 0)
+        #expect(Self.exists(ghost.recordPath), "a record TBD did not publish must never be unlinked")
+        #expect(result.foreignArtifactsLeftAlone == 1,
+                "only the record proved a foreign owner; the socket was probed instead")
+
+        // The socket is TBD's orphan: nothing can be listening at a dead pid's
+        // path, and the connect refused.
+        #expect(result.socketsUnlinked == 1)
+        #expect(!Self.exists(ghost.socketPath),
+                "a socket at a pid nobody holds must be reclaimed, whoever wrote the record beside it")
+
+        #expect(result.deferred == 0)
+        #expect(result.rowsForgotten == 1)
+        let remaining = try await store.all()
+        #expect(remaining.isEmpty, "nothing of TBD's is left for the row to name")
     }
 
     /// The socket half of the same rule. TBD created the path, but something is

--- a/Tests/TBDDaemonTests/ShadowPeerReconcilerTests.swift
+++ b/Tests/TBDDaemonTests/ShadowPeerReconcilerTests.swift
@@ -150,77 +150,7 @@ struct ShadowPeerReconcilerTests {
     /// real probe pointed into `makeScratchDirectory()` would answer
     /// `.inconclusive` without ever connecting — a green run measuring nothing.
     private static func makeShortScratchDirectory() throws -> URL {
-        let name = String(format: "tbd-shadow-%08x", UInt32.random(in: 0...UInt32.max))
-        let url = URL(fileURLWithPath: "/tmp").appendingPathComponent(name)
-        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
-        return url
-    }
-
-    /// Thrown when the test's own scaffolding could not be built. Never an
-    /// assertion about the code under test.
-    private struct SetupFailure: Swift.Error {}
-
-    private static func socketAddress(for path: String) -> sockaddr_un {
-        var address = sockaddr_un()
-        address.sun_family = sa_family_t(AF_UNIX)
-        let sunPathSize = MemoryLayout.size(ofValue: address.sun_path)
-        path.withCString { source in
-            withUnsafeMutablePointer(to: &address.sun_path) { destination in
-                destination.withMemoryRebound(to: CChar.self, capacity: sunPathSize) { chars in
-                    _ = strlcpy(chars, source, sunPathSize)
-                }
-            }
-        }
-        return address
-    }
-
-    /// Bind and listen at `path`, returning the listening descriptor. Nothing
-    /// ever accepts on it, so a connect completes into the accept queue and
-    /// stays there.
-    private static func bindListener(
-        at path: String, backlog: Int32, sourceLocation: SourceLocation = #_sourceLocation
-    ) throws -> Int32 {
-        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
-        try #require(fd >= 0, "could not create a listening socket", sourceLocation: sourceLocation)
-        var address = socketAddress(for: path)
-        unlink(path)
-        let bound = withUnsafePointer(to: &address) { pointer in
-            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { generic in
-                Darwin.bind(fd, generic, socklen_t(MemoryLayout<sockaddr_un>.size))
-            }
-        }
-        guard bound == 0, listen(fd, backlog) == 0 else {
-            let saved = errno
-            Darwin.close(fd)
-            Issue.record(
-                "could not listen at \(path) (errno \(saved))", sourceLocation: sourceLocation)
-            throw SetupFailure()
-        }
-        return fd
-    }
-
-    /// Connect to `path` and hold the connection open, filling one slot in the
-    /// listener's accept queue for as long as the caller holds the descriptor.
-    private static func connectAndHold(
-        to path: String, sourceLocation: SourceLocation = #_sourceLocation
-    ) throws -> Int32 {
-        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
-        try #require(fd >= 0, "could not create a client socket", sourceLocation: sourceLocation)
-        var address = socketAddress(for: path)
-        let connected = withUnsafePointer(to: &address) { pointer in
-            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { generic in
-                Darwin.connect(fd, generic, socklen_t(MemoryLayout<sockaddr_un>.size))
-            }
-        }
-        guard connected == 0 else {
-            let saved = errno
-            Darwin.close(fd)
-            Issue.record(
-                "could not fill the accept queue at \(path) (errno \(saved))",
-                sourceLocation: sourceLocation)
-            throw SetupFailure()
-        }
-        return fd
+        try UnixSocketTestListener.makeShortScratchDirectory(prefix: "tbd-shadow")
     }
 
     private struct PlantedShadow {
@@ -561,9 +491,9 @@ struct ShadowPeerReconcilerTests {
         let ghost = try await Self.plant(
             directory: directory, store: store, pid: 952, handle: "remote-saturated",
             writeSocket: false)
-        let listener = try Self.bindListener(at: ghost.socketPath, backlog: 1)
+        let listener = try UnixSocketTestListener.bindListener(at: ghost.socketPath, backlog: 1)
         defer { Darwin.close(listener) }
-        let queued = try Self.connectAndHold(to: ghost.socketPath)
+        let queued = try UnixSocketTestListener.connectAndHold(to: ghost.socketPath)
         defer { Darwin.close(queued) }
         #expect(
             UnixSocketShadowPeerProbe().listenerState(atPath: ghost.socketPath) == .refused,
@@ -603,7 +533,7 @@ struct ShadowPeerReconcilerTests {
         let ghost = try await Self.plant(
             directory: directory, store: store, pid: 953, handle: "remote-closed",
             writeSocket: false)
-        let listener = try Self.bindListener(at: ghost.socketPath, backlog: 8)
+        let listener = try UnixSocketTestListener.bindListener(at: ghost.socketPath, backlog: 8)
         Darwin.close(listener)
         #expect(Self.exists(ghost.socketPath))
 

--- a/Tests/TBDDaemonTests/ShadowPeerReconcilerTests.swift
+++ b/Tests/TBDDaemonTests/ShadowPeerReconcilerTests.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 import GRDB
 import Testing
@@ -140,6 +141,85 @@ struct ShadowPeerReconcilerTests {
         return url
     }
 
+    /// A scratch directory **directly under `/tmp`**, for the tests that bind a
+    /// real socket. `sockaddr_un.sun_path` is about 104 bytes on darwin and the
+    /// per-process temporary directory spends most of that on its own, so a
+    /// real probe pointed into `makeScratchDirectory()` would answer
+    /// `.inconclusive` without ever connecting — a green run measuring nothing.
+    private static func makeShortScratchDirectory() throws -> URL {
+        let name = String(format: "tbd-shadow-%08x", UInt32.random(in: 0...UInt32.max))
+        let url = URL(fileURLWithPath: "/tmp").appendingPathComponent(name)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    /// Thrown when the test's own scaffolding could not be built. Never an
+    /// assertion about the code under test.
+    private struct SetupFailure: Swift.Error {}
+
+    private static func socketAddress(for path: String) -> sockaddr_un {
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let sunPathSize = MemoryLayout.size(ofValue: address.sun_path)
+        path.withCString { source in
+            withUnsafeMutablePointer(to: &address.sun_path) { destination in
+                destination.withMemoryRebound(to: CChar.self, capacity: sunPathSize) { chars in
+                    _ = strlcpy(chars, source, sunPathSize)
+                }
+            }
+        }
+        return address
+    }
+
+    /// Bind and listen at `path`, returning the listening descriptor. Nothing
+    /// ever accepts on it, so a connect completes into the accept queue and
+    /// stays there.
+    private static func bindListener(
+        at path: String, backlog: Int32, sourceLocation: SourceLocation = #_sourceLocation
+    ) throws -> Int32 {
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        try #require(fd >= 0, "could not create a listening socket", sourceLocation: sourceLocation)
+        var address = socketAddress(for: path)
+        unlink(path)
+        let bound = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { generic in
+                Darwin.bind(fd, generic, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard bound == 0, listen(fd, backlog) == 0 else {
+            let saved = errno
+            Darwin.close(fd)
+            Issue.record(
+                "could not listen at \(path) (errno \(saved))", sourceLocation: sourceLocation)
+            throw SetupFailure()
+        }
+        return fd
+    }
+
+    /// Connect to `path` and hold the connection open, filling one slot in the
+    /// listener's accept queue for as long as the caller holds the descriptor.
+    private static func connectAndHold(
+        to path: String, sourceLocation: SourceLocation = #_sourceLocation
+    ) throws -> Int32 {
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        try #require(fd >= 0, "could not create a client socket", sourceLocation: sourceLocation)
+        var address = socketAddress(for: path)
+        let connected = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { generic in
+                Darwin.connect(fd, generic, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard connected == 0 else {
+            let saved = errno
+            Darwin.close(fd)
+            Issue.record(
+                "could not fill the accept queue at \(path) (errno \(saved))",
+                sourceLocation: sourceLocation)
+            throw SetupFailure()
+        }
+        return fd
+    }
+
     private struct PlantedShadow {
         let pid: pid_t
         let handle: String
@@ -233,7 +313,7 @@ struct ShadowPeerReconcilerTests {
         store: ShadowPeerArtifactStore,
         bridge: FakeBridge,
         signaller: FakeSignaller,
-        probe: FakeProbe = FakeProbe(),
+        probe: any ShadowPeerSocketProbing = FakeProbe(),
         procStarts: [pid_t: String] = [:]
     ) -> ShadowPeerReconciler {
         ShadowPeerReconciler(
@@ -369,10 +449,17 @@ struct ShadowPeerReconcilerTests {
     /// checks pid liveness and nothing else, so a record whose pid has been
     /// reused by an unrelated process survives it forever.
     ///
-    /// The artifacts are reclaimed and **the pid is never signalled** — it now
-    /// belongs to somebody else's process, and killing it would be the worst
-    /// thing this sweep could do.
-    @Test func aRecycledPIDGhostIsReclaimedWithoutEverSignallingThatPID() async throws {
+    /// **Neither the pid nor the socket named after it is touched while it
+    /// lives.** The pid belongs to somebody else's process, and killing it
+    /// would be the worst thing this sweep could do. The socket is the same
+    /// argument one step further out: a session binds exactly one socket, named
+    /// after its own pid, so a file at `<pid>.sock` while that pid is alive can
+    /// only have been bound by whoever holds it — and a connect cannot tell a
+    /// listener whose accept queue is momentarily full from a path nobody is
+    /// behind. Only the record carries proof of its own author, so only the
+    /// record is reclaimed here. The row is **deferred**, not retired: it is
+    /// the only entry naming a file a later sweep may still have to collect.
+    @Test func aRecycledPIDsSocketIsLeftAloneAndItsRowDeferredWhileThePIDLives() async throws {
         let directory = try Self.makeScratchDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
         let db = try TBDDatabase(inMemory: true)
@@ -400,10 +487,136 @@ struct ShadowPeerReconcilerTests {
         #expect(signaller.groupSignalled.isEmpty)
         #expect(signaller.isAlive(950), "the stranger holding the recycled pid must still be running")
 
+        // The record proved itself TBD's, so it goes.
         #expect(result.recordsUnlinked == 1)
-        #expect(result.socketsUnlinked == 1)
         #expect(!Self.exists(ghost.recordPath))
+
+        // The socket proved nothing, so it stays — and so does the row.
+        #expect(result.socketsUnlinked == 0)
+        #expect(Self.exists(ghost.socketPath),
+                "a socket at a live stranger's pid must never be unlinked on a refused connect")
+        #expect(result.deferred == 1)
+        #expect(result.rowsForgotten == 0)
+        let remaining = try await store.all().map(\.pid)
+        #expect(remaining == [950], "the row is the only entry naming that socket; it must survive")
+    }
+
+    /// The other half of that deferral, and this resource's answer to "who
+    /// reclaims the orphan": the sweep that finds the pid gone. The socket the
+    /// pass above refused to judge is reclaimed here, and the row that kept it
+    /// findable retires with it — so deferring leaks nothing, it waits.
+    @Test func theSweepThatFindsTheRecycledPIDGoneReclaimsTheSocketItDeferred() async throws {
+        let directory = try Self.makeScratchDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let db = try TBDDatabase(inMemory: true)
+        let store = db.shadowPeerArtifacts
+
+        let ghost = try await Self.plant(
+            directory: directory, store: store, pid: 950, handle: "remote-recycled")
+        let bridge = FakeBridge(inventories: [
+            ShadowPeerBridgeInventory(provider: "cloud", pidsByHandle: [:]),
+        ])
+
+        let firstPass = await Self.makeReconciler(
+            store: store, bridge: bridge, signaller: FakeSignaller(alive: [950]),
+            procStarts: [950: "Sun Aug 30 09:15:02 2026"]
+        ).sweep()
+        #expect(firstPass.deferred == 1)
+        #expect(Self.exists(ghost.socketPath))
+
+        // The stranger exits. Nothing else about the row has changed.
+        let secondPass = await Self.makeReconciler(
+            store: store, bridge: bridge, signaller: FakeSignaller(alive: [])
+        ).sweep()
+
+        #expect(secondPass.socketsUnlinked == 1)
         #expect(!Self.exists(ghost.socketPath))
+        #expect(secondPass.rowsForgotten == 1)
+        let remaining = try await store.all()
+        #expect(remaining.isEmpty)
+    }
+
+    /// **The exact case the pid gate exists for, driven through the real
+    /// probe.** A row whose pid was recycled, whose socket path now carries a
+    /// live listener whose accept queue happens to be full.
+    ///
+    /// On darwin that listener refuses the connect, indistinguishably from a
+    /// path nobody is behind — the test asserts the refusal before sweeping, so
+    /// it cannot pass for the wrong reason. The socket directory this feature
+    /// really uses is shared with every Claude Code session on the machine, so
+    /// unlinking on that refusal deletes a running session's socket out from
+    /// under it and leaves it silently unaddressable for the rest of its life,
+    /// while the next sweep reads the path as absent and retires the row
+    /// cleanly. Nothing about it is visible afterwards, which is why it is
+    /// pinned here.
+    @Test func aSaturatedListenerAtARecycledPIDSurvivesTheRealProbe() async throws {
+        let directory = try Self.makeShortScratchDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let db = try TBDDatabase(inMemory: true)
+        let store = db.shadowPeerArtifacts
+
+        let ghost = try await Self.plant(
+            directory: directory, store: store, pid: 952, handle: "remote-saturated",
+            writeSocket: false)
+        let listener = try Self.bindListener(at: ghost.socketPath, backlog: 1)
+        defer { Darwin.close(listener) }
+        let queued = try Self.connectAndHold(to: ghost.socketPath)
+        defer { Darwin.close(queued) }
+        #expect(
+            UnixSocketShadowPeerProbe().listenerState(atPath: ghost.socketPath) == .refused,
+            "the premise of this test is that a live saturated listener does refuse")
+
+        let signaller = FakeSignaller(alive: [952])
+        let bridge = FakeBridge(inventories: [
+            ShadowPeerBridgeInventory(provider: "cloud", pidsByHandle: [:]),
+        ])
+        let reconciler = Self.makeReconciler(
+            store: store, bridge: bridge, signaller: signaller,
+            probe: UnixSocketShadowPeerProbe(),
+            procStarts: [952: "Sun Aug 30 09:15:02 2026"])
+
+        let result = await reconciler.sweep()
+
+        #expect(result.socketsUnlinked == 0)
+        #expect(Self.exists(ghost.socketPath),
+                "a live session's socket was unlinked because its accept queue was momentarily full")
+        #expect(result.deferred == 1)
+        #expect(result.rowsForgotten == 0)
+        let remaining = try await store.all().map(\.pid)
+        #expect(remaining == [952])
+    }
+
+    /// The real probe's happy path, so the gate above is not the only thing
+    /// this file drives a socket through: a pid that is provably gone, and a
+    /// file its listener left behind when it closed. Closing a Unix listener
+    /// never unlinks its socket file, which is precisely why this orphan needs
+    /// a reconciler.
+    @Test func aClosedListenersFileAtADeadPIDIsUnlinkedByTheRealProbe() async throws {
+        let directory = try Self.makeShortScratchDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let db = try TBDDatabase(inMemory: true)
+        let store = db.shadowPeerArtifacts
+
+        let ghost = try await Self.plant(
+            directory: directory, store: store, pid: 953, handle: "remote-closed",
+            writeSocket: false)
+        let listener = try Self.bindListener(at: ghost.socketPath, backlog: 8)
+        Darwin.close(listener)
+        #expect(Self.exists(ghost.socketPath))
+
+        let signaller = FakeSignaller(alive: [])
+        let bridge = FakeBridge(inventories: [
+            ShadowPeerBridgeInventory(provider: "cloud", pidsByHandle: [:]),
+        ])
+        let reconciler = Self.makeReconciler(
+            store: store, bridge: bridge, signaller: signaller,
+            probe: UnixSocketShadowPeerProbe())
+
+        let result = await reconciler.sweep()
+
+        #expect(result.socketsUnlinked == 1)
+        #expect(!Self.exists(ghost.socketPath))
+        #expect(result.rowsForgotten == 1)
         let remaining = try await store.all()
         #expect(remaining.isEmpty)
     }
@@ -412,6 +625,13 @@ struct ShadowPeerReconcilerTests {
     /// rather than unlinked on the strength of its path: the pid's new owner is
     /// a real Claude Code session, which has written **its own** record at
     /// exactly `<pid>.json`. Unlinking that would delist a live teammate.
+    ///
+    /// That record is also proof about the socket beside it. A session binds
+    /// one socket, named after its own pid, so a record at `<pid>.json` written
+    /// by somebody else says who bound `<pid>.sock` too — and the sweep does
+    /// not probe it at all. Both artifacts are counted as foreign and left
+    /// where they are, and the row retires because nothing of TBD's remains for
+    /// it to name.
     @Test func aRecordARecycledPIDsNewOwnerWroteIsLeftOnDisk() async throws {
         let directory = try Self.makeScratchDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
@@ -433,8 +653,12 @@ struct ShadowPeerReconcilerTests {
         let result = await reconciler.sweep()
 
         #expect(result.recordsUnlinked == 0)
-        #expect(result.foreignArtifactsLeftAlone == 1)
+        #expect(result.socketsUnlinked == 0)
+        #expect(result.foreignArtifactsLeftAlone == 2,
+                "the record and the socket beside it are both somebody else's")
         #expect(Self.exists(ghost.recordPath), "a record TBD did not publish must never be unlinked")
+        #expect(Self.exists(ghost.socketPath),
+                "a socket beside a record somebody else wrote was bound by that somebody else")
         #expect(signaller.terminated.isEmpty)
         // Nothing is left to recognise, so the row retires rather than naming a
         // stranger's file forever.

--- a/Tests/TBDDaemonTests/UnixSocketShadowPeerProbeTests.swift
+++ b/Tests/TBDDaemonTests/UnixSocketShadowPeerProbeTests.swift
@@ -1,0 +1,176 @@
+import Darwin
+import Foundation
+import Testing
+
+@testable import TBDDaemonLib
+
+/// `UnixSocketShadowPeerProbe` — the one step of the shadow-peer sweep that
+/// touches a real socket, and the only place the platform gets to answer for
+/// itself.
+///
+/// Every case here binds an actual `AF_UNIX` listener rather than standing in a
+/// fake for the syscall. The fact this suite exists to pin is a **kernel** fact,
+/// and a fake would only restate whatever its author believed the kernel does —
+/// which is exactly the belief that was wrong.
+///
+/// Nothing goes near the socket directory the feature really uses; that one is
+/// shared with every Claude Code session on the machine. Each test gets its own
+/// directory, created directly under `/tmp` because `sockaddr_un.sun_path` is
+/// about 104 bytes on darwin and the per-process temporary directory spends
+/// most of that on its own.
+@Suite("UnixSocketShadowPeerProbe")
+struct UnixSocketShadowPeerProbeTests {
+
+    // MARK: - Scaffolding
+
+    /// Thrown when the test's own scaffolding could not be built. Never an
+    /// assertion about the code under test — the `Issue` was already recorded
+    /// where it was discovered.
+    private struct SetupFailure: Swift.Error {}
+
+    /// A scratch directory **directly under `/tmp`**, and short on purpose: the
+    /// probe answers `.inconclusive` without connecting at all when a path will
+    /// not fit in `sun_path`, so a suite built on a long temporary directory
+    /// would green on an answer that never went near a socket.
+    private static func makeScratchDirectory() throws -> URL {
+        let name = String(format: "tbd-probe-%08x", UInt32.random(in: 0...UInt32.max))
+        let url = URL(fileURLWithPath: "/tmp").appendingPathComponent(name)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private static func socketAddress(for path: String) -> sockaddr_un {
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let sunPathSize = MemoryLayout.size(ofValue: address.sun_path)
+        path.withCString { source in
+            withUnsafeMutablePointer(to: &address.sun_path) { destination in
+                destination.withMemoryRebound(to: CChar.self, capacity: sunPathSize) { chars in
+                    _ = strlcpy(chars, source, sunPathSize)
+                }
+            }
+        }
+        return address
+    }
+
+    /// Bind and listen at `path`, returning the listening descriptor. **Nothing
+    /// ever accepts on it**: a connect completes into the accept queue and
+    /// stays there, which is what lets a test hold the queue full.
+    private static func bindListener(
+        at path: String, backlog: Int32, sourceLocation: SourceLocation = #_sourceLocation
+    ) throws -> Int32 {
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        try #require(fd >= 0, "could not create a listening socket", sourceLocation: sourceLocation)
+        var address = socketAddress(for: path)
+        unlink(path)
+        let bound = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { generic in
+                Darwin.bind(fd, generic, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard bound == 0, listen(fd, backlog) == 0 else {
+            let saved = errno
+            Darwin.close(fd)
+            Issue.record(
+                "could not listen at \(path) (errno \(saved))", sourceLocation: sourceLocation)
+            throw SetupFailure()
+        }
+        return fd
+    }
+
+    /// Connect to `path` and **keep the connection open**, returning the client
+    /// descriptor. The listener never accepts it, so it occupies a slot in the
+    /// accept queue for as long as the caller holds the descriptor.
+    private static func connectAndHold(
+        to path: String, sourceLocation: SourceLocation = #_sourceLocation
+    ) throws -> Int32 {
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        try #require(fd >= 0, "could not create a client socket", sourceLocation: sourceLocation)
+        var address = socketAddress(for: path)
+        let connected = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { generic in
+                Darwin.connect(fd, generic, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard connected == 0 else {
+            let saved = errno
+            Darwin.close(fd)
+            Issue.record(
+                "could not fill the accept queue at \(path) (errno \(saved))",
+                sourceLocation: sourceLocation)
+            throw SetupFailure()
+        }
+        return fd
+    }
+
+    private static func exists(_ path: String) -> Bool {
+        FileManager.default.fileExists(atPath: path)
+    }
+
+    // MARK: - Cases
+
+    /// Nothing at the path at all. Already reclaimed — by the helper's own
+    /// exit, or by an earlier sweep.
+    @Test func aPathWithNoFileIsAbsent() throws {
+        let directory = try Self.makeScratchDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let path = directory.appendingPathComponent("1.sock").path
+
+        #expect(UnixSocketShadowPeerProbe().listenerState(atPath: path) == .absent)
+    }
+
+    /// A healthy listener with room in its accept queue — the shape of every
+    /// live session's socket, and the answer that must never lead to an unlink.
+    @Test func aListenerWithRoomInItsQueueIsListening() throws {
+        let directory = try Self.makeScratchDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let path = directory.appendingPathComponent("2.sock").path
+        let listener = try Self.bindListener(at: path, backlog: 8)
+        defer { Darwin.close(listener) }
+
+        #expect(UnixSocketShadowPeerProbe().listenerState(atPath: path) == .listening)
+    }
+
+    /// The orphan the sweep exists to collect: a process bound, listened, and
+    /// went away, leaving the file with nothing behind it. Closing a Unix
+    /// listener never unlinks its socket file, which is why the orphan exists.
+    @Test func aBoundFileWhoseListenerIsClosedIsRefused() throws {
+        let directory = try Self.makeScratchDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let path = directory.appendingPathComponent("3.sock").path
+        let listener = try Self.bindListener(at: path, backlog: 8)
+        Darwin.close(listener)
+
+        #expect(Self.exists(path), "closing a listener does not unlink its socket file")
+        #expect(UnixSocketShadowPeerProbe().listenerState(atPath: path) == .refused)
+    }
+
+    /// **The platform fact the reconciler's whole design turns on.**
+    ///
+    /// A live listener whose accept queue is full refuses a connect on darwin:
+    /// the queue's limit is exactly the backlog passed to `listen(2)`, the call
+    /// returns `ECONNREFUSED` immediately rather than blocking, and a
+    /// non-blocking connect never comes back in-progress. So `.refused` and
+    /// "nothing is listening" are one observation, and a sweep that unlinked on
+    /// `.refused` alone would delete a live session's socket out from under it
+    /// in the microseconds its queue happened to be full — leaving a running
+    /// session silently unaddressable for the rest of its life.
+    ///
+    /// `ShadowPeerReconciler` therefore never treats a refusal as proof on its
+    /// own: it unlinks only when the pid the file is named after is provably
+    /// gone, because that pid is the only process that could legitimately be
+    /// listening there.
+    @Test func aLiveListenerWithAFullAcceptQueueIsAlsoRefused() throws {
+        let directory = try Self.makeScratchDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let path = directory.appendingPathComponent("4.sock").path
+        let listener = try Self.bindListener(at: path, backlog: 1)
+        defer { Darwin.close(listener) }
+        let queued = try Self.connectAndHold(to: path)
+        defer { Darwin.close(queued) }
+
+        #expect(
+            UnixSocketShadowPeerProbe().listenerState(atPath: path) == .refused,
+            "a saturated listener is indistinguishable from an absent one at the connect")
+    }
+}

--- a/Tests/TBDDaemonTests/UnixSocketShadowPeerProbeTests.swift
+++ b/Tests/TBDDaemonTests/UnixSocketShadowPeerProbeTests.swift
@@ -23,84 +23,12 @@ struct UnixSocketShadowPeerProbeTests {
 
     // MARK: - Scaffolding
 
-    /// Thrown when the test's own scaffolding could not be built. Never an
-    /// assertion about the code under test — the `Issue` was already recorded
-    /// where it was discovered.
-    private struct SetupFailure: Swift.Error {}
-
     /// A scratch directory **directly under `/tmp`**, and short on purpose: the
     /// probe answers `.inconclusive` without connecting at all when a path will
     /// not fit in `sun_path`, so a suite built on a long temporary directory
     /// would green on an answer that never went near a socket.
     private static func makeScratchDirectory() throws -> URL {
-        let name = String(format: "tbd-probe-%08x", UInt32.random(in: 0...UInt32.max))
-        let url = URL(fileURLWithPath: "/tmp").appendingPathComponent(name)
-        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
-        return url
-    }
-
-    private static func socketAddress(for path: String) -> sockaddr_un {
-        var address = sockaddr_un()
-        address.sun_family = sa_family_t(AF_UNIX)
-        let sunPathSize = MemoryLayout.size(ofValue: address.sun_path)
-        path.withCString { source in
-            withUnsafeMutablePointer(to: &address.sun_path) { destination in
-                destination.withMemoryRebound(to: CChar.self, capacity: sunPathSize) { chars in
-                    _ = strlcpy(chars, source, sunPathSize)
-                }
-            }
-        }
-        return address
-    }
-
-    /// Bind and listen at `path`, returning the listening descriptor. **Nothing
-    /// ever accepts on it**: a connect completes into the accept queue and
-    /// stays there, which is what lets a test hold the queue full.
-    private static func bindListener(
-        at path: String, backlog: Int32, sourceLocation: SourceLocation = #_sourceLocation
-    ) throws -> Int32 {
-        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
-        try #require(fd >= 0, "could not create a listening socket", sourceLocation: sourceLocation)
-        var address = socketAddress(for: path)
-        unlink(path)
-        let bound = withUnsafePointer(to: &address) { pointer in
-            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { generic in
-                Darwin.bind(fd, generic, socklen_t(MemoryLayout<sockaddr_un>.size))
-            }
-        }
-        guard bound == 0, listen(fd, backlog) == 0 else {
-            let saved = errno
-            Darwin.close(fd)
-            Issue.record(
-                "could not listen at \(path) (errno \(saved))", sourceLocation: sourceLocation)
-            throw SetupFailure()
-        }
-        return fd
-    }
-
-    /// Connect to `path` and **keep the connection open**, returning the client
-    /// descriptor. The listener never accepts it, so it occupies a slot in the
-    /// accept queue for as long as the caller holds the descriptor.
-    private static func connectAndHold(
-        to path: String, sourceLocation: SourceLocation = #_sourceLocation
-    ) throws -> Int32 {
-        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
-        try #require(fd >= 0, "could not create a client socket", sourceLocation: sourceLocation)
-        var address = socketAddress(for: path)
-        let connected = withUnsafePointer(to: &address) { pointer in
-            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { generic in
-                Darwin.connect(fd, generic, socklen_t(MemoryLayout<sockaddr_un>.size))
-            }
-        }
-        guard connected == 0 else {
-            let saved = errno
-            Darwin.close(fd)
-            Issue.record(
-                "could not fill the accept queue at \(path) (errno \(saved))",
-                sourceLocation: sourceLocation)
-            throw SetupFailure()
-        }
-        return fd
+        try UnixSocketTestListener.makeShortScratchDirectory(prefix: "tbd-probe")
     }
 
     private static func exists(_ path: String) -> Bool {
@@ -125,7 +53,7 @@ struct UnixSocketShadowPeerProbeTests {
         let directory = try Self.makeScratchDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
         let path = directory.appendingPathComponent("2.sock").path
-        let listener = try Self.bindListener(at: path, backlog: 8)
+        let listener = try UnixSocketTestListener.bindListener(at: path, backlog: 8)
         defer { Darwin.close(listener) }
 
         #expect(UnixSocketShadowPeerProbe().listenerState(atPath: path) == .listening)
@@ -138,7 +66,7 @@ struct UnixSocketShadowPeerProbeTests {
         let directory = try Self.makeScratchDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
         let path = directory.appendingPathComponent("3.sock").path
-        let listener = try Self.bindListener(at: path, backlog: 8)
+        let listener = try UnixSocketTestListener.bindListener(at: path, backlog: 8)
         Darwin.close(listener)
 
         #expect(Self.exists(path), "closing a listener does not unlink its socket file")
@@ -164,9 +92,9 @@ struct UnixSocketShadowPeerProbeTests {
         let directory = try Self.makeScratchDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
         let path = directory.appendingPathComponent("4.sock").path
-        let listener = try Self.bindListener(at: path, backlog: 1)
+        let listener = try UnixSocketTestListener.bindListener(at: path, backlog: 1)
         defer { Darwin.close(listener) }
-        let queued = try Self.connectAndHold(to: path)
+        let queued = try UnixSocketTestListener.connectAndHold(to: path)
         defer { Darwin.close(queued) }
 
         #expect(

--- a/Tests/TBDDaemonTests/UnixSocketTestListener.swift
+++ b/Tests/TBDDaemonTests/UnixSocketTestListener.swift
@@ -1,0 +1,90 @@
+import Darwin
+import Foundation
+import Testing
+
+/// Shared `AF_UNIX` listener scaffolding for the two suites that bind a real
+/// socket to pin platform behavior: `UnixSocketShadowPeerProbeTests` and
+/// `ShadowPeerReconcilerTests`. Both live in the `TBDDaemonTests` target, so
+/// this is the one copy rather than two byte-identical private ones.
+enum UnixSocketTestListener {
+
+    /// Thrown when the test's own scaffolding could not be built. Never an
+    /// assertion about the code under test — the `Issue` was already recorded
+    /// where it was discovered.
+    struct SetupFailure: Error {}
+
+    /// A scratch directory **directly under `/tmp`**, and short on purpose: the
+    /// probe answers `.inconclusive` without connecting at all when a path will
+    /// not fit in `sun_path`, so a suite built on a long temporary directory
+    /// would green on an answer that never went near a socket.
+    static func makeShortScratchDirectory(prefix: String = "tbd-sock") throws -> URL {
+        let name = String(format: "\(prefix)-%08x", UInt32.random(in: 0...UInt32.max))
+        let url = URL(fileURLWithPath: "/tmp").appendingPathComponent(name)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    static func socketAddress(for path: String) -> sockaddr_un {
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let sunPathSize = MemoryLayout.size(ofValue: address.sun_path)
+        path.withCString { source in
+            withUnsafeMutablePointer(to: &address.sun_path) { destination in
+                destination.withMemoryRebound(to: CChar.self, capacity: sunPathSize) { chars in
+                    _ = strlcpy(chars, source, sunPathSize)
+                }
+            }
+        }
+        return address
+    }
+
+    /// Bind and listen at `path`, returning the listening descriptor. **Nothing
+    /// ever accepts on it**: a connect completes into the accept queue and
+    /// stays there, which is what lets a test hold the queue full.
+    static func bindListener(
+        at path: String, backlog: Int32, sourceLocation: SourceLocation = #_sourceLocation
+    ) throws -> Int32 {
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        try #require(fd >= 0, "could not create a listening socket", sourceLocation: sourceLocation)
+        var address = socketAddress(for: path)
+        unlink(path)
+        let bound = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { generic in
+                Darwin.bind(fd, generic, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard bound == 0, listen(fd, backlog) == 0 else {
+            let saved = errno
+            Darwin.close(fd)
+            Issue.record(
+                "could not listen at \(path) (errno \(saved))", sourceLocation: sourceLocation)
+            throw SetupFailure()
+        }
+        return fd
+    }
+
+    /// Connect to `path` and **keep the connection open**, returning the client
+    /// descriptor. The listener never accepts it, so it occupies a slot in the
+    /// accept queue for as long as the caller holds the descriptor.
+    static func connectAndHold(
+        to path: String, sourceLocation: SourceLocation = #_sourceLocation
+    ) throws -> Int32 {
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        try #require(fd >= 0, "could not create a client socket", sourceLocation: sourceLocation)
+        var address = socketAddress(for: path)
+        let connected = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { generic in
+                Darwin.connect(fd, generic, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard connected == 0 else {
+            let saved = errno
+            Darwin.close(fd)
+            Issue.record(
+                "could not fill the accept queue at \(path) (errno \(saved))",
+                sourceLocation: sourceLocation)
+            throw SetupFailure()
+        }
+        return fd
+    }
+}

--- a/docs/specs/2026-08-29-remote-peer-messaging-design.md
+++ b/docs/specs/2026-08-29-remote-peer-messaging-design.md
@@ -355,12 +355,20 @@ a session that has moved on, and would grow an ack layer the local channel does
 not have.
 
 **Link-down means the listener is closed and unlinked, not that it stops
-answering.** A listening socket cannot decline: `connect()` succeeds while the
-listener exists, and the protocol is connect-write-close with no handshake, so a
-bound socket always reports success to the sender. ECONNREFUSED is what makes a
-sender see the same failure as a dead local session and what makes the
+answering.** The protocol is connect-write-close with no handshake, so while the
+listener exists and has room in its accept queue a bound socket reports success
+to the sender and there is no way to decline a frame. ECONNREFUSED is what makes
+a sender see the same failure as a dead local session and what makes the
 `ListAgents` probe delist the row. Both halves **MUST** close and unlink on link
 loss.
+
+**A saturated listener refuses, and that frame is dropped.** On darwin the
+accept queue's limit is exactly the backlog passed to `listen(2)`, and a
+`connect()` that arrives with the queue full returns ECONNREFUSED immediately
+rather than blocking (measured). So a peer that is momentarily behind loses the
+frame aimed at it, indistinguishably from a peer that is gone. That is accepted:
+it is the same clean, unbuffered failure this section already specifies, and a
+retry layer would be the mailbox this design rejects.
 
 **The in-flight window is accepted, not solved.** A frame accepted by a shadow
 socket whose link dies before handoff is lost after the sender saw success. The
@@ -472,7 +480,8 @@ recorded:
 - helper processes with no bridged session behind them
 - shadow records with no live helper, including the **recycled-pid ghost** that
   Claude Code's reaper provably will not collect
-- socket files TBD created with nothing listening
+- socket files TBD created, at a pid that no longer exists, that refuse a
+  connect
 - records TBD published under a previous daemon generation
 
 It **MUST NOT** reclaim by inference — never "any socket with nothing
@@ -499,6 +508,27 @@ indistinguishable from any other session's by construction, since TBD puts no
 marker inside one, which is the reason the whitelist exists at all. The soak
 criterion — no ghost record outliving its daemon — is the field check that would
 surface it happening.
+
+**A refused connect is not proof that a socket is unowned, so the pid gates the
+unlink.** Since a saturated listener refuses exactly as an empty path does, the
+connect cannot distinguish "TBD's dead helper left this file" from "a live
+session is behind it and busy". The pid can: a Claude Code session and TBD's
+helper each bind exactly one socket, named after their own pid, so the only
+process that may legitimately be listening at `<pid>.sock` is the one holding
+that pid. Three rules follow, and they are what the reconciler implements:
+
+- A socket is unlinked only when the recorded pid is provably gone **and** a
+  connect refuses.
+- A socket at a pid that is alive but is not TBD's helper is never probed. Its
+  row is **deferred**, not retired — the row is the only record naming that
+  file, so the sweep that finds the pid gone is what reclaims it.
+- A socket whose sibling record carries a session id TBD never published is
+  never touched at all: that record is proof the pid was recycled and that the
+  socket belongs to the session that wrote it.
+
+Retrying the probe is not a substitute for the pid gate. It narrows the window
+in which a busy listener looks empty and cannot close it, and a listener whose
+accept loop is wedged refuses every attempt for as long as it lives.
 
 Detection is the half that has historically been missing: every unbounded leak
 in this repo's history went unnoticed because nothing counted it. So each sweep

--- a/docs/specs/2026-08-29-remote-peer-messaging-design.md
+++ b/docs/specs/2026-08-29-remote-peer-messaging-design.md
@@ -517,14 +517,19 @@ helper each bind exactly one socket, named after their own pid, so the only
 process that may legitimately be listening at `<pid>.sock` is the one holding
 that pid. Three rules follow, and they are what the reconciler implements:
 
-- A socket is unlinked only when the recorded pid is provably gone **and** a
-  connect refuses.
+- Once the recorded pid is provably gone the socket is probed, whoever wrote the
+  record beside it, and unlinked if the connect refuses. A record left behind by
+  a pid's later owner says who wrote that file; it says nothing about a socket
+  whose only possible listener has since exited, so it must not stop the probe —
+  answering "foreign" there would retire the row and strand the socket with
+  nothing left able to recognise it.
 - A socket at a pid that is alive but is not TBD's helper is never probed. Its
   row is **deferred**, not retired — the row is the only record naming that
   file, so the sweep that finds the pid gone is what reclaims it.
-- A socket whose sibling record carries a session id TBD never published is
-  never touched at all: that record is proof the pid was recycled and that the
-  socket belongs to the session that wrote it.
+- A socket at a **live** pid whose sibling record carries a session id TBD never
+  published is never touched at all, and its row retires: that record is proof
+  the pid was recycled and that the socket belongs to the live session that
+  wrote it, so nothing of TBD's remains for the row to name.
 
 Retrying the probe is not a substitute for the pid gate. It narrows the window
 in which a busy listener looks empty and cannot close it, and a listener whose


### PR DESCRIPTION
## What's broken

The shadow-peer sweep, which runs every 60 s from daemon boot and is not behind any flag, can unlink the socket of a **live foreign Claude Code session**. Every Claude Code session on a machine binds `<pid>.sock` into one shared directory, and TBD's peer helper binds its own pid there too. When a helper dies and its pid is later recycled by a real session, the sweep correctly refuses to signal that pid, then probes the socket at that path with a connect, reads `ECONNREFUSED`, and unlinks it.

The victim is never told. Claude Code binds once at startup, so from that moment the session is silently unaddressable: it drops out of peer listings and every message to it fails. TBD then covers its tracks: the next sweep finds no file, retires the row cleanly, and the unlink path logs only on failure. A user sees "that session stopped receiving messages" with no error anywhere.

## Why it happens

The code assumed that a connect to a listening Unix socket always succeeds, and that only a socket with nothing behind it refuses. On darwin that is false. `connect(2)` to an `AF_UNIX` socket whose listener's accept queue is full returns `ECONNREFUSED` immediately: the queue limit is exactly the backlog, the call never blocks, and a non-blocking connect never reports in-progress. The branch that mapped `EAGAIN`/`EINPROGRESS` to "listening" was dead code, and its safety guard, meant to protect a listener under load, failed open. A socket that is bound but not yet listening refuses the same way.

So at the connect, "a live listener that is momentarily saturated" and "nothing listening" are the same observation. A live Claude Code session's listener does saturate: measured against a running session, about 128 unanswered connects fit before the first refusal, and the queue drained within 50 ms. That needs a burst inside one event-loop stall, which is rare but reachable on a machine where a hundred sessions probe each other.

## When it broke

Introduced with the remote peer messaging reconciler (#762). The design spec carried the same false claim, the production probe had no test of its own, and every reconciler test used a fake probe, so the wrong semantics were never exercised.

## What this PR does

The pid, not the connect, is what proves a socket is unowned. A session and TBD's helper each bind exactly one socket named after their own pid, so the only process that can legitimately be listening at `<pid>.sock` is the one holding that pid. The sweep's socket step now follows three rules:

- **The pid is gone:** probe, and unlink on a refusal, whatever the sibling record said. No process holds the number, so nothing can legitimately be listening there, and leaving the file would strand it with no row to name it.
- **The pid is alive and is not TBD's helper:** never probe. If the file exists the row is deferred, not retired, so the sweep that finds the pid gone reclaims the file. This is the named-reconciler answer for the orphan.
- **The pid is alive and the record beside it carries a session id TBD never published:** never touch the socket. That record is proof the pid was recycled by a session that bound it. The row retires because nothing of TBD's remains.

No retries. Probing again narrows the window in which a busy listener looks empty but cannot make an indistinguishable signal distinguishable, and a listener whose accept loop is wedged refuses every attempt for as long as it lives.

Also: the dead `EAGAIN`/`EINPROGRESS` branch is deleted (anything unexpected already falls to `.inconclusive`, which the sweep refuses to act on); the two doc comments and the delivery queue's rationale in `ShadowPeerAttribution.swift` are corrected (the queue stays, because the write can park for the whole of `SO_SNDTIMEO`); and the spec states the measured behaviour as current design. A related but separate fact is recorded and left alone: a frame aimed at a saturated peer is refused and dropped rather than retried, which is the channel's designed no-buffering failure semantics.

## Assumptions

- Assumes every process that binds into the shared socket directory names its socket after its own pid. If a session ever bound a socket under another process's pid, a dead-pid probe could unlink a live listener.
- Assumes a residual window of microseconds between the liveness re-read and the `unlink(2)`, lost only if the pid is recycled and the new occupant reaches `bind()` inside it. Accepted on width; the same bind-before-listen race is why the design already forbids reclaiming "any socket with nothing listening".

## Evidence & verification

- **Platform fact:** reproduced on this machine with backlog 2: two non-blocking connects succeed, the third refuses instantly, a blocking connect refuses too, and one `accept()` restores success. The new `UnixSocketShadowPeerProbeTests` suite pins this with real sockets, including a `listen(fd, 1)` plus one held connect saturation case that must read `.refused`.
- **Red first, on CI.** The `test:` commit was pushed alone and the test workflow dispatched on it (run 33823780030). Against the unfixed code the four reconciler tests encoding the new rule failed and nothing else did, out of 4935 tests:

  ```
  ✘ Test aSaturatedListenerAtARecycledPIDSurvivesTheRealProbe() recorded an issue at
    ShadowPeerReconcilerTests.swift:580:9: Expectation failed: (result.socketsUnlinked → 1) == 0
  ✘ ... :581:9: Expectation failed: exists(ghost.socketPath → "/tmp/tbd-shadow-4e096579/952.sock")
  ```

  That is the bug: a live, saturated listener at a recycled pid had its socket unlinked by the sweep.
- **Discriminating tests** in `ShadowPeerReconcilerTests`: a stranger's socket survives and its row is deferred; the sweep that finds the pid gone reclaims it; a dead pid's socket is reclaimed even beside a stranger's record; the alive-pid foreign-record case leaves both artifacts; and the saturated case above, driven through the real probe.
- Green verdict is the CI run on this PR's head.

https://claude.ai/code/session_01Ejv5xquQtQxuzypNRH23wU
[🔌 Fix Shadow Peer Socket Unlink](https://cheapsteak.github.io/tbd/open/?worktree=D332707E-2C23-4DA6-89C8-A3D85261388D)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of Unix-socket peers when listeners are saturated, closed, or associated with recycled process IDs.
  - Prevented premature cleanup when socket ownership is uncertain.
  - Reclaimed stale socket artifacts only after confirming the associated process is inactive.
  - Frames sent to unavailable or saturated peers are dropped without buffering or retries.

- **Documentation**
  - Clarified socket delivery failures, cleanup safeguards, and peer reconciliation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->