### PR TITLE
Fix: A daemon restart parks the fleet on slow tmux probes, and a successor cannot take over safely

### DIFF
--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -730,34 +730,21 @@ public final class Daemon: Sendable {
             daemonLogger.error("Another daemon is already running (PID \(existingPID, privacy: .public)). Exiting.")
             Foundation.exit(1)
         case let .takeOver(predecessor):
-            // 4. Write PID file — before the signal, not after.
-            try pidFile.write()
-            daemonLogger.info("handover: claimed the pid file from predecessor daemon \(predecessor, privacy: .public); retiring it now")
-            let outcome = await DaemonHandover().retire(predecessor: predecessor)
-            if outcome == .stillAlive {
-                // A predecessor that survived SIGKILL is not a predecessor we
-                // may start alongside. Nothing further down serves as a
-                // backstop — the socket bind is hundreds of lines away, and by
-                // then this process has already run startup reconciliation
-                // against `state.db`. Two daemons there means two writers and
-                // two reconcilers with different opinions about which sessions
-                // are alive, which is the failure the whole single-instance
-                // gate exists to prevent.
-                //
-                // Hand the pid file back before going, so the world is exactly
-                // as it was found: the file names the live predecessor, the
-                // gate stays shut for the app's poller and for any stray
-                // restart, and nothing treats the daemon that is still serving
-                // as absent.
-                do {
-                    try pidFile.write(pid: predecessor)
-                } catch {
-                    daemonLogger.error("handover: could not restore predecessor daemon \(predecessor, privacy: .public)'s pid file claim: \(String(describing: error), privacy: .public)")
-                }
+            // 4. Claim the pid file, retire the predecessor, re-assert the
+            // claim. See `HandoverClaim` for why each of the three steps is
+            // there.
+            switch try await HandoverClaim(pidFile: pidFile).takeOver(from: predecessor) {
+            case .predecessorSurvived:
+                // Nothing downstream is a backstop: the socket bind is
+                // hundreds of lines past startup reconciliation, so this
+                // process would already have run a second reconciler against
+                // `state.db`. Two writers there is the failure the whole
+                // single-instance gate exists to prevent.
                 daemonLogger.error("handover: predecessor daemon \(predecessor, privacy: .public) survived SIGKILL — restored its pid file claim and exiting rather than running a second writer on state.db")
                 Foundation.exit(1)
+            case let .claimed(outcome):
+                daemonLogger.info("handover: predecessor daemon \(predecessor, privacy: .public) retired (\(outcome.rawValue, privacy: .public)); continuing startup")
             }
-            daemonLogger.info("handover: predecessor daemon \(predecessor, privacy: .public) retired (\(outcome.rawValue, privacy: .public)); continuing startup")
         case .normal:
             // 4. Write PID file
             try pidFile.write()

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -734,6 +734,29 @@ public final class Daemon: Sendable {
             try pidFile.write()
             daemonLogger.info("handover: claimed the pid file from predecessor daemon \(predecessor, privacy: .public); retiring it now")
             let outcome = await DaemonHandover().retire(predecessor: predecessor)
+            if outcome == .stillAlive {
+                // A predecessor that survived SIGKILL is not a predecessor we
+                // may start alongside. Nothing further down serves as a
+                // backstop — the socket bind is hundreds of lines away, and by
+                // then this process has already run startup reconciliation
+                // against `state.db`. Two daemons there means two writers and
+                // two reconcilers with different opinions about which sessions
+                // are alive, which is the failure the whole single-instance
+                // gate exists to prevent.
+                //
+                // Hand the pid file back before going, so the world is exactly
+                // as it was found: the file names the live predecessor, the
+                // gate stays shut for the app's poller and for any stray
+                // restart, and nothing treats the daemon that is still serving
+                // as absent.
+                do {
+                    try pidFile.write(pid: predecessor)
+                } catch {
+                    daemonLogger.error("handover: could not restore predecessor daemon \(predecessor, privacy: .public)'s pid file claim: \(String(describing: error), privacy: .public)")
+                }
+                daemonLogger.error("handover: predecessor daemon \(predecessor, privacy: .public) survived SIGKILL — restored its pid file claim and exiting rather than running a second writer on state.db")
+                Foundation.exit(1)
+            }
             daemonLogger.info("handover: predecessor daemon \(predecessor, privacy: .public) retired (\(outcome.rawValue, privacy: .public)); continuing startup")
         case .normal:
             // 4. Write PID file

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -271,7 +271,13 @@ public final class Daemon: Sendable {
     /// `TBD_WORKTREE_ID=<main-uuid>` or `CODEX_CI=1` from a managed launcher
     /// shell, every recreated pane would inherit stale routing/noninteractive
     /// state.
+    /// `TBD_HANDOVER_FROM_PID` is scrubbed here too, and the ordering matters:
+    /// `start()` reads it at the single-instance gate, several steps before
+    /// this runs. A tmux server bakes its spawn environment into every window
+    /// it later creates, so a variable left set would be handed to every pane
+    /// and to whatever those panes launch — including another daemon.
     public static func scrubInheritedTBDEnv() {
+        unsetenv(handoverFromPIDEnvVar)
         unsetenv("TBD_WORKTREE_ID")
         unsetenv("TBD_PROMPT_CONTEXT")
         unsetenv("TBD_PROMPT_INSTRUCTIONS")
@@ -702,14 +708,37 @@ public final class Daemon: Sendable {
         // would make this fresh daemon abort forever until that pid frees —
         // exactly the multi-minute "disconnected on restart" gap. cleanupIfStale
         // above already removed the pid/socket in that case, so read() is nil.
-        if let existingPID = pidFile.read(),
-           ProcessLiveness.isLiveNamedProcess(pid: existingPID, name: ProcessLiveness.daemonExecutableName) {
+        //
+        // 3a. `TBD_HANDOVER_FROM_PID` is the one way past that gate. When an
+        // update starts a successor with the running daemon's pid in that
+        // variable, the successor claims the pid file FIRST and then retires
+        // the predecessor. Claiming first is what closes the window a plain
+        // kill-then-start opens: the app polls every two seconds and spawns a
+        // daemon whenever the socket is missing *and* the pid file names no
+        // live daemon, so with the successor's pid in the file from the first
+        // instant, every spurious spawn exits at this same gate.
+        let handoverDecision = HandoverDecision.decide(
+            pidFileContents: pidFile.read(),
+            handoverEnv: ProcessInfo.processInfo.environment[handoverFromPIDEnvVar],
+            isLiveDaemon: {
+                ProcessLiveness.isLiveNamedProcess(
+                    pid: $0, name: ProcessLiveness.daemonExecutableName)
+            })
+
+        switch handoverDecision {
+        case let .refuse(existingPID):
             daemonLogger.error("Another daemon is already running (PID \(existingPID, privacy: .public)). Exiting.")
             Foundation.exit(1)
+        case let .takeOver(predecessor):
+            // 4. Write PID file — before the signal, not after.
+            try pidFile.write()
+            daemonLogger.info("handover: claimed the pid file from predecessor daemon \(predecessor, privacy: .public); retiring it now")
+            let outcome = await DaemonHandover().retire(predecessor: predecessor)
+            daemonLogger.info("handover: predecessor daemon \(predecessor, privacy: .public) retired (\(outcome.rawValue, privacy: .public)); continuing startup")
+        case .normal:
+            // 4. Write PID file
+            try pidFile.write()
         }
-
-        // 4. Write PID file
-        try pidFile.write()
 
         // Refresh the agent runtime integration assets up front so both
         // Claude and Codex sessions pick up the current TBD hook/plugin state
@@ -1102,6 +1131,18 @@ public final class Daemon: Sendable {
         await performStartupReconciliation(
             mockMode: mockMode, database: database, git: git, lifecycle: lifecycle,
             actuationLog: actuationLog)
+
+        // 8d-ii. Un-park a second time, AFTER the reconcile pass. The first run
+        // has to precede reconcile so the destructive scratch-server reaping
+        // works from a consistent view, but that ordering also means it cannot
+        // repair anything the same boot parks. This run can: it re-examines the
+        // parked rows and clears every one whose pane demonstrably still runs
+        // Claude. Cheap — it only looks at parked rows — and it is the repair
+        // half of the tri-state reconcile probes, which stop the parks that are
+        // pure guesswork rather than the ones that merely raced.
+        if mockMode == nil {
+            await rpcRouter.hibernationCoordinator.reconcileOnStartup()
+        }
 
         // 8e. Re-adopt holder-backed sessions. A `HolderReader` lives only in
         // the memory of the daemon that made it, so after a restart every live
@@ -1717,11 +1758,26 @@ public final class Daemon: Sendable {
             await http.stop()
         }
 
-        // Remove PID file
-        pidFile.remove()
+        // Remove the PID file only if it still names this process. During a
+        // handover the successor has already written its own pid over it, and
+        // deleting that claim would reopen the spawn race the successor-first
+        // write exists to close.
+        let ownedPIDFile = pidFile.removeIfOwned()
 
-        // Remove port file
-        try? FileManager.default.removeItem(atPath: TBDConstants.portFilePath)
+        // The port file holds a port, not a pid, so it cannot answer "is this
+        // mine?" on its own. The pid file is the proxy for it: one daemon
+        // writes both and one daemon removes both, so a pid file that was still
+        // ours means the port file beside it was ours too.
+        //
+        // When the pid file has already been claimed by a successor, this
+        // leaves a port file naming a port nobody is listening on — for the few
+        // moments until the successor binds and overwrites it. That stale
+        // window is the deliberately cheaper failure: deleting the file instead
+        // would race the successor's own write and could leave the app with no
+        // address at all for a daemon that is up and serving.
+        if ownedPIDFile {
+            try? FileManager.default.removeItem(atPath: TBDConstants.portFilePath)
+        }
 
         daemonLogger.info("Stopped.")
         Foundation.exit(0)

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -734,7 +734,10 @@ public final class Daemon: Sendable {
             // claim. See `HandoverClaim` for why each of the three steps is
             // there.
             switch try await HandoverClaim(pidFile: pidFile).takeOver(from: predecessor) {
-            case .predecessorSurvived:
+            case let .predecessorSurvived(claimRestored):
+                if !claimRestored {
+                    daemonLogger.error("handover: the pid file still names this exiting process — the next daemon start will clear it as stale")
+                }
                 // Nothing downstream is a backstop: the socket bind is
                 // hundreds of lines past startup reconciliation, so this
                 // process would already have run a second reconciler against

--- a/Sources/TBDDaemon/DaemonHandover.swift
+++ b/Sources/TBDDaemon/DaemonHandover.swift
@@ -103,10 +103,39 @@ public enum HandoverDecision: Equatable, Sendable {
 /// exercise the escalation in three polls instead of three hundred.
 public struct DaemonHandover: Sendable {
     /// How long to wait for a polite exit before escalating.
+    ///
+    /// **30 s is sized to `stop()`, and the alternative is what went wrong.**
+    /// `restart.sh` sends the daemon `SIGTERM`, sleeps **0.5 s**, and then
+    /// deletes the pid, socket and port files and starts the new daemon
+    /// regardless of whether the old one has finished — so a shutdown that
+    /// takes longer than half a second overlaps its successor and loses its own
+    /// files out from under it. Half a second is not a budget, it is a hope.
+    ///
+    /// The real shutdown is a sequence of awaits: the usage pollers and the
+    /// limit-resume scheduler stop, every holder reader is released one at a
+    /// time (`HolderReader.defaultStopTimeout` is 5 s each), the deferred
+    /// remote-backends boot task is cancelled and awaited, and both servers
+    /// stop. Every one of those is itself bounded, so the whole is bounded —
+    /// 30 s covers the ordinary case with room to spare, without being so long
+    /// that a wedged predecessor holds an operator's update open for minutes.
     public let termBudget: Duration
     /// How long to wait after `SIGKILL` before giving up.
+    ///
+    /// `SIGKILL` cannot be caught, blocked or ignored, so this is not a second
+    /// grace period — there is no cleanup left to run. The only reason a pid
+    /// outlives it is an uninterruptible wait in the kernel, and 5 s is long
+    /// enough to tell that apart from the microseconds an ordinary teardown
+    /// takes. A pid still there afterwards is `Outcome.stillAlive`, which
+    /// `Daemon.start()` treats as a reason not to start at all.
     public let killBudget: Duration
     /// Gap between liveness checks.
+    ///
+    /// The successor cannot bind until the predecessor is gone, so every
+    /// millisecond of this interval is a millisecond the socket is missing and
+    /// CLI calls fail. 100 ms keeps that tail short — a second-long poll would
+    /// add up to a second of dead socket for nothing — while 300 `kill(pid, 0)`
+    /// probes across the whole `SIGTERM` budget is far too little work to be
+    /// worth calling busy-polling.
     public let pollInterval: Duration
 
     private let sendSignal: @Sendable (pid_t, Int32) -> Void

--- a/Sources/TBDDaemon/DaemonHandover.swift
+++ b/Sources/TBDDaemon/DaemonHandover.swift
@@ -1,0 +1,153 @@
+import Darwin
+import Foundation
+import TBDShared
+import os
+
+private let handoverLogger = Logger(subsystem: "com.tbd.daemon", category: "handover")
+
+/// The environment variable a successor daemon is started with to say which
+/// daemon it is replacing.
+///
+/// **Contract, as `scripts/update.sh` uses it.** The update script builds a new
+/// daemon out of place, then launches it with
+/// `TBD_HANDOVER_FROM_PID=<pid of the running daemon>`. The successor's
+/// single-instance gate reads the variable exactly once, at startup, and honors
+/// it only when the pid file names a *live* `TBDDaemon` whose pid equals the
+/// value. Any other combination — a stale file, a different live daemon, an
+/// unparsable value — falls back to today's behavior, so a mistyped or
+/// out-of-date variable can never take over a daemon it was not aimed at.
+///
+/// The variable must not outlive that read: `Daemon.scrubInheritedTBDEnv()`
+/// unsets it before any tmux server is spawned, because a tmux server bakes its
+/// spawn environment into every window it later creates, and a pane carrying a
+/// stale handover pid would hand it to anything it launched.
+public let handoverFromPIDEnvVar = "TBD_HANDOVER_FROM_PID"
+
+/// What a starting daemon should do about the pid file it found.
+///
+/// A pure function of three inputs so every branch is reachable from a test
+/// without a second process: the pid the file holds, the handover variable, and
+/// whether that pid is a live `TBDDaemon`.
+public enum HandoverDecision: Equatable, Sendable {
+    /// No live daemon owns the pid file. Claim it and start normally.
+    case normal
+    /// The pid file names the live daemon we were sent to replace. Claim the
+    /// file first, then retire that daemon, then start normally.
+    case takeOver(predecessor: pid_t)
+    /// The pid file names a live daemon that is not ours to replace. Exit.
+    case refuse(existing: pid_t)
+
+    public static func decide(
+        pidFileContents: pid_t?,
+        handoverEnv: String?,
+        isLiveDaemon: (pid_t) -> Bool
+    ) -> HandoverDecision {
+        guard let existing = pidFileContents, isLiveDaemon(existing) else {
+            return .normal
+        }
+        guard let raw = handoverEnv?.trimmingCharacters(in: .whitespacesAndNewlines),
+              let requested = pid_t(raw),
+              requested == existing
+        else {
+            return .refuse(existing: existing)
+        }
+        return .takeOver(predecessor: existing)
+    }
+}
+
+/// Retires the predecessor daemon during a handover: `SIGTERM`, wait, then
+/// `SIGKILL` and a shorter wait.
+///
+/// The waiting is polled rather than deadline-computed because the clock is an
+/// existential (`any Clock<Duration>`) whose `Instant` type is erased, so there
+/// is no arithmetic to do on it — see `Tests/CLAUDE.md`, "Clock and date
+/// seams". Budgets are instance properties rather than constants so a test can
+/// exercise the escalation in three polls instead of three hundred.
+public struct DaemonHandover: Sendable {
+    /// How long to wait for a polite exit before escalating.
+    public let termBudget: Duration
+    /// How long to wait after `SIGKILL` before giving up.
+    public let killBudget: Duration
+    /// Gap between liveness checks.
+    public let pollInterval: Duration
+
+    private let sendSignal: @Sendable (pid_t, Int32) -> Void
+    private let isLive: @Sendable (pid_t) -> Bool
+    private let clock: any Clock<Duration>
+
+    /// What retiring the predecessor came to.
+    public enum Outcome: String, Sendable, Equatable {
+        /// The predecessor was already gone when we looked.
+        case alreadyGone
+        /// It exited within the `SIGTERM` budget.
+        case exitedAfterTerm
+        /// It needed `SIGKILL` and then exited.
+        case exitedAfterKill
+        /// It was still alive after `SIGKILL` and the second budget. The
+        /// successor starts anyway: it already owns the pid file, and a
+        /// process this stuck is not going to serve anything.
+        case stillAlive
+    }
+
+    public init(
+        termBudget: Duration = .seconds(30),
+        killBudget: Duration = .seconds(5),
+        pollInterval: Duration = .milliseconds(100),
+        sendSignal: @escaping @Sendable (pid_t, Int32) -> Void = { pid, signal in
+            _ = kill(pid, signal)
+        },
+        isLive: @Sendable @escaping (pid_t) -> Bool = { pid in
+            ProcessLiveness.isLiveNamedProcess(pid: pid, name: ProcessLiveness.daemonExecutableName)
+        },
+        clock: any Clock<Duration> = ContinuousClock()
+    ) {
+        self.termBudget = termBudget
+        self.killBudget = killBudget
+        self.pollInterval = pollInterval
+        self.sendSignal = sendSignal
+        self.isLive = isLive
+        self.clock = clock
+    }
+
+    /// Signal the predecessor and wait for it to go.
+    public func retire(predecessor: pid_t) async -> Outcome {
+        guard isLive(predecessor) else { return .alreadyGone }
+
+        handoverLogger.info("handover: sending SIGTERM to predecessor daemon \(predecessor, privacy: .public)")
+        sendSignal(predecessor, SIGTERM)
+        if await waitForExit(of: predecessor, budget: termBudget) {
+            handoverLogger.info("handover: predecessor daemon \(predecessor, privacy: .public) exited after SIGTERM")
+            return .exitedAfterTerm
+        }
+
+        handoverLogger.info("handover: predecessor daemon \(predecessor, privacy: .public) outlived the \(String(describing: self.termBudget), privacy: .public) SIGTERM budget — escalating to SIGKILL")
+        sendSignal(predecessor, SIGKILL)
+        if await waitForExit(of: predecessor, budget: killBudget) {
+            handoverLogger.info("handover: predecessor daemon \(predecessor, privacy: .public) exited after SIGKILL")
+            return .exitedAfterKill
+        }
+
+        handoverLogger.error("handover: predecessor daemon \(predecessor, privacy: .public) still alive after SIGKILL and \(String(describing: self.killBudget), privacy: .public) — starting anyway")
+        return .stillAlive
+    }
+
+    /// True once `pid` is no longer a live daemon, false if the budget runs out
+    /// first.
+    private func waitForExit(of pid: pid_t, budget: Duration) async -> Bool {
+        for _ in 0..<Self.pollCount(budget: budget, interval: pollInterval) {
+            try? await clock.sleep(for: pollInterval)
+            if !isLive(pid) { return true }
+        }
+        return false
+    }
+
+    /// How many polls fit in a budget, floored, never fewer than one.
+    static func pollCount(budget: Duration, interval: Duration) -> Int {
+        let attos = { (duration: Duration) -> Double in
+            Double(duration.components.seconds) * 1e18 + Double(duration.components.attoseconds)
+        }
+        let intervalAttos = attos(interval)
+        guard intervalAttos > 0 else { return 1 }
+        return max(1, Int((attos(budget) / intervalAttos).rounded(.down)))
+    }
+}

--- a/Sources/TBDDaemon/DaemonHandover.swift
+++ b/Sources/TBDDaemon/DaemonHandover.swift
@@ -311,8 +311,46 @@ public struct HandoverClaim: Sendable {
         // here. That window is the retirement poll interval at most, against
         // the app's two-second poll, and it is strictly narrower than the one
         // this write closes.
-        try writeClaim(ownPID)
+        //
+        // Retried like the hand-back, for the same reason: a whole-file
+        // replace that a transient error can lose, and here the predecessor is
+        // already dead, so one hiccup would otherwise turn a finished handover
+        // into an aborted start. If every attempt fails the start still
+        // aborts, because proceeding with a file that may name nobody is the
+        // two-successor race this write exists to close; the exit leaves a
+        // stale or missing pid file, which the app's poller answers by
+        // starting a fresh daemon from the installed bundle.
+        guard await writeClaimRetrying(ownPID, purpose: "re-assert this daemon's") else {
+            throw ReassertFailed(pid: ownPID, attempts: writeBackAttempts)
+        }
         return .claimed(outcome)
+    }
+
+    /// The re-assert after a successful retirement could not be written.
+    public struct ReassertFailed: LocalizedError, CustomStringConvertible, Sendable {
+        public let pid: pid_t
+        public let attempts: Int
+        public var description: String {
+            "handover: could not re-assert the pid file claim for \(pid) after \(attempts) attempts"
+        }
+        public var errorDescription: String? { description }
+    }
+
+    /// Write `pid` into the file, retrying `writeBackAttempts` times with
+    /// `writeBackRetryDelay` between attempts. Returns whether a write landed.
+    private func writeClaimRetrying(_ pid: pid_t, purpose: String) async -> Bool {
+        for attempt in 1...writeBackAttempts {
+            do {
+                try writeClaim(pid)
+                return true
+            } catch {
+                handoverLogger.error("handover: attempt \(attempt, privacy: .public) of \(self.writeBackAttempts, privacy: .public) to \(purpose, privacy: .public) pid file claim (\(pid, privacy: .public)) failed: \(String(describing: error), privacy: .public)")
+                if attempt < writeBackAttempts {
+                    try? await clock.sleep(for: writeBackRetryDelay)
+                }
+            }
+        }
+        return false
     }
 
     /// Put the predecessor's pid back in the file, retrying a few times.
@@ -333,16 +371,8 @@ public struct HandoverClaim: Sendable {
     ///
     /// Returns whether the claim was restored.
     private func restoreClaim(to predecessor: pid_t) async -> Bool {
-        for attempt in 1...writeBackAttempts {
-            do {
-                try writeClaim(predecessor)
-                return true
-            } catch {
-                handoverLogger.error("handover: attempt \(attempt, privacy: .public) of \(self.writeBackAttempts, privacy: .public) to restore predecessor daemon \(predecessor, privacy: .public)'s pid file claim failed: \(String(describing: error), privacy: .public)")
-                if attempt < writeBackAttempts {
-                    try? await clock.sleep(for: writeBackRetryDelay)
-                }
-            }
+        if await writeClaimRetrying(predecessor, purpose: "restore the predecessor's") {
+            return true
         }
         handoverLogger.error("handover: could not restore predecessor daemon \(predecessor, privacy: .public)'s pid file claim after \(self.writeBackAttempts, privacy: .public) attempts — the file now names this exiting process, which reads as a stale pid and is cleaned up by the next daemon start")
         return false

--- a/Sources/TBDDaemon/DaemonHandover.swift
+++ b/Sources/TBDDaemon/DaemonHandover.swift
@@ -226,27 +226,52 @@ public struct DaemonHandover: Sendable {
 /// The branch it replaces sat between the single-instance gate and the socket
 /// bind, hundreds of lines apart, and could only be exercised by hand.
 public struct HandoverClaim: Sendable {
-    private let pidFile: PIDFile
     private let handover: DaemonHandover
     private let ownPID: pid_t
+    /// How a claim is written. Defaults to the pid file itself.
+    ///
+    /// A seam rather than a direct call, because the retry below is only
+    /// interesting when a write fails and a later one succeeds, and contriving
+    /// a filesystem that breaks on that schedule is far less honest than
+    /// injecting the failure. Every write in this type goes through it, so the
+    /// default path is the one the tests exercise everywhere else.
+    private let writeClaim: @Sendable (pid_t) throws -> Void
+
+    /// How many times to try handing the claim back before giving up.
+    private let writeBackAttempts: Int
+    /// Gap between those attempts.
+    private let writeBackRetryDelay: Duration
+    private let clock: any Clock<Duration>
 
     /// What the caller should do next.
     public enum Result: Equatable, Sendable {
         /// The predecessor is gone and the pid file names us. Carry on.
         case claimed(DaemonHandover.Outcome)
-        /// The predecessor outlived `SIGKILL`. Its claim has been handed back
-        /// and the caller must not start.
-        case predecessorSurvived
+        /// The predecessor outlived `SIGKILL`. The caller must not start.
+        ///
+        /// `claimRestored` says whether the predecessor's pid made it back into
+        /// the file. It is a value rather than only a log line because it is the
+        /// difference between leaving the world as it was found and leaving a
+        /// file naming a pid that is about to die — the caller decides how
+        /// loudly to say so, and a test can assert it.
+        case predecessorSurvived(claimRestored: Bool)
     }
 
     public init(
         pidFile: PIDFile,
         handover: DaemonHandover = DaemonHandover(),
-        ownPID: pid_t = ProcessInfo.processInfo.processIdentifier
+        ownPID: pid_t = ProcessInfo.processInfo.processIdentifier,
+        writeBackAttempts: Int = 3,
+        writeBackRetryDelay: Duration = .milliseconds(100),
+        clock: any Clock<Duration> = ContinuousClock(),
+        writeClaim: (@Sendable (pid_t) throws -> Void)? = nil
     ) {
-        self.pidFile = pidFile
         self.handover = handover
         self.ownPID = ownPID
+        self.writeBackAttempts = max(1, writeBackAttempts)
+        self.writeBackRetryDelay = writeBackRetryDelay
+        self.clock = clock
+        self.writeClaim = writeClaim ?? { try pidFile.write(pid: $0) }
     }
 
     public func takeOver(from predecessor: pid_t) async throws -> Result {
@@ -254,20 +279,16 @@ public struct HandoverClaim: Sendable {
         // spurious spawn during the retirement — the app's two-second poller,
         // a stray `restart.sh` — meets a file naming a live daemon and exits at
         // the same gate we just came through.
-        try pidFile.write(pid: ownPID)
+        try writeClaim(ownPID)
         handoverLogger.info("handover: claimed the pid file from predecessor daemon \(predecessor, privacy: .public); retiring it now")
 
         let outcome = await handover.retire(predecessor: predecessor)
         if outcome == .stillAlive {
             // Hand the claim back so the world is exactly as it was found: the
             // file names the live predecessor, and nothing treats the daemon
-            // that is still serving as absent.
-            do {
-                try pidFile.write(pid: predecessor)
-            } catch {
-                handoverLogger.error("handover: could not restore predecessor daemon \(predecessor, privacy: .public)'s pid file claim: \(String(describing: error), privacy: .public)")
-            }
-            return .predecessorSurvived
+            // that is still serving as absent. Retried, because the write is a
+            // whole-file replace that a transient filesystem error can lose.
+            return .predecessorSurvived(claimRestored: await restoreClaim(to: predecessor))
         }
 
         // Re-assert the claim, because the predecessor may have deleted it on
@@ -290,7 +311,40 @@ public struct HandoverClaim: Sendable {
         // here. That window is the retirement poll interval at most, against
         // the app's two-second poll, and it is strictly narrower than the one
         // this write closes.
-        try pidFile.write(pid: ownPID)
+        try writeClaim(ownPID)
         return .claimed(outcome)
+    }
+
+    /// Put the predecessor's pid back in the file, retrying a few times.
+    ///
+    /// **Failing to restore it is not a two-writer hazard, and it is worth
+    /// saying why rather than leaving it to be re-derived.** This path is only
+    /// reached when the predecessor outlived `SIGKILL`, and `SIGKILL` cannot be
+    /// caught, blocked or ignored — a pid still present five seconds after it is
+    /// in an uninterruptible kernel wait, not serving RPCs. Meanwhile this
+    /// process is about to exit. So the worst case is a pid file naming a pid
+    /// that is dead or dying, which is exactly the stale-pid case the rest of
+    /// the system already reconciles: `PIDFile.cleanupIfStale` removes a file
+    /// whose pid is not a live `TBDDaemon` (called at the top of
+    /// `Daemon.start()`), and the app's poller spawns a fresh daemon from the
+    /// installed bundle whenever the pid file names no live daemon
+    /// (`startDaemonAndConnect` in `Sources/TBDApp/AppState.swift`). The cost of
+    /// the failure is a delayed recovery, not a corrupted one.
+    ///
+    /// Returns whether the claim was restored.
+    private func restoreClaim(to predecessor: pid_t) async -> Bool {
+        for attempt in 1...writeBackAttempts {
+            do {
+                try writeClaim(predecessor)
+                return true
+            } catch {
+                handoverLogger.error("handover: attempt \(attempt, privacy: .public) of \(self.writeBackAttempts, privacy: .public) to restore predecessor daemon \(predecessor, privacy: .public)'s pid file claim failed: \(String(describing: error), privacy: .public)")
+                if attempt < writeBackAttempts {
+                    try? await clock.sleep(for: writeBackRetryDelay)
+                }
+            }
+        }
+        handoverLogger.error("handover: could not restore predecessor daemon \(predecessor, privacy: .public)'s pid file claim after \(self.writeBackAttempts, privacy: .public) attempts — the file now names this exiting process, which reads as a stale pid and is cleaned up by the next daemon start")
+        return false
     }
 }

--- a/Sources/TBDDaemon/DaemonHandover.swift
+++ b/Sources/TBDDaemon/DaemonHandover.swift
@@ -122,8 +122,9 @@ public struct DaemonHandover: Sendable {
         /// It needed `SIGKILL` and then exited.
         case exitedAfterKill
         /// It was still alive after `SIGKILL` and the second budget. The
-        /// successor starts anyway: it already owns the pid file, and a
-        /// process this stuck is not going to serve anything.
+        /// successor must NOT start: see `Daemon.start()`, which hands the pid
+        /// file back to the predecessor and exits rather than put a second
+        /// writer on `state.db`.
         case stillAlive
     }
 
@@ -165,7 +166,7 @@ public struct DaemonHandover: Sendable {
             return .exitedAfterKill
         }
 
-        handoverLogger.error("handover: predecessor daemon \(predecessor, privacy: .public) still alive after SIGKILL and \(String(describing: self.killBudget), privacy: .public) — starting anyway")
+        handoverLogger.error("handover: predecessor daemon \(predecessor, privacy: .public) still alive after SIGKILL and \(String(describing: self.killBudget), privacy: .public) — the successor must not start alongside it")
         return .stillAlive
     }
 

--- a/Sources/TBDDaemon/DaemonHandover.swift
+++ b/Sources/TBDDaemon/DaemonHandover.swift
@@ -13,9 +13,21 @@ private let handoverLogger = Logger(subsystem: "com.tbd.daemon", category: "hand
 /// `TBD_HANDOVER_FROM_PID=<pid of the running daemon>`. The successor's
 /// single-instance gate reads the variable exactly once, at startup, and honors
 /// it only when the pid file names a *live* `TBDDaemon` whose pid equals the
-/// value. Any other combination — a stale file, a different live daemon, an
-/// unparsable value — falls back to today's behavior, so a mistyped or
-/// out-of-date variable can never take over a daemon it was not aimed at.
+/// value.
+///
+/// **The script always sets the variable, and sets it to `0` when no daemon is
+/// running.** So `0` is a first-class value meaning "there is nobody to hand
+/// over from", not a malformed one — the script does not have to branch on
+/// whether to export it at all, and this side does not have to tell an absent
+/// variable from a deliberate "none". Unset, empty, `0`, a negative number and
+/// anything unparsable are therefore all the same statement, and none of them
+/// authorises a take-over.
+///
+/// Every other combination falls back to today's behavior — the ordinary
+/// single-instance gate, which starts when no live daemon owns the pid file and
+/// exits when one does. A stale file, a pid that is not a live `TBDDaemon`, a
+/// different live daemon, a mistyped value: none of them can take over a daemon
+/// the variable was not aimed at.
 ///
 /// The variable must not outlive that read: `Daemon.scrubInheritedTBDEnv()`
 /// unsets it before any tmux server is spawned, because a tmux server bakes its
@@ -42,16 +54,42 @@ public enum HandoverDecision: Equatable, Sendable {
         handoverEnv: String?,
         isLiveDaemon: (pid_t) -> Bool
     ) -> HandoverDecision {
+        // Nobody live owns the pid file: start, whatever the variable says. A
+        // stale file was already removed by `PIDFile.cleanupIfStale`, so a
+        // handover aimed at a daemon that died before the successor launched
+        // lands here and is simply an ordinary start.
         guard let existing = pidFileContents, isLiveDaemon(existing) else {
             return .normal
         }
-        guard let raw = handoverEnv?.trimmingCharacters(in: .whitespacesAndNewlines),
-              let requested = pid_t(raw),
-              requested == existing
+        // A live daemon owns the file. Only an explicit, positive, matching pid
+        // that is itself a live daemon may displace it; everything else — unset,
+        // empty, `0` (the script's "no daemon was running"), negative,
+        // unparsable, or a different pid — leaves the ordinary gate to refuse.
+        guard let requested = requestedPredecessor(handoverEnv),
+              requested == existing,
+              isLiveDaemon(requested)
         else {
             return .refuse(existing: existing)
         }
         return .takeOver(predecessor: existing)
+    }
+
+    /// The pid the handover variable names, or `nil` when it names none.
+    ///
+    /// `nil` covers unset, empty, whitespace, unparsable, and every
+    /// non-positive value including the script's `0`. A pid of `0` is not a
+    /// process this daemon could ever be replacing — it addresses the caller's
+    /// own process group — so refusing it here rather than relying on a
+    /// liveness check keeps the "no predecessor" case from depending on what an
+    /// injected `isLiveDaemon` happens to say about pid `0`.
+    static func requestedPredecessor(_ handoverEnv: String?) -> pid_t? {
+        guard let raw = handoverEnv?.trimmingCharacters(in: .whitespacesAndNewlines),
+              let requested = pid_t(raw),
+              requested > 0
+        else {
+            return nil
+        }
+        return requested
     }
 }
 

--- a/Sources/TBDDaemon/DaemonHandover.swift
+++ b/Sources/TBDDaemon/DaemonHandover.swift
@@ -219,3 +219,78 @@ public struct DaemonHandover: Sendable {
         return max(1, Int((attos(budget) / intervalAttos).rounded(.down)))
     }
 }
+
+/// The pid-file choreography of a handover: claim, retire, re-assert.
+///
+/// Extracted from `Daemon.start()` so the sequence is reachable from a test.
+/// The branch it replaces sat between the single-instance gate and the socket
+/// bind, hundreds of lines apart, and could only be exercised by hand.
+public struct HandoverClaim: Sendable {
+    private let pidFile: PIDFile
+    private let handover: DaemonHandover
+    private let ownPID: pid_t
+
+    /// What the caller should do next.
+    public enum Result: Equatable, Sendable {
+        /// The predecessor is gone and the pid file names us. Carry on.
+        case claimed(DaemonHandover.Outcome)
+        /// The predecessor outlived `SIGKILL`. Its claim has been handed back
+        /// and the caller must not start.
+        case predecessorSurvived
+    }
+
+    public init(
+        pidFile: PIDFile,
+        handover: DaemonHandover = DaemonHandover(),
+        ownPID: pid_t = ProcessInfo.processInfo.processIdentifier
+    ) {
+        self.pidFile = pidFile
+        self.handover = handover
+        self.ownPID = ownPID
+    }
+
+    public func takeOver(from predecessor: pid_t) async throws -> Result {
+        // Claim first. With our pid in the file from this instant, every
+        // spurious spawn during the retirement — the app's two-second poller,
+        // a stray `restart.sh` — meets a file naming a live daemon and exits at
+        // the same gate we just came through.
+        try pidFile.write(pid: ownPID)
+        handoverLogger.info("handover: claimed the pid file from predecessor daemon \(predecessor, privacy: .public); retiring it now")
+
+        let outcome = await handover.retire(predecessor: predecessor)
+        if outcome == .stillAlive {
+            // Hand the claim back so the world is exactly as it was found: the
+            // file names the live predecessor, and nothing treats the daemon
+            // that is still serving as absent.
+            do {
+                try pidFile.write(pid: predecessor)
+            } catch {
+                handoverLogger.error("handover: could not restore predecessor daemon \(predecessor, privacy: .public)'s pid file claim: \(String(describing: error), privacy: .public)")
+            }
+            return .predecessorSurvived
+        }
+
+        // Re-assert the claim, because the predecessor may have deleted it on
+        // the way out.
+        //
+        // **This is for predecessors older than this change.** Their `stop()`
+        // ends with an unconditional `pidFile.remove()`, so a daemon built
+        // before `removeIfOwned` existed deletes OUR pid file as it exits — and
+        // the very first update on any machine is, by definition, handing over
+        // from exactly such a daemon. What follows is the failure the claim was
+        // supposed to prevent: no socket and no live pid, so the app's
+        // two-second poller spawns a daemon, which passes the gate because
+        // nothing owns the file, and now there are two successors. For a
+        // predecessor that carries `removeIfOwned` this write changes nothing —
+        // the file already names us — which is what makes it safe to do
+        // unconditionally rather than probe the predecessor's vintage.
+        //
+        // A third daemon could in principle claim the file between the
+        // predecessor's unlink and this write and have its claim overwritten
+        // here. That window is the retirement poll interval at most, against
+        // the app's two-second poll, and it is strictly narrower than the one
+        // this write closes.
+        try pidFile.write(pid: ownPID)
+        return .claimed(outcome)
+    }
+}

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
@@ -1120,7 +1120,24 @@ public actor HibernationCoordinator {
             logger.info("wake: window \(windowID, privacy: .public) on \(server, privacy: .public) is claimed by another terminal — recreating instead of respawning in place for terminal \(terminal.id, privacy: .public)")
         }
 
-        if !claimedByOther, await tmux.windowExists(server: server, windowID: windowID) {
+        // Tri-state, because the `else` arm below `killWindow`s the old window
+        // once its replacement exists — its own comment calls that out as "a
+        // transient windowExists misclassification must not leak a live
+        // window", and a timed-out probe is exactly such a misclassification.
+        // Acting on it destroys a window on ignorance. A server that is
+        // genuinely gone (the reboot case this recreate path exists for) still
+        // answers `.absent`, so only the unanswerable case changes: the wake
+        // fails and the row stays parked for the next focus or menu retry,
+        // which is what every other tmux failure on this path already does.
+        let windowPresence = claimedByOther
+            ? TmuxPresence.absent
+            : await tmux.probeWindow(server: server, windowID: windowID)
+        if windowPresence == .unknown {
+            logger.warning("wake: tmux gave no usable answer about window \(windowID, privacy: .public) on \(server, privacy: .public) for terminal \(terminal.id, privacy: .public) — leaving the row parked rather than recreating and killing on ignorance")
+            return .failed(.respawnFailed(
+                reason: "tmux did not answer whether window \(windowID) is still there; the row is unchanged — retry"))
+        }
+        if !claimedByOther, windowPresence == .alive {
             do {
                 guard let incarnationID = try await db.terminals.prepareHibernatedAgentRespawn(
                     id: terminal.id,

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -195,9 +195,23 @@ extension WorktreeLifecycle {
                 // while we waited. Only judge the server whose lock we hold.
                 guard let current = try await db.worktrees.getLocal(id: wt.id),
                       current.tmuxServer == wt.tmuxServer else { return }
-                if await hasLiveWindow(server: current.tmuxServer, worktreeID: current.id) {
+                switch await liveWindowPresence(
+                    server: current.tmuxServer, worktreeID: current.id)
+                {
+                case .alive:
                     logger.info("reconcile: keeping non-canonical tmux server \(current.tmuxServer, privacy: .public) for worktree \(current.id, privacy: .public) — it has live windows (promoted-scratch inheritance)")
                     return
+                case .unknown:
+                    // Renaming the server on ignorance is worse than renaming
+                    // it late: the row would be re-pointed at a server that
+                    // really has no windows, and the terminal sweep below
+                    // would then park and delete its rows on an answer that
+                    // looks affirmative. A later pass canonicalizes once tmux
+                    // answers.
+                    logger.warning("reconcile: leaving non-canonical tmux server \(current.tmuxServer, privacy: .public) for worktree \(current.id, privacy: .public) — tmux gave no usable answer about its windows; not canonicalizing this pass")
+                    return
+                case .absent:
+                    break
                 }
                 do {
                     try await db.worktrees.updateTmuxServer(
@@ -824,19 +838,52 @@ extension WorktreeLifecycle {
         }
     }
 
-    /// True when `server` is up AND hosts a live tmux window for at least one
-    /// of `worktreeID`'s terminal rows. Used by the stale-server self-heal to
-    /// distinguish a genuinely dead/renamed server (safe to canonicalize)
-    /// from a deliberately inherited one whose sessions are still running
-    /// (promoted scratch space). Early-exits on the first live window.
-    private func hasLiveWindow(server: String, worktreeID: UUID) async -> Bool {
-        guard await tmux.serverExists(server: server) else { return false }
+    /// Whether `server` hosts a live tmux window for any of `worktreeID`'s
+    /// terminal rows — `alive`, `absent`, or `unknown`.
+    ///
+    /// Used by the stale-server self-heal to distinguish a genuinely
+    /// dead/renamed server (safe to canonicalize) from a deliberately
+    /// inherited one whose sessions are still running (promoted scratch
+    /// space).
+    ///
+    /// **This is tri-state for the same reason the terminal sweep is, and the
+    /// two are load-bearing together.** A `Bool` here reads a timed-out probe
+    /// as "no live window", the row is re-pointed at the canonical server, and
+    /// the terminal sweep then probes windows on a server that genuinely does
+    /// not have them. Its answer is an honest `absent`, so the sweep's own
+    /// `unknown` guard never fires and the rows are parked and deleted on
+    /// evidence that was manufactured one pass earlier. Hardening the sweep
+    /// alone would have left that route open.
+    ///
+    /// `alive` on the first affirmative live window. Otherwise `unknown` if
+    /// any probe failed to answer, and `absent` only when every probe answered
+    /// and answered no.
+    ///
+    /// Rows carrying no tmux coordinate at all (holder-backed sessions, whose
+    /// `tmuxWindowID` is `""`) are skipped rather than probed: they are
+    /// evidence in neither direction, and probing `""` would answer `unknown`
+    /// forever and freeze the self-heal.
+    private func liveWindowPresence(server: String, worktreeID: UUID) async -> TmuxPresence {
+        switch await tmux.probeServer(server: server) {
+        case .absent:
+            return .absent
+        case .unknown:
+            return .unknown
+        case .alive:
+            break
+        }
         let terminals = (try? await db.terminals.list(worktreeID: worktreeID)) ?? []
-        for terminal in terminals {
-            if await tmux.windowExists(server: server, windowID: terminal.tmuxWindowID) {
-                return true
+        var sawUnknown = false
+        for terminal in terminals where !terminal.tmuxWindowID.isEmpty {
+            switch await tmux.probeWindow(server: server, windowID: terminal.tmuxWindowID) {
+            case .alive:
+                return .alive
+            case .unknown:
+                sawUnknown = true
+            case .absent:
+                continue
             }
         }
-        return false
+        return sawUnknown ? .unknown : .absent
     }
 }

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -570,14 +570,25 @@ extension WorktreeLifecycle {
         // Probe the server each worktree row actually stores, not a canonical
         // name. Promoted scratch worktrees keep their inherited scratch server.
         // Cached per server name — rows overwhelmingly share one server.
-        var serverAliveByName: [String: Bool] = [:]
+        //
+        // The probe is tri-state on purpose. A `Bool` probe reports a timed-out
+        // tmux as "gone", and both arms below destroy state on "gone", so a
+        // machine merely busy enough to blow the 15 s command ceiling used to
+        // park a live fleet — 49 of 56 lane sessions in one measured pass on
+        // 2026-09-02. `unknown` is ignorance, not evidence: it parks nothing,
+        // deletes nothing, and leaves the row for the next sweep.
+        var serverPresenceByName: [String: TmuxPresence] = [:]
         for wt in worktrees {
-            let serverAlive: Bool
-            if let cached = serverAliveByName[wt.tmuxServer] {
-                serverAlive = cached
+            let serverPresence: TmuxPresence
+            if let cached = serverPresenceByName[wt.tmuxServer] {
+                serverPresence = cached
             } else {
-                serverAlive = await tmux.serverExists(server: wt.tmuxServer)
-                serverAliveByName[wt.tmuxServer] = serverAlive
+                serverPresence = await tmux.probeServer(server: wt.tmuxServer)
+                serverPresenceByName[wt.tmuxServer] = serverPresence
+            }
+            if serverPresence == .unknown {
+                logger.warning("reconcile: skipping worktree \(wt.id, privacy: .public) — tmux server \(wt.tmuxServer, privacy: .public) gave no usable answer (probeServer: unknown); leaving its terminals alone")
+                continue
             }
             let terminals = try await db.terminals.list(worktreeID: wt.id)
             // Parked rows (`hibernatedAt` OR legacy `suspendedAt` — see
@@ -605,11 +616,19 @@ extension WorktreeLifecycle {
                 // closes it.
                 guard terminal.transport == .tmux else { continue }
 
-                var windowAlive = false
-                if serverAlive {
-                    windowAlive = await tmux.windowExists(
+                // A server that is positively absent has positively no
+                // windows on it, so the window probe is skipped rather than
+                // guessed at.
+                var windowPresence: TmuxPresence = .absent
+                if serverPresence == .alive {
+                    windowPresence = await tmux.probeWindow(
                         server: wt.tmuxServer, windowID: terminal.tmuxWindowID)
                 }
+                if windowPresence == .unknown {
+                    logger.warning("reconcile: skipping terminal \(terminal.id, privacy: .public) in worktree \(wt.id, privacy: .public) — window \(terminal.tmuxWindowID, privacy: .public) on server \(wt.tmuxServer, privacy: .public) gave no usable answer (probeWindow: unknown); leaving the row live")
+                    continue
+                }
+                let windowAlive = windowPresence == .alive
 
                 if windowAlive {
                     do {

--- a/Sources/TBDDaemon/PIDFile.swift
+++ b/Sources/TBDDaemon/PIDFile.swift
@@ -10,8 +10,12 @@ public struct PIDFile: Sendable {
         self.path = path ?? TBDConstants.pidFilePath
     }
 
-    public func write() throws {
-        let pid = ProcessInfo.processInfo.processIdentifier
+    /// Claim the pid file for `pid`, this process by default.
+    ///
+    /// The parameter exists for one caller: a successor whose handover failed
+    /// has to put the predecessor's pid back, returning the world to the state
+    /// it found. See `Daemon.start()`.
+    public func write(pid: pid_t = ProcessInfo.processInfo.processIdentifier) throws {
         try "\(pid)".write(toFile: path, atomically: true, encoding: .utf8)
     }
 

--- a/Sources/TBDDaemon/PIDFile.swift
+++ b/Sources/TBDDaemon/PIDFile.swift
@@ -39,6 +39,25 @@ public struct PIDFile: Sendable {
         try? FileManager.default.removeItem(atPath: path)
     }
 
+    /// Remove the pid file only if it still names *this* process.
+    ///
+    /// A handover puts two daemons on one pid file for a moment: the successor
+    /// writes its own pid over the file first, so that every spurious spawn in
+    /// the gap — the app's two-second poller, a stray `restart.sh` — meets a
+    /// file naming a live daemon and exits at the gate. The predecessor then
+    /// shuts down. An unconditional `remove()` there deletes the *successor's*
+    /// claim, reopening exactly the race the successor-first write closes.
+    ///
+    /// Returns whether the file was ours, so callers can chain other
+    /// process-owned artifacts off the same answer.
+    @discardableResult
+    public func removeIfOwned(pid: pid_t = ProcessInfo.processInfo.processIdentifier) -> Bool {
+        guard let recorded = read() else { return false }
+        guard recorded == pid else { return false }
+        try? FileManager.default.removeItem(atPath: path)
+        return true
+    }
+
     public func cleanupIfStale() {
         if isStale() {
             remove()

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -100,6 +100,27 @@ struct PaneSendRefusal: Sendable {
     let message: String
 }
 
+/// What the locked re-park closure in `handleTerminalRecreateWindow` concluded.
+///
+/// Three outcomes rather than the `didPark` flag this replaces, because the
+/// window probe is tri-state and each answer means something different to the
+/// caller: the row was parked, the window turned out to be alive so the request
+/// was stale, or tmux never answered and nothing was touched. Collapsing the
+/// last two would report a transport that could not be reached as a healthy
+/// window, which is the direction that loses a session.
+enum RecreateReparkOutcome: Sendable {
+    case parked(Terminal?)
+    case windowAlive(Terminal?)
+    case probeUnanswered(Terminal?)
+
+    var terminal: Terminal? {
+        switch self {
+        case let .parked(terminal), let .windowAlive(terminal), let .probeUnanswered(terminal):
+            return terminal
+        }
+    }
+}
+
 extension RPCRouter {
 
     // MARK: - Terminal Handlers
@@ -1099,9 +1120,22 @@ extension RPCRouter {
             try await db.worktrees.getLocal(id: terminal.worktreeID)
         }
         guard let railWorktree else { return .stopped }
-        return await tmux.windowExists(
-            server: railWorktree.tmuxServer, windowID: terminal.tmuxWindowID)
-            ? .running : .stopped
+        // Tri-state, and the type has said so all along: `ActivityRailLiveness`
+        // carries `.unknown` for exactly this, and the holder leg above already
+        // returns it. The tmux leg was the one collapsing "tmux says the window
+        // is gone" into the same answer as "tmux never answered" — and only
+        // `.stopped` lifts the rail, so a probe that timed out during a busy
+        // moment read as an observed exit and let a `--respectActivityRails`
+        // close delete the row and kill the window of a session that was
+        // mid-turn. A rail that cannot establish the session ended has to fail
+        // closed.
+        switch await tmux.probeWindow(
+            server: railWorktree.tmuxServer, windowID: terminal.tmuxWindowID
+        ) {
+        case .alive: return .running
+        case .absent: return .stopped
+        case .unknown: return .unknown
+        }
     }
 
     /// Tears down the holder behind a row that is about to be deleted: stops
@@ -1417,6 +1451,20 @@ extension RPCRouter {
             + "— fork the session instead."
     }
 
+    /// The refusal `terminal.recreateWindow` returns when tmux gave no usable
+    /// answer about the window.
+    ///
+    /// A sibling of `holderRecreateRefusal` and `holderInPlaceSwapRefusal` for
+    /// the same reason: one named factory per refusal, so the app, the CLI and
+    /// the tests assert the same text. This one is not about a transport that
+    /// has no window — it is about a window whose state could not be
+    /// established, which is a retry rather than a category error.
+    static func unansweredWindowProbeRefusal(terminalID: UUID) -> String {
+        "tmux did not answer whether terminal \(terminalID)'s window is still "
+            + "there within \(TmuxManager.commandTimeout). The window was left "
+            + "alone and the session is unchanged — retry once tmux responds."
+    }
+
     func handleTerminalRecreateWindow(
         _ paramsData: Data, actor: ActuationActor? = nil
     ) async throws -> RPCResponse {
@@ -1469,7 +1517,7 @@ extension RPCRouter {
                 try await tmux.withWorktreeServerLock(
                     db: db, worktreeID: worktree.id,
                     allowedStatuses: [worktree.status]
-                ) { currentWorktree -> (terminal: Terminal?, didPark: Bool) in
+                ) { currentWorktree -> RecreateReparkOutcome in
                     guard let currentTerminal = try await self.db.terminals.get(
                         id: terminal.id),
                           expectedReplacementState.matches(currentTerminal),
@@ -1481,12 +1529,27 @@ extension RPCRouter {
                     // The liveness decision and every following process mutation
                     // share the server lock with wake and profile replacement.
                     // A queued stale re-park therefore cannot kill their new pane.
-                    if await self.tmux.windowExists(
+                    //
+                    // Tri-state, because both arms below act: a `false` here
+                    // parks a resumable row and then `killWindow`s it. The
+                    // `Bool` probe answers `false` on a timeout, so a recreate
+                    // arriving while the machine is busy would park and kill a
+                    // session that is alive and working — on a user's gesture,
+                    // which makes it worse than the startup sweep's version of
+                    // the same bug. Ignorance is reported back to the caller
+                    // instead, and nothing is touched.
+                    switch await self.tmux.probeWindow(
                         server: currentWorktree.tmuxServer,
                         windowID: currentTerminal.tmuxWindowID
                     ) {
+                    case .alive:
                         logger.info("recreateWindow: window \(currentTerminal.tmuxWindowID, privacy: .public) for claude terminal \(currentTerminal.id, privacy: .public) is alive — ignoring stale recreate request")
-                        return (currentTerminal, false)
+                        return .windowAlive(currentTerminal)
+                    case .unknown:
+                        logger.warning("recreateWindow: tmux gave no usable answer about window \(currentTerminal.tmuxWindowID, privacy: .public) for claude terminal \(currentTerminal.id, privacy: .public) — refusing rather than parking and killing on ignorance")
+                        return .probeUnanswered(currentTerminal)
+                    case .absent:
+                        break
                     }
 
                     let currentState = TerminalHibernationSnapshot(terminal: currentTerminal)
@@ -1512,15 +1575,22 @@ extension RPCRouter {
                     }
                     await self.pendingQuestions.clear(terminalID: currentTerminal.id)
                     await self.broadcastPendingQuestions(terminalID: currentTerminal.id)
-                    return (try await self.db.terminals.get(id: currentTerminal.id), true)
+                    return .parked(try await self.db.terminals.get(id: currentTerminal.id))
                 }
+            }
+            if case .probeUnanswered = repark {
+                let refusal = Self.unansweredWindowProbeRefusal(terminalID: terminal.id)
+                // `transportFailed`, not a refusal: the daemon did not decline
+                // this act, it could not reach the transport to perform it.
+                await finishActuation(reparkID, .transportFailed, error: refusal)
+                return RPCResponse(error: refusal)
             }
             guard let updated = repark.terminal else {
                 await finishActuation(
                     reparkID, .refused(.notFound), error: "Terminal not found after suspend")
                 return RPCResponse(error: "Terminal not found after suspend")
             }
-            guard repark.didPark else {
+            guard case .parked = repark else {
                 await finishActuation(
                     reparkID, .refused(.notEligible), error: "Terminal window is alive")
                 return try RPCResponse(result: updated)

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -202,6 +202,21 @@ public struct TmuxManager: Sendable {
     /// `paneCurrentCommand(server:paneID:)`. Allows tests to return a specific
     /// command string without relying on tmux's actual pane_current_command.
     public let realModePaneCurrentCommandOverride: (@Sendable (String, String) -> String?)?
+    /// Optional test hook consulted by `probeServer` in dryRun mode: `server` →
+    /// the tri-state answer. Without it dryRun reports `.alive`, matching
+    /// `serverExists`'s unconditional dryRun `true`, so existing fixtures are
+    /// unchanged. Tests that need the `unknown` arm — a probe that never got an
+    /// answer — inject it here.
+    public let dryRunServerPresence: (@Sendable (String) -> TmuxPresence)?
+    /// Optional test hook consulted by `probeWindow` in dryRun mode:
+    /// `(server, windowID)` → the tri-state answer. Without it dryRun falls
+    /// back to `dryRunWindowIsDead` (dead → `.absent`, else `.alive`), so every
+    /// fixture written against the `Bool` probe keeps its meaning.
+    public let dryRunWindowPresence: (@Sendable (String, String) -> TmuxPresence)?
+    /// Optional test hook for real (non-dryRun) mode: override `probeServer`.
+    public let realModeServerPresenceOverride: (@Sendable (String) -> TmuxPresence?)?
+    /// Optional test hook for real (non-dryRun) mode: override `probeWindow`.
+    public let realModeWindowPresenceOverride: (@Sendable (String, String) -> TmuxPresence?)?
 
     /// Whether callers should treat `paneCurrentCommand` as a meaningful
     /// process-liveness signal. Plain dry-run fixtures intentionally return a
@@ -224,7 +239,7 @@ public struct TmuxManager: Sendable {
         }
     }
 
-    public init(dryRun: Bool = false, dryRunRecorder: (@Sendable ([String]) -> Void)? = nil, dryRunWindowIsDead: (@Sendable (String) -> Bool)? = nil, dryRunListWindows: (@Sendable (String, String) -> [(windowID: String, paneID: String)])? = nil, dryRunListSessions: (@Sendable (String) -> [TmuxSessionInfo])? = nil, dryRunCapturePane: (@Sendable (String, String) -> String)? = nil, dryRunPaneCurrentCommand: (@Sendable (String, String) -> String)? = nil, dryRunCreateWindowError: (@Sendable (String) -> Error?)? = nil, dryRunRespawnWindowError: (@Sendable (String) -> Error?)? = nil, dryRunKillWindowError: (@Sendable (String, String) -> Error?)? = nil, dryRunPaneSendTarget: (@Sendable (String, String) throws -> PaneSendTarget)? = nil, dryRunSessionSpared: (@Sendable (String, String) -> Bool)? = nil, dryRunPaneWindowID: (@Sendable (String, String) -> String?)? = nil, dryRunPasteBytes: (@Sendable (String, String, Data) -> Void)? = nil, realModeWindowExistsOverride: (@Sendable (String, String) -> Bool?)? = nil, realModePaneCurrentCommandOverride: (@Sendable (String, String) -> String?)? = nil, subprocessTimeout: Duration = TmuxManager.commandTimeout) {
+    public init(dryRun: Bool = false, dryRunRecorder: (@Sendable ([String]) -> Void)? = nil, dryRunWindowIsDead: (@Sendable (String) -> Bool)? = nil, dryRunListWindows: (@Sendable (String, String) -> [(windowID: String, paneID: String)])? = nil, dryRunListSessions: (@Sendable (String) -> [TmuxSessionInfo])? = nil, dryRunCapturePane: (@Sendable (String, String) -> String)? = nil, dryRunPaneCurrentCommand: (@Sendable (String, String) -> String)? = nil, dryRunCreateWindowError: (@Sendable (String) -> Error?)? = nil, dryRunRespawnWindowError: (@Sendable (String) -> Error?)? = nil, dryRunKillWindowError: (@Sendable (String, String) -> Error?)? = nil, dryRunPaneSendTarget: (@Sendable (String, String) throws -> PaneSendTarget)? = nil, dryRunSessionSpared: (@Sendable (String, String) -> Bool)? = nil, dryRunPaneWindowID: (@Sendable (String, String) -> String?)? = nil, dryRunPasteBytes: (@Sendable (String, String, Data) -> Void)? = nil, realModeWindowExistsOverride: (@Sendable (String, String) -> Bool?)? = nil, realModePaneCurrentCommandOverride: (@Sendable (String, String) -> String?)? = nil, dryRunServerPresence: (@Sendable (String) -> TmuxPresence)? = nil, dryRunWindowPresence: (@Sendable (String, String) -> TmuxPresence)? = nil, realModeServerPresenceOverride: (@Sendable (String) -> TmuxPresence?)? = nil, realModeWindowPresenceOverride: (@Sendable (String, String) -> TmuxPresence?)? = nil, subprocessTimeout: Duration = TmuxManager.commandTimeout) {
         self.dryRun = dryRun
         self.subprocessTimeout = subprocessTimeout
         self.counter = Counter()
@@ -244,6 +259,10 @@ public struct TmuxManager: Sendable {
         self.dryRunPasteBytes = dryRunPasteBytes
         self.realModeWindowExistsOverride = realModeWindowExistsOverride
         self.realModePaneCurrentCommandOverride = realModePaneCurrentCommandOverride
+        self.dryRunServerPresence = dryRunServerPresence
+        self.dryRunWindowPresence = dryRunWindowPresence
+        self.realModeServerPresenceOverride = realModeServerPresenceOverride
+        self.realModeWindowPresenceOverride = realModeWindowPresenceOverride
     }
 
     /// Runs one ownership transition while exclusively holding `server`.
@@ -1563,6 +1582,54 @@ public struct TmuxManager: Sendable {
             return true
         } catch {
             return false
+        }
+    }
+
+    /// Whether a tmux window exists, keeping "tmux says no" apart from "tmux
+    /// never answered".
+    ///
+    /// Prefer this over `windowExists` anywhere a `false` would destroy state.
+    /// `windowExists` answers `false` for a timeout, which is how a busy
+    /// machine gets its live sessions parked; `probeWindow` answers `.unknown`
+    /// there and lets the caller leave the row alone.
+    public func probeWindow(server: String, windowID: String) async -> TmuxPresence {
+        if dryRun {
+            if let hook = dryRunWindowPresence { return hook(server, windowID) }
+            return (dryRunWindowIsDead?(windowID) ?? false) ? .absent : .alive
+        }
+        if let override = realModeWindowPresenceOverride?(server, windowID) {
+            return override
+        }
+        do {
+            _ = try await runTmux(["-L", server, "list-panes", "-t", windowID])
+            return .alive
+        } catch {
+            let presence = TmuxPresenceClassifier.windowPresence(for: error)
+            if presence == .unknown {
+                logger.warning("probeWindow could not classify tmux failure for window \(windowID, privacy: .public) on server \(server, privacy: .public): \(String(describing: error), privacy: .public)")
+            }
+            return presence
+        }
+    }
+
+    /// Whether a tmux server is running, keeping "tmux says no" apart from
+    /// "tmux never answered". See `probeWindow` for why the distinction exists.
+    public func probeServer(server: String) async -> TmuxPresence {
+        if dryRun {
+            return dryRunServerPresence?(server) ?? .alive
+        }
+        if let override = realModeServerPresenceOverride?(server) {
+            return override
+        }
+        do {
+            _ = try await runTmux(["-L", server, "list-sessions"])
+            return .alive
+        } catch {
+            let presence = TmuxPresenceClassifier.serverPresence(for: error)
+            if presence == .unknown {
+                logger.warning("probeServer could not classify tmux failure for server \(server, privacy: .public): \(String(describing: error), privacy: .public)")
+            }
+            return presence
         }
     }
 

--- a/Sources/TBDDaemon/Tmux/TmuxPresence.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxPresence.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+/// What a tmux liveness probe actually learned.
+///
+/// The `Bool` probes (`serverExists`, `windowExists`) collapse two very
+/// different answers into `false`: "tmux ran and told us there is no such
+/// window" and "we never got an answer at all" — a spawn failure, or the 15 s
+/// `TmuxManager.commandTimeout` firing on a server that is merely busy. Callers
+/// that destroy state on `false` therefore destroy it on ignorance. Field
+/// measurement: a 2026-09-02 daemon restart parked 49 of 56 live lane sessions
+/// in one reconcile pass, every row carrying the same `hibernatedAt`, because
+/// the machine was still digesting a build and the probes timed out.
+///
+/// `TmuxPresence` keeps the two apart so a caller can choose. `absent` is a
+/// positive statement — tmux itself answered that the server or window does not
+/// exist — and is the only value that licenses parking or deleting a row.
+public enum TmuxPresence: String, Sendable, Equatable, CustomStringConvertible {
+    /// tmux answered and the resource is there.
+    case alive
+    /// tmux answered and the resource is not there. Positive evidence.
+    case absent
+    /// No usable answer: a timeout, a spawn failure, or output we cannot
+    /// classify. Ignorance, never evidence.
+    case unknown
+
+    public var description: String { rawValue }
+}
+
+/// Classifies the error a tmux probe threw into a `TmuxPresence`.
+///
+/// Deliberately a whitelist of tmux's own "it isn't there" messages rather than
+/// a blacklist of failures: anything unrecognised has to read as `unknown`, so
+/// a future tmux release that renames a message degrades to "leave the row
+/// alone" instead of to "destroy it". Only `TmuxError.commandFailed` can ever
+/// be `absent` — a `timedOut` never reached tmux, and `unexpectedOutput` means
+/// tmux answered something we could not read.
+enum TmuxPresenceClassifier {
+    /// tmux's phrasing when the server socket has no server behind it. Covers
+    /// both a clean "no server running on <socket>" and the connect failure a
+    /// missing socket file produces ("error connecting to <socket> (No such
+    /// file or directory)").
+    /// Kept to tmux's own two phrasings rather than a generic "no such file"
+    /// match: a tmux command that failed for an unrelated reason can easily
+    /// mention a missing file, and reading that as `absent` would be the exact
+    /// mistake this type exists to prevent.
+    static let serverAbsentMarkers = [
+        "no server running on",
+        "error connecting to"
+    ]
+
+    /// tmux's phrasing when a server is up but the target window is gone.
+    static let windowAbsentMarkers = [
+        "can't find window",
+        "can't find pane",
+        "no such window",
+        "window not found"
+    ]
+
+    /// The presence a *server* probe should report for a thrown error.
+    static func serverPresence(for error: Error) -> TmuxPresence {
+        presence(for: error, absentMarkers: serverAbsentMarkers)
+    }
+
+    /// The presence a *window* probe should report for a thrown error.
+    ///
+    /// A server-absent answer counts as window-absent: if there is no server,
+    /// there is positively no window on it. The reverse is not true, which is
+    /// why the two marker lists stay separate.
+    static func windowPresence(for error: Error) -> TmuxPresence {
+        presence(for: error, absentMarkers: windowAbsentMarkers + serverAbsentMarkers)
+    }
+
+    private static func presence(for error: Error, absentMarkers: [String]) -> TmuxPresence {
+        guard case let TmuxError.commandFailed(_, status, output) = error else {
+            // `.timedOut` and `.unexpectedOutput` are both "no usable answer".
+            return .unknown
+        }
+        // 127 is this file's own "tmux executable is unavailable" synthetic
+        // failure and anything else that never launched a binary. Nothing tmux
+        // says about a missing window arrives with it.
+        guard status != 127 else { return .unknown }
+        let haystack = output.lowercased()
+        return absentMarkers.contains(where: haystack.contains) ? .absent : .unknown
+    }
+}

--- a/Sources/TBDDaemon/Tmux/TmuxPresence.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxPresence.swift
@@ -34,20 +34,11 @@ public enum TmuxPresence: String, Sendable, Equatable, CustomStringConvertible {
 /// alone" instead of to "destroy it". Only `TmuxError.commandFailed` can ever
 /// be `absent` — a `timedOut` never reached tmux, and `unexpectedOutput` means
 /// tmux answered something we could not read.
+///
+/// The whitelist is of *meanings*, not prefixes. tmux reuses one phrasing for a
+/// whole family of socket errors, so `indicatesAbsentServer` has to read the
+/// errno text too — see its doc comment.
 enum TmuxPresenceClassifier {
-    /// tmux's phrasing when the server socket has no server behind it. Covers
-    /// both a clean "no server running on <socket>" and the connect failure a
-    /// missing socket file produces ("error connecting to <socket> (No such
-    /// file or directory)").
-    /// Kept to tmux's own two phrasings rather than a generic "no such file"
-    /// match: a tmux command that failed for an unrelated reason can easily
-    /// mention a missing file, and reading that as `absent` would be the exact
-    /// mistake this type exists to prevent.
-    static let serverAbsentMarkers = [
-        "no server running on",
-        "error connecting to"
-    ]
-
     /// tmux's phrasing when a server is up but the target window is gone.
     static let windowAbsentMarkers = [
         "can't find window",
@@ -56,21 +47,47 @@ enum TmuxPresenceClassifier {
         "window not found"
     ]
 
-    /// The presence a *server* probe should report for a thrown error.
-    static func serverPresence(for error: Error) -> TmuxPresence {
-        presence(for: error, absentMarkers: serverAbsentMarkers)
+    /// Whether tmux's output positively says no server is behind the socket.
+    ///
+    /// tmux's client prints "no server running on <socket>" for exactly one
+    /// errno, `ECONNREFUSED`, and falls back to "error connecting to <socket>
+    /// (<errno text>)" for every other socket error. So that second prefix on
+    /// its own proves nothing: `Permission denied` is a server we cannot reach,
+    /// not a server that is gone, and reading it as absence would park and
+    /// delete the rows of a perfectly live fleet — the exact mistake this type
+    /// exists to prevent. Only the `ENOENT` spelling joins the first phrase as
+    /// evidence, because there the socket file itself is not there.
+    static func indicatesAbsentServer(_ output: String) -> Bool {
+        let haystack = output.lowercased()
+        if haystack.contains("no server running on") { return true }
+        return haystack.contains("error connecting to")
+            && haystack.contains("no such file or directory")
     }
 
-    /// The presence a *window* probe should report for a thrown error.
+    /// Whether tmux's output positively says the target window is gone.
     ///
     /// A server-absent answer counts as window-absent: if there is no server,
     /// there is positively no window on it. The reverse is not true, which is
-    /// why the two marker lists stay separate.
-    static func windowPresence(for error: Error) -> TmuxPresence {
-        presence(for: error, absentMarkers: windowAbsentMarkers + serverAbsentMarkers)
+    /// why the two tests stay separate.
+    static func indicatesAbsentWindow(_ output: String) -> Bool {
+        let haystack = output.lowercased()
+        return windowAbsentMarkers.contains(where: haystack.contains)
+            || indicatesAbsentServer(output)
     }
 
-    private static func presence(for error: Error, absentMarkers: [String]) -> TmuxPresence {
+    /// The presence a *server* probe should report for a thrown error.
+    static func serverPresence(for error: Error) -> TmuxPresence {
+        presence(for: error, indicatesAbsence: indicatesAbsentServer)
+    }
+
+    /// The presence a *window* probe should report for a thrown error.
+    static func windowPresence(for error: Error) -> TmuxPresence {
+        presence(for: error, indicatesAbsence: indicatesAbsentWindow)
+    }
+
+    private static func presence(
+        for error: Error, indicatesAbsence: (String) -> Bool
+    ) -> TmuxPresence {
         guard case let TmuxError.commandFailed(_, status, output) = error else {
             // `.timedOut` and `.unexpectedOutput` are both "no usable answer".
             return .unknown
@@ -79,7 +96,6 @@ enum TmuxPresenceClassifier {
         // failure and anything else that never launched a binary. Nothing tmux
         // says about a missing window arrives with it.
         guard status != 127 else { return .unknown }
-        let haystack = output.lowercased()
-        return absentMarkers.contains(where: haystack.contains) ? .absent : .unknown
+        return indicatesAbsence(output) ? .absent : .unknown
     }
 }

--- a/Tests/TBDDaemonTests/DaemonHandoverTests.swift
+++ b/Tests/TBDDaemonTests/DaemonHandoverTests.swift
@@ -1,0 +1,172 @@
+import Foundation
+import TestSupport
+import Testing
+@testable import TBDDaemonLib
+
+/// The single-instance gate's one authorised exception, and the retirement it
+/// performs.
+///
+/// `.clockDriven` is a hang-catcher: the retire tests drive a virtual clock,
+/// and a sleep nobody advances would otherwise stop the whole run silently.
+@Suite("Daemon handover", .clockDriven)
+struct DaemonHandoverTests {
+
+    /// A `sendSignal`/`isLive` pair a test can both program and read back.
+    ///
+    /// `isLive` answers `true` until it has been asked `aliveForChecks` times,
+    /// which is how "the predecessor exits partway through the wait" is
+    /// expressed without a second process.
+    private final class Predecessor: @unchecked Sendable {
+        private let lock = NSLock()
+        private var checks = 0
+        private var signals: [Int32] = []
+        private let aliveForChecks: Int
+
+        init(aliveForChecks: Int) {
+            self.aliveForChecks = aliveForChecks
+        }
+
+        var sent: [Int32] {
+            lock.lock(); defer { lock.unlock() }
+            return signals
+        }
+
+        @Sendable func isLive(_ pid: pid_t) -> Bool {
+            lock.lock(); defer { lock.unlock() }
+            checks += 1
+            return checks <= aliveForChecks
+        }
+
+        @Sendable func send(_ pid: pid_t, _ signal: Int32) {
+            lock.lock(); defer { lock.unlock() }
+            signals.append(signal)
+        }
+    }
+
+    // MARK: - The decision
+
+    @Test("a stale pid file starts normally")
+    func noLiveDaemonIsNormal() {
+        #expect(
+            HandoverDecision.decide(
+                pidFileContents: 4242, handoverEnv: "4242", isLiveDaemon: { _ in false })
+                == .normal)
+        #expect(
+            HandoverDecision.decide(
+                pidFileContents: nil, handoverEnv: "4242", isLiveDaemon: { _ in true })
+                == .normal)
+    }
+
+    @Test("the daemon we were sent to replace is taken over")
+    func matchingHandoverPIDTakesOver() {
+        #expect(
+            HandoverDecision.decide(
+                pidFileContents: 4242, handoverEnv: "4242", isLiveDaemon: { $0 == 4242 })
+                == .takeOver(predecessor: 4242))
+        // Whitespace survives a shell export round-trip; a trailing newline
+        // must not turn a handover into a refusal.
+        #expect(
+            HandoverDecision.decide(
+                pidFileContents: 4242, handoverEnv: " 4242\n", isLiveDaemon: { $0 == 4242 })
+                == .takeOver(predecessor: 4242))
+    }
+
+    /// Everything else about a live daemon is today's behavior: exit. An
+    /// out-of-date or mistyped variable must never take over a daemon it was
+    /// not aimed at.
+    @Test("any other live daemon is refused")
+    func otherLiveDaemonIsRefused() {
+        let live: (pid_t) -> Bool = { _ in true }
+        #expect(
+            HandoverDecision.decide(pidFileContents: 4242, handoverEnv: nil, isLiveDaemon: live)
+                == .refuse(existing: 4242))
+        #expect(
+            HandoverDecision.decide(pidFileContents: 4242, handoverEnv: "99", isLiveDaemon: live)
+                == .refuse(existing: 4242))
+        #expect(
+            HandoverDecision.decide(pidFileContents: 4242, handoverEnv: "", isLiveDaemon: live)
+                == .refuse(existing: 4242))
+        #expect(
+            HandoverDecision.decide(pidFileContents: 4242, handoverEnv: "nonsense", isLiveDaemon: live)
+                == .refuse(existing: 4242))
+    }
+
+    // MARK: - The retirement
+
+    @Test("a predecessor that is already gone is not signalled")
+    func alreadyGonePredecessorIsNotSignalled() async {
+        let predecessor = Predecessor(aliveForChecks: 0)
+        let handover = DaemonHandover(
+            sendSignal: predecessor.send, isLive: predecessor.isLive,
+            clock: EventDrivenTestClock())
+        #expect(await handover.retire(predecessor: 4242) == .alreadyGone)
+        #expect(predecessor.sent.isEmpty)
+    }
+
+    @Test("a predecessor that exits inside the budget needs only SIGTERM")
+    func politeExitStopsAtSIGTERM() async throws {
+        // Alive for the entry check, gone by the first poll.
+        let predecessor = Predecessor(aliveForChecks: 1)
+        let clock = EventDrivenTestClock()
+        let handover = DaemonHandover(
+            termBudget: .milliseconds(300), killBudget: .milliseconds(100),
+            pollInterval: .milliseconds(100),
+            sendSignal: predecessor.send, isLive: predecessor.isLive, clock: clock)
+
+        let retirement = Task { await handover.retire(predecessor: 4242) }
+        try await clock.requireAdvanceWhenArmed(by: .milliseconds(100))
+
+        #expect(await retirement.value == .exitedAfterTerm)
+        #expect(predecessor.sent == [SIGTERM])
+    }
+
+    /// The escalation. Budgets are instance properties precisely so this costs
+    /// three virtual polls instead of three hundred real ones.
+    @Test("a predecessor that never exits is SIGKILLed and then given up on")
+    func stuckPredecessorEscalatesToSIGKILL() async throws {
+        let predecessor = Predecessor(aliveForChecks: .max)
+        let clock = EventDrivenTestClock()
+        let handover = DaemonHandover(
+            termBudget: .milliseconds(200), killBudget: .milliseconds(100),
+            pollInterval: .milliseconds(100),
+            sendSignal: predecessor.send, isLive: predecessor.isLive, clock: clock)
+
+        let retirement = Task { await handover.retire(predecessor: 4242) }
+        // Two polls inside the SIGTERM budget, then one inside the SIGKILL one.
+        for _ in 0..<3 {
+            try await clock.requireAdvanceWhenArmed(by: .milliseconds(100))
+        }
+
+        #expect(await retirement.value == .stillAlive)
+        #expect(predecessor.sent == [SIGTERM, SIGKILL])
+    }
+
+    @Test("a predecessor that only dies to SIGKILL reports that")
+    func stubbornPredecessorExitsAfterSIGKILL() async throws {
+        // Entry check + two SIGTERM polls alive, gone on the first SIGKILL poll.
+        let predecessor = Predecessor(aliveForChecks: 3)
+        let clock = EventDrivenTestClock()
+        let handover = DaemonHandover(
+            termBudget: .milliseconds(200), killBudget: .milliseconds(100),
+            pollInterval: .milliseconds(100),
+            sendSignal: predecessor.send, isLive: predecessor.isLive, clock: clock)
+
+        let retirement = Task { await handover.retire(predecessor: 4242) }
+        for _ in 0..<3 {
+            try await clock.requireAdvanceWhenArmed(by: .milliseconds(100))
+        }
+
+        #expect(await retirement.value == .exitedAfterKill)
+        #expect(predecessor.sent == [SIGTERM, SIGKILL])
+    }
+
+    // MARK: - Budget arithmetic
+
+    @Test("a budget floors to whole polls and never to zero")
+    func pollCountFloorsAtOne() {
+        #expect(DaemonHandover.pollCount(budget: .seconds(30), interval: .milliseconds(100)) == 300)
+        #expect(DaemonHandover.pollCount(budget: .milliseconds(250), interval: .milliseconds(100)) == 2)
+        #expect(DaemonHandover.pollCount(budget: .zero, interval: .milliseconds(100)) == 1)
+        #expect(DaemonHandover.pollCount(budget: .seconds(1), interval: .zero) == 1)
+    }
+}

--- a/Tests/TBDDaemonTests/DaemonHandoverTests.swift
+++ b/Tests/TBDDaemonTests/DaemonHandoverTests.swift
@@ -315,9 +315,94 @@ struct DaemonHandoverTests {
             pidFilePath: path, predecessorPID: 4242,
             aliveForChecks: .max, deletesPIDFileOnExit: false, advances: 3)
 
-        #expect(result == .predecessorSurvived)
+        #expect(result == .predecessorSurvived(claimRestored: true))
         #expect(PIDFile(path: path).read() == 4242,
                 "the successor kept a claim on a daemon that is still serving")
+    }
+
+    // MARK: - Handing the claim back
+
+    /// A `writeClaim` that fails on the attempts a test names.
+    ///
+    /// Call 1 is the opening claim, which must succeed or the fixture never
+    /// reaches the write-back at all; the failing calls are therefore counted
+    /// from 2.
+    private final class FlakyClaimWriter: @unchecked Sendable {
+        private let lock = NSLock()
+        private var calls = 0
+        private var written: [pid_t] = []
+        private let failingCalls: Set<Int>
+
+        init(failingCalls: Set<Int>) { self.failingCalls = failingCalls }
+
+        struct WriteRefused: Error {}
+
+        var recorded: [pid_t] {
+            lock.lock(); defer { lock.unlock() }
+            return written
+        }
+
+        @Sendable func write(_ pid: pid_t) throws {
+            lock.lock()
+            calls += 1
+            let call = calls
+            lock.unlock()
+            if failingCalls.contains(call) { throw WriteRefused() }
+            lock.lock(); written.append(pid); lock.unlock()
+        }
+    }
+
+    private func runSurvivingTakeOver(
+        failingCalls: Set<Int>, advances: Int
+    ) async throws -> (result: HandoverClaim.Result, writes: [pid_t]) {
+        let predecessor = Predecessor(aliveForChecks: .max)
+        let writer = FlakyClaimWriter(failingCalls: failingCalls)
+        let clock = EventDrivenTestClock()
+        let claim = HandoverClaim(
+            pidFile: PIDFile(path: tmpPidPath()),
+            handover: DaemonHandover(
+                termBudget: .milliseconds(200), killBudget: .milliseconds(100),
+                pollInterval: .milliseconds(100),
+                sendSignal: predecessor.send, isLive: predecessor.isLive, clock: clock),
+            ownPID: 777,
+            writeBackAttempts: 3,
+            writeBackRetryDelay: .milliseconds(100),
+            clock: clock,
+            writeClaim: writer.write)
+        let work = Task { try await claim.takeOver(from: 4242) }
+        for _ in 0..<advances {
+            try await clock.requireAdvanceWhenArmed(by: .milliseconds(100))
+        }
+        return (try await work.value, writer.recorded)
+    }
+
+    /// A transient failure must not cost the predecessor its claim. Three
+    /// retirement polls, then two write-back attempts fail and the third lands.
+    @Test("a write-back that fails twice and then succeeds still restores the claim")
+    func writeBackRetriesUntilItLands() async throws {
+        let run = try await runSurvivingTakeOver(
+            failingCalls: [2, 3], advances: 3 + 2)
+
+        #expect(run.result == .predecessorSurvived(claimRestored: true))
+        #expect(run.writes == [777, 4242],
+                "the predecessor's claim was not the last thing written")
+    }
+
+    /// Exhausting the retries is reported in the value, not only in a log line.
+    ///
+    /// It is also not a two-writer hazard, which is why the successor still
+    /// exits rather than pressing on: `SIGKILL` cannot be caught, so a pid still
+    /// present after it is in an uninterruptible wait rather than serving, and a
+    /// file naming a dying pid is the ordinary stale-pid case that
+    /// `PIDFile.cleanupIfStale` and the app's daemon poller already reconcile.
+    @Test("a write-back that never lands is reported, not swallowed")
+    func writeBackFailureIsReported() async throws {
+        let run = try await runSurvivingTakeOver(
+            failingCalls: [2, 3, 4], advances: 3 + 2)
+
+        #expect(run.result == .predecessorSurvived(claimRestored: false))
+        #expect(run.writes == [777],
+                "a failing write-back still recorded a claim")
     }
 
     // MARK: - Budget arithmetic

--- a/Tests/TBDDaemonTests/DaemonHandoverTests.swift
+++ b/Tests/TBDDaemonTests/DaemonHandoverTests.swift
@@ -355,7 +355,16 @@ struct DaemonHandoverTests {
     private func runSurvivingTakeOver(
         failingCalls: Set<Int>, advances: Int
     ) async throws -> (result: HandoverClaim.Result, writes: [pid_t]) {
-        let predecessor = Predecessor(aliveForChecks: .max)
+        try await runFlakyTakeOver(
+            aliveForChecks: .max, failingCalls: failingCalls, advances: advances)
+    }
+
+    /// A take-over against a predecessor that is alive for `aliveForChecks`
+    /// liveness checks, with a claim writer that fails on the named calls.
+    private func runFlakyTakeOver(
+        aliveForChecks: Int, failingCalls: Set<Int>, advances: Int
+    ) async throws -> (result: HandoverClaim.Result, writes: [pid_t]) {
+        let predecessor = Predecessor(aliveForChecks: aliveForChecks)
         let writer = FlakyClaimWriter(failingCalls: failingCalls)
         let clock = EventDrivenTestClock()
         let claim = HandoverClaim(
@@ -403,6 +412,54 @@ struct DaemonHandoverTests {
         #expect(run.result == .predecessorSurvived(claimRestored: false))
         #expect(run.writes == [777],
                 "a failing write-back still recorded a claim")
+    }
+
+    // MARK: - Re-asserting the claim
+
+    /// The re-assert after a successful retirement is the same kind of write as
+    /// the hand-back and gets the same retry: with the predecessor already
+    /// dead, one transient failure must not turn a finished handover into an
+    /// aborted start. One retirement poll, then two failed re-asserts and a
+    /// third that lands.
+    @Test("a re-assert that fails twice and then succeeds still claims")
+    func reassertRetriesUntilItLands() async throws {
+        let run = try await runFlakyTakeOver(
+            aliveForChecks: 1, failingCalls: [2, 3], advances: 1 + 2)
+
+        #expect(run.result == .claimed(.exitedAfterTerm))
+        #expect(run.writes == [777, 777],
+                "the re-assert did not land after the retries")
+    }
+
+    /// Exhausting the retries still aborts the start: a file that may name
+    /// nobody is the two-successor race the re-assert exists to close, and a
+    /// stale or missing pid file is what the app's poller recovers from.
+    @Test("a re-assert that never lands aborts the start")
+    func reassertFailureThrows() async throws {
+        let predecessor = Predecessor(aliveForChecks: 1)
+        let writer = FlakyClaimWriter(failingCalls: [2, 3, 4])
+        let clock = EventDrivenTestClock()
+        let claim = HandoverClaim(
+            pidFile: PIDFile(path: tmpPidPath()),
+            handover: DaemonHandover(
+                termBudget: .milliseconds(200), killBudget: .milliseconds(100),
+                pollInterval: .milliseconds(100),
+                sendSignal: predecessor.send, isLive: predecessor.isLive, clock: clock),
+            ownPID: 777,
+            writeBackAttempts: 3,
+            writeBackRetryDelay: .milliseconds(100),
+            clock: clock,
+            writeClaim: writer.write)
+        let work = Task { try await claim.takeOver(from: 4242) }
+        for _ in 0..<(1 + 2) {
+            try await clock.requireAdvanceWhenArmed(by: .milliseconds(100))
+        }
+
+        await #expect(throws: HandoverClaim.ReassertFailed.self) {
+            try await work.value
+        }
+        #expect(writer.recorded == [777],
+                "a failing re-assert still recorded a claim")
     }
 
     // MARK: - Budget arithmetic

--- a/Tests/TBDDaemonTests/DaemonHandoverTests.swift
+++ b/Tests/TBDDaemonTests/DaemonHandoverTests.swift
@@ -11,6 +11,10 @@ import Testing
 @Suite("Daemon handover", .clockDriven)
 struct DaemonHandoverTests {
 
+    private func tmpPidPath() -> String {
+        NSTemporaryDirectory() + "handover-\(UUID().uuidString).pid"
+    }
+
     /// A `sendSignal`/`isLive` pair a test can both program and read back.
     ///
     /// `isLive` answers `true` until it has been asked `aliveForChecks` times,
@@ -200,6 +204,120 @@ struct DaemonHandoverTests {
 
         #expect(await retirement.value == .exitedAfterKill)
         #expect(predecessor.sent == [SIGTERM, SIGKILL])
+    }
+
+    // MARK: - The pid-file choreography
+
+    /// A predecessor that reacts to `SIGTERM` by running whichever `stop()` it
+    /// was built with.
+    ///
+    /// `deletesPIDFileOnExit` is the shape of every daemon built before
+    /// `PIDFile.removeIfOwned` existed: its `stop()` ends with an
+    /// unconditional `remove()`, so it takes the successor's claim with it.
+    /// The first update on any machine hands over from exactly such a daemon.
+    private final class ExitingPredecessor: @unchecked Sendable {
+        private let lock = NSLock()
+        private var checks = 0
+        private let aliveForChecks: Int
+        private let pidFilePath: String
+        private let deletesPIDFileOnExit: Bool
+
+        init(aliveForChecks: Int, pidFilePath: String, deletesPIDFileOnExit: Bool) {
+            self.aliveForChecks = aliveForChecks
+            self.pidFilePath = pidFilePath
+            self.deletesPIDFileOnExit = deletesPIDFileOnExit
+        }
+
+        @Sendable func isLive(_ pid: pid_t) -> Bool {
+            lock.lock(); defer { lock.unlock() }
+            checks += 1
+            return checks <= aliveForChecks
+        }
+
+        @Sendable func send(_ pid: pid_t, _ signal: Int32) {
+            guard deletesPIDFileOnExit else { return }
+            try? FileManager.default.removeItem(atPath: pidFilePath)
+        }
+    }
+
+    private func runTakeOver(
+        pidFilePath: String,
+        predecessorPID: pid_t,
+        aliveForChecks: Int,
+        deletesPIDFileOnExit: Bool,
+        advances: Int
+    ) async throws -> HandoverClaim.Result {
+        let predecessor = ExitingPredecessor(
+            aliveForChecks: aliveForChecks, pidFilePath: pidFilePath,
+            deletesPIDFileOnExit: deletesPIDFileOnExit)
+        let clock = EventDrivenTestClock()
+        let claim = HandoverClaim(
+            pidFile: PIDFile(path: pidFilePath),
+            handover: DaemonHandover(
+                termBudget: .milliseconds(200), killBudget: .milliseconds(100),
+                pollInterval: .milliseconds(100),
+                sendSignal: predecessor.send, isLive: predecessor.isLive, clock: clock),
+            ownPID: 777)
+        let work = Task { try await claim.takeOver(from: predecessorPID) }
+        for _ in 0..<advances {
+            try await clock.requireAdvanceWhenArmed(by: .milliseconds(100))
+        }
+        return try await work.value
+    }
+
+    /// The first update on any machine: the running daemon predates this
+    /// change, so its `stop()` deletes the successor's pid file on the way out.
+    /// Without the re-assert the file names nobody, the app's poller sees no
+    /// socket and no live pid, and it spawns a second successor straight
+    /// through the gate.
+    @Test("a predecessor that deletes the pid file on exit does not take our claim with it")
+    func olderPredecessorDoesNotStealTheClaim() async throws {
+        let path = tmpPidPath()
+        defer { try? FileManager.default.removeItem(atPath: path) }
+        try "4242".write(toFile: path, atomically: true, encoding: .utf8)
+
+        let result = try await runTakeOver(
+            pidFilePath: path, predecessorPID: 4242,
+            aliveForChecks: 1, deletesPIDFileOnExit: true, advances: 1)
+
+        #expect(result == .claimed(.exitedAfterTerm))
+        #expect(PIDFile(path: path).read() == 777,
+                "an older predecessor deleted the successor's claim on its way out")
+    }
+
+    /// A predecessor carrying `removeIfOwned` leaves the file alone, and the
+    /// re-assert is then a no-op write. Same end state, which is what makes it
+    /// safe to do unconditionally rather than probe the predecessor's vintage.
+    @Test("a predecessor that leaves the pid file alone ends in the same place")
+    func newerPredecessorEndsWithOurClaimToo() async throws {
+        let path = tmpPidPath()
+        defer { try? FileManager.default.removeItem(atPath: path) }
+        try "4242".write(toFile: path, atomically: true, encoding: .utf8)
+
+        let result = try await runTakeOver(
+            pidFilePath: path, predecessorPID: 4242,
+            aliveForChecks: 1, deletesPIDFileOnExit: false, advances: 1)
+
+        #expect(result == .claimed(.exitedAfterTerm))
+        #expect(PIDFile(path: path).read() == 777)
+    }
+
+    /// The abort path still hands the claim back, and the re-assert must not
+    /// run ahead of it.
+    @Test("a predecessor that survives SIGKILL gets its claim back")
+    func survivingPredecessorGetsItsClaimBack() async throws {
+        let path = tmpPidPath()
+        defer { try? FileManager.default.removeItem(atPath: path) }
+        try "4242".write(toFile: path, atomically: true, encoding: .utf8)
+
+        // Two polls inside the SIGTERM budget, one inside the SIGKILL one.
+        let result = try await runTakeOver(
+            pidFilePath: path, predecessorPID: 4242,
+            aliveForChecks: .max, deletesPIDFileOnExit: false, advances: 3)
+
+        #expect(result == .predecessorSurvived)
+        #expect(PIDFile(path: path).read() == 4242,
+                "the successor kept a claim on a daemon that is still serving")
     }
 
     // MARK: - Budget arithmetic

--- a/Tests/TBDDaemonTests/DaemonHandoverTests.swift
+++ b/Tests/TBDDaemonTests/DaemonHandoverTests.swift
@@ -91,6 +91,48 @@ struct DaemonHandoverTests {
                 == .refuse(existing: 4242))
     }
 
+    /// `scripts/update.sh` always exports the variable and exports `0` when no
+    /// daemon is running, so `0` means "nobody to hand over from" rather than a
+    /// malformed value. It must behave exactly as an unset variable does: the
+    /// ordinary gate, which starts when the pid file is free and refuses when a
+    /// live daemon owns it.
+    @Test("the script's no-daemon sentinel is an ordinary start")
+    func zeroMeansNoPredecessor() {
+        let sentinels: [String?] = ["0", " 0\n", "-1", "", "   ", "nonsense", "12.5", nil]
+        for sentinel in sentinels {
+            #expect(
+                HandoverDecision.decide(
+                    pidFileContents: nil, handoverEnv: sentinel, isLiveDaemon: { _ in true })
+                    == .normal,
+                "a free pid file must start normally for handover value \(sentinel ?? "nil")")
+            #expect(
+                HandoverDecision.decide(
+                    pidFileContents: 4242, handoverEnv: sentinel, isLiveDaemon: { _ in true })
+                    == .refuse(existing: 4242),
+                "a live daemon must still be refused for handover value \(sentinel ?? "nil")")
+        }
+        #expect(HandoverDecision.requestedPredecessor("0") == nil)
+        #expect(HandoverDecision.requestedPredecessor("4242") == 4242)
+    }
+
+    /// A handover aimed at a daemon that died before the successor launched.
+    /// `PIDFile.cleanupIfStale` has already removed the stale file by the time
+    /// the gate runs, so this is an ordinary start — not a take-over of a
+    /// process that is no longer there.
+    @Test("a handover pid that is no longer a live daemon starts normally")
+    func deadPredecessorStartsNormally() {
+        #expect(
+            HandoverDecision.decide(
+                pidFileContents: nil, handoverEnv: "4242", isLiveDaemon: { _ in false })
+                == .normal)
+        // Belt and braces: even if the stale file survived cleanup, a pid that
+        // is not a live daemon cannot be taken over.
+        #expect(
+            HandoverDecision.decide(
+                pidFileContents: 4242, handoverEnv: "4242", isLiveDaemon: { _ in false })
+                == .normal)
+    }
+
     // MARK: - The retirement
 
     @Test("a predecessor that is already gone is not signalled")

--- a/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
@@ -2181,6 +2181,42 @@ struct HibernationCoordinatorTests {
         #expect(after?.hibernatedAt == nil)
     }
 
+    // MARK: - Wake and an unanswered window probe
+
+    /// The wake path's recreate arm `killWindow`s the old window once the
+    /// replacement exists — its own comment names "a transient windowExists
+    /// misclassification" as the thing that must not leak a live window, and a
+    /// timed-out probe is exactly such a misclassification. Acting on it
+    /// destroys a window on ignorance, so an unanswerable probe now fails the
+    /// wake and leaves the row parked for the next retry. A server that is
+    /// genuinely gone still answers `absent`, so reboot recovery is unchanged.
+    @Test func wakeRefusesToRecreateWhenTheWindowProbeGoesUnanswered() async throws {
+        let (db, _, terminalID) = try await setup()
+        try await db.terminals.setHibernated(id: terminalID, sessionID: "sess-1")
+
+        let recorded = RecordedTmuxCommands()
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunRecorder: recorded.append,
+            dryRunWindowPresence: { _, _ in .unknown })
+        let coord = HibernationCoordinator(
+            db: db, tmux: tmux, configDirManager: isolatedConfigDirManager(),
+            actuationLog: makeTestActuationLog())
+
+        let result = await coord.wake(terminalID: terminalID)
+
+        guard case let .respawnFailed(reason) = result else {
+            Issue.record("an unanswered window probe produced \(result) instead of a retryable failure")
+            return
+        }
+        #expect(reason.contains("retry"), "the failure must read as retryable: \(reason)")
+        let after = try #require(try await db.terminals.get(id: terminalID))
+        #expect(after.isParked,
+                "an unanswered window probe un-parked a row it could not establish anything about")
+        #expect(!recorded.snapshot().contains { $0.contains("kill-window") },
+                "an unanswered window probe killed a window: \(recorded.snapshot())")
+    }
+
     // MARK: - Startup reconciliation
 
     /// `reconcileOnStartup` clears a stale parked timestamp for a terminal whose

--- a/Tests/TBDDaemonTests/PIDFileStaleTests.swift
+++ b/Tests/TBDDaemonTests/PIDFileStaleTests.swift
@@ -61,4 +61,17 @@ import Testing
         let f = PIDFile(path: tmpPidPath())
         #expect(f.removeIfOwned(pid: 12345) == false)
     }
+
+    // A successor whose handover failed hands the file back, so the live
+    // predecessor keeps its claim and the app's poller does not read it as
+    // absent. `Daemon.start()` is the only caller that passes a pid.
+    @Test func writeCanRestoreAnotherProcessesClaim() throws {
+        let path = tmpPidPath()
+        defer { try? FileManager.default.removeItem(atPath: path) }
+        let f = PIDFile(path: path)
+        try f.write(pid: 999)
+        #expect(f.read() == 999)
+        try f.write(pid: 4242)
+        #expect(f.read() == 4242, "a later claim must overwrite the earlier one")
+    }
 }

--- a/Tests/TBDDaemonTests/PIDFileStaleTests.swift
+++ b/Tests/TBDDaemonTests/PIDFileStaleTests.swift
@@ -31,4 +31,34 @@ import Testing
         let f = PIDFile(path: path)
         #expect(f.isStale(isLiveDaemon: { _ in false }) == true)
     }
+
+    // MARK: - Compare-and-delete
+
+    @Test func removeIfOwnedRemovesOurOwnPidFile() throws {
+        let path = tmpPidPath()
+        try "12345".write(toFile: path, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(atPath: path) }
+        let f = PIDFile(path: path)
+        #expect(f.removeIfOwned(pid: 12345) == true)
+        #expect(FileManager.default.fileExists(atPath: path) == false)
+    }
+
+    // The handover case: a successor has already written its own pid over the
+    // file, and the predecessor is shutting down. An unconditional remove()
+    // here deletes the successor's claim and reopens the spawn race the
+    // successor-first write closes.
+    @Test func removeIfOwnedLeavesASuccessorsPidFile() throws {
+        let path = tmpPidPath()
+        try "999".write(toFile: path, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(atPath: path) }
+        let f = PIDFile(path: path)
+        #expect(f.removeIfOwned(pid: 12345) == false)
+        #expect(FileManager.default.fileExists(atPath: path) == true)
+        #expect(f.read() == 999, "the successor's claim was rewritten")
+    }
+
+    @Test func removeIfOwnedOnAMissingFileIsANoOp() {
+        let f = PIDFile(path: tmpPidPath())
+        #expect(f.removeIfOwned(pid: 12345) == false)
+    }
 }

--- a/Tests/TBDDaemonTests/ReconcileTmuxPresenceTests.swift
+++ b/Tests/TBDDaemonTests/ReconcileTmuxPresenceTests.swift
@@ -1,0 +1,194 @@
+import Foundation
+import TestSupport
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// What the startup reconcile does when the tmux probe fails to answer.
+///
+/// The pass parks resumable Claude rows and deletes everything else the moment
+/// it believes a window is gone, and until the tri-state probes it believed
+/// that on a timeout. On 2026-09-02 a restart of a busy machine parked 49 of 56
+/// live lane sessions in one pass, every row carrying the same `hibernatedAt`.
+/// Nothing was gone; the probes were merely slow.
+///
+/// Each test carries one resumable Claude row and one shell row, because the
+/// pass forks on exactly that: park versus delete. A guard placed inside either
+/// arm fails one of these tests, and a guard that swallowed the whole loop
+/// fails `absentStillParksAndDeletes`.
+@Suite("Reconcile and unanswered tmux probes")
+struct ReconcileTmuxPresenceTests {
+
+    private func makeLifecycle(db: TBDDatabase, tmux: TmuxManager) -> WorktreeLifecycle {
+        WorktreeLifecycle(db: db, git: GitManager(), tmux: tmux, hooks: HookResolver())
+    }
+
+    private func seedRepo(db: TBDDatabase, at repoPath: String) async throws -> (Repo, Worktree) {
+        let repo = try await db.repos.create(
+            path: repoPath, displayName: "acme", defaultBranch: "main")
+        let main = try await db.worktrees.createMain(
+            repoID: repo.id, name: "main", branch: "main", path: repoPath,
+            tmuxServer: TmuxManager.serverName(forRepoPath: repoPath))
+        return (repo, main)
+    }
+
+    private func seedTerminals(
+        db: TBDDatabase, worktree: Worktree
+    ) async throws -> (claude: Terminal, shell: Terminal) {
+        let claude = try await db.terminals.create(
+            worktreeID: worktree.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: TerminalLabel.claudeCode, claudeSessionID: "sess-tmux", kind: .claude)
+        let shell = try await db.terminals.create(
+            worktreeID: worktree.id, tmuxWindowID: "@2", tmuxPaneID: "%2", kind: .shell)
+        return (claude, shell)
+    }
+
+    private func runReconcile(
+        tmux: TmuxManager
+    ) async throws -> (db: TBDDatabase, claude: UUID, shell: UUID, cleanup: () -> Void) {
+        let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(db: db, tmux: tmux)
+        let (repo, main) = try await seedRepo(db: db, at: repoDir.path)
+        let rows = try await seedTerminals(db: db, worktree: main)
+        try await lifecycle.reconcile(
+            repoID: repo.id,
+            actuationLog: makeTestActuationLog(),
+            reapSharedScratchTmuxResources: true)
+        return (db, rows.claude.id, rows.shell.id, { try? FileManager.default.removeItem(at: tempDir) })
+    }
+
+    /// A server probe that never answered is ignorance about every row on that
+    /// server, so every row on it is left exactly as it was.
+    @Test("an unanswered server probe touches nothing")
+    func unknownServerLeavesRowsAlone() async throws {
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunWindowIsDead: { _ in true },
+            dryRunServerPresence: { _ in .unknown })
+        let run = try await runReconcile(tmux: tmux)
+        defer { run.cleanup() }
+
+        let claude = try #require(
+            try await run.db.terminals.get(id: run.claude),
+            "an unanswered server probe deleted a live Claude row")
+        #expect(claude.hibernatedAt == nil,
+                "an unanswered server probe parked a live Claude row")
+        #expect(try await run.db.terminals.get(id: run.shell) != nil,
+                "an unanswered server probe deleted a live shell row")
+    }
+
+    /// The server answered, the window probe did not. Same rule, one level down.
+    @Test("an unanswered window probe touches nothing")
+    func unknownWindowLeavesRowsAlone() async throws {
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunWindowIsDead: { _ in true },
+            dryRunServerPresence: { _ in .alive },
+            dryRunWindowPresence: { _, _ in .unknown })
+        let run = try await runReconcile(tmux: tmux)
+        defer { run.cleanup() }
+
+        let claude = try #require(
+            try await run.db.terminals.get(id: run.claude),
+            "an unanswered window probe deleted a live Claude row")
+        #expect(claude.hibernatedAt == nil,
+                "an unanswered window probe parked a live Claude row")
+        #expect(try await run.db.terminals.get(id: run.shell) != nil,
+                "an unanswered window probe deleted a live shell row")
+    }
+
+    /// Positive evidence still acts, and acts the way it always did. Without
+    /// this the tri-state could be satisfied by a pass that does nothing.
+    @Test("a window tmux says is gone is still parked or deleted")
+    func absentStillParksAndDeletes() async throws {
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunServerPresence: { _ in .alive },
+            dryRunWindowPresence: { _, _ in .absent })
+        let run = try await runReconcile(tmux: tmux)
+        defer { run.cleanup() }
+
+        let parked = try #require(
+            try await run.db.terminals.get(id: run.claude),
+            "a resumable Claude row was deleted instead of parked")
+        #expect(parked.hibernatedAt != nil,
+                "the tri-state probe stopped reconcile acting on positive evidence")
+        #expect(parked.hibernateReason == .recovery)
+        #expect(try await run.db.terminals.get(id: run.shell) == nil,
+                "the tri-state probe stopped reconcile deleting a non-resumable row")
+    }
+
+    /// A server tmux says is gone has positively no windows on it, so the rows
+    /// under it are reconciled without ever probing a window.
+    @Test("an absent server parks and deletes without a window probe")
+    func absentServerActsWithoutWindowProbe() async throws {
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunServerPresence: { _ in .absent },
+            dryRunWindowPresence: { _, _ in
+                Issue.record("reconcile probed a window on a server tmux said was gone")
+                return .alive
+            })
+        let run = try await runReconcile(tmux: tmux)
+        defer { run.cleanup() }
+
+        let parked = try #require(try await run.db.terminals.get(id: run.claude))
+        #expect(parked.hibernatedAt != nil)
+        #expect(try await run.db.terminals.get(id: run.shell) == nil)
+    }
+
+    /// The repair half, at the seam `Daemon.start()` calls.
+    ///
+    /// `Daemon.start()` runs `hibernationCoordinator.reconcileOnStartup()`
+    /// twice: once at step 8d before `performStartupReconciliation`, and once
+    /// straight after it (step 8d-ii). Only the second run can undo a park the
+    /// same boot made, and this composes the two halves the way that step does
+    /// — reconcile parks a row on a window probe that answered absent, then the
+    /// un-park pass finds the pane demonstrably still running Claude and
+    /// clears it. `Daemon.start()` itself binds listeners and cannot be driven
+    /// from a unit test, so the ordering is asserted here and the call site is
+    /// cited above.
+    @Test("the post-reconcile un-park pass clears a park made by the same boot")
+    func secondUnparkPassRepairsSameBootPark() async throws {
+        let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let parkingTmux = TmuxManager(
+            dryRun: true,
+            dryRunServerPresence: { _ in .alive },
+            dryRunWindowPresence: { _, _ in .absent })
+        let lifecycle = makeLifecycle(db: db, tmux: parkingTmux)
+        let (repo, main) = try await seedRepo(db: db, at: repoDir.path)
+        let rows = try await seedTerminals(db: db, worktree: main)
+
+        try await lifecycle.reconcile(
+            repoID: repo.id,
+            actuationLog: makeTestActuationLog(),
+            reapSharedScratchTmuxResources: true)
+
+        let parked = try #require(try await db.terminals.get(id: rows.claude.id))
+        #expect(parked.hibernatedAt != nil, "the fixture did not produce a park to repair")
+
+        // The window is there after all and the pane is running Claude — the
+        // race the second pass exists for. The un-park pass still asks the
+        // `Bool` probes, whose dry-run default is "alive"; a wrong `false`
+        // there only leaves a row parked, which is the conservative direction.
+        // `dryRunPaneCurrentCommand` reporting a version string is how the
+        // existing coordinator fixtures spell "a live claude process".
+        let repairingTmux = TmuxManager(
+            dryRun: true,
+            dryRunPaneCurrentCommand: { _, _ in "1.2.3" })
+        let coordinator = HibernationCoordinator(
+            db: db, tmux: repairingTmux,
+            configDirManager: makeIsolatedConfigDirManager(tag: "reconcile-unpark"),
+            actuationLog: makeTestActuationLog())
+        await coordinator.reconcileOnStartup()
+
+        let repaired = try #require(try await db.terminals.get(id: rows.claude.id))
+        #expect(repaired.hibernatedAt == nil,
+                "the post-reconcile un-park pass left a same-boot park in place")
+        #expect(repaired.claudeSessionID == parked.claudeSessionID)
+    }
+}

--- a/Tests/TBDDaemonTests/ReconcileTmuxPresenceTests.swift
+++ b/Tests/TBDDaemonTests/ReconcileTmuxPresenceTests.swift
@@ -138,6 +138,121 @@ struct ReconcileTmuxPresenceTests {
         #expect(try await run.db.terminals.get(id: run.shell) == nil)
     }
 
+    // MARK: - The stale-server self-heal
+
+    /// The self-heal that renames a worktree's non-canonical `tmuxServer`, and
+    /// why it needs the same tri-state treatment as the sweep above.
+    ///
+    /// A promoted scratch space's main worktree deliberately keeps the scratch
+    /// server its live sessions run on, so the rename fires only when that
+    /// server has no live window. Reading a timed-out probe as "no live window"
+    /// re-points the row at the canonical server, and the terminal sweep then
+    /// probes windows on a server that really does not have them. Its `absent`
+    /// is honest, so the sweep's own `unknown` guard never fires and the rows
+    /// are destroyed on evidence manufactured one pass earlier. Hardening the
+    /// sweep alone would have left that route open, which is why these four
+    /// tests sit beside the four above.
+    private func runSelfHeal(
+        tmux: TmuxManager, inheritedServer: String = "tbd-inherited-scratch"
+    ) async throws -> (db: TBDDatabase, worktree: UUID, canonical: String, cleanup: () -> Void) {
+        let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(db: db, tmux: tmux)
+        let repo = try await db.repos.create(
+            path: repoDir.path, displayName: "acme", defaultBranch: "main")
+        let canonical = TmuxManager.serverName(forRepoPath: repoDir.path)
+        #expect(inheritedServer != canonical, "the fixture must start non-canonical")
+        let main = try await db.worktrees.createMain(
+            repoID: repo.id, name: "main", branch: "main", path: repoDir.path,
+            tmuxServer: inheritedServer)
+        _ = try await db.terminals.create(
+            worktreeID: main.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: TerminalLabel.claudeCode, claudeSessionID: "sess-inherited", kind: .claude)
+
+        try await lifecycle.reconcile(
+            repoID: repo.id,
+            actuationLog: makeTestActuationLog(),
+            reapSharedScratchTmuxResources: true)
+
+        return (db, main.id, canonical, { try? FileManager.default.removeItem(at: tempDir) })
+    }
+
+    @Test("an unanswered server probe does not canonicalize the server name")
+    func unknownServerLeavesTheServerNameAlone() async throws {
+        let run = try await runSelfHeal(
+            tmux: TmuxManager(dryRun: true, dryRunServerPresence: { _ in .unknown }))
+        defer { run.cleanup() }
+
+        let worktree = try #require(try await run.db.worktrees.getLocal(id: run.worktree))
+        #expect(worktree.tmuxServer == "tbd-inherited-scratch",
+                "an unanswered server probe renamed the row's tmux server")
+    }
+
+    @Test("an unanswered window probe does not canonicalize the server name")
+    func unknownWindowLeavesTheServerNameAlone() async throws {
+        let run = try await runSelfHeal(tmux: TmuxManager(
+            dryRun: true,
+            dryRunServerPresence: { _ in .alive },
+            dryRunWindowPresence: { _, _ in .unknown }))
+        defer { run.cleanup() }
+
+        let worktree = try #require(try await run.db.worktrees.getLocal(id: run.worktree))
+        #expect(worktree.tmuxServer == "tbd-inherited-scratch",
+                "an unanswered window probe renamed the row's tmux server")
+    }
+
+    /// The promoted-scratch case the self-heal has always had to respect.
+    @Test("a live window keeps the inherited server name")
+    func aliveWindowKeepsTheInheritedServerName() async throws {
+        let run = try await runSelfHeal(tmux: TmuxManager(
+            dryRun: true,
+            dryRunServerPresence: { _ in .alive },
+            dryRunWindowPresence: { _, _ in .alive }))
+        defer { run.cleanup() }
+
+        let worktree = try #require(try await run.db.worktrees.getLocal(id: run.worktree))
+        #expect(worktree.tmuxServer == "tbd-inherited-scratch",
+                "the self-heal orphaned live windows by renaming their server")
+    }
+
+    /// Positive evidence still heals. Without this the tri-state could be
+    /// satisfied by a self-heal that never fires.
+    @Test("a server tmux says has no windows is still canonicalized")
+    func absentWindowStillCanonicalizes() async throws {
+        let run = try await runSelfHeal(tmux: TmuxManager(
+            dryRun: true,
+            dryRunServerPresence: { _ in .alive },
+            dryRunWindowPresence: { _, _ in .absent }))
+        defer { run.cleanup() }
+
+        let worktree = try #require(try await run.db.worktrees.getLocal(id: run.worktree))
+        #expect(worktree.tmuxServer == run.canonical,
+                "the tri-state probe stopped the self-heal acting on positive evidence")
+    }
+
+    /// A server tmux says is gone is positive evidence too, and it must not
+    /// need a window probe to reach the rename.
+    @Test("a server tmux says is gone is canonicalized without a window probe")
+    func absentServerCanonicalizes() async throws {
+        let run = try await runSelfHeal(tmux: TmuxManager(
+            dryRun: true,
+            dryRunServerPresence: { server in
+                // The canonical server is probed by the later passes; only the
+                // inherited one is under test here.
+                server == "tbd-inherited-scratch" ? .absent : .alive
+            },
+            dryRunWindowPresence: { server, _ in
+                if server == "tbd-inherited-scratch" {
+                    Issue.record("the self-heal probed a window on a server tmux said was gone")
+                }
+                return .absent
+            }))
+        defer { run.cleanup() }
+
+        let worktree = try #require(try await run.db.worktrees.getLocal(id: run.worktree))
+        #expect(worktree.tmuxServer == run.canonical)
+    }
+
     /// The repair half, at the seam `Daemon.start()` calls.
     ///
     /// `Daemon.start()` runs `hibernationCoordinator.reconcileOnStartup()`

--- a/Tests/TBDDaemonTests/RecreateWindowProbeTests.swift
+++ b/Tests/TBDDaemonTests/RecreateWindowProbeTests.swift
@@ -1,0 +1,145 @@
+import Foundation
+import TestSupport
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// `terminal.recreateWindow` and the window probe it decides on.
+///
+/// The Claude-resumable arm of this handler parks the row and then `killWindow`s
+/// it the moment it believes the window is gone. Believing that on a `false`
+/// meant believing it on a timeout, so a recreate arriving while the machine was
+/// busy parked and killed a session that was alive and working — on a user's own
+/// gesture, which makes it worse than the startup sweep's version of the same
+/// bug. Ignorance is now reported back to the caller and nothing is touched.
+///
+/// Every test fingerprints the row rather than only reading the response: a
+/// refusal that still parked or re-identified the row is precisely the failure
+/// under test, and the return value cannot see it.
+@Suite("recreateWindow and the window probe")
+struct RecreateWindowProbeTests {
+
+    private func isolatedConfigDirManager() -> ClaudeProfileConfigDirManager {
+        makeIsolatedConfigDirManager(tag: "recreate-probe")
+    }
+
+    private func seedWorktree(_ db: TBDDatabase) async throws -> (Worktree, URL) {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-recreate-repo-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let repo = try await db.repos.create(
+            path: dir.path, displayName: "acme", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "wt", branch: "main", path: dir.path,
+            tmuxServer: "tbd-recreate")
+        return (wt, dir)
+    }
+
+    private func seedClaudeTerminal(
+        _ db: TBDDatabase, worktreeID: UUID
+    ) async throws -> Terminal {
+        let terminal = try await db.terminals.create(
+            worktreeID: worktreeID, tmuxWindowID: "@7", tmuxPaneID: "%7",
+            label: TerminalLabel.claudeCode, claudeSessionID: "sess-recreate", kind: .claude)
+        try await db.terminals.setActivityState(
+            id: terminal.id, activityState: .idle, source: .derived)
+        return try #require(try await db.terminals.get(id: terminal.id))
+    }
+
+    private func router(_ db: TBDDatabase, tmux: TmuxManager) -> RPCRouter {
+        RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: tmux, hooks: HookResolver()),
+            tmux: tmux,
+            configDirManager: isolatedConfigDirManager(),
+            actuationLog: makeTestActuationLog())
+    }
+
+    /// Every column the park arm would touch.
+    private struct RowFingerprint: Equatable {
+        let tmuxWindowID: String
+        let tmuxPaneID: String
+        let claudeSessionID: String?
+        let hibernatedAt: Date?
+        let suspendedAt: Date?
+        let hibernateReason: HibernateReason?
+        let sessionIncarnationID: UUID?
+
+        init(_ t: Terminal) {
+            tmuxWindowID = t.tmuxWindowID
+            tmuxPaneID = t.tmuxPaneID
+            claudeSessionID = t.claudeSessionID
+            hibernatedAt = t.hibernatedAt
+            suspendedAt = t.suspendedAt
+            hibernateReason = t.hibernateReason
+            sessionIncarnationID = t.sessionIncarnationID
+        }
+    }
+
+    private func run(
+        windowPresence: TmuxPresence
+    ) async throws -> (response: RPCResponse, before: RowFingerprint,
+                       after: RowFingerprint, tmuxCalls: [[String]], terminalID: UUID) {
+        let db = try TBDDatabase(inMemory: true)
+        let recorded = RecordedTmuxArgs()
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunRecorder: { recorded.append($0) },
+            dryRunWindowPresence: { _, _ in windowPresence })
+        let (wt, dir) = try await seedWorktree(db)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let terminal = try await seedClaudeTerminal(db, worktreeID: wt.id)
+        let before = RowFingerprint(terminal)
+
+        let response = await router(db, tmux: tmux).handle(try RPCRequest(
+            method: RPCMethod.terminalRecreateWindow,
+            params: TerminalRecreateWindowParams(terminalID: terminal.id)))
+
+        let after = try #require(try await db.terminals.get(id: terminal.id))
+        return (response, before, RowFingerprint(after), recorded.snapshot(), terminal.id)
+    }
+
+    /// The regression. A probe that never answered must not become a park and a
+    /// kill; the caller is told to retry instead.
+    @Test("an unanswered probe parks nothing, kills nothing, and says so")
+    func unknownProbeRefusesAndLeavesTheRowAlone() async throws {
+        let run = try await run(windowPresence: .unknown)
+
+        #expect(!run.response.success)
+        #expect(run.response.error == RPCRouter.unansweredWindowProbeRefusal(
+            terminalID: run.terminalID))
+        #expect(run.after == run.before,
+                "an unanswered probe mutated the row it was supposed to leave alone")
+        #expect(!run.tmuxCalls.contains { $0.contains("kill-window") },
+                "an unanswered probe killed a window: \(run.tmuxCalls)")
+    }
+
+    /// Positive evidence still parks, exactly as before. Without this the
+    /// tri-state could be satisfied by a handler that never acts.
+    @Test("a window tmux says is gone is still parked")
+    func absentProbeStillParks() async throws {
+        let run = try await run(windowPresence: .absent)
+
+        #expect(run.response.success)
+        #expect(run.after.hibernatedAt != nil,
+                "the tri-state probe stopped recreateWindow acting on positive evidence")
+        #expect(run.after.claudeSessionID == run.before.claudeSessionID,
+                "the park discarded the session identity it exists to preserve")
+        #expect(run.tmuxCalls.contains { $0.contains("kill-window") },
+                "the park did not eliminate the dead pane: \(run.tmuxCalls)")
+    }
+
+    /// A live window means the request was stale. Unchanged behaviour: succeed,
+    /// touch nothing.
+    @Test("a live window is a stale request and is ignored")
+    func aliveProbeIgnoresTheRequest() async throws {
+        let run = try await run(windowPresence: .alive)
+
+        #expect(run.response.success)
+        #expect(run.after == run.before,
+                "a stale recreate request mutated a row whose window is alive")
+        #expect(!run.tmuxCalls.contains { $0.contains("kill-window") },
+                "a stale recreate request killed a live window: \(run.tmuxCalls)")
+    }
+}

--- a/Tests/TBDDaemonTests/TerminalCloseRailsTests.swift
+++ b/Tests/TBDDaemonTests/TerminalCloseRailsTests.swift
@@ -38,10 +38,17 @@ struct TerminalCloseRailsTests {
 
     /// `windowIsDead: true` forces the row's window to read as gone, which is
     /// what a crashed-mid-turn session looks like.
-    private func makeRouter(db: TBDDatabase, windowIsDead: Bool = false) -> RPCRouter {
+    private func makeRouter(
+        db: TBDDatabase, windowIsDead: Bool = false,
+        windowPresence: TmuxPresence? = nil
+    ) -> RPCRouter {
         var deadHook: (@Sendable (String) -> Bool)?
         if windowIsDead { deadHook = { _ in true } }
-        let tmux = TmuxManager(dryRun: true, dryRunWindowIsDead: deadHook)
+        var presenceHook: (@Sendable (String, String) -> TmuxPresence)?
+        if let windowPresence { presenceHook = { _, _ in windowPresence } }
+        let tmux = TmuxManager(
+            dryRun: true, dryRunWindowIsDead: deadHook,
+            dryRunWindowPresence: presenceHook)
         return RPCRouter(
             db: db,
             lifecycle: WorktreeLifecycle(
@@ -133,6 +140,26 @@ struct TerminalCloseRailsTests {
         #expect(resp.success, "a dead-window row cannot be mid-turn")
         #expect(resp.errorCode == nil)
         #expect(try await fx.db.terminals.get(id: fx.terminal.id) == nil)
+    }
+
+    /// The other half of the qualification, and the one that was missing.
+    ///
+    /// Only an *observed* stop may lift the rail. `windowExists` answered
+    /// `false` for a probe that timed out as readily as for a window that is
+    /// gone, so a busy machine could turn a mid-turn session into a "stopped"
+    /// one and let the close delete the row and kill the window. A rail that
+    /// cannot establish the session ended has to fail closed.
+    @Test("rails on: a mid-turn terminal whose window probe went unanswered is refused")
+    func railsOnRefusesWhenLivenessIsUnknown() async throws {
+        let fx = try await makeFixture(activityState: .working)
+        let router = makeRouter(db: fx.db, windowPresence: .unknown)
+
+        let resp = try await close(router, fx.terminal.id, rails: true)
+
+        #expect(!resp.success, "an unanswered probe lifted a rail it cannot satisfy")
+        #expect(resp.errorCode == RPCErrorCode.terminalBusy.rawValue)
+        #expect(try await fx.db.terminals.get(id: fx.terminal.id) != nil,
+                "an unanswered probe let the close delete a possibly-live session")
     }
 
     // MARK: - Idempotency and result payload

--- a/Tests/TBDDaemonTests/TmuxPresenceTests.swift
+++ b/Tests/TBDDaemonTests/TmuxPresenceTests.swift
@@ -21,11 +21,31 @@ struct TmuxPresenceTests {
         #expect(TmuxPresenceClassifier.serverPresence(for: error) == .absent)
     }
 
-    @Test func serverProbeReadsConnectFailureAsAbsent() {
+    /// tmux says "no server running on" only for ECONNREFUSED and falls back to
+    /// "error connecting to <socket> (<errno>)" for everything else, so the
+    /// prefix is read together with the errno text. ENOENT is absence: the
+    /// socket file itself is not there.
+    @Test func serverProbeReadsAMissingSocketAsAbsent() {
         let error = TmuxError.commandFailed(
             command: "tmux -L tbd-abc list-sessions", status: 1,
             output: "error connecting to /private/tmp/tmux-501/tbd-abc (No such file or directory)")
         #expect(TmuxPresenceClassifier.serverPresence(for: error) == .absent)
+        #expect(TmuxPresenceClassifier.windowPresence(for: error) == .absent)
+    }
+
+    /// The same prefix, a different errno, and the opposite meaning. A socket
+    /// we may not open is a server we cannot reach, not one that is gone —
+    /// reading it as absence would park and delete a live fleet's rows.
+    @Test func serverProbeReadsAnUnreachableSocketAsUnknown() {
+        for errnoText in ["Permission denied", "Connection reset by peer", "Operation timed out"] {
+            let error = TmuxError.commandFailed(
+                command: "tmux -L tbd-abc list-sessions", status: 1,
+                output: "error connecting to /private/tmp/tmux-501/tbd-abc (\(errnoText))")
+            #expect(TmuxPresenceClassifier.serverPresence(for: error) == .unknown,
+                    "a socket error of \(errnoText) was read as proof the server is gone")
+            #expect(TmuxPresenceClassifier.windowPresence(for: error) == .unknown,
+                    "a socket error of \(errnoText) was read as proof the window is gone")
+        }
     }
 
     @Test func windowProbeReadsTmuxCantFindWindowAsAbsent() {

--- a/Tests/TBDDaemonTests/TmuxPresenceTests.swift
+++ b/Tests/TBDDaemonTests/TmuxPresenceTests.swift
@@ -1,0 +1,122 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+
+/// Tri-state tmux probes: "tmux says it is gone" must stay distinguishable
+/// from "tmux never answered".
+///
+/// The classifier is a whitelist, so the assertions worth having are the ones
+/// that fall OFF the whitelist: a timeout, a spawn failure, and a failure
+/// message nobody recognised all have to read as `unknown`. Those are the
+/// values that used to arrive as `false` and get a live session parked.
+@Suite("Tmux presence probes")
+struct TmuxPresenceTests {
+
+    // MARK: - Classifier
+
+    @Test func serverProbeReadsTmuxNoServerAsAbsent() {
+        let error = TmuxError.commandFailed(
+            command: "tmux -L tbd-abc list-sessions", status: 1,
+            output: "no server running on /private/tmp/tmux-501/tbd-abc")
+        #expect(TmuxPresenceClassifier.serverPresence(for: error) == .absent)
+    }
+
+    @Test func serverProbeReadsConnectFailureAsAbsent() {
+        let error = TmuxError.commandFailed(
+            command: "tmux -L tbd-abc list-sessions", status: 1,
+            output: "error connecting to /private/tmp/tmux-501/tbd-abc (No such file or directory)")
+        #expect(TmuxPresenceClassifier.serverPresence(for: error) == .absent)
+    }
+
+    @Test func windowProbeReadsTmuxCantFindWindowAsAbsent() {
+        let error = TmuxError.commandFailed(
+            command: "tmux -L tbd-abc list-panes -t @7", status: 1,
+            output: "can't find window: @7")
+        #expect(TmuxPresenceClassifier.windowPresence(for: error) == .absent)
+    }
+
+    /// No server means positively no window on it. The reverse does not hold,
+    /// which is why the two marker lists are separate.
+    @Test func windowProbeInheritsServerAbsence() {
+        let error = TmuxError.commandFailed(
+            command: "tmux -L tbd-abc list-panes -t @7", status: 1,
+            output: "no server running on /private/tmp/tmux-501/tbd-abc")
+        #expect(TmuxPresenceClassifier.windowPresence(for: error) == .absent)
+    }
+
+    /// A server probe must NOT accept a window message as evidence about the
+    /// server — the server was plainly up to have said it.
+    @Test func serverProbeDoesNotAcceptWindowMessage() {
+        let error = TmuxError.commandFailed(
+            command: "tmux -L tbd-abc list-sessions", status: 1,
+            output: "can't find window: @7")
+        #expect(TmuxPresenceClassifier.serverPresence(for: error) == .unknown)
+    }
+
+    /// The regression this whole type exists for: the 15 s ceiling firing on a
+    /// busy machine is ignorance, and it used to be spelled `false`.
+    @Test func timeoutIsUnknownNotAbsent() {
+        let error = TmuxError.timedOut(
+            command: "tmux -L tbd-abc list-panes -t @7", timeout: .seconds(15))
+        #expect(TmuxPresenceClassifier.windowPresence(for: error) == .unknown)
+        #expect(TmuxPresenceClassifier.serverPresence(for: error) == .unknown)
+    }
+
+    @Test func missingTmuxExecutableIsUnknown() {
+        let error = TmuxError.commandFailed(
+            command: "tmux -L tbd-abc list-panes -t @7", status: 127,
+            output: "tmux executable is unavailable")
+        #expect(TmuxPresenceClassifier.windowPresence(for: error) == .unknown)
+    }
+
+    @Test func unrecognisedFailureIsUnknown() {
+        let error = TmuxError.commandFailed(
+            command: "tmux -L tbd-abc list-panes -t @7", status: 1,
+            output: "lost server")
+        #expect(TmuxPresenceClassifier.windowPresence(for: error) == .unknown)
+        #expect(TmuxPresenceClassifier.serverPresence(for: error) == .unknown)
+    }
+
+    @Test func unexpectedOutputIsUnknown() {
+        #expect(
+            TmuxPresenceClassifier.windowPresence(for: TmuxError.unexpectedOutput("???")) == .unknown)
+    }
+
+    // MARK: - Dry-run seams
+
+    /// Without a hook, dry-run keeps saying exactly what the `Bool` probes said
+    /// — alive server, alive window — so every fixture written before the
+    /// tri-state existed keeps its meaning.
+    @Test func dryRunDefaultsMatchTheBoolProbes() async {
+        let tmux = TmuxManager(dryRun: true)
+        #expect(await tmux.probeServer(server: "tbd-abc") == .alive)
+        #expect(await tmux.probeWindow(server: "tbd-abc", windowID: "@1") == .alive)
+        #expect(await tmux.serverExists(server: "tbd-abc"))
+        #expect(await tmux.windowExists(server: "tbd-abc", windowID: "@1"))
+    }
+
+    @Test func dryRunWindowIsDeadStillMeansAbsent() async {
+        let tmux = TmuxManager(dryRun: true, dryRunWindowIsDead: { $0 == "@2" })
+        #expect(await tmux.probeWindow(server: "tbd-abc", windowID: "@2") == .absent)
+        #expect(await tmux.probeWindow(server: "tbd-abc", windowID: "@1") == .alive)
+    }
+
+    @Test func dryRunPresenceHooksWin() async {
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunWindowIsDead: { _ in true },
+            dryRunServerPresence: { _ in .unknown },
+            dryRunWindowPresence: { _, _ in .unknown })
+        #expect(await tmux.probeServer(server: "tbd-abc") == .unknown)
+        #expect(await tmux.probeWindow(server: "tbd-abc", windowID: "@2") == .unknown)
+    }
+
+    @Test func realModeOverridesAnswerWithoutTmux() async {
+        let tmux = TmuxManager(
+            dryRun: false,
+            realModeServerPresenceOverride: { $0 == "tbd-abc" ? .unknown : nil },
+            realModeWindowPresenceOverride: { _, window in window == "@9" ? .absent : nil })
+        #expect(await tmux.probeServer(server: "tbd-abc") == .unknown)
+        #expect(await tmux.probeWindow(server: "tbd-abc", windowID: "@9") == .absent)
+    }
+}

--- a/docs/specs/2026-09-04-automatic-version-updates-design.md
+++ b/docs/specs/2026-09-04-automatic-version-updates-design.md
@@ -238,7 +238,16 @@ Sequence, with the app running throughout:
    successor instead **writes its own pid over the file first**, then sends
    the predecessor `SIGTERM`, then waits for the predecessor's pid to exit —
    polling, bounded at 30 s, then `SIGKILL` and one more wait. Only then
-   does it continue its normal start.
+   does it continue its normal start. A predecessor that outlives `SIGKILL`
+   aborts the start: the successor writes the predecessor's pid back into the
+   file (three attempts, 100 ms apart) and exits, and the result says whether
+   the write-back landed. A write-back that never lands is not a two-writer
+   hazard — `SIGKILL` cannot be caught, so a pid still present after it is in
+   an uninterruptible kernel wait, not serving, and the successor is exiting
+   too. The file then names a dead or dying pid, which is the ordinary
+   stale-pid case with an existing reconciler: `PIDFile.cleanupIfStale` at
+   the top of `Daemon.start()` removes it, and the app's poller starts a fresh
+   daemon from the installed bundle. Recovery is delayed, not corrupted.
 2. The predecessor's `stop()` runs as today, except it **removes the pid file
    only if the file still names its own pid** (compare-and-delete) and removes
    the port file the same way. Its socket unlinks are unchanged: the
@@ -274,6 +283,13 @@ the handover safe:
   consistent view; the second run un-parks anything the same boot parked
   whose pane demonstrably still runs Claude. The pass is cheap: it only
   examines parked rows.
+- Every other caller that mutates on a negative probe takes the tri-state
+  probe too, and treats `unknown` as a refusal to act: `terminal.recreateWindow`
+  (which parks and kills on absence) returns a retryable error and touches
+  nothing; the activity rail's tmux leg reports `unknown` so a close that
+  respects rails fails closed; and the wake path's recreate arm fails the wake
+  and leaves the row parked rather than kill a window it could not see.
+  Callers that only skip on a negative answer keep the `Bool` probes.
 
 Holder-transport sessions are unaffected: the predecessor's `releaseAll` and
 the successor's `adoptAll` already bracket a restart, and the handover

--- a/docs/specs/2026-09-04-automatic-version-updates-design.md
+++ b/docs/specs/2026-09-04-automatic-version-updates-design.md
@@ -1,0 +1,367 @@
+# Automatic version updates — design
+
+TBD is built from source and installed by `scripts/restart.sh`. Nothing tells
+an operator that the running daemon is behind `main`, and the only way to move
+forward is a restart that has, in the field, parked most of a live fleet. This
+spec adds three things: a **build identity** every binary can report, an
+**update check** that compares the running daemon with the latest commit on
+`main`, and an **update path** that builds the new version out of place and
+hands the fleet over to it without losing a session. The autonomous half
+ships behind a default-off setting.
+
+## 1. What is wrong today
+
+- **No binary knows what it is.** `TBDConstants.version` is the literal
+  `"0.1.0"` and has never changed. `daemon.status` reports it, `tbd --version`
+  prints it, nothing compares it to anything. The only identity that exists is
+  the daemon's executable *path*, which `DaemonBuildSkew` compares against the
+  app's expectation to show a banner. A daemon thirteen commits behind `main`
+  is indistinguishable from one at `main`.
+- **No source of "latest".** The repo has no tags and no release workflow.
+  Latest means the head of `main` on the upstream remote.
+- **Restart is the only update, and it is not fleet-safe.** `restart.sh` sends
+  the daemon `SIGTERM`, waits 0.5 s, deletes the pid and socket files, and
+  starts the new daemon from the worktree's `.build`. The new daemon's
+  startup reconcile probes every tmux window with a 15 s ceiling and treats a
+  timeout the same as an absent window: it parks the Claude rows under it
+  with `reason: .recovery` and **deletes** non-Claude rows and their tabs. On
+  a machine still digesting the build, a probe that is merely slow parks the
+  fleet. Field measurement: a 2026-09-02 restart parked 49 of 56 lane
+  sessions in one pass, all with the same `hibernatedAt`. The un-park repair
+  (`HibernationCoordinator.reconcileOnStartup`) runs *before* the parking
+  pass, so it cannot fix the parks the same boot creates.
+- **The launch environment is fragile.** The daemon inherits whatever
+  environment launched the app. When LaunchServices relaunches the app at
+  login it ignores the bundle's `LSEnvironment.PATH`; the daemon then runs
+  with `/usr/bin:/bin:/usr/sbin:/sbin` and every git operation that needs a
+  Homebrew tool fails (measured 2026-09-04: `git worktree add` in a git-lfs
+  repo). That fix is a separate bug-fix PR, but the update path must never
+  depend on the launcher's environment either.
+
+## 2. Goals and non-goals
+
+Goals:
+
+- Every TBD binary reports the commit it was built from, and the daemon's
+  `status` carries it.
+- `tbd version` shows CLI, daemon, and latest-known commits and says plainly
+  whether an update is available. The app shows a one-line notice.
+- `tbd update` moves the whole installation (daemon, app, CLI) to the latest
+  `main` with one command, building out of place and handing over without
+  parking live sessions. Where a session is nonetheless parked, the update
+  repairs it, paced.
+- An `auto` mode runs that same path unattended, default off, with a durable
+  log of what it did.
+- The pieces that encode policy — how often to check, how many sessions to
+  wake at once — live where an operator can edit them without a rebuild.
+
+Non-goals:
+
+- A release channel, tags, or signed downloadable builds. Latest is a commit.
+- Zero-downtime RPC. During the handover the socket is briefly absent, as it
+  is during any restart today; CLI calls in that window fail and retry as
+  they do now.
+- Rolling back. The previous build directory is kept on disk so an operator
+  can restart from it by hand; no automated rollback.
+- Changing how the pty holder transport survives restarts. It already does.
+
+## 3. Placement
+
+Per `docs/theory-placement.md`, compiled behavior is limited to facts,
+mechanisms, and invariants:
+
+- **Facts (compiled):** build identity; latest commit on `main` as last
+  observed; when it was observed; whether the running daemon is behind.
+- **Mechanisms (compiled):** the successor-first handover; reconcile probes
+  that distinguish *absent* from *unknown*; a post-reconcile un-park pass;
+  compare-and-delete of the pid file.
+- **Theories (authored, in `scripts/update.sh`):** the check interval's
+  default, the wake concurrency and stagger, whether the app is restarted,
+  which build configuration to install. All are constants at the top of the
+  script or flags on it.
+- **The one policy the daemon holds is the setting itself** — `off`,
+  `check`, or `auto` — because the timer that runs the check has to live in
+  a long-lived process, and the daemon is the only one TBD owns.
+
+## 4. Build identity
+
+A `BuildIdentity` value in `TBDShared`:
+
+- `commit` (full SHA), `shortCommit`, `branch` (may be `HEAD` for a detached
+  build), `builtAt` (ISO-8601), `sourceWorktree` (absolute path), `dirty`
+  (Bool), `origin` (how it was learned: `.stamp`, `.worktreeHead`).
+- Learned at process start, once, from **a JSON sidecar next to the
+  executable**: `TBDBuildIdentity.json` in the same directory as the resolved
+  binary, or in `Contents/` of the app bundle. The sidecar is written by the
+  build wrapper before the compiler runs (see §7), so its contents describe
+  the tree the binary came from. A build that bypassed the wrapper has no
+  sidecar; the loader then falls back to `git rev-parse HEAD` of the worktree
+  derived from the executable path (the parent of `.build`), marked
+  `.worktreeHead` so a consumer can tell it might be stale, and finally to
+  `nil`.
+- `daemon.status` gains an optional `buildIdentity` field. `tbd --version`
+  prints `0.1.0 (<shortCommit>)` when known. The CLI installed into
+  `~/.local/bin` is a hard link and has no sidecar; it reports the fallback
+  or nothing, which is acceptable — the daemon's identity is the one that
+  matters.
+
+Why a sidecar and not a generated Swift file: a generated source file makes
+every commit a rebuild of `TBDShared` and everything above it; a sidecar
+changes nothing in the compile graph. Why not `Bundle.module` resources: the
+daemon and CLI run from places where the resource bundle is not next to them,
+and `Bundle.module` traps when the bundle is missing.
+
+## 5. Update check
+
+A daemon actor `UpdateChecker` (new file under `Sources/TBDDaemon/Update/`,
+injected clock per the repo rule):
+
+- Runs only when `update_mode` is `check` or `auto`. Reads the setting on
+  each tick so `tbd config set` takes effect without a restart.
+- A tick runs `git ls-remote <url> refs/heads/main` where `<url>` is the
+  `upstream` remote of the daemon's source worktree, else `origin`, else
+  the setting is unusable and the checker logs once and idles. `ls-remote`
+  moves no objects and writes nothing to any worktree.
+- Result is held in memory as `UpdateStatus { latestCommit, observedAt,
+  relation }` with `relation` one of `upToDate`, `behind`, `unknown`.
+  `behind` is "latest differs from ours and ours is not ahead of it";
+  ahead-ness is decided by `git merge-base --is-ancestor` in the source
+  worktree when the latest commit is present locally, otherwise the relation
+  is `behind` with `behindBy == nil`. When the update clone (§7) exists and
+  has fetched, `behindBy` is `rev-list --count` there.
+- Exposed as an optional `update` field on `daemon.status`, and by
+  `tbd version` (which prints the cached status, or runs one check
+  synchronously with `--check`).
+- Interval: the daemon uses a constant (one hour) unless the environment
+  variable `TBD_UPDATE_CHECK_INTERVAL` overrides it; the script's `--auto`
+  path does not depend on the interval.
+- In `auto` mode, when the relation is `behind` and the latest commit is
+  not one the checker has already attempted, it launches
+  `<sourceWorktree>/scripts/update.sh --auto` detached (own session, stdout
+  and stderr to `~/tbd/updates/update.log`) and records the attempted commit.
+  A failed attempt is not retried until `main` moves; a manual `tbd update`
+  always runs. Nothing else in the daemon acts on an update.
+
+## 6. The setting
+
+A config column `update_mode`, added by a timestamped SQL migration
+(`Sources/TBDDaemon/Database/Migrations/<stamp>_config_update_mode.sql`;
+the numbered Swift block is frozen). The column is `TEXT` with **no
+`DEFAULT` clause**, in the house tri-state style: a pre-migration row reads
+`NULL` ("never chose") and resolves through the single constant
+`Config.updateModeDefault`, which is `.off`. Graduation later edits that one
+constant and nothing else, and a deliberate opt-in stays distinguishable from
+the backfilled value.
+
+The value decodes to `enum UpdateMode: String, Codable, Sendable { off,
+check, auto }` in `TBDShared`. The GRDB `ConfigRecord` field is `String?`,
+resolved in `toModel()` with an injected default so tests drive both values;
+an unrecognised string resolves to the default and is logged once. The shared
+`Config` model, the record, and the migration change in one commit.
+
+Surfaces: `tbd config get` prints it; `tbd config set update-mode
+<off|check|auto>` writes it through a `config.setUpdateMode` RPC that writes
+the column on every call; the app's Settings shows a three-way picker fed
+from `daemon.capabilities` (which gains `updateMode`) and writes through the
+same RPC. The checker reads the setting on each tick, so no `*Live` twin is
+needed: a change takes effect at the next tick without a restart.
+
+Default-off satisfies the "large or risky behavior" rule: with the default,
+the daemon runs no timer and spawns nothing. `check` is a read-only network
+call. `auto` is the only branch that acts.
+
+## 7. The update path (`scripts/update.sh`, `tbd update`)
+
+`tbd update` is a thin CLI command: it asks the daemon for its source
+worktree, execs `<sourceWorktree>/scripts/update.sh` with the user's
+arguments, and inherits the user's environment. The script is the procedure:
+
+1. **Locate or create the update clone** at `~/tbd/updates/src`
+   (`TBDConstants.updatesDir`, honors `TBD_HOME`). A dedicated clone, not a
+   worktree of the operator's checkout: it must not appear in anyone's
+   `git worktree list`, must not be reaped by `reclaim-build.sh` (which
+   scans TBD worktrees and `.claude/worktrees`, never `~/tbd/updates`), and
+   must be safe to `checkout --detach` at any time. Its `origin` is the
+   upstream URL resolved as in §5.
+2. **Fetch and check out** `origin/main` detached. If the fetched
+   `scripts/update.sh` differs from the running copy, re-exec the fetched one
+   with the same arguments (guarded by an environment marker so it happens
+   once). This is how the procedure itself updates.
+3. **Stamp** `TBDBuildIdentity.json` into `.build/<config>/` (commit, branch,
+   time, worktree, dirty) and **build** `TBDDaemon`, `TBDApp`, and `tbd`
+   with `scripts/swift-safe build -c release --product …`, the same module
+   cache flags as `restart.sh`. A failed build stops here; the running
+   installation is untouched.
+4. **Assemble, sign, and install** the app bundle to `/Applications/TBD.app`
+   exactly as `restart.sh` does today. That code moves out of `restart.sh`
+   into `scripts/restart-bundle-lib.sh` so the two scripts share it; the
+   sidecar is copied into `Contents/`, next to `SourceWorktreePath.txt`,
+   which now points at the update clone.
+5. **Hand over** (§8): start the new daemon with
+   `TBD_HANDOVER_FROM_PID=<old pid>` and wait until `tbd daemon status`
+   reports the new executable path and build identity, bounded at 120 s.
+6. **Restart the app** — kill the exact installed executable path, `open`
+   the bundle with `--env PATH=$PATH` as `restart.sh` does. `--no-app` skips
+   this. The app is a viewer; nothing in it holds a session.
+7. **Repair parks.** List terminals; every row parked with
+   `hibernateReason == recovery` and `hibernatedAt` after the handover began
+   is a candidate. The daemon's own post-reconcile pass (§8) has already
+   un-parked those whose pane still runs Claude; what remains are sessions
+   whose process is genuinely gone. The script wakes them with
+   `tbd terminal wake`, `WAKE_CONCURRENCY` at a time (default 3, the
+   app's `wakeAllBatchSize`), `WAKE_STAGGER_SECONDS` apart (default 2),
+   because N simultaneous `claude --resume` respawns have taken the machine
+   down before (#284, #367). `--no-wake` skips this; `--wake-only` runs only
+   this step against a daemon that is already new.
+8. **Log** every step with a timestamp to `~/tbd/updates/update.log` and
+   print a summary: old commit, new commit, commits advanced, sessions
+   un-parked by the daemon, sessions woken by the script, sessions it could
+   not wake and why.
+
+`--check` prints the same comparison as `tbd version --check` and exits.
+`--dry-run` does everything up to the build without installing or handing
+over. `--debug` builds the debug configuration. `--auto` is what the daemon
+passes: non-interactive, and it refuses to run if another update is in
+flight (a lock file under `~/tbd/updates/`).
+
+The script is written to the same conventions as `restart.sh` and gets a
+`scripts/update.test.sh` covering argument handling, the self-re-exec guard,
+the wake-candidate filter, and the batching, against a fake `tbd`.
+
+## 8. Handover
+
+Sequence, with the app running throughout:
+
+1. The successor starts with `TBD_HANDOVER_FROM_PID` set. Its
+   single-instance gate finds the pid file naming a live `TBDDaemon`. Today
+   that exits. In handover mode, when the live pid equals the variable, the
+   successor instead **writes its own pid over the file first**, then sends
+   the predecessor `SIGTERM`, then waits for the predecessor's pid to exit —
+   polling, bounded at 30 s, then `SIGKILL` and one more wait. Only then
+   does it continue its normal start.
+2. The predecessor's `stop()` runs as today, except it **removes the pid file
+   only if the file still names its own pid** (compare-and-delete) and removes
+   the port file the same way. Its socket unlinks are unchanged: the
+   successor has not bound yet, so there is nothing to protect.
+3. The successor binds the sockets and serves.
+
+Why successor-first: the app polls every two seconds and spawns a daemon the
+moment the socket is missing *and* the pid file does not name a live daemon.
+With the successor's pid in the file from the first instant, every spurious
+spawn — the app's, or a stray `restart.sh` — exits at the gate. This closes
+the race that a plain kill-then-start opens, and it needs no new RPC.
+
+Why not overlap (successor serving while the predecessor drains): two daemons
+would be two writers on `state.db` and two reconcilers with different
+opinions. The brief socket gap is the price of a single writer, and it is the
+same gap every restart has today.
+
+Reconcile hardening, which applies to every daemon start and is what makes
+the handover safe:
+
+- `TmuxManager` gains tri-state probes: `probeServer` and `probeWindow`
+  return `alive`, `absent`, or `unknown`. `absent` requires tmux to have
+  answered (exit status from a live server saying no such window or server);
+  a timeout, a spawn failure, or an unparseable answer is `unknown`. The
+  existing `Bool` probes stay for their other callers.
+- `reconcileTerminalsWhileLocked` acts only on `absent`. On `unknown` it logs
+  the terminal and moves on, leaving the row live. A wedged tmux therefore
+  parks nothing; an operator can still park by hand. The delete arm for
+  non-Claude rows likewise fires only on `absent`.
+- After `performStartupReconciliation`, the daemon runs
+  `hibernationCoordinator.reconcileOnStartup()` a second time. The first
+  run still precedes reconcile so shared scratch servers are reaped from a
+  consistent view; the second run un-parks anything the same boot parked
+  whose pane demonstrably still runs Claude. The pass is cheap: it only
+  examines parked rows.
+
+Holder-transport sessions are unaffected: the predecessor's `releaseAll` and
+the successor's `adoptAll` already bracket a restart, and the handover
+shortens the gap between them rather than lengthening it.
+
+## 9. Surfaces
+
+- `tbd version` — CLI commit, daemon commit and executable path, latest
+  known commit and when it was observed, relation, and one line: `Update
+  available: <short> → <short> (N commits behind). Run: tbd update`, or
+  `Up to date`, or `Unknown — run tbd version --check`.
+- `tbd daemon status` — gains `buildIdentity` and `update` in JSON; the
+  text form adds `Build:` and `Update:` lines.
+- App — a one-line notice in the same place as the daemon-build-skew banner,
+  from the same `daemon.status` response, dismissible per commit.
+- `tbd config get|set update-mode`.
+- `docs/updating.md` — the operator-facing page: what `tbd update` does,
+  what happens to running sessions, the modes, the log, and how to restart
+  from the previous build by hand.
+
+## 10. Testing
+
+- `BuildIdentity` loader: sidecar present; sidecar absent with a git
+  worktree derivable from the path; neither.
+- `UpdateStatus` relation: equal commits, local ahead, local behind with and
+  without a count, unknown latest.
+- `UpdateChecker` with an injected clock: `off` runs nothing; `check`
+  ticks and never launches; `auto` launches once per latest commit and not
+  again for the same commit; setting changes take effect on the next tick.
+- Handover gate: pid file names the handover pid — successor claims the file
+  and signals; pid file names a different live daemon — successor exits as
+  before; pid file stale — normal path.
+- `PIDFile` compare-and-delete: removes when it names our pid; leaves a
+  file naming another pid.
+- Tri-state probes and reconcile: `unknown` leaves rows live and deletes
+  nothing; `absent` parks and deletes as before; the second un-park pass
+  clears a park made by the same boot.
+- A schema suite under `Tests/TBDDaemonTests/Config/` in the shape of
+  `RemoteDeleteFlagTests`: the column reads `NULL` before any gesture,
+  migrating only to the identifier before it reproduces the old schema, and
+  resolution is asserted against both default values. The migration passes
+  `scripts/lint-migrations.py`. Both branches of `update_mode` wherever
+  behavior forks.
+- `scripts/update.test.sh` as in §7.
+
+## 11. Rollout
+
+- Ships default-off. The first run is manual: `tbd update` from a login
+  shell. Its summary reports what it did to running sessions.
+- Soak in `check` for the notice, then `auto` for one operator, then
+  consider flipping the default to `check` (a forcing `UPDATE` migration,
+  because the column default backfills).
+- The PATH bug fix is a prerequisite for `auto` on this machine only in the
+  sense that a daemon with a bare PATH cannot build; the new daemon carries
+  its own PATH fallbacks, and the script runs under the invoking shell.
+
+## 12. Rejected alternatives
+
+- **A `daemon.restart` RPC that execs the new binary in place.** Loses the
+  successor-first pid claim, cannot change the environment of the new
+  process without a wrapper anyway, and puts the update procedure into
+  compiled code where every change to it is a rebuild.
+- **Building in the operator's worktree.** The worktree may be on a feature
+  branch, dirty, or mid-build; `restart.sh` already refuses to install from
+  such a tree. A dedicated clone is always on `main`.
+- **Overlapping daemons with a retire handshake.** Shorter socket gap, but
+  two `state.db` writers and two reconcilers during the overlap. Not worth
+  the gap it saves.
+- **Treating a probe timeout as "gone" but retrying later.** A retry does
+  not undo a deleted tab. The row must not be touched on ambiguous evidence
+  in the first place — the same conclusion as the bounded terminal recovery
+  design.
+- **A generated Swift source for the commit.** Rebuilds `TBDShared` on every
+  commit and every worktree switch.
+- **Version numbers.** Nothing produces them; a commit is what an operator
+  can look up.
+
+## 13. Decisions taken from the request, and what remains open
+
+The request (relayed 2026-09-04) fixed: opt-in and default-off; out-of-place
+build; hand over without killing sessions where the architecture allows,
+paced wake otherwise; never lose a session's prompt or state; a clear log;
+`tbd version` and an app notice; tests and a doc section. The following were
+decided here and should be confirmed by a human before `auto` is enabled
+anywhere:
+
+- Latest means the head of `main` on the `upstream` remote, else `origin`.
+- The update clone lives at `~/tbd/updates/src` and builds release.
+- The check interval defaults to one hour.
+- `auto` restarts the app as well as the daemon.
+- Wake concurrency 3 and stagger 2 s are script constants, not settings.


### PR DESCRIPTION
## The problem, measured

A daemon restart runs `reconcileTerminalsWhileLocked`, which probes every tmux
window with a 15 s ceiling and then parks the Claude-resumable rows whose window
it believes is gone and **deletes** the rest along with their tabs. `windowExists`
and `serverExists` swallow every failure — including `TmuxError.timedOut` — into
`false`, so "the machine is busy" and "the window is gone" are the same answer.

On 2026-09-02 a restart of a loaded machine parked **49 of 56 live lane sessions
in one pass**, every row carrying the same `hibernatedAt`. Nothing was gone. The
repair pass, `HibernationCoordinator.reconcileOnStartup`, runs *before* the
parking pass, so it could not undo any of it.

Separately, there is no safe way for a new daemon to replace a running one. The
single-instance gate exits when the pid file names a live `TBDDaemon`, so an
update has to kill first and start second — and in that gap the app, which polls
every two seconds, spawns a daemon of its own.

## What this changes

**1. Tri-state tmux probes.** `TmuxPresence` (`alive` / `absent` / `unknown`)
plus `TmuxManager.probeServer` and `probeWindow`. `absent` requires tmux itself
to have answered on a non-zero exit with one of its own messages ("no server
running on", "can't find window", "no such window"…); a timeout, a spawn
failure, a 127, or an unrecognised message is `unknown`. The classifier is a
whitelist on purpose, so a tmux release that renames a message degrades to
"leave the row alone".

The whitelist is of meanings rather than prefixes, because tmux reuses one
phrasing for a whole family of socket errors. It prints "no server running on"
only for `ECONNREFUSED` and falls back to "error connecting to <socket>
(<errno>)" for everything else, so that prefix is read together with the errno
text: `No such file or directory` is absence, because the socket file itself is
not there, while `Permission denied` is a server we cannot reach and stays
`unknown`. The existing `Bool` probes and their seams
are untouched for their other callers; the new probes get matching dry-run and
real-mode override seams.

**2. Reconcile acts only on positive evidence, in both places that judge tmux.**
In the terminal sweep, an `unknown` server skips its whole worktree and an
`unknown` window skips that row. Both log at `.warning` with the worktree,
terminal, server and window. Neither parks nor deletes. `alive` and `absent`
behave exactly as before, and an `absent` server still short-cuts the window
probe because a server that is gone has positively no windows on it.

The stale-server self-heal needed the same treatment, and hardening the sweep
alone would have left a route straight around it. `hasLiveWindow` decides
whether to rewrite a worktree's non-canonical `tmuxServer` to the canonical one,
and it still used the `Bool` probes: a timeout read as "no live window", the row
was re-pointed at the canonical server, and the sweep then probed windows on a
server that genuinely does not have them. Its `absent` is honest, so the sweep's
new `unknown` guard never fires and the rows are destroyed on evidence
manufactured one pass earlier. It is now `liveWindowPresence`, returning `alive`
on the first affirmative window, `unknown` if any probe failed to answer, and
`absent` only when every probe answered no. Rows with no tmux coordinate at all
(holder-backed, `tmuxWindowID == ""`) are skipped rather than probed, since they
are evidence in neither direction and probing `""` would freeze the self-heal.

**Every other `serverExists`/`windowExists` call was surveyed. Three of them
acted on a `false`, and all three now take the tri-state probe.** Each shared
the sweep's defect — a timeout read as evidence of absence, gating a mutation —
at a smaller scope:

- `handleTerminalRecreateWindow`, the Claude-resumable arm: on `false` it parked
  the row and then `killWindow`ed it, on a user's own gesture. It now switches on
  `probeWindow`: `alive` still short-circuits the stale request, `absent` still
  parks and kills, and `unknown` returns
  `unansweredWindowProbeRefusal` with the row and window untouched, recorded as
  `.transportFailed` in the actuation log. The locked closure returns a
  `RecreateReparkOutcome` (`parked` / `windowAlive` / `probeUnanswered`) instead
  of a `didPark` flag, so the two non-parking answers cannot be confused.
- `sessionLivenessForActivityRails`, the tmux leg: it collapsed the `Bool` probe
  onto `.running`/`.stopped` although `ActivityRailLiveness` already carries
  `.unknown` for this and the holder leg already returns it. Only an observed
  stop may lift the rail, so a timed-out probe let `tbd terminal close` (rails
  on by default) delete a mid-turn session. It now maps `unknown` through, and
  the rail fails closed.
- `HibernationCoordinator.wake`, the recreate arm: it `killWindow`s the old
  window once the replacement exists, and its own comment named "a transient
  windowExists misclassification" as the thing that must not leak a live
  window. It now probes tri-state; `unknown` fails the wake with a retryable
  `respawnFailed` and leaves the row parked. A server that is genuinely gone
  (the reboot case this arm exists for) still answers `absent`.

The remaining callers do not mutate on `false`, so a timeout there fails in
the safe direction and they are left alone:

- The server-reaping pass in the same file skips on `false` and only kills a
  server on `true`.
- `HibernationCoordinator`'s park eligibility check refuses to park.
- `reconcileOnStartup` skips a repair, which the second pass retries; un-parking
  already requires affirmative evidence, so converting it would change nothing.
- `LimitResumeActuator` and `DeskSessionManager` skip a candidate.
- `PreSession`'s poll returns `.paneKilled` for a pane created seconds earlier
  by the same call, which only sends a notification and continues.

**3. A second un-park pass.** `Daemon.start()` now calls
`hibernationCoordinator.reconcileOnStartup()` again after
`performStartupReconciliation` (step 8d-ii), keeping the first call where it is.
The first has to precede reconcile so the destructive scratch-server reaping
works from a consistent view, which is also why it cannot repair a park the same
boot creates. The second can. It only examines parked rows, so it is cheap.

**4. Successor-first handover.**

- `PIDFile.removeIfOwned()` compare-and-deletes: it removes the file only when
  the file still names the calling process. `Daemon.stop()` uses it, and removes
  the port file only when the pid file was still ours. The port file holds a
  port, not a pid, so it cannot answer "is this mine?" on its own; the pid file
  is its proxy, since one daemon writes and removes both. During a handover that
  leaves a briefly stale port file until the successor binds and overwrites it,
  which is the cheaper failure than racing the successor's own write.
- `HandoverDecision.decide(pidFileContents:handoverEnv:isLiveDaemon:)` is a pure
  three-branch helper: `.normal` when no live daemon owns the file, `.takeOver`
  when the live pid equals `TBD_HANDOVER_FROM_PID`, `.refuse` for any other live
  daemon (today's `exit(1)`). Only an explicit, positive, matching pid that is
  itself a live daemon can displace one.
- On `.takeOver`, `Daemon.start()` writes **its own pid file first**, then
  `DaemonHandover.retire` sends `SIGTERM`, polls every 100 ms for up to 30 s,
  escalates to `SIGKILL` and waits 5 s more. Each step logs at `.info` with
  `privacy: .public`. Claiming the file first is the whole point: with the
  successor's pid there from the first instant, every spurious spawn in the gap
  — the app's poller, a stray `restart.sh` — exits at the same gate.
- A predecessor that survives `SIGKILL` aborts the startup. Nothing downstream
  was a backstop: the socket bind is hundreds of lines past step 8d, so the
  successor would already have run a second reconciler against `state.db`. It
  now writes the **predecessor's** pid back into the file and exits, returning
  the world to the state it found — a file naming a dead process would read to
  the app's poller as "no daemon" and have it spawn one against a predecessor
  that is still serving. The write-back is retried (three attempts, 100 ms
  apart, on the injected clock) because it is a whole-file replace that a
  transient I/O error can lose, and its outcome is carried in the result
  (`.predecessorSurvived(claimRestored:)`) rather than only logged, so
  `Daemon.start()` logs the stranded file at `.error` and a test can assert it.
  **A write-back that never lands is not a two-writer hazard, and the orphan it
  leaves has a named reconciler.** `SIGKILL` cannot be caught, blocked or
  ignored, so a pid still present five seconds after it is in an uninterruptible
  kernel wait, not serving RPCs — and this process is about to exit. The worst
  case is therefore a pid file naming a dead or dying pid, which is the ordinary
  stale-pid case the system already reconciles: `PIDFile.cleanupIfStale` at the
  top of `Daemon.start()` removes a file whose pid is not a live `TBDDaemon`,
  and the app's poller (`startDaemonAndConnect`) spawns a fresh daemon from the
  installed bundle whenever the pid file names no live daemon. The cost of the
  failure is a delayed recovery, not a corrupted one.
- After a successful retirement the successor writes its pid **a second time**.
  See "the first update from an older daemon" below for why.

## The first update from an older daemon

The very first update on any machine hands over from a daemon that predates this
PR, and those daemons end `stop()` with an unconditional `pidFile.remove()`. So
the successor claims the file, sends `SIGTERM`, and the predecessor deletes the
successor's claim on its way out. What follows is exactly the failure the claim
exists to prevent: no socket and no live pid, so the app's two-second poller
spawns a daemon, it passes the gate because nothing owns the file, and there are
two successors.

The take-over therefore re-asserts the claim once the predecessor is gone. For a
predecessor carrying `removeIfOwned` the file already names us and the write
changes nothing, which is what makes it safe to do unconditionally rather than
try to detect the predecessor's vintage. A third daemon could in principle claim
the file between the predecessor's unlink and this write; that window is one
retirement poll interval against the app's two-second poll, and strictly
narrower than the one the write closes.

The three-step sequence moved out of `Daemon.start()` into `HandoverClaim` so it
is reachable from a test. It previously sat between the single-instance gate and
the socket bind, hundreds of lines apart, and could only be exercised by hand.
- `TBD_HANDOVER_FROM_PID` is added to `scrubInheritedTBDEnv()`, which runs
  several steps *after* the gate reads it. A tmux server bakes its spawn
  environment into every window it creates, so a stale handover pid must not
  survive into a pane.

## How `scripts/update.sh` will use `TBD_HANDOVER_FROM_PID`

The update script (spec §7, not in this PR) builds the new daemon out of place
into `~/tbd/updates/src`, installs the bundle, then launches the successor with
`TBD_HANDOVER_FROM_PID=<pid of the running daemon>` and waits for
`tbd daemon status` to report the new executable. The variable is honoured only
when the pid file names a *live* `TBDDaemon` with exactly that pid.

**The script always exports the variable, and exports `0` when no daemon is
running**, so it never has to branch on whether to set it. `0` is therefore a
first-class value meaning "nobody to hand over from", and unset, empty,
whitespace, `0`, a negative number and a non-number are all one statement: no
take-over. What follows is the ordinary single-instance gate, which starts when
the pid file is free and exits when a live daemon owns it. A handover aimed at a
daemon that died before the successor launched lands on the normal path, because
`PIDFile.cleanupIfStale` has already removed the stale file by the time the gate
runs. The contract is documented on `handoverFromPIDEnvVar`.

## Tests

New suites, and both branches of every new conditional:

- `TmuxPresenceTests` — the classifier (`absent` for each tmux message, server
  probe refusing a window message as evidence, `unknown` for a timeout, a 127,
  an unrecognised failure and `unexpectedOutput`), the socket-errno split
  (ENOENT is `absent`; `Permission denied`, `Connection reset by peer` and
  `Operation timed out` are `unknown` from both probes), and the dry-run /
  real-mode seams, including that a dry-run with no hook still answers what the
  `Bool` probes answered.
- `ReconcileTmuxPresenceTests` — for the terminal sweep: unknown server leaves
  both rows untouched; unknown window leaves both rows untouched; `absent` still
  parks the resumable Claude row with `reason: .recovery` and deletes the shell
  row; an absent server acts without probing a window; and the second un-park
  pass clears a park the reconcile pass just made. Each test carries one row of
  each kind, so a guard placed inside either arm of the park/delete fork fails.
  For the self-heal: unknown server and unknown window each leave the row's
  server name alone, a live window keeps the inherited name (the
  promoted-scratch case), and `absent` — window or server — still canonicalizes.
- `DaemonHandoverTests` — the decision helper's three branches (including a
  trailing newline on the variable and a mismatched pid); every no-predecessor
  value (`0`, whitespace-padded `0`, negative, empty, whitespace, unparsable,
  unset) asserted against both a free pid file and a live daemon; a handover pid
  that is no longer a live daemon; `retire` on an `EventDrivenTestClock`:
  already gone, exits inside the `SIGTERM` budget, dies only to `SIGKILL`, never
  exits at all; and the `HandoverClaim` choreography against a real temp pid
  file — an older predecessor that deletes the file on exit still leaves our
  claim standing, a newer one that leaves it alone ends in the same state, and
  one that survives `SIGKILL` gets its own claim handed back with no re-assert.
  The signal-sending and liveness closures are injected.
- `PIDFileStaleTests` — `removeIfOwned` removes our own file, leaves a
  successor's pid file intact and unrewritten, and no-ops on a missing file;
  `write(pid:)` can restore another process's claim.
- `RecreateWindowProbeTests` — `terminal.recreateWindow` against each probe
  answer, fingerprinting every column the park arm touches: `unknown` refuses
  with `unansweredWindowProbeRefusal`, mutates nothing and issues no
  `kill-window`; `absent` still parks, keeps the session identity and kills the
  dead pane; `alive` succeeds and touches nothing.
- `TerminalCloseRailsTests.railsOnRefusesWhenLivenessIsUnknown` — a mid-turn
  row whose window probe went unanswered is refused with `terminalBusy` and
  survives, alongside the existing dead-window case that still lifts the rail.
- `HibernationCoordinatorTests.wakeRefusesToRecreateWhenTheWindowProbeGoesUnanswered`
  — an `unknown` probe on the recreate arm fails the wake with a retryable
  reason, leaves the row parked and issues no `kill-window`.
- `DaemonHandoverTests` write-back cases, on an injected `writeClaim` that fails
  on named calls: two failures then a success still restores the claim
  (`claimRestored: true`, writes `[777, 4242]`); three failures report
  `claimRestored: false` with only the opening claim written.

`Daemon.start()` itself binds listeners and cannot be driven from a unit test,
so the double un-park is asserted at the coordinator seam and the call site is
cited in the test.

```
Test run with 4986 tests in 439 suites passed after 97.775 seconds with 71 known issues.   (--filter TBDDaemonTests, at 6cd96d63)
```

`scripts/swift-safe build` clean. `swiftlint --strict`: 0 violations in 927 files.

Design spec: `docs/specs/2026-09-04-automatic-version-updates-design.md` §8,
committed here so the PR references it.

No flag: this is a bug fix that makes an existing destructive path require
positive evidence, plus a gate that opens only for an explicit environment
variable that nothing sets yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SwPTd69A1awTHB2TA3suCC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added successor-first daemon handover for safer restarts and upgrades.
  * Added startup repair that restores newly recovered Claude sessions.
  * Added ownership-aware PID-file cleanup during shutdown.

* **Bug Fixes**
  * Improved tmux detection by distinguishing active, absent, and uncertain states.
  * Prevented terminal changes, recreation, or closure when tmux status cannot be confirmed.
  * Preserved predecessor and successor daemon state during handover cleanup.

* **Documentation**
  * Added a design specification for configurable automatic version updates and rollout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
