### PR TITLE
Feat: Turn the pty-holder transport on from Settings instead of by hand-crafting a socket message

### DIFF
--- a/Sources/TBDApp/AppState+ModelProfiles.swift
+++ b/Sources/TBDApp/AppState+ModelProfiles.swift
@@ -382,6 +382,48 @@ extension AppState {
         }
     }
 
+    /// Help text for the pty-holder transport toggle.
+    ///
+    /// A stored constant rather than a literal in the view so it is assertable:
+    /// it must describe what changes and when, and it must **not** promise
+    /// speed. The design spec is explicit that the justification is scaling
+    /// headroom rather than current latency — there is no measured latency win
+    /// on a quiet machine — so a rewrite that added one would be telling the
+    /// operator something untrue about their own machine.
+    static let ptyHolderHelp = """
+        Each new session runs on its own terminal rather than inside a tmux \
+        window. Sessions already running stay on tmux; the change takes effect \
+        as they end and respawn. Attached sessions keep running uninterrupted \
+        across daemon restarts. Less scrollback is kept than tmux retains. Off \
+        by default (soaking).
+        """
+
+    /// Why the pty-holder toggle is inert on this daemon. Shown only when
+    /// `ptyHolderSupported` is false, mirroring the control-mode toggle's
+    /// "Requires tmux 3.2 or later" caption: with the flag on and no way to
+    /// start a holder, every create falls back to tmux silently, so the switch
+    /// would change nothing at all.
+    static let ptyHolderUnsupportedCaption =
+        "Requires the TBDHolder helper beside the daemon binary; this daemon could not find it."
+
+    /// Persist the pty-holder transport gate, then re-fetch capabilities so the
+    /// Settings toggle reflects the daemon's persisted state.
+    ///
+    /// **Applies to sessions created after the call, and to no others.** A
+    /// session records its transport at creation and keeps it for life, so
+    /// turning this on never moves a running tmux session onto a holder, and
+    /// turning it off never takes a live holder session away.
+    func setPtyHolderEnabled(_ enabled: Bool) async {
+        do {
+            try await ptyHolderFlagSetter(enabled)
+            await refreshDaemonCapabilities()
+        } catch {
+            logger.error("Failed to set pty holder transport: \(error, privacy: .public)")
+            showAlert(
+                "Failed to set the session transport: \(error.localizedDescription)", isError: true)
+        }
+    }
+
     /// Persist the worktree auto-trust switch, then re-fetch capabilities so
     /// the Settings toggle reflects the daemon's persisted state. Applies to
     /// the next Claude spawn or wake; never un-trusts an already-seeded path.

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -1434,6 +1434,10 @@ final class AppState {
     /// injectable for the same reason as `controlModeSetter`.
     @ObservationIgnored lazy var queuedPromptFlagSetter: @MainActor (Bool) async throws -> Void =
         { [daemonClient] enabled in try await daemonClient.setQueuedPrompt(enabled: enabled) }
+    /// How `setPtyHolderEnabled` persists the pty-holder transport gate —
+    /// injectable for the same reason as `controlModeSetter`.
+    @ObservationIgnored lazy var ptyHolderFlagSetter: @MainActor (Bool) async throws -> Void =
+        { [daemonClient] enabled in try await daemonClient.setPtyHolderEnabled(enabled: enabled) }
     /// How `setClaudeCloudEnabled` persists the Claude cloud gate — injectable
     /// for the same reason as `controlModeSetter`, so the Settings toggle's
     /// success and failure branches are testable without a real daemon.

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -1179,6 +1179,18 @@ actor DaemonClient {
         )
     }
 
+    /// Persist the pty-holder transport gate (default OFF). Read fresh at spawn
+    /// time, so no daemon restart is needed — but it applies only to sessions
+    /// created after the call: a session records its transport at creation and
+    /// keeps it for life. Sending either value is an explicit gesture that
+    /// survives a later change to the shipped default.
+    func setPtyHolderEnabled(enabled: Bool) async throws {
+        try await callVoidAsync(
+            method: RPCMethod.configSetPtyHolderEnabled,
+            params: ConfigSetPtyHolderEnabledParams(enabled: enabled)
+        )
+    }
+
     /// Persist the Claude cloud sessions gate (default OFF). The daemon builds
     /// its provider manager only at boot, so this takes effect on the next
     /// daemon restart rather than the next gesture.

--- a/Sources/TBDApp/Settings/SettingsView.swift
+++ b/Sources/TBDApp/Settings/SettingsView.swift
@@ -268,6 +268,7 @@ struct GeneralSettingsTab: View {
                 Toggle("Suspend idle Claude before sleep", isOn: $autoSuspend)
                     .help("Experimental: best-effort exit idle Claude instances when the machine is about to sleep, so a tmux server that dies during a long sleep has less to recover. Off by default — may interrupt long-running work.")
                 controlModeToggle
+                ptyHolderToggle
                 hibernateInputVetoToggle
                 autoCloseSetupToggle
                 queuedPromptToggle
@@ -301,6 +302,28 @@ struct GeneralSettingsTab: View {
             )
             .font(.caption)
             .foregroundStyle(.secondary)
+        }
+    }
+
+    /// Pty-holder transport opt-in. Reads the persisted flag from
+    /// `daemon.capabilities` and writes via `config.setPtyHolderEnabled`.
+    /// Disabled with an explanation when the daemon could not locate the
+    /// `TBDHolder` helper — the same second half the spawn gate asks, without
+    /// which the flag would be honored by falling back to tmux every time.
+    @ViewBuilder
+    private var ptyHolderToggle: some View {
+        let capabilities = appState.daemonCapabilities
+        let supported = capabilities?.ptyHolderSupported ?? false
+        Toggle("Run new sessions without tmux", isOn: Binding(
+            get: { capabilities?.ptyHolderEnabled ?? false },
+            set: { newValue in Task { await appState.setPtyHolderEnabled(newValue) } }
+        ))
+        .help(AppState.ptyHolderHelp)
+        .disabled(!supported)
+        if !supported {
+            Text(AppState.ptyHolderUnsupportedCaption)
+                .font(.caption)
+                .foregroundStyle(.secondary)
         }
     }
 

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -840,7 +840,14 @@ public final class RPCRouter: Sendable {
             claudeCloudEnabled: config.claudeCloudEnabled,
             claudeCloudLive: claudeCloudLive,
             remoteDeleteEnabled: config.remoteDeleteEnabled,
-            updateMode: config.updateMode))
+            updateMode: config.updateMode,
+            ptyHolderEnabled: config.ptyHolderEnabled,
+            // The same second half the spawn gate asks
+            // (`WorktreeLifecycle+Create`): a registry can exist and still be
+            // unable to start a holder, and with the flag on that combination
+            // falls back to tmux silently. Reported so Settings can say so
+            // instead of offering a switch that would change nothing.
+            ptyHolderSupported: holderRegistry?.canSpawn == true))
     }
 
     // MARK: - PR Status

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -3557,6 +3557,20 @@ public struct DaemonCapabilitiesResult: Codable, Sendable {
     /// `config.get` so the toggle and the daemon can never disagree about which
     /// of them last wrote the column.
     public let updateMode: UpdateMode
+    /// Whether the pty-holder transport gate (`pty_holder_enabled`) is set.
+    /// Default OFF while it soaks. Read at spawn time, so the Settings toggle
+    /// reads it back from here rather than from a local guess — and a session
+    /// already running keeps the transport it was created on either way.
+    public let ptyHolderEnabled: Bool
+    /// Whether this daemon could actually put a new session on a holder — that
+    /// is, whether it located the `TBDHolder` helper beside its own binary
+    /// (`HolderRegistry.canSpawn`). Computed daemon-side, exactly as
+    /// `controlModeSupported` is, so the app never inspects the filesystem.
+    ///
+    /// With the flag on and this false, every create silently falls back to
+    /// tmux — so Settings disables the toggle and says why rather than offering
+    /// a switch that would change nothing.
+    public let ptyHolderSupported: Bool
 
     public init(controlModeEnabled: Bool,
                 tmuxVersion: String? = nil,
@@ -3572,7 +3586,9 @@ public struct DaemonCapabilitiesResult: Codable, Sendable {
                 claudeCloudEnabled: Bool = Config.claudeCloudEnabledDefault,
                 claudeCloudLive: Bool = false,
                 remoteDeleteEnabled: Bool = Config.remoteDeleteEnabledDefault,
-                updateMode: UpdateMode = Config.updateModeDefault) {
+                updateMode: UpdateMode = Config.updateModeDefault,
+                ptyHolderEnabled: Bool = Config.ptyHolderDefault,
+                ptyHolderSupported: Bool = false) {
         self.controlModeEnabled = controlModeEnabled
         self.tmuxVersion = tmuxVersion
         self.controlModeSupported = controlModeSupported
@@ -3588,6 +3604,8 @@ public struct DaemonCapabilitiesResult: Codable, Sendable {
         self.claudeCloudLive = claudeCloudLive
         self.remoteDeleteEnabled = remoteDeleteEnabled
         self.updateMode = updateMode
+        self.ptyHolderEnabled = ptyHolderEnabled
+        self.ptyHolderSupported = ptyHolderSupported
     }
 
     public init(from decoder: Decoder) throws {
@@ -3636,6 +3654,16 @@ public struct DaemonCapabilitiesResult: Codable, Sendable {
         // whole decode.
         updateMode = (try? c.decode(UpdateMode.self, forKey: .updateMode))
             ?? Config.updateModeDefault
+        // New fields for the pty-holder transport gate. A daemon that does not
+        // send `ptyHolderEnabled` has no holder path at all, so fall through to
+        // the shipped default rather than assuming the transport is live.
+        // `supported` is a fact about THIS daemon's own installation, so an
+        // absent value is honestly false — which greys the toggle out on an
+        // older daemon instead of offering a switch it would ignore.
+        ptyHolderEnabled = try c.decodeIfPresent(
+            Bool.self, forKey: .ptyHolderEnabled) ?? Config.ptyHolderDefault
+        ptyHolderSupported = try c.decodeIfPresent(
+            Bool.self, forKey: .ptyHolderSupported) ?? false
     }
 }
 

--- a/Tests/TBDAppTests/PtyHolderSettingsTests.swift
+++ b/Tests/TBDAppTests/PtyHolderSettingsTests.swift
@@ -1,0 +1,136 @@
+import Foundation
+import Testing
+@testable import TBDApp
+import TBDShared
+
+/// The Settings surface for the pty-holder transport gate — the flag that had
+/// no user-facing control at all, so its soak could not be started by any
+/// ordinary gesture.
+///
+/// Every test that constructs `AppState` does so against a unique throwaway
+/// `UserDefaults` suite and tears it down — TBDApp ships as an unbundled SPM
+/// executable, so `UserDefaults.standard` is the running developer's real
+/// `TBDApp.plist`.
+@MainActor
+@Suite("PtyHolderSettings")
+struct PtyHolderSettingsTests {
+
+    private func withAppState(_ body: (AppState) async -> Void) async {
+        let name = "tbd-pty-holder-settings-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: name)!
+        await body(AppState(userDefaults: defaults))
+        defaults.removePersistentDomain(forName: name)
+    }
+
+    // MARK: - The setter, both directions and both branches
+
+    @Test func setterPersistsOnAndRefreshesCapabilities() async {
+        await withAppState { state in
+            var written: [Bool] = []
+            var refreshes = 0
+            state.ptyHolderFlagSetter = { @MainActor enabled in written.append(enabled) }
+            state.daemonCapabilitiesFetcher = { @MainActor in
+                refreshes += 1
+                return DaemonCapabilitiesResult(
+                    controlModeEnabled: false, ptyHolderEnabled: true, ptyHolderSupported: true)
+            }
+
+            await state.setPtyHolderEnabled(true)
+
+            #expect(written == [true])
+            #expect(refreshes == 1)
+            #expect(state.daemonCapabilities?.ptyHolderEnabled == true)
+        }
+    }
+
+    /// The off branch is its own test rather than a second assertion, because
+    /// turning the transport OFF is the operator's exit from the soak and a
+    /// setter that ignored its argument would pass the on-only test.
+    @Test func setterPersistsOffAndRefreshesCapabilities() async {
+        await withAppState { state in
+            var written: [Bool] = []
+            state.ptyHolderFlagSetter = { @MainActor enabled in written.append(enabled) }
+            state.daemonCapabilitiesFetcher = { @MainActor in
+                DaemonCapabilitiesResult(
+                    controlModeEnabled: false, ptyHolderEnabled: false, ptyHolderSupported: true)
+            }
+
+            await state.setPtyHolderEnabled(false)
+
+            #expect(written == [false])
+            #expect(state.daemonCapabilities?.ptyHolderEnabled == false)
+        }
+    }
+
+    @Test func setterSurfacesAFailureAndLeavesCapabilitiesAlone() async {
+        struct Boom: Error {}
+        await withAppState { state in
+            var refreshes = 0
+            state.ptyHolderFlagSetter = { @MainActor _ in throw Boom() }
+            state.daemonCapabilitiesFetcher = { @MainActor in
+                refreshes += 1
+                return nil
+            }
+
+            await state.setPtyHolderEnabled(true)
+
+            #expect(refreshes == 0, "a failed write must not be followed by a refresh")
+            #expect(state.alertMessage != nil)
+        }
+    }
+
+    // MARK: - The help text
+
+    /// The one claim the design spec forbids. Its §"why" is explicit that the
+    /// justification is scaling headroom, not current latency — there is no
+    /// measured win on a quiet machine — so a rewrite that promised speed
+    /// would tell the operator something untrue about their own machine. This
+    /// assertion fails on exactly that rewrite and on nothing else a faithful
+    /// edit would do.
+    @Test func theHelpTextMakesNoSpeedClaim() {
+        let help = AppState.ptyHolderHelp.lowercased()
+        for word in ["faster", "fast", "speed", "quicker", "latency", "snappier", "responsive"] {
+            #expect(!help.contains(word), "the help text must not promise speed: found \"\(word)\"")
+        }
+    }
+
+    /// The four things an operator has to know before flipping it, each of
+    /// which is a fact about their sessions rather than a description of the
+    /// implementation. Pinned by substring per fact, so a rewording that keeps
+    /// a fact passes and a rewrite that drops one fails.
+    @Test func theHelpTextCarriesEveryFactAnOperatorNeeds() {
+        let help = AppState.ptyHolderHelp
+        #expect(help.contains("Each new session runs on its own terminal rather than inside a tmux window."),
+                "what changes, and that it is per-session")
+        #expect(help.contains("Sessions already running stay on tmux; the change takes effect as they end and respawn."),
+                "that it is not retroactive")
+        #expect(help.contains("Attached sessions keep running uninterrupted across daemon restarts."),
+                "what the operator gains")
+        #expect(help.contains("Less scrollback is kept than tmux retains."),
+                "what the operator gives up")
+        #expect(help.contains("Off by default (soaking)."))
+    }
+
+    /// The disabled-state caption. It exists because the spawn gate asks two
+    /// questions, not one: with no `TBDHolder` helper the flag is honored by
+    /// falling back to tmux every single time, so a switch offered there would
+    /// change nothing. The caption has to name the missing helper — "not
+    /// available" alone would leave the operator with nothing to fix.
+    @Test func theUnsupportedCaptionNamesTheMissingHelper() {
+        #expect(AppState.ptyHolderUnsupportedCaption ==
+            "Requires the TBDHolder helper beside the daemon binary; this daemon could not find it.")
+    }
+
+    // MARK: - What the toggle renders from
+
+    /// Capabilities are nil until the first successful fetch, and the toggle
+    /// must read OFF and greyed rather than claiming a transport the daemon has
+    /// not confirmed.
+    @Test func anUnfetchedCapabilityReadsOffAndUnsupported() async {
+        await withAppState { state in
+            #expect(state.daemonCapabilities == nil)
+            #expect((state.daemonCapabilities?.ptyHolderEnabled ?? false) == false)
+            #expect((state.daemonCapabilities?.ptyHolderSupported ?? false) == false)
+        }
+    }
+}

--- a/Tests/TBDDaemonTests/PtyHolderSettingsRPCTests.swift
+++ b/Tests/TBDDaemonTests/PtyHolderSettingsRPCTests.swift
@@ -1,0 +1,197 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+import TestSupport
+
+/// The RPC surface behind the Settings toggle for the pty-holder transport:
+/// the `config.setPtyHolderEnabled` verb and the `daemon.capabilities`
+/// read-back the toggle renders from.
+///
+/// The toggle reads the daemon's value rather than a local guess, so the two
+/// halves it renders — the persisted flag and whether this daemon could
+/// actually start a holder — both have to arrive over the wire and both have
+/// to be able to say either thing.
+@Suite("Pty holder settings RPC")
+struct PtyHolderSettingsRPCTests {
+
+    private func makeRouterAndDB() throws -> (RPCRouter, TBDDatabase) {
+        let db = try TBDDatabase(inMemory: true)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db,
+                git: GitManager(),
+                tmux: TmuxManager(dryRun: true),
+                hooks: HookResolver()
+            ),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date(),
+            actuationLog: makeTestActuationLog()
+        )
+        return (router, db)
+    }
+
+    private func setPtyHolder(_ router: RPCRouter, enabled: Bool) async throws {
+        let request = try RPCRequest(
+            method: RPCMethod.configSetPtyHolderEnabled,
+            params: ConfigSetPtyHolderEnabledParams(enabled: enabled))
+        let response = await router.handle(request)
+        #expect(response.success, "error: \(response.error ?? "nil")")
+    }
+
+    private func capabilities(_ router: RPCRouter) async throws -> DaemonCapabilitiesResult {
+        let response = await router.handle(RPCRequest(method: RPCMethod.daemonCapabilities))
+        return try response.decodeResult(DaemonCapabilitiesResult.self)
+    }
+
+    // MARK: - config.setPtyHolderEnabled
+
+    @Test("config.setPtyHolderEnabled persists the opt-in")
+    func setEnabledPersists() async throws {
+        let (router, db) = try makeRouterAndDB()
+        try await setPtyHolder(router, enabled: true)
+        #expect(try await db.config.get().ptyHolderEnabled == true)
+    }
+
+    /// The off branch, and it is not the same assertion as "never touched": a
+    /// deliberate opt-out has to be a real `0`, so it survives the day the
+    /// shipped default graduates to true.
+    @Test("config.setPtyHolderEnabled persists an explicit opt-out as a real 0")
+    func setDisabledPersists() async throws {
+        let (router, db) = try makeRouterAndDB()
+        try await setPtyHolder(router, enabled: false)
+        #expect(try await db.config.get().ptyHolderEnabled == false)
+        let stored = try await db.writerForTests.read { conn in
+            try ConfigRecord.fetchOne(conn, key: ConfigStore.singletonID)?.pty_holder_enabled
+        }
+        #expect(stored == false, "an explicit off must be a stored 0, not a NULL")
+    }
+
+    /// The third state: nobody has chosen. A row that has never been written
+    /// reads NULL, so the shipped default is what the toggle shows — and the
+    /// opt-out above is distinguishable from it.
+    @Test("an untouched install stores NULL, not a 0")
+    func untouchedStoresNull() async throws {
+        let (_, db) = try makeRouterAndDB()
+        let stored = try await db.writerForTests.read { conn in
+            try ConfigRecord.fetchOne(conn, key: ConfigStore.singletonID)?.pty_holder_enabled
+        }
+        #expect(stored == nil)
+    }
+
+    // MARK: - daemon.capabilities
+
+    @Test("capabilities reports the pty-holder flag OFF by default")
+    func capabilitiesDefaultsOff() async throws {
+        let (router, _) = try makeRouterAndDB()
+        #expect(try await capabilities(router).ptyHolderEnabled == Config.ptyHolderDefault)
+        #expect(Config.ptyHolderDefault == false, "the shipped default is still OFF during the soak")
+    }
+
+    /// The round trip the toggle actually performs: set, read back, set back,
+    /// read back. Both directions, because a payload that hard-coded either
+    /// value would pass a one-directional test.
+    @Test("capabilities re-evaluates the pty-holder flag without a restart")
+    func capabilitiesReEvaluatesFlag() async throws {
+        let (router, _) = try makeRouterAndDB()
+
+        try await setPtyHolder(router, enabled: true)
+        #expect(try await capabilities(router).ptyHolderEnabled == true)
+
+        try await setPtyHolder(router, enabled: false)
+        #expect(try await capabilities(router).ptyHolderEnabled == false)
+    }
+
+    // MARK: - The supported half
+
+    /// No registry at all — mock mode, and the state every unit-test router is
+    /// in. `canSpawn` cannot be true, so Settings greys the toggle out.
+    @Test("capabilities reports the transport unsupported with no registry")
+    func capabilitiesUnsupportedWithoutRegistry() async throws {
+        let (router, _) = try makeRouterAndDB()
+        #expect(try await capabilities(router).ptyHolderSupported == false)
+    }
+
+    /// A registry that exists but has no spawner — a daemon whose `TBDHolder`
+    /// binary an upgrade moved away. The registry is still built, because
+    /// adoption reaches a running holder through its socket; it just cannot
+    /// start a new one, so the create gate falls back to tmux and the toggle
+    /// must not claim otherwise.
+    @Test("capabilities reports unsupported for a registry that cannot spawn")
+    func capabilitiesUnsupportedWithoutSpawner() async throws {
+        let (router, _) = try makeRouterAndDB()
+        router.holderRegistry = HolderRegistry(
+            owner: HolderOwnerToken(rawValue: "acme-installation"),
+            environment: ["TBD_HOME": "/tmp/tbd-ph-\(UUID().uuidString.prefix(8))"],
+            listTerminals: { [] },
+            spawner: nil)
+        #expect(try await capabilities(router).ptyHolderSupported == false)
+    }
+
+    /// The opposite branch, so the field is not merely a constant false: a
+    /// registry holding a spawner reports supported. `canSpawn` is decided in
+    /// `init` from the spawner's presence alone, so nothing is launched here.
+    @Test("capabilities reports supported for a registry that can spawn")
+    func capabilitiesSupportedWithSpawner() async throws {
+        let (router, _) = try makeRouterAndDB()
+        router.holderRegistry = HolderRegistry(
+            owner: HolderOwnerToken(rawValue: "acme-installation"),
+            environment: ["TBD_HOME": "/tmp/tbd-ph-\(UUID().uuidString.prefix(8))"],
+            listTerminals: { [] },
+            spawner: HolderSpawner(
+                executableURL: URL(fileURLWithPath: "/nonexistent/TBDHolder")))
+        #expect(try await capabilities(router).ptyHolderSupported == true)
+    }
+
+    /// The two halves are independent: turning the flag on cannot conjure a
+    /// helper, and the toggle has to be able to show "on, but this daemon
+    /// cannot act on it".
+    @Test("the flag and the supported half move independently")
+    func flagAndSupportAreIndependent() async throws {
+        let (router, _) = try makeRouterAndDB()
+        try await setPtyHolder(router, enabled: true)
+        let result = try await capabilities(router)
+        #expect(result.ptyHolderEnabled == true)
+        #expect(result.ptyHolderSupported == false)
+    }
+
+    // MARK: - Codable back-compat
+
+    /// An older daemon sends neither field. `enabled` falls through to the
+    /// shipped default rather than pretending the transport is live, and
+    /// `supported` is honestly false — which greys the toggle out instead of
+    /// offering a switch that daemon would ignore.
+    @Test("capabilities JSON without the pty-holder fields decodes conservatively")
+    func capabilitiesDecodeBackCompat() throws {
+        let json = Data(#"{"controlModeEnabled":true,"controlModeSupported":false}"#.utf8)
+        let result = try JSONDecoder().decode(DaemonCapabilitiesResult.self, from: json)
+        #expect(result.ptyHolderEnabled == Config.ptyHolderDefault)
+        #expect(result.ptyHolderSupported == false)
+    }
+
+    /// …and a daemon that does send them is believed, in both directions, so
+    /// the decoder is not just returning its fallbacks.
+    @Test("capabilities JSON carrying the pty-holder fields round-trips")
+    func capabilitiesDecodeCarriesValues() throws {
+        let on = Data(#"{"ptyHolderEnabled":true,"ptyHolderSupported":true}"#.utf8)
+        let onResult = try JSONDecoder().decode(DaemonCapabilitiesResult.self, from: on)
+        #expect(onResult.ptyHolderEnabled == true)
+        #expect(onResult.ptyHolderSupported == true)
+
+        let off = Data(#"{"ptyHolderEnabled":false,"ptyHolderSupported":false}"#.utf8)
+        let offResult = try JSONDecoder().decode(DaemonCapabilitiesResult.self, from: off)
+        #expect(offResult.ptyHolderEnabled == false)
+        #expect(offResult.ptyHolderSupported == false)
+    }
+
+    @Test("ConfigSetPtyHolderEnabledParams round-trips both values")
+    func paramsRoundTrip() throws {
+        for value in [true, false] {
+            let decoded = try JSONDecoder().decode(
+                ConfigSetPtyHolderEnabledParams.self,
+                from: try JSONEncoder().encode(ConfigSetPtyHolderEnabledParams(enabled: value)))
+            #expect(decoded.enabled == value)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The pty-holder transport — running a session on its own pty instead of inside a
tmux window — has been in the tree behind `pty_holder_enabled` since #807, and
until now there was no way for a person to turn it on. Not a Settings toggle,
not a `tbd config set` key. The only route was hand-crafting a message to the
daemon socket, which meant the design's own rollout plan ("enable on a
development machine running a real fleet at real load") could not be carried out
by any ordinary gesture.

This adds the switch. Settings → Experimental now has **Run new sessions without
tmux**, next to the other soak flags. Turn it on and the sessions you create
after that run on a holder; the ones already running are untouched.

A feature is not complete until you can toggle it on from a UI somewhere.

## Why this shape

**No spec.** This is a minor UI change that exposes a flag, a column, an RPC
verb and a handler that all already exist. It revises no theory of the system:
the transport, its gate, its tri-state column and its semantics were all decided
in [`docs/specs/2026-08-30-pty-holder-session-transport-design.md`](docs/specs/2026-08-30-pty-holder-session-transport-design.md).

**It mirrors the control-mode toggle end to end**, because that chain already
solves the two problems this one has. The toggle reads its value from
`daemon.capabilities` rather than from a local guess, so the switch and the
daemon can never disagree about which of them last wrote the column; and the
setter re-fetches capabilities only after a successful write, so a transient RPC
failure cannot snap the toggle back to a state the daemon is not in.

**The disabled-with-reason treatment carries over, because the precondition is
real.** The spawn gate asks two questions, not one:
`config.ptyHolderEnabled && holderRegistry?.canSpawn == true`. A daemon that
cannot locate its `TBDHolder` helper still builds a registry — adoption reaches
an already-running holder through its socket, so a user's live sessions survive
an upgrade that moved the binary — but it cannot start a new one. With the flag
on and no helper, every create silently falls back to tmux. So the capability
payload carries `ptyHolderSupported` alongside the flag, computed daemon-side
exactly as `controlModeSupported` is, and Settings greys the switch out and
names the missing helper rather than offering a switch that would change
nothing.

**App Settings only — no `tbd config set` key.** Considered and declined; one
surface is enough for a soak switch.

**The help text makes no speed claim.** The design spec is explicit that the
justification is scaling headroom, not current latency, and that there is no
measured win on a quiet machine. A test enforces this.

## What this PR does

Most of the chain was already there — `RPCMethod.configSetPtyHolderEnabled`, its
router handler, `ConfigStore.setPtyHolderEnabled`, `Config.ptyHolderEnabled` and
the tri-state column all landed with the transport. No migration.

- `Sources/TBDShared/RPCProtocol.swift` — `ptyHolderEnabled` and
  `ptyHolderSupported` on `DaemonCapabilitiesResult`, both decoding
  conservatively when an older daemon omits them.
- `Sources/TBDDaemon/Server/RPCRouter.swift` — `daemon.capabilities` reports
  both, `supported` from the same `canSpawn` the spawn gate asks.
- `Sources/TBDApp/DaemonClient.swift` — `setPtyHolderEnabled(enabled:)`.
- `Sources/TBDApp/AppState.swift` — the `ptyHolderFlagSetter` injection seam.
- `Sources/TBDApp/AppState+ModelProfiles.swift` — `setPtyHolderEnabled(_:)`, plus
  the help text and the unsupported caption as assertable constants.
- `Sources/TBDApp/Settings/SettingsView.swift` — `ptyHolderToggle` in
  `Section("Experimental")`.

## Flag & rollout

**Flag:** `pty_holder_enabled` (existing; `Config.ptyHolderDefault == false`).
Default OFF, unchanged by this PR.

**How a human turns it on, which is the whole point:** Settings →
Experimental → **Run new sessions without tmux**. It takes effect on the next
session created — no daemon restart, and nothing already running moves. Turning
it back off is the exit from the soak and is equally a gesture: it writes a real
`0`, which is what keeps a deliberate opt-out from being swept up the day the
shipped default graduates.

If the toggle is greyed out with "Requires the TBDHolder helper beside the
daemon binary", the running daemon has no `TBDHolder` next to it — rebuild via
`scripts/restart.sh` from the worktree rather than flipping anything.

**Graduation:** unchanged and owned by the transport's own spec — this PR only
makes the soak startable. Graduation is a one-line change to
`Config.ptyHolderDefault`, which reaches everyone who never touched the toggle
and preserves every explicit opt-out.

## Assumptions

- `canSpawn` is decided once, in `HolderRegistry.init`, from whether a spawner
  was supplied. So `ptyHolderSupported` is a fact about the running daemon's
  boot: moving `TBDHolder` under a live daemon does not change it until the
  daemon restarts. That matches how the spawn gate behaves, which is what the
  toggle is describing.
- The help text's scrollback sentence assumes the emulator's bounded history
  (`HolderReader.scrollbackLines`) stays smaller than tmux's `history-limit`. If
  that constant grows past it, the sentence needs revisiting.

## Evidence & verification

Not visually verified by me — a live daemon and app belonging to this machine's
owner are running, so I did not restart anything. The visual check is theirs.

`Tests/TBDDaemonTests/PtyHolderSettingsRPCTests.swift` — the RPC round trip and
the read-back:

- `config.setPtyHolderEnabled` persists an opt-in, and persists an opt-out as a
  stored `0` rather than a NULL; an untouched install stores NULL. All three
  states of the tri-state column are distinguished.
- `daemon.capabilities` re-evaluates the flag in **both** directions without a
  restart — a payload that hard-coded either value fails one of the two legs.
- `ptyHolderSupported` is asserted false for no registry, false for a registry
  with no spawner, and **true** for one holding a spawner. A constant cannot
  satisfy both the true and the false legs, so the field is genuinely wired to
  `canSpawn` rather than to a literal. (Nothing is launched: `canSpawn` is
  `spawner != nil`, decided in `init`.)
- The two halves are asserted to move independently — flag on, supported false —
  which is the state the disabled caption exists for.
- Back-compat: an older daemon's payload decodes to the shipped default and
  `supported: false`; a payload that carries both values is believed in both
  directions, so the decoder is not merely returning its fallbacks.

`Tests/TBDAppTests/PtyHolderSettingsTests.swift` — the app side, against a
throwaway `UserDefaults` suite torn down after each test:

- The setter writes `true` and writes `false` (separate tests: a setter that
  ignored its argument would pass an on-only test) and refreshes capabilities
  after each.
- A failing write surfaces an alert and does **not** refresh — the branch that
  keeps a transient RPC failure from nil-ing the capabilities out from under the
  toggle.
- The help text carries each of the four facts an operator needs before
  flipping it, and contains no speed claim. That second test fails on exactly
  the rewrite the design spec warns against and on nothing a faithful edit
  would do.
- An unfetched capability reads off and unsupported, so the toggle cannot claim
  a transport the daemon has not confirmed.

Commands run, with real exit codes:

- `scripts/swift-safe build --build-tests` → exit 0
- `scripts/test.sh --filter 'PtyHolderSettingsRPCTests|PtyHolderSettingsTests|PtyHolderFlagTests'`
  → exit 0, **31 tests in 3 suites passed**
- `swiftlint --strict` → exit 0, 0 violations in 974 files

[20260830-boring-panda](https://cheapsteak.github.io/tbd/open/?worktree=A1E9CF50-E608-4F3C-BA8F-377D60BB7478)

https://claude.ai/code/session_01VmxVag4BeDdC65msZCawvK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Experimental setting to enable or disable the PTY holder transport.
  * Displays whether the PTY holder is supported and provides explanatory help text when unavailable.
  * Changes are saved and reflected in refreshed daemon capabilities.
  * Shows an alert if the setting cannot be saved.

* **Bug Fixes**
  * Added backward-compatible handling for capability data from older daemon versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->