### PR TITLE
Fix: Stop a dying daemon from unlinking a live successor daemon's socket

### DIFF
--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -2970,12 +2970,24 @@ final class AppState {
             // The socket file is deliberately left where it is. Clearing the
             // rendezvous path is the job of whoever is about to bind it, and
             // the daemon spawned below does exactly that in its own
-            // `SocketServer.start()` — so removing it here adds nothing when
-            // the pid file really is stale, and deletes a live daemon's socket
-            // when it is stale only because a successor has already bound and
-            // has not rewritten the pid file yet. That successor would keep
-            // accepting on a listener no client can reach, with nothing to
-            // restore the path if the spawn below then fails.
+            // `SocketServer.start()`.
+            //
+            // What removing it here can cost is a live daemon's rendezvous:
+            // the pid file reads as stale for as long as a successor has bound
+            // the socket without having rewritten the pid file yet, and
+            // deleting the socket there leaves that successor accepting on a
+            // listener no client can reach.
+            //
+            // What it buys, against that, is bounded. It is not true that the
+            // bind below always eventually runs: this method returns early
+            // when no TBDDaemon binary is found and when `process.run()`
+            // throws, and even on the spawned path `Daemon.start()` can throw
+            // between its own pid-file cleanup and the socket bind hundreds of
+            // lines later. So a stale socket file can outlive this branch. It
+            // is left anyway, because an unbound socket file behaves to a
+            // client exactly like a missing one — `connect(2)` fails either
+            // way — while an unlinked live one silently strands a working
+            // daemon.
             logger.warning("""
             Stale daemon pid file: pid \(pid, privacy: .public) is not a live \
             TBDDaemon — removing the pid file before spawning

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -2963,15 +2963,24 @@ final class AppState {
                 await connectAndLoadInitialState()
                 return
             }
-            // Stale artifacts — dead pid, or pid recycled by another process
-            // (e.g. after a reboot). Remove them so the spawn below starts
-            // from a clean slate instead of tripping over a dead socket.
+            // Stale pid file — dead pid, or pid recycled by another process
+            // (e.g. after a reboot). Remove it so the spawn below starts from
+            // a clean slate.
+            //
+            // The socket file is deliberately left where it is. Clearing the
+            // rendezvous path is the job of whoever is about to bind it, and
+            // the daemon spawned below does exactly that in its own
+            // `SocketServer.start()` — so removing it here adds nothing when
+            // the pid file really is stale, and deletes a live daemon's socket
+            // when it is stale only because a successor has already bound and
+            // has not rewritten the pid file yet. That successor would keep
+            // accepting on a listener no client can reach, with nothing to
+            // restore the path if the spawn below then fails.
             logger.warning("""
             Stale daemon pid file: pid \(pid, privacy: .public) is not a live \
-            TBDDaemon — removing pid file and socket before spawning
+            TBDDaemon — removing the pid file before spawning
             """)
             try? FileManager.default.removeItem(atPath: pidPath)
-            try? FileManager.default.removeItem(atPath: TBDConstants.socketPath)
         }
 
         // Find TBDDaemon binary using sibling and source-worktree candidates

--- a/Sources/TBDDaemon/PIDFile.swift
+++ b/Sources/TBDDaemon/PIDFile.swift
@@ -62,10 +62,27 @@ public struct PIDFile: Sendable {
         return true
     }
 
+    /// Remove a stale pid file. **The socket file is deliberately left alone.**
+    ///
+    /// Removing it here buys nothing: the only thing that needs the rendezvous
+    /// path free is `bind(2)`, and `SocketServer.start()` clears the path
+    /// itself immediately before binding — on every path that gets that far,
+    /// including this one.
+    ///
+    /// What it can cost is a live daemon's rendezvous. A pid file reads as
+    /// stale whenever the pid it names is not a live `TBDDaemon`, and a
+    /// successor daemon writes its pid file (step 4 of `Daemon.start()`) well
+    /// before it binds the socket, so "stale pid, live socket" is a state the
+    /// path really passes through. Deleting the socket there leaves the
+    /// successor accepting on a listener no client can reach, and nothing
+    /// restores the path until this daemon reaches its own bind — the whole of
+    /// a startup later, or never, if that startup throws first.
+    ///
+    /// Clearing the rendezvous path is the act of whoever is about to bind it,
+    /// and of nobody else. See `SocketServer.unlinkSocketFile(ifStillIdentity:)`.
     public func cleanupIfStale() {
         if isStale() {
             remove()
-            try? FileManager.default.removeItem(atPath: TBDConstants.socketPath)
         }
     }
 }

--- a/Sources/TBDDaemon/PIDFile.swift
+++ b/Sources/TBDDaemon/PIDFile.swift
@@ -64,22 +64,26 @@ public struct PIDFile: Sendable {
 
     /// Remove a stale pid file. **The socket file is deliberately left alone.**
     ///
-    /// Removing it here buys nothing: the only thing that needs the rendezvous
-    /// path free is `bind(2)`, and `SocketServer.start()` clears the path
-    /// itself immediately before binding — on every path that gets that far,
-    /// including this one.
-    ///
-    /// What it can cost is a live daemon's rendezvous. A pid file reads as
-    /// stale whenever the pid it names is not a live `TBDDaemon`, and a
-    /// successor daemon writes its pid file (step 4 of `Daemon.start()`) well
+    /// What removing it here can cost is a live daemon's rendezvous. A pid file
+    /// reads as stale whenever the pid it names is not a live `TBDDaemon`, and
+    /// a successor daemon writes its pid file (step 4 of `Daemon.start()`) well
     /// before it binds the socket, so "stale pid, live socket" is a state the
     /// path really passes through. Deleting the socket there leaves the
-    /// successor accepting on a listener no client can reach, and nothing
-    /// restores the path until this daemon reaches its own bind — the whole of
-    /// a startup later, or never, if that startup throws first.
+    /// successor accepting on a listener no client can reach.
     ///
-    /// Clearing the rendezvous path is the act of whoever is about to bind it,
-    /// and of nobody else. See `SocketServer.unlinkSocketFile(ifStillIdentity:)`.
+    /// What it buys, against that, is bounded. The only thing that needs the
+    /// rendezvous path free is `bind(2)`, and `SocketServer.start()` clears the
+    /// path itself immediately before binding — but this runs at step 2 of
+    /// `Daemon.start()` and that bind is hundreds of lines later, with plenty
+    /// of `throw`s in between, so it is not true that the bind always
+    /// eventually runs. A startup that fails first can leave a stale socket
+    /// file behind.
+    ///
+    /// It is left anyway, because an unbound socket file behaves to a client
+    /// exactly like a missing one — `connect(2)` fails either way — while an
+    /// unlinked live one silently strands a working daemon. Clearing the
+    /// rendezvous path is the act of whoever is about to bind it, and of
+    /// nobody else. See `SocketServer.unlinkSocketFile(ifStillIdentity:)`.
     public func cleanupIfStale() {
         if isStale() {
             remove()

--- a/Sources/TBDDaemon/Server/HTTPServer.swift
+++ b/Sources/TBDDaemon/Server/HTTPServer.swift
@@ -18,6 +18,13 @@ public final class HTTPServer: Sendable {
     private let group: MultiThreadedEventLoopGroup
     private nonisolated(unsafe) var channel: Channel?
 
+    /// Keeps the shutdown to one run, however many `stop()` calls arrive.
+    /// `Daemon.stop()` is not deduplicated and this server is torn down right
+    /// after `SocketServer`, so an escalated SIGTERM-then-SIGINT reaches it
+    /// twice; a second run would wedge here instead and the shutdown would
+    /// never reach its `exit(0)`. See `ShutdownLatch`.
+    private let shutdownLatch = ShutdownLatch()
+
     /// The port the server is bound to, available after start().
     public nonisolated(unsafe) var port: Int = 0
 
@@ -60,15 +67,18 @@ public final class HTTPServer: Sendable {
         logger.info("Listening on http://127.0.0.1:\(self.port, privacy: .public)")
     }
 
-    /// Stop the server and clean up.
+    /// Stop the server and clean up. Safe to call any number of times, from
+    /// any number of tasks at once.
     public func stop() async {
-        do {
-            try await channel?.close()
-        } catch {
-            // Already closed
+        await shutdownLatch.run {
+            do {
+                try await self.channel?.close()
+            } catch {
+                // Already closed
+            }
+            try? await self.group.shutdownGracefully()
+            try? FileManager.default.removeItem(atPath: self.portFilePath)
         }
-        try? await group.shutdownGracefully()
-        try? FileManager.default.removeItem(atPath: portFilePath)
     }
 }
 

--- a/Sources/TBDDaemon/Server/ShutdownLatch.swift
+++ b/Sources/TBDDaemon/Server/ShutdownLatch.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// Runs an `async` shutdown exactly once, and lets every caller await that one
+/// run.
+///
+/// Nothing serializes daemon shutdown: SIGTERM and SIGINT each fire an
+/// independent, undeduplicated `Task { await daemon.stop() }` in `main.swift`,
+/// and a supervisor escalating signals sends both. Both reach every server's
+/// `stop()` through `Daemon.stop()`.
+///
+/// For a NIO-backed server, running the shutdown body twice does not merely
+/// repeat work — it hangs. The body's first act is `channel.close()`, which off
+/// the event loop is `eventLoop.execute { ... }` fulfilling a promise, and a
+/// `SelectableEventLoop` whose group has already shut down *discards* submitted
+/// work: `_schedule0` takes the `!validExternalStateToScheduleTasks` branch,
+/// prints "Cannot schedule tasks on an EventLoop that has already shut down"
+/// and returns without enqueuing anything. The promise is never fulfilled, so
+/// `try await channel.close()` suspends for good — and the event-loop threads
+/// have already exited, so the wedged task leaves a process at 0% CPU with
+/// nothing to see.
+///
+/// (`MultiThreadedEventLoopGroup.shutdownGracefully()` itself is *not* the
+/// problem, and it is worth saying so because it looks like the culprit: it
+/// documents that a repeat call is safe and its handler still runs, and its
+/// implementation switches on `runState` under a lock — `.closing` appends the
+/// handler to the pending list, `.closed` dispatches it immediately — so
+/// repeated and concurrent calls both complete. Once the body runs once,
+/// though, the question stops arising at all.)
+///
+/// Callers `await` the one run rather than returning early, so `stop()` still
+/// means "the shutdown has finished" for everyone who called it. The task is
+/// unstructured on purpose: it does not inherit its creator's cancellation, so
+/// a cancelled signal handler cannot abandon a shutdown other callers are
+/// waiting on.
+final class ShutdownLatch: Sendable {
+    private nonisolated(unsafe) var task: Task<Void, Never>?
+    private let lock = NSLock()
+
+    /// Run `body` if this is the first call; otherwise await the run the first
+    /// call started. Later `body` arguments are never invoked — every caller of
+    /// a given latch passes the same shutdown.
+    func run(_ body: @escaping @Sendable () async -> Void) async {
+        await started(body).value
+    }
+
+    /// Hand back the single run, starting it if this is the first call.
+    /// Synchronous and lock-held so two callers arriving together cannot both
+    /// start one.
+    private func started(_ body: @escaping @Sendable () async -> Void) -> Task<Void, Never> {
+        lock.lock()
+        defer { lock.unlock() }
+        if let task { return task }
+        let created = Task { await body() }
+        task = created
+        return created
+    }
+}

--- a/Sources/TBDDaemon/Server/SocketServer.swift
+++ b/Sources/TBDDaemon/Server/SocketServer.swift
@@ -17,6 +17,14 @@ public final class SocketServer: Sendable {
     private let group: MultiThreadedEventLoopGroup
     private nonisolated(unsafe) var channel: Channel?
 
+    /// Identity of the socket file this server actually bound, read from the
+    /// path right after `bind(2)`. `nil` until a successful bind, and again
+    /// once `stop()` has settled the file.
+    ///
+    /// This is what licenses the unlink in `stop()`. See
+    /// `unlinkOwnedSocketFile()`.
+    private nonisolated(unsafe) var boundSocketIdentity: SocketFileIdentity?
+
     /// Number of currently connected clients. Updated atomically.
     private let _connectedClients = ManagedAtomic<Int>(0)
 
@@ -47,8 +55,14 @@ public final class SocketServer: Sendable {
         let connectedClients = self._connectedClients
         let limiter = self.limiter
 
+        // The backlog is deliberately not set here: this bootstrap is handed an
+        // already-bound descriptor (below), and NIO listens on it while
+        // constructing the channel — before any server-channel option is
+        // applied — so the accept queue takes NIO's own default of 128. That is
+        // strictly more forgiving than the 64 it replaces, which matters because
+        // a full accept queue is indistinguishable from a dead socket at the
+        // client's `connect(2)`.
         let bootstrap = ServerBootstrap(group: group)
-            .serverChannelOption(.backlog, value: 64)
             .childChannelInitializer { channel in
                 channel.eventLoop.makeCompletedFuture {
                     let handler = SocketRPCHandler(
@@ -60,14 +74,40 @@ public final class SocketServer: Sendable {
                 }
             }
 
-        let ch = try await bootstrap.bind(
-            unixDomainSocketPath: socketPath
-        ).get()
-
-        // Set socket permissions so any local user can connect
-        chmod(socketPath, 0o700)
+        // Bind the socket here and hand NIO the descriptor, rather than calling
+        // `bind(unixDomainSocketPath:)` and letting NIO do it.
+        //
+        // NIO's own bind marks the server socket `cleanupOnClose`, and that
+        // cleanup runs `unlink(2)` on the *path* the socket was bound to when
+        // the channel closes — its only check is that something at that path is
+        // a socket, never that it is still the socket this process created. So
+        // a daemon shutting down deletes the rendezvous file that a successor
+        // daemon has since bound, and the successor keeps accepting on a
+        // listener no client can reach. Handing NIO a descriptor that is
+        // already bound sets `cleanupOnClose` to false — "socket already bound,
+        // owner must clean up" — which is what puts the unlink under the
+        // ownership check in `unlinkOwnedSocketFile()`.
+        let boundFD = try Self.bindListeningSocket(at: socketPath)
+        // Read the file's identity as close to `bind(2)` as possible, before
+        // any await gives a successor the chance to replace it. A successor
+        // daemon's `start()` unlinks whatever is at this path and binds a fresh
+        // socket, so the inode is what separates our file from theirs.
+        let identity = SocketFileIdentity(path: socketPath)
+        let ch: Channel
+        do {
+            ch = try await bootstrap.withBoundSocket(boundFD).get()
+        } catch {
+            // Do not close `boundFD` here: NIO takes ownership of the
+            // descriptor as soon as it wraps it, and closing a descriptor
+            // another layer already closed can later shut down an unrelated
+            // reused one. The socket file is unambiguously ours, so reclaim
+            // that and let a failed start surface.
+            try? fm.removeItem(atPath: socketPath)
+            throw error
+        }
 
         self.channel = ch
+        self.boundSocketIdentity = identity
         logger.info("Listening on \(self.socketPath, privacy: .public)")
     }
 
@@ -79,7 +119,138 @@ public final class SocketServer: Sendable {
             // Already closed
         }
         try? await group.shutdownGracefully()
+        unlinkOwnedSocketFile()
+    }
+
+    /// Create an `AF_UNIX` stream socket and `bind(2)` it at `path`, returning
+    /// the bound descriptor for NIO to adopt.
+    ///
+    /// Only creation and bind happen here. NIO sets the descriptor
+    /// non-blocking and calls `listen(2)` on it while it builds the channel,
+    /// exactly as it would for a socket it had made itself. What changes is
+    /// ownership of the *file*: because NIO did not open the path, it will not
+    /// unlink the path when the channel closes, and `stop()` decides that
+    /// instead.
+    private static func bindListeningSocket(at path: String) throws -> Int32 {
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        let pathBytes = Array(path.utf8)
+        let capacity = MemoryLayout.size(ofValue: addr.sun_path)
+        guard pathBytes.count < capacity else {
+            throw SocketServerStartError.socketPathTooLong(path: path, limit: capacity - 1)
+        }
+        withUnsafeMutableBytes(of: &addr.sun_path) { raw in
+            raw.copyBytes(from: pathBytes)
+            raw[pathBytes.count] = 0
+        }
+
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else {
+            throw SocketServerStartError.socketCreationFailed(code: errno)
+        }
+
+        let bound = withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+                bind(fd, sockPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard bound == 0 else {
+            let code = errno
+            close(fd)
+            throw SocketServerStartError.bindFailed(path: path, code: code)
+        }
+
+        // Restrict the socket before anything can connect to it. NIO's listen
+        // comes later, so there is no window here where the file is reachable
+        // at the old mode.
+        chmod(path, 0o700)
+        return fd
+    }
+
+    /// Reclaim the socket file **only if it is still the one this server
+    /// bound.**
+    ///
+    /// The socket path is a rendezvous every daemon generation binds in turn,
+    /// so existence at that path proves nothing about who owns it. A successor
+    /// that has already bound is the common case: it unlinked our file and
+    /// created its own under the same name. Unlinking on existence alone
+    /// deletes the successor's socket, and it never finds out — it keeps
+    /// accepting on an open listener no client can reach any more, and every
+    /// client fails against a path that is simply gone.
+    ///
+    /// The honest primitive is the file's identity, not its name: `(st_dev,
+    /// st_ino)` captured immediately after `bind(2)` names one inode, and a
+    /// successor's `bind(2)` always makes a different one. So the unlink is
+    /// gated on that identity still being what sits at the path.
+    ///
+    /// A residual window of microseconds remains between the `lstat(2)` and the
+    /// `unlink(2)`, lost only if a successor unlinks our file and binds its own
+    /// inside it — darwin has no unlink-if-inode primitive to close it with. It
+    /// is accepted on width; the unconditional unlink it replaces lost the same
+    /// race for the whole of every shutdown.
+    private func unlinkOwnedSocketFile() {
+        guard let bound = boundSocketIdentity else {
+            // Never bound, or already settled. Nothing here is ours.
+            return
+        }
+        boundSocketIdentity = nil
+        guard let current = SocketFileIdentity(path: socketPath) else {
+            // Already gone — reclaimed by a successor's `start()`, or by hand.
+            return
+        }
+        guard current == bound else {
+            let boundInode = bound.inode
+            let currentInode = current.inode
+            logger.info(
+                "Leaving socket at \(self.socketPath, privacy: .public) in place: it is now inode \(currentInode, privacy: .public), not the \(boundInode, privacy: .public) this server bound"
+            )
+            return
+        }
         try? FileManager.default.removeItem(atPath: socketPath)
+    }
+}
+
+// MARK: - Start errors
+
+/// Why binding the RPC socket failed. These are all fatal to daemon startup;
+/// they exist so the failure names itself instead of arriving as a bare errno.
+public enum SocketServerStartError: Error, LocalizedError, CustomStringConvertible {
+    case socketPathTooLong(path: String, limit: Int)
+    case socketCreationFailed(code: Int32)
+    case bindFailed(path: String, code: Int32)
+
+    public var errorDescription: String? { description }
+
+    public var description: String {
+        switch self {
+        case .socketPathTooLong(let path, let limit):
+            return "socket path is \(path.utf8.count) bytes, over the \(limit)-byte sun_path limit: \(path)"
+        case .socketCreationFailed(let code):
+            return "socket(AF_UNIX, SOCK_STREAM): \(String(cString: strerror(code)))"
+        case .bindFailed(let path, let code):
+            return "bind(2) on \(path): \(String(cString: strerror(code)))"
+        }
+    }
+}
+
+// MARK: - Socket file identity
+
+/// The identity of a file on disk — `(st_dev, st_ino)` — as distinct from its
+/// path. Two sockets bound in turn at one path are two different inodes, and
+/// that is the only thing that tells them apart.
+struct SocketFileIdentity: Equatable {
+    let device: dev_t
+    let inode: ino_t
+
+    /// Reads the identity of whatever is at `path`, or `nil` if nothing is.
+    ///
+    /// `lstat` rather than `stat`: a symlink swapped in at the path is not the
+    /// socket we bound, and must not be mistaken for it.
+    init?(path: String) {
+        var info = stat()
+        guard lstat(path, &info) == 0 else { return nil }
+        self.device = info.st_dev
+        self.inode = info.st_ino
     }
 }
 

--- a/Sources/TBDDaemon/Server/SocketServer.swift
+++ b/Sources/TBDDaemon/Server/SocketServer.swift
@@ -25,6 +25,21 @@ public final class SocketServer: Sendable {
     /// `unlinkOwnedSocketFile()`.
     private nonisolated(unsafe) var boundSocketIdentity: SocketFileIdentity?
 
+    /// Runs in `start()` between `bind(2)` and NIO adopting the bound
+    /// descriptor, and may throw to fail the start from inside that window.
+    /// `nil` in production, where the window holds nothing but the handover.
+    ///
+    /// The window is the one a successor daemon can bind the path in, so it is
+    /// where a failed start can be caught deleting somebody else's socket. The
+    /// failures that actually occur there are NIO refusing the descriptor —
+    /// kernel-level refusals no in-process test can provoke without either
+    /// hanging (a shut-down event loop drops the submitted task and the future
+    /// never completes) or tripping NIO's own debug assertions on a
+    /// half-constructed channel. So the seam exists to make that cleanup
+    /// reachable, and it is handed the descriptor so a caller that fails the
+    /// start can close it rather than leak it.
+    private let beforeAdoptingBoundSocket: (@Sendable (Int32) async throws -> Void)?
+
     /// Number of currently connected clients. Updated atomically.
     private let _connectedClients = ManagedAtomic<Int>(0)
 
@@ -36,11 +51,20 @@ public final class SocketServer: Sendable {
         _connectedClients.load(ordering: .relaxed)
     }
 
-    public init(router: RPCRouter, socketPath: String? = nil) {
+    public convenience init(router: RPCRouter, socketPath: String? = nil) {
+        self.init(router: router, socketPath: socketPath, beforeAdoptingBoundSocket: nil)
+    }
+
+    init(
+        router: RPCRouter,
+        socketPath: String?,
+        beforeAdoptingBoundSocket: (@Sendable (Int32) async throws -> Void)?
+    ) {
         self.router = router
         // See HookResolver — resolve here, not at the caller's site.
         self.socketPath = socketPath ?? TBDConstants.socketPath
         self.group = MultiThreadedEventLoopGroup(numberOfThreads: 2)
+        self.beforeAdoptingBoundSocket = beforeAdoptingBoundSocket
     }
 
     /// Start listening on the Unix domain socket.
@@ -95,14 +119,23 @@ public final class SocketServer: Sendable {
         let identity = SocketFileIdentity(path: socketPath)
         let ch: Channel
         do {
+            try await beforeAdoptingBoundSocket?(boundFD)
             ch = try await bootstrap.withBoundSocket(boundFD).get()
         } catch {
             // Do not close `boundFD` here: NIO takes ownership of the
             // descriptor as soon as it wraps it, and closing a descriptor
             // another layer already closed can later shut down an unrelated
-            // reused one. The socket file is unambiguously ours, so reclaim
-            // that and let a failed start surface.
-            try? fm.removeItem(atPath: socketPath)
+            // reused one.
+            //
+            // Reclaim the socket file under the same ownership check the
+            // shutdown path uses. `identity` was true of the path at the
+            // instant it was read, and the `await` above is a suspension
+            // point: a successor daemon's `start()` can run inside it,
+            // unlinking our file and binding its own. Removing on existence
+            // alone here would delete the successor's live socket — the bug
+            // `unlinkOwnedSocketFile()` exists to prevent, reached through a
+            // failed start instead of a shutdown.
+            unlinkSocketFile(ifStillIdentity: identity)
             throw error
         }
 
@@ -167,8 +200,20 @@ public final class SocketServer: Sendable {
         return fd
     }
 
-    /// Reclaim the socket file **only if it is still the one this server
-    /// bound.**
+    /// Reclaim the socket file this server bound, if it is still there and
+    /// still ours. Called once, at shutdown; the identity is consumed so a
+    /// second call finds nothing to claim.
+    private func unlinkOwnedSocketFile() {
+        guard let bound = boundSocketIdentity else {
+            // Never bound, or already settled. Nothing here is ours.
+            return
+        }
+        boundSocketIdentity = nil
+        unlinkSocketFile(ifStillIdentity: bound)
+    }
+
+    /// Remove the file at `socketPath` **only if it is still the one whose
+    /// identity is `identity`.**
     ///
     /// The socket path is a rendezvous every daemon generation binds in turn,
     /// so existence at that path proves nothing about who owns it. A successor
@@ -188,12 +233,17 @@ public final class SocketServer: Sendable {
     /// inside it — darwin has no unlink-if-inode primitive to close it with. It
     /// is accepted on width; the unconditional unlink it replaces lost the same
     /// race for the whole of every shutdown.
-    private func unlinkOwnedSocketFile() {
-        guard let bound = boundSocketIdentity else {
-            // Never bound, or already settled. Nothing here is ours.
+    ///
+    /// Both places that reclaim the file come through here — the shutdown in
+    /// `stop()`, and the cleanup of a `start()` that failed after `bind(2)`.
+    /// The hazard is the same either way: between capturing the identity and
+    /// unlinking, a successor daemon may have taken the path over.
+    private func unlinkSocketFile(ifStillIdentity identity: SocketFileIdentity?) {
+        guard let bound = identity else {
+            // The `lstat(2)` after `bind(2)` found nothing, so this server can
+            // name no file as its own. Claim nothing.
             return
         }
-        boundSocketIdentity = nil
         guard let current = SocketFileIdentity(path: socketPath) else {
             // Already gone — reclaimed by a successor's `start()`, or by hand.
             return

--- a/Sources/TBDDaemon/Server/SocketServer.swift
+++ b/Sources/TBDDaemon/Server/SocketServer.swift
@@ -23,7 +23,18 @@ public final class SocketServer: Sendable {
     ///
     /// This is what licenses the unlink in `stop()`. See
     /// `unlinkOwnedSocketFile()`.
+    ///
+    /// Only ever read through `takeBoundSocketIdentity()`, which reads and
+    /// clears it under `identityLock`. Nothing serializes callers of `stop()`:
+    /// SIGTERM and SIGINT each fire an independent, undeduplicated
+    /// `Task { await daemon.stop() }` in `main.swift`, so two shutdowns can
+    /// overlap. A plain read-then-nil lets both see the same identity and both
+    /// reach the unlink, and the loser of that race is unlinking against a
+    /// path a successor may have taken over in between — the very thing the
+    /// identity exists to prevent. Taking it atomically means exactly one
+    /// shutdown ever holds a claim on the file.
     private nonisolated(unsafe) var boundSocketIdentity: SocketFileIdentity?
+    private let identityLock = NSLock()
 
     /// Runs in `start()` between `bind(2)` and NIO adopting the bound
     /// descriptor, and may throw to fail the start from inside that window.
@@ -39,6 +50,17 @@ public final class SocketServer: Sendable {
     /// reachable, and it is handed the descriptor so a caller that fails the
     /// start can close it rather than leak it.
     private let beforeAdoptingBoundSocket: (@Sendable (Int32) async throws -> Void)?
+
+    /// Runs inside `takeBoundSocketIdentity()`, after the identity is read and
+    /// before it is cleared — the window two overlapping shutdowns race for.
+    /// `nil` in production.
+    ///
+    /// That window is a few instructions wide, so no test can land inside it
+    /// by timing alone; holding it open here is what makes the race
+    /// reproducible. Under `identityLock` a second claimant waits outside the
+    /// window instead of reading the same identity, which is exactly what the
+    /// test measures.
+    private let duringIdentityClaim: (@Sendable () -> Void)?
 
     /// Number of currently connected clients. Updated atomically.
     private let _connectedClients = ManagedAtomic<Int>(0)
@@ -58,13 +80,15 @@ public final class SocketServer: Sendable {
     init(
         router: RPCRouter,
         socketPath: String?,
-        beforeAdoptingBoundSocket: (@Sendable (Int32) async throws -> Void)?
+        beforeAdoptingBoundSocket: (@Sendable (Int32) async throws -> Void)?,
+        duringIdentityClaim: (@Sendable () -> Void)? = nil
     ) {
         self.router = router
         // See HookResolver — resolve here, not at the caller's site.
         self.socketPath = socketPath ?? TBDConstants.socketPath
         self.group = MultiThreadedEventLoopGroup(numberOfThreads: 2)
         self.beforeAdoptingBoundSocket = beforeAdoptingBoundSocket
+        self.duringIdentityClaim = duringIdentityClaim
     }
 
     /// Start listening on the Unix domain socket.
@@ -140,7 +164,7 @@ public final class SocketServer: Sendable {
         }
 
         self.channel = ch
-        self.boundSocketIdentity = identity
+        storeBoundSocketIdentity(identity)
         logger.info("Listening on \(self.socketPath, privacy: .public)")
     }
 
@@ -201,15 +225,40 @@ public final class SocketServer: Sendable {
     }
 
     /// Reclaim the socket file this server bound, if it is still there and
-    /// still ours. Called once, at shutdown; the identity is consumed so a
-    /// second call finds nothing to claim.
+    /// still ours. The claim is taken exactly once, so a second shutdown —
+    /// sequential or concurrent — finds nothing to claim and does nothing.
     private func unlinkOwnedSocketFile() {
-        guard let bound = boundSocketIdentity else {
-            // Never bound, or already settled. Nothing here is ours.
+        guard let bound = takeBoundSocketIdentity() else {
+            // Never bound, or already claimed by another shutdown. Nothing
+            // here is ours.
             return
         }
-        boundSocketIdentity = nil
         unlinkSocketFile(ifStillIdentity: bound)
+    }
+
+    /// Record the identity of the file this server just bound. Held under
+    /// `identityLock` so a shutdown racing the tail of `start()` sees either
+    /// the whole claim or none of it.
+    private func storeBoundSocketIdentity(_ identity: SocketFileIdentity?) {
+        identityLock.lock()
+        defer { identityLock.unlock() }
+        boundSocketIdentity = identity
+    }
+
+    /// Read and clear `boundSocketIdentity` in one step, so overlapping
+    /// shutdowns cannot both come away holding the claim.
+    ///
+    /// Internal rather than private so a test can call it concurrently and
+    /// count the claimants: "at most one" is the whole guarantee, and it is
+    /// not observable from the outside once the losers have correctly done
+    /// nothing.
+    func takeBoundSocketIdentity() -> SocketFileIdentity? {
+        identityLock.lock()
+        defer { identityLock.unlock() }
+        let claimed = boundSocketIdentity
+        duringIdentityClaim?()
+        boundSocketIdentity = nil
+        return claimed
     }
 
     /// Remove the file at `socketPath` **only if it is still the one whose
@@ -296,6 +345,17 @@ struct SocketFileIdentity: Equatable {
     ///
     /// `lstat` rather than `stat`: a symlink swapped in at the path is not the
     /// socket we bound, and must not be mistaken for it.
+    ///
+    /// By the path, and not by `fstat(2)` on the bound descriptor, however
+    /// tempting the tighter window looks: on darwin the two do not name the
+    /// same thing. `fstat(2)` on a bound `AF_UNIX` descriptor reports the
+    /// socket's own in-kernel vnode — a different inode, with `st_dev` of -1 —
+    /// not the filesystem entry `bind(2)` created. Measured on darwin 25.1:
+    /// `fstat` answered `dev=-1 ino=15302332` for a socket whose path
+    /// `lstat`ed as `dev=16777235 ino=863366896`. An identity captured that
+    /// way could never equal the one read back from the path, so every
+    /// ownership check would fail closed and the socket file would never be
+    /// reclaimed at all.
     init?(path: String) {
         var info = stat()
         guard lstat(path, &info) == 0 else { return nil }

--- a/Sources/TBDDaemon/Server/SocketServer.swift
+++ b/Sources/TBDDaemon/Server/SocketServer.swift
@@ -25,16 +25,20 @@ public final class SocketServer: Sendable {
     /// `unlinkOwnedSocketFile()`.
     ///
     /// Only ever read through `takeBoundSocketIdentity()`, which reads and
-    /// clears it under `identityLock`. Nothing serializes callers of `stop()`:
-    /// SIGTERM and SIGINT each fire an independent, undeduplicated
-    /// `Task { await daemon.stop() }` in `main.swift`, so two shutdowns can
-    /// overlap. A plain read-then-nil lets both see the same identity and both
-    /// reach the unlink, and the loser of that race is unlinking against a
-    /// path a successor may have taken over in between — the very thing the
-    /// identity exists to prevent. Taking it atomically means exactly one
-    /// shutdown ever holds a claim on the file.
+    /// clears it under `identityLock`. `stop()` runs its body once, so in
+    /// practice one shutdown reaches the claim — but the claim also races the
+    /// tail of `start()`, which stores the identity from whichever task ran
+    /// the bind. A plain read-then-nil would let a claimant see a half-written
+    /// claim, and a claimant that comes away with an identity goes on to
+    /// unlink against it. Reading and clearing under the lock keeps that
+    /// atomic.
     private nonisolated(unsafe) var boundSocketIdentity: SocketFileIdentity?
     private let identityLock = NSLock()
+
+    /// Keeps the shutdown to one run, however many `stop()` calls arrive. See
+    /// `ShutdownLatch` for why a second run would hang rather than merely
+    /// repeat itself.
+    private let shutdownLatch = ShutdownLatch()
 
     /// Runs in `start()` between `bind(2)` and NIO adopting the bound
     /// descriptor, and may throw to fail the start from inside that window.
@@ -52,15 +56,15 @@ public final class SocketServer: Sendable {
     private let beforeAdoptingBoundSocket: (@Sendable (Int32) async throws -> Void)?
 
     /// Runs inside `takeBoundSocketIdentity()`, after the identity is read and
-    /// before it is cleared — the window two overlapping shutdowns race for.
+    /// before it is cleared, and is handed what the claimant came away with.
     /// `nil` in production.
     ///
-    /// That window is a few instructions wide, so no test can land inside it
-    /// by timing alone; holding it open here is what makes the race
-    /// reproducible. Under `identityLock` a second claimant waits outside the
-    /// window instead of reading the same identity, which is exactly what the
-    /// test measures.
-    private let duringIdentityClaim: (@Sendable () -> Void)?
+    /// It serves two tests. Counting the non-`nil` identities it is handed is
+    /// how "the socket file was claimed exactly once" is observed from inside
+    /// a real `stop()`, which has no other outward sign. And the read-and-clear
+    /// window is a few instructions wide, so no test can land inside it by
+    /// timing alone; blocking here holds it open so contention is reproducible.
+    private let duringIdentityClaim: (@Sendable (SocketFileIdentity?) -> Void)?
 
     /// Number of currently connected clients. Updated atomically.
     private let _connectedClients = ManagedAtomic<Int>(0)
@@ -81,7 +85,7 @@ public final class SocketServer: Sendable {
         router: RPCRouter,
         socketPath: String?,
         beforeAdoptingBoundSocket: (@Sendable (Int32) async throws -> Void)?,
-        duringIdentityClaim: (@Sendable () -> Void)? = nil
+        duringIdentityClaim: (@Sendable (SocketFileIdentity?) -> Void)? = nil
     ) {
         self.router = router
         // See HookResolver — resolve here, not at the caller's site.
@@ -168,15 +172,19 @@ public final class SocketServer: Sendable {
         logger.info("Listening on \(self.socketPath, privacy: .public)")
     }
 
-    /// Stop the server and clean up.
+    /// Stop the server and clean up. Safe to call any number of times, from
+    /// any number of tasks at once: the body below runs once and every caller
+    /// returns only when it has finished. See `ShutdownLatch`.
     public func stop() async {
-        do {
-            try await channel?.close()
-        } catch {
-            // Already closed
+        await shutdownLatch.run {
+            do {
+                try await self.channel?.close()
+            } catch {
+                // Already closed
+            }
+            try? await self.group.shutdownGracefully()
+            self.unlinkOwnedSocketFile()
         }
-        try? await group.shutdownGracefully()
-        unlinkOwnedSocketFile()
     }
 
     /// Create an `AF_UNIX` stream socket and `bind(2)` it at `path`, returning
@@ -225,14 +233,9 @@ public final class SocketServer: Sendable {
     }
 
     /// Reclaim the socket file this server bound, if it is still there and
-    /// still ours. The claim is taken exactly once, so a second shutdown —
-    /// sequential or concurrent — finds nothing to claim and does nothing.
-    ///
-    /// Internal rather than private so a test can run this step twice without
-    /// running `stop()` twice: NIO's `shutdownGracefully` never completes when
-    /// the group is already shut down, so a second `stop()` suspends forever.
-    /// This is the step a second shutdown would reach.
-    func unlinkOwnedSocketFile() {
+    /// still ours. The claim is taken exactly once, so anything that reaches
+    /// this a second time finds nothing to claim and does nothing.
+    private func unlinkOwnedSocketFile() {
         guard let bound = takeBoundSocketIdentity() else {
             // Never bound, or already claimed by another shutdown. Nothing
             // here is ours.
@@ -256,12 +259,14 @@ public final class SocketServer: Sendable {
     /// Internal rather than private so a test can call it concurrently and
     /// count the claimants: "at most one" is the whole guarantee, and it is
     /// not observable from the outside once the losers have correctly done
-    /// nothing.
+    /// nothing. `stop()` no longer runs twice, so this lock is the second line
+    /// of that defence rather than the first — it still stands between a
+    /// shutdown and the `start()` that is storing the claim.
     func takeBoundSocketIdentity() -> SocketFileIdentity? {
         identityLock.lock()
         defer { identityLock.unlock() }
         let claimed = boundSocketIdentity
-        duringIdentityClaim?()
+        duringIdentityClaim?(claimed)
         boundSocketIdentity = nil
         return claimed
     }

--- a/Sources/TBDDaemon/Server/SocketServer.swift
+++ b/Sources/TBDDaemon/Server/SocketServer.swift
@@ -227,7 +227,12 @@ public final class SocketServer: Sendable {
     /// Reclaim the socket file this server bound, if it is still there and
     /// still ours. The claim is taken exactly once, so a second shutdown —
     /// sequential or concurrent — finds nothing to claim and does nothing.
-    private func unlinkOwnedSocketFile() {
+    ///
+    /// Internal rather than private so a test can run this step twice without
+    /// running `stop()` twice: NIO's `shutdownGracefully` never completes when
+    /// the group is already shut down, so a second `stop()` suspends forever.
+    /// This is the step a second shutdown would reach.
+    func unlinkOwnedSocketFile() {
         guard let bound = takeBoundSocketIdentity() else {
             // Never bound, or already claimed by another shutdown. Nothing
             // here is ours.

--- a/Tests/CLAUDE.md
+++ b/Tests/CLAUDE.md
@@ -376,6 +376,30 @@ instead of leaving an anonymous job timeout. `BoundedGateWaitTests` reproduces
 the wedge on any machine by deriving its holder count from
 `activeProcessorCount`.
 
+**The preference stops at an unstructured task, and that changes the bound,
+not the call site.** SE-0417 carries a task executor preference into child
+tasks and default actors and *not* into `Task {}` or `Task.detached`. Several
+production seams hand their work to an unstructured task on purpose —
+`ShutdownLatch` does, so a cancelled signal handler cannot abandon a shutdown
+other callers await — and that work is then scheduled on the cooperative pool
+however the test started the call. It is not pinning a thread, and no
+`gateHoldingTask` can move it, so the only correct response is to bound a gate
+released from beyond such a hop at `TestDeadlines.saturatedPass` (90 s) and
+give the outer observation a strictly larger budget, so a genuinely lost
+handshake still reports before the wedge does. A snappier inner bound reports
+starvation the outer bound was sized to tolerate — which is exactly how
+`SocketServerSocketOwnershipTests` went red on a 30 s staging gate while every
+assertion in the test passed.
+
+**Wait on a gate from a task, not a bare `Thread`, whenever the test owns the
+thread.** `Test.current` and `Configuration.current` are task-locals; without
+them Swift Testing names an expired gate «unknown» and, rather than lose an
+event it cannot route, posts it to every registered event handler — so one
+expiry prints as several identical lines and names no test. `gateHoldingTask`
+is still off the cooperative pool and carries both, so it costs nothing to
+prefer. Where production code owns the thread, «unknown» is unavoidable and
+the test's own downstream assertions are what name the failure.
+
 ## Quarantine — `.flaky(issue:)`
 
 There is no blanket retry policy, in any tier, and there will not be one:

--- a/Tests/TBDDaemonTests/BoundedGateWaitTests.swift
+++ b/Tests/TBDDaemonTests/BoundedGateWaitTests.swift
@@ -125,6 +125,35 @@ struct BoundedGateWaitTests {
         #expect(dispatchRan, "gate holders must not consume the workers needed by unrelated dispatch work")
     }
 
+    @Test("the executor preference does not survive an unstructured Task")
+    func unstructuredTaskLeavesTheGateExecutor() async {
+        // SE-0417's inheritance rule decides how much a `gateHoldingTask` at a
+        // call site actually covers: the preference reaches child tasks and
+        // default actors, and NOT `Task {}` or `Task.detached`. So a callee
+        // that hands its work to an unstructured task — `ShutdownLatch` does,
+        // deliberately — runs that work on the cooperative pool however its
+        // caller was started, and a gate released from beyond that hop is
+        // subject to the pass's scheduling latency rather than to any thread
+        // this executor owns.
+        //
+        // Every gate bound in the repo rests on that split, so it is pinned
+        // here rather than remembered. If the second expectation ever fails,
+        // the language changed and those bounds are re-derivable, not broken.
+        let (sameTask, unstructured) = await gateHoldingTask { () -> (String?, String?) in
+            let onOurThread = runningThreadName()
+            let afterUnstructuredHop = await Task { runningThreadName() }.value
+            return (onOurThread, afterUnstructuredHop)
+        }.value
+        #expect(
+            sameTask == GateExecutor.threadName,
+            "gateHoldingTask must run the operation's own frames on a thread the tests own"
+        )
+        #expect(
+            unstructured != GateExecutor.threadName,
+            "an unstructured Task must not inherit the preference; if it now does, re-derive every gate bound sized for the cooperative pool"
+        )
+    }
+
     @Test("the timeout diagnostic names the gate and the deadline")
     func timeoutDescriptionCarriesTheDiagnostic() {
         let description = String(
@@ -134,6 +163,16 @@ struct BoundedGateWaitTests {
     }
 }
 
+
+/// Which thread is running this continuation.
+///
+/// Synchronous on purpose: `Thread.current` is unavailable from an async
+/// context precisely because the answer changes across a suspension point —
+/// and that change is the thing under test here, so the read is deliberate
+/// rather than an oversight.
+private func runningThreadName() -> String? {
+    Thread.current.name
+}
 
 /// Minimal thread-safe counter — the holders increment from threads that are
 /// about to block, so this cannot be an actor.

--- a/Tests/TBDDaemonTests/PIDFileStaleTests.swift
+++ b/Tests/TBDDaemonTests/PIDFileStaleTests.swift
@@ -32,6 +32,21 @@ import Testing
         #expect(f.isStale(isLiveDaemon: { _ in false }) == true)
     }
 
+    // The cleanup still cleans: a pid file naming this very process is stale
+    // (alive, but not a TBDDaemon) and must go. The socket file it used to
+    // remove alongside is now left to whoever binds it — pinned by
+    // `SocketServerSocketOwnershipTests.onlyTheBinderClearsTheRendezvousPath`.
+    @Test func cleanupRemovesAStalePidFile() throws {
+        let path = tmpPidPath()
+        let selfPID = ProcessInfo.processInfo.processIdentifier
+        try "\(selfPID)".write(toFile: path, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(atPath: path) }
+
+        PIDFile(path: path).cleanupIfStale()
+
+        #expect(FileManager.default.fileExists(atPath: path) == false)
+    }
+
     // MARK: - Compare-and-delete
 
     @Test func removeIfOwnedRemovesOurOwnPidFile() throws {

--- a/Tests/TBDDaemonTests/ServerShutdownLatchTests.swift
+++ b/Tests/TBDDaemonTests/ServerShutdownLatchTests.swift
@@ -1,0 +1,133 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+import TestSupport
+
+// A daemon shutdown must survive being asked for twice.
+//
+// SIGTERM and SIGINT each fire an independent, undeduplicated
+// `Task { await daemon.stop() }` in main.swift, and `Daemon.stop()` is not
+// itself deduplicated, so an escalating supervisor runs the whole teardown
+// twice. Every NIO-backed server in that teardown wedges on a second run —
+// `channel.close()` off the event loop submits work to a loop whose group has
+// shut down, and such a loop discards submitted work rather than running it, so
+// the close promise is never fulfilled. A wedged teardown never reaches its
+// `exit(0)`.
+@Suite("Repeat server shutdowns")
+struct ServerShutdownLatchTests {
+
+    /// Throwaway RPCRouter: in-memory DB + dryRun tmux, so no real tmux server
+    /// is contacted and nothing under ~/tbd is touched.
+    private func makeRouter() throws -> RPCRouter {
+        let db = try TBDDatabase(inMemory: true)
+        return RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db,
+                git: GitManager(),
+                tmux: TmuxManager(dryRun: true),
+                hooks: HookResolver()
+            ),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date(),
+            actuationLog: makeTestActuationLog()
+        )
+    }
+
+    @Test("the latch runs its body once, and every caller waits for that one run")
+    func latchRunsItsBodyOnceAndEveryCallerWaits() async throws {
+        let latch = ShutdownLatch()
+        let runs = ShutdownCounter()
+        let returned = ShutdownCounter()
+        let returnedBeforeTheBodyFinished = ShutdownCounter()
+        let bodyFinished = ShutdownFlag()
+        let callers = 8
+
+        for _ in 0..<callers {
+            Task.detached {
+                await latch.run {
+                    runs.increment()
+                    // Suspends, so a caller that failed to wait for the run
+                    // would return while this is still in flight.
+                    for _ in 0..<100 { await Task.yield() }
+                    bodyFinished.set()
+                }
+                if !bodyFinished.isSet { returnedBeforeTheBodyFinished.increment() }
+                returned.increment()
+            }
+        }
+
+        #expect(
+            await waitUntil({ returned.count == callers }, timeout: .seconds(15)),
+            "only \(returned.count) of \(callers) callers returned"
+        )
+        #expect(runs.count == 1, "the latch ran its body \(runs.count) times; exactly one may")
+        #expect(
+            returnedBeforeTheBodyFinished.count == 0,
+            "\(returnedBeforeTheBodyFinished.count) callers returned before the shutdown had finished"
+        )
+    }
+
+    @Test("a second shutdown of the HTTP server returns")
+    func repeatHTTPServerStopReturns() async throws {
+        // The sibling of `SocketServer` in the same teardown, and the one a
+        // fixed `SocketServer` would otherwise hand the hang straight on to:
+        // `Daemon.stop()` stops the socket server and then this one.
+        let portFilePath = "/tmp/tbd-httpshutdown-\(UUID().uuidString.prefix(8)).port"
+        defer { unlink(portFilePath) }
+
+        let server = HTTPServer(router: try makeRouter(), portFilePath: portFilePath)
+        try await server.start()
+        await server.stop()
+
+        let returned = ShutdownCounter()
+        // Detached and waited on with a deadline rather than awaited directly:
+        // the failure under test is a shutdown that never returns, and awaiting
+        // it would wedge the whole run instead of reporting it.
+        Task.detached {
+            await server.stop()
+            returned.increment()
+        }
+        #expect(
+            await waitUntil({ returned.count == 1 }, timeout: .seconds(15)),
+            "the second stop() never returned"
+        )
+    }
+}
+
+/// Counts callers or runs across threads.
+private final class ShutdownCounter: @unchecked Sendable {
+    private var value = 0
+    private let lock = NSLock()
+
+    func increment() {
+        lock.lock()
+        defer { lock.unlock() }
+        value += 1
+    }
+
+    var count: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
+    }
+}
+
+/// Set once by the latched body, read by every caller as it returns.
+private final class ShutdownFlag: @unchecked Sendable {
+    private var value = false
+    private let lock = NSLock()
+
+    func set() {
+        lock.lock()
+        defer { lock.unlock() }
+        value = true
+    }
+
+    var isSet: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
+    }
+}

--- a/Tests/TBDDaemonTests/ServerShutdownLatchTests.swift
+++ b/Tests/TBDDaemonTests/ServerShutdownLatchTests.swift
@@ -49,8 +49,15 @@ struct ServerShutdownLatchTests {
                 await latch.run {
                     runs.increment()
                     // Suspends, so a caller that failed to wait for the run
-                    // would return while this is still in flight.
-                    for _ in 0..<100 { await Task.yield() }
+                    // would return while this is still in flight. One yield
+                    // would already open that window; a few widen it without
+                    // making the test's cost depend on how loaded the machine
+                    // is. Every `Task.yield()` is a full trip to the back of
+                    // the process-wide run queue, and in the saturated pass
+                    // that queue holds thousands of runnable tasks — the
+                    // hundred yields this started out with took longer than
+                    // the whole wait below.
+                    for _ in 0..<20 { await Task.yield() }
                     bodyFinished.set()
                 }
                 if !bodyFinished.isSet { returnedBeforeTheBodyFinished.increment() }
@@ -58,10 +65,16 @@ struct ServerShutdownLatchTests {
             }
         }
 
-        #expect(
-            await waitUntil({ returned.count == callers }, timeout: .seconds(15)),
-            "only \(returned.count) of \(callers) callers returned"
-        )
+        // `waitFor` at the repo-wide saturated-pass budget rather than a snug
+        // few seconds. These callers are detached tasks, so the thing being
+        // waited on is the cooperative pool getting round to them: 5,059 tests
+        // share one process and a pool three threads wide on CI's runner, and
+        // scheduling latency there is measured in tens of seconds. A shorter
+        // bound reports queueing as a wedged latch.
+        try await waitFor(
+            "all \(callers) latch callers to return",
+            observed: { "\(returned.count) of \(callers) returned" }
+        ) { returned.count == callers }
         #expect(runs.count == 1, "the latch ran its body \(runs.count) times; exactly one may")
         #expect(
             returnedBeforeTheBodyFinished.count == 0,
@@ -89,10 +102,10 @@ struct ServerShutdownLatchTests {
             await server.stop()
             returned.increment()
         }
-        #expect(
-            await waitUntil({ returned.count == 1 }, timeout: .seconds(15)),
-            "the second stop() never returned"
-        )
+        try await waitFor(
+            "the second stop() to return",
+            observed: { "\(returned.count) of 1 returned" }
+        ) { returned.count == 1 }
     }
 }
 

--- a/Tests/TBDDaemonTests/SocketServerSocketOwnershipTests.swift
+++ b/Tests/TBDDaemonTests/SocketServerSocketOwnershipTests.swift
@@ -178,16 +178,18 @@ struct SocketServerSocketOwnershipTests {
         try await server.start()
 
         let claims = ClaimCounter()
-        let finished = DispatchGroup()
+        let finished = ClaimCounter()
         for _ in 0..<claimants {
-            finished.enter()
             Thread.detachNewThread {
                 atCallSite.signal()
                 if server.takeBoundSocketIdentity() != nil { claims.increment() }
-                finished.leave()
+                finished.increment()
             }
         }
-        #expect(finished.wait(timeout: .now() + 30) == .success, "the claimant threads never finished")
+        #expect(
+            await waitUntil({ finished.count == claimants }, timeout: .seconds(30)),
+            "the claimant threads never finished"
+        )
         #expect(
             claims.count == 1,
             "\(claims.count) of \(claimants) overlapping shutdowns came away owning the socket file; only one may"
@@ -196,36 +198,37 @@ struct SocketServerSocketOwnershipTests {
         await server.stop()
     }
 
-    @Test("overlapping shutdowns still reclaim the server's own socket file, once")
-    func overlappingShutdownsReclaimTheFileOnce() async throws {
+    @Test("a second reclaim after a successor took over claims nothing")
+    func repeatReclaimLeavesTheSuccessorAlone() async throws {
         let socketPath = scratchSocketPath()
         defer { unlink(socketPath) }
 
-        // The end-to-end half of the test above: whatever the claim does under
-        // contention, a pile of concurrent shutdowns must still reclaim the
-        // file this server bound, and a shutdown that arrives after a
-        // successor has taken the path over must leave the successor alone.
+        // The file-level half of the claim-once guarantee: the first shutdown
+        // reclaims the file this server bound, and the reclaim step a second
+        // shutdown would run must find nothing left to claim.
+        //
+        // `unlinkOwnedSocketFile()` rather than a second `stop()`, and
+        // `takeBoundSocketIdentity()` rather than overlapping `stop()` calls in
+        // the test above, for the same reason: NIO's `shutdownGracefully` never
+        // completes when the group is already shut down, so a second `stop()`
+        // suspends its task forever with no thread left to show for it. The
+        // contested step in production is the claim, and that is what these
+        // tests contend for.
         let server = SocketServer(router: try makeRouter(), socketPath: socketPath)
         try await server.start()
 
-        await withTaskGroup(of: Void.self) { group in
-            for _ in 0..<8 {
-                group.addTask { await server.stop() }
-            }
-        }
+        await server.stop()
         #expect(inode(of: socketPath) == nil, "the shutdown must still reclaim its own file")
 
-        // A successor now binds the path. Any further shutdown of the old
-        // server must find nothing left to claim and leave it alone.
         let successor = SuccessorSocket()
         defer { successor.release() }
         successor.takeOver(path: socketPath)
         let successorInode = try #require(successor.inode)
 
-        await server.stop()
+        server.unlinkOwnedSocketFile()
         #expect(
             inode(of: socketPath) == successorInode,
-            "a repeat shutdown deleted the successor's socket"
+            "a repeat reclaim deleted the successor's socket"
         )
     }
 

--- a/Tests/TBDDaemonTests/SocketServerSocketOwnershipTests.swift
+++ b/Tests/TBDDaemonTests/SocketServerSocketOwnershipTests.swift
@@ -37,9 +37,7 @@ struct SocketServerSocketOwnershipTests {
     /// identity the fix turns on — a path check alone cannot tell one server's
     /// socket from another's.
     private func inode(of path: String) -> ino_t? {
-        var info = stat()
-        guard lstat(path, &info) == 0 else { return nil }
-        return info.st_ino
+        socketFileInode(at: path)
     }
 
     /// Open an AF_UNIX/SOCK_STREAM client and connect() to `path`. Returns the
@@ -140,5 +138,135 @@ struct SocketServerSocketOwnershipTests {
         )
 
         await incumbent.stop()
+    }
+
+    @Test("a start that fails after binding leaves a successor's socket alone")
+    func failedStartLeavesSuccessorSocketAlone() async throws {
+        let socketPath = scratchSocketPath()
+        defer { unlink(socketPath) }
+
+        // The other end of the same race, reached from startup rather than
+        // shutdown. `start()` binds the rendezvous file and then awaits NIO
+        // adopting the descriptor; that await is a suspension point, so a
+        // successor daemon can bind the path inside it. If the adoption then
+        // fails, the cleanup must not delete the file the successor now owns.
+        let successor = SuccessorSocket()
+        defer { successor.release() }
+
+        let predecessor = SocketServer(
+            router: try makeRouter(),
+            socketPath: socketPath,
+            beforeAdoptingBoundSocket: { boundFD in
+                // This descriptor never reaches NIO, so close it here rather
+                // than leak it for the life of the test process.
+                close(boundFD)
+                successor.takeOver(path: socketPath)
+                throw AdoptionRefused()
+            }
+        )
+
+        await #expect(throws: AdoptionRefused.self) {
+            try await predecessor.start()
+        }
+
+        let predecessorInode = try #require(successor.displacedInode)
+        let successorInode = try #require(successor.inode)
+        #expect(
+            successorInode != predecessorInode,
+            "the successor's bind must produce a new inode, or this test proves nothing"
+        )
+        #expect(
+            socketFileInode(at: socketPath) == successorInode,
+            "the failed start deleted the live successor's socket"
+        )
+
+        // And the successor must still be reachable through the path.
+        let clientFd = connectRawClient(to: socketPath)
+        #expect(clientFd >= 0, "clients can no longer reach the live daemon at \(socketPath)")
+        if clientFd >= 0 { close(clientFd) }
+    }
+
+    @Test("a start that fails after binding still reclaims the file it bound")
+    func failedStartReclaimsItsOwnSocket() async throws {
+        let socketPath = scratchSocketPath()
+        defer { unlink(socketPath) }
+
+        // Nobody takes the path over inside the window, so the file is this
+        // server's to clean up. The ownership check on the failure path must
+        // not degenerate into "never unlink" and strand a socket file.
+        let server = SocketServer(
+            router: try makeRouter(),
+            socketPath: socketPath,
+            beforeAdoptingBoundSocket: { boundFD in
+                close(boundFD)
+                throw AdoptionRefused()
+            }
+        )
+
+        await #expect(throws: AdoptionRefused.self) {
+            try await server.start()
+        }
+
+        #expect(
+            socketFileInode(at: socketPath) == nil,
+            "a failed start left its own socket file behind"
+        )
+    }
+}
+
+/// `st_ino` of whatever is at `path`, or nil if nothing is. `lstat` rather
+/// than `stat`, matching the production check.
+private func socketFileInode(at path: String) -> ino_t? {
+    var info = stat()
+    guard lstat(path, &info) == 0 else { return nil }
+    return info.st_ino
+}
+
+/// What NIO refusing the bound descriptor looks like to `start()`. The real
+/// refusals are kernel-level and cannot be provoked in-process, so the test
+/// injects the failure at the same point in the same window.
+private struct AdoptionRefused: Error {}
+
+/// A stand-in for a successor daemon taking the rendezvous path over: unlink
+/// whatever is there, then `bind(2)` + `listen(2)` its own socket under the
+/// same name — exactly what another daemon's `start()` leaves behind.
+private final class SuccessorSocket: @unchecked Sendable {
+    /// The inode this displaced, i.e. the predecessor's own socket file.
+    private(set) var displacedInode: ino_t?
+    /// The inode of the socket now at the path.
+    private(set) var inode: ino_t?
+    private var fd: Int32 = -1
+
+    func takeOver(path: String) {
+        displacedInode = socketFileInode(at: path)
+        unlink(path)
+
+        let newFD = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard newFD >= 0 else { return }
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        let pathBytes = Array(path.utf8)
+        withUnsafeMutableBytes(of: &addr.sun_path) { raw in
+            raw.copyBytes(from: pathBytes)
+            raw[pathBytes.count] = 0
+        }
+        let bound = withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+                bind(newFD, sockPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard bound == 0, listen(newFD, 8) == 0 else {
+            close(newFD)
+            return
+        }
+        fd = newFD
+        inode = socketFileInode(at: path)
+    }
+
+    func release() {
+        if fd >= 0 {
+            close(fd)
+            fd = -1
+        }
     }
 }

--- a/Tests/TBDDaemonTests/SocketServerSocketOwnershipTests.swift
+++ b/Tests/TBDDaemonTests/SocketServerSocketOwnershipTests.swift
@@ -160,12 +160,19 @@ struct SocketServerSocketOwnershipTests {
         // unsynchronized read to land in the window. Taken under a lock, the
         // others wait outside it and come away with nothing; taken with a
         // plain read-then-nil, all eight read the same identity.
+        //
+        // Every wait below is bounded and reached from a dedicated `Thread`,
+        // never from the cooperative pool: a blocked pool thread is one the
+        // work that would release it can no longer run on, and the pool is
+        // three threads wide on CI's runner.
         let claimants = 8
         let atCallSite = DispatchSemaphore(value: 0)
         let windowIsHeld = FirstArrivalFlag()
         let claimWindow: @Sendable (SocketFileIdentity?) -> Void = { _ in
             guard windowIsHeld.takeFirst() else { return }
-            for _ in 0..<(claimants - 1) { atCallSite.wait() }
+            for index in 0..<(claimants - 1) {
+                atCallSite.waitForGate("claimant \(index + 2) of \(claimants) reaching the claim call site")
+            }
             usleep(50_000)
         }
 
@@ -186,10 +193,10 @@ struct SocketServerSocketOwnershipTests {
                 finished.increment()
             }
         }
-        #expect(
-            await waitUntil({ finished.count == claimants }, timeout: .seconds(15)),
-            "the claimant threads never finished"
-        )
+        try await waitFor(
+            "all \(claimants) claimant threads to finish",
+            observed: { "\(finished.count) of \(claimants) finished" }
+        ) { finished.count == claimants }
         #expect(
             claims.count == 1,
             "\(claims.count) of \(claimants) overlapping shutdowns came away owning the socket file; only one may"
@@ -220,15 +227,31 @@ struct SocketServerSocketOwnershipTests {
         // together are not this case, because both get their `channel.close()`
         // in while the loop is still alive; that ordering survives even
         // without the fix, so a test built on it proves nothing.
+        //
+        // The staging gate blocks whichever thread runs the shutdown body, so
+        // that thread must not be a cooperative-pool one: the pool is three
+        // threads wide on CI's runner, and the statement that releases the
+        // gate needs a thread from it. Both `stop()` calls therefore start
+        // with `gateHoldingTask` — either of them may be the one that wins the
+        // latch and runs the body — and every wait is bounded through
+        // `waitForGate`, which names the gate instead of parking a thread for
+        // good. See Tests/CLAUDE.md, "Thread-blocking gates run off the
+        // cooperative pool".
         let claims = ClaimCounter()
         let firstShutdownIsAtTheReclaimStep = DispatchSemaphore(value: 0)
         let secondCallerHasArrived = DispatchSemaphore(value: 0)
         let holdTheFirstShutdown = FirstArrivalFlag()
+        // Short of the observation's own budget on purpose: if the staging
+        // never happens, this test should degrade to the weaker "both stop()
+        // calls returned" check and say why, rather than have the outer wait
+        // expire first and report a wedge that is really a lost handshake.
+        let stagingDeadline: Duration = .seconds(30)
         let claimWindow: @Sendable (SocketFileIdentity?) -> Void = { identity in
             if identity != nil { claims.increment() }
             guard holdTheFirstShutdown.takeFirst() else { return }
             firstShutdownIsAtTheReclaimStep.signal()
-            _ = secondCallerHasArrived.wait(timeout: .now() + 10)
+            secondCallerHasArrived.waitForGate(
+                "the second stop() caller to reach stop()", timeout: stagingDeadline)
             // Covers the hop between the second caller reaching `stop()` and
             // `stop()` reaching the latch, so the first shutdown is still
             // in flight when it gets there.
@@ -244,30 +267,31 @@ struct SocketServerSocketOwnershipTests {
         try await server.start()
         #expect(inode(of: socketPath) != nil)
 
-        // Detached and waited on with a deadline rather than gathered in a
-        // task group: the failure under test is a shutdown that never returns,
-        // and a task group would wedge the whole run alongside it instead of
-        // reporting it.
+        // Unstructured and waited on with a deadline rather than gathered in
+        // a task group: the failure under test is a shutdown that never
+        // returns, and a task group would wedge the whole run alongside it
+        // instead of reporting it.
         let finished = ClaimCounter()
-        Task.detached {
+        _ = gateHoldingTask {
             await server.stop()
             finished.increment()
         }
         // On its own thread so the bounded wait cannot occupy a cooperative
         // pool thread the first shutdown may need.
         Thread.detachNewThread {
-            _ = firstShutdownIsAtTheReclaimStep.wait(timeout: .now() + 10)
+            firstShutdownIsAtTheReclaimStep.waitForGate(
+                "the first shutdown to reach its reclaim step", timeout: stagingDeadline)
             secondCallerHasArrived.signal()
-            Task.detached {
+            _ = gateHoldingTask {
                 await server.stop()
                 finished.increment()
             }
         }
 
-        #expect(
-            await waitUntil({ finished.count == 2 }, timeout: .seconds(15)),
-            "only \(finished.count) of 2 overlapping stop() calls returned; a shutdown is wedged"
-        )
+        try await waitFor(
+            "both overlapping stop() calls to return",
+            observed: { "\(finished.count) of 2 returned" }
+        ) { finished.count == 2 }
         #expect(
             claims.count == 1,
             "\(claims.count) of the overlapping shutdowns came away owning the socket file; exactly one may"
@@ -300,10 +324,10 @@ struct SocketServerSocketOwnershipTests {
             await server.stop()
             secondStopReturned.increment()
         }
-        #expect(
-            await waitUntil({ secondStopReturned.count == 1 }, timeout: .seconds(15)),
-            "the second stop() never returned"
-        )
+        try await waitFor(
+            "the second stop() to return",
+            observed: { "\(secondStopReturned.count) of 1 returned" }
+        ) { secondStopReturned.count == 1 }
         #expect(
             inode(of: socketPath) == successorInode,
             "a repeat shutdown deleted the successor's socket"

--- a/Tests/TBDDaemonTests/SocketServerSocketOwnershipTests.swift
+++ b/Tests/TBDDaemonTests/SocketServerSocketOwnershipTests.swift
@@ -1,0 +1,144 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+import TestSupport
+
+// A dying daemon must not unlink a live successor's socket.
+//
+// The socket path is a rendezvous every daemon generation binds in turn: a new
+// daemon's `start()` removes whatever file is there and binds its own. If the
+// outgoing daemon's `stop()` then unlinks on existence alone, it deletes the
+// successor's socket. The successor never finds out — it keeps accepting on a
+// listener no client can reach, and every client fails against a path that is
+// simply gone. Only the file's identity, not its name, tells the two apart.
+@Suite("SocketServer socket-file ownership")
+struct SocketServerSocketOwnershipTests {
+
+    /// Throwaway RPCRouter: in-memory DB + dryRun tmux, so no real tmux server
+    /// is contacted and nothing under ~/tbd is touched.
+    private func makeRouter() throws -> RPCRouter {
+        let db = try TBDDatabase(inMemory: true)
+        return RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db,
+                git: GitManager(),
+                tmux: TmuxManager(dryRun: true),
+                hooks: HookResolver()
+            ),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date(),
+            actuationLog: makeTestActuationLog()
+        )
+    }
+
+    /// `st_ino` of whatever is at `path`, or nil if nothing is. This is the
+    /// identity the fix turns on — a path check alone cannot tell one server's
+    /// socket from another's.
+    private func inode(of path: String) -> ino_t? {
+        var info = stat()
+        guard lstat(path, &info) == 0 else { return nil }
+        return info.st_ino
+    }
+
+    /// Open an AF_UNIX/SOCK_STREAM client and connect() to `path`. Returns the
+    /// connected fd, or -1. This is the client's-eye view: it is what actually
+    /// breaks when the socket file is unlinked out from under a live listener.
+    private func connectRawClient(to path: String) -> Int32 {
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else { return -1 }
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        path.withCString { ptr in
+            withUnsafeMutablePointer(to: &addr.sun_path) { pathPtr in
+                UnsafeMutableRawPointer(pathPtr).copyMemory(from: ptr, byteCount: strlen(ptr) + 1)
+            }
+        }
+        let result = withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+                connect(fd, sockPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        if result != 0 {
+            close(fd)
+            return -1
+        }
+        return fd
+    }
+
+    /// Short /tmp path, well under the ~104-byte `sun_path` limit. NOT ~/tbd/sock.
+    private func scratchSocketPath() -> String {
+        "/tmp/tbd-sockown-\(UUID().uuidString.prefix(8)).sock"
+    }
+
+    @Test("a stopping server leaves a successor's socket at the same path alone")
+    func successorSocketSurvivesPredecessorStop() async throws {
+        let socketPath = scratchSocketPath()
+        defer { unlink(socketPath) }
+
+        // Daemon A binds the rendezvous path.
+        let serverA = SocketServer(router: try makeRouter(), socketPath: socketPath)
+        try await serverA.start()
+        let inodeA = try #require(inode(of: socketPath))
+
+        // Daemon B takes the path over: its start() unlinks A's file and binds
+        // its own, so the path now names a different inode.
+        let serverB = SocketServer(router: try makeRouter(), socketPath: socketPath)
+        try await serverB.start()
+        let inodeB = try #require(inode(of: socketPath))
+        #expect(inodeB != inodeA, "B's bind must produce a new inode, or this test proves nothing")
+
+        // A shuts down afterwards — the orphaned-daemon case.
+        await serverA.stop()
+
+        // B's socket must still be there, and must still be B's.
+        #expect(inode(of: socketPath) == inodeB, "A's stop() deleted the live successor's socket")
+
+        // And a client must still be able to reach B through the path.
+        let clientFd = connectRawClient(to: socketPath)
+        #expect(clientFd >= 0, "clients can no longer reach the live daemon at \(socketPath)")
+        if clientFd >= 0 { close(clientFd) }
+
+        await serverB.stop()
+    }
+
+    @Test("a stopping server still reclaims the socket it bound itself")
+    func serverReclaimsItsOwnSocket() async throws {
+        let socketPath = scratchSocketPath()
+        defer { unlink(socketPath) }
+
+        let server = SocketServer(router: try makeRouter(), socketPath: socketPath)
+        try await server.start()
+        #expect(inode(of: socketPath) != nil)
+
+        await server.stop()
+
+        // Nobody else took the path over, so the file is this server's to clean
+        // up. The ownership check must not turn into "never unlink".
+        #expect(inode(of: socketPath) == nil, "a server must still reclaim its own socket file")
+    }
+
+    @Test("a server that never bound unlinks nothing")
+    func neverStartedServerUnlinksNothing() async throws {
+        let socketPath = scratchSocketPath()
+        defer { unlink(socketPath) }
+
+        // Somebody else's socket sits at the path.
+        let incumbent = SocketServer(router: try makeRouter(), socketPath: socketPath)
+        try await incumbent.start()
+        let incumbentInode = try #require(inode(of: socketPath))
+
+        // A second server is constructed but never starts — a daemon that lost
+        // the race to bind and is now being torn down.
+        let neverStarted = SocketServer(router: try makeRouter(), socketPath: socketPath)
+        await neverStarted.stop()
+
+        #expect(
+            inode(of: socketPath) == incumbentInode,
+            "stop() on a server that never bound deleted a live socket"
+        )
+
+        await incumbent.stop()
+    }
+}

--- a/Tests/TBDDaemonTests/SocketServerSocketOwnershipTests.swift
+++ b/Tests/TBDDaemonTests/SocketServerSocketOwnershipTests.swift
@@ -161,10 +161,13 @@ struct SocketServerSocketOwnershipTests {
         // others wait outside it and come away with nothing; taken with a
         // plain read-then-nil, all eight read the same identity.
         //
-        // Every wait below is bounded and reached from a dedicated `Thread`,
+        // Every wait below is bounded and reached from a `gateHoldingTask`,
         // never from the cooperative pool: a blocked pool thread is one the
         // work that would release it can no longer run on, and the pool is
-        // three threads wide on CI's runner.
+        // three threads wide on CI's runner. A task rather than a bare
+        // `Thread` because the two things Swift Testing needs to attribute an
+        // expired gate — `Test.current` and `Configuration.current` — are
+        // task-locals, and a bare `Thread` has neither.
         let claimants = 8
         let atCallSite = DispatchSemaphore(value: 0)
         let windowIsHeld = FirstArrivalFlag()
@@ -187,7 +190,7 @@ struct SocketServerSocketOwnershipTests {
         let claims = ClaimCounter()
         let finished = ClaimCounter()
         for _ in 0..<claimants {
-            Thread.detachNewThread {
+            _ = gateHoldingTask {
                 atCallSite.signal()
                 if server.takeBoundSocketIdentity() != nil { claims.increment() }
                 finished.increment()
@@ -228,24 +231,38 @@ struct SocketServerSocketOwnershipTests {
         // in while the loop is still alive; that ordering survives even
         // without the fix, so a test built on it proves nothing.
         //
-        // The staging gate blocks whichever thread runs the shutdown body, so
-        // that thread must not be a cooperative-pool one: the pool is three
-        // threads wide on CI's runner, and the statement that releases the
-        // gate needs a thread from it. Both `stop()` calls therefore start
-        // with `gateHoldingTask` — either of them may be the one that wins the
-        // latch and runs the body — and every wait is bounded through
-        // `waitForGate`, which names the gate instead of parking a thread for
-        // good. See Tests/CLAUDE.md, "Thread-blocking gates run off the
-        // cooperative pool".
+        // Nothing this test starts parks a cooperative-pool thread: both
+        // `stop()` calls and the thread that waits on the staging gate go
+        // through `gateHoldingTask`, and every wait is bounded through
+        // `waitForGate`. See Tests/CLAUDE.md, "Thread-blocking gates run off
+        // the cooperative pool".
+        //
+        // **`gateHoldingTask` cannot reach the shutdown body, though.**
+        // `SocketServer.stop()` hands that body to `ShutdownLatch`, which runs
+        // it in an unstructured `Task` so a cancelled signal handler cannot
+        // abandon a shutdown other callers await — and SE-0417 carries a task
+        // executor preference into child tasks and default actors but *not*
+        // into `Task {}`. So the work that signals the gate below is scheduled
+        // on the cooperative pool however this test starts `stop()`,
+        // competing with a parallel pass that admits all ~5,000 tests at once
+        // against a 3-thread runner.
+        //
+        // That is a scheduling cost, not a wedge, and the gate's bound has to
+        // absorb it.
         let claims = ClaimCounter()
         let firstShutdownIsAtTheReclaimStep = DispatchSemaphore(value: 0)
         let secondCallerHasArrived = DispatchSemaphore(value: 0)
         let holdTheFirstShutdown = FirstArrivalFlag()
-        // Short of the observation's own budget on purpose: if the staging
-        // never happens, this test should degrade to the weaker "both stop()
-        // calls returned" check and say why, rather than have the outer wait
-        // expire first and report a wedge that is really a lost handshake.
-        let stagingDeadline: Duration = .seconds(30)
+        // The saturated-pass budget the rest of the repo derives its waits
+        // from, and the observation below gets a strictly larger one. That
+        // ordering is what makes a genuinely lost handshake report itself as a
+        // lost handshake and degrade to the weaker "both stop() calls
+        // returned" check, rather than surface as a wedge. A snappier bound
+        // here reports starvation the outer bound was sized to tolerate:
+        // measured on CI at 30 s, where the handshake was merely late and
+        // every other assertion in this test still passed.
+        let stagingDeadline: Duration = TestDeadlines.saturatedPass
+        let bothStopsReturnedDeadline: Duration = TestGate.deadline
         let claimWindow: @Sendable (SocketFileIdentity?) -> Void = { identity in
             if identity != nil { claims.increment() }
             guard holdTheFirstShutdown.takeFirst() else { return }
@@ -276,9 +293,14 @@ struct SocketServerSocketOwnershipTests {
             await server.stop()
             finished.increment()
         }
-        // On its own thread so the bounded wait cannot occupy a cooperative
-        // pool thread the first shutdown may need.
-        Thread.detachNewThread {
+        // Off the cooperative pool so the bounded wait cannot occupy a thread
+        // the first shutdown may need, and a task rather than a bare `Thread`
+        // so an expired gate is attributed to this test: Swift Testing reads
+        // `Test.current` and `Configuration.current` from task-locals, and
+        // with neither it names the failure «unknown» and posts it to every
+        // registered event handler rather than lose it — one expiry, several
+        // identical lines.
+        _ = gateHoldingTask {
             firstShutdownIsAtTheReclaimStep.waitForGate(
                 "the first shutdown to reach its reclaim step", timeout: stagingDeadline)
             secondCallerHasArrived.signal()
@@ -290,6 +312,7 @@ struct SocketServerSocketOwnershipTests {
 
         try await waitFor(
             "both overlapping stop() calls to return",
+            deadline: bothStopsReturnedDeadline,
             observed: { "\(finished.count) of 2 returned" }
         ) { finished.count == 2 }
         #expect(

--- a/Tests/TBDDaemonTests/SocketServerSocketOwnershipTests.swift
+++ b/Tests/TBDDaemonTests/SocketServerSocketOwnershipTests.swift
@@ -140,6 +140,149 @@ struct SocketServerSocketOwnershipTests {
         await incumbent.stop()
     }
 
+    @Test("only one of many overlapping shutdowns claims the socket file")
+    func onlyOneOverlappingShutdownClaimsTheFile() async throws {
+        let socketPath = scratchSocketPath()
+        defer { unlink(socketPath) }
+
+        // Nothing serializes `stop()`: SIGTERM and SIGINT each fire their own
+        // undeduplicated `Task { await daemon.stop() }` in main.swift, so a
+        // supervisor escalating signals can run two shutdowns at once. Every
+        // claimant goes on to unlink against the identity it came away with,
+        // so a second claimant is a second unlink — aimed at a path a
+        // successor may have taken over by then, which is the one thing the
+        // identity exists to prevent. At most one claim, always.
+        //
+        // The read-and-clear window is a few instructions wide, so no amount
+        // of starting threads and hoping will land inside it. `claimWindow`
+        // holds it open instead: the first claimant waits until every other
+        // thread has reached the call site, then lingers long enough for an
+        // unsynchronized read to land in the window. Taken under a lock, the
+        // others wait outside it and come away with nothing; taken with a
+        // plain read-then-nil, all eight read the same identity.
+        let claimants = 8
+        let atCallSite = DispatchSemaphore(value: 0)
+        let windowIsHeld = FirstArrivalFlag()
+        let claimWindow: @Sendable () -> Void = {
+            guard windowIsHeld.takeFirst() else { return }
+            for _ in 0..<(claimants - 1) { atCallSite.wait() }
+            usleep(50_000)
+        }
+
+        let server = SocketServer(
+            router: try makeRouter(),
+            socketPath: socketPath,
+            beforeAdoptingBoundSocket: nil,
+            duringIdentityClaim: claimWindow
+        )
+        try await server.start()
+
+        let claims = ClaimCounter()
+        let finished = DispatchGroup()
+        for _ in 0..<claimants {
+            finished.enter()
+            Thread.detachNewThread {
+                atCallSite.signal()
+                if server.takeBoundSocketIdentity() != nil { claims.increment() }
+                finished.leave()
+            }
+        }
+        #expect(finished.wait(timeout: .now() + 30) == .success, "the claimant threads never finished")
+        #expect(
+            claims.count == 1,
+            "\(claims.count) of \(claimants) overlapping shutdowns came away owning the socket file; only one may"
+        )
+
+        await server.stop()
+    }
+
+    @Test("overlapping shutdowns still reclaim the server's own socket file, once")
+    func overlappingShutdownsReclaimTheFileOnce() async throws {
+        let socketPath = scratchSocketPath()
+        defer { unlink(socketPath) }
+
+        // The end-to-end half of the test above: whatever the claim does under
+        // contention, a pile of concurrent shutdowns must still reclaim the
+        // file this server bound, and a shutdown that arrives after a
+        // successor has taken the path over must leave the successor alone.
+        let server = SocketServer(router: try makeRouter(), socketPath: socketPath)
+        try await server.start()
+
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<8 {
+                group.addTask { await server.stop() }
+            }
+        }
+        #expect(inode(of: socketPath) == nil, "the shutdown must still reclaim its own file")
+
+        // A successor now binds the path. Any further shutdown of the old
+        // server must find nothing left to claim and leave it alone.
+        let successor = SuccessorSocket()
+        defer { successor.release() }
+        successor.takeOver(path: socketPath)
+        let successorInode = try #require(successor.inode)
+
+        await server.stop()
+        #expect(
+            inode(of: socketPath) == successorInode,
+            "a repeat shutdown deleted the successor's socket"
+        )
+    }
+
+    /// The rendezvous path is cleared by whoever is about to bind it, and by
+    /// nobody else. `SocketServer` is that code: `start()` clears the path
+    /// immediately before `bind(2)`, and `stop()` reclaims the file only while
+    /// the path still resolves to the inode it bound.
+    ///
+    /// Two startup paths used to remove it on the strength of a stale pid file
+    /// — `PIDFile.cleanupIfStale()` and `AppState.startDaemonAndConnect()` —
+    /// and a pid file reads as stale for as long as a successor has bound the
+    /// socket without having rewritten it yet. Removing it there deletes a
+    /// live daemon's socket and puts nothing in its place: the path stays
+    /// empty for the whole of the next daemon's startup, and for good if that
+    /// startup throws first.
+    ///
+    /// Pinned against the source text because those removals resolve
+    /// `TBDConstants.socketPath` from the process environment, and the only
+    /// runtime seam for that is a process-global this target must not mutate:
+    /// `ConstantsTests` pins that no suite in this process sets
+    /// `TBD_SOCKET_PATH`, and `scripts/test.sh` sets it for the whole run. A
+    /// source pin is a weak instrument in general; here it is the available
+    /// one.
+    @Test("nothing outside SocketServer removes the rendezvous socket file")
+    func onlyTheBinderClearsTheRendezvousPath() throws {
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()   // Tests/TBDDaemonTests
+            .deletingLastPathComponent()   // Tests
+            .deletingLastPathComponent()   // repo root
+        let fm = FileManager.default
+        var offenders: [String] = []
+        var scanned = 0
+
+        for module in ["Sources/TBDDaemon", "Sources/TBDApp"] {
+            let dir = root.appendingPathComponent(module)
+            let files = fm.enumerator(at: dir, includingPropertiesForKeys: nil)?
+                .compactMap { $0 as? URL }
+                .filter { $0.pathExtension == "swift" } ?? []
+            for file in files where file.lastPathComponent != "SocketServer.swift" {
+                guard let text = try? String(contentsOf: file, encoding: .utf8) else { continue }
+                scanned += 1
+                for (index, line) in text.split(separator: "\n", omittingEmptySubsequences: false).enumerated() {
+                    let code = line.trimmingCharacters(in: .whitespaces)
+                    guard !code.hasPrefix("//"), code.contains("TBDConstants.socketPath") else { continue }
+                    guard code.contains("removeItem") || code.contains("unlink(") else { continue }
+                    offenders.append("\(file.lastPathComponent):\(index + 1): \(code)")
+                }
+            }
+        }
+
+        #expect(scanned > 100, "the source scan found almost nothing to read — it is passing vacuously")
+        #expect(
+            offenders.isEmpty,
+            "these remove the rendezvous socket without binding it: \(offenders.joined(separator: "; "))"
+        )
+    }
+
     @Test("a start that fails after binding leaves a successor's socket alone")
     func failedStartLeavesSuccessorSocketAlone() async throws {
         let socketPath = scratchSocketPath()
@@ -279,5 +422,39 @@ private final class SuccessorSocket: @unchecked Sendable {
             close(fd)
             fd = -1
         }
+    }
+}
+
+/// Lets exactly one caller through — the first claimant, which is the one that
+/// holds the read-and-clear window open for everybody else.
+private final class FirstArrivalFlag: @unchecked Sendable {
+    private var taken = false
+    private let lock = NSLock()
+
+    func takeFirst() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        if taken { return false }
+        taken = true
+        return true
+    }
+}
+
+/// Counts how many concurrent callers came away holding the socket file's
+/// identity. The guarantee under test is that the answer is one.
+private final class ClaimCounter: @unchecked Sendable {
+    private var value = 0
+    private let lock = NSLock()
+
+    func increment() {
+        lock.lock()
+        defer { lock.unlock() }
+        value += 1
+    }
+
+    var count: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
     }
 }

--- a/Tests/TBDDaemonTests/SocketServerSocketOwnershipTests.swift
+++ b/Tests/TBDDaemonTests/SocketServerSocketOwnershipTests.swift
@@ -184,6 +184,14 @@ struct SocketServerSocketOwnershipTests {
         let clientFd = connectRawClient(to: socketPath)
         #expect(clientFd >= 0, "clients can no longer reach the live daemon at \(socketPath)")
         if clientFd >= 0 { close(clientFd) }
+
+        // Tearing the failed server down afterwards must not finish the job
+        // its failed start did not do — it bound nothing it still owns.
+        await predecessor.stop()
+        #expect(
+            socketFileInode(at: socketPath) == successorInode,
+            "stop() after a failed start deleted the live successor's socket"
+        )
     }
 
     @Test("a start that fails after binding still reclaims the file it bound")
@@ -211,6 +219,9 @@ struct SocketServerSocketOwnershipTests {
             socketFileInode(at: socketPath) == nil,
             "a failed start left its own socket file behind"
         )
+
+        // Releases the event loop group the failed start left running.
+        await server.stop()
     }
 }
 

--- a/Tests/TBDDaemonTests/SocketServerSocketOwnershipTests.swift
+++ b/Tests/TBDDaemonTests/SocketServerSocketOwnershipTests.swift
@@ -163,7 +163,7 @@ struct SocketServerSocketOwnershipTests {
         let claimants = 8
         let atCallSite = DispatchSemaphore(value: 0)
         let windowIsHeld = FirstArrivalFlag()
-        let claimWindow: @Sendable () -> Void = {
+        let claimWindow: @Sendable (SocketFileIdentity?) -> Void = { _ in
             guard windowIsHeld.takeFirst() else { return }
             for _ in 0..<(claimants - 1) { atCallSite.wait() }
             usleep(50_000)
@@ -187,7 +187,7 @@ struct SocketServerSocketOwnershipTests {
             }
         }
         #expect(
-            await waitUntil({ finished.count == claimants }, timeout: .seconds(30)),
+            await waitUntil({ finished.count == claimants }, timeout: .seconds(15)),
             "the claimant threads never finished"
         )
         #expect(
@@ -198,22 +198,92 @@ struct SocketServerSocketOwnershipTests {
         await server.stop()
     }
 
-    @Test("a second reclaim after a successor took over claims nothing")
-    func repeatReclaimLeavesTheSuccessorAlone() async throws {
+    @Test("two overlapping shutdowns both finish, and the socket file is claimed once")
+    func overlappingStopsBothFinishAndClaimTheFileOnce() async throws {
         let socketPath = scratchSocketPath()
         defer { unlink(socketPath) }
 
-        // The file-level half of the claim-once guarantee: the first shutdown
-        // reclaims the file this server bound, and the reclaim step a second
-        // shutdown would run must find nothing left to claim.
-        //
-        // `unlinkOwnedSocketFile()` rather than a second `stop()`, and
-        // `takeBoundSocketIdentity()` rather than overlapping `stop()` calls in
-        // the test above, for the same reason: NIO's `shutdownGracefully` never
-        // completes when the group is already shut down, so a second `stop()`
-        // suspends its task forever with no thread left to show for it. The
-        // contested step in production is the claim, and that is what these
-        // tests contend for.
+        // The real path this branch exists to survive. SIGTERM and SIGINT each
+        // fire an independent, undeduplicated `Task { await daemon.stop() }` in
+        // main.swift, both reach `SocketServer.stop()` through `Daemon.stop()`,
+        // and a supervisor escalating signals sends both. Running the shutdown
+        // body twice hangs rather than merely repeating: `channel.close()` off
+        // the event loop is `eventLoop.execute { ... }` fulfilling a promise,
+        // and a loop whose group has shut down discards submitted work, so the
+        // promise is never fulfilled. Both `stop()` calls must return, and the
+        // socket file must be claimed once — a second claimant would go on to
+        // unlink against a path a successor may hold by then.
+        // The overlap is staged rather than hoped for, and staged at the point
+        // that is actually dangerous: the second caller enters `stop()` while
+        // the first is at its reclaim step — past `shutdownGracefully()`, so
+        // the event loop is already gone. Two `stop()` calls that merely start
+        // together are not this case, because both get their `channel.close()`
+        // in while the loop is still alive; that ordering survives even
+        // without the fix, so a test built on it proves nothing.
+        let claims = ClaimCounter()
+        let firstShutdownIsAtTheReclaimStep = DispatchSemaphore(value: 0)
+        let secondCallerHasArrived = DispatchSemaphore(value: 0)
+        let holdTheFirstShutdown = FirstArrivalFlag()
+        let claimWindow: @Sendable (SocketFileIdentity?) -> Void = { identity in
+            if identity != nil { claims.increment() }
+            guard holdTheFirstShutdown.takeFirst() else { return }
+            firstShutdownIsAtTheReclaimStep.signal()
+            _ = secondCallerHasArrived.wait(timeout: .now() + 10)
+            // Covers the hop between the second caller reaching `stop()` and
+            // `stop()` reaching the latch, so the first shutdown is still
+            // in flight when it gets there.
+            usleep(50_000)
+        }
+
+        let server = SocketServer(
+            router: try makeRouter(),
+            socketPath: socketPath,
+            beforeAdoptingBoundSocket: nil,
+            duringIdentityClaim: claimWindow
+        )
+        try await server.start()
+        #expect(inode(of: socketPath) != nil)
+
+        // Detached and waited on with a deadline rather than gathered in a
+        // task group: the failure under test is a shutdown that never returns,
+        // and a task group would wedge the whole run alongside it instead of
+        // reporting it.
+        let finished = ClaimCounter()
+        Task.detached {
+            await server.stop()
+            finished.increment()
+        }
+        // On its own thread so the bounded wait cannot occupy a cooperative
+        // pool thread the first shutdown may need.
+        Thread.detachNewThread {
+            _ = firstShutdownIsAtTheReclaimStep.wait(timeout: .now() + 10)
+            secondCallerHasArrived.signal()
+            Task.detached {
+                await server.stop()
+                finished.increment()
+            }
+        }
+
+        #expect(
+            await waitUntil({ finished.count == 2 }, timeout: .seconds(15)),
+            "only \(finished.count) of 2 overlapping stop() calls returned; a shutdown is wedged"
+        )
+        #expect(
+            claims.count == 1,
+            "\(claims.count) of the overlapping shutdowns came away owning the socket file; exactly one may"
+        )
+        #expect(inode(of: socketPath) == nil, "the overlapping shutdowns left the socket file behind")
+    }
+
+    @Test("a second shutdown after a successor took over leaves the successor alone")
+    func repeatStopLeavesTheSuccessorAlone() async throws {
+        let socketPath = scratchSocketPath()
+        defer { unlink(socketPath) }
+
+        // The sequential half of the same guarantee, and the case a signal
+        // escalation actually produces most often: SIGTERM shuts the server
+        // down, a successor daemon binds the rendezvous path, and SIGINT then
+        // runs a second `stop()`. It must return, and it must claim nothing.
         let server = SocketServer(router: try makeRouter(), socketPath: socketPath)
         try await server.start()
 
@@ -225,10 +295,18 @@ struct SocketServerSocketOwnershipTests {
         successor.takeOver(path: socketPath)
         let successorInode = try #require(successor.inode)
 
-        server.unlinkOwnedSocketFile()
+        let secondStopReturned = ClaimCounter()
+        Task.detached {
+            await server.stop()
+            secondStopReturned.increment()
+        }
+        #expect(
+            await waitUntil({ secondStopReturned.count == 1 }, timeout: .seconds(15)),
+            "the second stop() never returned"
+        )
         #expect(
             inode(of: socketPath) == successorInode,
-            "a repeat reclaim deleted the successor's socket"
+            "a repeat shutdown deleted the successor's socket"
         )
     }
 

--- a/Tests/TestSupport/BoundedGateSupport.swift
+++ b/Tests/TestSupport/BoundedGateSupport.swift
@@ -79,6 +79,11 @@ public final class GateExecutor: TaskExecutor, @unchecked Sendable {
     /// exists so `gateHoldingTask` does not mint a queue per call site.
     public static let shared = GateExecutor()
 
+    /// The name every job thread carries. Exposed so a test can tell "on a
+    /// thread these tests own" from "on the cooperative pool" — which is the
+    /// only way to pin SE-0417's inheritance rule rather than remember it.
+    public static let threadName = "com.tbd.tests.gate-executor"
+
     private init() {}
 
     public func enqueue(_ job: consuming ExecutorJob) {
@@ -87,7 +92,7 @@ public final class GateExecutor: TaskExecutor, @unchecked Sendable {
         let thread = Thread {
             job.runSynchronously(on: executor)
         }
-        thread.name = "com.tbd.tests.gate-executor"
+        thread.name = Self.threadName
         thread.qualityOfService = .userInitiated
         thread.start()
     }
@@ -100,6 +105,19 @@ public final class GateExecutor: TaskExecutor, @unchecked Sendable {
 /// test runs while the gate is closed, and the `signal()` that releases it —
 /// stays on the pool, which is the point: it needs a thread, and this call is
 /// what guarantees one is left.
+///
+/// **The preference stops at an unstructured task.** SE-0417 carries a task
+/// executor preference into child tasks (`async let`, task groups) and into
+/// default actors, and *not* into `Task {}` or `Task.detached`. So this call
+/// covers the operation's own frames and the actors it hops through, but not
+/// work a callee hands to an unstructured task — `ShutdownLatch` does exactly
+/// that, deliberately, so a cancelled signal handler cannot abandon a shutdown
+/// other callers are awaiting. Work beyond such a hop is scheduled on the
+/// cooperative pool however its caller was started, so a gate released from
+/// there is subject to the pass's scheduling latency and must be bounded by
+/// ``TestDeadlines/saturatedPass`` rather than by a snappier number. It is not
+/// pinning a thread, and no call-site change can move it; only the bound is
+/// yours to get right. `BoundedGateWaitTests` pins the rule.
 public func gateHoldingTask<Success: Sendable>(
     _ operation: @escaping @Sendable () async -> Success
 ) -> Task<Success, Never> {
@@ -244,10 +262,15 @@ public struct TestGateTimeout: Error, CustomStringConvertible {
     public var description: String {
         """
         test gate "\(gate)" was never signalled within \(after) — the releasing \
-        statement never ran. If the holding side was started with a plain \
-        `Task` rather than `gateHoldingTask`, it blocked a cooperative-pool \
-        thread and starved the work that would have released it. See \
-        Tests/TestSupport/BoundedGateSupport.swift.
+        statement did not run in time. Two causes, and they need different \
+        fixes. (1) The holding side was started with a plain `Task` rather than \
+        `gateHoldingTask`, so it blocked a cooperative-pool thread the release \
+        needed: move it. (2) The release itself runs on the pool and was merely \
+        starved — which an unstructured `Task` anywhere on its path guarantees, \
+        because SE-0417 does not carry an executor preference into `Task {}`, \
+        so `gateHoldingTask` at the call site does not cover work a callee \
+        hands to one: size the bound at `TestDeadlines.saturatedPass` instead. \
+        See Tests/TestSupport/BoundedGateSupport.swift.
         """
     }
 }
@@ -270,10 +293,17 @@ extension DispatchSemaphore {
     ///   Ignorable — the recorded issue is the report — but returned so a
     ///   caller that can act on the distinction may.
     ///
-    /// Note: a gate reached from a plain dispatch queue or `Thread` has no
-    /// task-local test context, so its issue may be reported against the run
-    /// rather than attributed to one test. The process unwedging is the point;
-    /// the test's own downstream assertions then fail with their own names.
+    /// Note: a gate reached from a plain dispatch queue or `Thread` has
+    /// neither `Test.current` nor `Configuration.current` — both are
+    /// task-locals. Swift Testing then names the failure «unknown» and, rather
+    /// than lose an event it cannot route, posts it to *every* registered
+    /// event handler, so one expiry prints as several identical lines. Where
+    /// the test owns the thread, reach the gate from `gateHoldingTask`
+    /// instead: it is still off the cooperative pool, and being a task it
+    /// carries the context that attributes the failure to the test. Where
+    /// production code owns the thread — a receive loop, a dispatch callback —
+    /// «unknown» is the price. The process unwedging is the point; the test's
+    /// own downstream assertions then fail with their own names.
     @discardableResult
     public func waitForGate(
         _ name: String,


### PR DESCRIPTION
## What's broken

Stopping a TBD daemon deletes the Unix socket of a *different*, live daemon that
has since taken over the same path.

Concretely: daemon A is shutting down while daemon B has already bound
`~/tbd/sock`. A's shutdown unlinks the path. B keeps running and keeps
listening — on a socket file that no longer has a name — so every client gets a
connection failure against a path that isn't there, and B never notices anything
is wrong. Recovery is a second restart.

I hit this for real while verifying an unrelated feature: killing an orphaned
daemon took the live daemon's socket with it.

## Why it happens

The daemon's shutdown removed the socket file unconditionally — it never checked
whether the file at that path was still the one it created.

**There were two unlinks, and the one in our code was not the one that bit.**
Fixing only the obvious one left the bug fully alive, and the test caught it:
NIO unlinks the socket too. `ServerBootstrap.bind(unixDomainSocketPath:)` builds
its `ServerSocket` with `cleanupOnClose = true`, and closing that socket calls
`unlink(2)` on the bound *path*, checking only that the file is a socket — never
that it is the same socket. So closing the channel deleted the successor's file
before our own cleanup reached any guard at all.

## What this PR does

- **Captures the socket file's identity at bind time** — `(st_dev, st_ino)` via
  `lstat(2)` immediately after `bind(2)` — and unlinks on shutdown only if the
  path still resolves to that same inode. A successor's `bind(2)` always
  produces a different inode, so a takeover is unambiguous.
- **Takes the unlink back from NIO.** The socket is now created and bound
  directly and handed to `bootstrap.withBoundSocket(_:)`, whose descriptor NIO
  documents as owner-cleaned. NIO still sets it non-blocking and calls
  `listen(2)`.
- Moves `chmod` to immediately after `bind(2)`, before anything can connect.
- **Puts the failed-start cleanup under the same check.** `start()` captures the
  identity and then *awaits* NIO adopting the descriptor; that await is a
  suspension point a successor can bind inside. Removing the file on existence
  alone there deletes the successor's live socket — the same bug, reached from a
  failed startup instead of a shutdown. Both reclaim sites now call one
  `unlinkSocketFile(ifStillIdentity:)`.

This follows the same shape as #802 — prove ownership, then unlink — with the
file's inode standing in for that fix's pid, because a socket file carries no
identity of its own. That fix's residual race transfers verbatim: there is a
microsecond window between the `lstat(2)` and the `unlink(2)`, and darwin has no
unlink-if-inode primitive to close it.

- **Takes the claim on the file exactly once.** The identity is read and
  cleared in one step under a lock. Nothing serializes `stop()` — SIGTERM and
  SIGINT each fire an independent, undeduplicated `Task { await daemon.stop() }`
  in `main.swift`, which a supervisor escalating signals will do — so with a
  plain read-then-nil two shutdowns could both come away holding the same
  identity, and the loser then unlinks against a path a successor may hold by
  then. That is this fix's own protection, defeated.
- **Stops two startup paths from unlinking a socket they are not about to
  bind.** `PIDFile.cleanupIfStale()` and `AppState.startDaemonAndConnect()`
  each removed the socket file once the pid file's recorded pid was judged not
  a live `TBDDaemon`, with no check of the socket's current occupant. Both
  removals are gone. See "Clearing the path is the binder's act" below.
- **Runs each server's shutdown exactly once, because a second one hangs.**
  `SocketServer.stop()` and `HTTPServer.stop()` now go through a shared
  `ShutdownLatch`: the first call runs the body, and every later call —
  sequential or concurrent — `await`s that same run. See "A second `stop()`
  used to hang" below, which also corrects what round two of this PR said was
  hanging.

The pre-bind removal in `start()` is deliberately left alone: that is the
intended takeover, and it is exactly what makes the successor's inode differ.

## Clearing the path is the binder's act

The rendezvous path is cleared by whoever is about to bind it, and by nobody
else. `SocketServer` is that code: `start()` clears the path immediately before
`bind(2)`, and `stop()` reclaims the file only while the path still resolves to
the inode it bound.

Two startup paths broke that rule on the strength of a stale pid file, and a pid
file reads as stale for exactly as long as a successor has bound the socket
without having rewritten it yet. Deleting the socket there costs a live daemon
its rendezvous and puts nothing in its place: the path stays empty for the whole
of the next daemon's startup, and for good if that startup throws first.

Removing them is not quite free, and an earlier round of this PR overstated the
case for it. The claim was that `SocketServer.start()`'s pre-bind unlink always
eventually runs on every path that used to reach the removed code. It does not.
`AppState.startDaemonAndConnect()` returns early when no `TBDDaemon` binary is
found and when `process.run()` throws, before the daemon it would spawn exists
to bind anything; and `Daemon.start()` can throw between its own
`cleanupIfStale()` (step 2) and the socket bind hundreds of lines later. On
those paths a stale socket file now outlives the cleanup that used to remove it.

The removals are still right, because the two failures are not comparable. An
unbound socket file behaves to a client exactly like a missing one —
`connect(2)` fails either way, and the next daemon to bind clears the path
regardless — whereas unlinking a *live* successor's socket silently strands a
working daemon that keeps accepting on a listener no client can reach, with
nothing to restore the path. The comments at both sites now say that, rather
than claiming the bind always follows.

That is also why the guard sketched for these sites in an earlier round is not
what shipped. Porting `SocketFileIdentity` into `TBDShared` to reach the
app-side call site would have made the removals *safe*; deleting them makes them
*unnecessary*, which is a smaller change and a stronger invariant. (A
`connect(2)` probe remains unsound for the same reason as before: #802 measured
darwin refusing instantly once the accept queue fills, so refused does not mean
gone.)

`HolderSpawner.swift:252` and `PeerHelper.swift:190` are a different rendezvous
and stay out of scope.

## A second `stop()` used to hang, and it was not `shutdownGracefully()`

Nothing serializes `Daemon.stop()`: SIGTERM and SIGINT each fire an
independent, undeduplicated `Task { await daemon.stop() }` in `main.swift`,
both reach the servers through `Daemon.stop()`, and a supervisor escalating
signals sends both. Round two of this PR recorded that a second `stop()` wedges
and attributed it to `MultiThreadedEventLoopGroup.shutdownGracefully()`. **That
attribution was wrong**, and the correction changes the fix.

- `shutdownGracefully()` is safe to call again, and safe to call concurrently.
  Its own documentation says so — "Even though calling `shutdownGracefully`
  more than once should be avoided, it is safe to do so and execution of the
  `handler` is guaranteed" — and the implementation backs it. Every call takes
  `shutdownLock` and switches on `runState`: `.closing` appends the handler to
  the pending-callback list, `.closed` dispatches it immediately, and only a
  caller that found `.running` drives the shutdown, completing the rest from its
  `g.notify` block (`MultiThreadedEventLoopGroup.swift:404-511`, swift-nio
  2.96.0). Concurrent callers serialize on that lock.
- **`channel.close()` is what hangs.** Off the event loop it is
  `eventLoop.execute { self.close0(mode:promise:) }`
  (`ChannelPipeline.swift:788`), and `SelectableEventLoop._schedule0` on a loop
  whose group has shut down takes the `!validExternalStateToScheduleTasks`
  branch: it prints "Cannot schedule tasks on an EventLoop that has already
  shut down. This will be upgraded to a forced crash in future SwiftNIO
  versions." and returns *without enqueuing anything*
  (`SelectableEventLoop.swift:480-492`). The close promise is never fulfilled,
  so `try await channel.close()` suspends for good — and the event-loop threads
  have already exited, so the wedged task leaves a process at 0% CPU with
  nothing to see. This is the same mechanism already recorded further down for
  why the failed-start window needs an injected seam.

Both NIO-backed servers in the teardown have that shape, so both go through a
shared `ShutdownLatch`. `HTTPServer` is included deliberately rather than as
scope creep: `Daemon.stop()` stops the socket server and then the HTTP server,
so fixing only the first would hand the same hang to the next line and the
second shutdown still would not reach its `exit(0)`.

The latch settles both halves at once. The body runs exactly once, so no
`close()` is ever submitted to a dead loop and `shutdownGracefully()` is never
called twice or concurrently at all; and a later caller `await`s that same run
rather than returning early, so `stop()` still means "the shutdown has
finished" for everyone who called it. The task is unstructured on purpose — it
does not inherit its creator's cancellation, so a cancelled signal handler
cannot abandon a shutdown other callers are waiting on.

One thing measurement corrected here too, and the tests are shaped by it: two
`stop()` calls that merely *start* together are not the dangerous case. Both get
their `channel.close()` in while the event loop is still alive, so that ordering
survives even without the latch. The case that hangs is a `stop()` that arrives
after another has passed `shutdownGracefully()`, so the overlapping test stages
exactly that.

## Why the identity comes from the path, not the descriptor

`fstat(2)` on the bound descriptor looks like a free tightening of the window
against `lstat(2)` on the path — the bind and the stat are back-to-back
syscalls, but an OS-level race could in principle let a successor unlink and
rebind between them, so this process would record the *successor's* inode as
its own.

It does not work on darwin, where the two do not name the same object. `fstat`
on a bound `AF_UNIX` descriptor reports the socket's own in-kernel vnode, with
`st_dev` of -1, not the filesystem entry `bind(2)` created. Measured on darwin
25.1, over both a C and a Python probe:

```
fstat dev=-1        ino=15302332
lstat dev=16777235  ino=863366896
```

An identity captured that way could never equal the one read back from the
path, so every ownership check would fail closed and the socket file would never
be reclaimed at all — a strictly worse failure than the misattribution it was
meant to prevent. The measurement is recorded on `SocketFileIdentity` so it is
not re-proposed.

## Assumptions

- Assumes `(st_dev, st_ino)` identifies a socket file across the process's
  lifetime. If the path is moved and restored, or the filesystem reuses an inode
  after deletion within one daemon's life, the check could read a foreign file
  as ours. Neither is reachable through any path TBD takes.

## One behavior change to weigh deliberately

`withBoundSocket` calls `listen(2)` during channel construction, *before*
server-channel options are applied, so the explicit `.backlog` of 64 no longer
reaches the socket and it takes NIO's default of **128**. This is forced by the
seam rather than chosen. It moves in the safe direction — and #802 measured why
a fuller accept queue matters, since darwin refuses a connect instantly once the
backlog fills rather than blocking.

Verified against the vendored source, swift-nio 2.96.0 (`Package.resolved`
revision `b315658`):

- `cleanupOnClose` is off for a pre-bound descriptor —
  `ServerSocket.init(socket:setNonBlocking:)` sets `cleanupOnClose = false  //
  socket already bound, owner must clean up` (`ServerSocket.swift:83`), and
  `ServerSocket.close()` computes the path to unlink only when that flag is set
  (`ServerSocket.swift:148`). NIO's own bind path takes the other branch:
  `cleanupOnClose = true` for `.unix` (`ServerSocket.swift:56`).
- NIO still calls `listen(2)`. `ServerBootstrap.withBoundSocket(_:)`
  (`Bootstrap.swift:344`) builds `ServerSocketChannel(socket:eventLoop:group:)`
  (`Bootstrap.swift:353`), whose initializer ends in `try
  self.socket.listen(backlog: backlog)` (`SocketChannel.swift:253`).
- The backlog is NIO's default 128. `ServerSocketChannel.backlog` is
  `private var backlog: Int32 = 128` (`SocketChannel.swift:208`), and that
  `listen` runs inside `makeServerChannel` (`Bootstrap.swift:403`), which
  `bind0` invokes *before* `serverChannelOptions.applyAllChannelOptions(to:)`
  (`Bootstrap.swift:413`) — so a `.backlog` option would be recorded by
  `setOption0` (`SocketChannel.swift:273`) with no second `listen` to apply it.

## Evidence & verification

- **The repro is the test**: server A binds, server B rebinds the same path, A
  stops. B's inode must still be at the path *and* a real `connect(2)` must
  succeed.
- **Discriminating proof** — with the source fix reverted and the tests kept,
  the shutdown cases fail, reporting the path resolving to no inode at all and
  `connect(2)` returning `-1`. Reverting only the failed-start gate to the old
  unconditional remove reddens the failed-start successor test alone, with the
  other four green. With the fix, 6 tests in 2 suites pass.
- Two further tests pin that the check cannot degenerate into "never unlink": a
  server with no successor still reclaims its own file at shutdown, and a start
  that fails after binding still reclaims the file it just bound.
- **The claim-once guarantee has its own discriminating test.**
  `onlyOneOverlappingShutdownClaimsTheFile` runs eight concurrent claimants and
  requires exactly one to come away owning the file. The read-and-clear window
  is a few instructions wide, so the race cannot be reached by starting threads
  and hoping: a `duringIdentityClaim` seam — `nil` in production, alongside the
  existing `beforeAdoptingBoundSocket` one — holds the window open until every
  thread has reached the call site. Under the lock the losers wait outside it
  and come away with nothing; with a plain read-then-nil all eight read the
  same identity.
- **The startup rule is pinned too.**
  `onlyTheBinderClearsTheRendezvousPath` scans TBDDaemon and TBDApp and
  requires that nothing outside `SocketServer` removes
  `TBDConstants.socketPath`. It is a source-text pin because that path resolves
  from a process-global this test target must not mutate — `ConstantsTests`
  pins that no suite in this process sets `TBD_SOCKET_PATH`, and
  `scripts/test.sh` sets it for the whole run. `cleanupRemovesAStalePidFile` is
  the positive control that the pid-file cleanup still cleans.
- The failed-start window is reached through an injected step in `start()`,
  `nil` in production. The real failures there are NIO refusing the descriptor,
  and the in-process ways to force one either hang (a shut-down event loop drops
  the submitted task and never completes the future —
  `SelectableEventLoop.execute` swallows the enqueue failure,
  `SelectableEventLoop.swift:461`) or trip NIO's own debug assertions on a
  half-constructed channel (`BaseSocket.deinit` asserts `!isOpen`,
  `BaseSocket.swift:261`).
- `swiftlint --strict`: 0 violations across 925 files.
- **The second round's two tests were run against the fixes reverted, and both
  fail there.** 12 tests in 2 suites, 2 issues:
  `only one of many overlapping shutdowns claims the socket file` fails with
  `(claims.count -> 2) == 1`, and
  `nothing outside SocketServer removes the rendezvous socket file` fails naming
  both offenders, `PIDFile.swift:63` and `AppState.swift:2953`. With the fixes
  in place the same 12 pass in 0.330 s.
- **The overlapping-shutdown path is now tested end to end, through the real
  `stop()`.** Three tests, and all three go through production entry points:
  - `overlappingStopsBothFinishAndClaimTheFileOnce` starts a server and stages
    two genuinely overlapping `stop()` calls — the `duringIdentityClaim` seam
    holds the first shutdown at its reclaim step, past
    `shutdownGracefully()`, until the second caller is at `stop()` — then
    requires both to return, the socket file to be claimed exactly once, and
    the file to be gone. The seam now carries the identity the claimant came
    away with, which is how "claimed exactly once" is observed from inside a
    real `stop()`; it has no other outward sign.
  - `repeatStopLeavesTheSuccessorAlone` covers the sequential half a signal
    escalation actually produces: shut down, let a successor bind the path,
    `stop()` again. It must return, and it must leave the successor's socket
    alone.
  - `repeatHTTPServerStopReturns` pins the sibling server in the same teardown,
    and `latchRunsItsBodyOnceAndEveryCallerWaits` pins the latch itself — eight
    callers, one run, and nobody returning before that run has finished.

  All of them wait on detached tasks with a deadline rather than awaiting
  directly or gathering a task group, because the failure under test is a
  shutdown that never returns: a task group would wedge the whole run alongside
  it instead of reporting it.
- **Discriminating proof for the latch**: with only the two `stop()` bodies
  un-latched (called directly again) and everything else in the branch kept,
  **19 tests in 3 suites, 3 failures**, one
  per shutdown path: the overlapping test reporting `finished.count == 2` never
  satisfied at its 15 s deadline, `repeatStopLeavesTheSuccessorAlone` the same
  for its second `stop()`, and `repeatHTTPServerStopReturns` the same for the
  HTTP server. `latchRunsItsBodyOnceAndEveryCallerWaits` still passes there,
  because it exercises the latch directly. Restored, the same 19 pass in
  0.399 s.

  An earlier shape of the overlapping test — two `stop()` calls simply started
  together — passed against the un-latched code, which is what turned up the
  ordering point above and is why the overlap is staged instead.

## Follow-ups not taken here

Two sibling unconditional unlinks are left as out of scope:
`HolderSpawner.swift:252` and `PeerHelper.swift:190`. They are a different
rendezvous — the per-session pty-holder sockets under `~/tbd/holders/`, which
have their own named reconciler — but the same "unlink only what you still own"
question applies to them, and the holder one is worth a look.

[20260830-boring-panda](https://cheapsteak.github.io/tbd/open/?worktree=A1E9CF50-E608-4F3C-BA8F-377D60BB7478)

https://claude.ai/code/session_01TMmwK6VzokeGobKs8YunXZ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Unix socket lifecycle handling to prevent older daemon instances from removing successor sockets.
  - Socket cleanup now occurs only when the server owns the socket, including during shutdown and startup failures.
  - Stale PID recovery no longer removes a socket that may belong to another daemon.
  - Improved reliability when multiple daemon instances use the same socket path.
  - Repeated or concurrent shutdown requests now complete safely without duplicate cleanup.
  - Startup failures now provide specific errors for oversized paths, socket creation failures, and binding failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



