### PR TITLE
Fix: Stop ServerShutdownLatchTests from blocking unrelated PRs by keeping the latch off a starved cooperative pool

### DIFF
--- a/Sources/TBDDaemon/Server/ShutdownLatch.swift
+++ b/Sources/TBDDaemon/Server/ShutdownLatch.swift
@@ -32,9 +32,25 @@ import Foundation
 /// unstructured on purpose: it does not inherit its creator's cancellation, so
 /// a cancelled signal handler cannot abandon a shutdown other callers are
 /// waiting on.
+///
+/// Being unstructured also means it inherits no task-executor preference
+/// (SE-0417 carries one into child tasks and default actors, not into
+/// `Task {}`), so by default the run lands on the cooperative pool however the
+/// caller was started. `executor` exists for tests and nothing else: a test
+/// that exercises the latch directly injects `GateExecutor` so the run cannot
+/// starve behind a saturated parallel pass. Production constructs every latch
+/// with the default, and the daemon declares no task executor of its own.
 final class ShutdownLatch: Sendable {
     private nonisolated(unsafe) var task: Task<Void, Never>?
     private let lock = NSLock()
+    private let executor: (any TaskExecutor)?
+
+    /// - Parameter executor: Where the single run is scheduled. `nil` — the
+    ///   production value — means the cooperative pool. Tests that drive the
+    ///   latch directly pass an executor they own; see the type comment.
+    init(executor: (any TaskExecutor)? = nil) {
+        self.executor = executor
+    }
 
     /// Run `body` if this is the first call; otherwise await the run the first
     /// call started. Later `body` arguments are never invoked — every caller of
@@ -50,7 +66,7 @@ final class ShutdownLatch: Sendable {
         lock.lock()
         defer { lock.unlock() }
         if let task { return task }
-        let created = Task { await body() }
+        let created = Task(executorPreference: executor) { await body() }
         task = created
         return created
     }

--- a/Tests/CLAUDE.md
+++ b/Tests/CLAUDE.md
@@ -379,17 +379,25 @@ instead of leaving an anonymous job timeout. `BoundedGateWaitTests` reproduces
 the wedge on any machine by deriving its holder count from
 `activeProcessorCount`.
 
-**The preference stops at an unstructured task, and that changes the bound,
-not the call site.** SE-0417 carries a task executor preference into child
+**The preference stops at an unstructured task; what moves it is the callee,
+not the call site, and where the test does not own the callee only the bound
+is left.** SE-0417 carries a task executor preference into child
 tasks and default actors and *not* into `Task {}` or `Task.detached`. Several
 production seams hand their work to an unstructured task on purpose —
 `ShutdownLatch` does, so a cancelled signal handler cannot abandon a shutdown
 other callers await — and that work is then scheduled on the cooperative pool
 however the test started the call. It is not pinning a thread, and no
-`gateHoldingTask` can move it, so the only correct response is to bound a gate
-released from beyond such a hop at `TestDeadlines.saturatedPass` (90 s) and
-give the outer observation a strictly larger budget, so a genuinely lost
-handshake still reports before the wedge does. A snappier inner bound reports
+`gateHoldingTask` can move it. Where the test owns the callee, inject the
+executor into the callee instead: `ShutdownLatch(executor:)` is that seam,
+and `ServerShutdownLatchTests` builds its latch on `GateExecutor.shared` so
+its run cannot queue behind the pass at all — a bound cannot fix a queue that
+never drains, and CI measured 0 of 8 detached callers back after 90 s while
+the test's own polling task ran on time: a detached task runs at default
+priority, behind every higher-priority test task the pass keeps runnable. Where the test reaches the hop through production
+code it does not construct — a server's `stop()` — bound a gate released from
+beyond it at `TestDeadlines.saturatedPass` (90 s) and give the outer
+observation a strictly larger budget, so a genuinely lost handshake still
+reports before the wedge does. A snappier inner bound reports
 starvation the outer bound was sized to tolerate — which is exactly how
 `SocketServerSocketOwnershipTests` went red on a 30 s staging gate while every
 assertion in the test passed.

--- a/Tests/TBDDaemonTests/ServerShutdownLatchTests.swift
+++ b/Tests/TBDDaemonTests/ServerShutdownLatchTests.swift
@@ -37,27 +37,45 @@ struct ServerShutdownLatchTests {
 
     @Test("the latch runs its body once, and every caller waits for that one run")
     func latchRunsItsBodyOnceAndEveryCallerWaits() async throws {
-        let latch = ShutdownLatch()
+        // Nothing this test waits on is scheduled on the cooperative pool.
+        //
+        // It used to be: the callers were `Task.detached` and the latch's own
+        // run is an unstructured `Task`, which SE-0417 keeps off any executor
+        // preference its creator carries. Both land on the pool, and a
+        // detached task carries no priority, so in a parallel pass that
+        // admits ~5,000 tests against a 3-thread runner they queue behind
+        // every higher-priority test task for as long as the pass keeps the
+        // pool busy. CI observed exactly that: 0 of 8 callers back after
+        // 90 s, while this test's own polling loop — a test-priority task —
+        // kept running the whole time. No bound fixes queueing that never
+        // drains, so the pool is taken out of the picture instead: the
+        // callers start with `gateHoldingTask`, and the latch is built with
+        // the same `GateExecutor` so its run lands on threads these tests own
+        // too. `latchRunsItsBodyOnTheInjectedExecutor` pins that the seam
+        // actually carries the run.
+        //
+        // With the run on a thread the test owns, the body can be *held*
+        // rather than merely slowed: it blocks on a gate the test releases
+        // once every caller has arrived, so a caller that failed to wait for
+        // the run has the whole hold to return early in, not a window of a
+        // few yields whose width depends on the machine.
+        let latch = ShutdownLatch(executor: GateExecutor.shared)
         let runs = ShutdownCounter()
+        let bodyThread = ThreadNameBox()
+        let arrived = ShutdownCounter()
         let returned = ShutdownCounter()
         let returnedBeforeTheBodyFinished = ShutdownCounter()
         let bodyFinished = ShutdownFlag()
+        let releaseTheBody = DispatchSemaphore(value: 0)
         let callers = 8
 
         for _ in 0..<callers {
-            Task.detached {
+            _ = gateHoldingTask {
+                arrived.increment()
                 await latch.run {
                     runs.increment()
-                    // Suspends, so a caller that failed to wait for the run
-                    // would return while this is still in flight. One yield
-                    // would already open that window; a few widen it without
-                    // making the test's cost depend on how loaded the machine
-                    // is. Every `Task.yield()` is a full trip to the back of
-                    // the process-wide run queue, and in the saturated pass
-                    // that queue holds thousands of runnable tasks — the
-                    // hundred yields this started out with took longer than
-                    // the whole wait below.
-                    for _ in 0..<20 { await Task.yield() }
+                    bodyThread.recordCurrentThread()
+                    releaseTheBody.waitForGate("the test to release the shutdown body")
                     bodyFinished.set()
                 }
                 if !bodyFinished.isSet { returnedBeforeTheBodyFinished.increment() }
@@ -65,12 +83,17 @@ struct ServerShutdownLatchTests {
             }
         }
 
-        // `waitFor` at the repo-wide saturated-pass budget rather than a snug
-        // few seconds. These callers are detached tasks, so the thing being
-        // waited on is the cooperative pool getting round to them: 5,059 tests
-        // share one process and a pool three threads wide on CI's runner, and
-        // scheduling latency there is measured in tens of seconds. A shorter
-        // bound reports queueing as a wedged latch.
+        try await waitFor(
+            "all \(callers) callers to reach the latch while its run is held",
+            observed: { "\(arrived.count) of \(callers) arrived, \(runs.count) runs" }
+        ) { arrived.count == callers && runs.count == 1 }
+        // One signal per caller rather than one: a latch that wrongly ran the
+        // body more than once would otherwise park its extra runs on the gate
+        // until `TestGate.deadline`, after this test has already reported. Over-
+        // signalling costs nothing, and the duplicate run is still reported —
+        // by the `runs` expectation below, which is the one that names it.
+        for _ in 0..<callers { releaseTheBody.signal() }
+
         try await waitFor(
             "all \(callers) latch callers to return",
             observed: { "\(returned.count) of \(callers) returned" }
@@ -79,6 +102,47 @@ struct ServerShutdownLatchTests {
         #expect(
             returnedBeforeTheBodyFinished.count == 0,
             "\(returnedBeforeTheBodyFinished.count) callers returned before the shutdown had finished"
+        )
+        // Self-pinned rather than remembered: the gate above blocks whatever
+        // thread runs the body, and only the `executor:` argument keeps that
+        // off the cooperative pool. Drop it and this is what goes red.
+        #expect(
+            bodyThread.name == GateExecutor.threadName,
+            "the held body ran on \(bodyThread.name ?? "an unnamed thread"); it must run on a thread the tests own"
+        )
+    }
+
+    @Test("a default-constructed latch runs its body once across repeat calls")
+    func defaultLatchRunsItsBodyOnce() async {
+        // The production configuration — `SocketServer` and `HTTPServer` both
+        // build their latch with no executor — keeps its once-only coverage.
+        // Sequential rather than concurrent callers, because this run does go
+        // to the cooperative pool: it is one task at the test's own priority,
+        // which is the same exposure every other test in the pass has, and not
+        // eight detached callers at default priority.
+        let latch = ShutdownLatch()
+        let runs = ShutdownCounter()
+        await latch.run { runs.increment() }
+        await latch.run { runs.increment() }
+        #expect(runs.count == 1, "the latch ran its body \(runs.count) times; exactly one may")
+    }
+
+    @Test("the latch runs its body on the injected executor")
+    func latchRunsItsBodyOnTheInjectedExecutor() async {
+        // The seam the test above rests on. `gateHoldingTask` alone does not
+        // reach the run — `BoundedGateWaitTests` pins that an unstructured
+        // `Task` drops the preference — so the latch has to carry the executor
+        // itself, and this is the check that it does. If this fails, the test
+        // above is back to racing the cooperative pool, whatever its bound.
+        let latch = ShutdownLatch(executor: GateExecutor.shared)
+        let bodyThread = await gateHoldingTask { () -> String? in
+            let box = ThreadNameBox()
+            await latch.run { box.recordCurrentThread() }
+            return box.name
+        }.value
+        #expect(
+            bodyThread == GateExecutor.threadName,
+            "the latch's run landed on \(bodyThread ?? "an unnamed thread"), not the injected executor"
         )
     }
 
@@ -95,10 +159,14 @@ struct ServerShutdownLatchTests {
         await server.stop()
 
         let returned = ShutdownCounter()
-        // Detached and waited on with a deadline rather than awaited directly:
-        // the failure under test is a shutdown that never returns, and awaiting
-        // it would wedge the whole run instead of reporting it.
-        Task.detached {
+        // Started as a separate task and waited on with a deadline rather
+        // than awaited directly: the failure under test is a shutdown that
+        // never returns, and awaiting it would wedge the whole run instead of
+        // reporting it. `gateHoldingTask` keeps the caller off the cooperative
+        // pool; the server's own latch has no executor injected, but its run
+        // already finished with the first `stop()`, so this second call awaits
+        // a completed task and never needs the pool to make progress.
+        _ = gateHoldingTask {
             await server.stop()
             returned.increment()
         }
@@ -121,6 +189,28 @@ private final class ShutdownCounter: @unchecked Sendable {
     }
 
     var count: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
+    }
+}
+
+/// Records the thread the latched body ran on, from inside that body.
+///
+/// The read is synchronous on purpose: `Thread.current` is unavailable across
+/// a suspension point precisely because the answer can change there, and
+/// which thread the body starts on is the thing under test.
+private final class ThreadNameBox: @unchecked Sendable {
+    private var value: String?
+    private let lock = NSLock()
+
+    func recordCurrentThread() {
+        lock.lock()
+        defer { lock.unlock() }
+        value = Thread.current.name
+    }
+
+    var name: String? {
         lock.lock()
         defer { lock.unlock() }
         return value

--- a/Tests/TBDDaemonTests/SocketServerSocketOwnershipTests.swift
+++ b/Tests/TBDDaemonTests/SocketServerSocketOwnershipTests.swift
@@ -248,7 +248,9 @@ struct SocketServerSocketOwnershipTests {
         // against a 3-thread runner.
         //
         // That is a scheduling cost, not a wedge, and the gate's bound has to
-        // absorb it.
+        // absorb it. (`ShutdownLatch(executor:)` would pin the run, but the
+        // server builds its own latch with the default; only a test that
+        // holds a latch directly — `ServerShutdownLatchTests` — can inject.)
         let claims = ClaimCounter()
         let firstShutdownIsAtTheReclaimStep = DispatchSemaphore(value: 0)
         let secondCallerHasArrived = DispatchSemaphore(value: 0)

--- a/Tests/TestSupport/BoundedGateSupport.swift
+++ b/Tests/TestSupport/BoundedGateSupport.swift
@@ -116,8 +116,14 @@ public final class GateExecutor: TaskExecutor, @unchecked Sendable {
 /// cooperative pool however its caller was started, so a gate released from
 /// there is subject to the pass's scheduling latency and must be bounded by
 /// ``TestDeadlines/saturatedPass`` rather than by a snappier number. It is not
-/// pinning a thread, and no call-site change can move it; only the bound is
-/// yours to get right. `BoundedGateWaitTests` pins the rule.
+/// pinning a thread, and no call-site change can move it. What can move it is
+/// the callee taking the executor itself: `ShutdownLatch(executor:)` exists
+/// for tests that hold a latch of their own, and `ServerShutdownLatchTests`
+/// builds one on `GateExecutor.shared` so nothing it waits on touches the
+/// pool. A test that reaches a latch through a server's `stop()` has no such
+/// handle — the servers build their latches with the default — so there the
+/// bound is still the only thing yours to get right. `BoundedGateWaitTests`
+/// pins the rule.
 public func gateHoldingTask<Success: Sendable>(
     _ operation: @escaping @Sendable () async -> Success
 ) -> Task<Success, Never> {
@@ -262,14 +268,16 @@ public struct TestGateTimeout: Error, CustomStringConvertible {
     public var description: String {
         """
         test gate "\(gate)" was never signalled within \(after) — the releasing \
-        statement did not run in time. Two causes, and they need different \
+        statement did not run in time. Three causes, and they need different \
         fixes. (1) The holding side was started with a plain `Task` rather than \
         `gateHoldingTask`, so it blocked a cooperative-pool thread the release \
-        needed: move it. (2) The release itself runs on the pool and was merely \
-        starved — which an unstructured `Task` anywhere on its path guarantees, \
-        because SE-0417 does not carry an executor preference into `Task {}`, \
-        so `gateHoldingTask` at the call site does not cover work a callee \
-        hands to one: size the bound at `TestDeadlines.saturatedPass` instead. \
+        needed: move it. (2) The release runs on the pool beyond an unstructured \
+        `Task` in a callee the test constructs — SE-0417 does not carry an \
+        executor preference into `Task {}`, so `gateHoldingTask` at the call \
+        site does not reach it: inject the executor into the callee instead, as \
+        `ShutdownLatch(executor:)` allows. (3) The hop sits inside production \
+        code the test does not construct, so nothing can move it and it was \
+        merely starved: size the bound at `TestDeadlines.saturatedPass`. \
         See Tests/TestSupport/BoundedGateSupport.swift.
         """
     }


### PR DESCRIPTION
## What's broken

`ServerShutdownLatchTests` is flaky on CI and has started failing PRs that touch nothing near it. The failure is always the same line:

```
✘ "the latch runs its body once, and every caller waits for that one run"
   ServerShutdownLatchTests.swift:74: timed out waiting for all 8 latch callers
   to return — observed 0 of 8 returned after polling up to 90.0 seconds
```

It failed twice in a row on #813 (daemon environment scrubbing) and once on its own PR, #806, before that. Raising the bound from 15 s to the repo-wide 90 s saturated-pass budget did not help: the count is always **0 of 8**, never "nearly there".

## Why it happens

Every task the test waited on was scheduled on Swift's cooperative pool, and on CI's 3-thread runner that pool is shared with a parallel pass of ~5,000 tests.

Two things put the work there. The eight callers were `Task.detached`, and `ShutdownLatch` runs the shutdown body in an unstructured `Task` on purpose, so a cancelled signal handler cannot abandon a shutdown other callers are awaiting. SE-0417 carries a task-executor preference into child tasks and default actors, but not into `Task {}` or `Task.detached`, so `gateHoldingTask` at the call site could reach the callers but never the body.

The "0 of 8" is what points at priority rather than plain load. A detached task carries no priority. The test's own polling loop is a test-priority task, and it kept running: the test reported at ~109 s against a 90 s bound, so the poller was getting scheduled roughly on time while the detached callers and the body they were waiting on got no time at all. With higher-priority test tasks continuously runnable, work at the default priority sits at the back of the queue for as long as the pass keeps the pool busy. No bound fixes a queue that does not drain.

## What this PR does

Takes the cooperative pool out of the test entirely, instead of bounding its latency again.

- `ShutdownLatch` gains an `executor` initializer parameter, defaulting to `nil`. The single run is created with `Task(executorPreference: executor)`, which with `nil` is exactly the old `Task {}`. Both production call sites (`SocketServer`, `HTTPServer`) construct the latch with the default, so nothing in the daemon changes. The doc comment says plainly that the parameter exists for tests.
- The test builds its latch on `GateExecutor.shared` and starts its callers with `gateHoldingTask`, so every task it waits on runs on threads the tests own.
- With the body on a thread the test owns, it is *held* on a `DispatchSemaphore` (via `waitForGate`) until every caller has reached the latch, rather than slowed by a loop of `Task.yield()`. "Every caller waited" is now checked across the whole hold, not across a window of yields whose width depended on the machine.
- The main test also records which thread ran the held body and asserts it is a `GateExecutor` thread, so dropping the `executor:` argument later goes red instead of silently blocking a pool thread. A second test pins the seam on its own, and a third keeps once-only coverage for a default-constructed latch, which is the production configuration, using sequential calls so its one pool hop runs at the test's own priority.
- `repeatHTTPServerStopReturns` moves its one detached caller to `gateHoldingTask` for the same reason. Its second `stop()` awaits a run that already completed, so it never needs the pool.
- `Tests/CLAUDE.md`, the `gateHoldingTask` doc comment, the `TestGateTimeout` failure text, and the sibling comment in `SocketServerSocketOwnershipTests` no longer say the hop cannot be moved. They now say when to inject the executor (the test owns the latch) and when the bound is still the only lever (the test reaches the latch through a server's `stop()`).

Rejected: `.serialized` on the suite only serializes tests within the suite; the other ~5,000 tests still saturate the pool. Awaiting the detached tasks' values to trigger priority escalation would make the race less likely, not gone, and leans on runtime internals.

## Evidence & verification

The fix is reasoned from the mechanism. This machine has far more cores than the runner, so the failure does not reproduce locally and a green local run is not evidence on its own.

- `scripts/test.sh --parallel --filter '^TBDDaemonTests\.'`: exit 0, `Test run with 5140 tests in 453 suites passed after 240.9 seconds`, 0 failures. The three latch tests took 50–60 s each, which is the pass's own scheduling latency, not the suite: the pass-wide median test duration was 48.8 s and 2145 of 2424 tests exceeded 45 s.
- `scripts/swift-safe build --build-tests`: exit 0, `Build complete!`.
- `/opt/homebrew/bin/swiftlint --strict`: 0 violations in 974 files.

The new executor test discriminates the seam: without the `executorPreference` change it fails, because an unstructured `Task` drops the preference (`BoundedGateWaitTests` pins that independently). The nil branch is production behavior and is covered by the new sequential once-only test and by the existing `repeatHTTPServerStopReturns`, which uses a server-built latch.

An independent review pass (high level) over the diff found no high-severity issue; its four lower findings (two doc contradictions, lost once-only coverage for the default latch, the main test's pool-safety resting on one unpinned argument) are addressed in this commit. After those edits: `scripts/test.sh --filter 'ServerShutdownLatchTests|BoundedGateWaitTests'` ran 11 tests in 2 suites, all passing, and lint is still clean.

https://claude.ai/code/session_015rAjHRW1CYMaegGk3BG4uD
[20260905-concrete-ermine](https://cheapsteak.github.io/tbd/open/?worktree=739E392F-E355-452C-9144-E74051F2BAF3)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved shutdown coordination to support more predictable behavior during repeated or overlapping server shutdowns.

- **Tests**
  - Expanded coverage for shutdown execution, caller waiting, repeated stops, and executor placement.
  - Added deterministic scheduling controls to reduce timing-sensitive test failures.

- **Documentation**
  - Clarified guidance for testing executor behavior, bounded waits, and shutdown-related timeout diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->