### PR TITLE
Fix: terminal.output on holder sessions hides missing characters as invisible NULs (1,595 live on one machine)

### DIFF
--- a/Sources/TBDDaemon/Holder/HolderReader.swift
+++ b/Sources/TBDDaemon/Holder/HolderReader.swift
@@ -1186,7 +1186,7 @@ private final class HolderEmulator: @unchecked Sendable {
             var lines: [String] = []
             lines.reserveCapacity(terminal.rows)
             for row in 0..<terminal.rows {
-                lines.append(terminal.getLine(row: row)?.translateToString(trimRight: true) ?? "")
+                lines.append(terminal.getLine(row: row).map(Self.rowText) ?? "")
             }
             return Self.joined(lines)
         }
@@ -1203,7 +1203,7 @@ private final class HolderEmulator: @unchecked Sendable {
             var lines: [String] = []
             var row = terminal.buffer.totalLinesTrimmed
             while let line = terminal.getScrollInvariantLine(row: row) {
-                lines.append(line.translateToString(trimRight: true))
+                lines.append(Self.rowText(line))
                 row += 1
             }
             if lines.count > maxLines {
@@ -1250,6 +1250,38 @@ private final class HolderEmulator: @unchecked Sendable {
     /// The grid's dimensions, read under the same lock as everything else here.
     var size: (columns: Int, rows: Int) {
         terminal.terminalLock.withLock { (terminal.cols, terminal.rows) }
+    }
+
+    /// One row of the grid as text, the way a reader of `terminal.output`
+    /// needs it: **a cell nobody ever wrote projects as a space, never as
+    /// `U+0000`.**
+    ///
+    /// A never-written or erased cell holds `CharData.Null`, whose code is 0,
+    /// and `translateToString`'s default path renders that literally. The
+    /// result looks right and is not: a TUI paints differentially, positioning
+    /// the cursor past the cells it is leaving alone rather than overwriting
+    /// them with blanks, so the skipped cells become invisible NULs scattered
+    /// through the line — and which cells get skipped changes with every
+    /// repaint, so the holes appear to move. Every consumer of this string
+    /// matches on text (fleet supervision, the pending-input rail, the login
+    /// driver), and a NUL is a missing character nothing displays. `tmux
+    /// capture-pane`, which this replaces for machine reads, returns spaces;
+    /// so does the app-side serializer in `TerminalCellWalk`.
+    ///
+    /// `skipNullCellsFollowingWide` is the other half and not optional: the
+    /// trailing cell of a two-column glyph carries code 0 as well, and padding
+    /// *it* to a space would put a stray blank after every CJK character and
+    /// every emoji. Trimming is unaffected — `trimRight` is computed from
+    /// `getTrimmedLength()` before the projection runs, so a row nobody wrote
+    /// still renders empty rather than as a row of spaces.
+    private static func rowText(_ line: BufferLine) -> String {
+        line.translateToString(
+            trimRight: true,
+            skipNullCellsFollowingWide: true,
+            characterProvider: { cell in
+                let character = cell.getCharacter()
+                return character == Character(Unicode.Scalar(0)) ? " " : character
+            })
     }
 
     /// Trailing blank lines are dropped — a screen is 24 rows whether or not

--- a/Tests/TBDDaemonTests/EmulatorFeedChunkingTests.swift
+++ b/Tests/TBDDaemonTests/EmulatorFeedChunkingTests.swift
@@ -1,0 +1,410 @@
+import Foundation
+import SwiftTerm
+import Testing
+
+/// The screen a headless emulator paints must not depend on where the reader's
+/// `read()` boundaries happened to fall.
+///
+/// `HolderReader` drains a pty in chunks of up to 64 KB and feeds each chunk to
+/// one long-lived `Terminal`. Nothing about a pty guarantees where those chunks
+/// split: the same output can arrive as one 8 KB read or as two hundred small
+/// ones, and the split points move from redraw to redraw. So the emulator owes
+/// the caller a property — **the painted screen is a function of the byte
+/// stream, not of its chunking** — and every escape sequence, every multi-byte
+/// UTF-8 character, and every column-boundary wrap has to survive being cut in
+/// half.
+///
+/// This suite exists because a holder-backed session was observed rendering
+/// single characters missing from otherwise intact words ("brown" as "brow "),
+/// stable across repeated reads of one static screen but moving to different
+/// lines after a redraw — the signature of a chunk-boundary artefact rather
+/// than of anything the program actually drew.
+///
+/// Rendering walks the buffer one row at a time, the way
+/// `HolderReader.renderScreen` does, so a difference here is a difference a
+/// user would have seen. What the subject is, though, is the *cells* — whether
+/// a byte landed in the grid at all — which is why the walk here stays the
+/// plain one and does not need to track the projection production applies on
+/// top of it.
+@Suite struct EmulatorFeedChunkingTests {
+
+    private static let columns = 100
+    private static let rows = 24
+
+    // MARK: - The property
+
+    /// One chunk versus two, at the cuts that can plausibly matter.
+    ///
+    /// Not every offset: cutting between two ordinary printable bytes exercises
+    /// the same code as cutting between the two before them, and paying for
+    /// tens of thousands of full renders to learn that costs half a minute per
+    /// run. What is *not* sampled is anything with internal structure — every
+    /// offset inside an escape sequence and inside a multi-byte UTF-8
+    /// character is tried, because those are the cuts that leave the parser
+    /// holding half a token. The plain runs between them get a coarse stride
+    /// so a regression in the boring path still has somewhere to show up.
+    @Test func aSingleSplitAnywhereInTheStreamPaintsTheSameScreen() {
+        let stream = Self.claudeShapedStream()
+        let reference = Self.render(chunks: [stream[...]])
+
+        let offsets = Self.interestingSplitOffsets(in: stream)
+        // Guards the sampler itself: a bug that returned only the stride would
+        // silently drop the cases this test exists for.
+        #expect(offsets.count > stream.count / 7 + 100)
+
+        var firstFailure: (index: Int, screen: String)?
+        for k in offsets {
+            let painted = Self.render(chunks: [stream[..<k], stream[k...]])
+            if painted != reference {
+                firstFailure = (k, painted)
+                break
+            }
+        }
+
+        if let failure = firstFailure {
+            Issue.record(
+                """
+                Splitting the stream at byte \(failure.index) changed the screen.
+                Context: \(Self.describe(stream, around: failure.index))
+                \(Self.diff(reference: reference, actual: failure.screen))
+                """)
+        }
+        #expect(firstFailure == nil)
+    }
+
+    /// The same stream cut into uniform runs, which is what a slow writer or a
+    /// contended pty actually produces. Every stride, including 1, must land on
+    /// the same screen as one whole feed.
+    @Test(arguments: [1, 2, 3, 7, 13, 64, 511, 1024])
+    func aStreamFedInFixedSizeRunsPaintsTheSameScreen(stride: Int) {
+        let stream = Self.claudeShapedStream()
+        let reference = Self.render(chunks: [stream[...]])
+
+        var chunks: [ArraySlice<UInt8>] = []
+        var start = 0
+        while start < stream.count {
+            let end = min(start + stride, stream.count)
+            chunks.append(stream[start..<end])
+            start = end
+        }
+
+        let painted = Self.render(chunks: chunks)
+        #expect(
+            painted == reference,
+            """
+            Feeding in runs of \(stride) changed the screen.
+            \(Self.diff(reference: reference, actual: painted))
+            """)
+    }
+
+    /// Redrawing the identical stream over an emulator that already painted it
+    /// must be a no-op. A TUI repaints constantly; if the second pass differs
+    /// the holes would appear to move on their own.
+    @Test func feedingTheSameStreamTwicePaintsTheSameScreen() {
+        let stream = Self.claudeShapedStream()
+        let once = Self.render(chunks: [stream[...]])
+        let twice = Self.render(chunks: [stream[...], stream[...]])
+        #expect(
+            once == twice,
+            "A redraw of the identical stream changed the screen.\n\(Self.diff(reference: once, actual: twice))")
+    }
+
+    /// Wide glyphs straddling the right margin, and combining marks that extend
+    /// the glyph before them. Both are the cases where a cut between two bytes
+    /// of one *character* — not one sequence — decides how many cells get used.
+    ///
+    /// Sampled the same way, and nothing is given up by it: every offset inside
+    /// every multi-byte character here is one of the offsets the sampler keeps.
+    @Test func wideAndCombiningCharactersSurviveEverySplit() {
+        let stream = Self.wideCharacterStream()
+        let reference = Self.render(chunks: [stream[...]])
+
+        var firstFailure: (index: Int, screen: String)?
+        for k in Self.interestingSplitOffsets(in: stream) {
+            let painted = Self.render(chunks: [stream[..<k], stream[k...]])
+            if painted != reference {
+                firstFailure = (k, painted)
+                break
+            }
+        }
+
+        if let failure = firstFailure {
+            Issue.record(
+                """
+                Splitting the wide/combining stream at byte \(failure.index) changed the screen.
+                Context: \(Self.describe(stream, around: failure.index))
+                \(Self.diff(reference: reference, actual: failure.screen))
+                """)
+        }
+        #expect(firstFailure == nil)
+    }
+
+    /// A chunk larger than the drain thread's 64 KB read buffer, to rule out a
+    /// cap or a truncation inside a single feed. Fed whole, it must match the
+    /// same bytes fed in 64 KB pieces — which is what the reader would deliver.
+    @Test func aChunkLargerThanTheDrainBufferIsNotTruncated() {
+        var stream: [UInt8] = []
+        var copies = 0
+        while stream.count < 200_000 {
+            stream.append(contentsOf: Self.claudeShapedStream())
+            copies += 1
+        }
+        #expect(copies > 1)
+
+        let whole = Self.render(chunks: [stream[...]])
+
+        var chunks: [ArraySlice<UInt8>] = []
+        var start = 0
+        while start < stream.count {
+            let end = min(start + 65_536, stream.count)
+            chunks.append(stream[start..<end])
+            start = end
+        }
+        let inReads = Self.render(chunks: chunks)
+
+        #expect(
+            whole == inReads,
+            "A >64 KB stream painted differently whole than in 64 KB reads.\n\(Self.diff(reference: whole, actual: inReads))")
+    }
+
+    /// The screen is not merely chunk-independent, it is *right*.
+    ///
+    /// A determinism check compares two runs of the same code and passes when
+    /// both are wrong in the same way. This one compares the painted cells
+    /// against what the bytes say they should be: an SGR change between every
+    /// pair of letters, started at every column offset so that the style switch
+    /// lands on the right margin, on the cell before it, and on the cell after
+    /// it. Nothing here may swallow a letter.
+    ///
+    /// Padding is `.` rather than a space so that `trimRight: true` cannot hide
+    /// a hole at the end of a row.
+    @Test(arguments: [false, true])
+    func styleChangesBetweenLettersNeverSwallowOne(byteAtATime: Bool) {
+        let letters = "abcdefghij"
+        for offset in 0..<(Self.columns + 4) {
+            var out = "\(Self.esc)[2J\(Self.esc)[H"
+            out += String(repeating: ".", count: offset)
+            for (index, letter) in letters.enumerated() {
+                out += "\(Self.esc)[3\(index % 8)m\(letter)"
+            }
+            out += "\(Self.esc)[0m"
+            let bytes = Array(out.utf8)
+
+            let chunks: [ArraySlice<UInt8>]
+            if byteAtATime {
+                chunks = (0..<bytes.count).map { bytes[$0..<($0 + 1)] }
+            } else {
+                chunks = [bytes[...]]
+            }
+            let painted = Self.render(chunks: chunks).components(separatedBy: "\n").joined()
+            let expected = String(repeating: ".", count: offset) + letters
+            #expect(
+                painted == expected,
+                "offset \(offset), byteAtATime=\(byteAtATime): painted \(painted.debugDescription)")
+        }
+    }
+
+    /// The same, with a non-ASCII glyph in the middle of the run. It takes the
+    /// print path off its ASCII fast path for everything that follows, which is
+    /// the other side of the branch the previous test covers.
+    @Test(arguments: [false, true])
+    func aNonASCIIGlyphMidRunNeverSwallowsANeighbour(byteAtATime: Bool) {
+        for offset in 0..<(Self.columns + 4) {
+            var out = "\(Self.esc)[2J\(Self.esc)[H"
+            out += String(repeating: ".", count: offset)
+            out += "abcd\(Self.esc)[1m✻\(Self.esc)[0mefgh"
+            let bytes = Array(out.utf8)
+
+            let chunks: [ArraySlice<UInt8>]
+            if byteAtATime {
+                chunks = (0..<bytes.count).map { bytes[$0..<($0 + 1)] }
+            } else {
+                chunks = [bytes[...]]
+            }
+            let painted = Self.render(chunks: chunks).components(separatedBy: "\n").joined()
+            let expected = String(repeating: ".", count: offset) + "abcd✻efgh"
+            #expect(
+                painted == expected,
+                "offset \(offset), byteAtATime=\(byteAtATime): painted \(painted.debugDescription)")
+        }
+    }
+
+    // MARK: - Rendering, the way the daemon does it
+
+    private static func render(chunks: [ArraySlice<UInt8>]) -> String {
+        let delegate = SilentDelegate()
+        let terminal = SwiftTerm.Terminal(
+            delegate: delegate,
+            options: TerminalOptions(cols: columns, rows: rows, scrollback: 500))
+        for chunk in chunks {
+            terminal.terminalLock.withLock { terminal.feed(buffer: chunk) }
+        }
+        return terminal.terminalLock.withLock {
+            var lines: [String] = []
+            lines.reserveCapacity(terminal.rows)
+            for row in 0..<terminal.rows {
+                lines.append(terminal.getLine(row: row)?.translateToString(trimRight: true) ?? "")
+            }
+            while let last = lines.last, last.isEmpty { lines.removeLast() }
+            return lines.joined(separator: "\n")
+        }
+    }
+
+    // MARK: - The stream
+
+    private static let esc = "\u{1b}"
+
+    /// Output shaped like a Claude Code frame: truecolour SGR runs inside
+    /// words, lines longer than the terminal is wide so they autowrap, box
+    /// drawing and wide glyphs, synchronized-output and bracketed-paste mode
+    /// toggles, absolute cursor positioning, erase-to-end-of-line, and an
+    /// Ink-style "walk back up N rows and rewrite" pass.
+    private static func claudeShapedStream() -> [UInt8] {
+        var out = ""
+        out += "\(esc)[?2004h"
+        out += "\(esc)[?2026h"
+        out += "\(esc)[2J\(esc)[H"
+
+        for i in 0..<12 {
+            let number = String(format: "%03d", i)
+            out += "\(esc)[38;2;\(20 + i * 5);\(200 - i * 3);\(120 + i)m"
+            out += "line \(number): the quick "
+            out += "\(esc)[1mbrown\(esc)[0m"
+            out += " fox jumps over the lazy dog and keeps going to pad this out"
+            out += "\(esc)[38;2;90;120;200m │ ─── ⏵ ✻ tail\(esc)[39m"
+            out += "\r\n"
+        }
+        out += "\(esc)[?2026l"
+
+        // An absolute repositioning pass that rewrites in place with ESC[K,
+        // the way a status region repaints.
+        for row in 5...12 {
+            out += "\(esc)[\(row);1H\(esc)[K"
+            out += "\(esc)[2m╭─ status \(row) ─────────────────────────────╮\(esc)[22m"
+        }
+
+        // Ink's diff renderer: walk up N rows, carriage return, erase the whole
+        // line, rewrite it.
+        out += "\(esc)[10A"
+        for step in 0..<10 {
+            out += "\r\(esc)[2K"
+            out += "\(esc)[1m✻\(esc)[0m redrawn row \(step) — this text is deliberately long enough that it wraps past the hundredth column of the grid"
+            out += "\(esc)[1B"
+        }
+        out += "\r\n"
+
+        out += "\(esc)[?2004l"
+        out += "\(esc)[38;2;255;170;0m⏵⏵ done\(esc)[39m\r\n"
+        return Array(out.utf8)
+    }
+
+    /// A grid whose right margin is crossed by a two-cell glyph at every
+    /// starting column, plus base letters carrying combining marks.
+    private static func wideCharacterStream() -> [UInt8] {
+        var out = "\(esc)[2J\(esc)[H"
+        for offset in 0..<12 {
+            out += String(repeating: "a", count: columns - 1 - offset)
+            out += "漢字テスト"
+            out += "e\u{301}o\u{308}n\u{303}"
+            out += "\r\n"
+        }
+        return Array(out.utf8)
+    }
+
+    // MARK: - Choosing where to cut
+
+    /// The cuts worth paying for: every offset with structure on either side of
+    /// it, plus a coarse stride over everything else.
+    ///
+    /// "Structure" is an escape sequence or a multi-byte UTF-8 character —
+    /// anything the parser holds partial state across. Every offset inside one,
+    /// and the offset immediately after it, is included; a cut between two
+    /// plain printable bytes exercises the same branch as its neighbours, so
+    /// those are sampled rather than enumerated.
+    private static func interestingSplitOffsets(in stream: [UInt8]) -> [Int] {
+        guard stream.count > 1 else { return [] }
+        var interesting = [Bool](repeating: false, count: stream.count)
+
+        // The coarse pass, so the boring runs still have somewhere to fail.
+        for offset in Swift.stride(from: 1, to: stream.count, by: 7) {
+            interesting[offset] = true
+        }
+
+        // Every cut inside an escape sequence, and the one just after it.
+        var index = 0
+        while index < stream.count {
+            guard stream[index] == 0x1b else {
+                index += 1
+                continue
+            }
+            var end = index + 1
+            if end < stream.count, stream[end] == UInt8(ascii: "[") || stream[end] == UInt8(ascii: "]") {
+                let isOperatingSystemCommand = stream[end] == UInt8(ascii: "]")
+                end += 1
+                while end < stream.count {
+                    let byte = stream[end]
+                    if isOperatingSystemCommand {
+                        if byte == 0x07 || byte == 0x1b { break }
+                    } else if (0x40...0x7e).contains(byte) {
+                        break
+                    }
+                    end += 1
+                }
+            }
+            let last = min(end + 1, stream.count - 1)
+            if index + 1 <= last {
+                for offset in (index + 1)...last { interesting[offset] = true }
+            }
+            index = end + 1
+        }
+
+        // Every cut inside a multi-byte character, and the one just after it.
+        for offset in 1..<stream.count
+        where stream[offset] & 0xc0 == 0x80 || stream[offset - 1] & 0x80 != 0 {
+            interesting[offset] = true
+        }
+
+        return (1..<stream.count).filter { interesting[$0] }
+    }
+
+    // MARK: - Reporting
+
+    /// What the bytes on either side of a cut are, so a failure names the
+    /// sequence it landed inside rather than only an offset.
+    private static func describe(_ stream: [UInt8], around index: Int) -> String {
+        let lower = max(0, index - 12)
+        let upper = min(stream.count, index + 12)
+        func show(_ slice: ArraySlice<UInt8>) -> String {
+            slice.map { byte in
+                switch byte {
+                case 0x1b: return "<ESC>"
+                case 0x0d: return "<CR>"
+                case 0x0a: return "<LF>"
+                case 0x20...0x7e: return String(UnicodeScalar(byte))
+                default: return String(format: "<%02x>", byte)
+                }
+            }.joined()
+        }
+        return "…\(show(stream[lower..<index]))‖\(show(stream[index..<upper]))…"
+    }
+
+    private static func diff(reference: String, actual: String) -> String {
+        let left = reference.components(separatedBy: "\n")
+        let right = actual.components(separatedBy: "\n")
+        var report: [String] = []
+        for row in 0..<max(left.count, right.count) {
+            let a = row < left.count ? left[row] : "<absent>"
+            let b = row < right.count ? right[row] : "<absent>"
+            if a != b {
+                report.append("row \(row) expected: \(a.debugDescription)")
+                report.append("row \(row)   actual: \(b.debugDescription)")
+            }
+        }
+        if report.isEmpty { return "(rows identical; the strings differ elsewhere)" }
+        return report.prefix(8).joined(separator: "\n")
+    }
+}
+
+private final class SilentDelegate: TerminalDelegate {
+    func send(source: SwiftTerm.Terminal, data: ArraySlice<UInt8>) {}
+}

--- a/Tests/TBDDaemonTests/HolderRenderProjectionTests.swift
+++ b/Tests/TBDDaemonTests/HolderRenderProjectionTests.swift
@@ -1,0 +1,189 @@
+import Darwin
+import Foundation
+import Testing
+
+@testable import TBDDaemonLib
+
+/// What `terminal.output` owes its readers: **text, with no invisible holes in
+/// it.**
+///
+/// A holder-backed session's screen is the daemon's own headless emulator, and
+/// a cell that no program ever wrote holds `CharData.Null` — code 0. Rendering
+/// that cell literally puts `U+0000` into the string. Nothing displays it,
+/// nothing in a diff shows it, and every consumer that matches on the text —
+/// fleet supervision, the hibernation pending-input rail, the interactive
+/// login driver — silently fails to find the characters on either side of it.
+///
+/// The holes are not rare and they are not stationary. A TUI like Claude Code
+/// paints differentially: instead of overwriting a run of cells with blanks it
+/// *positions the cursor past them* (`\r ESC[82C ESC[1B ● high`,
+/// `✻ ESC[3G Cogitated`), so every skipped cell becomes a NUL, and which cells
+/// get skipped changes with each repaint — the holes appear to move.
+///
+/// tmux `capture-pane`, which this render replaces for machine reads, returns
+/// spaces. So does the app-side serializer (`TerminalCellWalk`). This suite
+/// pins the daemon's renderer to the same projection.
+///
+/// It exercises the production path rather than a copy of it: `ingest` feeds
+/// the reader's emulator synchronously, and `renderScreen` /
+/// `renderScreenWithScrollback` are the very functions `terminal.output`
+/// calls. No drain thread and no real pty are involved, so nothing here is
+/// timing-dependent.
+@Suite struct HolderRenderProjectionTests {
+
+    private static let nul = "\u{0}"
+    private static let esc = "\u{1b}"
+
+    // MARK: - Positioned writes leave spaces, not NULs
+
+    /// The signature that started this: a spinner glyph, a jump to column 3,
+    /// and a word. The cell between them was never written.
+    @Test("a cursor jump on the current row renders as a space")
+    func aColumnJumpRendersAsASpace() async throws {
+        let harness = try Harness(columns: 40, rows: 8)
+        defer { harness.tearDown() }
+
+        await harness.reader.ingest(preamble: Self.data("✻\(Self.esc)[3GCogitated"))
+        let screen = await harness.reader.renderScreen()
+
+        #expect(screen.components(separatedBy: "\n").first == "✻ Cogitated")
+        #expect(
+            !screen.contains(Self.nul),
+            "the rendered screen carries U+0000: \(screen.debugDescription)")
+    }
+
+    /// Cursor-forward from the start of a row. Five columns nobody wrote.
+    @Test("cursor-forward leaves spaces across the columns it skipped")
+    func cursorForwardLeavesSpaces() async throws {
+        let harness = try Harness(columns: 40, rows: 8)
+        defer { harness.tearDown() }
+
+        await harness.reader.ingest(preamble: Self.data("\r\(Self.esc)[5Cx"))
+        let screen = await harness.reader.renderScreen()
+
+        #expect(screen == "     x", "rendered \(screen.debugDescription)")
+    }
+
+    /// An absolute position onto a lower row. The rows above it were never
+    /// touched at all, and must stay *empty* — the trailing-blank trim runs off
+    /// `getTrimmedLength()`, which is computed before the projection, so
+    /// turning never-written cells into spaces must not pad blank rows out to
+    /// the full width.
+    @Test("a positioned write pads its own row and leaves the rows above empty")
+    func aPositionedWriteLeavesBlankRowsBlank() async throws {
+        let harness = try Harness(columns: 40, rows: 8)
+        defer { harness.tearDown() }
+
+        await harness.reader.ingest(preamble: Self.data("\(Self.esc)[3;10Hhello"))
+        let screen = await harness.reader.renderScreen()
+
+        let rows = screen.components(separatedBy: "\n")
+        #expect(rows.count == 3, "rendered \(screen.debugDescription)")
+        #expect(rows.first == "")
+        #expect(rows.dropFirst().first == "")
+        #expect(rows.last == "         hello", "rendered \(rows.last.debugDescription)")
+        #expect(!screen.contains(Self.nul))
+    }
+
+    // MARK: - Wide glyphs
+
+    /// The trailing half of a two-cell glyph carries code 0 as well, and it is
+    /// *not* an unwritten cell: projecting it as a space would double the width
+    /// of every CJK character and every emoji.
+    @Test("a wide glyph is not padded with a stray space")
+    func wideGlyphsAreNotDoubled() async throws {
+        let harness = try Harness(columns: 40, rows: 8)
+        defer { harness.tearDown() }
+
+        await harness.reader.ingest(preamble: Self.data("日本 x"))
+        let screen = await harness.reader.renderScreen()
+
+        #expect(screen == "日本 x", "rendered \(screen.debugDescription)")
+        #expect(!screen.contains(Self.nul))
+    }
+
+    /// Wide glyphs and a positioned write on the row below, to show the two
+    /// projections do not interfere: the gap after `a` is three spaces because
+    /// `ESC[4G` is column 4, and the wide row above is still two glyphs wide.
+    @Test("columns still line up on the row after a wide-glyph run")
+    func columnsLineUpBelowAWideGlyphRun() async throws {
+        let harness = try Harness(columns: 40, rows: 8)
+        defer { harness.tearDown() }
+
+        await harness.reader.ingest(preamble: Self.data("日本\r\na\(Self.esc)[4Gb"))
+        let screen = await harness.reader.renderScreen()
+
+        #expect(screen == "日本\na  b", "rendered \(screen.debugDescription)")
+        #expect(!screen.contains(Self.nul))
+    }
+
+    // MARK: - The scrollback render
+
+    /// `renderScreenWithScrollback` is a second, separate walk over the buffer
+    /// and needs the projection in its own right. The gap here is deliberately
+    /// placed on a line that has already scrolled off the viewport, so only the
+    /// scrollback path can produce it.
+    @Test("the scrollback render projects never-written cells as spaces too")
+    func scrollbackRenderProjectsNeverWrittenCells() async throws {
+        let harness = try Harness(columns: 40, rows: 5)
+        defer { harness.tearDown() }
+
+        var stream = ""
+        for index in 0..<8 {
+            if index == 1 {
+                stream += "\(Self.esc)[10Cgap\r\n"
+            } else {
+                stream += "row \(index)\r\n"
+            }
+        }
+        await harness.reader.ingest(preamble: Self.data(stream))
+
+        let viewport = await harness.reader.renderScreen()
+        #expect(
+            !viewport.contains("gap"),
+            "the gap line is still on screen, so this asserts nothing about scrollback")
+
+        let history = await harness.reader.renderScreenWithScrollback(maxLines: 100)
+        #expect(
+            history.contains("          gap"),
+            "rendered \(history.debugDescription)")
+        #expect(
+            !history.contains(Self.nul),
+            "the rendered scrollback carries U+0000: \(history.debugDescription)")
+    }
+
+    // MARK: - Harness
+
+    private static func data(_ text: String) -> Data { Data(text.utf8) }
+
+    /// A `HolderReader` over one end of a socketpair, never started.
+    ///
+    /// Nothing on this path reads a tty's ioctls, and starting the drain would
+    /// only add a thread and a wait to a test whose whole subject is what the
+    /// emulator renders. `ingest` feeds the same emulator the drain loop feeds,
+    /// on the calling thread.
+    private struct Harness {
+        let reader: HolderReader
+        private let ours: Int32
+
+        init(columns: Int, rows: Int) throws {
+            var pair: [Int32] = [-1, -1]
+            try #require(socketpair(AF_UNIX, SOCK_STREAM, 0, &pair) == 0)
+            ours = pair[1]
+            // The reader owns `pair[0]` and closes it in `tearDown`.
+            reader = HolderReader(
+                sessionID: UUID(),
+                ptyFD: pair[0],
+                columns: columns,
+                rows: rows,
+                scrollbackLines: 200)
+        }
+
+        /// Closes this side only. The reader's own end is closed by its
+        /// `deinit`, which is safe precisely because the reader is `.idle`:
+        /// no thread was ever started, so none can be inside a read on it.
+        func tearDown() {
+            close(ours)
+        }
+    }
+}


### PR DESCRIPTION
## What's broken

Reading a holder-backed Claude Code session through `terminal.output` (the daemon-side replacement for tmux `capture-pane`, used by `tbd terminal output`, the supervision babysitter, the hibernation pending-input rail and the interactive-login driver) returns text with characters missing. In a stress test, a 40-line paste came back as `pad thi  out` and `the quick brow  fox`, with the affected lines changing between reads: one line corrupt across three reads of a static screen, then clean while two others went bad after the TUI redrew. Nothing in the output signals that anything is missing, so any consumer that matches on text makes decisions on a string that is not what is on screen.

## Why it happens

The daemon drains the session's pty into a headless SwiftTerm emulator and renders that emulator's rows with `translateToString`. On its default path that call emits U+0000 for every cell the program never wrote, because an unwritten cell holds `CharData.Null` with code 0 and the character projection passes it through unchanged. Trailing unwritten cells are trimmed, but leading and interior ones are not.

Claude Code paints differentially and positions rather than pads: it moves the cursor with `ESC[nC` and `ESC[nG` over cells it considers already correct instead of writing spaces, and rewrites only the cells that changed since its previous frame. So wherever the TUI skipped a cell, the daemon's string carries a NUL. A NUL is invisible in a terminal and survives JSON untouched, which is exactly "a character is missing and nothing says so". Which cells the TUI skips depends on what its previous frame held at those columns, so a repaint moves the holes.

The emulator's grid itself is correct. Replaying real Claude Code bytes captured from a 40x100 pty (zero tokens, through the repo's fake model API) into the fork's emulator and comparing cell by cell against an independent emulator gives an identical grid on every row, for every chunking of the byte stream, and across a resize round trip. Mapping code 0 to a space in the projection makes the two agree on 40 of 40 rows. The app-side serializer (`TerminalCellWalk`) already makes that mapping, and tmux `capture-pane` returns spaces, so the daemon was the one surface projecting differently.

Two other candidates were tested and ruled out, and the tests that rule out the first are kept:

- **Parser losing cells on pty read boundaries.** A Claude-shaped 7 KB stream and the real captured stream were fed whole, at the real read boundaries, byte at a time, and split inside every escape sequence. Every screen was identical and correct. `EmulatorFeedChunkingTests` pins this.
- **The jiggle painting at cols+1 into a cols-wide grid.** Against the real TUI with the grid held at 100 columns, the child does repaint at 101 columns within 0.4 ms, which transiently garbles full-width chrome for a few milliseconds, but the restore repaint is a full re-layout that rewrites every cell, and no payload text row ever reaches column 100. Thirty-five captures across gap values of 0, 10, 50 and 200 ms showed no persistent hole.

## What this PR does

- `HolderReader`'s emulator wrapper renders rows through one helper that passes `skipNullCellsFollowingWide: true` and a character provider mapping code 0 to a space. Both are needed: the second half of a wide glyph is also code 0 and has to be dropped, not spaced, so `日本` stays two cells. Both `renderScreen` and `renderScreenWithScrollback` use it, so `terminal.output` and its scrollback variant agree.
- `HolderRenderProjectionTests` feeds cursor-positioned writes, positioned rows, wide glyphs and a scrolled buffer through the production render path and asserts spaces, correct column alignment, and no U+0000 anywhere.
- `EmulatorFeedChunkingTests` records the refuted parser hypothesis and guards the determinism the holder drain relies on.

Not changed here, deliberately, and noted for separate follow-ups:

- The jiggle's transient cols+1 corruption of full-width chrome is real but heals within milliseconds on the next repaint and is not what the report describes. A daemon dying inside that 10 ms window would leave the pty one column wide for its successor to adopt at; one live session was seen holding a 221-cell row in a 220-column pty.
- The same code-0 projection now exists independently in `TerminalCellWalk` (app-side snapshots), `HolderReader.rowText` (daemon reads), and a third bare `translateToString()` in the app's click-to-open path (`TBDTerminalView.extractFilePath`), which still carries the defect for its own consumer. Nothing enforces that the three agree; a shared helper is the right fix once a spec-free moment allows it.
- `TBDDaemonTests` imports SwiftTerm without declaring the product in `Package.swift`; it resolves transitively today. A one-line dependency addition would make it explicit, deferred because a `Package.swift` edit forces a full rebuild on the shared machine.

## Assumptions

- Consumers of `terminal.output` want tmux `capture-pane` semantics for blank cells (spaces), not a distinction between "written space" and "never written". If a consumer ever needs that distinction, it needs a different projection, not NULs.
- A hole reported as missing text is a never-written cell. If a future report shows 0x20 rather than U+0000 at the hole in the raw JSON, a different mechanism is at work and this fix does not cover it.

## Evidence & verification

- **Repro in the lab**: replaying a 17 KB real capture into the daemon's render path produced `✻\0Cogitated` and 82 NULs of indentation on one row.
- **Repro in the field**: a sweep of `terminal.output` across the nine live holder sessions on the affected machine, decoded and counted, found 1,595 U+0000 characters across the five sessions with activity (26, 29, 29, 17 and 13 affected rows), and zero in the four sitting idle at a settled, fully painted screen, which is what differential painting predicts. The NULs are not always literal `` escapes on the wire, so count after decoding.
- **Discriminating test**: all six cases in `HolderRenderProjectionTests` fail on the unfixed code, each rendering U+0000 where a space or nothing is expected (the raw NULs even truncate the test runner's own diagnostic lines), and all pass with the fix. Trailing never-written cells still trim to an empty row.
- `scripts/swift-safe build --build-tests`: exit 0.
- `scripts/test.sh --filter 'HolderRenderProjectionTests|EmulatorFeedChunkingTests'`: exit 0, 13 tests in 2 suites.
- `scripts/test.sh --filter 'Holder'`: exit 0, 440 tests in 59 suites, since `HolderReader` changed.
- `/opt/homebrew/bin/swiftlint --strict`: 0 violations.

https://claude.ai/code/session_01B9W4N5zQJmDEpwgeBPPq5r
[holder-fixture-leak](https://cheapsteak.github.io/tbd/open/?worktree=238E1922-5582-4AA8-821A-D7DF45683CF1)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved terminal screen and scrollback rendering so unwritten cells appear as spaces instead of embedded null characters.
  - Preserved correct handling of wide characters, combining characters, cursor movement, blank rows, and right-trimmed output.
  - Ensured rendered output remains consistent regardless of input chunking, including split UTF-8 sequences and large reads.

- **Tests**
  - Added comprehensive coverage for Unicode rendering, redraws, style changes, scrollback, and chunk-boundary independence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->