### PR TITLE
Fix: A paste into a holder-backed session is finished rather than truncated at 1 KB

### DIFF
--- a/Sources/TBDApp/Terminal/OutgoingDrainNotifier.swift
+++ b/Sources/TBDApp/Terminal/OutgoingDrainNotifier.swift
@@ -1,0 +1,98 @@
+import Darwin
+import Dispatch
+import Foundation
+import os
+
+private let logger = Logger(subsystem: "com.tbd.app", category: "outgoingDrain")
+
+/// Tells `OutgoingInputQueue` when the session's pty can take more.
+///
+/// **Armed only while the outbox is non-empty**, and that is measured, not
+/// stylistic: readiness notification is level-triggered, so a notifier left
+/// armed over a writable descriptor and an empty outbox fires tens to hundreds
+/// of thousands of times per second (44,486 / 182,060 / 47,845 across three
+/// measured runs). The queue disarms on the edge where the outbox empties, and
+/// the implementation below makes `arm`/`disarm` idempotent so that edge can be
+/// signalled more than once without unbalancing anything.
+@MainActor
+protocol OutgoingDrainNotifier: AnyObject {
+    /// Start reporting readiness. Idempotent.
+    func arm()
+    /// Stop reporting it. Idempotent.
+    func disarm()
+    /// Permanent teardown. After this the notifier never calls back, whatever
+    /// the descriptor does. Idempotent.
+    func cancel()
+}
+
+/// A `DispatchSource` write source on the main queue. Its handler is main-actor
+/// by construction (the source's queue is `.main`), so `assumeIsolated` is
+/// sound and the drain runs on the same executor as every append.
+///
+/// ## The suspend count is the whole safety story
+///
+/// A `DispatchSource` is created suspended. `resume()` and `suspend()` are a
+/// **counted** pair, and libdispatch traps (SIGTRAP 133) on the release of a
+/// source whose count is non-zero — as it does on an over-resume. Every one of
+/// these was measured fatal: releasing while suspended, `suspend → cancel →
+/// release` with no rebalancing resume, two suspends against one resume, and
+/// `resume` on an already-running source.
+///
+/// So this type keeps the count in {0, 1} and tracks which it is. `isArmed`
+/// is not a convenience: it is what makes a second `arm()` or a second
+/// `disarm()` a no-op instead of a crash, and it is what tells `cancel()`
+/// whether a resume is owed.
+@MainActor
+final class WriteSourceDrainNotifier: OutgoingDrainNotifier {
+    private var source: (any DispatchSourceWrite)?
+    /// `true` when the source is running (suspend count 0), `false` when it is
+    /// suspended (count 1). A source starts suspended, so this starts `false`.
+    private var isArmed = false
+
+    init(fileDescriptor: Int32, onWritable: @escaping @MainActor () -> Void) {
+        let source = DispatchSource.makeWriteSource(
+            fileDescriptor: fileDescriptor, queue: .main)
+        source.setEventHandler {
+            MainActor.assumeIsolated { onWritable() }
+        }
+        self.source = source
+    }
+
+    func arm() {
+        guard let source, !isArmed else { return }
+        isArmed = true
+        source.resume()
+    }
+
+    /// Called on the edge where the outbox empties, and it must not be skipped:
+    /// see the fires-per-second measurement in this file's protocol comment.
+    func disarm() {
+        guard let source, isArmed else { return }
+        isArmed = false
+        source.suspend()
+    }
+
+    /// **Cancel, then rebalance to a suspend count of zero, then release.**
+    ///
+    /// A notifier at teardown is usually *suspended* — the ordinary state is an
+    /// empty outbox — and releasing it there is the SIGTRAP. The resume after
+    /// the cancel is what returns the count to zero; it cannot deliver an
+    /// event, because a cancelled source's event handler does not run and this
+    /// call is already on the source's own serial queue.
+    ///
+    /// It also has a second job. After `suspend → cancel`, a cancel handler
+    /// does **not** run until the rebalancing resume lands (measured: still
+    /// unrun 0.5 s later). This type installs no cancel handler precisely so
+    /// nothing important waits on that; if one is ever added — to close a
+    /// descriptor, say — it will not run until this resume, and anything
+    /// ordered after it must account for the deferral.
+    func cancel() {
+        guard let source else { return }
+        self.source = nil
+        source.cancel()
+        if !isArmed { source.resume() }   // count back to zero before release
+        isArmed = true                    // running, cancelled, and safe to drop
+        logger.debug(
+            "writeSourceDrainNotifier: cancelled, suspend count rebalanced before release")
+    }
+}

--- a/Sources/TBDApp/Terminal/OutgoingInputQueue.swift
+++ b/Sources/TBDApp/Terminal/OutgoingInputQueue.swift
@@ -41,6 +41,34 @@ private let logger = Logger(subsystem: "com.tbd.app", category: "outgoingInputQu
 /// called, and nothing can interleave between them, because there is no
 /// suspension point for anything to interleave at.
 ///
+/// ## The outbox, and what it holds behind it
+///
+/// A pty master takes 1,022 bytes in raw mode and then refuses, so a paste
+/// above a kilobyte into a child that is not reading is written short. Nothing
+/// can un-write the prefix and nothing can ask the pty how much room it has,
+/// so the only repair is to finish the write: **whoever committed the prefix
+/// owns the remainder, and nothing else may reach that pty until it has
+/// landed.**
+///
+/// The remainder goes in `outbox`, and every later chunk — the rest of the
+/// paste, the keystrokes after it, an injection released from the paste hold —
+/// is appended behind it, whole, in arrival order. `drain()` finishes it when
+/// the transport says it can take more. Two consequences worth stating
+/// outright:
+///
+/// - **Ordering is FIFO across both streams.** A keystroke typed after a short
+///   paste lands after the paste's end marker. That is what keeps a child from
+///   being left in bracketed-paste mode with the person's typing absorbed into
+///   the paste.
+/// - **Held, never dropped, and never bypassed.** Nothing the person typed is
+///   discarded while the panel owns the pty, and no byte jumps the queue —
+///   including `0x03`, which could not be written any sooner anyway, since the
+///   queue that refused everything else will refuse it too.
+///
+/// The outbox has no size cap: the paste that filled it was already accepted at
+/// the view, and the bytes are a copy in this process's memory. Its bound is
+/// the descriptor — `EIO` or `EBADF` — never a clock.
+///
 /// ## What is guaranteed, and what is not
 ///
 /// The guarantee is a **safety** guarantee, not an ordering one: **while a
@@ -83,20 +111,46 @@ private let logger = Logger(subsystem: "com.tbd.app", category: "outgoingInputQu
 /// nothing. Reorder them only with this paragraph in hand.
 @MainActor
 final class OutgoingInputQueue {
-    /// Performs the actual write once the queue has decided a chunk may go
-    /// out now, and reports whether anything took the bytes: `false` means
-    /// the panel had no live transport to hand them to (no `localProcess`, or
-    /// a control-mode panel with no attach), so nothing was written and
-    /// nothing ever will be for this chunk.
+    /// What one attempt at the transport achieved.
     ///
-    /// **That return value is the ack.** A holder-backed panel takes the
-    /// `.localPTY` arm with a nil `localProcess` today, so a seam that could
-    /// not say "not written" would have this queue ack `written: true` for a
-    /// byte that reached nothing — the daemon would then not fall back and the
-    /// prompt would be lost invisibly, which the plan's Global Constraints
-    /// forbid. The injection path must treat `false` as "fall back and write
-    /// directly", not as an ack to log.
-    private let write: @MainActor (Data) -> Bool
+    /// Three cases, because the middle one is neither of the other two: a pty
+    /// master takes a prefix and refuses the rest while remaining perfectly
+    /// alive, and calling that a failure is what made a truncated paste look
+    /// like a dead transport.
+    enum WriteAttempt: Equatable {
+        /// Every byte was taken.
+        case accepted
+        /// The transport took `written` bytes (possibly zero) and refused the
+        /// rest. It is alive and will take more later; the remainder is this
+        /// queue's to keep and finish.
+        case refused(written: Int)
+        /// Nothing will ever land through this transport: no descriptor, a
+        /// dead child (`EIO`), a torn-down panel. `written` may be non-zero —
+        /// a prefix can be committed and the descriptor die before the rest.
+        case unwritable(written: Int)
+    }
+
+    /// Hands one chunk to the panel's transport and reports what it took.
+    ///
+    /// **This is the ack.** `.accepted` and `.refused` both mean the bytes are
+    /// with a writer that will complete or report — for `.refused` this queue
+    /// is that writer — and both are reported to the daemon as
+    /// `written: true`. Only `.unwritable` is `false`, and it means what it
+    /// says: nothing was written and nothing will be, so the daemon must fall
+    /// back rather than log an ack.
+    private let attempt: @MainActor (Data) -> WriteAttempt
+    /// Asks the host to start telling this queue when the transport can take
+    /// more (`drain()`), and to stop. Called on the edges only: armed when the
+    /// outbox becomes non-empty, disarmed when it empties. A drain notifier
+    /// left armed over an empty outbox is a main-queue spin, not a leak — see
+    /// `drain()`.
+    private let armDrain: @MainActor () -> Void
+    private let disarmDrain: @MainActor () -> Void
+    /// Publishes the panel-level backpressure indicator: a byte count while a
+    /// stall has lasted longer than `backpressureThreshold`, `nil` when it has
+    /// cleared. Never called per accepted chunk — a multi-MiB paste would
+    /// otherwise redraw the panel a few thousand times.
+    private let onBackpressureChange: @MainActor (Int?) -> Void
     private let clock: any Clock<Duration>
     /// How long a held injection waits for `endUserPaste()` before the queue
     /// stops trusting the paste to ever close and writes it anyway. An
@@ -119,6 +173,11 @@ final class OutgoingInputQueue {
     /// *default*, and every other test in the suite supplies a bound of its
     /// own to isolate the behaviour it is after.
     private let pasteHoldBound: Duration
+    /// How long an episode has to last before the panel says anything about it
+    /// to the person. A paste into a child that is reading normally drains in
+    /// a handful of main-actor turns, and a banner that flickered on every one
+    /// of those would be noise about a system working correctly.
+    private let backpressureThreshold: Duration
 
     private var isPasteOpen = false
     /// The last outcome `enqueueUserBytes` saw. Exists only to make
@@ -145,14 +204,51 @@ final class OutgoingInputQueue {
     /// would be unreachable code.
     private var pendingInjections: [PendingInjection] = []
 
+    /// The remainder of a short write, followed by every chunk that arrived
+    /// while it was outstanding — from both streams, whole, in arrival order.
+    ///
+    /// `[Data]` rather than one concatenated buffer: the FIFO already makes the
+    /// byte stream contiguous, and concatenating would copy megabytes of a
+    /// large paste on every append. Chunk boundaries are not delivery
+    /// boundaries — the kernel cuts wherever it runs out of room, including
+    /// inside a chunk — they are only how the queue stores what it owes.
+    private var outbox: [Data] = []
+    /// Maintained incrementally. Summing `outbox` per keystroke would make an
+    /// O(n) walk out of the one operation that must stay O(1).
+    private var pendingBytes = 0
+    private var isDrainArmed = false
+    /// The largest `pendingBytes` reached during the current episode, for the
+    /// one `.info` line an episode logs when it ends.
+    private var episodePeakBytes = 0
+    private var backpressureTask: Task<Void, Never>?
+    private var isBackpressureVisible = false
+
+    /// Test-only: bytes the queue owes the session right now.
+    var pendingByteCountForTesting: Int { pendingBytes }
+    /// Test-only: how many chunks are waiting, which is what discriminates a
+    /// FIFO that appends from one that coalesces.
+    var outboxChunkCountForTesting: Int { outbox.count }
+    /// Test-only: how many times a dropped outbox has been logged. The count,
+    /// not a bit, for the reason `userWriteOutcomeTransitionsForTesting`
+    /// documents: an unconditional log leaves the bit identical.
+    private(set) var outboxDropLogsForTesting = 0
+
     init(
         pasteHoldBound: Duration = HolderInputTiming.pasteHoldBound,
+        backpressureThreshold: Duration = .seconds(1),
         clock: any Clock<Duration> = ContinuousClock(),
-        write: @escaping @MainActor (Data) -> Bool
+        armDrain: @escaping @MainActor () -> Void = {},
+        disarmDrain: @escaping @MainActor () -> Void = {},
+        onBackpressureChange: @escaping @MainActor (Int?) -> Void = { _ in },
+        attempt: @escaping @MainActor (Data) -> WriteAttempt
     ) {
-        self.write = write
+        self.attempt = attempt
+        self.armDrain = armDrain
+        self.disarmDrain = disarmDrain
+        self.onBackpressureChange = onBackpressureChange
         self.clock = clock
         self.pasteHoldBound = pasteHoldBound
+        self.backpressureThreshold = backpressureThreshold
     }
 
     /// Releases any injection still waiting on a paste that never closed —
@@ -162,7 +258,7 @@ final class OutgoingInputQueue {
     ///
     /// The paste is closed as part of this, so the queue is left inert rather
     /// than half-torn-down: an injection arriving after teardown resolves
-    /// promptly on whatever `write` reports (`false`, for a panel whose
+    /// promptly on whatever the transport reports (`false`, for a panel whose
     /// transport is gone) instead of being parked behind a paste nobody will
     /// ever close.
     func shutdown() {
@@ -172,6 +268,11 @@ final class OutgoingInputQueue {
         }
         pendingInjections.removeAll()
         isPasteOpen = false
+        // The descriptor is about to close, so the remainder can never land.
+        // Dropping it here rather than in the panel keeps the byte count — the
+        // only thing worth logging — where it is known, and `transportDied`
+        // carries the disarm this teardown owes the notifier.
+        transportDied()
     }
 
     /// Test-only: how many injections are currently held behind an open
@@ -192,7 +293,8 @@ final class OutgoingInputQueue {
     /// matters: a diagnostic that logged unconditionally would leave the bit
     /// identical and this count climbing per keystroke. Zero means the panel
     /// has been in one state throughout — which for a working panel is the
-    /// expected reading.
+    /// expected reading, **and a short write must leave it there**: a held
+    /// remainder is not a panel whose keystrokes are going nowhere.
     private(set) var userWriteOutcomeTransitionsForTesting = 0
 
     /// Test-only: whether a user paste is currently open. Lets a test drive
@@ -207,19 +309,21 @@ final class OutgoingInputQueue {
 
     /// Write a chunk of user-originated bytes (a keystroke, or one of the
     /// three chunks of a bracketed paste). Goes out immediately, in this same
-    /// main-actor turn. Fire-and-forget by design: the caller is a
+    /// main-actor turn — or, if the transport is still owed bytes from an
+    /// earlier short write, joins the back of the outbox, which is an O(1)
+    /// append with no hop. Fire-and-forget by design: the caller is a
     /// synchronous SwiftTerm delegate callback with nobody to report a
     /// transport failure to, exactly as it was before this queue existed
     /// (`localProcess?.send` / `fdSidecar.sendInput` were already
     /// fire-and-forget).
     ///
-    /// Nobody to report to is not the same as nothing to say: `write` now
-    /// *knows* the bytes reached no transport, and on a holder-backed panel
-    /// that is true of every keystroke, so a human types and the only
-    /// diagnostic is absence. `noteUserWriteOutcome` turns that into one log
-    /// line per episode.
+    /// Nobody to report to is not the same as nothing to say: the transport
+    /// now *knows* when the bytes reached nothing, and on a panel whose child
+    /// has exited that is true of every keystroke, so a human types and the
+    /// only diagnostic is absence. `noteUserWriteOutcome` turns that into one
+    /// log line per episode.
     func enqueueUserBytes(_ data: Data) {
-        noteUserWriteOutcome(write(data))
+        noteUserWriteOutcome(submit(data))
     }
 
     /// Edge-triggered diagnostic for the user's stream: one line when
@@ -263,18 +367,186 @@ final class OutgoingInputQueue {
         flushPending()
     }
 
+    // MARK: - The outbox
+
+    /// The one place a chunk is either written or queued. Returns whether a
+    /// writer that will complete or report has it.
+    ///
+    /// **The order of the two branches is the ordering guarantee.** A non-empty
+    /// outbox means somebody is owed bytes, so nothing may go to the kernel
+    /// ahead of them — not a keystroke, not an injection, not `0x03`. Moving an
+    /// interrupt to the front would reorder the person's input against itself
+    /// and deliver nothing sooner, because the queue that refused the paste
+    /// will refuse the interrupt too.
+    ///
+    /// **`.unwritable` is not latched into a permanent verdict**, and that is
+    /// deliberate. It is the only answer available for two very different
+    /// states: a pty whose child has exited, which will refuse forever, and a
+    /// panel whose transport is merely absent for a moment — a sidecar between
+    /// reconnects, a `localProcess` not yet built. Short-circuiting every later
+    /// chunk on the first `.unwritable` would silently wedge the second kind
+    /// for the life of the panel, and would make `noteUserWriteOutcome`'s
+    /// "reaching a transport again" edge unreachable. Re-attempting costs one
+    /// refused `write(2)` per chunk on a genuinely dead descriptor, which is
+    /// what the panel already paid before this queue existed; the logging that
+    /// would actually be expensive is latched at both ends already.
+    @discardableResult
+    private func submit(_ data: Data) -> Bool {
+        guard outbox.isEmpty else {
+            append(data)
+            return true
+        }
+        switch attempt(data) {
+        case .accepted:
+            return true
+        case .refused(let written):
+            append(data.dropFirst(written))
+            return true
+        case .unwritable:
+            transportDied()
+            return false
+        }
+    }
+
+    private func append(_ data: some DataProtocol) {
+        guard !data.isEmpty else { return }
+        let wasEmpty = outbox.isEmpty
+        outbox.append(Data(data))
+        pendingBytes += data.count
+        episodePeakBytes = max(episodePeakBytes, pendingBytes)
+        if wasEmpty { beginEpisode() }
+    }
+
+    /// Finish what the kernel refused. Called by the drain notifier whenever
+    /// the transport can take more — never on a timer, and never speculatively.
+    ///
+    /// **Every exit from this function leaves the notifier armed if and only if
+    /// the outbox is non-empty**, and that is a correctness requirement rather
+    /// than tidiness. Readiness notification is level-triggered: an armed
+    /// source over an idle, writable pty whose handler writes nothing was
+    /// measured firing 44,486 / 182,060 / 47,845 times per second, so a path
+    /// that returns with an empty outbox still armed is the main queue at 100%
+    /// until the panel closes. There are exactly three exits — the loop's
+    /// `.accepted` fallthrough (`endEpisode()`), the `.refused` return (still
+    /// owed bytes, stays armed) and `transportDied()` (which calls
+    /// `endEpisode()`) — and adding a fourth means adding a disarm.
+    ///
+    /// **Bounded by the descriptor, not by a clock.** A child that does not
+    /// read for thirty seconds holds the outbox for thirty seconds; that is the
+    /// truth of the session, and it is what tmux does in the same state.
+    /// Expiring the hold would only convert a stall into a tear: the queue is
+    /// full, so the bytes released by an expiry could not be written either,
+    /// and the payload would be cut with somebody else's bytes in the gap.
+    func drain() {
+        while let head = outbox.first {
+            switch attempt(head) {
+            case .accepted:
+                outbox.removeFirst()
+                pendingBytes -= head.count
+            case .refused(let written):
+                if written > 0 {
+                    outbox[0] = Data(head.dropFirst(written))
+                    pendingBytes -= written
+                }
+                // Stay armed and return to the run loop: the transport has no
+                // more room this turn, and spinning here is the main-actor
+                // block this design forbids.
+                refreshBackpressure()
+                return
+            case .unwritable:
+                transportDied()
+                return
+            }
+        }
+        endEpisode()
+    }
+
+    /// The arm edge, taken exactly once per episode — when the outbox goes
+    /// from empty to non-empty.
+    private func beginEpisode() {
+        isDrainArmed = true
+        armDrain()
+        logger.info("""
+            outgoingInputQueue: the session's pty refused a write; \
+            \(self.pendingBytes, privacy: .public) bytes are queued and will be \
+            written as the child reads
+            """)
+        backpressureTask = Task { [weak self, backpressureThreshold, clock] in
+            // Inherits this main-actor context, so the wake-up lands on the
+            // same serial executor every other mutation here runs on.
+            while !Task.isCancelled {
+                try? await clock.sleep(for: backpressureThreshold)
+                guard !Task.isCancelled, let self else { return }
+                self.refreshBackpressure(force: true)
+            }
+        }
+    }
+
+    /// The disarm edge. `isDrainArmed` makes it idempotent, which matters
+    /// twice over: `drain()` and `transportDied()` and `shutdown()` can all
+    /// reach it, and the notifier behind `disarmDrain` is a counted
+    /// suspend/resume pair that traps when unbalanced.
+    private func endEpisode() {
+        guard isDrainArmed else { return }
+        isDrainArmed = false
+        disarmDrain()
+        backpressureTask?.cancel()
+        backpressureTask = nil
+        if isBackpressureVisible {
+            isBackpressureVisible = false
+            onBackpressureChange(nil)
+        }
+        logger.info("""
+            outgoingInputQueue: the session's pty is taking input again; the \
+            episode peaked at \(self.episodePeakBytes, privacy: .public) queued bytes
+            """)
+        episodePeakBytes = 0
+    }
+
+    /// Publishes the pending count when the episode has outlasted the
+    /// threshold. `force` is the timer's tick; an ordinary drain only refreshes
+    /// a banner that is already showing, so a fast episode never draws one.
+    private func refreshBackpressure(force: Bool = false) {
+        guard force || isBackpressureVisible else { return }
+        isBackpressureVisible = true
+        onBackpressureChange(pendingBytes)
+    }
+
+    /// The transport is gone for good. Everything it was owed is dropped —
+    /// there is no longer anybody to read it — and the episode ends, which is
+    /// what disarms the notifier.
+    private func transportDied() {
+        if pendingBytes > 0 {
+            outboxDropLogsForTesting += 1
+            logger.error("""
+                outgoingInputQueue: the session's pty is gone with \
+                \(self.pendingBytes, privacy: .public) bytes still unwritten; \
+                they are dropped — the child that was to read them has exited
+                """)
+        }
+        outbox.removeAll()
+        pendingBytes = 0
+        endEpisode()
+    }
+
     // MARK: - Daemon injection
 
-    /// Enqueues a daemon-originated injection. Returns whether it was
-    /// actually written — the caller (the injection-ack path) reports this
-    /// truthfully to the daemon, so ownership transfers on the write, not on
-    /// the call: the value is whatever `write` reported, and it is produced
-    /// only after `write` has run.
+    /// Enqueues a daemon-originated injection. Returns whether a writer that
+    /// will complete or report has it — the caller (the injection-ack path)
+    /// reports this truthfully to the daemon, so ownership transfers on the
+    /// submit, not on the call.
+    ///
+    /// `true` covers both "the transport took every byte" and "the transport
+    /// took a prefix, or none, and this queue owns the rest": in either case
+    /// the bytes are with a writer that will finish them, which is the meaning
+    /// `true` already carries on the `localProcess` and sidecar arms of
+    /// `performOutgoingWrite`. `false` means, and only means, that nothing was
+    /// written and nothing will be.
     ///
     /// `async` because it may have to wait for a paste to close. When no
     /// paste is open it returns without ever suspending.
     func enqueueInjection(_ data: Data) async -> Bool {
-        guard isPasteOpen else { return write(data) }
+        guard isPasteOpen else { return submit(data) }
         return await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
             hold(data: data, continuation: continuation)
         }
@@ -308,7 +580,7 @@ final class OutgoingInputQueue {
         let pending = pendingInjections.remove(at: index)
         logger.info(
             "outgoingInputQueue: injection held past the paste-hold bound with the paste still open; writing it anyway")
-        pending.continuation.resume(returning: write(pending.data))
+        pending.continuation.resume(returning: submit(pending.data))
     }
 
     private func flushPending() {
@@ -317,7 +589,7 @@ final class OutgoingInputQueue {
         pendingInjections.removeAll()
         for pending in toFlush {
             pending.timeoutTask.cancel()
-            pending.continuation.resume(returning: write(pending.data))
+            pending.continuation.resume(returning: submit(pending.data))
         }
     }
 }

--- a/Sources/TBDApp/Terminal/PTYWrite.swift
+++ b/Sources/TBDApp/Terminal/PTYWrite.swift
@@ -1,85 +1,75 @@
 import Darwin
 import Foundation
 
-/// Writing a whole payload to a pty master, from the app's side.
+/// One non-blocking attempt to hand a payload to a pty master, from the app's
+/// side.
 ///
-/// Exists because the app now writes to a session's pty as well as reading it
-/// (a holder-backed panel holds its own `dup` of the master), and a single
-/// `write(2)` to a tty is not a delivery: the terminal's input queue is small
-/// — a few hundred bytes to a couple of KiB — so a multi-KiB injected prompt
-/// short-writes routinely whenever the child is not draining it fast.
+/// Exists because the app writes to a session's pty as well as reading it (a
+/// holder-backed panel holds its own `dup` of the master), and a single
+/// `write(2)` to a tty is not a delivery: a raw-mode master accepts
+/// `TTYHOG − 2` — measured at 1,022 bytes — and then refuses, so every payload
+/// above a kilobyte into an agent session is short-written whenever the child
+/// is not draining it at that instant.
 ///
-/// ## Why it waits at all, and why so briefly
+/// ## Why it does not wait
 ///
-/// The caller is `TerminalPanelView.performOutgoingWrite`, which is
-/// synchronous and main-actor: it has to answer "did this go out?" in the turn
-/// the bytes arrived in, because that answer is the ack the daemon reads and
-/// because a keystroke must not acquire a scheduling hop. So the wait is a
-/// `poll(POLLOUT)` loop with a **20 ms** ceiling — enough for the kernel to
-/// hand a few buffer-fulls to a child that is reading, far too short to be
-/// felt as typing latency, and self-limiting for a child that is not reading
-/// at all (the budget expires once and the payload is refused).
+/// It used to spend a 20 ms `poll(POLLOUT)` budget looking for room, because
+/// there was nowhere to keep what the kernel refused: the budget's expiry was
+/// the truncation point. `OutgoingInputQueue` now keeps the remainder and
+/// finishes it on write-readiness, so waiting here buys nothing and costs the
+/// main actor — the caller is `TerminalPanelView.performOutgoingWrite`, which
+/// is synchronous, main-actor, and must answer in the turn a keystroke arrived
+/// in. One `write(2)`, no `poll`, and the refusal is reported rather than
+/// waited out.
+///
+/// **Nothing here decides where the payload is cut.** The kernel commits per
+/// byte (`ptcwrite` feeds the tty queue a byte at a time and returns how many
+/// it took), so a marker or a multi-byte UTF-8 sequence can be split. That is
+/// healed by the *next* accepted bytes continuing the same stream with nothing
+/// written in between — which is the outbox's hold, not this function's
+/// business.
 enum PTYWrite {
-    /// What one attempt achieved. Three outcomes, not two, because the middle
-    /// one is the case that decides how the daemon's fail-open fallback
-    /// behaves.
+    /// What one attempt achieved. Three outcomes, and the middle one is not a
+    /// failure: it is the normal shape of writing to a tty whose child is busy.
     enum Outcome: Equatable {
         /// Every byte reached the terminal's input queue.
         case complete
-        /// Nothing was written — the queue was full for the whole budget, or
-        /// the descriptor is gone. The clean refusal: the caller reports
-        /// `false`, the daemon rewrites the payload itself, and the session
-        /// sees it exactly once.
-        case nothingWritten
-        /// A prefix went and the rest did not. The caller reports it as a
-        /// failure — and what that buys today is less than it looks.
-        ///
-        /// The intent is that the daemon rewrites the whole payload on top of
-        /// the prefix: visibly doubled rather than quietly truncated, the
-        /// deliberate side of the fork this design takes everywhere. **The
-        /// daemon usually cannot do that**, and least of all in the state this
-        /// case arises in. A short write happens while a viewer is attached
-        /// and its child is not draining; an acknowledged attach has already
-        /// released the daemon's reader and closed its descriptor, so
-        /// `HolderInjectionCourier`'s fallback finds nothing to write to and
-        /// answers `.notDelivered`. What is actually left behind is a
-        /// truncated fragment on the session and a transport error at the
-        /// caller — the duplicate-versus-loss fork resolved, here, on the loss
-        /// side.
-        ///
-        /// The behavior stands rather than being patched because whether the
-        /// daemon can rewrite is the descriptor question — whether it keeps a
-        /// **write-only** dup across an attach — and that is a human decision
-        /// already filed. Decided one way, the paragraph above becomes true as
-        /// written and nothing here changes; decided the other, this is where
-        /// the honest resolution goes.
+        /// The kernel took `written` bytes (possibly zero, for a queue that was
+        /// already full) and refused the rest with `EAGAIN`. **The transport is
+        /// alive**; the remainder is the caller's to keep and finish. The
+        /// caller must not report this as a failed write — the prefix is
+        /// committed and cannot be un-written, so a `false` here is what makes
+        /// a sender re-send on top of it.
         case partial(written: Int)
-        /// The descriptor rejected the write outright (`EIO` on a pty whose
-        /// child is gone, `EBADF`, …). Nothing was written.
-        case failed(errno: Int32)
+        /// The descriptor rejected the write (`EIO` once the last slave closes,
+        /// `EBADF` after teardown, …). Nothing more will ever land through it.
+        /// `written` may be non-zero: a prefix can be committed and the
+        /// descriptor die before the rest goes, and the caller needs to know
+        /// both — it drops what it was holding *and* reports the write
+        /// unwritten, because the honest answer to "did this arrive" for a
+        /// child that is gone is no.
+        case failed(errno: Int32, written: Int)
     }
 
-    /// Default ceiling on how long one call may spend waiting for room.
-    static let defaultBudgetMilliseconds: Int32 = 20
+    // The absence of the poll is not testable. A test that "proves" no wait
+    // happens has to assert on elapsed time, and every threshold that
+    // separates 0 ms from the old 20 ms budget is inside the noise of a loaded
+    // shared box. What replaces the test is the type: there is no budget
+    // parameter to pass, and no `poll` in the body. Reviewers enforce it.
 
-    /// Write all of `data` to `fd`, waiting for room only within `budget`.
+    /// Write as much of `data` to `fd` as the kernel will take, right now.
     ///
     /// The pty master this is called on is `O_NONBLOCK` — the flag lives on the
     /// open file description the daemon opened and rides the `dup` (see
     /// `HolderAttachment.ptyFD`) — so `write` returns rather than parking the
-    /// main actor, and the `poll` below is the only waiting that happens. A
-    /// blocking descriptor would still be correct here, just less bounded; the
-    /// flags belong to whoever vended the descriptor and this call must not
-    /// change them out from under a concurrent reader.
-    static func all(
-        _ data: Data, to fd: Int32,
-        budgetMilliseconds budget: Int32 = defaultBudgetMilliseconds
-    ) -> Outcome {
+    /// main actor. A blocking descriptor would park it, which is why this call
+    /// must never be given one and must never change the flags out from under
+    /// a concurrent reader.
+    static func all(_ data: Data, to fd: Int32) -> Outcome {
         guard !data.isEmpty else { return .complete }
-        guard fd >= 0 else { return .nothingWritten }
+        guard fd >= 0 else { return .failed(errno: EBADF, written: 0) }
         return data.withUnsafeBytes { raw -> Outcome in
             var offset = 0
-            var remaining = budget
             while offset < raw.count {
                 let written = Darwin.write(
                     fd, raw.baseAddress!.advanced(by: offset), raw.count - offset)
@@ -88,24 +78,11 @@ enum PTYWrite {
                     continue
                 }
                 if written < 0, errno == EINTR { continue }
-                guard written < 0, errno == EAGAIN || errno == EWOULDBLOCK else {
-                    let code = errno
-                    return offset == 0 ? .failed(errno: code) : .partial(written: offset)
+                let code = errno
+                if code == EAGAIN || code == EWOULDBLOCK {
+                    return .partial(written: offset)
                 }
-                guard remaining > 0 else {
-                    return offset == 0 ? .nothingWritten : .partial(written: offset)
-                }
-                // Slices rather than one long wait, so a descriptor that never
-                // becomes writable still costs at most `budget` in total and a
-                // spurious `EINTR` from `poll` does not restart the clock.
-                let slice = min(remaining, 5)
-                var watched = pollfd(fd: fd, events: Int16(POLLOUT), revents: 0)
-                let ready = poll(&watched, 1, slice)
-                if ready < 0, errno != EINTR {
-                    let code = errno
-                    return offset == 0 ? .failed(errno: code) : .partial(written: offset)
-                }
-                remaining -= slice
+                return .failed(errno: code, written: offset)
             }
             return .complete
         }

--- a/Sources/TBDApp/Terminal/TerminalBackpressurePresentation.swift
+++ b/Sources/TBDApp/Terminal/TerminalBackpressurePresentation.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// The panel-level backpressure banner's copy.
+///
+/// Panel-level rather than in-pane: an in-pane status line writes into the
+/// scrollback of a session that is, by construction, in the middle of a paste,
+/// so the notice would land inside the person's pasted text.
+///
+/// A pure function of the byte count so the copy can be pinned by a test
+/// without driving SwiftUI. Whether the banner *appears* is the queue's
+/// business (`OutgoingInputQueue`'s backpressure edges); this is only what it
+/// says once it does.
+enum TerminalBackpressurePresentation {
+    /// What the banner reads while `pendingBytes` are queued behind a pty that
+    /// has stopped accepting writes.
+    ///
+    /// Deliberately says nothing about loss: nothing is dropped and nothing
+    /// has failed. The bytes are queued and land when the agent reads them,
+    /// and telling a person otherwise sends them to restart a working session.
+    static func message(pendingBytes: Int) -> String {
+        "This session is not accepting input — \(amount(pendingBytes)) waiting"
+    }
+
+    private static func amount(_ bytes: Int) -> String {
+        guard bytes >= 1_024 else { return "\(bytes) bytes" }
+        let formatter = ByteCountFormatter()
+        formatter.allowedUnits = [.useKB, .useMB]
+        formatter.countStyle = .file
+        formatter.isAdaptive = false
+        return formatter.string(fromByteCount: Int64(bytes))
+    }
+}

--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -2144,12 +2144,23 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
         /// panel that never typed rather than from `send` — is
         /// compiler-checked main-actor, and so is the queue itself.
         ///
-        /// `false` from the write closure means the bytes reached nothing;
-        /// `enqueueInjection` reports that to the daemon so it can fall back
-        /// to writing directly. A dead `self` reports `false` for the same
-        /// reason.
+        /// `.unwritable` from the attempt closure means the bytes reached
+        /// nothing; `enqueueInjection` reports that to the daemon so it can
+        /// fall back to writing directly. A dead `self` is `.unwritable` for
+        /// the same reason.
+        ///
+        /// **This adapter is temporary and reports no partial writes.**
+        /// `performOutgoingWrite` still answers a `Bool`, so a short write to a
+        /// holder-backed pty is reported here as `.unwritable` — which is what
+        /// it already meant before the outbox existed. Nothing wired to this
+        /// panel therefore gets an outbox yet; giving it one means teaching
+        /// `performOutgoingWrite` and `writeToHolderPTY` to report the kernel's
+        /// cut, and passing this queue a real drain notifier.
         private lazy var outgoingQueue = OutgoingInputQueue { [weak self] data in
-            self?.performOutgoingWrite(data) ?? false
+            guard let self, self.performOutgoingWrite(data) else {
+                return .unwritable(written: 0)
+            }
+            return .accepted
         }
 
         /// Delivers one chunk `outgoingQueue` has decided may go out now, and

--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -473,6 +473,15 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
         /// and does not touch the one-reader invariant: a pty master's read and
         /// write halves are independent queues, and multiple writers to one
         /// master are ordinary.
+        ///
+        /// **A short write here is kept, not lost.** A raw-mode master takes
+        /// 1,022 bytes and then refuses, so this descriptor is the one place a
+        /// panel can be handed back a remainder; `writeToHolderPTY` reports the
+        /// kernel's cut and `OutgoingInputQueue` finishes it. That gives the
+        /// descriptor a second owner: `drainNotifier` watches **this same
+        /// number** for write-readiness, which is why it must be cancelled
+        /// before the close in `stopHolderReader` and why nothing may lower
+        /// this field without cancelling it first.
         private var holderWriteFD: Int32 = -1
 
         /// Whether the last write to `holderWriteFD` failed outright, so
@@ -852,6 +861,24 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
                     \(self.panelID, privacy: .public) to write to \
                     (errno \(errno, privacy: .public)); this panel is read-only
                     """)
+            } else {
+                // The outbox's other half: something has to say when the pty
+                // can take more, or a refused remainder waits for a keystroke
+                // that may never come. Built here, over the same descriptor
+                // the writes go to, and cancelled in `stopHolderReader` before
+                // that descriptor closes.
+                //
+                // It is created *disarmed*, and stays that way until the queue
+                // is actually owed bytes: a readiness source over an idle,
+                // writable pty fires tens of thousands of times a second, so
+                // the arm/disarm edges wired into `outgoingQueue` are what
+                // keep this from being the main queue at 100% for as long as
+                // the panel is open.
+                drainNotifier = WriteSourceDrainNotifier(
+                    fileDescriptor: holderWriteFD
+                ) { [weak self] in
+                    self?.outgoingQueue.drain()
+                }
             }
             let holder = viewHolder
             let reader = HolderStreamReader(
@@ -969,6 +996,19 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
                 injectionRegistration = nil
                 appState?.terminalInjections.unregister(registration)
             }
+            // Cancelled before the queue drops its outbox and before the
+            // descriptor closes: a readiness callback that ran after the close
+            // would write to whatever the kernel reissued that number to. Both
+            // this call and the source's handler are on the main queue, which
+            // is serial, so a cancelled notifier cannot fire afterwards.
+            //
+            // `cancel()` and then `nil`, never `nil` alone: the notifier is
+            // usually *suspended* at this point (the ordinary state is an empty
+            // outbox), and releasing a `DispatchSource` whose suspend count is
+            // non-zero is a SIGTRAP, not a leak. `cancel()` is what rebalances
+            // the count before the release.
+            drainNotifier?.cancel()
+            drainNotifier = nil
             outgoingQueue.shutdown()
             // Closed here, unlike the reader's descriptor: this one is only
             // ever touched from the main actor, so there is no thread to hand
@@ -2149,26 +2189,49 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
         /// fall back to writing directly. A dead `self` is `.unwritable` for
         /// the same reason.
         ///
-        /// **This adapter is temporary and reports no partial writes.**
-        /// `performOutgoingWrite` still answers a `Bool`, so a short write to a
-        /// holder-backed pty is reported here as `.unwritable` — which is what
-        /// it already meant before the outbox existed. Nothing wired to this
-        /// panel therefore gets an outbox yet; giving it one means teaching
-        /// `performOutgoingWrite` and `writeToHolderPTY` to report the kernel's
-        /// cut, and passing this queue a real drain notifier.
-        private lazy var outgoingQueue = OutgoingInputQueue { [weak self] data in
-            guard let self, self.performOutgoingWrite(data) else {
-                return .unwritable(written: 0)
-            }
-            return .accepted
-        }
+        /// The three seams below the attempt are what give this panel an
+        /// outbox rather than a truncation point. `armDrain`/`disarmDrain`
+        /// carry the queue's "the outbox owes bytes" edges to the drain
+        /// notifier — and only those edges, because a notifier left armed over
+        /// an empty outbox is the main queue at 100% (Task 1 measured 44,486 /
+        /// 182,060 / 47,845 fires per second). `onBackpressureChange` carries
+        /// the panel-level indicator's byte count, and is called on the
+        /// episode's edges and its threshold tick rather than per chunk.
+        private lazy var outgoingQueue = OutgoingInputQueue(
+            armDrain: { [weak self] in self?.drainNotifier?.arm() },
+            disarmDrain: { [weak self] in self?.drainNotifier?.disarm() },
+            onBackpressureChange: { [weak self] pending in
+                self?.onOutgoingBackpressureChange?(pending)
+            },
+            attempt: { [weak self] data in
+                self?.performOutgoingWrite(data) ?? .unwritable(written: 0)
+            })
+
+        /// Tells `outgoingQueue` when this session's pty can take more. Built
+        /// with `holderWriteFD` in `startHolderClient`, and cancelled in
+        /// `stopHolderReader` **before** that descriptor closes — a readiness
+        /// callback that ran after the close would write to whatever the
+        /// kernel reissued that number to.
+        ///
+        /// `nil` on every panel that is not holder-backed: a `LocalProcess`
+        /// panel writes through `DispatchIO`, which owns its own completion,
+        /// and a control-mode panel writes frames to the sidecar. Neither can
+        /// short-write to this actor, so neither needs a drain.
+        private var drainNotifier: (any OutgoingDrainNotifier)?
+
+        /// Publishes this panel's backpressure state: the queued byte count
+        /// once a stall has outlasted the queue's threshold, `nil` when the
+        /// outbox has emptied. A closure rather than an `AppState` property so
+        /// a per-second byte count during one panel's stall does not emit an
+        /// observation to every reader of that object.
+        var onOutgoingBackpressureChange: (@MainActor (Int?) -> Void)?
 
         /// Delivers one chunk `outgoingQueue` has decided may go out now, and
-        /// reports whether anything actually took it. Same two destinations
-        /// `send(source:data:)` used before the queue existed —
-        /// `OutgoingInputRoute.decide` is unchanged, and it still runs in the
-        /// same main-actor turn the bytes arrived in, so a tab switch cannot
-        /// nil `controlModeAttach` between the decision and the write.
+        /// reports what took it. Same two destinations `send(source:data:)`
+        /// used before the queue existed — `OutgoingInputRoute.decide` is
+        /// unchanged, and it still runs in the same main-actor turn the bytes
+        /// arrived in, so a tab switch cannot nil `controlModeAttach` between
+        /// the decision and the write.
         ///
         /// A holder-backed panel has neither `localProcess` nor
         /// `controlModeAttach`, so it falls into `.localPTY` — and there it
@@ -2176,16 +2239,19 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
         /// (`holderWriteFD`), which is what makes the app the attached
         /// session's only writer and the daemon's injection path worth having.
         ///
-        /// `true` means *handed off*, which is the strongest claim available
-        /// synchronously: both destinations complete asynchronously
-        /// (`DispatchIO` for the pty, the sidecar client's own send queue for
-        /// the frame), so a write that fails after this returns cannot be
-        /// reported here. The daemon's fail-open deadline is what covers that
-        /// residue. Both arms report every refusal that *is* knowable at call
-        /// time, which is the whole obligation this seam can carry: a missing
-        /// or dead `localProcess`, and for the sidecar a missing attach, a
-        /// disconnected client, an over-cap payload or an encode failure.
-        private func performOutgoingWrite(_ data: Data) -> Bool {
+        /// **`.accepted` and `.refused` both mean handed off**, which is the
+        /// strongest claim available synchronously and the meaning this seam
+        /// has always carried: the `localProcess` arm hands bytes to
+        /// `DispatchIO` and the sidecar arm to the client's own send queue, and
+        /// neither can report a failure that happens after this returns — the
+        /// daemon's fail-open deadline is what covers that residue. The pty arm
+        /// now joins them: `.refused` means the kernel took a prefix (possibly
+        /// none) and `outgoingQueue` owns the rest and will finish it on
+        /// write-readiness. Only `.unwritable` is a report of loss — no
+        /// descriptor, a dead or exited child, a missing attach, a disconnected
+        /// sidecar, an over-cap payload, an encode failure — and it is the only
+        /// answer that reaches the daemon as `written: false`.
+        private func performOutgoingWrite(_ data: Data) -> OutgoingInputQueue.WriteAttempt {
             switch OutgoingInputRoute.decide(
                 controlModeAttached: controlModeAttach != nil, byteCount: data.count) {
             case .localPTY:
@@ -2197,15 +2263,17 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
                 if holderWriteFD >= 0 { return writeToHolderPTY(data) }
                 // `running` counts as much as non-nil: `LocalProcess.send`
                 // silently drops everything once the child has exited, so
-                // reporting `true` for a dead child would be the same
+                // reporting `.accepted` for a dead child would be the same
                 // fabricated ack in a different shape.
-                guard let localProcess, localProcess.running else { return false }
+                guard let localProcess, localProcess.running else {
+                    return .unwritable(written: 0)
+                }
                 localProcess.send(data: [UInt8](data)[...])
-                return true
+                return .accepted
             case .sidecarInput:
                 // `isConnected` belongs in the guard for the same reason
                 // `running` does above: the sidecar client drops an `.input`
-                // frame whose socket is gone, so a `true` here would be a
+                // frame whose socket is gone, so an `.accepted` here would be a
                 // *systematic* fabricated ack for as long as the drop lasts,
                 // not a rare one.
                 //
@@ -2232,8 +2300,8 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
                 // read again on the client's own send queue, so a
                 // disconnection between this check and that read is a TOCTOU
                 // this arm cannot see. Acceptable for exactly the reason the
-                // `.localPTY` arm's residue is — `true` means handed off, and
-                // the daemon's fail-open deadline is the cover — and a
+                // `.localPTY` arm's residue is — `.accepted` means handed off,
+                // and the daemon's fail-open deadline is the cover — and a
                 // synchronous answer that waited for the queue would put a
                 // socket write in a keystroke's main-actor turn.
                 //
@@ -2244,49 +2312,68 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
                 // for, so `OutgoingInputQueue.noteUserWriteOutcome`'s recovery
                 // line ("user input is reaching a transport again") can fire
                 // on a transport that will not deliver. It carries exactly the
-                // strength this `true` does — handed off — and no more.
+                // strength this `.accepted` does — handed off — and no more.
                 guard let attach = controlModeAttach, let appState,
                     appState.daemonClient.fdSidecar.isConnected
-                else { return false }
+                else { return .unwritable(written: 0) }
                 return appState.daemonClient.fdSidecar.sendInput(
                     worktreeID: attach.worktreeID, paneID: attach.paneID, bytes: data)
+                    ? .accepted : .unwritable(written: 0)
             }
         }
 
         /// Write one chunk to this holder session's pty, and report what the
         /// kernel took.
         ///
-        /// One attempt, no waiting: a raw-mode pty master accepts 1,022 bytes
-        /// and then refuses, and `PTYWrite.all` reports the refusal rather than
-        /// polling for room on the main actor.
+        /// **One attempt, no waiting.** A raw-mode pty master accepts 1,022
+        /// bytes (`TTYHOG − 2`, measured) and then refuses, so any payload
+        /// above a kilobyte into a child that is not draining at that instant
+        /// is written short. This used to spend a 20 ms `poll` budget hoping
+        /// the child would read, and then reported the whole write a failure
+        /// with the prefix already committed — a truncated fragment on the
+        /// session and an error at the caller, the loss side of a fork this
+        /// design takes on the duplicate side everywhere else.
         ///
-        /// **A partial write is still reported unwritten here, and that is a
-        /// loss.** Nothing yet keeps the remainder, so a payload above a
-        /// kilobyte into a child that is not draining leaves a truncated
-        /// fragment on the session. The outbox in `OutgoingInputQueue` is what
-        /// fixes it, and this function is rewritten when it lands.
+        /// **The remainder is now kept, not lost.** `.refused(written:)` hands
+        /// it back to `OutgoingInputQueue`, which holds every later byte from
+        /// every stream behind it and finishes it when the pty is next
+        /// writable. So a short write is no longer a failure to report; it is
+        /// the ordinary shape of writing to a busy tty, and the ack the caller
+        /// carries to the daemon means what it means on the other two arms of
+        /// `performOutgoingWrite` — accepted by a writer that will complete or
+        /// report.
+        ///
+        /// **What is bounded by what.** The remainder is bounded by the
+        /// descriptor: it ends when the write returns `EIO` (the last slave
+        /// closed) or `EBADF` (teardown), and by nothing else. No clock
+        /// truncates it, because a clock expiring on a full queue could not
+        /// write the released bytes either — it would only cut the payload with
+        /// somebody else's bytes in the gap. What the person gets instead of a
+        /// timeout is the panel's backpressure indicator.
         ///
         /// **`.failed` is edge-triggered, and it has to be.** Once the child
         /// exits, every write to the master returns `EIO` — and nothing lowers
         /// `holderWriteFD`, because `HolderStreamReader.readLoop` closes its
         /// own descriptor on EOF and never calls `stopHolderReader`. An
         /// unconditional line there is one `.error` per keystroke for as long
-        /// as somebody keeps typing at a dead session.
-        private func writeToHolderPTY(_ data: Data) -> Bool {
+        /// as somebody keeps typing at a dead session. The queue logs the
+        /// dropped byte count once for the same episode; this logs the errno
+        /// once.
+        ///
+        /// A partial write is deliberately **not** logged. It is routine —
+        /// about once per KiB of any large paste — and a line per occurrence is
+        /// exactly the per-event logging this file's hot path warns against.
+        /// The episode's start and end are logged by `OutgoingInputQueue`,
+        /// once each, with the peak byte count.
+        private func writeToHolderPTY(_ data: Data) -> OutgoingInputQueue.WriteAttempt {
             switch PTYWrite.all(data, to: holderWriteFD) {
             case .complete:
                 holderWriteIsFailing = false
-                return true
+                return .accepted
             case .partial(let written):
                 holderWriteIsFailing = false
-                guard written > 0 else { return false }
-                logger.error("""
-                    terminal \(self.panelID, privacy: .public): only \
-                    \(written, privacy: .public) of \(data.count, privacy: .public) bytes \
-                    reached the session's pty; the remainder is dropped until the outbox lands
-                    """)
-                return false
-            case .failed(let code, _):
+                return .refused(written: written)
+            case .failed(let code, let written):
                 if !holderWriteIsFailing {
                     holderWriteIsFailing = true
                     holderWriteFailureLogsForTesting += 1
@@ -2296,7 +2383,7 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
                         descriptor are not logged until a write succeeds again
                         """)
                 }
-                return false
+                return .unwritable(written: written)
             }
         }
 

--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -2242,75 +2242,40 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
             }
         }
 
-        /// Write one chunk to this holder session's pty, and report whether
-        /// all of it went.
+        /// Write one chunk to this holder session's pty, and report what the
+        /// kernel took.
         ///
-        /// **What a short write means here, and what it costs today.**
-        /// A pty master's input queue is small, so a multi-KiB injected prompt
-        /// can legitimately take only a prefix; `PTYWrite.all` waits a few
-        /// milliseconds for room and then gives up rather than parking the
-        /// main actor. A partial write is reported as a **failure**, on the
-        /// reasoning that the daemon then rewrites the whole payload on top of
-        /// the prefix — visibly doubled rather than quietly truncated.
+        /// One attempt, no waiting: a raw-mode pty master accepts 1,022 bytes
+        /// and then refuses, and `PTYWrite.all` reports the refusal rather than
+        /// polling for room on the main actor.
         ///
-        /// **The daemon cannot rewrite in this state.** This panel is
-        /// attached, so the acknowledgement has already released the daemon's
-        /// reader and closed its descriptor, and `HolderInjectionCourier`'s
-        /// fail-open fallback answers `.notDelivered` instead of writing. So a
-        /// 6 KB prompt into a panel whose agent is momentarily not draining
-        /// leaves a **truncated fragment** in the composer while the caller is
-        /// told the send failed. Not silent — the caller is told and the
-        /// actuation row records it — but a loss, and the fork this design
-        /// takes everywhere resolved on the wrong side of itself.
-        ///
-        /// It is left this way on purpose. Whether the daemon can rewrite is
-        /// the descriptor question — whether it keeps a **write-only** dup
-        /// across an attach — which is a human decision already filed;
-        /// answered one way the reasoning above becomes true as written, and
-        /// changing the retry semantics here now would pre-empt it. Reporting
-        /// `true` for a prefix is not the alternative: that is the invisible
-        /// loss this path exists to prevent, with no error anywhere.
-        ///
-        /// Only the partial case logs every time. "Nothing was written"
-        /// needs no line of its own — for user bytes `OutgoingInputQueue`
-        /// already emits one edge-triggered line per episode, and for an
-        /// injection the return value reaches the daemon, which is a stronger
-        /// channel than a log. A partial write is rare enough to be worth a
-        /// line each time, because it is what explains the truncation that
-        /// follows it, and it is per-payload rather than per-keystroke anyway.
+        /// **A partial write is still reported unwritten here, and that is a
+        /// loss.** Nothing yet keeps the remainder, so a payload above a
+        /// kilobyte into a child that is not draining leaves a truncated
+        /// fragment on the session. The outbox in `OutgoingInputQueue` is what
+        /// fixes it, and this function is rewritten when it lands.
         ///
         /// **`.failed` is edge-triggered, and it has to be.** Once the child
         /// exits, every write to the master returns `EIO` — and nothing lowers
         /// `holderWriteFD`, because `HolderStreamReader.readLoop` closes its
         /// own descriptor on EOF and never calls `stopHolderReader`. An
         /// unconditional line there is one `.error` per keystroke for as long
-        /// as somebody keeps typing at a dead session, which is exactly the
-        /// per-keystroke logging this file warns against above and R20 built
-        /// the queue's own latch to avoid.
+        /// as somebody keeps typing at a dead session.
         private func writeToHolderPTY(_ data: Data) -> Bool {
             switch PTYWrite.all(data, to: holderWriteFD) {
             case .complete:
                 holderWriteIsFailing = false
                 return true
-            case .nothingWritten:
-                // A full input queue, not a dead descriptor: the write path is
-                // alive, so the next `.failed` starts a new episode and logs.
-                holderWriteIsFailing = false
-                return false
             case .partial(let written):
                 holderWriteIsFailing = false
+                guard written > 0 else { return false }
                 logger.error("""
                     terminal \(self.panelID, privacy: .public): only \
                     \(written, privacy: .public) of \(data.count, privacy: .public) bytes \
-                    reached the session's pty; reporting the write unwritten — the daemon \
-                    re-sends the payload whole if it still holds a descriptor for this pty, \
-                    and otherwise the session keeps the prefix
+                    reached the session's pty; the remainder is dropped until the outbox lands
                     """)
                 return false
-            case .failed(let code):
-                // One line per episode, keyed on the transition rather than on
-                // the errno: a descriptor that has started failing keeps
-                // failing, and the interesting fact is when it began.
+            case .failed(let code, _):
                 if !holderWriteIsFailing {
                     holderWriteIsFailing = true
                     holderWriteFailureLogsForTesting += 1

--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -496,11 +496,14 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
         /// A write-only `dup` of this holder session's pty master, and the
         /// app's write destination for one (`performOutgoingWrite`'s
         /// `.localPTY` arm). Without it a holder-backed panel has nowhere to
-        /// put a byte: it has no `LocalProcess` and no control-mode attach, so
-        /// every keystroke and every daemon injection would report unwritten
-        /// and the daemon's fallback would become the only delivery path —
-        /// which is the opposite of the property this transport is for, that
-        /// the app is the attached session's ONLY writer.
+        /// put a byte: it has no `LocalProcess` and no control-mode attach.
+        ///
+        /// A `dup` that fails leaves the panel read-only: every write reports
+        /// `.unwritable`, the queue holds nothing, and the daemon keeps
+        /// delivering through its own descriptor — which is the opposite of
+        /// the property this transport is for, that the app is the attached
+        /// session's ONLY writer. That is distinct from a pty that merely
+        /// refuses: a refusal is held and finished, and reported accepted.
         ///
         /// A separate descriptor rather than the reader's own, because the
         /// reader closes its descriptor **on its own thread** on the way out

--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -100,6 +100,13 @@ struct TerminalPanelView: View {
     @State private var proxyWarning: String?
     @State private var didProbe = false
     @State private var recoveryGuidanceMessage: String?
+    /// Bytes this panel's outgoing queue is holding for a pty that has stopped
+    /// accepting writes, once the stall has outlasted the queue's threshold;
+    /// `nil` whenever nothing is waiting. Panel-local `@State` rather than an
+    /// `AppState` property on purpose: a byte count that ticks once a second
+    /// during one panel's stall would otherwise emit an observation to every
+    /// reader of that object.
+    @State private var pendingOutgoingBytes: Int?
 
     /// Profile id pinned to this terminal (if any). Used as the `.task` id so
     /// the probe re-fires once AppState populates. `nil` while AppState hasn't
@@ -169,6 +176,30 @@ struct TerminalPanelView: View {
                 .padding(.vertical, 5)
                 .background(Color.orange.opacity(0.18))
             }
+            // Passive backpressure indicator: shows only while this panel's
+            // outgoing queue is holding bytes a stalled pty refused, and only
+            // once that stall has outlasted the queue's threshold. Clears
+            // itself when the outbox drains — no dismiss affordance, matching
+            // the input-health indicator above.
+            //
+            // A sibling in this VStack rather than an overlay, so it never
+            // covers the terminal: the panel's app-wide scroll/click monitors
+            // filter on `tv.bounds.contains(point)`, and a view drawn OVER the
+            // terminal would have to be told to suppress them. This one sits
+            // outside those bounds and carries no controls.
+            if let pendingOutgoingBytes {
+                HStack(spacing: 6) {
+                    Image(systemName: "hourglass")
+                        .foregroundStyle(.orange)
+                    Text(TerminalBackpressurePresentation.message(pendingBytes: pendingOutgoingBytes))
+                        .font(.caption)
+                    Spacer()
+                }
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(Color.orange.opacity(0.18))
+                .accessibilityElement(children: .combine)
+            }
             TerminalPanelRepresentable(
                 terminalID: terminalID,
                 tmuxServer: tmuxServer,
@@ -181,6 +212,7 @@ struct TerminalPanelView: View {
                 onTerminalNotification: onTerminalNotification,
                 onMissingWindow: onMissingWindow,
                 onRecoveryGuidance: { recoveryGuidanceMessage = $0 },
+                onOutgoingBackpressureChange: { pendingOutgoingBytes = $0 },
                 initialSnapshot: initialSnapshot,
                 isSuspendedSnapshot: isSuspendedSnapshot,
                 parkedNoticeMessage: parkedNoticeMessage,
@@ -264,6 +296,8 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
     @EnvironmentObject var appearance: AppearanceSettings
     var onMissingWindow: (@MainActor () async -> AutomaticTerminalRecreationOutcome)?
     var onRecoveryGuidance: (@MainActor (String) -> Void)?
+    /// Carries this panel's queued-byte count to the parent's `@State` banner.
+    var onOutgoingBackpressureChange: (@MainActor (Int?) -> Void)?
     var initialSnapshot: String?
     var isSuspendedSnapshot: Bool = false
     var parkedNoticeMessage: String? = nil
@@ -303,6 +337,7 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
         context.coordinator.syncTabCloseContext(tabCloseContext, for: terminalID)
         context.coordinator.onMissingWindow = onMissingWindow
         context.coordinator.onRecoveryGuidance = onRecoveryGuidance
+        context.coordinator.onOutgoingBackpressureChange = onOutgoingBackpressureChange
         context.coordinator.shouldSuppressEvents = shouldSuppressEvents
 
         // Feed snapshot before tmux connects so the user sees the last state
@@ -399,6 +434,10 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
             .isCodexTerminal == true
         context.coordinator.syncTabCloseContext(tabCloseContext, for: terminalID)
         context.coordinator.onRecoveryGuidance = onRecoveryGuidance
+        // Re-assigned here as well as in `makeNSView`: the closure captures the
+        // parent's CURRENT `@State` setter, and a coordinator still holding the
+        // one from `makeNSView` writes into a stale view identity.
+        context.coordinator.onOutgoingBackpressureChange = onOutgoingBackpressureChange
     }
 
     static func dismantleNSView(_ nsView: TBDTerminalView, coordinator: Coordinator) {

--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -985,6 +985,18 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
         /// descriptor, not to the view. `shutdown()` is idempotent, and
         /// `cleanup()` keeps its own call for panels that never had a holder.
         ///
+        /// **A remainder outstanding here is dropped, and that is a decision.**
+        /// The handback carries the screen, not unwritten input, so a person who
+        /// closes a tab while their paste is still draining into a stalled child
+        /// loses its tail — logged with the byte count, never silently. One
+        /// hazard is named rather than solved: if the dropped remainder held a
+        /// paste's end marker, the child is left mid-paste after the handback,
+        /// and a later injection can be absorbed into it. Keeping a writer alive
+        /// past the handback to land a pending marker is possible and is
+        /// deliberately not done — it puts new state into the most delicate
+        /// teardown in this file for a case that needs a large paste, a stalled
+        /// child and a close inside the stall at once.
+        ///
         /// The view holder is deliberately **not** cleared here: on the detach
         /// path the reader's last chunk is exactly the output the handback
         /// preamble is serialized from, so the sink has to outlive the stop.

--- a/Sources/TBDDaemon/Holder/HolderInjectionCourier.swift
+++ b/Sources/TBDDaemon/Holder/HolderInjectionCourier.swift
@@ -84,9 +84,10 @@ actor HolderInjectionCourier {
         /// The ordinary case, and the only one that is not a fallback.
         case detached
         /// The app answered, and its answer was that nothing took the bytes.
-        /// Trustworthy — every refusal the app can know synchronously reports
-        /// `false` — so this is the one fallback that is certain not to
-        /// duplicate.
+        /// Trustworthy — the app answers `false` only when it has no writer at
+        /// all, never when the session's pty merely refused a payload the app
+        /// is still holding and will finish — so this is the one fallback that
+        /// is certain not to duplicate.
         case viewerReportedNothingWritten
         /// The injection frame could not be put on the sidecar at all, so the
         /// app never saw it.

--- a/Sources/TBDDaemon/Holder/HolderRegistry.swift
+++ b/Sources/TBDDaemon/Holder/HolderRegistry.swift
@@ -1903,6 +1903,17 @@ actor HolderRegistry {
     /// rendezvous that provably has nobody behind it, establishes that this
     /// session is over; every other way a round trip can fail is retried within
     /// the same budget and then kept. See `exitProbeOutcome`.
+    ///
+    /// **A push is an answer, even when the round trip that carried it failed.**
+    /// The holder pushes the exit at whichever client is connected and winds
+    /// down in the same breath, so a probe that connected a moment before the
+    /// child was reaped is handed the status and then finds the socket gone
+    /// underneath it. That push answers no request, so `HolderClient`'s barrier
+    /// retires it — into `lastPushedDescription`, which exists for exactly this
+    /// and is what is read here. Without it the reclaimer discards the very
+    /// fact it asked for, asks again at a rendezvous the holder has already
+    /// unlinked, reads the `ENOENT` as absence, and records
+    /// `exitedStatusUnknown` for a child that exited perfectly ordinarily.
     private static func confirmChildExit(
         socketPath: String,
         expecting owner: HolderOwnerToken,
@@ -1920,11 +1931,22 @@ actor HolderRegistry {
                 case .exited, .exitedStatusUnknown:
                     return description.status
                 case .alive:
-                    break
+                    // An exit can be pushed in the same breath as an answer
+                    // that was already on the wire; the `close()` above retires
+                    // it. It is about the same child and it is newer than the
+                    // answer it trailed, so it supersedes it.
+                    if let pushed = pushedTerminalStatus(
+                        await client.lastPushedDescription, expecting: owner) {
+                        return pushed
+                    }
                 }
             } catch {
                 await client.close()
-                switch exitProbeOutcome(for: error) {
+                switch exitProbeOutcome(
+                    for: error,
+                    pushedByTheHolder: await client.lastPushedDescription,
+                    expecting: owner
+                ) {
                 case .established(let status):
                     return status
                 case .keep:
@@ -1959,6 +1981,48 @@ actor HolderRegistry {
         case retry
         /// Nothing here says the session ended. The reader stays.
         case keep
+    }
+
+    /// What a probe knows when its round trip failed **and** the holder had
+    /// already pushed a status down that same connection.
+    ///
+    /// The push outranks the failure, and nothing else here changes. A holder
+    /// that pushes has answered: it observed its own child, said how it ended,
+    /// and then wound down — which is precisely why the connection the push
+    /// arrived on is dead by the time the caller looks at it. Reading the
+    /// failure instead would retry, find the rendezvous unlinked, and record
+    /// `exitedStatusUnknown` for a status the daemon was holding all along.
+    ///
+    /// A push from another installation's holder is ignored, on the same rule
+    /// the answered path applies to `description.owner`; so is one that says
+    /// the child is still alive, which the holder never sends but which must
+    /// not be read as a terminal status if it ever did.
+    ///
+    /// Pure, and separate from the errno classification below so that both stay
+    /// pinnable case by case without standing up a holder for each one.
+    static func exitProbeOutcome(
+        for error: Swift.Error,
+        pushedByTheHolder pushed: HolderChildDescription?,
+        expecting owner: HolderOwnerToken
+    ) -> ExitProbeOutcome {
+        if let status = pushedTerminalStatus(pushed, expecting: owner) {
+            return .established(status)
+        }
+        return exitProbeOutcome(for: error)
+    }
+
+    /// The terminal status in a holder's unsolicited push, if it carries one
+    /// this registry may act on.
+    static func pushedTerminalStatus(
+        _ pushed: HolderChildDescription?, expecting owner: HolderOwnerToken
+    ) -> HolderChildStatus? {
+        guard let pushed, pushed.owner == owner else { return nil }
+        switch pushed.status {
+        case .exited, .exitedStatusUnknown:
+            return pushed.status
+        case .alive:
+            return nil
+        }
     }
 
     /// How a thrown `describe` bears on releasing a reader.

--- a/Sources/TBDDaemon/Holder/HolderSpawner.swift
+++ b/Sources/TBDDaemon/Holder/HolderSpawner.swift
@@ -50,7 +50,9 @@ struct HolderSpawnResult: Sendable {
 ///      unowned: it is probed, and only a connect that fails outright licenses
 ///      unlinking it.
 ///   4. The lock travels to the holder as a **descriptor number**, placed by a
-///      `posix_spawn` `dup2` file action.
+///      `posix_spawn` `dup2` file action — and so does the launch request,
+///      which carries the session's environment and therefore may not go on a
+///      command line that `ps` shows to every process on the machine.
 ///   5. The holder's stdio is detached, with stderr somewhere retrievable.
 ///   6. The daemon drops its own copy of the lock, so the holder alone holds it
 ///      and the kernel drops it when the holder dies.
@@ -93,6 +95,30 @@ struct HolderSpawner {
     /// the holder validates that it landed above 2.
     static let lockDescriptorNumber: Int32 = 9
 
+    /// The descriptor number the launch request is placed on in the holder.
+    ///
+    /// **The launch request is not on the command line, and must never go
+    /// back.** `HolderLaunchRequest` carries the session's entire environment,
+    /// and a process's argv is readable by every process running as the same
+    /// user — `ps -ww` prints it — so a holder launched with the request on
+    /// argv published that session's credentials to the process table for the
+    /// session's whole life. Same for the holder's own environment, which
+    /// `ps -E` prints for the same audience, so moving the payload there is not
+    /// a fix either. A descriptor is the one channel of the three that no
+    /// process outside this tree can name.
+    static let launchDescriptorNumber: Int32 = 10
+
+    /// The lowest number the spawner will relocate an inherited descriptor to.
+    ///
+    /// Above **every** target number, not merely above its own: with two dup2
+    /// file actions in play, a source parked on the *other* action's target
+    /// would be overwritten by it, and whether that mattered would depend on
+    /// the order the two actions happen to run in. Relocating both sources
+    /// above both targets removes the question.
+    private static var descriptorRelocationFloor: Int32 {
+        max(lockDescriptorNumber, launchDescriptorNumber) + 1
+    }
+
     /// How long to wait for a freshly spawned holder to bind and answer.
     /// Generous because it covers a cold `execve` of a debug binary under a
     /// loaded machine, and bounded because a holder that never binds must fail
@@ -126,6 +152,9 @@ struct HolderSpawner {
         case rendezvousDirectoryUnavailable(path: String, detail: String)
         case lockUnavailable(path: String, detail: String)
         case spawnFailed(executable: String, errno: Int32)
+        /// The launch request could not be placed on its descriptor. Raised
+        /// **before** anything is spawned, so nothing exists to reclaim.
+        case launchPayloadUndeliverable(bytes: Int, errno: Int32)
 
         var errorDescription: String? {
             switch self {
@@ -150,6 +179,9 @@ struct HolderSpawner {
             case .spawnFailed(let executable, let code):
                 return "could not spawn \(executable): "
                     + "\(String(cString: strerror(code))) (errno \(code))"
+            case .launchPayloadUndeliverable(let bytes, let code):
+                return "could not hand the holder its \(bytes)-byte launch request: "
+                    + "\(String(cString: strerror(code))) (errno \(code)); nothing was spawned"
             }
         }
     }
@@ -581,6 +613,98 @@ struct HolderSpawner {
 
     // MARK: - Launching
 
+    /// The holder's command line, in full.
+    ///
+    /// **Everything here is world-readable, so nothing secret may appear in
+    /// it.** Same-user processes read argv with `ps`, which is what made
+    /// carrying the launch request on this list a credential leak for the whole
+    /// life of every session. What remains is a session UUID, a rendezvous
+    /// path, two descriptor numbers and an installation token — public facts
+    /// about where the holder's files are, not about what the job will run.
+    /// Extracted from `launchHolder` so that stays assertable without spawning
+    /// anything: `HolderLaunchArgumentTests` pins the whole list.
+    static func commandLine(
+        executablePath: String,
+        sessionID: UUID,
+        socketPath: String,
+        owner: HolderOwnerToken
+    ) -> [String] {
+        [
+            executablePath,
+            "--session", sessionID.uuidString,
+            "--socket", socketPath,
+            "--lock-fd", String(lockDescriptorNumber),
+            "--launch-fd", String(launchDescriptorNumber),
+            "--owner", owner.rawValue,
+        ]
+    }
+
+    /// Puts the launch request somewhere only the holder can read it, and
+    /// returns the descriptor to hand it.
+    ///
+    /// A `socketpair`, rather than either of the two obvious alternatives:
+    ///
+    ///   - **A file** — even one created 0600 and unlinked after reading —
+    ///     would be a new durable on-disk resource holding the session's
+    ///     credentials, and so would owe a reclaimer for the copy left behind
+    ///     by a daemon that died between creating it and unlinking it. This
+    ///     owes none: there is no name, in any namespace, at any instant. The
+    ///     payload lives in a socket buffer that the kernel frees when the last
+    ///     descriptor closes, which happens on every path — the `defer` here, a
+    ///     holder that never starts, and a holder SIGKILLed before it reads.
+    ///   - **A pipe** cannot be resized on darwin (`F_SETPIPE_SZ` is Linux
+    ///     only), so a request larger than the pipe buffer could only be
+    ///     delivered by writing *after* the spawn and blocking until the holder
+    ///     read it — a daemon thread parked on a process that may never reach
+    ///     `main`. A unix socket's buffers take `SO_SNDBUF`/`SO_RCVBUF`, so the
+    ///     whole request is written before anything is spawned.
+    ///
+    /// The write end is non-blocking and closed here: a kernel that refused to
+    /// grow the buffer surfaces as `EAGAIN` on a spawn that has not happened
+    /// yet, rather than as a deadlock, and closing it is what gives the holder
+    /// an EOF to stop reading at. Data already queued on the peer survives that
+    /// close — it sits in the read end's receive buffer, which this process
+    /// still holds open. `EPIPE` cannot arise for the same reason.
+    static func makeLaunchPayloadChannel(_ launch: HolderLaunchRequest) throws -> Int32 {
+        let payload = try JSONEncoder().encode(launch)
+
+        var descriptors: [Int32] = [-1, -1]
+        guard socketpair(AF_UNIX, SOCK_STREAM, 0, &descriptors) == 0 else {
+            throw Error.launchPayloadUndeliverable(bytes: payload.count, errno: errno)
+        }
+        let writeEnd = descriptors[0]
+        let readEnd = descriptors[1]
+
+        // Sized to the payload plus slack on BOTH ends: a unix stream socket
+        // queues what is sent onto the *receiver's* buffer, so the send end's
+        // capacity alone does not decide whether a write fits. Failures are
+        // ignored deliberately — the write below is the real test, and a kernel
+        // that refused to grow may still have had room.
+        var capacity = Int32(clamping: payload.count + 4096)
+        let size = socklen_t(MemoryLayout<Int32>.size)
+        _ = setsockopt(readEnd, SOL_SOCKET, SO_RCVBUF, &capacity, size)
+        _ = setsockopt(writeEnd, SOL_SOCKET, SO_SNDBUF, &capacity, size)
+        _ = fcntl(writeEnd, F_SETFL, O_NONBLOCK)
+
+        var offset = 0
+        while offset < payload.count {
+            let written = payload.withUnsafeBytes { raw -> Int in
+                write(writeEnd, raw.baseAddress?.advanced(by: offset), payload.count - offset)
+            }
+            if written > 0 {
+                offset += written
+                continue
+            }
+            let saved = errno
+            if written < 0, saved == EINTR { continue }
+            close(writeEnd)
+            close(readEnd)
+            throw Error.launchPayloadUndeliverable(bytes: payload.count, errno: saved)
+        }
+        close(writeEnd)
+        return readEnd
+    }
+
     private func launchHolder(
         sessionID: UUID,
         socketPath: String,
@@ -590,15 +714,19 @@ struct HolderSpawner {
         environment: [String: String],
         lock: HolderLock
     ) throws -> Int32 {
-        let payload = try JSONEncoder().encode(launch).base64EncodedString()
-        let arguments = [
-            executableURL.path,
-            "--session", sessionID.uuidString,
-            "--socket", socketPath,
-            "--lock-fd", String(Self.lockDescriptorNumber),
-            "--launch", payload,
-            "--owner", owner.rawValue,
-        ]
+        let arguments = Self.commandLine(
+            executablePath: executableURL.path,
+            sessionID: sessionID,
+            socketPath: socketPath,
+            owner: owner)
+
+        // Built before anything else in this function, and before any process
+        // exists: every byte of the request is in the kernel's hands by the
+        // time `posix_spawn` is called, so a payload that cannot be delivered
+        // fails a spawn that never happened rather than stranding a holder
+        // waiting on a stream nobody will finish writing.
+        let launchSource = try Self.makeLaunchPayloadChannel(launch)
+        defer { close(launchSource) }
 
         // `</dev/null` and a real file for stdout/stderr, never inherited
         // descriptors. A holder that inherits the daemon's stdout holds that
@@ -629,28 +757,41 @@ struct HolderSpawner {
         // concurrent `posix_spawn` in the daemon, and an unrelated child that
         // inherited it would hold this session UUID unreclaimable until it
         // died.
-        let lockSource = fcntl(lock.fileDescriptor, F_DUPFD_CLOEXEC, Self.lockDescriptorNumber + 1)
+        let lockSource = fcntl(
+            lock.fileDescriptor, F_DUPFD_CLOEXEC, Self.descriptorRelocationFloor)
         guard lockSource >= 0 else {
             throw Error.spawnFailed(executable: executableURL.path, errno: errno)
         }
         defer { close(lockSource) }
 
+        // The launch descriptor is relocated for the same reason and by the
+        // same call. `makeLaunchPayloadChannel` returns whatever number the
+        // kernel had free, which can be the target of either dup2 below.
+        let relocatedLaunch = fcntl(launchSource, F_DUPFD_CLOEXEC, Self.descriptorRelocationFloor)
+        guard relocatedLaunch >= 0 else {
+            throw Error.spawnFailed(executable: executableURL.path, errno: errno)
+        }
+        defer { close(relocatedLaunch) }
+
         var actions: posix_spawn_file_actions_t?
         posix_spawn_file_actions_init(&actions)
         defer { posix_spawn_file_actions_destroy(&actions) }
         // File actions run IN ORDER, and fd numbers collide. The stdio dup2s
-        // come first and the lock's dup2 last, so that if the log or /dev/null
-        // descriptor happens to land on the target number it has already been
-        // copied to its final home by the time the lock overwrites it. There
-        // are deliberately NO trailing closes: a close scheduled after the
-        // lock's dup2 would destroy the descriptor it just placed.
+        // come first and the inherited descriptors last, so that if the log or
+        // /dev/null descriptor happens to land on one of the target numbers it
+        // has already been copied to its final home by the time it is
+        // overwritten. Neither source can be a target — both were relocated
+        // above `descriptorRelocationFloor` — so the last two are independent.
+        // There are deliberately NO trailing closes: a close scheduled after a
+        // dup2 would destroy the descriptor it just placed.
         posix_spawn_file_actions_adddup2(&actions, nullFD, 0)
         posix_spawn_file_actions_adddup2(&actions, logFD, 1)
         posix_spawn_file_actions_adddup2(&actions, logFD, 2)
         posix_spawn_file_actions_adddup2(&actions, lockSource, Self.lockDescriptorNumber)
+        posix_spawn_file_actions_adddup2(&actions, relocatedLaunch, Self.launchDescriptorNumber)
 
         // Everything the daemon happens to have open without FD_CLOEXEC would
-        // otherwise arrive in a process that outlives it. The four descriptors
+        // otherwise arrive in a process that outlives it. The five descriptors
         // above are named in file actions and survive; nothing else does.
         var attributes: posix_spawnattr_t?
         posix_spawnattr_init(&attributes)

--- a/Sources/TBDHolder/Holder.swift
+++ b/Sources/TBDHolder/Holder.swift
@@ -634,6 +634,15 @@ final class Holder {
 /// could not name the inherited descriptor, and therefore could not keep it
 /// out of the job — which is the one thing about the lock that must not
 /// happen. The holder never calls `HolderLock.acquire` itself.
+///
+/// **The launch request arrives the same way, and for a security reason.** A
+/// process's argv is world-readable to every process running as the same user
+/// — `ps -ww` prints it — and a `HolderLaunchRequest` carries the session's
+/// entire environment. Carrying it on the command line published every
+/// credential in that environment to the process table for the whole life of
+/// the session. It now travels as bytes on `--launch-fd`, a descriptor the
+/// spawner placed with a `posix_spawn` file action exactly as it places the
+/// lock, and which nothing outside this process tree can name.
 struct HolderArguments: Equatable {
     var sessionID: UUID
     var socketPath: String
@@ -646,8 +655,15 @@ struct HolderArguments: Equatable {
 
     static let usage = """
         usage: TBDHolder --session <uuid> --socket <path> --lock-fd <n> \
-        --launch <base64-json> [--owner <token>]
+        --launch-fd <n> [--owner <token>]
         """
+
+    /// The most a launch request may be. A descriptor is not argv: nothing
+    /// bounds it for us, so a hostile or confused writer could otherwise make
+    /// the holder allocate without limit before it has bound anything. Sized
+    /// far above any real environment (`ARG_MAX` on darwin is a quarter of it,
+    /// and the payload used to have to fit inside that).
+    static let maximumLaunchPayloadBytes = 4 * 1024 * 1024
 
     /// `arguments` excludes argv[0].
     ///
@@ -688,11 +704,14 @@ struct HolderArguments: Equatable {
         guard let lockFD = Int32(lockText) else {
             throw HolderStartupError.invalidLockDescriptorArgument(lockText)
         }
-        let launchText = try required("launch")
-        guard let launchData = Data(base64Encoded: launchText),
-              let launch = try? JSONDecoder().decode(HolderLaunchRequest.self, from: launchData) else {
-            throw HolderStartupError.invalidLaunchPayload
+        let launchFDText = try required("launch-fd")
+        guard let launchFD = Int32(launchFDText) else {
+            throw HolderStartupError.invalidLaunchDescriptorArgument(launchFDText)
         }
+        // Read here, at the invocation boundary, rather than in `run()`: the
+        // rest of the holder is written against a `HolderLaunchRequest` it
+        // already has, and the descriptor is spent the moment it is read.
+        let launch = try readLaunchRequest(fromDescriptor: launchFD)
 
         return HolderArguments(
             sessionID: sessionID,
@@ -700,6 +719,56 @@ struct HolderArguments: Equatable {
             lockFD: lockFD,
             launch: launch,
             owner: HolderOwnerToken(rawValue: values["owner"] ?? ""))
+    }
+
+    /// Drains the launch request from the descriptor the spawner placed it on,
+    /// and closes that descriptor.
+    ///
+    /// Read to end of file rather than to a length word: the spawner writes the
+    /// whole request and then closes its end before this process is even
+    /// created, so EOF is the frame. A short read is therefore not a partial
+    /// message, it is a stream that has not finished arriving, and the loop
+    /// simply continues.
+    ///
+    /// The descriptor is closed as soon as it is spent, and always — including
+    /// on every failure path. It must not still be open at `forkpty`: the job's
+    /// descriptor sweep would close it anyway, but a launch request is the one
+    /// thing in this process that holds the session's secrets, and the window
+    /// in which a fork could copy it is worth not having. Stdio is exempt, so
+    /// that a holder driven by hand with `--launch-fd 0 < request.json` does
+    /// not close its own standard input out from under itself.
+    static func readLaunchRequest(fromDescriptor descriptor: Int32) throws -> HolderLaunchRequest {
+        func done() {
+            if descriptor > 2 { close(descriptor) }
+        }
+
+        var payload = Data()
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        while true {
+            let count = buffer.withUnsafeMutableBytes { raw in
+                read(descriptor, raw.baseAddress, raw.count)
+            }
+            if count > 0 {
+                guard payload.count + count <= maximumLaunchPayloadBytes else {
+                    done()
+                    throw HolderStartupError.unreadableLaunchPayload(
+                        descriptor: descriptor, errno: EFBIG)
+                }
+                payload.append(contentsOf: buffer[0..<count])
+                continue
+            }
+            if count == 0 { break }
+            let saved = errno
+            if saved == EINTR { continue }
+            done()
+            throw HolderStartupError.unreadableLaunchPayload(descriptor: descriptor, errno: saved)
+        }
+        done()
+
+        guard let launch = try? JSONDecoder().decode(HolderLaunchRequest.self, from: payload) else {
+            throw HolderStartupError.invalidLaunchPayload
+        }
+        return launch
     }
 }
 
@@ -731,6 +800,8 @@ enum HolderStartupError: LocalizedError, Equatable {
     case missingArgument(String)
     case invalidSessionID(String)
     case invalidLaunchPayload
+    case invalidLaunchDescriptorArgument(String)
+    case unreadableLaunchPayload(descriptor: Int32, errno: Int32)
     case invalidLockDescriptorArgument(String)
     case invalidLockDescriptor(Int32)
     case socketPathTooLong(path: String, limit: Int)
@@ -746,7 +817,8 @@ enum HolderStartupError: LocalizedError, Equatable {
     var exitCode: Int32 {
         switch self {
         case .unknownArgument, .missingValue, .missingArgument, .invalidSessionID,
-             .invalidLaunchPayload, .invalidLockDescriptorArgument, .invalidLockDescriptor,
+             .invalidLaunchPayload, .invalidLaunchDescriptorArgument, .unreadableLaunchPayload,
+             .invalidLockDescriptorArgument, .invalidLockDescriptor,
              .socketPathTooLong:
             return HolderExitCode.badInvocation
         case .socketDirectoryUnavailable, .cannotBind, .cannotListen, .forkFailed:
@@ -765,7 +837,13 @@ enum HolderStartupError: LocalizedError, Equatable {
         case .invalidSessionID(let text):
             return "--session must be a UUID, got \"\(text)\""
         case .invalidLaunchPayload:
-            return "--launch must be base64-encoded JSON for a HolderLaunchRequest"
+            return "the bytes on --launch-fd must be JSON for a HolderLaunchRequest"
+        case .invalidLaunchDescriptorArgument(let text):
+            return "--launch-fd must be a descriptor number, got \"\(text)\""
+        case .unreadableLaunchPayload(let descriptor, let code):
+            return "could not read the launch request from --launch-fd \(descriptor): "
+                + "\(String(cString: strerror(code))) (errno \(code)). The spawner must write "
+                + "the request to that descriptor and close its own end"
         case .invalidLockDescriptorArgument(let text):
             return "--lock-fd must be a descriptor number, got \"\(text)\""
         case .invalidLockDescriptor(let fd):

--- a/Sources/TBDHolder/main.swift
+++ b/Sources/TBDHolder/main.swift
@@ -6,7 +6,11 @@ import Foundation
 // Invoked as:
 //
 //   TBDHolder --session <uuid> --socket <path> --lock-fd <n> \
-//             --launch <base64-json HolderLaunchRequest> [--owner <token>]
+//             --launch-fd <n> [--owner <token>]
+//
+// The `HolderLaunchRequest` arrives as JSON on `--launch-fd` rather than on
+// the command line, because a `ps` from any process running as the same user
+// reads argv and that request carries the session's whole environment.
 //
 // Argument parsing and exactly one call into `Holder`. Every decision the
 // holder makes lives in `Holder.swift`, so it can be exercised without

--- a/Tests/TBDAppTests/HolderInjectionDeliveryTests.swift
+++ b/Tests/TBDAppTests/HolderInjectionDeliveryTests.swift
@@ -419,19 +419,16 @@ struct HolderInjectionDeliveryTests {
         #expect(Data(buffer[0..<max(0, read)]) == Data("echo hi\r".utf8))
     }
 
-    /// The decision R24 asks for, pinned: a payload that only partly fits is a
-    /// **failure**, so the daemon rewrites the whole thing. A duplicated
-    /// prompt is visible and recoverable; a silently truncated one is not.
-    @Test("a payload that does not fit is reported as partial, never as written")
-    func oversizePayloadReportsPartialRatherThanWritten() throws {
-        let (readEnd, writeEnd) = try makeSocketPair()
-        defer { Darwin.close(readEnd); Darwin.close(writeEnd) }
-        // Nobody ever reads `readEnd`, so the socket buffer fills and stays
-        // full — the same shape as a child that has stopped reading its tty.
-        _ = fcntl(writeEnd, F_SETFL, fcntl(writeEnd, F_GETFL, 0) | O_NONBLOCK)
-        let payload = Data(repeating: 0x61, count: 8 * 1024 * 1024)
+    /// The remainder is now the caller's to keep, and the caller has to know
+    /// how much of it there is: `written` is the cut, and the outbox slices
+    /// the payload at exactly that offset.
+    @Test("a payload larger than the pty's input queue reports what the kernel took")
+    func oversizePayloadReportsWhatTheKernelTook() throws {
+        let pty = try RawPTYPair()
+        defer { pty.close() }
+        let payload = Data(repeating: 0x61, count: 4 * 1024)
 
-        let outcome = PTYWrite.all(payload, to: writeEnd, budgetMilliseconds: 5)
+        let outcome = PTYWrite.all(payload, to: pty.ptyFD)
 
         guard case .partial(let written) = outcome else {
             // Recorded as an Error, not a String: only `Issue.record(some
@@ -440,8 +437,22 @@ struct HolderInjectionDeliveryTests {
             Issue.record(UnexpectedWriteOutcome(expected: "partial", actual: outcome))
             return
         }
-        #expect(written > 0)
+        #expect(written > 0, "a raw-mode pty takes a prefix before it refuses")
         #expect(written < payload.count)
+        // The cut is where the kernel put it, and the bytes on the far side
+        // are exactly the prefix — the property the outbox's slicing rests on.
+        #expect(pty.drainSessionFully() == payload.prefix(written))
+    }
+
+    /// A queue that is already full takes nothing, and that is NOT a failure:
+    /// the transport is alive and the whole payload becomes the outbox's.
+    @Test("a full pty queue is a refusal of everything, not a failure")
+    func fullQueueRefusesEverything() throws {
+        let pty = try RawPTYPair()
+        defer { pty.close() }
+        pty.fillPTY()
+
+        #expect(PTYWrite.all(Data("x".utf8), to: pty.ptyFD) == .partial(written: 0))
     }
 
     /// The unwritable descriptor is a **live, read-only** fd this test owns,
@@ -454,18 +465,19 @@ struct HolderInjectionDeliveryTests {
     /// descriptor and read back `.complete` — a flake and a cross-test
     /// corruption source in one. An fd held open for the duration cannot be
     /// reissued, and `write(2)` against `O_RDONLY` is `EBADF` just the same.
-    @Test("an unwritable descriptor is a failure, and an absent one writes nothing")
+    @Test("an unwritable descriptor is a failure, and an absent one is EBADF")
     func deadDescriptorsAreReported() throws {
         let readOnly = Darwin.open("/dev/null", O_RDONLY)
         try #require(readOnly >= 0)
         defer { Darwin.close(readOnly) }
 
         let outcome = PTYWrite.all(Data("x".utf8), to: readOnly)
-        guard case .failed = outcome else {
+        guard case .failed(_, let written) = outcome else {
             Issue.record(UnexpectedWriteOutcome(expected: "failed", actual: outcome))
             return
         }
-        #expect(PTYWrite.all(Data("x".utf8), to: -1) == .nothingWritten)
+        #expect(written == 0, "a descriptor that refuses outright committed no prefix")
+        #expect(PTYWrite.all(Data("x".utf8), to: -1) == .failed(errno: EBADF, written: 0))
         #expect(PTYWrite.all(Data(), to: -1) == .complete, "an empty write asks nothing of the fd")
     }
 }

--- a/Tests/TBDAppTests/HolderWriteOutboxTests.swift
+++ b/Tests/TBDAppTests/HolderWriteOutboxTests.swift
@@ -151,8 +151,15 @@ struct HolderWriteOutboxTests {
         #expect(queue.pendingByteCountForTesting > 0)
 
         // The last slave closes: every further write to the master is EIO,
-        // which is the child having exited.
+        // which is the child having exited. Required rather than assumed —
+        // "dead" and "merely full" are one answer from the panel's side, and
+        // only the first is what the three assertions below are about.
         panel.pty.closeSessionEnd()
+        try #require(panel.pty.ptyRejectsWrites(), """
+            the fixture must actually have produced EIO, or this row is about a \
+            pty that is only full: a session end this process closed stays open \
+            in any child that inherited the descriptor
+            """)
         queue.drain()
 
         #expect(queue.pendingByteCountForTesting == 0)

--- a/Tests/TBDAppTests/HolderWriteOutboxTests.swift
+++ b/Tests/TBDAppTests/HolderWriteOutboxTests.swift
@@ -1,0 +1,258 @@
+import AppKit
+import Darwin
+import Foundation
+import SwiftTerm
+import TBDShared
+import Testing
+
+@testable import TBDApp
+import TestSupport
+
+/// The panel's write step end to end, against a **real pty** whose slave is in
+/// raw mode and unread — the fixture that makes the 1,022-byte refusal
+/// deterministic.
+///
+/// A socket pair, which the sibling `HolderInjectionDelivery` suite uses, has
+/// no `TTYHOG`, no line discipline and no `ptcwrite`, so it can never produce
+/// the short write this whole subsystem exists for. Everything here needs the
+/// real refusal.
+@Suite("HolderWriteOutbox")
+struct HolderWriteOutboxTests {
+
+    // MARK: - The payload arrives whole
+
+    @MainActor
+    @Test("a paste larger than the pty's queue is delivered whole, markers and all")
+    func largePasteIsDeliveredWhole() async throws {
+        let panel = try await makeHolderPanel()
+        defer { panel.tearDown() }
+        let start = Data(EscapeSequences.bracketedPasteStart)
+        let body = Data(repeating: 0x61, count: 8 * 1024)
+        let end = Data(EscapeSequences.bracketedPasteEnd)
+
+        // The production path: four chunks through `Coordinator.send`, in one
+        // main-actor turn, exactly as SwiftTerm's paste emits the first three.
+        panel.coordinator.send(source: panel.view, data: [UInt8](start)[...])
+        panel.coordinator.send(source: panel.view, data: [UInt8](body)[...])
+        panel.coordinator.send(source: panel.view, data: [UInt8](end)[...])
+        panel.coordinator.send(source: panel.view, data: [UInt8]("Z".utf8)[...])
+
+        var expected = Data()
+        expected.append(start)
+        expected.append(body)
+        expected.append(end)
+        expected.append(Data("Z".utf8))
+        let delivered = try await panel.pty.drainUntil(byteCount: expected.count)
+
+        #expect(delivered == expected, """
+            every byte exactly once and in order: a truncated payload, a lost \
+            end marker or a keystroke ahead of the marker all fail here
+            """)
+    }
+
+    @MainActor
+    @Test("a keystroke typed during a stall is held, not dropped, and lands in order")
+    func keystrokeDuringAStallIsHeld() async throws {
+        let panel = try await makeHolderPanel()
+        defer { panel.tearDown() }
+        // Learn this kernel's ceiling rather than hard-coding 1,022, then put
+        // the queue back into the full state: the very first byte of what is
+        // typed next is refused, which is a stall rather than a partial.
+        panel.pty.fillPTY()
+        let ceiling = panel.pty.drainAll()
+        #expect(ceiling > 0, "the fixture must have actually filled the queue")
+        let refilled = panel.pty.fillPTY()
+
+        panel.coordinator.send(source: panel.view, data: [UInt8]("first".utf8)[...])
+        panel.coordinator.send(source: panel.view, data: [UInt8]("second".utf8)[...])
+
+        #expect(panel.coordinator.outgoingQueueForTesting.pendingByteCountForTesting == 11,
+                "both keystrokes are held; a dropped one is the regression this replaces")
+
+        let delivered = try await panel.pty.drainUntil(byteCount: refilled + 11)
+
+        #expect(delivered.suffix(11) == Data("firstsecond".utf8),
+                "held keystrokes are written in the order they were typed")
+    }
+
+    // MARK: - The interim ack, all four rows
+
+    @MainActor
+    @Test("a partial injection is acked accepted, not failed")
+    func partialInjectionIsAckedAccepted() async throws {
+        let panel = try await makeHolderPanel()
+        defer { panel.tearDown() }
+        let handler = try #require(
+            panel.state.terminalInjections.registeredHandlerForTesting(
+                terminalID: panel.terminalID))
+
+        // 4 KiB into an empty raw-mode queue: a kilobyte goes, the rest is
+        // refused and becomes the panel's to finish.
+        let acked = await handler(panel.terminalID, Data(repeating: 0x62, count: 4_096))
+
+        #expect(panel.coordinator.outgoingQueueForTesting.pendingByteCountForTesting > 0,
+                "the fixture must actually produce a remainder, or this row is vacuous")
+        #expect(acked == true, """
+            `true` means accepted by a writer that will complete — the daemon \
+            must NOT fall back and write the payload a second time on top of a \
+            prefix this panel is still finishing
+            """)
+    }
+
+    @MainActor
+    @Test("an injection into a queue that takes nothing at all is still acked accepted")
+    func fullQueueInjectionIsAckedAccepted() async throws {
+        let panel = try await makeHolderPanel()
+        defer { panel.tearDown() }
+        panel.pty.fillPTY()
+        let handler = try #require(
+            panel.state.terminalInjections.registeredHandlerForTesting(
+                terminalID: panel.terminalID))
+
+        #expect(await handler(panel.terminalID, Data("hi\r".utf8)) == true,
+                "zero bytes taken by a live pty is a refusal to hold, not a failure")
+    }
+
+    /// The matrix's negative control, and it is honest about being one: this
+    /// row passed before the outbox too, because an unwritable descriptor was
+    /// already the one thing reported unwritten. It is here so the three rows
+    /// above cannot be satisfied by a seam that simply answers `true` always.
+    @MainActor
+    @Test("an injection into a dead descriptor is acked unwritten")
+    func injectionIntoADeadDescriptorIsAckedUnwritten() async throws {
+        // A live, read-only descriptor, never a number this test just closed:
+        // suites run in parallel in one process and a closed number can be
+        // reissued to a stranger's file before the write below runs. It is not
+        // closed here either — the panel's reader owns it and closes it on the
+        // way out, exactly as it owns the vended pty in the other rows.
+        let readOnly = Darwin.open("/dev/null", O_RDONLY)
+        try #require(readOnly >= 0)
+        let panel = try await makeHolderPanel(vending: readOnly)
+        defer { panel.tearDown() }
+        let handler = try #require(
+            panel.state.terminalInjections.registeredHandlerForTesting(
+                terminalID: panel.terminalID))
+
+        #expect(await handler(panel.terminalID, Data("hi\r".utf8)) == false,
+                "nothing will land through this descriptor, and the daemon must fall back")
+    }
+
+    @MainActor
+    @Test("a prefix followed by EIO is acked unwritten and drops what was held")
+    func prefixThenEIOIsAckedUnwritten() async throws {
+        let panel = try await makeHolderPanel()
+        defer { panel.tearDown() }
+        let queue = panel.coordinator.outgoingQueueForTesting
+        let handler = try #require(
+            panel.state.terminalInjections.registeredHandlerForTesting(
+                terminalID: panel.terminalID))
+        // A prefix goes, a remainder is held.
+        #expect(await handler(panel.terminalID, Data(repeating: 0x62, count: 4_096)) == true)
+        #expect(queue.pendingByteCountForTesting > 0)
+
+        // The last slave closes: every further write to the master is EIO,
+        // which is the child having exited.
+        panel.pty.closeSessionEnd()
+        queue.drain()
+
+        #expect(queue.pendingByteCountForTesting == 0)
+        #expect(queue.outboxDropLogsForTesting == 1)
+        #expect(await handler(panel.terminalID, Data("hi\r".utf8)) == false, """
+            once the child is gone, the honest answer to "was it written" is no \
+            — even though a prefix did reach the pty
+            """)
+    }
+
+    // MARK: - The fixture
+
+    /// The panel wired the way production wires one, attached to a real pty
+    /// master. `startHolderClient` is the production attach path, so the drain
+    /// notifier under test is the one it builds — nothing here injects a fake.
+    @MainActor
+    private func makeHolderPanel(vending: Int32? = nil) async throws -> HolderPanel {
+        let pty = try RawPTYPair()
+        let vended = vending ?? Darwin.dup(pty.ptyFD)
+        try #require(vended >= 0)
+        // The real vend is a `dup` of a pty the daemon opened `O_NONBLOCK`, and
+        // the flag rides the dup; a blocking descriptor here would park the
+        // main actor rather than refuse.
+        _ = fcntl(vended, F_SETFL, fcntl(vended, F_GETFL, 0) | O_NONBLOCK)
+
+        let worktreeID = UUID()
+        let terminalID = UUID()
+        let state = AppState()
+        // A holder row carries empty tmux coordinates by construction.
+        state.terminals[worktreeID] = [Terminal(
+            id: terminalID,
+            worktreeID: worktreeID,
+            tmuxWindowID: "",
+            tmuxPaneID: "",
+            label: "Shell",
+            kind: .shell,
+            transport: .holder
+        )]
+
+        // Isolated defaults: `AppearanceSettings` must never read or write the
+        // developer's real TBDApp.plist.
+        let suiteName = "TBDAppTests.HolderWriteOutbox.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        let view = TBDTerminalView(
+            frame: CGRect(x: 0, y: 0, width: 600, height: 300),
+            font: TBDTerminalView.defaultMonospaceFont,
+            appearance: AppearanceSettings(defaults: defaults))
+
+        let coordinator = TerminalPanelRepresentable.Coordinator()
+        coordinator.appState = state
+        coordinator.panelID = terminalID
+        coordinator.holderAttachClient = StubAttach(
+            attachment: HolderAttachment(
+                ptyFD: vended, generation: 7, snapshotPreamble: Data()))
+
+        await coordinator.startHolderClient(terminalView: view)
+
+        return HolderPanel(
+            state: state, coordinator: coordinator, view: view, terminalID: terminalID,
+            pty: pty, defaults: defaults, suiteName: suiteName)
+    }
+
+    /// Stands in for the daemon's two attach RPCs, handing over a descriptor
+    /// the test can read. A copy of `HolderInjectionDeliveryTests`'s stub
+    /// rather than a shared one: it is nine lines, and making it internal to
+    /// share it couples two suites for nothing.
+    private struct StubAttach: HolderAttaching {
+        let attachment: HolderAttachment
+
+        func attach(
+            worktreeID: UUID, paneID: String, terminalID: UUID
+        ) async throws -> HolderAttachment { attachment }
+
+        func ready(
+            worktreeID: UUID, paneID: String, terminalID: UUID, generation: UInt64
+        ) async throws {}
+
+        func detach(
+            worktreeID: UUID, paneID: String, terminalID: UUID, generation: UInt64,
+            snapshotPreamble: Data
+        ) async throws {}
+    }
+
+    @MainActor
+    private struct HolderPanel {
+        let state: AppState
+        let coordinator: TerminalPanelRepresentable.Coordinator
+        let view: TBDTerminalView
+        let terminalID: UUID
+        /// The session's side. The reader closes the descriptor it was handed;
+        /// this fixture owns the rest, and `close()` is idempotent over a
+        /// session end a test closed early.
+        let pty: RawPTYPair
+        let defaults: UserDefaults
+        let suiteName: String
+
+        func tearDown() {
+            coordinator.cleanup()
+            pty.close()
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+    }
+}

--- a/Tests/TBDAppTests/HolderWriteOutboxTests.swift
+++ b/Tests/TBDAppTests/HolderWriteOutboxTests.swift
@@ -163,6 +163,40 @@ struct HolderWriteOutboxTests {
             """)
     }
 
+    // MARK: - Teardown with a remainder outstanding
+
+    // What this test cannot reach: that a readiness callback is *impossible*
+    // after cancellation. That is a property of one serial queue, not of this
+    // code — a test could only observe that it did not happen on this run,
+    // which is true of a racy implementation too. Driving `drain()` by hand
+    // after the teardown is the closest observable: it proves the queue is
+    // inert, which is the half that is ours.
+    @MainActor
+    @Test("a teardown with a remainder outstanding drops it, logs the count, and cannot fire after")
+    func teardownWithARemainderDropsAndLogs() async throws {
+        let panel = try await makeHolderPanel()
+        // `tearDown()` is still deferred: `cleanup()` and `close()` are both
+        // idempotent, and the deferred call is what removes the isolated
+        // defaults suite whatever this test does to the panel.
+        defer { panel.tearDown() }
+        let queue = panel.coordinator.outgoingQueueForTesting
+        panel.pty.fillPTY()
+        panel.coordinator.send(
+            source: panel.view, data: [UInt8](Data(repeating: 0x61, count: 4_096))[...])
+        #expect(queue.pendingByteCountForTesting > 0,
+                "the fixture must actually produce a remainder, or this test is vacuous")
+
+        panel.coordinator.cleanup()
+
+        #expect(queue.pendingByteCountForTesting == 0)
+        #expect(queue.outboxDropLogsForTesting == 1,
+                "a person who closes a tab mid-stall loses the tail of their paste — logged, never silent")
+        // The descriptor is closed; a drain that ran now would write to a
+        // reissued fd number. Drive one deliberately and require it to be inert.
+        queue.drain()
+        #expect(queue.pendingByteCountForTesting == 0)
+    }
+
     // MARK: - The fixture
 
     /// The panel wired the way production wires one, attached to a real pty

--- a/Tests/TBDAppTests/OutgoingDrainNotifierTests.swift
+++ b/Tests/TBDAppTests/OutgoingDrainNotifierTests.swift
@@ -1,0 +1,196 @@
+import Darwin
+import Dispatch
+import Foundation
+import Testing
+
+@testable import TBDApp
+import TestSupport
+
+/// A pipe whose write end is empty, and therefore always writable. It stands in
+/// for the panel's pty descriptor for the one question these tests ask — does
+/// this adapter's `arm` / `disarm` / `cancel` reach the source's counted
+/// suspend/resume pair correctly — without needing a child process. Task 1 of
+/// the plan already measured that write-readiness fires on a `dup` of a pty
+/// master; that is the platform's behaviour, and it is not re-litigated here.
+@MainActor
+private final class WritablePipe {
+    let readEnd: Int32
+    let writeEnd: Int32
+
+    init() {
+        var fds: [Int32] = [-1, -1]
+        let rc = fds.withUnsafeMutableBufferPointer { pipe($0.baseAddress!) }
+        precondition(rc == 0, "pipe() failed: \(errno)")
+        readEnd = fds[0]
+        writeEnd = fds[1]
+    }
+
+    /// Close only after the source over `writeEnd` has been cancelled *and* the
+    /// cancellation has had a turn of the main queue to land. Closing a
+    /// descriptor a live source still watches is a use-after-close the moment
+    /// the kernel reissues the number.
+    func close() {
+        Darwin.close(readEnd)
+        Darwin.close(writeEnd)
+    }
+}
+
+/// Mutable state a `@MainActor` event handler can reach without capturing the
+/// notifier that owns it strongly (the source retains the handler, so a strong
+/// capture would be a cycle).
+@MainActor
+private final class DrainRecorder {
+    var notifier: WriteSourceDrainNotifier?
+    var fires = 0
+    var firesAfterDisarm = 0
+    var firesAfterCancel = 0
+}
+
+/// `.serialized` because each test arms a source on the main queue and then
+/// waits on the main actor for it to fire; running two of them concurrently
+/// would have each one's wait competing with the other's handler for the same
+/// executor. `.clockDriven` is the hang bound: a notifier that never fires
+/// would otherwise sit in the poll loop, and the loop's own deadline is the
+/// first line of defence rather than the only one.
+@MainActor
+@Suite("WriteSourceDrainNotifier", .clockDriven, .serialized)
+struct OutgoingDrainNotifierTests {
+    /// Poll the main actor until `condition` holds or the deadline passes.
+    /// Sleeping yields the main actor, which is what lets the source's handler
+    /// — dispatched to `.main` — run at all.
+    private func waitUntil(
+        _ condition: () -> Bool,
+        within seconds: Double = 5
+    ) async {
+        let deadline = ContinuousClock.now.advanced(by: .seconds(seconds))
+        while !condition(), ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+    }
+
+    /// Let anything already queued on the main queue run, so "it did not fire
+    /// again" is a reading rather than an assumption.
+    private func settle() async {
+        try? await Task.sleep(for: .milliseconds(100))
+    }
+
+    @Test("arm() reports readiness, and disarm() stops it")
+    func armThenDisarm() async {
+        let pipe = WritablePipe()
+        let recorder = DrainRecorder()
+        recorder.notifier = WriteSourceDrainNotifier(
+            fileDescriptor: pipe.writeEnd
+        ) { [weak recorder] in
+            guard let recorder else { return }
+            recorder.fires += 1
+            if recorder.fires == 1 {
+                recorder.notifier?.disarm()
+            } else {
+                // A disarm that did not reach `suspend()` leaves a level-
+                // triggered source firing tens of thousands of times a second
+                // (Task 1: 44,486 / 182,060 / 47,845). Cancelling on the
+                // second fire stops that at once so the run reddens quickly
+                // instead of spending the suite's time limit with the main
+                // queue pinned. Measured: with `suspend()` removed the run
+                // dies on SIGTRAP rather than on this expectation, because a
+                // disarm that did not suspend makes the very next cancel an
+                // over-resume. Red either way; the signal is not the message.
+                recorder.firesAfterDisarm += 1
+                recorder.notifier?.cancel()
+            }
+        }
+
+        // Nothing before the arm: the source is created suspended.
+        await settle()
+        #expect(recorder.fires == 0)
+
+        recorder.notifier?.arm()
+        await waitUntil { recorder.fires > 0 }
+        #expect(recorder.fires == 1, "an armed source over a writable pipe must report readiness")
+
+        await settle()
+        #expect(
+            recorder.firesAfterDisarm == 0,
+            "disarm() must suspend the source; a level-triggered source left armed spins")
+
+        recorder.notifier?.cancel()
+        await settle()
+        pipe.close()
+    }
+
+    @Test("cancel() ends delivery for good, including from inside the handler")
+    func cancelStopsDelivery() async {
+        let pipe = WritablePipe()
+        let recorder = DrainRecorder()
+        recorder.notifier = WriteSourceDrainNotifier(
+            fileDescriptor: pipe.writeEnd
+        ) { [weak recorder] in
+            guard let recorder else { return }
+            recorder.fires += 1
+            if recorder.fires == 1 {
+                recorder.notifier?.cancel()
+            } else {
+                recorder.firesAfterCancel += 1
+            }
+        }
+
+        recorder.notifier?.arm()
+        await waitUntil { recorder.fires > 0 }
+        #expect(recorder.fires == 1)
+
+        await settle()
+        #expect(
+            recorder.firesAfterCancel == 0,
+            "a cancelled notifier must never call back again")
+
+        // Post-cancel calls are no-ops rather than an unbalanced suspend count.
+        recorder.notifier?.arm()
+        recorder.notifier?.disarm()
+        await settle()
+        #expect(recorder.fires == 1)
+
+        pipe.close()
+    }
+
+    /// The suspend count itself is not observable, and every way of getting it
+    /// wrong takes the whole test runner down with SIGTRAP 133 rather than
+    /// failing an assertion. So this test discriminates by *surviving*: without
+    /// the `isArmed` guards, the doubled `arm()` is an over-resume, the doubled
+    /// `disarm()` is two suspends against one resume, and the `cancel()` that
+    /// follows releases a source with a non-zero count — all three measured
+    /// fatal in Task 1. Its assertion is a formality; the signal is that the
+    /// process is still alive to run it.
+    @Test("arm(), disarm() and cancel() are idempotent, and cancel() rebalances")
+    func idempotentAndBalanced() async {
+        let pipe = WritablePipe()
+        let recorder = DrainRecorder()
+        recorder.notifier = WriteSourceDrainNotifier(
+            fileDescriptor: pipe.writeEnd
+        ) { [weak recorder] in
+            recorder?.fires += 1
+            recorder?.notifier?.disarm()
+        }
+
+        recorder.notifier?.arm()
+        recorder.notifier?.arm()
+        await waitUntil { recorder.fires > 0 }
+        recorder.notifier?.disarm()
+        recorder.notifier?.disarm()
+        // The ordinary teardown state: suspended. Releasing here without the
+        // rebalancing resume is the trap.
+        recorder.notifier?.cancel()
+        recorder.notifier?.cancel()
+
+        await settle()
+        #expect(recorder.fires >= 1)
+
+        // And the other teardown state: cancelled while armed, which owes no
+        // resume. A `cancel()` that resumed unconditionally would over-resume.
+        let second = WriteSourceDrainNotifier(fileDescriptor: pipe.writeEnd) {}
+        second.arm()
+        second.cancel()
+        await settle()
+
+        pipe.close()
+    }
+}

--- a/Tests/TBDAppTests/OutgoingInputQueueTests.swift
+++ b/Tests/TBDAppTests/OutgoingInputQueueTests.swift
@@ -34,6 +34,12 @@ struct OutgoingInputQueueTests {
     /// `write` was actually invoked (not the order it was enqueued — that
     /// distinction is exactly what these tests are checking), and stands in
     /// for the transport's own verdict via `result`.
+    ///
+    /// This suite's transport is all-or-nothing on purpose: it never reports
+    /// `.refused`, so the outbox stays empty throughout and every assertion
+    /// below is about the paste hold alone. The short-write behaviour has its
+    /// own suite (`OutgoingInputQueue outbox`), and keeping the two apart is
+    /// what makes a failure here mean the hold broke rather than the queue.
     @MainActor
     private final class WriteRecorder {
         private(set) var writes: [Data] = []
@@ -42,9 +48,9 @@ struct OutgoingInputQueueTests {
         /// `localProcess`, so the bytes reach nothing.
         var result = true
 
-        func write(_ data: Data) -> Bool {
+        func write(_ data: Data) -> OutgoingInputQueue.WriteAttempt {
             writes.append(data)
-            return result
+            return result ? .accepted : .unwritable(written: 0)
         }
     }
 

--- a/Tests/TBDAppTests/OutgoingOutboxTests.swift
+++ b/Tests/TBDAppTests/OutgoingOutboxTests.swift
@@ -1,0 +1,410 @@
+import Clocks
+import Foundation
+import SwiftTerm
+import Testing
+
+@testable import TBDApp
+import TestSupport
+
+/// Tier 1. The transport is a fake with a byte capacity, which models a full
+/// pty input queue exactly: it takes what fits, refuses the rest, and only
+/// takes more when the test says the child drained. No pty, no timing, no
+/// scheduling — every assertion is observable in the turn it happens in.
+///
+/// `.clockDriven` is at suite level because two tests below `await` a
+/// continuation a broken implementation would never resume, and one drives the
+/// backpressure timer on a `TestClock`; each needs its own hang bound.
+///
+// Two properties here are not testable and should not be faked:
+//
+// 1. That a keystroke acquires no scheduling hop. The queue is synchronous
+//    and `@MainActor`, so any test of it would assert on the absence of a
+//    suspension the compiler already forbids at these call sites.
+// 2. That the outbox has no upper bound. "It holds an arbitrarily large
+//    paste" is untestable in the useful direction — a test can hold 100 MB
+//    and prove nothing about 101 MB — and the memory cost of trying is
+//    itself a shared-box hazard.
+@MainActor
+@Suite("OutgoingInputQueue outbox", .clockDriven, .serialized)
+struct OutgoingOutboxTests {
+
+    /// A transport with a bounded input queue. `capacity` is what it will take
+    /// before refusing; `drain(_:)` is the child reading.
+    @MainActor
+    final class FakeTransport {
+        private(set) var accepted = Data()
+        private(set) var attempts = 0
+        var capacity: Int
+        var isDead = false
+
+        init(capacity: Int) { self.capacity = capacity }
+
+        func attempt(_ data: Data) -> OutgoingInputQueue.WriteAttempt {
+            attempts += 1
+            if isDead { return .unwritable(written: 0) }
+            let room = min(capacity, data.count)
+            accepted.append(data.prefix(room))
+            capacity -= room
+            return room == data.count ? .accepted : .refused(written: room)
+        }
+
+        /// The child reading: makes room, nothing more.
+        func drain(_ bytes: Int) { capacity += bytes }
+    }
+
+    /// Counts *transitions*, not calls, so a queue that armed or disarmed twice
+    /// in a row is invisible in `arms`/`disarms` — which is why `isArmed` is
+    /// asserted alongside them. The real notifier behind these edges is a
+    /// counted `DispatchSource` suspend/resume pair that traps the process when
+    /// unbalanced, so both halves matter.
+    @MainActor
+    final class NotifierSpy {
+        private(set) var arms = 0
+        private(set) var disarms = 0
+        private(set) var isArmed = false
+        func arm() { if !isArmed { arms += 1 }; isArmed = true }
+        func disarm() { if isArmed { disarms += 1 }; isArmed = false }
+    }
+
+    /// Records what the panel-level backpressure indicator was told, including
+    /// the `nil` that clears it.
+    @MainActor
+    final class BackpressureSpy {
+        private(set) var published: [Int?] = []
+        func record(_ pendingBytes: Int?) { published.append(pendingBytes) }
+    }
+
+    private func makeQueue(
+        capacity: Int, clock: TestClock<Duration> = TestClock(),
+        notifier: NotifierSpy? = nil, backpressure: BackpressureSpy? = nil
+    ) -> (OutgoingInputQueue, FakeTransport, NotifierSpy) {
+        let transport = FakeTransport(capacity: capacity)
+        let spy = notifier ?? NotifierSpy()
+        let queue = OutgoingInputQueue(
+            clock: clock,
+            armDrain: { spy.arm() },
+            disarmDrain: { spy.disarm() },
+            onBackpressureChange: { backpressure?.record($0) },
+            attempt: { transport.attempt($0) })
+        return (queue, transport, spy)
+    }
+
+    /// A bounded wait that never saw its effect, on the primary failure line.
+    /// Copied rather than shared with `OutgoingInputQueueTests`: it is fifteen
+    /// lines, and a test-support type for two suites costs more than the
+    /// duplication.
+    private struct HeldInjectionCountTimeout: Error, CustomStringConvertible {
+        let expected: Int
+        let observed: Int
+        let timeout: Duration
+
+        var description: String {
+            """
+            OutgoingInputQueue: expected \(expected) held injection(s) — observed \(observed) \
+            after polling up to \(timeout) of real time
+            """
+        }
+    }
+
+    /// Bounded real-time poll for `queue.pendingInjectionCountForTesting`.
+    /// Needed because creating `Task { await queue.enqueueInjection(_:) }` only
+    /// SCHEDULES that call — it does not run it. Nothing on the user side needs
+    /// this: `enqueueUserBytes`, `beginUserPaste` and `endUserPaste` are
+    /// synchronous.
+    private func waitForHeldInjections(
+        _ expected: Int, on queue: OutgoingInputQueue,
+        timeout: Duration = .seconds(8),
+        sourceLocation: SourceLocation = #_sourceLocation
+    ) async {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while queue.pendingInjectionCountForTesting != expected {
+            if ContinuousClock.now > deadline {
+                Issue.record(
+                    HeldInjectionCountTimeout(
+                        expected: expected,
+                        observed: queue.pendingInjectionCountForTesting,
+                        timeout: timeout),
+                    sourceLocation: sourceLocation)
+                return
+            }
+            // Bounded scheduling-handshake poll, not the behaviour under test.
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+    }
+
+    // MARK: - The remainder is kept
+
+    @Test("a refused remainder is kept, not dropped")
+    func refusedRemainderIsKept() {
+        let (queue, transport, notifier) = makeQueue(capacity: 1_022)
+
+        queue.enqueueUserBytes(Data(repeating: 0x61, count: 4_096))
+
+        #expect(transport.accepted.count == 1_022)
+        #expect(queue.pendingByteCountForTesting == 4_096 - 1_022)
+        #expect(notifier.isArmed, "a non-empty outbox must arm the drain")
+    }
+
+    @Test("everything enqueued behind a remainder is held, in order, and never written early")
+    func laterChunksAreHeldBehindTheRemainder() {
+        let (queue, transport, _) = makeQueue(capacity: 1_022)
+        let payload = Data(repeating: 0x61, count: 4_096)
+
+        queue.enqueueUserBytes(payload)
+        queue.enqueueUserBytes(Data("Z".utf8))
+
+        #expect(transport.accepted == payload.prefix(1_022),
+                "a keystroke behind a remainder must not overtake it")
+        // Two chunks, not one: the FIFO appends whole chunks rather than
+        // coalescing them into a buffer it would have to copy on every append.
+        #expect(queue.outboxChunkCountForTesting == 2)
+
+        // The half that actually discriminates. Above, the transport had no
+        // room either, so a queue with no hold at all would have had the
+        // keystroke refused and appended anyway and passed. Here the child has
+        // read: the transport WOULD take this keystroke this instant, and it
+        // must still not get it, because 3,074 bytes of the paste are ahead of
+        // it and `drain()` is the only thing allowed to move them.
+        transport.drain(1_000_000)
+        queue.enqueueUserBytes(Data("Y".utf8))
+
+        #expect(transport.accepted == payload.prefix(1_022),
+                "a keystroke must not overtake a remainder just because there is room for it")
+        #expect(queue.pendingByteCountForTesting == (4_096 - 1_022) + 2)
+        #expect(queue.outboxChunkCountForTesting == 3)
+    }
+
+    @Test("draining delivers every byte exactly once, in arrival order")
+    func drainDeliversEverythingInOrder() {
+        let (queue, transport, notifier) = makeQueue(capacity: 1_022)
+        let payload = Data(repeating: 0x61, count: 4_096)
+        let keystroke = Data("Z".utf8)
+
+        queue.enqueueUserBytes(payload)
+        queue.enqueueUserBytes(keystroke)
+        // The child reads in three bites; the notifier fires once per bite.
+        for _ in 0..<3 {
+            transport.drain(2_000)
+            queue.drain()
+        }
+
+        #expect(transport.accepted == payload + keystroke)
+        #expect(queue.pendingByteCountForTesting == 0)
+        #expect(!notifier.isArmed, "an empty outbox must disarm")
+        #expect(notifier.disarms == 1)
+    }
+
+    /// The measured hazard, pinned: an armed notifier over an empty outbox is
+    /// 44k–182k main-queue callbacks per second, so a path that empties the
+    /// outbox without disarming is the main queue at 100% until the panel
+    /// closes. Every path that can empty the outbox is walked here, because the
+    /// one that forgets to disarm is the one that ships.
+    @Test("the notifier is never left armed over an empty outbox, by any path")
+    func notifierIsNeverArmedOverAnEmptyOutbox() {
+        // Path 1: nothing was ever refused.
+        let (quiet, _, quietNotifier) = makeQueue(capacity: 1_000_000)
+        quiet.enqueueUserBytes(Data("Z".utf8))
+        #expect(quietNotifier.arms == 0, "a write that fits must not arm anything")
+
+        // Path 2: drained to empty.
+        let (drained, transport, drainedNotifier) = makeQueue(capacity: 1_022)
+        drained.enqueueUserBytes(Data(repeating: 0x61, count: 4_096))
+        #expect(drainedNotifier.isArmed, "positive control: the episode really started")
+        transport.drain(1_000_000)
+        drained.drain()
+        #expect(!drainedNotifier.isArmed)
+
+        // Path 3: the transport died with bytes outstanding.
+        let (died, deadTransport, deadNotifier) = makeQueue(capacity: 1_022)
+        died.enqueueUserBytes(Data(repeating: 0x61, count: 4_096))
+        #expect(deadNotifier.isArmed, "positive control: the episode really started")
+        deadTransport.isDead = true
+        died.drain()
+        #expect(!deadNotifier.isArmed)
+
+        // Path 4: teardown with bytes outstanding.
+        let (torn, _, tornNotifier) = makeQueue(capacity: 1_022)
+        torn.enqueueUserBytes(Data(repeating: 0x61, count: 4_096))
+        #expect(tornNotifier.isArmed, "positive control: the episode really started")
+        torn.shutdown()
+        #expect(!tornNotifier.isArmed)
+    }
+
+    /// The other half of the same invariant: the edges are idempotent, so a
+    /// second disarm cannot unbalance the counted suspend/resume pair behind
+    /// them. `NotifierSpy` counts transitions, not calls, so a queue that
+    /// disarmed twice would show `disarms == 1` here and a real notifier would
+    /// have trapped — which is why the spy also asserts on its own state.
+    @Test("the arm and disarm edges fire once per episode")
+    func armAndDisarmAreEdges() {
+        let (queue, transport, notifier) = makeQueue(capacity: 1_022)
+
+        queue.enqueueUserBytes(Data(repeating: 0x61, count: 4_096))
+        queue.enqueueUserBytes(Data("Z".utf8))       // still refusing; no second arm
+        transport.drain(1_000_000)
+        queue.drain()
+        queue.drain()                                 // a spurious readiness fire
+        queue.shutdown()                              // and a teardown after that
+
+        #expect(notifier.arms == 1)
+        #expect(notifier.disarms == 1)
+        #expect(!notifier.isArmed)
+    }
+
+    // MARK: - The paste shape
+
+    @Test("a paste's end marker is delivered after its payload, and a later keystroke after that")
+    func pasteMarkersAndKeystrokeKeepTheirOrder() {
+        let (queue, transport, _) = makeQueue(capacity: 1_022)
+        let start = Data(EscapeSequences.bracketedPasteStart)
+        let body = Data(repeating: 0x61, count: 4_096)
+        let end = Data(EscapeSequences.bracketedPasteEnd)
+
+        queue.beginUserPaste()
+        queue.enqueueUserBytes(start)
+        queue.enqueueUserBytes(body)
+        queue.enqueueUserBytes(end)
+        queue.endUserPaste()
+        queue.enqueueUserBytes(Data("Z".utf8))
+        transport.drain(1_000_000)
+        queue.drain()
+
+        // Built up statement by statement: a four-term `Data` concatenation
+        // inside `#expect` blows the type-checker's budget.
+        var expected = start
+        expected.append(body)
+        expected.append(end)
+        expected.append(Data("Z".utf8))
+        #expect(transport.accepted == expected, """
+            the end marker must reach the child, and after the payload — a lost \
+            or reordered ESC[201~ leaves the child in bracketed-paste mode
+            """)
+    }
+
+    /// The refinement this work carries into the single-typist lease: with an
+    /// outbox, "the paste is closed" and "the end marker has reached the
+    /// child" are different moments — and the FIFO is what keeps an injection
+    /// released at the first from landing before the second.
+    @Test("an injection released by endUserPaste lands after an end marker still in the outbox")
+    func releasedInjectionLandsAfterTheStillQueuedEndMarker() async throws {
+        let (queue, transport, _) = makeQueue(capacity: 1_022)
+        let body = Data(repeating: 0x61, count: 4_096)
+        let end = Data(EscapeSequences.bracketedPasteEnd)
+
+        queue.beginUserPaste()
+        queue.enqueueUserBytes(body)
+        queue.enqueueUserBytes(end)
+        let injected = Task { await queue.enqueueInjection(Data("INJECTED\r".utf8)) }
+        await waitForHeldInjections(1, on: queue)
+        // The child reads BEFORE the paste closes, so the transport would take
+        // the injection the instant `endUserPaste` releases it. That is the
+        // whole hazard: the paste is closed, but its end marker is still in the
+        // outbox, and only the FIFO keeps the injection behind it.
+        transport.drain(1_000_000)
+        queue.endUserPaste()
+        queue.drain()
+
+        #expect(await injected.value == true)
+        let text = transport.accepted
+        let markerAt = try #require(text.range(of: end))
+        let injectionAt = try #require(text.range(of: Data("INJECTED\r".utf8)))
+        #expect(markerAt.upperBound <= injectionAt.lowerBound,
+                "an injection must never precede a paste's end marker")
+    }
+
+    // MARK: - The ack, and the drop
+
+    @Test("an injection appended behind a remainder is accepted, not refused")
+    func injectionBehindARemainderIsAccepted() async {
+        let (queue, _, _) = makeQueue(capacity: 1_022)
+        queue.enqueueUserBytes(Data(repeating: 0x61, count: 4_096))
+
+        #expect(await queue.enqueueInjection(Data("hi\r".utf8)) == true, """
+            `true` means accepted by a writer that will complete — the same \
+            meaning the localProcess and sidecar arms carry
+            """)
+    }
+
+    @Test("a dead transport drops the outbox, reports unwritten, and logs once")
+    func deadTransportDropsTheOutbox() async {
+        let (queue, transport, notifier) = makeQueue(capacity: 1_022)
+        queue.enqueueUserBytes(Data(repeating: 0x61, count: 4_096))
+        transport.isDead = true
+
+        queue.drain()
+
+        #expect(queue.pendingByteCountForTesting == 0)
+        #expect(!notifier.isArmed)
+        #expect(queue.outboxDropLogsForTesting == 1)
+        #expect(await queue.enqueueInjection(Data("hi\r".utf8)) == false,
+                "nothing will land through a dead transport, and the ack must say so")
+        // Still one: the drop line belongs to the episode that lost bytes, not
+        // to every later chunk offered to a transport that is still gone.
+        #expect(queue.outboxDropLogsForTesting == 1)
+    }
+
+    @Test("a short write is not a transport failure and never logs one")
+    func shortWriteIsNotATransportFailure() {
+        let (queue, _, _) = makeQueue(capacity: 1_022)
+
+        queue.enqueueUserBytes(Data(repeating: 0x61, count: 4_096))
+
+        #expect(queue.userWriteOutcomeTransitionsForTesting == 0, """
+            "keystrokes are being dropped" is false for a held remainder; only \
+            a genuinely absent transport may log it
+            """)
+    }
+
+    // MARK: - The backpressure edge
+
+    @Test("the indicator appears only after the threshold, and clears on drain")
+    func backpressureAppearsAfterTheThresholdAndClears() async {
+        let clock = TestClock<Duration>()
+        let backpressure = BackpressureSpy()
+        let (queue, transport, _) = makeQueue(
+            capacity: 1_022, clock: clock, backpressure: backpressure)
+
+        queue.enqueueUserBytes(Data(repeating: 0x61, count: 4_096))
+        await clock.advanceWhenSuspended(by: .milliseconds(900))
+        #expect(backpressure.published.isEmpty,
+                "a stall shorter than the threshold is not worth a banner")
+
+        await clock.advanceWhenSuspended(by: .milliseconds(200))
+        #expect(backpressure.published == [4_096 - 1_022])
+
+        transport.drain(1_000_000)
+        queue.drain()
+        // Exactly two publications, and the second is the clear: the indicator
+        // is an edge, not a per-chunk readout, so a queue that republished on
+        // every accepted chunk of a 3 KB remainder would redden here.
+        #expect(backpressure.published == [4_096 - 1_022, nil],
+                "the banner clears when the outbox empties")
+    }
+
+    /// The other half of the threshold, and the one the timer test cannot
+    /// reach: `drain()`'s `.refused` exit is the only path that can publish
+    /// without the timer having fired, so it is the only place an
+    /// unconditional publish would hide.
+    @Test("a partial drain before the threshold draws no banner")
+    func partialDrainBeforeTheThresholdDrawsNoBanner() {
+        let backpressure = BackpressureSpy()
+        let (queue, transport, _) = makeQueue(capacity: 1_022, backpressure: backpressure)
+
+        queue.enqueueUserBytes(Data(repeating: 0x61, count: 4_096))
+        // The child reads a little, twice — each `drain()` takes the `.refused`
+        // exit with bytes still owed. Virtual time never moves, so the
+        // threshold has provably not elapsed.
+        for _ in 0..<2 {
+            transport.drain(500)
+            queue.drain()
+        }
+
+        #expect(queue.pendingByteCountForTesting > 0,
+                "positive control: the episode is still open, so a banner was possible")
+        #expect(backpressure.published.isEmpty, """
+            a stall the person never noticed must not flash a banner on its way \
+            out: the indicator is drawn by the threshold timer, and a partial \
+            drain only refreshes one that is already showing
+            """)
+    }
+}

--- a/Tests/TBDAppTests/RawPTYPair.swift
+++ b/Tests/TBDAppTests/RawPTYPair.swift
@@ -41,8 +41,25 @@ final class RawPTYPair {
         guard m >= 0, grantpt(m) == 0, unlockpt(m) == 0,
               let name = ptsname(m)
         else { throw Failure.openFailed(errno) }
-        let s = Darwin.open(name, O_RDWR | O_NOCTTY)
+        let s = Darwin.open(name, O_RDWR | O_NOCTTY | O_CLOEXEC)
         guard s >= 0 else { Darwin.close(m); throw Failure.openFailed(errno) }
+        // **Close-on-exec, and the session end is where it is load-bearing.**
+        // Sibling suites in this same process keep long-lived children alive
+        // for the whole run — `QuietIngestTests` holds a `/bin/sleep 120`,
+        // `TerminalTeardownReapTests` its own — and a `fork`/`posix_spawn`
+        // hands a child every descriptor that is not `FD_CLOEXEC`. A child
+        // holding an inherited copy of the session end keeps the line
+        // discipline connected, so `closeSessionEnd()` stops making the master
+        // `EIO`: on a full queue it answers `EAGAIN` instead, which the panel
+        // correctly reads as "refused, still alive", and the EIO row fails with
+        // its remainder still held. Measured against a `/bin/sleep` child
+        // holding the session end: errno 35, and errno 5 on the same write the
+        // moment the child exits. `lsof` on a failing run named eight `sleep`
+        // processes on this pty's slave, all on the fixture's own fd number.
+        // `posix_openpt` takes no `O_CLOEXEC`, so the master needs the `fcntl`;
+        // it matters less (a child holding only the master still sees `EIO`)
+        // but a session pty leaking into every child is worth not doing.
+        _ = fcntl(m, F_SETFD, FD_CLOEXEC)
         // Raw mode is the whole point: the 1,022-byte ceiling binds only with
         // ICANON off. In canonical mode a MiB goes through with no short write
         // and every assertion below passes vacuously.
@@ -134,8 +151,19 @@ final class RawPTYPair {
     /// A deadline that passes throws `DrainTimeout` carrying what was expected
     /// and what actually arrived, so "the remainder never landed" is a named
     /// failure with the observed prefix length in it rather than a hang.
+    ///
+    /// **The default is a hang bound, not a latency budget**, and it is sized
+    /// for the fast parallel pass rather than for an idle machine. A payload
+    /// takes one write-readiness round trip per 1,022 bytes — eight of them for
+    /// an 8 KiB paste — and every one of those goes through a main queue this
+    /// process shares with the whole ~4,700-test population, where the cost of
+    /// a hop is scheduling rather than work. At five seconds CI reached the
+    /// deadline three rounds in (3,066 of 8,205 bytes delivered) with the drain
+    /// behaving exactly as designed. Forty-five seconds matches the house
+    /// wall-clock guards (`Tests/CLAUDE.md`, "Population is the scheduler"),
+    /// and a passing run never spends any of it.
     @MainActor
-    func drainUntil(byteCount: Int, within: Duration = .seconds(5)) async throws -> Data {
+    func drainUntil(byteCount: Int, within: Duration = .seconds(45)) async throws -> Data {
         var out = Data()
         let deadline = ContinuousClock.now.advanced(by: within)
         while out.count < byteCount {
@@ -159,6 +187,27 @@ final class RawPTYPair {
         guard sessionEndIsOpen else { return }
         sessionEndIsOpen = false
         Darwin.close(sessionEnd)
+    }
+
+    /// Whether the pty now rejects writes **outright** — `EIO`, the line
+    /// discipline's report that the last session end is gone — rather than
+    /// merely refusing them for want of room.
+    ///
+    /// A row that closes the session end and then asserts on `EIO` behaviour
+    /// should require this first, because the two states are indistinguishable
+    /// from the panel's side of the queue and only one of them is what such a
+    /// row is about: a session end this process closed can still be open in
+    /// another process — a child that inherited the descriptor — and the tty
+    /// stays connected until that copy goes too. `O_CLOEXEC` above is what
+    /// stops that happening; this is the tripwire if it ever does again.
+    ///
+    /// **Call it only with the queue full**, which is the state every such row
+    /// is already in: the probe is a real one-byte write, and into a live pty
+    /// with room it would land.
+    func ptyRejectsWrites() -> Bool {
+        var probe: UInt8 = 0
+        let written = Darwin.write(ptyFD, &probe, 1)
+        return written < 0 && errno != EAGAIN && errno != EWOULDBLOCK
     }
 
     func close() {

--- a/Tests/TBDAppTests/RawPTYPair.swift
+++ b/Tests/TBDAppTests/RawPTYPair.swift
@@ -28,6 +28,13 @@ final class RawPTYPair {
     let ptyFD: Int32
     /// The slave end, held open and unread so the master's queue stays full.
     let sessionEnd: Int32
+    /// Both ends are closed exactly once, and a test may close the session end
+    /// early (`closeSessionEnd()`) to make the master return `EIO`. Without
+    /// these flags the `close()` in a `defer` would close a number the kernel
+    /// has already reissued — and every test target compiles into one process,
+    /// so the new owner would be another suite's socket or file.
+    private var sessionEndIsOpen = true
+    private var ptyIsOpen = true
 
     init() throws {
         let m = posix_openpt(O_RDWR | O_NOCTTY)
@@ -47,6 +54,14 @@ final class RawPTYPair {
         // the dup; a blocking master here would hang the test rather than
         // refuse.
         _ = fcntl(m, F_SETFL, fcntl(m, F_GETFL, 0) | O_NONBLOCK)
+        // And the session end, so a read that finds nothing returns instead of
+        // parking the caller. `drainSessionFully` polls first and would be
+        // fine either way, but `drainAll`/`drainUntil` read until the queue is
+        // empty — on a blocking slave that last read never returns, and on the
+        // main actor it takes the drain notifier's own queue down with it.
+        // Nothing about the 1,022-byte ceiling depends on this flag: it is a
+        // property of the line discipline, not of how the reader waits.
+        _ = fcntl(s, F_SETFL, fcntl(s, F_GETFL, 0) | O_NONBLOCK)
         ptyFD = m
         sessionEnd = s
     }
@@ -92,8 +107,76 @@ final class RawPTYPair {
         return out
     }
 
-    func close() {
+    /// Reads everything the slave has right now and reports how much that was.
+    ///
+    /// Used to learn *this* kernel's ceiling rather than hard-coding 1,022: the
+    /// number is measured on one arm64 macOS and a test that asserts on it
+    /// turns a kernel change into a red run instead of a finding.
+    @discardableResult
+    func drainAll() -> Int {
+        var total = 0
+        while true {
+            let chunk = drainSession(64 * 1024)
+            if chunk.isEmpty { return total }
+            total += chunk.count
+        }
+    }
+
+    /// Reads the slave until `byteCount` bytes have arrived, yielding the main
+    /// actor between reads so the panel's drain notifier — a `DispatchSource`
+    /// on the main queue — can run and write the next slice.
+    ///
+    /// The yield is the point. A synchronous poll loop on the main actor would
+    /// block the very queue that delivers write-readiness, and the remainder
+    /// would never move; this is why the helper is `async` and `@MainActor`
+    /// rather than a sibling of `drainSessionFully`.
+    ///
+    /// A deadline that passes throws `DrainTimeout` carrying what was expected
+    /// and what actually arrived, so "the remainder never landed" is a named
+    /// failure with the observed prefix length in it rather than a hang.
+    @MainActor
+    func drainUntil(byteCount: Int, within: Duration = .seconds(5)) async throws -> Data {
+        var out = Data()
+        let deadline = ContinuousClock.now.advanced(by: within)
+        while out.count < byteCount {
+            let chunk = drainSession(64 * 1024)
+            if !chunk.isEmpty {
+                out.append(chunk)
+                continue
+            }
+            guard ContinuousClock.now < deadline else {
+                throw DrainTimeout(expected: byteCount, observed: out.count)
+            }
+            try await Task.sleep(for: .milliseconds(1))
+        }
+        return out
+    }
+
+    /// Closes the slave and leaves the master open, so every later write to the
+    /// master returns `EIO` — the line discipline's report that the child is
+    /// gone. `close()` stays correct over it.
+    func closeSessionEnd() {
+        guard sessionEndIsOpen else { return }
+        sessionEndIsOpen = false
         Darwin.close(sessionEnd)
+    }
+
+    func close() {
+        closeSessionEnd()
+        guard ptyIsOpen else { return }
+        ptyIsOpen = false
         Darwin.close(ptyFD)
+    }
+}
+
+/// What `drainUntil` throws when the session end never saw the bytes it was
+/// promised. Carries observed against expected, because the count that did
+/// arrive is what tells a truncation from a stall.
+struct DrainTimeout: Error, CustomStringConvertible {
+    let expected: Int
+    let observed: Int
+
+    var description: String {
+        "the session end never received \(expected) bytes; \(observed) arrived"
     }
 }

--- a/Tests/TBDAppTests/RawPTYPair.swift
+++ b/Tests/TBDAppTests/RawPTYPair.swift
@@ -1,0 +1,99 @@
+import Darwin
+import Foundation
+
+/// A real pty pair whose slave is in raw mode and never read, so the master
+/// refuses at `TTYHOG − 2` (measured: 1,022 bytes on arm64 macOS) exactly as a
+/// session whose agent has stopped draining does.
+///
+/// **No child process.** All test targets compile into one process and Swift
+/// Testing runs suites in parallel, so `fork`/`forkpty` here would be a
+/// multithreaded fork and a stray process on a shared box. The kernel path
+/// under test — `ptcwrite` refusing once the slave's queues hold `TTYHOG − 2`
+/// with `ICANON` off — is a property of the line discipline, not of who owns
+/// the slave, so holding the slave in-process exercises the same code.
+///
+/// `posix_openpt` rather than `openpty`: the latter lives in `util.h`, which
+/// is not reliably in Darwin's module map from Swift.
+///
+/// The two ends are spelled `ptyFD` and `sessionEnd` rather than by their
+/// POSIX names, for the reason `HolderProtocol.swift` gives for the holder's
+/// verbs: SwiftLint's `inclusive_language` rule refuses those words in a
+/// *declaration*, and a suppression is worse than a name whose doc comment
+/// says which end it is. `ptyFD` matches what production holds
+/// (`HolderAttachment.ptyFD`, a dup of the master); `sessionEnd` matches what
+/// the sibling panel fixture calls the far end. Prose below still says
+/// "master" and "slave", because that is what the kernel calls them.
+final class RawPTYPair {
+    /// The master end — what a panel writes through.
+    let ptyFD: Int32
+    /// The slave end, held open and unread so the master's queue stays full.
+    let sessionEnd: Int32
+
+    init() throws {
+        let m = posix_openpt(O_RDWR | O_NOCTTY)
+        guard m >= 0, grantpt(m) == 0, unlockpt(m) == 0,
+              let name = ptsname(m)
+        else { throw Failure.openFailed(errno) }
+        let s = Darwin.open(name, O_RDWR | O_NOCTTY)
+        guard s >= 0 else { Darwin.close(m); throw Failure.openFailed(errno) }
+        // Raw mode is the whole point: the 1,022-byte ceiling binds only with
+        // ICANON off. In canonical mode a MiB goes through with no short write
+        // and every assertion below passes vacuously.
+        var t = termios()
+        tcgetattr(s, &t)
+        cfmakeraw(&t)
+        tcsetattr(s, TCSANOW, &t)
+        // The vended descriptor is O_NONBLOCK in production and the flag rides
+        // the dup; a blocking master here would hang the test rather than
+        // refuse.
+        _ = fcntl(m, F_SETFL, fcntl(m, F_GETFL, 0) | O_NONBLOCK)
+        ptyFD = m
+        sessionEnd = s
+    }
+
+    enum Failure: Error { case openFailed(Int32) }
+
+    /// Writes until the kernel refuses, and reports how many bytes it took.
+    /// Never assert on the number: 1,022 is measured on one kernel, and a
+    /// hard-coded ceiling turns a kernel change into a red test rather than a
+    /// finding.
+    @discardableResult
+    func fillPTY() -> Int {
+        var total = 0
+        let chunk = [UInt8](repeating: 0x61, count: 4096)
+        while true {
+            let n = chunk.withUnsafeBytes { Darwin.write(ptyFD, $0.baseAddress, $0.count) }
+            if n > 0 { total += n; continue }
+            if n < 0 && errno == EINTR { continue }
+            return total
+        }
+    }
+
+    /// Reads up to `maxBytes` off the slave, which is what makes room on the
+    /// master — the child draining, in one call.
+    func drainSession(_ maxBytes: Int) -> Data {
+        var buffer = [UInt8](repeating: 0, count: maxBytes)
+        let n = buffer.withUnsafeMutableBytes { Darwin.read(sessionEnd, $0.baseAddress, maxBytes) }
+        return n > 0 ? Data(buffer[0..<n]) : Data()
+    }
+
+    /// Reads everything the slave has, in bounded slices. Used to reassemble a
+    /// payload the panel wrote across several drains.
+    func drainSessionFully(within milliseconds: Int32 = 2000) -> Data {
+        var out = Data()
+        var remaining = milliseconds
+        while remaining > 0 {
+            var watched = pollfd(fd: sessionEnd, events: Int16(POLLIN), revents: 0)
+            guard poll(&watched, 1, 10) > 0 else { remaining -= 10; continue }
+            let chunk = drainSession(64 * 1024)
+            if chunk.isEmpty { break }
+            out.append(chunk)
+        }
+        return out
+    }
+
+    func close() {
+        Darwin.close(sessionEnd)
+        Darwin.close(ptyFD)
+    }
+}

--- a/Tests/TBDAppTests/TerminalBackpressurePresentationTests.swift
+++ b/Tests/TBDAppTests/TerminalBackpressurePresentationTests.swift
@@ -1,0 +1,29 @@
+import Testing
+
+@testable import TBDApp
+
+/// The copy is a pure function of the byte count so it can be pinned without
+/// driving SwiftUI: the banner's *appearance* is covered by the queue's
+/// backpressure-edge tests, and this covers what it says.
+@Suite("TerminalBackpressurePresentation")
+struct TerminalBackpressurePresentationTests {
+    @Test("the message names the session's state and how much is waiting")
+    func messageNamesTheWait() {
+        #expect(TerminalBackpressurePresentation.message(pendingBytes: 900)
+                == "This session is not accepting input — 900 bytes waiting")
+        #expect(TerminalBackpressurePresentation.message(pendingBytes: 4_096)
+                == "This session is not accepting input — 4.1 KB waiting")
+    }
+
+    /// The copy must not say "dropped" or "failed": nothing is dropped and
+    /// nothing has failed. The bytes are queued and will land when the agent
+    /// reads them, and telling a person otherwise sends them to restart a
+    /// session that is working.
+    @Test("the message never claims a loss")
+    func messageNeverClaimsALoss() {
+        let text = TerminalBackpressurePresentation.message(pendingBytes: 4_096)
+        #expect(!text.lowercased().contains("drop"))
+        #expect(!text.lowercased().contains("fail"))
+        #expect(!text.lowercased().contains("lost"))
+    }
+}

--- a/Tests/TBDDaemonLiveTests/Holder/HolderReclaimTests.swift
+++ b/Tests/TBDDaemonLiveTests/Holder/HolderReclaimTests.swift
@@ -325,6 +325,88 @@ struct HolderReclaimTests {
             """)
     }
 
+    // MARK: - An exit the holder pushed instead of answering
+
+    /// A holder that pushes its exit and winds down in the same breath has
+    /// answered, and the reclaimer must record what it said.
+    ///
+    /// This is the interleaving that put `exitedStatusUnknown` in the record
+    /// for a job that exited 7. The holder pushes the terminal status at
+    /// whichever client is connected when it reaps, and the *next* thing it
+    /// does is break its loop, close its listener and unlink its rendezvous —
+    /// so a probe that connected a moment before the reap is handed the status
+    /// and then finds nothing underneath it. The push answers no request, so
+    /// `HolderClient`'s barrier retires it rather than serving it, and the verb
+    /// fails; a reclaimer that read only the failure would ask again at a path
+    /// that is now `ENOENT`, read that as absence, and record a status nobody
+    /// collected — while holding the real one.
+    ///
+    /// Driven by hand rather than through `adopt`, because which side of the
+    /// push the probe's request lands on is decided by microseconds: the
+    /// scenario is reproducible end to end (once in 120 runs of
+    /// `drainsAFinishedJobsOutputBeforeReleasingIt` under a loaded machine) but
+    /// not schedulable. Here the connection that receives the push is the
+    /// fixture's own, so every link is deterministic — the stranding, the
+    /// unlinked rendezvous, and the classification that has to survive both.
+    @Test func recordsAnExitTheHolderPushedRatherThanAnswered() async throws {
+        let fixture = try await HolderProcessFixture.start(command: "printf 'LAST\\n'; exit 7")
+        defer { fixture.tearDown() }
+
+        // The handshake connection stays open deliberately: it is the holder's
+        // one client, and therefore the one the exit push will land on.
+        let (description, ptyFD) = try await fixture.client.handOverPTY()
+        #expect(description.status == .alive, "the job wedged in ttywait is not finished exiting")
+        defer { Darwin.close(ptyFD) }
+
+        // Draining is what lets the wedged child finish exiting at all.
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        #expect(read(ptyFD, &buffer, buffer.count) > 0)
+
+        // The wait is a `waitpid`, not a liveness probe: the holder is this
+        // process's own child, so `kill(pid, 0)` goes on answering for the
+        // corpse until somebody collects it — and collecting it is owed here
+        // anyway, since nobody else can.
+        let woundDown = await pollUntil("the holder to push its exit and wind down") {
+            var collected: Int32 = 0
+            return waitpid(fixture.handle.holderPID, &collected, WNOHANG)
+                == fixture.handle.holderPID
+        }
+        #expect(woundDown, "the holder never wound down after pushing its exit")
+        fixture.noteHolderReaped()
+
+        // The verb fails, because the holder hung up the moment it pushed.
+        var thrown: Swift.Error?
+        do { _ = try await fixture.client.describe() } catch { thrown = error }
+        let failure = try #require(thrown, "the holder answered a connection it had already closed")
+
+        // And the status it pushed is in the daemon's hands all the same.
+        let pushed = try #require(
+            await fixture.client.lastPushedDescription,
+            "the holder's pushed exit was thrown away instead of retired")
+        #expect(pushed.status == .exited(code: 7))
+
+        // The rendezvous is gone, so asking again learns nothing: this is the
+        // `ENOENT` that used to be recorded as the session's terminal status.
+        let socketPath = try HolderRendezvous.socketPath(
+            sessionID: fixture.sessionID,
+            environment: HolderProcessFixture.environment(home: fixture.home))
+        #expect(
+            !FileManager.default.fileExists(atPath: socketPath),
+            "a holder that wound down cleanly unlinks its rendezvous")
+        #expect(
+            HolderRegistry.exitProbeOutcome(
+                for: HolderClient.Error.cannotConnect(path: socketPath, errno: ENOENT))
+                == .established(.exitedStatusUnknown),
+            "the next probe's verdict, with nothing but the failure to go on")
+
+        // With the push in hand it is the exit code, not an unknown.
+        #expect(
+            HolderRegistry.exitProbeOutcome(
+                for: failure, pushedByTheHolder: pushed, expecting: fixture.owner)
+                == .established(.exited(code: 7)),
+            "the reclaimer discarded a status the holder had already given it")
+    }
+
     // MARK: - Support
 
     /// A holder-transport row; the same shape `HolderAdoptionTests` uses, and

--- a/Tests/TBDDaemonTests/Holder/HolderExitProbeClassificationTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HolderExitProbeClassificationTests.swift
@@ -138,4 +138,104 @@ import Testing
             HolderRegistry.exitProbeOutcome(for: CancellationError()) == .keep,
             "a cancelled probe answered nothing and must not release a reader")
     }
+
+    // MARK: - A status the holder pushed before the round trip failed
+
+    /// A holder that pushed its exit has answered, whatever the connection did
+    /// afterwards.
+    ///
+    /// This is the shape the reclaimer actually meets, and the one that
+    /// recorded a wrong status: the holder pushes at whichever client is
+    /// connected and winds down in the same breath, so the probe is handed
+    /// `.exited(code: 7)` and *then* finds the socket hung up under it. The
+    /// push is retired as unsolicited — correctly, it answers no request — and
+    /// reading only the failure retries at a rendezvous the holder has already
+    /// unlinked, where `ENOENT` reads as absence and `exitedStatusUnknown` goes
+    /// into the record for a child that exited ordinarily.
+    @Test func aPushedExitOutranksTheFailureThatFollowedIt() {
+        for failure: HolderClient.Error in [
+            .peerClosed,
+            .transportFailed("Broken pipe"),
+            .cannotConnect(path: "/tmp/gone.sock", errno: ENOENT),
+            .cannotConnect(path: "/tmp/gone.sock", errno: ECONNREFUSED),
+        ] {
+            let outcome = HolderRegistry.exitProbeOutcome(
+                for: failure,
+                pushedByTheHolder: Self.description(status: .exited(code: 7)),
+                expecting: Self.owner)
+            #expect(
+                outcome == .established(.exited(code: 7)),
+                """
+                the holder said how its child ended and the daemon was holding the answer; \
+                \(failure) must not overwrite it: \(outcome)
+                """)
+        }
+    }
+
+    /// No push leaves every classification exactly as it was.
+    @Test func noPushLeavesTheErrnoRulesUntouched() {
+        #expect(
+            HolderRegistry.exitProbeOutcome(
+                for: HolderClient.Error.peerClosed,
+                pushedByTheHolder: nil,
+                expecting: Self.owner) == .retry)
+        #expect(
+            HolderRegistry.exitProbeOutcome(
+                for: HolderClient.Error.cannotConnect(path: "/tmp/gone.sock", errno: ENOENT),
+                pushedByTheHolder: nil,
+                expecting: Self.owner) == .established(.exitedStatusUnknown))
+        #expect(
+            HolderRegistry.exitProbeOutcome(
+                for: HolderClient.Error.rejected(version: 1),
+                pushedByTheHolder: nil,
+                expecting: Self.owner) == .keep)
+    }
+
+    /// A push from another installation's holder is not this registry's answer.
+    ///
+    /// The same rule the answered path applies to `description.owner`, and it
+    /// has to hold here too: a rendezvous path can be re-bound by a holder some
+    /// other TBD spawned, and its child's exit says nothing about this one's.
+    @Test func aPushFromAnotherInstallationIsIgnored() {
+        let outcome = HolderRegistry.exitProbeOutcome(
+            for: HolderClient.Error.peerClosed,
+            pushedByTheHolder: Self.description(
+                status: .exited(code: 7), owner: HolderOwnerToken(rawValue: "someone-else")),
+            expecting: Self.owner)
+        #expect(outcome == .retry, "a stranger's holder answered for its own child: \(outcome)")
+    }
+
+    /// A push that says the child is alive establishes nothing.
+    ///
+    /// The holder pushes only from its reaping branch, so it never sends this —
+    /// which is exactly why it is pinned: a status that is not terminal must
+    /// not become one by riding an unsolicited frame.
+    @Test func aPushThatSaysAliveEstablishesNothing() {
+        let outcome = HolderRegistry.exitProbeOutcome(
+            for: HolderClient.Error.peerClosed,
+            pushedByTheHolder: Self.description(status: .alive),
+            expecting: Self.owner)
+        #expect(outcome == .retry, "\"still running\" is not a terminal status: \(outcome)")
+    }
+
+    // MARK: - Support
+
+    private static let owner = HolderOwnerToken(rawValue: "acme-installation")
+
+    private static func description(
+        status: HolderChildStatus, owner: HolderOwnerToken = HolderExitProbeClassificationTests.owner
+    ) -> HolderChildDescription {
+        HolderChildDescription(
+            childPID: 4242,
+            ttyName: "/dev/ttys004",
+            status: status,
+            launch: HolderLaunchRequest(
+                executable: "/bin/sh",
+                arguments: ["-c", "exit 7"],
+                workingDirectory: "/tmp",
+                environment: [:],
+                columns: 80,
+                rows: 24),
+            owner: owner)
+    }
 }

--- a/Tests/TBDDaemonTests/Holder/HolderLaunchArgumentTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HolderLaunchArgumentTests.swift
@@ -1,0 +1,173 @@
+import Darwin
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+import TBDShared
+
+/// What a holder's command line may contain, and where its launch request
+/// travels instead.
+///
+/// The rule these tests exist to hold: **a `HolderLaunchRequest` never touches
+/// argv.** It carries the session's entire environment, and argv is readable by
+/// every process running as the same user — one `ps -ww` and a session's
+/// credentials are in the process table for as long as the session lives. The
+/// request goes down a descriptor the spawner places with a `posix_spawn` file
+/// action, which nothing outside the process tree can name.
+///
+/// The command line is asserted as a **whole list**, not searched for the one
+/// string that used to leak. A blacklist only ever catches the leak somebody
+/// already thought of; pinning the entire list means any future argument
+/// carrying anything from the launch request has to fail this test to get in.
+@Suite("Holder launch arguments")
+struct HolderLaunchArgumentTests {
+    /// Distinctive, obviously fake stand-ins for the secret-bearing fields.
+    /// Nothing here is a real credential; they exist to be searched for — so
+    /// none of them may share a substring with anything the command line
+    /// legitimately carries, or the search below would fail for the wrong
+    /// reason.
+    private static let launch = HolderLaunchRequest(
+        executable: "/bin/zsh",
+        arguments: ["-lc", "run-the-agent --flag"],
+        workingDirectory: "/tmp/the-sessions-working-directory",
+        environment: [
+            "PATH": "/usr/bin:/bin",
+            "TERM": "xterm-256color",
+            "EXAMPLE_API_KEY": "placeholder-launch-secret-do-not-log",
+        ],
+        columns: 120,
+        rows: 40)
+
+    private static let owner = HolderOwnerToken(rawValue: "tbd-home:/tmp/an-installation")
+
+    // MARK: - argv
+
+    @Test func theCommandLineIsExactlyTheseArguments() {
+        let session = UUID()
+        let arguments = HolderSpawner.commandLine(
+            executablePath: "/opt/tbd/TBDHolder",
+            sessionID: session,
+            socketPath: "/tmp/holders/\(session.uuidString.lowercased()).sock",
+            owner: Self.owner)
+
+        #expect(arguments == [
+            "/opt/tbd/TBDHolder",
+            "--session", session.uuidString,
+            "--socket", "/tmp/holders/\(session.uuidString.lowercased()).sock",
+            "--lock-fd", "9",
+            "--launch-fd", "10",
+            "--owner", "tbd-home:/tmp/an-installation",
+        ])
+    }
+
+    /// The same claim from the other direction, so a failure says *what* leaked
+    /// rather than only that the list changed. Every secret-bearing field of
+    /// the request is looked for in every argument.
+    @Test func noPartOfTheLaunchRequestReachesTheCommandLine() {
+        let session = UUID()
+        let arguments = HolderSpawner.commandLine(
+            executablePath: "/opt/tbd/TBDHolder",
+            sessionID: session,
+            socketPath: "/tmp/holders/\(session.uuidString.lowercased()).sock",
+            owner: Self.owner)
+        let commandLine = arguments.joined(separator: " ")
+
+        var forbidden = Array(Self.launch.environment.keys)
+        forbidden += Array(Self.launch.environment.values)
+        forbidden += Self.launch.arguments
+        forbidden += [Self.launch.executable, Self.launch.workingDirectory]
+        // The encoded request in both shapes it has ever been passed in.
+        let json = try? JSONEncoder().encode(Self.launch)
+        forbidden += [
+            String(decoding: json ?? Data(), as: UTF8.self),
+            (json ?? Data()).base64EncodedString(),
+        ]
+
+        for secret in forbidden where !secret.isEmpty {
+            #expect(
+                !commandLine.contains(secret),
+                """
+                "\(secret)" reached the holder's command line, where `ps` shows it to \
+                every process running as this user
+                """)
+        }
+
+        // Encoding is not concealment, and base64 is how the request used to
+        // ride argv — a shape the plain-substring search above cannot see,
+        // because the encoder is free to order the JSON keys differently than
+        // this test would. So decode every argument and refuse any that turns
+        // out to be a launch request.
+        for argument in arguments {
+            guard let decoded = Data(base64Encoded: argument),
+                  let smuggled = try? JSONDecoder().decode(
+                      HolderLaunchRequest.self, from: decoded)
+            else { continue }
+            Issue.record("""
+                an argument decodes to a launch request for \(smuggled.executable) with \
+                \(smuggled.environment.count) environment entries; encoding it does not \
+                keep it out of `ps`
+                """)
+        }
+    }
+
+    /// Both inherited descriptors must be above stdio and distinct: `forkpty`
+    /// dup2s the pty slave onto 0/1/2 in the job, and two file actions aimed at
+    /// one number would mean the holder read one of them as the other.
+    @Test func theInheritedDescriptorNumbersAreDistinctAndAboveStdio() {
+        #expect(HolderSpawner.lockDescriptorNumber > 2)
+        #expect(HolderSpawner.launchDescriptorNumber > 2)
+        #expect(HolderSpawner.lockDescriptorNumber != HolderSpawner.launchDescriptorNumber)
+    }
+
+    // MARK: - The descriptor the request travels on
+
+    @Test func theLaunchRequestTravelsWholeOnItsDescriptor() throws {
+        let descriptor = try HolderSpawner.makeLaunchPayloadChannel(Self.launch)
+        defer { close(descriptor) }
+
+        let payload = Self.readToEndOfFile(descriptor)
+        let decoded = try JSONDecoder().decode(HolderLaunchRequest.self, from: payload)
+        #expect(decoded == Self.launch)
+        #expect(decoded.environment["EXAMPLE_API_KEY"] == "placeholder-launch-secret-do-not-log")
+    }
+
+    /// The whole request is queued before `posix_spawn` is ever called and the
+    /// writing end is closed, so the holder reads to end of file and stops.
+    /// Were the write deferred until after the spawn, a holder that never
+    /// reached `main` would park the daemon thread that was feeding it.
+    @Test func theWritingEndIsAlreadyClosedSoTheReaderSeesEndOfFile() throws {
+        let descriptor = try HolderSpawner.makeLaunchPayloadChannel(Self.launch)
+        defer { close(descriptor) }
+        _ = Self.readToEndOfFile(descriptor)
+
+        var byte: UInt8 = 0
+        #expect(read(descriptor, &byte, 1) == 0, "a second read must report end of file, not block")
+    }
+
+    /// A request far larger than any real environment still fits: the channel
+    /// sizes its buffers to the payload, which is the reason it is a socket
+    /// rather than a darwin pipe (whose buffer cannot be resized).
+    @Test func aLargeRequestStillFitsWithoutADeadlock() throws {
+        var big = Self.launch
+        big.environment["BULK"] = String(repeating: "x", count: 256 * 1024)
+        let descriptor = try HolderSpawner.makeLaunchPayloadChannel(big)
+        defer { close(descriptor) }
+
+        let decoded = try JSONDecoder().decode(
+            HolderLaunchRequest.self, from: Self.readToEndOfFile(descriptor))
+        #expect(decoded == big)
+    }
+
+    private static func readToEndOfFile(_ descriptor: Int32) -> Data {
+        var payload = Data()
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        while true {
+            let count = buffer.withUnsafeMutableBytes { read(descriptor, $0.baseAddress, $0.count) }
+            if count > 0 {
+                payload.append(contentsOf: buffer[0..<count])
+                continue
+            }
+            if count < 0, errno == EINTR { continue }
+            return payload
+        }
+    }
+}

--- a/Tests/TBDHolderTests/HolderBinaryTests.swift
+++ b/Tests/TBDHolderTests/HolderBinaryTests.swift
@@ -77,14 +77,19 @@ struct HolderBinaryTests {
             environment: ["PATH": "/usr/bin:/bin"],
             columns: 80,
             rows: 24)
-        let payload = try JSONEncoder().encode(launch).base64EncodedString()
+        let launchPath = NSTemporaryDirectory() + "tbd-launch-\(UUID().uuidString.prefix(8)).json"
+        try JSONEncoder().encode(launch).write(to: URL(fileURLWithPath: launchPath))
+        defer { try? FileManager.default.removeItem(atPath: launchPath) }
+        // The request arrives on a descriptor, not on argv: `ps` shows argv to
+        // every process running as this user, and it carries the environment.
         let command = [
             "exec 9</dev/null;",
             "exec", Self.shellQuoted(executable.path),
             "--session", UUID().uuidString,
             "--socket", "/dev/null/holders/session.sock",
             "--lock-fd", "9",
-            "--launch", Self.shellQuoted(payload),
+            "--launch-fd", "3",
+            "3<", Self.shellQuoted(launchPath),
         ].joined(separator: " ")
 
         let process = Process()

--- a/Tests/TBDHolderTests/HolderInvocationTests.swift
+++ b/Tests/TBDHolderTests/HolderInvocationTests.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 import Testing
 @testable import TBDHolder
@@ -16,16 +17,45 @@ struct HolderInvocationTests {
         columns: 120,
         rows: 40)
 
+    /// A descriptor holding `bytes`, closed on the writing side so a reader
+    /// sees end of file — the shape `HolderSpawner` hands the holder. Returned
+    /// open; `HolderArguments.parse` closes it as it consumes it.
+    private static func descriptor(holding bytes: Data) throws -> Int32 {
+        var ends: [Int32] = [-1, -1]
+        try #require(pipe(&ends) == 0, "could not make a payload pipe")
+        bytes.withUnsafeBytes { raw in
+            var offset = 0
+            while offset < raw.count {
+                let written = write(ends[1], raw.baseAddress?.advanced(by: offset), raw.count - offset)
+                guard written > 0 else { break }
+                offset += written
+            }
+        }
+        close(ends[1])
+        return ends[0]
+    }
+
+    /// The launch request travels on a descriptor, never on argv: argv is
+    /// readable with `ps` by anything running as the same user, and the request
+    /// carries the session's whole environment.
     private static func commandLine(
         session: UUID,
         lockFD: String = "9",
+        launchFD: String? = nil,
+        payload: Data? = nil,
         owner: String? = "installation-abc"
     ) throws -> [String] {
+        let resolvedFD: String
+        if let launchFD {
+            resolvedFD = launchFD
+        } else {
+            resolvedFD = String(try descriptor(holding: payload ?? JSONEncoder().encode(launch)))
+        }
         var arguments = [
             "--session", session.uuidString,
             "--socket", "/tmp/holders/session.sock",
             "--lock-fd", lockFD,
-            "--launch", try JSONEncoder().encode(launch).base64EncodedString(),
+            "--launch-fd", resolvedFD,
         ]
         if let owner { arguments += ["--owner", owner] }
         return arguments
@@ -81,13 +111,80 @@ struct HolderInvocationTests {
             _ = try HolderArguments.parse(["--socket"])
         }
         #expect(throws: HolderStartupError.invalidLaunchPayload) {
-            _ = try HolderArguments.parse([
-                "--session", UUID().uuidString,
-                "--socket", "/tmp/x.sock",
-                "--lock-fd", "9",
-                "--launch", "not-base64-json",
-            ])
+            _ = try HolderArguments.parse(try Self.commandLine(
+                session: UUID(), payload: Data("not-json".utf8)))
         }
+    }
+
+    // MARK: - The launch descriptor
+
+    /// The launch request is a DESCRIPTOR NUMBER, never the request itself. A
+    /// holder that took the bytes on its command line published the session's
+    /// entire environment — every credential in it — to the process table, where
+    /// `ps` shows argv to anything running as the same user, for as long as the
+    /// session lived.
+    @Test func refusesTheRequestItselfWhereADescriptorBelongs() throws {
+        let inlinePayload = try JSONEncoder().encode(Self.launch).base64EncodedString()
+        let arguments = try Self.commandLine(session: UUID(), launchFD: inlinePayload)
+        #expect(throws: HolderStartupError.invalidLaunchDescriptorArgument(inlinePayload)) {
+            _ = try HolderArguments.parse(arguments)
+        }
+    }
+
+    /// A descriptor the spawner never placed is a spawner bug, and must be said
+    /// so rather than surfacing as an empty request that decodes to nothing.
+    ///
+    /// `-1` rather than a large unused number: this process opens descriptors
+    /// on other threads throughout the run, so any number that merely happens
+    /// to be free right now could be taken before the read. -1 never can be.
+    @Test func refusesADescriptorNothingWasPlacedOn() throws {
+        #expect(throws: HolderStartupError.unreadableLaunchPayload(descriptor: -1, errno: EBADF)) {
+            _ = try HolderArguments.parse(try Self.commandLine(session: UUID(), launchFD: "-1"))
+        }
+    }
+
+    /// The descriptor is spent by parsing and must not still be open at
+    /// `forkpty`: a launch request is the one thing in the holder that holds the
+    /// session's secrets, and a fork would copy it into the job.
+    ///
+    /// Asserted from the far end of a socket pair rather than by asking whether
+    /// the number is still open — a closed number can be handed straight back
+    /// out to another thread, so only the peer can answer this without racing.
+    @Test func theLaunchDescriptorIsClosedOnceItIsRead() throws {
+        var ends: [Int32] = [-1, -1]
+        try #require(socketpair(AF_UNIX, SOCK_STREAM, 0, &ends) == 0)
+        let ours = ends[0]
+        let holders = ends[1]
+        defer { close(ours) }
+
+        try JSONEncoder().encode(Self.launch).withUnsafeBytes { raw in
+            _ = write(ours, raw.baseAddress, raw.count)
+        }
+        // Half-close, not close: the holder's end must see end of file while
+        // this end stays open to watch what becomes of it.
+        shutdown(ours, SHUT_WR)
+        _ = fcntl(ours, F_SETFL, O_NONBLOCK)
+
+        var byte: UInt8 = 0
+        #expect(
+            read(ours, &byte, 1) == -1 && errno == EAGAIN,
+            "precondition: the holder's end is still open before parsing")
+
+        let parsed = try HolderArguments.parse(
+            try Self.commandLine(session: UUID(), launchFD: String(holders)))
+        #expect(parsed.launch == Self.launch)
+        #expect(read(ours, &byte, 1) == 0, "the spent descriptor must be closed, not left open")
+    }
+
+    /// A request split across reads is a stream that has not finished arriving,
+    /// not a truncated message: the frame is end of file. Forced by a request
+    /// twice the read buffer, which no single `read` can return.
+    @Test func aRequestLargerThanOneReadIsReassembled() throws {
+        var big = Self.launch
+        big.environment["BULK"] = String(repeating: "x", count: 8_000)
+        let parsed = try HolderArguments.parse(try Self.commandLine(
+            session: UUID(), payload: try JSONEncoder().encode(big)))
+        #expect(parsed.launch == big)
     }
 
     // MARK: - Framing
@@ -158,6 +255,8 @@ struct HolderInvocationTests {
             .missingArgument("session"),
             .invalidSessionID("not-a-uuid"),
             .invalidLaunchPayload,
+            .invalidLaunchDescriptorArgument("eyJleGVjdXRhYmxlIjoi"),
+            .unreadableLaunchPayload(descriptor: 10, errno: EBADF),
             .invalidLockDescriptorArgument("/tmp/holders/session.lock"),
             .invalidLockDescriptor(1),
             .socketPathTooLong(path: "/tmp/holders/session.sock", limit: 104),

--- a/Tests/TBDHolderTests/TestHolderSupport.swift
+++ b/Tests/TBDHolderTests/TestHolderSupport.swift
@@ -174,14 +174,22 @@ final class HolderFixture {
         var lockReleased = false
         defer { if !lockReleased { lock.release() } }
 
-        let payload = try JSONEncoder().encode(launch).base64EncodedString()
+        // The launch request travels on a DESCRIPTOR, never on argv — argv is
+        // readable with `ps` by anything running as the same user, and the
+        // request carries the session's whole environment. Production places
+        // that descriptor with a `posix_spawn` file action; the bootstrap shell
+        // gets there with a redirect from a file in its own scratch home, which
+        // `teardown` removes with the rest of it.
+        let launchPath = home + "/launch.json"
+        try JSONEncoder().encode(launch).write(to: URL(fileURLWithPath: launchPath))
         let command = [
             shellQuoted(executable.path),
             "--session", shellQuoted(session.uuidString),
             "--socket", shellQuoted(socketPath),
             "--lock-fd", "9",
-            "--launch", shellQuoted(payload),
+            "--launch-fd", "3",
             "--owner", shellQuoted(owner),
+            "3<", shellQuoted(launchPath),
             "&",
             "echo $! >", shellQuoted(pidPath),
         ].joined(separator: " ")

--- a/docs/specs/2026-09-03-single-typist-injection-design.md
+++ b/docs/specs/2026-09-03-single-typist-injection-design.md
@@ -86,10 +86,15 @@ open, so only the viewer can say when it is safe.
   you are not mid-paste, and hold the person's keystrokes until I say I am
   done.
 - **`injectionClear` (viewer → daemon)** answers one intent by its id. The
-  viewer answers immediately when no paste is open, and otherwise on
-  `endUserPaste` — the hold-and-release machinery `OutgoingInputQueue` already
-  has (`OutgoingInputQueue.swift:243-251`, `:264-292`), holding its own answer
-  instead of somebody else's bytes. Answering starts the keystroke hold.
+  viewer answers immediately when no paste is open, and otherwise when the
+  paste's end marker has been **accepted by the kernel** — which is
+  `endUserPaste` plus however long the viewer's outbox takes to land the
+  marker, since a stalled child can leave the marker queued for as long as it
+  stalls ([`2026-09-04-pty-write-completion-design.md`](2026-09-04-pty-write-completion-design.md)).
+  The machinery is the hold-and-release `OutgoingInputQueue` already has
+  (`beginUserPaste`/`endUserPaste`, and the outbox behind them), holding its
+  own answer instead of somebody else's bytes. Answering starts the keystroke
+  hold.
 - **`injectionDone` (daemon → viewer)** ends the hold, whatever the write's
   outcome.
 
@@ -101,24 +106,40 @@ each receive loop rather than desyncing the stream
 `FDVendingServer.swift:345-348`). A viewer built before the lease existed
 simply never answers, and the daemon's bound covers it.
 
-**What bounds the wait, and what expiry means.** The viewer bounds its own hold
-at `pasteHoldBound` (two seconds, `HolderInputTiming.pasteHoldBound` in
-TBDShared): a paste
-still open at that point gets the answer anyway. The daemon's lease bound must
-therefore be strictly *longer* than the viewer's hold bound — three seconds
-against two. That ordering is load-bearing in the same way its predecessor was,
-and in mirror image: were the daemon's bound the shorter one, every injection
-the viewer legitimately held would be written while the paste was still open,
-making the between-markers collision systematic instead of rare.
+**What bounds the wait, and what expiry means.** The viewer bounds at
+`pasteHoldBound` (two seconds, `HolderInputTiming.pasteHoldBound` in TBDShared)
+how long an open paste may defer its answer: a paste still open at that point
+gets the answer anyway. That clock covers the paste being open; it does not
+cover the end marker's journey into the kernel, which is bounded by the
+descriptor instead. The daemon's lease bound must therefore be strictly
+*longer* than the viewer's hold bound — three seconds against two. That
+ordering is load-bearing in the same way its predecessor was, and in mirror
+image: were the daemon's bound the shorter one, every injection the viewer
+legitimately held would be written while the paste was still open, making the
+between-markers collision systematic instead of rare.
 
-With that ordering, an expired lease means exactly one thing: **the viewer is
-not running its main actor at all.** A paste is three synchronous main-actor
-delegate calls with no suspension point between them, so a live app answers
-within a turn. The daemon writes when the bound expires, and the worst case is
-that the injection is absorbed into a person's paste — visible in the composer,
-the trailing `\r` rendered as a newline rather than a submit, and observable as
-not-landed. It is a paste collision, and it can never be a duplicate, because
-nobody else writes.
+With that ordering, an expired lease has two readings. The first, and the one
+the bound is sized for: **the viewer is not running its main actor at all.** A
+paste is three synchronous main-actor delegate calls with no suspension point
+between them, so a live app answers within a turn. The daemon writes when the
+bound expires, and the worst case is that the injection is absorbed into a
+person's paste — visible in the composer, the trailing `\r` rendered as a
+newline rather than a submit, and observable as not-landed. It is a paste
+collision, and it can never be a duplicate, because nobody else writes.
+
+The second reading is the rarer of the two, and it resolves the same way: the
+viewer is alive and a large paste is still draining into a stalled child, so
+the end marker has not been accepted yet. Both readings end with the daemon
+writing on its bound, the injection absorbed into the person's paste, visible
+in the composer and never doubled. An explicit "still draining" answer that
+extends the lease is the obvious refinement, and it waits on a soak showing
+the residue is felt.
+
+**The two kinds of bound stay distinct.** The keystroke hold that waits on
+another process's `injectionDone` is bounded by a clock, because that process
+can die silently. The viewer's own remainder is bounded by the descriptor —
+`EIO` or `EBADF` — and by nothing else; the hold's clock bound does not apply
+to it.
 
 A stale viewer claim — a session whose viewer record outlives its panel —
 degrades to exactly that bounded wait per injection, rather than to a send path
@@ -271,12 +292,14 @@ sidecar is, and the difference decides the design:
 
 ## Finishing the write
 
-Both writers give up today: the daemon's own path after a 250 ms budget
-(`HolderReader.swift:965`, `:1062-1088`), and the viewer's after roughly 20 ms,
-reporting a partial write as unwritten and keeping the prefix
-(`TerminalPanelView.swift:2065-2085`). Above a kilobyte into a raw-mode pty
-that is the *ordinary* path, not an edge — so a writer that gives up after one
-attempt truncates by default.
+Above a kilobyte into a raw-mode pty a short write is the *ordinary* path, not
+an edge, so a writer that gives up after one attempt truncates by default. The
+viewer already finishes what it starts: it keeps the remainder the kernel
+refused and drains it on write-readiness, bounded by the descriptor
+([`2026-09-04-pty-write-completion-design.md`](2026-09-04-pty-write-completion-design.md)).
+The daemon's own path still gives up, after a 250 ms budget
+(`HolderReader.swift:965`, `:1062-1088`) — and under single typist that is the
+path every injection takes.
 
 - **The process that started a write finishes it.** The holder finishes
   injections; the viewer finishes the person's own pastes, resuming from
@@ -372,9 +395,10 @@ entire path, which has no users to protect.
 
 A second column would also have a broken quadrant. Holder on, single-typist
 off is the arrangement this design replaces, and it is known-defective in ways
-already recorded: an injection above a kilobyte into an attached panel leaves a
-truncated fragment in the composer, and a viewer claim outliving its panel
-stops sends working for the daemon's lifetime. Keeping it selectable would
+already recorded: the ack deadline resolves a writer's silence with a timer, so
+an app that is alive but slow gets written over and the injection doubled, and
+a viewer claim outliving its panel stops sends working for the daemon's
+lifetime. Keeping it selectable would
 preserve a path we have decided is wrong and would double every soak.
 
 Both branches of the gate remain testable, because both still exist: a tmux

--- a/docs/specs/2026-09-04-pty-write-completion-design.md
+++ b/docs/specs/2026-09-04-pty-write-completion-design.md
@@ -1,0 +1,710 @@
+# Completing a write to a session's pty
+
+## Summary
+
+A write to a holder-backed session's pty master can commit a prefix of the
+payload and drop the remainder. It is not a rare failure: a raw-mode pty
+accepts 1,022 bytes and then refuses, so every payload above a kilobyte into an
+agent session depends on the child draining its input *during* the write, and
+both of TBD's writers give up on a clock — the viewer after 20 ms, the daemon
+after 250 ms — with the prefix already delivered.
+
+Nothing can un-write a prefix, and nothing can ask a pty how much room it has,
+so the defect cannot be avoided; it can only be repaired by **finishing the
+write**. The design rule is one sentence: **whoever committed the prefix owns
+the remainder, and nothing else may write to that pty until the remainder has
+landed.** The second clause is the hard part. A write that spans several
+main-actor turns is no longer atomic with respect to the person at the
+keyboard, and a keystroke that lands between two of its turns tears the payload
+— for a bracketed paste, between its markers.
+
+The accepted answer to "who writes an injection" is already committed:
+[`2026-09-03-single-typist-injection-design.md`](2026-09-03-single-typist-injection-design.md)
+makes the daemon the only injection writer, routes every injection through the
+session's holder, and has the holder finish it from an outbox bounded by the
+child's death. That spec also says, in one sentence, that the viewer finishes
+the person's own pastes and holds subsequent keystrokes behind the remainder.
+**This document is that sentence, designed** — the viewer-side outbox and the
+hold on user bytes — and it is the piece of single-typist that can land first
+and on its own, because it needs no protocol change and fixes the two victims
+that are entirely inside the app. It does not re-derive the holder outbox; it
+sequences against it.
+
+Three victims were examined. All three are reachable, and one of them is worse
+than a truncation: a large paste whose end marker is lost leaves the child in
+bracketed-paste mode, where everything typed afterwards is absorbed into the
+paste. The verdicts and the evidence are in "The three victims" below.
+
+## The defect
+
+### The mechanism, measured
+
+A pty master's input queue is bounded by `TTYHOG`, and the bound binds in raw
+mode only:
+
+- **Raw mode** (`ICANON` off — what every full-screen agent TUI sets) — a
+  non-blocking master accepts **1,022 bytes** and then returns `EAGAIN`, with
+  the short write on the very first call. 1,022 is `TTYHOG − 2`.
+- **Canonical mode** (a shell at its prompt) — a MiB accepted with no short
+  write at any size tried.
+
+Measured directly on a development macOS machine (arm64) by opening a pty pair,
+leaving the slave unread, and writing to a non-blocking master until the kernel
+refused; the method and the numbers are recorded in the measured addendum to
+[`2026-09-03-injection-delivery-alternatives.md`](2026-09-03-injection-delivery-alternatives.md).
+The mechanism is `ptcwrite` in XNU's pty driver: the master's write path
+refuses once the slave's raw and canonical queues together hold `TTYHOG − 2`
+bytes and the line discipline is non-canonical. Two consequences of that code,
+read from the published source rather than measured, matter to this design:
+
+- **Commitment is per byte, not per call.** `ptcwrite` feeds the queue a byte
+  at a time until it is full and then returns how many it took. A six-byte
+  paste marker can therefore be torn — three bytes accepted, three refused —
+  not merely lost whole.
+- **`poll(POLLOUT)` says "some room", never "how much".** There is no
+  interface on the master side that reports the input queue's free space, so
+  a writer cannot know before writing whether a payload will fit.
+
+So any payload above about a kilobyte into an agent session is delivered
+whole only if the child drains its input while the write is in progress. A
+child that is busy — rendering, in a synchronous computation, or blocked — does
+not, and the write returns short.
+
+### Where the writers give up
+
+- **The viewer** – `PTYWrite.all`
+  (`Sources/TBDApp/Terminal/PTYWrite.swift:74`) loops on `write(2)` and a
+  `poll(POLLOUT)` in 5 ms slices (`:101`) inside a **20 ms** total budget
+  (`:63`), and returns `.partial(written:)` (`:56`) when the budget expires
+  with a prefix delivered. Its caller `writeToHolderPTY`
+  (`Sources/TBDApp/Terminal/TerminalPanelView.swift:2272`) maps `.partial` to
+  `false` and logs one line (`:2282`). Above it, `performOutgoingWrite`
+  (`:2159`) is synchronous and main-actor, and its `Bool` is the only report
+  the write ever makes.
+- **The daemon** – `PTYDescriptor.writeAll`
+  (`Sources/TBDDaemon/Holder/HolderReader.swift:1085`) is the same loop with a
+  **250 ms** budget (`:988`), throwing `writeTimedOut(unwritten:)` (`:1103`)
+  with the prefix delivered. It runs under the descriptor's lock (`:1086`),
+  the same lock the drain thread's `read` takes (`:1026`), so every
+  millisecond it waits is a millisecond the daemon is not reading the child's
+  output.
+
+Both budgets exist for good reasons — the viewer's because a keystroke must be
+answered in the turn it arrived in, the daemon's because an actor must not park
+on a child that has stopped reading — and both are wrong as *truncation
+points*, because expiry discards the remainder rather than keeping it.
+
+## The three victims
+
+Each case was traced through the code rather than assumed. Line numbers are
+against the tree this document was written in.
+
+### Case 1 — a daemon injection into an attached session: reachable, as described, with a second shape
+
+The chain: `performHolderSend`
+(`Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift:3127`) composes
+the whole message — dispatch envelope, body, submitting `\r` — and hands it to
+`HolderInjectionCourier.deliver`
+(`Sources/TBDDaemon/Holder/HolderInjectionCourier.swift:201`). With a viewer
+attached, the courier puts an `.injection` frame on the sidecar; the app's
+handler (`Sources/TBDApp/AppState+TerminalFocus.swift:128-140`) routes it to
+the panel (`Sources/TBDApp/Terminal/TerminalInjectionRouter.swift:94`), which
+calls `OutgoingInputQueue.enqueueInjection`
+(`Sources/TBDApp/Terminal/OutgoingInputQueue.swift:264`) →
+`performOutgoingWrite` → `writeToHolderPTY` → `PTYWrite.all`. A payload above
+1,022 bytes into a child that does not drain within 20 ms returns `.partial`;
+the panel reports `false`; the app acks `written: false`; the courier takes the
+`.viewerReportedNothingWritten` arm (`HolderInjectionCourier.swift:235`) and
+calls `writeDirectly`, which looks up the daemon's reader
+(`Sources/TBDDaemon/Daemon.swift:843-851`).
+
+What happens next depends on the attach state, and the two outcomes are both
+wrong:
+
+- **An acknowledged attach.** `confirmAttach`
+  (`Sources/TBDDaemon/Holder/HolderRegistry.swift:1396`) stops the daemon's
+  reader and with it the descriptor, so `reader(for:)` is nil, the courier
+  answers `.notDelivered`, and `performHolderSend` records
+  `.transportFailed` and returns the error (`:3173-3181`). **The session
+  holds a truncated fragment; the caller is told the send failed.** The
+  error is honest and the state is wrong — and the fragment includes the
+  dispatch envelope's opening tag with no closing tag and no `\r`, so it sits
+  unsubmitted in the composer for the next human or injection to append to.
+- **A timed-out attach.** `cancelPendingAttach`'s `.unacknowledged` arm leaves
+  the reader suspended with its descriptor open (the courier's own doc comment
+  at `HolderInjectionCourier.swift:186-198` names this), so the fallback
+  *writes the whole payload on top of the prefix*: **prefix plus whole, in the
+  composer, and the actuation row records a successful dispatch.** The
+  duplicate-versus-loss fork, resolved on the duplicate side, with the
+  duplicate being a fragment.
+
+One refinement to the brief's statement: the ordinary way a viewer's child is
+"not draining" at the instant of an injection is that it is *busy*, and
+supervision nudges are sent precisely when an agent is busy or stuck. This
+case is not an edge of the injection path; for payloads above a kilobyte it is
+its common path.
+
+### Case 2 — a human's paste into a holder-backed panel: reachable, silent, a regression
+
+The brief's belief is confirmed by the code. The route:
+
+- `TBDTerminalView.paste` (`Sources/TBDApp/Terminal/TBDTerminalView.swift:103`)
+  hands the pasteboard to `onControlModePaste`, whose decision
+  (`Sources/TBDApp/Terminal/PasteInterception.swift:46`) is `.passthrough`
+  whenever no control-mode attach is live — which is every holder-backed
+  panel — so `super.paste` runs (`TBDTerminalView.swift:117`).
+- SwiftTerm's paste path, when the child has enabled bracketed-paste mode,
+  makes **three separate `send` calls**: the start marker, the payload as one
+  chunk, the end marker
+  (`.build/checkouts/SwiftTerm/Sources/SwiftTerm/Mac/MacTerminalView.swift:2351-2356`).
+  On the main thread its delivery buffer drains synchronously and preserves
+  each call's boundary
+  (`.build/checkouts/SwiftTerm/Sources/SwiftTerm/Apple/AppleTerminalView.swift:1053-1054`,
+  `:1073-1075`), so `Coordinator.send(source:data:)`
+  (`TerminalPanelView.swift:2052`) sees three chunks in one main-actor turn.
+- `send` calls `outgoingQueue.enqueueUserBytes` for each (`:2109-2113`);
+  `enqueueUserBytes` (`OutgoingInputQueue.swift:209`) is synchronous and
+  fire-and-forget; `performOutgoingWrite` takes the `.localPTY` arm and,
+  because the panel holds `holderWriteFD` (`TerminalPanelView.swift:830`),
+  calls `writeToHolderPTY` → `PTYWrite.all` with the 20 ms budget.
+
+A payload above 1,022 bytes into a child that does not drain the whole of it
+within 20 ms is written short. What the user then sees and does not see:
+
+- **No error anywhere.** `enqueueUserBytes` has no caller to report to, so
+  the `false` goes to `noteUserWriteOutcome` (`OutgoingInputQueue.swift:228`),
+  which logs — once, at `.info` — that user input "reached no transport" and
+  "keystrokes are being dropped" (`:236`). Both halves are false: the
+  transport is alive and a prefix was written. The next keystroke logs a
+  "recovery". Nothing reaches the pane or the panel.
+- **The composer shows a shortened paste.** For a paste the user can see in
+  full that is a visible truncation; for a long one it is not.
+- **It is a regression on both predecessors.** The local-PTY path hands the
+  payload to `LocalProcess.send`, which writes through `DispatchIO`
+  (`.build/checkouts/SwiftTerm/Sources/SwiftTerm/LocalProcess.swift:222-245`)
+  — a queued, completing write that never truncates. The control-mode path
+  ships the paste as a `.paste` frame that tmux completes. The holder path is
+  the first of the three in which a paste can be cut short.
+- **The gap between permitted and delivered is large.** Nothing caps a
+  passthrough paste; `SidecarFrameCodec.maxPasteBytes`
+  (`Sources/TBDShared/SidecarFraming.swift:133`) is just under 4 MiB and
+  applies to the control-mode frame, so a multi-megabyte paste is accepted at
+  the view and delivered to the extent of the child's draining in 20 ms.
+
+What could not be measured, and is stated as a judgment: how often 20 ms
+suffices for a paste of a few KiB into an *idle* agent. The budget allows four
+5 ms slices; a child that reads and re-renders on every chunk of input — the
+shape of a TUI composer — will not drain a 4 KiB paste in four slices on most
+turns. Treat the outbox path below as the ordinary path for any paste above a
+kilobyte, not as a rare one.
+
+### Case 3 — a bracketed paste whose end marker is lost: reachable; the consequence is the child's to decide
+
+The sequence inside one main-actor turn, from `send` (`:2109-2113`):
+
+1. `ESC[200~` — six bytes; accepted, since the queue is usually not full.
+2. The payload — `PTYWrite.all` writes 1,022 bytes (less the marker), then
+   polls for the rest of its 20 ms, then returns `.partial`.
+3. `ESC[201~` — a fresh `PTYWrite.all` with a fresh 20 ms. If the queue is
+   still full — the child has not drained at all in the last 5 ms slice of
+   step 2 and does not in the next 20 ms — it returns `.nothingWritten`, the
+   panel reports `false`, and **the end marker is dropped.** No line is
+   logged: the edge already fired in step 2.
+4. `endUserPaste()` runs regardless, so the *app's* bookkeeping says the paste
+   is closed while the *child's* is still open.
+
+So the transport-level precondition is a child that does not drain for roughly
+40 ms after the payload filled its queue. A render pass or a garbage-collection
+pause in an agent TUI is that long routinely, so this is reachable, and it is
+reachable from the same paste that truncates in case 2 — it is the second
+half of the same event, not an independent one. Two further shapes fall out of
+the per-byte commitment described above:
+
+- **A torn end marker**: room for three bytes leaves `ESC[2` in the queue and
+  `01~` dropped. The child's parser sees an unfinished CSI sequence followed by
+  whatever is typed next, which is worse than a clean loss.
+- **A cut inside the payload**: a multi-byte UTF-8 sequence or an escape
+  sequence in the pasted text can be split, and the remainder never arrives.
+
+Whether a lost end marker *wedges* the session is a property of the child's
+paste parser, which is outside this repository and was not verified:
+
+- A parser following the xterm convention accumulates until `ESC[201~` with no
+  timeout. Everything typed afterwards — including Enter and Ctrl-C, which in
+  raw mode are just bytes — is appended to the paste. In a TUI that renders a
+  large paste as a placeholder, typed text vanishes into the placeholder. That
+  is the "swallows everything typed afterwards" outcome the brief describes,
+  and it is what the convention predicts.
+- A parser with a burst timeout self-heals after its timeout. The repository's
+  own comments note that at least one agent TUI has a paste-burst heuristic
+  (`RPCRouter+TerminalHandlers.swift:3118-3126`), but whether it also bounds
+  an *explicit* bracketed paste is not known.
+- **There is a recovery, and it is not obvious**: pasting anything small
+  again sends a fresh `ESC[200~ … ESC[201~`, whose end marker closes the
+  child's paste state. A user who does not know that sees a session that has
+  stopped responding to the keyboard.
+
+The recommendation is to treat this as session-wedging until an agent TUI is
+observed to recover on its own. It does change the priority: case 2 loses a
+paste, case 3 loses the keyboard, and they are the same paste.
+
+**A consequence for the single-typist paste lease.** The lease relies on the
+viewer knowing whether a paste is open. Today "open" means "between
+`beginUserPaste()` and `endUserPaste()`", two calls in one main-actor turn.
+With a lost or still-queued end marker the child is mid-paste long after that
+turn, so an injection the viewer clears as "outside the paste" lands inside it
+and is absorbed. Completing the user's paste is therefore not only a fix for
+the person at the keyboard; it is what makes the lease's answer true. The
+refinement this forces is in "Sequencing against single-typist".
+
+## What is fixed, and what must not break
+
+The constraints this design is written against, each from a prior decision:
+
+- **A keystroke must not acquire a scheduling hop.** The output direction of
+  the same panel carries an explicit warning from the paint-starvation
+  investigation (`TerminalPanelView.swift:819-823`), and `OutgoingInputQueue`
+  is a `@MainActor final class` rather than an actor for the same reason
+  (`OutgoingInputQueue.swift:21-35`). Typing stays synchronous and inline.
+- **The main actor must not block.** A longer inline wait is not an option.
+- **The bound ordering holds.** `pasteHoldBound` (2 s,
+  `OutgoingInputQueue.swift:109`, `:137`) stays strictly shorter than the
+  daemon's `ackDeadline` (5 s, `HolderInjectionCourier.swift:151`); nothing
+  here adds a wait between an injection's arrival and its acknowledgement.
+- **One writer per session at any moment.** Two processes may hold write
+  descriptors on a pty master — that is ordinary (`TerminalPanelView.swift:474`)
+  — but a message must be contiguous on the wire. A multi-turn write must
+  therefore hold every other byte bound for the same pty behind it.
+- **Never report a write as done when it was not.** The ack chain, the
+  actuation record and the courier's fallback all rest on this.
+- **The single-typist decision stands.** The daemon is the only injection
+  writer; the holder finishes injections from its outbox; the viewer holds
+  keystrokes for the span of an injection. Nothing here reopens those.
+
+## Avoidance is not available
+
+The brief asks whether the prefix can be kept from being committed at all.
+Each formulation was checked against the mechanism:
+
+- **Refuse if it will not fit.** Needs the queue's free space, which the
+  master side cannot read; `poll(POLLOUT)` reports only that at least one byte
+  would be accepted. Not available.
+- **Chunk and confirm.** Writing in queue-sized pieces changes nothing about
+  commitment — each piece is committed the same way, per byte — and the first
+  piece is still a prefix if the second is refused. What chunking *can* buy is
+  boundary alignment: a writer that never asks the kernel to take part of a
+  marker or part of a UTF-8 sequence cannot be torn *inside* one, only
+  *between* them. That is worth having, and it is a property of how the
+  remainder is cut, not a way to avoid having one.
+- **A smaller unit of commitment.** The unit is a byte and the kernel offers
+  no transaction. There is no formulation in which a prefix is never
+  committed, short of not writing until the child is known to be reading —
+  and the only probe of that is the write itself.
+- **Sender-side retry.** Cannot un-write; doubles the prefix. It is the
+  courier's fallback today, and case 1's second shape is what it produces.
+
+So repair — finishing the write — is the only option, and the design space is
+*who* holds the remainder, *what* is held behind it, and *what bounds* the
+holding.
+
+## The rule: whoever committed the prefix owns the remainder
+
+- **The process whose syscall committed the prefix keeps the remainder and
+  finishes it.** For the viewer's own bytes that is the viewer. For an
+  injection under single-typist that is the holder, from its outbox. For an
+  injection in the interim before the holder verb lands, it is the viewer when
+  attached — the case 1 chain above — and the daemon when detached.
+- **Nothing else bound for that pty is written until the remainder has
+  landed.** Within one process this is a FIFO outbox: every later chunk from
+  every stream is appended behind the remainder, whole, in arrival order.
+  Across processes it is the single-typist keystroke hold, which this design
+  builds the viewer half of.
+- **The bound is the descriptor, not a clock, for a wait on the kernel; a
+  clock, for a wait on another process.** A remainder waits on the child
+  draining, and the descriptor reports the terminal condition of that wait —
+  `EIO` when the last slave closes, `EBADF` after teardown. A clock adds
+  nothing but a truncation point. A hold that waits on *another process's*
+  report — the single-typist injection hold waiting for `injectionDone` —
+  needs a clock, because that process can die silently. Keeping the two kinds
+  of bound distinct is what makes each defensible.
+
+## The design: a viewer-side outbox in `OutgoingInputQueue`
+
+`OutgoingInputQueue` is already the single serialization point for everything
+one panel writes, main-actor confined, and it already holds and releases. It
+gains an outbox: the remainder of a short write, and everything that arrives
+while the outbox is non-empty.
+
+### The write step
+
+`performOutgoingWrite` keeps its synchronous shape and its `Bool`. Behind it,
+`writeToHolderPTY` makes **one non-blocking attempt** and hands whatever the
+kernel refused back to the queue:
+
+- `PTYWrite.all` is called with a budget of **zero** — one `write(2)`, no
+  `poll`. The 20 ms budget existed only because there was nowhere to keep a
+  remainder; with an outbox, waiting inline buys nothing and costs the main
+  actor. The `Outcome` collapses accordingly: `.complete`, `.partial(written:)`
+  now meaning "the rest is the caller's to keep", and `.failed(errno:)`;
+  `.nothingWritten` becomes `.partial(written: 0)` for a full queue and
+  `.failed` for a dead descriptor.
+- **The remainder is cut on a boundary the child can parse.** The outbox
+  keeps the unwritten bytes exactly as the kernel left them — the kernel
+  decides the cut, per byte — so the alignment obligation is on the *next*
+  write, not on this one: when the outbox drains, it offers the kernel the
+  whole remainder, and whatever the kernel takes next continues the same byte
+  stream without a gap. A torn marker or a split UTF-8 sequence is healed by
+  the very next accepted bytes, provided nothing else was written in between.
+  That proviso is the hold.
+- `true` from the write means **accepted by a writer that will complete or
+  report** — the same meaning `true` already carries on the other two arms of
+  `performOutgoingWrite`, whose own comment (`TerminalPanelView.swift:2147-2158`)
+  defines it as "handed off" to `DispatchIO` or the sidecar's send queue.
+  `false` means, and now only means, that nothing was written and nothing
+  will be: no descriptor, or `EIO`/`EBADF` on the attempt. A prefix followed
+  by `EIO` reports `false` and drops the outbox: the child is gone, and the
+  honest answer to "was it written" is no.
+
+### The hold on user bytes
+
+- **While the outbox is non-empty, `enqueueUserBytes` appends instead of
+  writing.** The append is O(1) on the main actor with no hop; the keystroke's
+  *write* happens when the descriptor is next writable. This is not a latency
+  cost in the ordinary case, because the ordinary case has an empty outbox and
+  writes inline exactly as today; it is a cost only while the pty is refusing
+  bytes — when the alternative to queueing the keystroke is dropping it.
+- **Order is FIFO across both streams.** A paste's three chunks, the
+  keystrokes after it, and an injection released from the paste hold are
+  written in arrival order and never interleaved. A keystroke typed after a
+  short paste lands after the paste's end marker, which is the property case
+  3 needs.
+- **No byte bypasses the hold, including `0x03`.** The same ruling
+  single-typist makes for its injection hold, for a stronger reason here: the
+  queue is full, so an interrupt moved to the front cannot be written either;
+  the bypass would reorder the person's input against itself and deliver
+  nothing sooner.
+- **Held, never dropped.** Nothing the person typed is discarded while the
+  panel owns the pty. The outbox has no size cap of its own; the paste that
+  filled it was already accepted at the view, and the bytes are a copy in the
+  app's memory.
+
+### Draining
+
+- A **write-readiness source on the main queue**
+  (`DispatchSource.makeWriteSource(fileDescriptor:queue:)` on `holderWriteFD`,
+  precedent: the read source at `Sources/TBDApp/TBDApp.swift:405`) is resumed
+  when the outbox becomes non-empty and suspended when it empties. Its handler
+  runs on the main queue, so it is main-actor by construction
+  (`MainActor.assumeIsolated`), and it drains with the same zero-budget
+  `PTYWrite.all`: write what the kernel takes, keep the rest, return to the
+  run loop. The source fires at most once per kernel-accepted chunk — about
+  once per KiB the child reads — so a multi-MiB paste costs the main queue a
+  few thousand short callbacks spread over the seconds the child takes to read
+  it, which is the child's pace and not the app's.
+- **The bound is `EIO`/`EBADF`, never a clock.** A child that does not drain
+  for thirty seconds holds the outbox for thirty seconds. That is the truth of
+  the session: tmux, in the same state, buffers the same bytes for the same
+  time. What the user gets is not a timeout but a signal (below).
+- **`EIO` drops the outbox and logs** how many bytes were unwritten, at
+  `.error`, once. The reader's own `EOF` handling ends the panel's session;
+  the write side does not need to.
+
+### Teardown and detach
+
+- **`stopHolderReader`** (`TerminalPanelView.swift:949`) cancels the write
+  source before closing `holderWriteFD` (`:960`); both are main-actor, and a
+  cancelled source on the same serial queue cannot fire after its
+  cancellation. The outbox is dropped there, with one `.error` line naming
+  the byte count, and `shutdown()` keeps its existing job of releasing parked
+  injections as unwritten.
+- **A detach with a remainder outstanding drops it.** The handback carries
+  the screen, not unwritten input, and a person who closes a tab during a
+  stall loses the tail of their own paste — logged, not silent. One hazard
+  is named rather than solved: if the remainder held a paste's end marker,
+  the child is left mid-paste after the handback and a later injection can
+  be absorbed into it. Keeping the writer alive past the handback just long
+  enough to land the marker is possible — writers are not readers, and the
+  descriptor rules allow it — but it puts new state into the most delicate
+  teardown in the file for a case that requires a large paste, a stalled
+  child, and a close inside the stall. It is a decision, below.
+
+### The injection path, in the interim before single-typist
+
+Until the holder `write` verb lands, an injection into an attached session is
+still written by the viewer, and the outbox changes what a short one means:
+
+- **The remainder of an injection goes into the same outbox**, behind the
+  paste hold it already respects, and subsequent user bytes are held behind
+  it. This is the single-typist keystroke hold, exercised early and for the
+  same payload shape, with one difference: it is released by the descriptor
+  rather than by an `injectionDone` frame, because in the interim the viewer
+  is the process making the syscall and can see the completion itself.
+- **The ack is `written: true` on acceptance.** Acceptance by a writer that
+  completes or reports is the meaning `true` already has on the other two
+  arms, and it is the meaning single-typist gives its own `accepted` outcome
+  ("a success, not a deferral: the bytes are in the process that owns the
+  pty"). The viewer owns the pty while attached. The ack is sent in the same
+  turn as today, so the 2 s / 5 s ordering is untouched.
+- **What this fixes at once.** Case 1's first shape — truncated fragment plus
+  an honest error — becomes a completed injection and a truthful dispatch.
+  Case 1's second shape — prefix plus whole through a timed-out attach — is
+  gone, because `false` is no longer produced for a partial.
+- **The residue, named.** An app that dies with an injection remainder in its
+  outbox has acked `true` for bytes that will not land. The daemon's
+  app-death path seizes the session (`HolderRegistry.swift:1457`, `:1519`),
+  so the event is loud, but the actuation row reads dispatched. This is the
+  same residue the `localProcess` and sidecar arms carry today under the same
+  `true`, and it is the residue single-typist deletes by deleting the viewer's
+  injection write altogether. The alternative — acking on completion — would
+  push a slow child's ack past the 5 s deadline and trigger the fallback on a
+  write still in progress, which the alternatives research already rejected
+  (`2026-09-03-injection-delivery-alternatives.md`, section 8). A two-phase
+  sidecar ack would be correct and is not built, because single-typist
+  deletes the frames it would ride on.
+
+### The signal, instead of silence
+
+- **The diagnostic stops lying.** `noteUserWriteOutcome` is fed `false` only
+  when there is genuinely no transport; a short write is not a transport
+  failure and never reaches it. A separate edge-triggered `.info` line marks
+  the start and end of an outbox episode with the peak byte count.
+- **The user sees backpressure.** When the outbox has been non-empty for
+  longer than a short threshold (on the order of a second, on an injected
+  clock), the panel shows that the session is not accepting input and how
+  much is waiting, and clears it when the outbox drains. The mechanism is a
+  published pending-byte count on the coordinator; the presentation is a
+  minor UI question and not fixed here. In-pane status lines of the
+  `"\r\n[...]\r\n"` kind are *not* used for this: they write into the
+  scrollback of a session that is mid-paste.
+- **Senders learn `accepted` versus `delivered`** under single-typist's
+  outcomes; the interim ack cannot carry the distinction and does not
+  pretend to.
+
+## The daemon's paths
+
+### The detached path and the holder verb
+
+A queued prompt into a *detached* session — the most common supervision
+shape — goes through `HolderReader.write` (`HolderReader.swift:520`) and the
+250 ms `writeAll`. Above a kilobyte into a busy agent it truncates exactly as
+the viewer's path does, and returns an honest `writeTimedOut`. This document
+does not give that path a stopgap, for two reasons that are both in the
+single-typist spec:
+
+- **The fix is the holder outbox**, drained from the holder's own `poll` loop
+  (`Sources/TBDHolder/Holder.swift:392-435`, 50 ms slices at `:604`) with
+  `POLLOUT` on the master while an outbox is non-empty, bounded by `EIO`.
+  That is designed, approved and unbuilt; building a second outbox in the
+  daemon's `DrainLoop` first would spend the same effort in the place the
+  spec chose not to put it.
+- **Lengthening the budget is the one move that must not be made.** `writeAll`
+  holds the read lock across its `poll` waits; a longer wait stalls the drain,
+  and a child blocked on its output does not read its input. Raising 250 ms
+  makes the detached path *less* likely to complete, not more.
+
+### The version-skew fallback
+
+Single-typist keeps the daemon's direct write for sessions whose holder
+predates the `write` verb — a write-only handle, demoted from the reader on
+attach. That handle inherits `writeAll` and its 250 ms truncation point for
+the remaining life of those sessions. The recommendation is to leave it
+budgeted and honest: the population is bounded (holders are never upgraded in
+place, so it only shrinks), the error names the unwritten count, and the
+alternative is a daemon-side outbox drained off the lock — real work for a
+shrinking population. If the interim before the verb lands turns out to be
+long, that judgment should be revisited; it is a decision, below.
+
+## Candidates, evaluated
+
+Each candidate against the brief's criteria: does the whole payload arrive,
+can it double, can it tear or truncate, can it wedge the session, what it
+costs, and what it newly breaks.
+
+- **Loop longer inline** – raising 20 ms or 250 ms. Arrives only if the child
+  drains within the new budget; never doubles; truncates past the budget;
+  still wedges on a lost marker; costs nothing to build; blocks the main actor
+  (viewer) and stalls the drain under the lock (daemon). Rejected: it moves
+  the truncation point without removing it.
+- **Refuse or chunk-and-confirm** – see "Avoidance is not available". Not
+  buildable on a pty.
+- **A viewer outbox with a hold on user bytes** (recommended for the viewer's
+  own writes and the interim injection) – arrives whenever the child ever
+  drains, bounded by `EIO`; never doubles from this process; cannot tear,
+  because nothing from this process is written between remainder chunks;
+  cannot leave a marker unwritten while the panel lives; costs a small
+  addition to `OutgoingInputQueue`, a write source, and a diagnostic; newly
+  creates the felt cost of held keystrokes during a stall (which were being
+  dropped before) and the drop-on-detach residue.
+- **A background writer thread owning the descriptor** – the read side's
+  shape, mirrored. Same delivery properties as the outbox; but every
+  keystroke would hop to the thread, or the queue would need a two-locus
+  "inline if idle, else hand off" rule with a lock between the main actor and
+  the thread. Rejected on the no-hop constraint and on complexity that buys
+  nothing the main-queue source lacks.
+- **A two-phase sidecar ack** (accepted now, delivered later) – would let the
+  daemon's record distinguish the two states in the interim. Rejected: it
+  builds frames and deadline logic that single-typist deletes, and the
+  interim's `accepted`-means-`true` already carries the honest half.
+- **The daemon completes through a retained write-only dup** – single-typist's
+  rejected primary and surviving fallback. Not re-litigated here.
+- **The holder outbox** – single-typist's answer for injections; arrives,
+  never doubles, cannot be torn by another injection, bounded by `EIO`. Not
+  re-derived here; this design sequences before it.
+- **Sender-side retry** – the courier's fallback today. Doubles the prefix.
+  Rejected as a mechanism; kept out of the interim by never reporting `false`
+  for a partial.
+
+## Sequencing against single-typist
+
+**This is a piece of that work, and it goes first.** Specifically:
+
+- The viewer outbox and the hold on user bytes *are* the keystroke hold
+  single-typist mandates, built with the user's own remainder as its first
+  client. When `injectionIntent` / `injectionDone` land, they become a second
+  reason for the same hold, with a clock bound of their own because they wait
+  on another process. Nothing has to be rebuilt.
+- It needs no protocol change, no holder change and no daemon change, so it
+  can land alone, be soaked alone, and fix cases 2 and 3 alone.
+  The felt cost of holding keystrokes — the one thing single-typist's soak
+  would otherwise be the first to discover — is discovered here, on the
+  person's own pastes, before the daemon depends on it.
+- Case 1 is fixed *properly* by the holder verb and *adequately* by the
+  interim semantics above; the interim code is the same outbox and is deleted
+  with the viewer's injection path when the verb lands.
+
+Two refinements to single-typist follow from the outbox, and should be
+carried into it when it is implemented rather than left to be rediscovered:
+
+- **"Paste open" for the lease means "until the end marker has been accepted
+  by the kernel"**, not "until `endUserPaste()` was called". With an outbox
+  the two can differ by as long as the child stalls, and a lease answered on
+  the delegate call is answered while the child is still mid-paste. The
+  viewer's own hold bound (2 s) and the daemon's lease bound (3 s) keep their
+  ordering; what changes is the residue they bound. Single-typist states that
+  an expired lease means the viewer is not running its main actor; with the
+  outbox it can also mean the viewer is alive and a large paste is still
+  draining into a stalled child. Both resolve the same way — the daemon
+  writes, the injection is absorbed into the paste, visible and never
+  doubled — and the second is rarer than the first. An explicit "still
+  draining" answer that extends the lease is the obvious refinement and is
+  deferred until a soak shows the residue is felt.
+- **The two kinds of bound stay distinct.** The user-remainder hold is
+  bounded by the descriptor; the injection hold is bounded by a clock.
+  Single-typist's text says its hold "ends on `injectionDone` or after its
+  own bound" and should not be read as applying that bound to the person's
+  own remainder.
+
+## Reconcilers
+
+Per the doctrine in
+[`2026-08-15-named-reconciler-doctrine-design.md`](2026-08-15-named-reconciler-doctrine-design.md):
+**this design introduces no new kind of durable resource and no new creation
+path to one.** The outbox is memory in the app, owned by a descriptor whose
+close drops it, in a panel whose teardown is already ordered; it writes no
+file, mints no process, and touches no row. The write source is a dispatch
+source cancelled by the same teardown that closes its descriptor. Nothing
+outlives the request that created it except in the app's own memory, and an
+app that dies takes its outbox with it — which is the interim residue named
+above, not an orphan.
+
+## Flag
+
+**No flag of its own.** The change is confined to holder-backed panels, which
+exist only under `pty_holder_enabled` (default off, `Config.ptyHolderDefault`,
+`Sources/TBDShared/Models.swift:1698`) and have never shipped on. It replaces
+the panel's write step, which the repo's rule names as flag-worthy — and the
+flag it lands behind is the one wrapped around the entire transport, for the
+reason single-typist gives: a second column would keep selectable a quadrant
+(holder on, completion off) that is known-defective in the three ways this
+document records. Both branches remain testable, because a tmux panel's write
+path is untouched. If this were to land after `pty_holder_enabled` had
+graduated, it would need its own default-off column with the tri-state
+discipline.
+
+## Testing
+
+- **The outbox against a real pty**: a pty pair with the slave in raw mode and
+  unread, which the measured 1,022-byte ceiling makes deterministic. A 4 KiB
+  write leaves a remainder; bytes enqueued afterwards are held in order; a
+  read on the slave drains in order and the slave receives every byte exactly
+  once; closing the slave produces `EIO`, drops the outbox, and logs once.
+- **The paste shape end to end**: three chunks through the production
+  `Coordinator.send` path with a full queue; the end marker is delivered after
+  the payload, and a keystroke enqueued after the paste is delivered after the
+  marker. This is the test that discriminates case 3.
+- **The interim ack**: a partial injection acks `true`; a full-queue
+  injection acks `true`; a dead descriptor acks `false`; a prefix followed by
+  `EIO` acks `false`. The daemon-side courier tests already cover what each
+  answer makes the daemon do.
+- **Teardown with a remainder**: `stopHolderReader` cancels the source before
+  the close, drops the outbox, logs the count, and a write source that fires
+  after cancellation is impossible on the same queue.
+- **The signal**: with an injected clock, the pending-byte indicator appears
+  after the threshold and clears on drain; the "no transport" line is never
+  logged for a short write.
+- **The write source on a pty master**: an implementation-time check that a
+  write-readiness source on a `dup` of a pty master fires when the slave
+  drains. If it does not, the fallback is a `poll(POLLOUT)` on a helper thread
+  that hops to the main queue once per readiness — one hop per accepted chunk,
+  never per keystroke.
+
+## What could not be determined
+
+- **How an agent TUI's parser treats a missing `ESC[201~`** — whether it
+  accumulates indefinitely (a wedge) or times out (a self-heal). The design
+  does not depend on the answer; the priority of the fix does.
+- **How long agents stall without draining stdin**, which sets how often the
+  hold is felt at the keyboard and how often single-typist's lease residue
+  occurs. Unmeasured; the outbox's backpressure indicator is what will
+  measure it in the field.
+- **Whether kqueue write-readiness fires on a `dup` of a pty master** on the
+  deployed macOS. Expected from the driver's kqueue support; to be checked
+  before the fallback is discarded.
+- **How often 20 ms suffices today** for a paste above a kilobyte into an idle
+  agent — that is, how often the outbox path will be the path taken. The
+  design treats it as ordinary.
+- **Per-byte tearing of a marker at the kernel** is read from the pty
+  driver's source, not measured. The measured addendum's probe establishes
+  the ceiling, not the cut boundary.
+
+## Decisions that need a human
+
+1. **Sequencing.** Land the viewer-side outbox and user-byte hold now, as the
+   first slice of single-typist, with the holder `write` verb next and no
+   separate stopgap for the daemon's detached path. *Recommended: yes.*
+   The alternative — a daemon-side outbox in `DrainLoop` as an interim —
+   builds half of single-typist's sender-outcome surface in the place the
+   spec chose not to put it.
+2. **Interim ack semantics.** While the viewer still writes injections,
+   `written: true` means "accepted by a completing writer", matching the
+   other two arms and single-typist's `accepted`. *Recommended: yes*, with
+   the app-death residue recorded in the PR. The alternative keeps today's
+   honest-error-with-truncated-fragment until the verb lands.
+3. **The bound on the user's own remainder.** Descriptor-bounded, no clock,
+   with a visible indicator; versus a clock bound that releases held
+   keystrokes to interleave into the remainder. *Recommended: no clock.*
+   Expiry would only convert a wedge into a tear while the queue is full.
+4. **Interrupt bypass.** None; `0x03` is held with everything else, as
+   single-typist rules for its own hold. *Recommended: none.*
+5. **Detach with a remainder outstanding.** Drop and log, with the mid-paste
+   hazard named; versus keeping the writer alive past the handback to land a
+   pending end marker. *Recommended: drop and log*, and file the marker case
+   as a follow-up if the soak shows it.
+6. **The lease refinement for single-typist.** "Paste open" means until the
+   end marker is kernel-accepted; the bounds keep their values; the new
+   residue is recorded; a "still draining" extension is deferred.
+   *Recommended: yes*, applied to the single-typist spec when it is
+   implemented.
+7. **The version-skew fallback.** Leave `writeAll` at 250 ms and honest for
+   sessions whose holder predates the verb, rather than giving the daemon's
+   handle an outbox. *Recommended: leave it*, revisited if the interim before
+   the verb is long.
+8. **The inline budget.** Drop `PTYWrite.defaultBudgetMilliseconds` to zero
+   once the outbox exists, so no keystroke ever polls on the main actor.
+   *Recommended: zero.*
+9. **Flag.** No column of its own; ships under `pty_holder_enabled`.
+   *Recommended: none.*
+10. **The backpressure indicator's form.** A panel-level indicator with the
+    pending byte count after about a second, not an in-pane status line.
+    *Recommended: panel-level*; the exact presentation is a minor UI choice
+    for the implementer.


### PR DESCRIPTION
## Summary

Paste a long prompt into an agent session that TBD renders through the pty
holder — a full-screen TUI, so the pty is in raw mode — and until now only the
first kilobyte arrived. A raw-mode pty master accepts 1,022 bytes and then
refuses; the app wrote once, waited 20 ms for room that a busy agent was never
going to make, and reported the whole write a failure with that first kilobyte
already committed. What the person saw was a prompt cut off mid-sentence, and,
because the paste's closing `ESC[201~` was part of what got dropped, a composer
left stuck in bracketed-paste mode.

After this change the panel finishes every write it starts. What the kernel
refuses is kept in an outbox, every later byte from every stream — the rest of
the paste, the keystrokes typed after it, a daemon injection released from the
paste hold — queues behind it whole and in arrival order, and the queue drains
whenever the pty says it can take more. A paste is no longer truncated, the end
marker is never lost, and a keystroke typed behind a stalled paste lands after
it rather than inside it.

The visible trade is that keystrokes are now *held* during a stall where they
were previously *dropped*. That is the intended trade, and a panel-level
backpressure banner is what makes it legible: "This session is not accepting
input — 4 KB waiting", shown only once a stall has outlasted a second, and
cleared when the outbox empties. It deliberately says nothing about loss,
because nothing is lost.

## Why this shape

Spec: [`docs/specs/2026-09-04-pty-write-completion-design.md`](docs/specs/2026-09-04-pty-write-completion-design.md).
All ten of its "decisions that need a human" were settled before implementation
and each resolved to its own recommendation.

The load-bearing decisions:

- **The bound is the descriptor, never a clock.** An episode ends on `EIO` (the
  last slave closed) or `EBADF` (teardown) and on nothing else. A clock that
  expired on a full queue could not write the released bytes either — it could
  only cut the payload with somebody else's bytes in the gap, which is the
  failure this change exists to remove.
- **"Written" means accepted by a writer that will complete or report.** That
  is the meaning the seam already carried on its `localProcess` and sidecar
  arms, where bytes go to `DispatchIO` and to a client send queue and neither
  can report a failure that happens after the call returns. The pty arm now
  joins them: a kernel refusal acks `written: true` because the app is that
  writer. Only a genuinely absent transport — no descriptor, an exited child,
  a disconnected sidecar — acks `false`.
- **No interrupt bypass.** `0x03` queues with everything else. It could not
  have been written any sooner in any case: the queue that refused everything
  else refuses it too.
- **The outbox is `[Data]`, not one buffer.** Contiguity comes from the FIFO;
  concatenating would copy a multi-megabyte paste on every append.
- **The drain notifier is armed only while the outbox is non-empty.** See the
  measurements below — this is a correctness requirement, not tidiness.

## What this PR does

- `PTYWrite.all` collapses to one non-blocking `write(2)` with no `poll`, and
  reports three outcomes: `.complete`, `.partial(written:)`, and
  `.failed(errno:written:)`. The 20 ms budget parameter is deleted rather than
  defaulted to zero — a parameter nobody passes, over a loop nothing reaches,
  is a hazard waiting for someone to restore it.
- `OutgoingInputQueue` gains the outbox, the hold, `drain()`, the episode
  diagnostic and the backpressure edges. It stays a `@MainActor final class`
  with synchronous, hop-free `enqueueUserBytes` / `beginUserPaste` /
  `endUserPaste`; appending to the outbox is O(1) and is the only new work a
  keystroke does.
- New `OutgoingDrainNotifier` seam plus `WriteSourceDrainNotifier`, a
  `DispatchSource` write source on the main queue over the panel's own pty
  descriptor.
- `TerminalPanelView`: `performOutgoingWrite` and `writeToHolderPTY` return an
  attempt outcome instead of `Bool`; the notifier's lifecycle is wired into
  `startHolderClient` / `stopHolderReader`, cancelled before the descriptor
  closes; the backpressure banner and its plumbing.
- `TerminalBackpressurePresentation` — the banner's copy as a pure function of
  the byte count, so a test can pin it without driving SwiftUI.
- Tests: `RawPTYPair` (a real pty pair, raw-mode and unread, in-process with no
  child), `OutgoingOutboxTests` (the outbox against a capacity-bounded fake —
  no pty, no timing), `HolderWriteOutboxTests` (the panel end to end against a
  real pty), `OutgoingDrainNotifierTests`, and the `PTYWrite`-level tests in
  `HolderInjectionDeliveryTests` following the outcome collapse.
- Prose: `holderWriteFD`'s doc, and the courier's `viewerReportedNothingWritten`
  doc, which described `false` as covering "every refusal the app can know
  synchronously" — a kernel refusal now acks `true`.

**Deliberately not changed:** `HolderReader.writeAll` keeps its 250 ms budget
and stays honest. The daemon's detached path still writes through
`HolderReader.write` on the daemon's own descriptor, and gives up on a payload
that does not land inside that budget — so the truncation this PR removes for
an attached panel remains real for a detached session. The daemon does not get
an outbox in this branch, and there is no holder `write` verb: the single-typist
spec designs one, and nothing in `Sources/` implements it
(`HolderProtocolVersion.current` is 1 and `HolderProtocol.swift` has no such
case). Closing the detached side is that spec's work, not this PR's.

## Flag & rollout

**No new flag.** This ships under `pty_holder_enabled`
(`Config.ptyHolderDefault`, `Sources/TBDShared/Models.swift:1698`), which is
default-off and has never shipped on. No new config column, no new
`UserDefaults` key.

Both branches of that gate stay testable, because both still exist: a tmux
panel's write path is untouched, and a holder panel's is this one. Adding a
second column would have created a broken quadrant — "holder on, outbox off" is
the truncating arrangement this change removes — and would double the soak for
a path with no users to protect.

Graduation is `pty_holder_enabled`'s own graduation; this changes nothing about
that plan.

## Reconcilers

No new kind of durable resource, and no new creation path to one. The outbox is
memory in the app, owned by a descriptor whose close drops it, inside a panel
whose teardown is already ordered: the drain notifier is cancelled by the same
teardown that closes the descriptor it watches, and `stopHolderReader` cancels
before the close rather than after. An app that dies takes its outbox with it,
which is the interim residue named below and not an orphan for a sweep to find.

## Assumptions

- **The panel's pty descriptor is `O_NONBLOCK`.** The flag lives on the open
  file description the daemon opened and rides the `dup`. A blocking descriptor
  would park the main actor inside `PTYWrite.all` instead of returning a
  refusal. If that ever stops being true, keystroke latency breaks, not
  correctness.
- **The kernel cuts a write wherever it runs out of room**, including inside a
  multi-byte UTF-8 sequence or a paste marker. Nothing tries to choose the cut.
  What heals it is the hold: the next accepted bytes continue the same stream
  with nothing written in between.
- **A viewer that stops draining stalls its own writes.** While attached, the
  panel is the session's reader, so an agent blocked on output does not read
  its input. Completion is coupled to the app's liveness for everything past
  the first kilobyte; delivery and non-duplication are not.

## The interim ack residue, stated plainly

With the interim ack, a kernel refusal reports `written: true` to the daemon,
because the bytes are with a writer that will complete them. **If that writer
goes away before the outbox drains, those bytes are lost and the daemon has
already been told they landed.** The actuation row reads dispatched for a
message that did not fully arrive.

**It is not only app death.** `stopHolderReader` calls
`outgoingQueue.shutdown()`, which drops the outbox on *every* panel teardown —
closing the tab, detaching, or a refused `attach.ready`. So an injection acked
`true` with its remainder queued behind a stalled child is lost when a person
closes that tab, with the app perfectly alive and the daemon re-adopting a
session that never learns. Supervision nudges are aimed at busy agents, and
closing a busy agent's tab is an ordinary thing to do, so this is the more
reachable half of the residue rather than a corner of it.

The event is not silent — the daemon's app-death path seizes the session
(`HolderRegistry.swift:1457`, `:1519`), so app death itself is loud — but the
row is wrong, and nothing reconciles it. This is the same residue the
`localProcess` and sidecar arms already carry under the same `true`, now
extended to cover a remainder rather than only an in-flight handoff.
`2026-09-03-single-typist-injection-design.md` deletes it outright, by deleting
the viewer's injection write.

## Evidence & verification

### The spike, and what it settled

Before any of this was built, a throwaway spike (compiled with `swiftc`
directly, nothing committed) measured a real pty on this kernel. Verdict A:
**write-readiness fires cleanly on a `dup` of a pty master.** The shipped
notifier is therefore `WriteSourceDrainNotifier`, a `DispatchSource` write
source on the main queue.

- **Raw-mode ceiling: 1,022 bytes** (`TTYHOG − 2`), then `EAGAIN` immediately —
  identical across six runs of six. This is what makes `RawPTYPair`
  deterministic. No test hard-codes the number; each learns its own kernel's
  ceiling.
- **The source fires after the child drains: 3/3.** The load-bearing question.
- **The source is quiet while the queue is full and nothing drains: 0 fires,
  3/3** — but only a *fresh* source armed after the queue is already full
  answers that question. Arming a source that was suspended while the queue was
  empty reports exactly one fire, a resume-edge artifact that is neither
  "silent" nor "spinning".
- **An armed source over an idle, writable pty with a handler that writes
  nothing fires 44,486 / 182,060 / 47,845 times per second.** This is why
  disarm-on-empty is a correctness requirement rather than an efficiency one:
  an outbox left armed while empty is the main queue at 100% for as long as the
  panel is open. Every path that can empty the outbox disarms on that edge, and
  a test walks all four of them (nothing was ever refused, drained to empty,
  transport died, teardown).
- **With a production-shaped handler** — drain until `EAGAIN` on every fire —
  it self-limits to a few hundred main-queue hops per second carrying 1.3–1.9
  KB each: 247 hops / 428 KB, 187 / 239 KB, 507 / 939 KB. That confirms the
  spec's cost claim of about one hop per KiB the child reads.
- **`poll(POLLOUT)` reports readiness on the same `dup`** (`revents = 4`). The
  `poll`-thread notifier therefore stays viable as a fallback. It was not
  needed and is not built; the `OutgoingDrainNotifier` protocol is the seam
  that would take it.
- **The suspend/resume balance.** Only `suspend → cancel → resume → release`
  survives. Releasing a source whose suspend count is non-zero traps with
  SIGTRAP 133, and so does over-resuming. After `suspend → cancel`, the cancel
  handler does not run until a rebalancing `resume()` lands — a deferred-close
  ordering hazard the teardown path respects.

### Tests

Three tiers, each discriminating:

- **No pty, no timing** — the outbox against a fake transport with a byte
  capacity, which models a full tty input queue exactly. The remainder is kept,
  later chunks are held in order and never overtake it, a drain delivers every
  byte exactly once, the arm and disarm edges fire once per episode, an
  injection released by `endUserPaste` lands after an end marker still queued,
  a dead transport drops the outbox and logs once, a short write never logs a
  transport failure, and the banner appears only after the threshold and clears
  on drain.
- **A real pty** — `RawPTYPair`, raw-mode and unread, in-process with no child
  (all test targets compile into one process and Swift Testing runs suites in
  parallel, so `forkpty` here would be a multithreaded fork and a stray process
  on a shared machine). The three-chunk paste, the keystroke behind it, the
  interim ack matrix, teardown with a remainder outstanding.
- **The notifier itself** — arm/disarm idempotence and the teardown balance.

Three properties are deliberately untested, each with a comment saying why
rather than an assertion that greens either way: the absence of the `poll` (any
threshold separating 0 ms from 20 ms is inside the noise of a loaded machine —
what replaces the test is the type, which has no budget parameter and no
`poll`); and two named in the plan at Task 3 and Task 6.

### Follow-up filed, not built

**A detach with a pending end marker leaves the child mid-paste.** Decision #5
accepts this for now: the remainder is dropped at teardown, and if it held the
closing `ESC[201~` the child stays in bracketed-paste mode until something else
closes it. File it as an issue if the soak shows it is felt.

**An explicit "still draining" answer for the single-typist paste lease.** The
lease's expiry now has a second reading — a viewer that is alive with a large
paste still draining into a stalled child. It resolves the same way as the
first (the daemon writes on its bound, the injection is absorbed into the
person's paste, visible and never doubled), and the refinement waits on a soak
showing the residue is felt. Recorded in
`docs/specs/2026-09-03-single-typist-injection-design.md`.

---

[20260830-boring-panda](https://cheapsteak.github.io/tbd/open/?worktree=A1E9CF50-E608-4F3C-BA8F-377D60BB7478)

https://claude.ai/code/session_01VmxVag4BeDdC65msZCawvK



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Terminal input now preserves ordering and completes partially accepted writes, including large pastes and injected input.
  - Added a passive backpressure indicator showing pending terminal input.
  - Launch data is transferred through a protected channel without exposing request contents in process arguments.

- **Bug Fixes**
  - Improved handling of stalled, disconnected, and closing terminal sessions, with clearer completion, failure, and exit-status reporting.

- **Documentation**
  - Added specifications covering terminal write completion, input sequencing, backpressure, and injection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->