### PR TITLE
Fix: Stop the "run without tmux" toggle from silently doing nothing after a restart

### DIFF
--- a/docs/specs/2026-09-04-automatic-version-updates-design.md
+++ b/docs/specs/2026-09-04-automatic-version-updates-design.md
@@ -197,14 +197,17 @@ arguments, and inherits the user's environment. The script is the procedure:
    must be safe to `checkout --detach` at any time. Its `origin` is the
    upstream URL resolved as in §5.
 2. **Fetch and check out** `origin/main` detached. If the fetched
-   `scripts/update.sh` differs from the running copy, re-exec the fetched one
-   with the same arguments (guarded by an environment marker so it happens
-   once). This is how the procedure itself updates.
+   `scripts/update.sh`, or either library it sources, differs from the running
+   copy, re-exec the fetched script with the same arguments (guarded by an
+   environment marker so it happens once). This is how the procedure itself
+   updates.
 3. **Stamp** `TBDBuildIdentity.json` into `.build/<config>/` (commit, branch,
-   time, worktree, dirty) and **build** `TBDDaemon`, `TBDApp`, and `tbd`
-   with `scripts/swift-safe build -c release --product …`, the same module
-   cache flags as `restart.sh`. A failed build stops here; the running
-   installation is untouched.
+   time, worktree, dirty) and **build** every product in `RUNTIME_PRODUCTS`
+   (`scripts/restart-bundle-lib.sh`, the list `restart.sh` builds from too:
+   the daemon, the app, the CLI, and the helpers the daemon looks for beside
+   its own binary) with `scripts/swift-safe build -c release --product …`,
+   the same module cache flags as `restart.sh`. A failed build stops here;
+   the running installation is untouched.
 4. **Assemble, sign, and install** the app bundle to `/Applications/TBD.app`
    exactly as `restart.sh` does today. That code moves out of `restart.sh`
    into `scripts/restart-bundle-lib.sh` so the two scripts share it; the

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -36,16 +36,18 @@ these steps in order.
   source worktree, else that worktree's `origin`, else whatever `--remote` you
   pass.
 - **Fetches and detaches onto `origin/main`.** If the fetched copy of
-  `scripts/update.sh` differs from the one running, the fetched one takes over
-  with the same arguments. That is how the procedure updates itself, and an
-  environment marker holds it to a single hop.
+  `scripts/update.sh`, or of either library it sources, differs from the one
+  running, the fetched script takes over with the same arguments. That is how
+  the procedure updates itself, and an environment marker holds it to a single
+  hop.
 - **Stamps the build identity.** `TBDBuildIdentity.json` lands in the build
   directory before the compiler runs, recording the commit, the branch, the
   build time, the clone's path, and whether the tree was dirty. Every binary
   reads the sidecar beside it, which is how `tbd version` knows what is
   running.
-- **Builds** `TBDDaemon`, `TBDApp` and `TBDCLI` through `scripts/swift-safe`,
-  with the same shared module cache `scripts/restart.sh` uses. A failed build
+- **Builds** the same products `scripts/restart.sh` builds — `TBDDaemon`,
+  `TBDApp`, `TBDCLI`, `TBDHolder` and `TBDPeerHelper` — through
+  `scripts/swift-safe`, with the same shared module cache. A failed build
   stops here and the running installation is untouched.
 - **Assembles, signs and installs** `/Applications/TBD.app`, using the same
   code `scripts/restart.sh` uses (`scripts/restart-bundle-lib.sh`). The bundle

--- a/scripts/mock.sh
+++ b/scripts/mock.sh
@@ -52,6 +52,8 @@ up() {
     # Both halves matter: `swift-safe` holds the machine-global admission lock
     # (#576) so parallel worktrees can't start competing compiler swarms, and
     # naming the two products keeps the mock from building the whole package.
+    # Deliberately not RUNTIME_PRODUCTS (restart-bundle-lib.sh): a mock daemon
+    # wires no holder registry and no peer bridge, so it needs no sibling helper.
     echo "Building mock products..."
     (cd "$REPO_ROOT" \
         && scripts/swift-safe build --product TBDApp \

--- a/scripts/restart-bundle-lib.sh
+++ b/scripts/restart-bundle-lib.sh
@@ -59,6 +59,16 @@ BUILD_IDENTITY_PATHSPECS=(
 #                  (ShadowPeerHelperProcessSpawner). Missing, a remote lane
 #                  fails to arm with executableMissing.
 #
+# Every product here is all-or-nothing: a helper that fails to compile stops
+# the restart or update the same way a daemon that fails to compile does. That
+# is deliberate. Each helper degrades gracefully at runtime when it is ABSENT,
+# and that graceful path is exactly how a never-built helper went unnoticed;
+# building it as a warning would put the same silent degradation one scroll
+# above the "Daemon ready" line. The holder and peer helper depend on
+# TBDShared and nothing else, and the CLI on TBDShared plus packages the
+# daemon also links, so a helper that fails while the daemon builds is a
+# broken tree, and a broken tree is what a restart should refuse.
+#
 # scripts/restart-bundle-lib.test.sh checks that each name is an executable
 # target in Package.swift, so a rename or typo fails there and not on the next
 # restart.

--- a/scripts/restart-bundle-lib.sh
+++ b/scripts/restart-bundle-lib.sh
@@ -36,6 +36,35 @@ BUILD_IDENTITY_PATHSPECS=(
     Package.resolved
 )
 
+# Every product a running installation needs. scripts/restart.sh and
+# scripts/update.sh both build exactly this list, so a product added here
+# reaches both paths. TBDCLI, TBDHolder and TBDPeerHelper are each found by a
+# SIBLING lookup beside the daemon binary, and a sibling that was never built
+# fails in the field rather than in the build:
+#
+#   TBDDaemon      launched in place from .build/<config>.
+#   TBDApp         hard-linked into the .app bundle by assemble_app_bundle.
+#   TBDCLI         `tbd`. Every replacement agent process is handed the
+#                  daemon's sibling copy as TBD_CLI_PATH and its hooks run that
+#                  one, swallowing the error when it is missing
+#                  (AgentProcessEnvironment, ClaudeHookOverlay,
+#                  CodexHomeManager). update.sh also re-links an existing
+#                  ~/.local/bin/tbd hard link to it.
+#   TBDHolder      the pty holder the daemon spawns for a holder-backed session
+#                  (HolderSpawner.locateSiblingExecutable). Missing, the daemon
+#                  reports ptyHolderSupported=false: the Settings toggle greys
+#                  out, and a toggle that was already on sends every new
+#                  session to tmux with no error.
+#   TBDPeerHelper  the shadow-peer helper for remote peer messaging
+#                  (ShadowPeerHelperProcessSpawner). Missing, a remote lane
+#                  fails to arm with executableMissing.
+#
+# scripts/restart-bundle-lib.test.sh checks that each name is an executable
+# target in Package.swift, so a rename or typo fails there and not on the next
+# restart.
+# shellcheck disable=SC2034 # consumed by the two scripts that source this file
+RUNTIME_PRODUCTS=(TBDDaemon TBDApp TBDCLI TBDHolder TBDPeerHelper)
+
 # MARK: - Build identity
 
 # Escape a value for embedding in a JSON string literal. Backslashes first,

--- a/scripts/restart-bundle-lib.test.sh
+++ b/scripts/restart-bundle-lib.test.sh
@@ -416,6 +416,24 @@ test_stop_and_launch_use_the_anchored_pattern() {
     unset STUB_LOG
 }
 
+test_runtime_products_are_executable_targets() {
+    local product
+    if [ "${#RUNTIME_PRODUCTS[@]}" -eq 0 ]; then
+        fail "RUNTIME_PRODUCTS names at least one product"
+        return
+    fi
+    # A name that is not an executable target fails every restart at the
+    # per-product build step, so pin each one to Package.swift.
+    for product in "${RUNTIME_PRODUCTS[@]}"; do
+        if grep -A1 "\.executableTarget(" "$REPO_ROOT/Package.swift" \
+                | grep -q "name: \"$product\""; then
+            pass "RUNTIME_PRODUCTS: $product is an executable target"
+        else
+            fail "RUNTIME_PRODUCTS: $product is not an executable target in Package.swift"
+        fi
+    done
+}
+
 test_helper_refuses_direct_execution() {
     if bash "$HELPER" >/dev/null 2>&1; then
         fail "the helper refuses to be run directly"
@@ -441,6 +459,7 @@ test_install_replaces_the_previous_bundle
 test_install_rejects_missing_arguments
 test_exec_pattern_escaping
 test_stop_and_launch_use_the_anchored_pattern
+test_runtime_products_are_executable_targets
 test_helper_refuses_direct_execution
 
 if [ "$FAIL" -ne 0 ]; then

--- a/scripts/restart.sh
+++ b/scripts/restart.sh
@@ -171,7 +171,7 @@ fi
 if [ "$skip_build" = false ]; then
     echo "Building..."
     t0=$SECONDS
-    # Build the two PRODUCTS rather than the whole package.
+    # Build the runtime PRODUCTS rather than the whole package.
     #
     # A whole-package build compiles the test targets too, and
     # Tests/TestSupport does `@testable import TBDDaemonLib`, which needs
@@ -182,11 +182,14 @@ if [ "$skip_build" = false ]; then
     # reporting failure, and it is why the exit code below could not be
     # checked before this change.
     #
-    # SwiftPM honors only the LAST --product, so these are two invocations.
-    # Restarting needs exactly these two products; the test targets are
-    # scripts/test.sh's job, not the restart path's.
+    # SwiftPM honors only the LAST --product, so each is its own invocation.
+    # The list is RUNTIME_PRODUCTS in restart-bundle-lib.sh, shared with
+    # scripts/update.sh: the daemon, the app, and every helper the daemon
+    # looks for beside its own binary (see the list for what each one does
+    # when it is missing). The test targets are scripts/test.sh's job, not
+    # the restart path's.
     build_ok=true
-    for product in TBDDaemon TBDApp; do
+    for product in "${RUNTIME_PRODUCTS[@]}"; do
         # Capture the status, THEN print. Piping the build straight into
         # `tail` would make the pipeline's status `tail`'s (always 0) — the
         # very status-discarding bug this block exists to fix.
@@ -194,6 +197,11 @@ if [ "$skip_build" = false ]; then
                 -c "$build_config" --product "$product" \
                 "${MODULE_CACHE_FLAGS[@]}") 2>&1 ); then
             build_ok=false
+            # The rest would build behind the same machine-global lock and
+            # scroll the failure off the screen, and the restart below is
+            # abandoned either way.
+            printf '%s\n' "$build_out" | tail -3
+            break
         fi
         printf '%s\n' "$build_out" | tail -3
     done

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -65,7 +65,6 @@ PREVIOUS_BUNDLE="$UPDATE_HOME/previous/TBD.app"
 CLI_INSTALL_PATH="$HOME/.local/bin/tbd"
 
 UPDATE_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-UPDATE_SCRIPT_PATH="$UPDATE_SCRIPT_DIR/$(basename "${BASH_SOURCE[0]}")"
 
 # MARK: - Options (set by parse_args)
 
@@ -467,15 +466,22 @@ should_reexec() {
 }
 
 maybe_reexec() {
-    local fetched="$UPDATE_SRC/scripts/update.sh"
-    if should_reexec "$fetched" "$UPDATE_SCRIPT_PATH"; then
-        log "re-exec: the fetched update.sh differs from the running one"
-        # Carry the lock across. `exec` replaces the image but keeps the pid,
-        # so the file already names the process that is about to run; clearing
-        # the trap stops the outgoing image from deleting it on the way out.
-        trap - EXIT
-        TBD_UPDATE_REEXEC=1 exec bash "$fetched" "$@"
-    fi
+    # The libraries this script sources count as much as the script: main
+    # reads them from the RUNNING tree, so a change that lands only in one of
+    # them — the product list in restart-bundle-lib.sh, say — would otherwise
+    # run the old copy against the new sources with nothing to trigger the hop.
+    local name
+    for name in update.sh restart-bundle-lib.sh restart-environment-lib.sh; do
+        if should_reexec "$UPDATE_SRC/scripts/$name" "$UPDATE_SCRIPT_DIR/$name"; then
+            log "re-exec: the fetched $name differs from the running one"
+            # Carry the lock across. `exec` replaces the image but keeps the
+            # pid, so the file already names the process that is about to run;
+            # clearing the trap stops the outgoing image from deleting it on
+            # the way out.
+            trap - EXIT
+            TBD_UPDATE_REEXEC=1 exec bash "$UPDATE_SRC/scripts/update.sh" "$@"
+        fi
+    done
 }
 
 # MARK: - Build
@@ -494,9 +500,11 @@ build_products() {
     )
 
     # SwiftPM honors only the last --product, so these are separate
-    # invocations. TBDCLI is built too: `tbd update` is run through that binary,
-    # and an update that leaves the CLI behind reports a version it is not.
-    for product in TBDDaemon TBDApp TBDCLI; do
+    # invocations. The list is RUNTIME_PRODUCTS in restart-bundle-lib.sh, shared
+    # with scripts/restart.sh; it includes TBDCLI because `tbd update` is run
+    # through that binary, and an update that leaves the CLI behind reports a
+    # version it is not.
+    for product in "${RUNTIME_PRODUCTS[@]}"; do
         log "building $product ($BUILD_CONFIG)"
         # Capture the status, THEN print. Piping the build into `tail` would
         # make the pipeline's status tail's, which is always zero.

--- a/scripts/update.test.sh
+++ b/scripts/update.test.sh
@@ -4,7 +4,7 @@
 # Nothing here builds, installs, signals a daemon, or touches a real ~/tbd.
 # HOME and TBD_HOME point at a temp directory for every case; `tbd`, `open`,
 # `codesign` and `security` are stubs on a temp PATH; and the update clone is a
-# real clone of a fixture repo whose `scripts/swift-safe` writes three empty
+# real clone of a fixture repo whose `scripts/swift-safe` writes five empty
 # files instead of compiling. git is the real git, against fixture repos.
 #
 # The end-to-end cases stop at --dry-run, which is the last step before the
@@ -789,6 +789,23 @@ EOF
     fi
 }
 
+test_reexec_when_only_a_sourced_library_differs() {
+    local case_dir out
+    case_dir="$(mkcase reexec-lib-case)"
+    # The fetched update.sh is byte-identical to the running one; only the
+    # library it sources has moved on.
+    printf "\n# a newer library\n" >> "$case_dir/remote/scripts/restart-bundle-lib.sh"
+    git -C "$case_dir/remote" commit -q -am "library only"
+
+    out="$(run_update "$case_dir" --dry-run --no-wake)"
+    assert_contains "a library-only change re-execs" \
+        "re-exec: the fetched restart-bundle-lib.sh differs" "$out"
+    assert_contains "and the fetched script completes the dry run" \
+        "installing nothing" "$out"
+    assert_eq "the hop happens once" "1" \
+        "$(printf "%s" "$out" | grep -c "re-exec: the fetched")"
+}
+
 # MARK: - --check
 
 test_check_reports_without_changing_anything() {
@@ -909,7 +926,7 @@ EOF
 #
 # One fetch-and-build, asserted from every angle: what it built, what it wrote,
 # what it refused to touch, and what it reported. A second run costs a clone
-# and three fake builds, so the cases share this one.
+# and five fake builds, so the cases share this one.
 
 test_dry_run_builds_but_installs_nothing() {
     local case_dir out sidecar log
@@ -925,6 +942,8 @@ test_dry_run_builds_but_installs_nothing() {
     assert_contains "--dry-run builds the daemon" "building TBDDaemon" "$out"
     assert_contains "--dry-run builds the app" "building TBDApp" "$out"
     assert_contains "--dry-run builds the CLI" "building TBDCLI" "$out"
+    assert_contains "--dry-run builds the pty holder" "building TBDHolder" "$out"
+    assert_contains "--dry-run builds the peer helper" "building TBDPeerHelper" "$out"
     assert_contains "--dry-run says it installs nothing" "installing nothing" "$out"
     assert_not_contains "--dry-run does not assemble a bundle" \
         "assembling and installing" "$out"
@@ -934,7 +953,7 @@ test_dry_run_builds_but_installs_nothing() {
     else
         pass "--dry-run does not launch the app"
     fi
-    assert_eq "--dry-run builds the release configuration by default" "3" \
+    assert_eq "--dry-run builds the release configuration by default" "5" \
         "$(grep -c 'release' "$case_dir/build.log")"
 
     # The sidecar the build stamped.
@@ -979,7 +998,7 @@ test_debug_flag_selects_the_debug_configuration() {
     local case_dir
     case_dir="$(mkcase debug-case)"
     run_update "$case_dir" --dry-run --debug >/dev/null 2>&1
-    assert_eq "--debug builds the debug configuration" "3" \
+    assert_eq "--debug builds the debug configuration" "5" \
         "$(grep -c 'debug' "$case_dir/build.log")"
 }
 
@@ -1611,6 +1630,7 @@ test_source_worktree_resolution
 test_json_field_reads_nested_paths
 test_reexec_predicate
 test_reexec_happens_once_and_passes_arguments
+test_reexec_when_only_a_sourced_library_differs
 test_check_reports_without_changing_anything
 test_check_fallback_decides_ancestry_like_the_daemon
 test_dry_run_builds_but_installs_nothing


### PR DESCRIPTION
## What's broken

Enable "Run new sessions without tmux" in Settings, restart TBD with `scripts/restart.sh`, create a session: it runs in a tmux window exactly as before, and nothing says why. On a daemon that has never had the holder binary the toggle is greyed out with a caption blaming the missing helper, but once the flag is on, every restart from then on silently degrades: the daemon comes up without the helper and routes each new session to tmux. `tbd update` produces the same daemon.

Measured on one machine before the fix: after a clean `scripts/restart.sh`, `.build/debug/TBDHolder` did not exist, and `daemon.capabilities` reported `ptyHolderEnabled: true` alongside `ptyHolderSupported: false`. Building that one product by hand (about 17 seconds) and restarting flipped `ptyHolderSupported` to true.

Two more helpers have the same shape of failure and were also never built by a restart:

- **The CLI.** Every replacement agent process (hibernation resume, terminal replacement) is handed the daemon's sibling `TBDCLI` path as `TBD_CLI_PATH`, and the Claude and Codex hook lines run that binary with errors swallowed. With no sibling, those sessions' hook events never reach the daemon.
- **The peer helper.** With remote peer messaging enabled, a remote lane spawns `TBDPeerHelper` beside the daemon and fails to arm when it is missing. Its own doc comment already claimed the restart script stages it.

## Why it happens

The daemon does not run holder-backed sessions, hooks, or remote lanes itself. It spawns small helper binaries, and it finds each one in exactly one place: beside its own executable. That choice is deliberate, so a stray binary on `PATH` can never own the daemon's sessions.

`scripts/restart.sh` built two products, `TBDDaemon` and `TBDApp`, under a comment saying restarting needs exactly those two. That was true before any sibling helper existed. `scripts/update.sh` kept its own list, `TBDDaemon`, `TBDApp` and `TBDCLI`, added for the CLI's version report. Two lists in two files drifted independently, and none of the sibling lookups fails loudly enough for a restart to notice.

## When it broke

The `TBDHolder` target arrived in #767 and the daemon began spawning through it in #777. `TBD_CLI_PATH` arrived in #751 and `TBDPeerHelper` in #762. The restart script's product list was never revisited, and nothing exercises the restart script end to end, so the mismatch stayed invisible until the toggle in #810 gave a person a reason to expect the feature to work.

## What this PR does

- The product list lives once, as `RUNTIME_PRODUCTS` in `scripts/restart-bundle-lib.sh`, which both scripts already source. It names the daemon, the app, and the three sibling helpers, with a comment per product saying what breaks when it is missing.
- `scripts/restart.sh` and `scripts/update.sh` loop over that list. The per-product `swift-safe` invocation and its exit-status capture are unchanged. The restart loop now stops at the first failed product: with five products, building the rest behind the same machine-global lock only delayed the abort and scrolled the failure off the screen.
- The `tbd update` self re-exec compares the two libraries the script sources, not just `update.sh`. The product list now lives in one of those libraries, which `update.sh` reads from the running tree, so a change that landed only there would otherwise build the old list against new sources with nothing to trigger the hop.
- `docs/updating.md` and the automatic-updates spec describe the product list and the widened re-exec trigger. `scripts/mock.sh` says why its own two-product list deliberately stays put: a mock daemon wires no holder registry and no peer bridge.

The `~/.local/bin/tbd` hard link is deliberately not touched. The app's launch-time installer already detects an inode mismatch against the sibling `TBDCLI` and prompts to refresh, and that prompt is a user gesture. Building `TBDCLI` here makes the sibling the daemon hands to hooks exist; refreshing the hard link is the existing prompt's job and stays a separate concern.

`scripts/mock.sh` builds only the daemon and app. Its mock daemon wires no holder registry and no peer bridge, so it needs neither helper.

## Assumptions

**A helper that fails to compile blocks the restart or update, on purpose.** Before this change neither script touched the holder or the peer helper, so a compile error in one of them could not stop a restart. Now it does, exactly as a daemon compile error does. The alternative, building helpers as a warning and continuing, was rejected: each helper degrades gracefully at runtime when it is absent, and that graceful path is precisely how a never-built helper went unnoticed, so a warning would put the same silent degradation one scroll above the "Daemon ready" line. The holder and peer helper depend on `TBDShared` and nothing else, and the CLI on `TBDShared` plus packages the daemon also links, so a helper failing while the daemon builds means the tree is broken, and a broken tree is what a restart should refuse. If a helper ever grows a dependency the daemon does not share, this assumption is the one to revisit.

## Evidence & verification

- The update harness (`scripts/update.test.sh`) runs the real `scripts/update.sh` against a stubbed `swift-safe`. It now asserts that `TBDHolder` and `TBDPeerHelper` are built, that five builds run per configuration, and that a fetched tree whose only change is in `restart-bundle-lib.sh` re-execs exactly once and completes the dry run. Against the pre-change `update.sh` each of those assertions fails; on this branch the whole harness passes (202 ok, 0 fail).
- Not covered, and worth a follow-up: nothing pins the sibling lookups in `Sources/` to the list. The next helper that lands with a sibling lookup still depends on someone adding it here. A test enumerating those lookups would be grep-shaped over Swift source, so it was not added.
- The bundle-lib harness (`scripts/restart-bundle-lib.test.sh`) pins every name in the list to an executable target in `Package.swift`, so a typo or rename fails there rather than on the next restart. A mutated list with a bogus name reddens it; the real list passes (59 ok).
- `scripts/restart.sh`'s own build loop is not reachable from any harness (the `restart-*-lib.test.sh` files cover the sourced libraries, not the top-level script). Sharing the list is what closes that gap: the loop can no longer disagree with the tested list.
- Each of the three helper products builds through the exact invocation the loop now runs, `scripts/swift-safe build --product <name>`, with exit 0 in this worktree.
- Not live-verified on this branch: the machine runs a live fleet, so no restart was performed here. The before/after capability flip described above was observed by hand with the same product build on the same machine.

https://claude.ai/code/session_01Mc559dNKWt4WMua2C1vEmv
[holder-restart-build](https://cheapsteak.github.io/tbd/open/?worktree=C9AFC30F-A8BF-4C54-9423-0E9AB805F2A1)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updates now refresh themselves when supporting update scripts change, with safeguards against repeated handoffs.
  - Restart and update operations now build all required runtime products, including holder and peer-helper components.
  - Build metadata documentation now covers the source path and uncommitted changes.

- **Bug Fixes**
  - Restart operations stop safely when any required product fails to build.

- **Tests**
  - Added coverage ensuring all required runtime products are executable targets and sourced-script changes trigger updates correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->