### PR TITLE
Fix: A daemon relaunched at login loses its PATH, and every LFS repo stops creating worktrees

### DIFF
--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -2421,7 +2421,10 @@ final class AppState {
             return nil
         }
         return "Couldn't create worktree \"\(worktree.displayName)\" — the git worktree add failed. " +
-               "See Console (log show --predicate 'subsystem == \"com.tbd.daemon\"') for details."
+               // Absolute path deliberately: `log` is a zsh builtin that eats
+               // the arguments and prints nothing, so the bare command reads
+               // as "there was nothing logged".
+               "See Console (/usr/bin/log show --predicate 'subsystem == \"com.tbd.daemon\"') for details."
     }
 
     /// Apply a Claude session rollover (post-`/clear` / `/compact` / startup)

--- a/Sources/TBDApp/Helpers/LaunchEnvironment.swift
+++ b/Sources/TBDApp/Helpers/LaunchEnvironment.swift
@@ -1,0 +1,78 @@
+import Foundation
+import os
+
+private let launchEnvironmentLogger = Logger(subsystem: "com.tbd.app", category: "launch-environment")
+
+/// Makes the process `PATH` match the one the bundle asked to be launched with.
+///
+/// `scripts/restart.sh` records the developer's `PATH` in the app bundle's
+/// `Info.plist` under `LSEnvironment.PATH`. LaunchServices applies that key when
+/// it launches the bundle — but not on every path into the app. A relaunch at
+/// login after a reboot has been observed starting TBD with launchd's bare
+/// `/usr/bin:/bin:/usr/sbin:/sbin`, and everything the app spawns, the daemon
+/// included, inherits it. The daemon then runs `git` without `/opt/homebrew/bin`
+/// on its `PATH`, and an LFS repo stops creating worktrees.
+///
+/// So the app reads the key itself and adopts it. The plist is a contract the
+/// build wrote for this exact binary, not ambient state, and adopting it makes
+/// the two launch routes agree.
+enum LaunchEnvironment {
+
+    /// The `PATH` to install, or `nil` when nothing needs to change.
+    ///
+    /// Pure, so the decision is testable without touching the real environment.
+    /// Returns `nil` when the bundle names no `PATH`, and when the current
+    /// `PATH` already contains every directory the bundle asked for — the
+    /// ordinary terminal launch, where the inherited `PATH` is a superset and
+    /// overwriting it would discard entries the plist never knew about.
+    static func pathToAdopt(currentPATH: String?, bundlePATH: String?) -> String? {
+        guard let bundlePATH, !bundlePATH.isEmpty else { return nil }
+
+        let wanted = bundlePATH
+            .split(separator: ":", omittingEmptySubsequences: true)
+            .map(String.init)
+        guard !wanted.isEmpty else { return nil }
+
+        let present = Set(
+            (currentPATH ?? "")
+                .split(separator: ":", omittingEmptySubsequences: true)
+                .map(String.init)
+        )
+        return wanted.allSatisfy(present.contains) ? nil : bundlePATH
+    }
+
+    /// Reads `LSEnvironment.PATH` from the running bundle and installs it when
+    /// the process `PATH` does not already cover it. Returns the adopted value,
+    /// or `nil` when nothing changed.
+    ///
+    /// Must run before anything spawns a subprocess: `setenv` mutates `environ`,
+    /// which is what `Process` hands a child when it is given no explicit
+    /// environment, so a child started earlier keeps the `PATH` it was born with.
+    @discardableResult
+    static func adoptBundlePATHIfNeeded(
+        infoDictionary: [String: Any]? = Bundle.main.infoDictionary,
+        currentPATH: String? = ProcessInfo.processInfo.environment["PATH"],
+        install: (String) -> Void = { setenv("PATH", $0, 1) }
+    ) -> String? {
+        let bundlePATH = (infoDictionary?["LSEnvironment"] as? [String: Any])?["PATH"] as? String
+        guard let adopted = pathToAdopt(currentPATH: currentPATH, bundlePATH: bundlePATH) else {
+            if bundlePATH == nil {
+                launchEnvironmentLogger.info(
+                    "No LSEnvironment.PATH in the bundle; keeping the launch PATH"
+                )
+            } else {
+                launchEnvironmentLogger.info(
+                    "Launch PATH already covers LSEnvironment.PATH; leaving it alone"
+                )
+            }
+            return nil
+        }
+        install(adopted)
+        launchEnvironmentLogger.info("""
+        Adopted LSEnvironment.PATH from the bundle — the launch PATH \
+        (\(currentPATH ?? "<unset>", privacy: .public)) did not cover it; \
+        subprocesses now get \(adopted, privacy: .public)
+        """)
+        return adopted
+    }
+}

--- a/Sources/TBDApp/TBDApp.swift
+++ b/Sources/TBDApp/TBDApp.swift
@@ -439,6 +439,18 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 @main
 struct TBDAppMain: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+
+    /// Adopt the bundle's `LSEnvironment.PATH` before anything can spawn a child.
+    ///
+    /// **Declaration order is the mechanism.** Swift evaluates a struct's
+    /// stored-property default expressions in source order, and `appState`
+    /// below spawns the daemon, which inherits this process's `PATH`. So this
+    /// property must stay above it — moving it down silently reinstates the bug
+    /// on the launches that need it most (LaunchServices relaunching the
+    /// installed bundle at login without applying the key itself). `appDelegate`
+    /// above only constructs the delegate object; its launch callbacks run later.
+    private let adoptedLaunchPATH: String? = LaunchEnvironment.adoptBundlePATHIfNeeded()
+
     /// `@State`, not `@StateObject`: `AppState` is `@Observable`.
     ///
     /// The swap is not purely notational and was audited rather than assumed.
@@ -483,7 +495,11 @@ struct TBDAppMain: App {
     }
 
     init() {
-        lifecycleLogger.info("TBDApp launching pid=\(getpid(), privacy: .public)")
+        let didAdoptLaunchPATH = adoptedLaunchPATH != nil
+        lifecycleLogger.info("""
+        TBDApp launching pid=\(getpid(), privacy: .public) \
+        adoptedLaunchPATH=\(didAdoptLaunchPATH, privacy: .public)
+        """)
         DiffSyntaxHighlighter.warmUp()
     }
 

--- a/Sources/TBDApp/TBDApp.swift
+++ b/Sources/TBDApp/TBDApp.swift
@@ -443,12 +443,17 @@ struct TBDAppMain: App {
     /// Adopt the bundle's `LSEnvironment.PATH` before anything can spawn a child.
     ///
     /// **Declaration order is the mechanism.** Swift evaluates a struct's
-    /// stored-property default expressions in source order, and `appState`
-    /// below spawns the daemon, which inherits this process's `PATH`. So this
-    /// property must stay above it — moving it down silently reinstates the bug
-    /// on the launches that need it most (LaunchServices relaunching the
-    /// installed bundle at login without applying the key itself). `appDelegate`
-    /// above only constructs the delegate object; its launch callbacks run later.
+    /// stored-property default expressions in source order, so this `setenv`
+    /// runs before the `appState` expression below is even evaluated. That
+    /// initializer does not spawn the daemon itself — it schedules an async
+    /// `Task` that later calls `startDaemonAndConnect()` — and the ordering
+    /// holds through that indirection: `Process` given a nil `environment`
+    /// inherits the live `environ` as it stands at `run()` time, which is long
+    /// after this line. So this property must stay above `appState`; moving it
+    /// down silently reinstates the bug on the launches that need it most
+    /// (LaunchServices relaunching the installed bundle at login without
+    /// applying the key itself). `appDelegate` above only constructs the
+    /// delegate object; its launch callbacks run later still.
     private let adoptedLaunchPATH: String? = LaunchEnvironment.adoptBundlePATHIfNeeded()
 
     /// `@State`, not `@StateObject`: `AppState` is `@Observable`.

--- a/Sources/TBDCLI/Commands/WorktreeCommands.swift
+++ b/Sources/TBDCLI/Commands/WorktreeCommands.swift
@@ -180,10 +180,14 @@ struct WorktreeCreate: AsyncParsableCommand {
                 // named nothing, and the two obvious guesses are both wrong:
                 // ~/Library/Logs/TBD/exceptions.log is the app's crash log, and
                 // predicating on TBDApp searches the wrong process entirely.
+                //
+                // The absolute path is load-bearing: `log` is a zsh builtin
+                // that consumes the arguments and prints nothing, so a bare
+                // `log show` reads as "the daemon logged nothing".
                 throw CLIError.invalidArgument("""
                     Worktree creation failed and was rolled back. The daemon logged why:
 
-                      log show --predicate 'subsystem == "com.tbd.daemon"' --last 5m --info
+                      /usr/bin/log show --predicate 'subsystem == "com.tbd.daemon"' --last 5m --info
 
                     (Common cause: the branch already exists and is checked out in \
                     another worktree — git's error names that directory.)

--- a/Sources/TBDDaemon/Codex/CodexHomeManager.swift
+++ b/Sources/TBDDaemon/Codex/CodexHomeManager.swift
@@ -432,17 +432,10 @@ enum CodexExecutableResolver {
             isUsableExecutable(atPath: $0)
         }
     ) -> String? {
-        let fallbackDirectories = [
-            "\(homeDirectory)/.local/bin",
-            "\(homeDirectory)/.volta/bin",
-            "\(homeDirectory)/.cargo/bin",
-            "/opt/homebrew/bin",
-            "/usr/local/bin",
-            "/usr/bin",
-            "/bin",
-        ]
-        let augmentedSearchPath = ([environment["PATH"]].compactMap { $0 }
-            + fallbackDirectories).joined(separator: ":")
+        let augmentedSearchPath = ExecutableSearchPath.augmented(
+            environment["PATH"],
+            homeDirectory: homeDirectory
+        )
 
         return try? resolve(
             configuredOverride: environment[executableOverrideEnvironmentKey],

--- a/Sources/TBDDaemon/Git/GitManager.swift
+++ b/Sources/TBDDaemon/Git/GitManager.swift
@@ -1,4 +1,5 @@
 import Foundation
+import TBDShared
 import os
 
 private let logger = Logger(subsystem: "com.tbd.daemon", category: "GitManager")
@@ -800,7 +801,8 @@ public struct GitManager: Sendable {
     // MARK: - Private
 
     /// The environment every git subprocess runs with: the daemon's own
-    /// environment, with the locale pinned to `C`.
+    /// environment, with the locale pinned to `C` and `PATH` floored with the
+    /// usual package-manager directories.
     ///
     /// Git's stderr is the only signal several callers have for *why* a command
     /// failed, and one of those decisions is destructive: `WorktreeLifecycle`'s
@@ -815,12 +817,26 @@ public struct GitManager: Sendable {
     /// bare dict would drop `PATH`, `HOME`, `SSH_AUTH_SOCK` and friends from
     /// every git call the daemon makes. (Same mistake, different subsystem:
     /// commit 56fa912f had to restore the launch `PATH` for tmux.)
+    ///
+    /// Inheriting `PATH` is necessary but not sufficient, because the daemon's
+    /// own `PATH` can be launchd's bare `/usr/bin:/bin:/usr/sbin:/sbin` — the
+    /// app is spawned that way whenever LaunchServices relaunches the bundle
+    /// without applying its `LSEnvironment`, and the daemon inherits it. Git
+    /// hands that environment to its filters and hooks, so an LFS repo with
+    /// `filter.lfs.required` then fails every `worktree add` with "git-lfs:
+    /// command not found" and exit 128. Appending the fallback directories
+    /// gives those children a floor without ever demoting a real launch `PATH`.
     static func gitEnvironment(
         inheriting base: [String: String] = ProcessInfo.processInfo.environment
     ) -> [String: String] {
         // `LC_ALL` is the one git actually obeys last; `LANG` is pinned too so
         // the child's own subprocesses don't see a mixed locale.
-        return base.merging(["LC_ALL": "C", "LANG": "C"]) { _, pinned in pinned }
+        let home = base["HOME"] ?? FileManager.default.homeDirectoryForCurrentUser.path
+        return base.merging([
+            "LC_ALL": "C",
+            "LANG": "C",
+            "PATH": ExecutableSearchPath.augmented(base["PATH"], homeDirectory: home),
+        ]) { _, pinned in pinned }
     }
 
     /// Runs a git command with the given arguments at the given directory and returns stdout.

--- a/Sources/TBDShared/ExecutableSearchPath.swift
+++ b/Sources/TBDShared/ExecutableSearchPath.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// Where to look for a command when the ambient `PATH` cannot be trusted.
+///
+/// A GUI process does not inherit a login shell's `PATH`. When TBD is launched
+/// from a terminal it gets the developer's full path; when LaunchServices
+/// relaunches the installed `.app` — at login after a reboot, from Spotlight,
+/// via "reopen windows" — it can get launchd's bare
+/// `/usr/bin:/bin:/usr/sbin:/sbin` instead, and everything the app spawns
+/// inherits that. `scripts/restart.sh` writes the developer's `PATH` into the
+/// bundle's `LSEnvironment`, but that is a request LaunchServices does not
+/// always honour, so subprocess environments need a floor of their own.
+///
+/// The floor is **appended**, never prepended: a real launch `PATH` still wins,
+/// including a user's deliberate ordering of shims (volta, asdf, a
+/// project-local `node_modules/.bin`). These directories only ever answer a
+/// lookup that would otherwise have failed.
+public enum ExecutableSearchPath {
+    /// Common package-manager and system directories, in the order a lookup
+    /// should try them. Home-relative entries come first because a
+    /// user-installed tool should win over a system copy of the same name.
+    public static func fallbackDirectories(
+        homeDirectory: String = FileManager.default.homeDirectoryForCurrentUser.path
+    ) -> [String] {
+        [
+            "\(homeDirectory)/.local/bin",
+            "\(homeDirectory)/.volta/bin",
+            "\(homeDirectory)/.cargo/bin",
+            "/opt/homebrew/bin",
+            "/opt/homebrew/sbin",
+            "/usr/local/bin",
+            "/usr/bin",
+            "/bin",
+            "/usr/sbin",
+            "/sbin",
+        ]
+    }
+
+    /// `path` with every missing fallback directory appended.
+    ///
+    /// Existing entries keep their order and their precedence; a directory
+    /// already present is not repeated, so calling this twice is the same as
+    /// calling it once. A nil or empty `path` yields the fallbacks alone.
+    public static func augmented(
+        _ path: String?,
+        homeDirectory: String = FileManager.default.homeDirectoryForCurrentUser.path
+    ) -> String {
+        let existing = (path ?? "")
+            .split(separator: ":", omittingEmptySubsequences: true)
+            .map(String.init)
+
+        var seen = Set<String>()
+        var ordered: [String] = []
+        for directory in existing + fallbackDirectories(homeDirectory: homeDirectory)
+        where seen.insert(directory).inserted {
+            ordered.append(directory)
+        }
+        return ordered.joined(separator: ":")
+    }
+}

--- a/Tests/TBDAppTests/LaunchEnvironmentTests.swift
+++ b/Tests/TBDAppTests/LaunchEnvironmentTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import Testing
+@testable import TBDApp
+
+/// Tier 1. Whether the app should overwrite its own `PATH` with the one
+/// `scripts/restart.sh` recorded in the bundle's `LSEnvironment`.
+@Suite struct LaunchEnvironmentTests {
+
+    private let bundlePATH = "/Users/test/.local/bin:/opt/homebrew/bin:/usr/bin:/bin"
+
+    @Test func noBundlePATHMeansNothingToAdopt() {
+        #expect(LaunchEnvironment.pathToAdopt(currentPATH: "/usr/bin:/bin", bundlePATH: nil) == nil)
+        #expect(LaunchEnvironment.pathToAdopt(currentPATH: "/usr/bin:/bin", bundlePATH: "") == nil)
+    }
+
+    /// The terminal launch: the inherited `PATH` is a superset, so adopting the
+    /// plist's would discard entries it never knew about.
+    @Test func aCurrentPATHThatAlreadyCoversTheBundlePATHIsKept() {
+        #expect(LaunchEnvironment.pathToAdopt(
+            currentPATH: "/Users/me/shims:" + bundlePATH,
+            bundlePATH: bundlePATH
+        ) == nil)
+        #expect(LaunchEnvironment.pathToAdopt(
+            currentPATH: bundlePATH, bundlePATH: bundlePATH
+        ) == nil)
+        // Order is not what "covers" means — the same directories reshuffled
+        // still cover, and reshuffling them back would fight the user's shell.
+        #expect(LaunchEnvironment.pathToAdopt(
+            currentPATH: "/bin:/usr/bin:/opt/homebrew/bin:/Users/test/.local/bin",
+            bundlePATH: bundlePATH
+        ) == nil)
+    }
+
+    /// The login relaunch: launchd's bare `PATH` is missing Homebrew, so the
+    /// bundle's contract wins.
+    @Test func aBarePATHAdoptsTheBundlePATH() {
+        #expect(LaunchEnvironment.pathToAdopt(
+            currentPATH: "/usr/bin:/bin:/usr/sbin:/sbin", bundlePATH: bundlePATH
+        ) == bundlePATH)
+        #expect(LaunchEnvironment.pathToAdopt(
+            currentPATH: nil, bundlePATH: bundlePATH
+        ) == bundlePATH)
+        #expect(LaunchEnvironment.pathToAdopt(
+            currentPATH: "", bundlePATH: bundlePATH
+        ) == bundlePATH)
+    }
+
+    /// One missing directory is enough — that is the whole failure, since
+    /// `git-lfs` lives in exactly one of them.
+    @Test func oneMissingDirectoryIsEnoughToAdopt() {
+        #expect(LaunchEnvironment.pathToAdopt(
+            currentPATH: "/Users/test/.local/bin:/usr/bin:/bin",
+            bundlePATH: bundlePATH
+        ) == bundlePATH)
+    }
+
+    @Test func adoptInstallsThePlistPATHWhenTheLaunchPATHIsBare() {
+        var installed: [String] = []
+        let adopted = LaunchEnvironment.adoptBundlePATHIfNeeded(
+            infoDictionary: ["LSEnvironment": ["PATH": bundlePATH]],
+            currentPATH: "/usr/bin:/bin:/usr/sbin:/sbin",
+            install: { installed.append($0) }
+        )
+
+        #expect(adopted == bundlePATH)
+        #expect(installed == [bundlePATH])
+    }
+
+    @Test func adoptInstallsNothingWhenThereIsNothingToAdopt() {
+        var installed: [String] = []
+        func adopt(_ info: [String: Any]?, current: String?) -> String? {
+            LaunchEnvironment.adoptBundlePATHIfNeeded(
+                infoDictionary: info, currentPATH: current, install: { installed.append($0) }
+            )
+        }
+
+        // Unbundled execution — no Info.plist at all.
+        #expect(adopt(nil, current: "/usr/bin:/bin") == nil)
+        // A bundle built without the key.
+        #expect(adopt(["CFBundleIdentifier": "com.example.test"], current: "/usr/bin:/bin") == nil)
+        // The key present but not a string.
+        #expect(adopt(["LSEnvironment": ["PATH": 42]], current: "/usr/bin:/bin") == nil)
+        // Already covered.
+        #expect(adopt(["LSEnvironment": ["PATH": bundlePATH]], current: bundlePATH) == nil)
+
+        #expect(installed.isEmpty)
+    }
+}

--- a/Tests/TBDAppTests/LaunchEnvironmentTests.swift
+++ b/Tests/TBDAppTests/LaunchEnvironmentTests.swift
@@ -85,4 +85,57 @@ import Testing
 
         #expect(installed.isEmpty)
     }
+
+    // MARK: - Cross-source consistency
+
+    /// The adoption only works because of where it sits in `TBDAppMain`.
+    ///
+    /// Swift evaluates a struct's stored-property default expressions in source
+    /// order, `setenv` reaches only children born after it, and `appState`'s
+    /// initializer is what spawns the daemon. So `adoptedLaunchPATH` must be
+    /// declared above `appState` — and nothing in the compiler says so. Moving the
+    /// property down, or adding a new subprocess-spawning property above it, would
+    /// leave a daemon on launchd's bare `PATH` again with every test still green.
+    /// This is the tie: it reads the source file and fails on the wrong order.
+    @Test func adoptedLaunchPATHIsDeclaredBeforeTheAppStateThatSpawnsTheDaemon() throws {
+        // Walk up from this source file to the repo root (the dir holding `Sources/`).
+        var dir = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        let relativeSourcePath = "Sources/TBDApp/TBDApp.swift"
+        while !FileManager.default.fileExists(atPath: dir.appendingPathComponent(relativeSourcePath).path) {
+            let parent = dir.deletingLastPathComponent()
+            // Reached the filesystem root without finding it — skip rather than
+            // fail, so a packaged/sandboxed test run doesn't red for the wrong reason.
+            guard parent.path != dir.path else { return }
+            dir = parent
+        }
+        let source = try String(
+            contentsOf: dir.appendingPathComponent(relativeSourcePath), encoding: .utf8
+        )
+
+        let adoptionDeclaration = "private let adoptedLaunchPATH"
+        let appStateDeclaration = "private var appState"
+
+        // Both must be found, and found once: a renamed property would otherwise
+        // make this check pass by matching nothing.
+        #expect(source.components(separatedBy: adoptionDeclaration).count == 2, """
+        expected exactly one `\(adoptionDeclaration)` declaration in \
+        \(relativeSourcePath) — was the property renamed or removed?
+        """)
+        #expect(source.components(separatedBy: appStateDeclaration).count == 2, """
+        expected exactly one `\(appStateDeclaration)` declaration in \
+        \(relativeSourcePath) — was the property renamed or removed?
+        """)
+
+        let adoption = try #require(source.range(of: adoptionDeclaration))
+        let appState = try #require(source.range(of: appStateDeclaration))
+
+        #expect(adoption.lowerBound < appState.lowerBound, """
+        `\(adoptionDeclaration)` must be declared BEFORE `\(appStateDeclaration)` in \
+        \(relativeSourcePath). Stored-property defaults are evaluated in source \
+        order, and AppState's initializer spawns the daemon, which inherits this \
+        process's PATH. Declared after it, the setenv lands too late and a daemon \
+        started by a LaunchServices relaunch keeps launchd's bare PATH — the bug \
+        this property exists to fix.
+        """)
+    }
 }

--- a/Tests/TBDAppTests/LaunchEnvironmentTests.swift
+++ b/Tests/TBDAppTests/LaunchEnvironmentTests.swift
@@ -91,12 +91,16 @@ import Testing
     /// The adoption only works because of where it sits in `TBDAppMain`.
     ///
     /// Swift evaluates a struct's stored-property default expressions in source
-    /// order, `setenv` reaches only children born after it, and `appState`'s
-    /// initializer is what spawns the daemon. So `adoptedLaunchPATH` must be
-    /// declared above `appState` — and nothing in the compiler says so. Moving the
-    /// property down, or adding a new subprocess-spawning property above it, would
-    /// leave a daemon on launchd's bare `PATH` again with every test still green.
-    /// This is the tie: it reads the source file and fails on the wrong order.
+    /// order, so the `setenv` must run before the `appState` expression is
+    /// evaluated. `AppState.init` does not spawn the daemon itself — it
+    /// schedules an async `Task` that later calls `startDaemonAndConnect()` —
+    /// and the ordering holds through that indirection because a `Process`
+    /// given a nil `environment` inherits the live `environ` as it stands at
+    /// `run()` time. So `adoptedLaunchPATH` must be declared above `appState`,
+    /// and nothing in the compiler says so. Moving the property down, or adding
+    /// a new subprocess-spawning property above it, would leave a daemon on
+    /// launchd's bare `PATH` again with every test still green. This is the
+    /// tie: it reads the source file and fails on the wrong order.
     @Test func adoptedLaunchPATHIsDeclaredBeforeTheAppStateThatSpawnsTheDaemon() throws {
         // Walk up from this source file to the repo root (the dir holding `Sources/`).
         var dir = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
@@ -132,10 +136,13 @@ import Testing
         #expect(adoption.lowerBound < appState.lowerBound, """
         `\(adoptionDeclaration)` must be declared BEFORE `\(appStateDeclaration)` in \
         \(relativeSourcePath). Stored-property defaults are evaluated in source \
-        order, and AppState's initializer spawns the daemon, which inherits this \
-        process's PATH. Declared after it, the setenv lands too late and a daemon \
-        started by a LaunchServices relaunch keeps launchd's bare PATH — the bug \
-        this property exists to fix.
+        order, and AppState.init schedules the Task that calls \
+        startDaemonAndConnect(); the daemon Process inherits this process's environ \
+        as it stands when it runs. Declared above appState, the setenv is done \
+        before that Task even exists. Declared below it, whether the PATH lands \
+        before the spawn is left to main-actor scheduling — and when it loses, a \
+        daemon started by a LaunchServices relaunch keeps launchd's bare PATH, the \
+        bug this property exists to fix.
         """)
     }
 }

--- a/Tests/TBDDaemonTests/GitManagerTests.swift
+++ b/Tests/TBDDaemonTests/GitManagerTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+import TBDShared
 @testable import TBDDaemonLib
 
 struct GitManagerTests {
@@ -317,9 +318,42 @@ struct GitManagerTests {
         ])
         #expect(composed["LC_ALL"] == "C")
         #expect(composed["LANG"] == "C")
-        #expect(composed["PATH"] == "/opt/homebrew/bin:/usr/bin")
+        #expect(composed["PATH"]?.hasPrefix("/opt/homebrew/bin:/usr/bin:") == true,
+                "the inherited PATH must keep its order and precedence")
         #expect(composed["HOME"] == "/Users/test")
         #expect(composed["SSH_AUTH_SOCK"] == "/tmp/agent.sock")
+    }
+
+    /// The daemon can be started by an app that LaunchServices relaunched with
+    /// launchd's bare `PATH`. Git hands its environment to LFS filters and
+    /// hooks, so without a floor every `worktree add` in an LFS repo dies with
+    /// "git-lfs: command not found".
+    @Test func gitSubprocessPATHIsFlooredWithTheUsualToolDirectories() {
+        let composed = GitManager.gitEnvironment(inheriting: [
+            "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+            "HOME": "/Users/test",
+        ])
+        let directories = (composed["PATH"] ?? "").split(separator: ":").map(String.init)
+
+        #expect(Array(directories.prefix(4)) == ["/usr/bin", "/bin", "/usr/sbin", "/sbin"],
+                "the launch PATH must stay ahead of the floor")
+        #expect(directories.contains("/opt/homebrew/bin"))
+        #expect(directories.contains("/Users/test/.local/bin"))
+        #expect(directories.count == Set(directories).count)
+    }
+
+    /// The other branch: a `PATH` that already names every fallback is left
+    /// exactly as inherited.
+    @Test func anAlreadyCompletePATHIsInheritedUnchanged() {
+        let full = ExecutableSearchPath
+            .fallbackDirectories(homeDirectory: "/Users/test")
+            .joined(separator: ":")
+        let composed = GitManager.gitEnvironment(inheriting: [
+            "PATH": full,
+            "HOME": "/Users/test",
+        ])
+
+        #expect(composed["PATH"] == full)
     }
 
     // MARK: - Helpers

--- a/Tests/TBDSharedTests/ExecutableSearchPathTests.swift
+++ b/Tests/TBDSharedTests/ExecutableSearchPathTests.swift
@@ -1,0 +1,87 @@
+import Foundation
+import Testing
+@testable import TBDShared
+
+/// Tier 1. The `PATH` floor a GUI-launched process needs when LaunchServices
+/// hands it launchd's bare `/usr/bin:/bin:/usr/sbin:/sbin`.
+@Suite struct ExecutableSearchPathTests {
+
+    private let home = "/Users/test"
+
+    @Test func bareLaunchdPATHGainsTheFallbacksAfterWhatItAlreadyHad() {
+        let augmented = ExecutableSearchPath.augmented(
+            "/usr/bin:/bin:/usr/sbin:/sbin", homeDirectory: home
+        )
+
+        #expect(augmented == [
+            "/usr/bin", "/bin", "/usr/sbin", "/sbin",
+            "/Users/test/.local/bin",
+            "/Users/test/.volta/bin",
+            "/Users/test/.cargo/bin",
+            "/opt/homebrew/bin",
+            "/opt/homebrew/sbin",
+            "/usr/local/bin",
+        ].joined(separator: ":"))
+    }
+
+    /// The failure that motivated this: git could not find `git-lfs`, which
+    /// Homebrew installs into `/opt/homebrew/bin`.
+    @Test func homebrewIsReachableFromABareLaunchdPATH() {
+        let directories = ExecutableSearchPath
+            .augmented("/usr/bin:/bin:/usr/sbin:/sbin", homeDirectory: home)
+            .split(separator: ":").map(String.init)
+        #expect(directories.contains("/opt/homebrew/bin"))
+    }
+
+    /// The other branch: a `PATH` that already covers every fallback is
+    /// returned unchanged, so a real login shell's ordering is never disturbed.
+    @Test func aPATHThatAlreadyCoversTheFallbacksIsUnchanged() {
+        let full = (["/Users/test/bin"]
+            + ExecutableSearchPath.fallbackDirectories(homeDirectory: home))
+            .joined(separator: ":")
+
+        #expect(ExecutableSearchPath.augmented(full, homeDirectory: home) == full)
+    }
+
+    /// Fallbacks are appended, never promoted: a developer's shim directory
+    /// keeps its precedence over the system copy of the same tool.
+    @Test func existingEntriesKeepTheirOrderAndPrecedence() {
+        let augmented = ExecutableSearchPath
+            .augmented("/opt/homebrew/bin:/Users/test/shims:/usr/bin", homeDirectory: home)
+            .split(separator: ":").map(String.init)
+
+        #expect(Array(augmented.prefix(3)) == ["/opt/homebrew/bin", "/Users/test/shims", "/usr/bin"])
+        // The fallback list also names /opt/homebrew/bin and /usr/bin; neither
+        // is re-appended, so neither loses its position to a later duplicate.
+        #expect(augmented.firstIndex(of: "/opt/homebrew/bin") == 0)
+        #expect(augmented.firstIndex(of: "/usr/bin") == 2)
+    }
+
+    @Test func repeatedDirectoriesAppearOnceAndAugmentingIsIdempotent() {
+        let once = ExecutableSearchPath.augmented("/usr/bin:/usr/bin:/bin", homeDirectory: home)
+        let twice = ExecutableSearchPath.augmented(once, homeDirectory: home)
+
+        #expect(once == twice)
+        let directories = once.split(separator: ":").map(String.init)
+        #expect(directories.count == Set(directories).count)
+    }
+
+    @Test func homeRelativeDirectoriesExpandAgainstTheGivenHome() {
+        let augmented = ExecutableSearchPath.augmented(nil, homeDirectory: "/Users/x")
+
+        #expect(augmented.hasPrefix("/Users/x/.local/bin:/Users/x/.volta/bin:/Users/x/.cargo/bin:"))
+        #expect(!augmented.contains("/Users/test"))
+    }
+
+    @Test func anEmptyOrMissingPATHYieldsTheFallbacksAlone() {
+        let expected = ExecutableSearchPath
+            .fallbackDirectories(homeDirectory: home)
+            .joined(separator: ":")
+
+        #expect(ExecutableSearchPath.augmented(nil, homeDirectory: home) == expected)
+        #expect(ExecutableSearchPath.augmented("", homeDirectory: home) == expected)
+        // Empty segments (a stray leading or doubled colon) are dropped rather
+        // than becoming an entry meaning "the current directory".
+        #expect(ExecutableSearchPath.augmented("::", homeDirectory: home) == expected)
+    }
+}


### PR DESCRIPTION
## The bug

In a repo configured with `filter.lfs.required=true`, every `tbd worktree create` failed:

```
git-lfs: command not found
fatal: the remote end hung up unexpectedly
exit 128
```

`git-lfs` is only in `/opt/homebrew/bin`, and the daemon running the `git worktree add` had launchd's bare `PATH=/usr/bin:/bin:/usr/sbin:/sbin`.

How it got there: the app was not started from a terminal. LaunchServices relaunched the installed `/Applications/TBD.app` at login after a reboot and did **not** apply the bundle's `LSEnvironment.PATH` — the key `scripts/restart.sh` writes via `scripts/restart-environment-lib.sh` (56fa912f, #608 "preserve launch PATH for tmux"). The app got launchd's `PATH`, spawned the daemon, and the daemon inherited it. The same commit that added the plist mechanism also removed the daemon's own `PATH` augmentation, so nothing backstopped a bad launch environment.

Evidence:

- Failures began at 09:47 on 2026-09-04, after a 09:31 LaunchServices relaunch following a reboot. Zero failures in the prior three days.
- The installed bundle's `Info.plist` does carry `LSEnvironment.PATH`.
- The running app and daemon both had the bare `PATH`.

So the plist is a request LaunchServices honours on some launch routes and not others, and the daemon had no floor of its own.

## The fix

Two independent belts, either of which resolves the reproduced failure.

- **Daemon.** `GitManager.gitEnvironment` now appends the usual package-manager and system directories to whatever `PATH` it inherited: `~/.local/bin`, `~/.volta/bin`, `~/.cargo/bin`, `/opt/homebrew/{bin,sbin}`, `/usr/local/bin`, then the system dirs. Appended, never prepended, so a real launch `PATH` keeps its precedence and a user's shim ordering is untouched. Git hands this environment to its LFS filter and its hooks, which is why this alone fixes the failure.
- **App.** At launch, before anything can spawn the daemon, the app reads `LSEnvironment.PATH` out of its own bundle and installs it with `setenv` when the process `PATH` does not already contain every entry of it. The decision is a pure function, `LaunchEnvironment.pathToAdopt(currentPATH:bundlePATH:)`, so both branches are unit-testable without touching the real environment. The outcome is logged at `.info` on `com.tbd.app`, category `launch-environment`.

The augmentation itself lives in `TBDShared` as `ExecutableSearchPath`. The Codex executable resolver had its own copy of nearly the same list and now shares this one, which also gives it de-duplication it did not have.

Ordering note, since it is the part that can silently regress: the adoption is a stored property of the `App` struct declared **above** `appState`, and Swift evaluates stored-property defaults in source order, so the `setenv` runs before the `appState` expression is evaluated. `AppState.init` does not spawn the daemon itself — it schedules an async `Task` that later calls `startDaemonAndConnect()` — and the ordering holds through that indirection: a `Process` given a nil `environment` inherits the live `environ` as it stands at `run()` time, which is long after the adoption. A comment on the property says so, and a test now enforces the order.

## Legibility

The CLI's failed-create message pointed at `log show --predicate ...`. `log` is a zsh builtin that consumes the arguments and prints nothing, so following the hint read as "the daemon logged nothing". Both that message and the app's equivalent alert now say `/usr/bin/log show`. The daemon already embeds git's stderr in what it logs; the error path is otherwise unchanged.

## Tests

New tier-1 suites, both branches of each conditional:

- `ExecutableSearchPathTests` (`Tests/TBDSharedTests`) — a bare launchd `PATH` gains the fallbacks appended; a `PATH` that already covers them is returned unchanged; existing entries keep their order and precedence; no duplicates and augmenting twice equals augmenting once; home-relative entries expand against the given home; empty or missing `PATH` yields the fallbacks alone.
- `LaunchEnvironmentTests` (`Tests/TBDAppTests`) — nil when the bundle names no `PATH` (absent plist, absent key, non-string value), nil when the current `PATH` already covers it including when reshuffled, the bundle `PATH` when one directory is missing or the `PATH` is bare. Plus the install closure firing exactly once in the adopt case and never otherwise.
- `GitManagerTests` gains two cases for the floor and its no-op branch; the existing locale-pinning case was updated to assert `PATH` precedence rather than byte equality.

```
✔ Test run with 13 tests in 2 suites passed   (ExecutableSearchPathTests, LaunchEnvironmentTests)
✔ Test run with 33 tests in 3 suites passed   (adds GitManagerTests)
✔ Test run with 7 tests in 1 suite passed     (CodexUsageParserTests, covering the resolver refactor)
```

`scripts/swift-safe build` is clean and `swiftlint --strict` reports 0 violations across 929 files.

## No spec

This is a bug fix. It restores the system to the theory it already had — the daemon's git subprocesses are supposed to find the developer's tools — rather than revising it. No flag: there is no state to destroy and no autonomous behavior, and gating a `PATH` floor default-off would ship the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SwPTd69A1awTHB2TA3suCC

[Archive Agent Box Sessions](https://cheapsteak.github.io/tbd/open/?worktree=9C81D24D-12C8-4945-88A7-431D2116B526)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved executable discovery by adopting bundle-provided PATH settings and adding reliable fallback directories.
  * Git and child processes now inherit more complete executable paths while preserving existing precedence and avoiding duplicates.

* **Bug Fixes**
  * Fixed Console logging commands to use the absolute system executable, improving worktree error diagnostics.

* **Tests**
  * Added coverage for PATH adoption, fallback ordering, deduplication, and subprocess environment behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
