### PR TITLE
Feat: Teach hibernation the pty-holder transport so idle holder sessions can park and wake

### DIFF
--- a/Sources/TBDApp/AppState+ModelProfiles.swift
+++ b/Sources/TBDApp/AppState+ModelProfiles.swift
@@ -424,6 +424,41 @@ extension AppState {
         }
     }
 
+    /// Help text for the pty-holder auto-hibernation toggle.
+    ///
+    /// A stored constant rather than a literal in the view, same reasoning as
+    /// `ptyHolderHelp`: it must describe what changes, and it must be honest
+    /// about the one thing it cannot do — check a session open in a viewer for
+    /// unsent input, the way the tmux rail can.
+    static let holderHibernationHelp = """
+        Off by default. When on, idle holder-backed Claude sessions are parked \
+        by the same sweep and rails as tmux sessions, manual Hibernate acts on \
+        them, and wake starts a fresh holder running claude --resume. Sessions \
+        currently open in a viewer are not parked, because the daemon cannot \
+        check them for unsent input.
+        """
+
+    /// Why the holder-hibernation toggle is inert on this daemon — same
+    /// reasoning and the same caption as `ptyHolderUnsupportedCaption`: with no
+    /// `TBDHolder` helper there is no holder-backed session for this gate to
+    /// ever act on.
+    static let holderHibernationUnsupportedCaption =
+        "Requires the TBDHolder helper beside the daemon binary; this daemon could not find it."
+
+    /// Persist the pty-holder auto-hibernation gate, then re-fetch
+    /// capabilities so the Settings toggle reflects the daemon's persisted
+    /// state. Applies on the next hibernation sweep.
+    func setHolderHibernationEnabled(_ enabled: Bool) async {
+        do {
+            try await holderHibernationFlagSetter(enabled)
+            await refreshDaemonCapabilities()
+        } catch {
+            logger.error("Failed to set holder hibernation: \(error, privacy: .public)")
+            showAlert(
+                "Failed to set holder hibernation: \(error.localizedDescription)", isError: true)
+        }
+    }
+
     /// Persist the worktree auto-trust switch, then re-fetch capabilities so
     /// the Settings toggle reflects the daemon's persisted state. Applies to
     /// the next Claude spawn or wake; never un-trusts an already-seeded path.

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -1438,6 +1438,13 @@ final class AppState {
     /// injectable for the same reason as `controlModeSetter`.
     @ObservationIgnored lazy var ptyHolderFlagSetter: @MainActor (Bool) async throws -> Void =
         { [daemonClient] enabled in try await daemonClient.setPtyHolderEnabled(enabled: enabled) }
+    /// How `setHolderHibernationEnabled` persists the pty-holder
+    /// auto-hibernation gate — injectable for the same reason as
+    /// `controlModeSetter`.
+    @ObservationIgnored lazy var holderHibernationFlagSetter: @MainActor (Bool) async throws -> Void =
+        { [daemonClient] enabled in
+            try await daemonClient.setHolderHibernationEnabled(enabled: enabled)
+        }
     /// How `setClaudeCloudEnabled` persists the Claude cloud gate — injectable
     /// for the same reason as `controlModeSetter`, so the Settings toggle's
     /// success and failure branches are testable without a real daemon.

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -1191,6 +1191,17 @@ actor DaemonClient {
         )
     }
 
+    /// Persist the pty-holder auto-hibernation gate (default OFF). Applies on
+    /// the next hibernation sweep — no daemon restart needed. Sending either
+    /// value is an explicit gesture that survives a later change to the
+    /// shipped default.
+    func setHolderHibernationEnabled(enabled: Bool) async throws {
+        try await callVoidAsync(
+            method: RPCMethod.configSetHolderHibernationEnabled,
+            params: ConfigSetHolderHibernationEnabledParams(enabled: enabled)
+        )
+    }
+
     /// Persist the Claude cloud sessions gate (default OFF). The daemon builds
     /// its provider manager only at boot, so this takes effect on the next
     /// daemon restart rather than the next gesture.

--- a/Sources/TBDApp/Settings/SettingsView.swift
+++ b/Sources/TBDApp/Settings/SettingsView.swift
@@ -269,6 +269,7 @@ struct GeneralSettingsTab: View {
                     .help("Experimental: best-effort exit idle Claude instances when the machine is about to sleep, so a tmux server that dies during a long sleep has less to recover. Off by default — may interrupt long-running work.")
                 controlModeToggle
                 ptyHolderToggle
+                holderHibernationToggle
                 hibernateInputVetoToggle
                 autoCloseSetupToggle
                 queuedPromptToggle
@@ -322,6 +323,28 @@ struct GeneralSettingsTab: View {
         .disabled(!supported)
         if !supported {
             Text(AppState.ptyHolderUnsupportedCaption)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    /// Pty-holder auto-hibernation opt-in. Reads the persisted flag from
+    /// `daemon.capabilities` and writes via `config.setHolderHibernationEnabled`.
+    /// Disabled with the same "no TBDHolder helper" explanation as
+    /// `ptyHolderToggle`, since there is no holder-backed session for this
+    /// gate to ever act on without one.
+    @ViewBuilder
+    private var holderHibernationToggle: some View {
+        let capabilities = appState.daemonCapabilities
+        let supported = capabilities?.ptyHolderSupported ?? false
+        Toggle("Hibernate pty-holder sessions", isOn: Binding(
+            get: { capabilities?.holderHibernationEnabled ?? false },
+            set: { newValue in Task { await appState.setHolderHibernationEnabled(newValue) } }
+        ))
+        .help(AppState.holderHibernationHelp)
+        .disabled(!supported)
+        if !supported {
+            Text(AppState.holderHibernationUnsupportedCaption)
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }

--- a/Sources/TBDApp/Sidebar/RowActionMenuActions.swift
+++ b/Sources/TBDApp/Sidebar/RowActionMenuActions.swift
@@ -93,11 +93,23 @@ struct RowActionMenuActions {
         }?.gone ?? false
     }
 
+    /// The daemon's `holder_hibernation_enabled` soak gate, off until the
+    /// daemon has answered `daemon.capabilities`. The menu must offer only what
+    /// the daemon will actually do: with the gate off a holder-backed session
+    /// is refused a park, so offering one would produce an error and nothing
+    /// else.
+    private var holderHibernationEnabled: Bool {
+        appState.daemonCapabilities?.holderHibernationEnabled ?? false
+    }
+
     /// Build the pure model context from live `AppState`. Mirrors exactly the
     /// inputs the old `SidebarContextMenu` read inline.
     func context() -> RowActionMenu.Context {
         RowActionMenu.Context(
-            hasHibernatableClaude: terminals.contains { $0.isManuallyHibernatable },
+            hasHibernatableClaude: terminals.contains {
+                $0.isManuallyHibernatable(
+                    holderHibernationEnabled: holderHibernationEnabled)
+            },
             // "Wake" acts on any PARKED session (authoritative hibernatedAt OR
             // legacy suspendedAt) — the unified park state.
             hasHibernatedClaude: terminals.contains { $0.isParked },
@@ -173,7 +185,10 @@ struct RowActionMenuActions {
 
         case .hibernateNow:
             let wtID = worktree.id
-            let ids = terminals.filter { $0.isManuallyHibernatable }.map { $0.id }
+            let ids = terminals.filter {
+                $0.isManuallyHibernatable(
+                    holderHibernationEnabled: holderHibernationEnabled)
+            }.map { $0.id }
             Task {
                 for id in ids {
                     await appState.hibernateTerminal(terminalID: id, worktreeID: wtID)

--- a/Sources/TBDApp/Sidebar/RowActionMenuActions.swift
+++ b/Sources/TBDApp/Sidebar/RowActionMenuActions.swift
@@ -102,14 +102,27 @@ struct RowActionMenuActions {
         appState.daemonCapabilities?.holderHibernationEnabled ?? false
     }
 
+    /// The sessions this row's "Hibernate now" would actually act on.
+    ///
+    /// `ManualParkAffordance` adds the app-only half of the question to
+    /// `isManuallyHibernatable`: a holder-backed session whose panel currently
+    /// owns the pty would be refused by the daemon, whose pending-input rail
+    /// cannot read a screen it no longer has. The fan-out and the menu item's
+    /// visibility read the SAME list, so the row can never offer a park that
+    /// would sweep nothing.
+    private var manuallyParkableTerminals: [Terminal] {
+        terminals.filter {
+            ManualParkAffordance.isOfferable(
+                $0, holderHibernationEnabled: holderHibernationEnabled,
+                panelHoldsPTY: appState.terminalInjections.holdsPTY(terminalID: $0.id))
+        }
+    }
+
     /// Build the pure model context from live `AppState`. Mirrors exactly the
     /// inputs the old `SidebarContextMenu` read inline.
     func context() -> RowActionMenu.Context {
         RowActionMenu.Context(
-            hasHibernatableClaude: terminals.contains {
-                $0.isManuallyHibernatable(
-                    holderHibernationEnabled: holderHibernationEnabled)
-            },
+            hasHibernatableClaude: !manuallyParkableTerminals.isEmpty,
             // "Wake" acts on any PARKED session (authoritative hibernatedAt OR
             // legacy suspendedAt) — the unified park state.
             hasHibernatedClaude: terminals.contains { $0.isParked },
@@ -185,10 +198,7 @@ struct RowActionMenuActions {
 
         case .hibernateNow:
             let wtID = worktree.id
-            let ids = terminals.filter {
-                $0.isManuallyHibernatable(
-                    holderHibernationEnabled: holderHibernationEnabled)
-            }.map { $0.id }
+            let ids = manuallyParkableTerminals.map { $0.id }
             Task {
                 for id in ids {
                     await appState.hibernateTerminal(terminalID: id, worktreeID: wtID)

--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -525,16 +525,50 @@ enum TabParkMenuModel {
         case wake
     }
 
-    /// nil = show neither item (no terminal, non-Claude terminal, or a Claude
-    /// session that is mid-turn / waiting on a permission prompt).
+    /// nil = show neither item (no terminal, non-Claude terminal, a Claude
+    /// session that is mid-turn / waiting on a permission prompt, or a holder
+    /// tab whose panel currently owns the pty).
     static func action(
-        for terminal: Terminal?, holderHibernationEnabled: Bool
+        for terminal: Terminal?, holderHibernationEnabled: Bool, panelHoldsPTY: Bool
     ) -> ParkAction? {
         guard let terminal else { return nil }
-        if terminal.isManuallyHibernatable(
-            holderHibernationEnabled: holderHibernationEnabled) { return .hibernate }
+        if ManualParkAffordance.isOfferable(
+            terminal, holderHibernationEnabled: holderHibernationEnabled,
+            panelHoldsPTY: panelHoldsPTY) { return .hibernate }
         if terminal.isParked { return .wake }
         return nil
+    }
+}
+
+/// Whether a manual "Hibernate now" may be *offered* for a terminal right now.
+///
+/// `Terminal.isManuallyHibernatable` answers whether the row is parkable in
+/// principle. This adds the one thing only the app knows: on the pty-holder
+/// transport the daemon's pending-input rail reads its OWN emulator, which is
+/// frozen for as long as a viewer holds the pty, so it fail-closes on any park
+/// asked for while a panel is attached. The app attaches a panel to every live
+/// tab, so an unconditional Hibernate item on a holder tab is an action that
+/// always errors — and an item that always errors is worse than no item.
+///
+/// The daemon's refusal stays as the backstop, because the two views of "is a
+/// viewer attached" can disagree for the width of an attach or detach RPC. What
+/// this removes is the *routine* failure, not the race.
+///
+/// **Why suppression rather than releasing the viewer first.** The orderly
+/// detach-and-handback lives in the panel coordinator's `cleanup()` path and is
+/// not reachable as a standalone awaitable step: it tears the attach down for
+/// good and nothing re-establishes one for a panel that stays on screen. A
+/// park that then refused — for unsent input, say — would leave a live tab
+/// showing a terminal nothing is driving. Suppressing the item costs the user
+/// one gesture (close the tab, or park the worktree from the sidebar); the
+/// alternative costs them the session's screen.
+enum ManualParkAffordance {
+    static func isOfferable(
+        _ terminal: Terminal, holderHibernationEnabled: Bool, panelHoldsPTY: Bool
+    ) -> Bool {
+        guard terminal.isManuallyHibernatable(
+            holderHibernationEnabled: holderHibernationEnabled) else { return false }
+        return !(terminal.transport == .holder && panelHoldsPTY)
     }
 }
 
@@ -991,7 +1025,12 @@ private struct TabBarItem: View {
             switch TabParkMenuModel.action(
                 for: terminal,
                 holderHibernationEnabled:
-                    appState.daemonCapabilities?.holderHibernationEnabled ?? false
+                    appState.daemonCapabilities?.holderHibernationEnabled ?? false,
+                // This tab's own panel is exactly the viewer that would make
+                // the daemon fail the park closed — see `ManualParkAffordance`.
+                panelHoldsPTY: terminal.map {
+                    appState.terminalInjections.holdsPTY(terminalID: $0.id)
+                } ?? false
             ) {
             case .hibernate:
                 Button {

--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -559,8 +559,14 @@ enum TabParkMenuModel {
 /// not reachable as a standalone awaitable step: it tears the attach down for
 /// good and nothing re-establishes one for a panel that stays on screen. A
 /// park that then refused — for unsent input, say — would leave a live tab
-/// showing a terminal nothing is driving. Suppressing the item costs the user
-/// one gesture (close the tab, or park the worktree from the sidebar); the
+/// showing a terminal nothing is driving.
+///
+/// The remedy is to stop holding the pty: close the tab, or let the panel be
+/// evicted from the viewer slots. Parking the worktree from the sidebar is
+/// **not** a way around this — that route fans out through the same daemon
+/// park, which fail-closes on the same attached viewer — so the app suppresses
+/// it for an attached holder row too, and the two surfaces stay honest with
+/// each other. What suppression costs the user is that one gesture; the
 /// alternative costs them the session's screen.
 enum ManualParkAffordance {
     static func isOfferable(

--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -512,6 +512,11 @@ enum SwapProfileMenu {
 /// `isManuallyHibernatable` requires the terminal NOT be parked — so at most
 /// one item ever shows. Extracted from the view so each branch is
 /// unit-testable without SwiftUI (same pattern as `RowActionMenu`).
+///
+/// `holderHibernationEnabled` is the daemon's `holder_hibernation_enabled`
+/// capability. The menu must agree with the rail the daemon will apply: a
+/// Hibernate item offered on a holder tab while the soak gate is off would
+/// only ever produce a refusal the user cannot act on.
 enum TabParkMenuModel {
     enum ParkAction: Equatable {
         /// Terminal is live and manually hibernatable → offer "Hibernate".
@@ -522,9 +527,12 @@ enum TabParkMenuModel {
 
     /// nil = show neither item (no terminal, non-Claude terminal, or a Claude
     /// session that is mid-turn / waiting on a permission prompt).
-    static func action(for terminal: Terminal?) -> ParkAction? {
+    static func action(
+        for terminal: Terminal?, holderHibernationEnabled: Bool
+    ) -> ParkAction? {
         guard let terminal else { return nil }
-        if terminal.isManuallyHibernatable { return .hibernate }
+        if terminal.isManuallyHibernatable(
+            holderHibernationEnabled: holderHibernationEnabled) { return .hibernate }
         if terminal.isParked { return .wake }
         return nil
     }
@@ -980,7 +988,11 @@ private struct TabBarItem: View {
             // the worktree. A scheduled auto-resume can still be pending on a
             // live session that hit its limit, so keep the cancel affordance
             // here too (#341).
-            switch TabParkMenuModel.action(for: terminal) {
+            switch TabParkMenuModel.action(
+                for: terminal,
+                holderHibernationEnabled:
+                    appState.daemonCapabilities?.holderHibernationEnabled ?? false
+            ) {
             case .hibernate:
                 Button {
                     guard let terminalID = terminal?.id else { return }

--- a/Sources/TBDApp/Terminal/TerminalInjectionRouter.swift
+++ b/Sources/TBDApp/Terminal/TerminalInjectionRouter.swift
@@ -63,6 +63,23 @@ final class TerminalInjectionRouter {
         entries[terminalID]?.deliver
     }
 
+    /// Whether some panel currently owns this session's pty.
+    ///
+    /// A claim is taken the instant `attach.ready` is accepted and withdrawn by
+    /// `stopHolderReader`, so it is true over exactly the span in which the
+    /// daemon is NOT this session's reader. That makes it the app's answer to
+    /// the question the daemon fail-closes on: a manual park asked for now
+    /// would be refused, because the pending-input rail cannot read a screen
+    /// the daemon no longer has. The menu reads it so the refusal is never
+    /// offered as an action.
+    ///
+    /// It is a fact about *this app's* panels, not about the daemon's viewer
+    /// table, and the two can disagree for the width of an attach or detach
+    /// RPC. That is why the daemon keeps its own refusal: this one is the UX.
+    func holdsPTY(terminalID: UUID) -> Bool {
+        entries[terminalID] != nil
+    }
+
     func register(
         terminalID: UUID, deliver: @escaping @MainActor (UUID, Data) async -> Bool
     ) -> Registration {

--- a/Sources/TBDCLI/Commands/ConfigCommands.swift
+++ b/Sources/TBDCLI/Commands/ConfigCommands.swift
@@ -6,7 +6,7 @@ struct ConfigCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "config",
         abstract: "Get or set global TBD settings",
-        subcommands: [ConfigGet.self, ConfigSet.self]
+        subcommands: [ConfigGet.self, ConfigSet.self, ConfigHolderHibernation.self]
     )
 }
 
@@ -132,5 +132,44 @@ struct ConfigSet: AsyncParsableCommand {
         default:
             throw CLIError.invalidArgument(Self.unknownKeyMessage(key))
         }
+    }
+}
+
+/// The soak switch for parking, waking and limit-resuming Claude sessions on
+/// the pty-holder transport — auto-hibernation's holder leg. Off — the shipped
+/// default — the sweep and the manual Hibernate action leave holder-backed
+/// sessions alone.
+///
+/// It is a switch of its own rather than a value under `pty_holder_enabled`:
+/// that outer gate has to be ON for a holder row to exist at all, so it cannot
+/// express "transport on, hibernation not yet" — both `pty_holder_enabled` and
+/// this flag are needed for a holder session to actually park.
+struct ConfigHolderHibernation: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "holder-hibernation",
+        abstract: "Enable or disable auto-hibernation for pty-holder sessions (default off)",
+        discussion: """
+            The soak switch for parking, waking and limit-resuming Claude \
+            sessions on the pty-holder transport. Off — the shipped default — \
+            the hibernation sweep and manual Hibernate leave holder-backed \
+            sessions alone.
+
+            Requires `pty_holder_enabled` to also be on: that outer gate has to \
+            be on for any holder session to exist, and this flag decides \
+            whether the ones that exist get hibernated.
+            """
+    )
+    @Argument(help: "on | off") var state: String
+    mutating func run() async throws {
+        let enabled: Bool
+        switch state.lowercased() {
+        case "on", "true", "enable": enabled = true
+        case "off", "false", "disable": enabled = false
+        default: throw ValidationError("Expected 'on' or 'off', got: \(state)")
+        }
+        try SocketClient().callVoid(
+            method: RPCMethod.configSetHolderHibernationEnabled,
+            params: ConfigSetHolderHibernationEnabledParams(enabled: enabled))
+        print("Holder hibernation \(enabled ? "enabled" : "disabled").")
     }
 }

--- a/Sources/TBDDaemon/Actuation/ActuationOutcome+Park.swift
+++ b/Sources/TBDDaemon/Actuation/ActuationOutcome+Park.swift
@@ -54,7 +54,8 @@ extension ActuationOutcome {
         // The row is there but cannot be woken as asked: nothing to resume, or
         // the profile it was pinned to no longer exists.
         case .noSessionID, .profileMissing: return .refused(.notEligible)
-        // The transport this row runs on has no park/wake mechanic yet.
+        // The row's transport has a park/wake mechanic, but this install has
+        // not armed it: `holder_hibernation_enabled` is off.
         case .holderTransport: return .refused(.notEligible)
         }
     }

--- a/Sources/TBDDaemon/Claude/LimitResumeActuator.swift
+++ b/Sources/TBDDaemon/Claude/LimitResumeActuator.swift
@@ -59,7 +59,7 @@ public struct ProductionPaneProcessInspector: PaneProcessInspecting {
 
 /// Runs one actuation attempt for a scheduled resume: eligibility checks, the
 /// send — tmux's Escape/continue/Enter key sequence, or the holder transport's
-/// single write of the same three things — and post-send verification, which is
+/// two writes of the same three things — and post-send verification, which is
 /// the same for both because it reads hook-fed state and the transcript rather
 /// than anything the transport can see.
 public struct LimitResumeActuator: LimitResumeActuating {
@@ -97,38 +97,44 @@ public struct LimitResumeActuator: LimitResumeActuating {
     static let holderWriteRefused =
         "the resume could not be written to the holder-backed session"
 
-    /// The single message the holder arm writes: `ESC`, the literal, carriage
-    /// return — 10 bytes.
+    /// The first of the holder arm's two writes: `ESC`, alone — one byte.
     ///
-    /// **One write, not three.** The tmux arm sends Escape, the text and Enter
-    /// as three `send-keys` calls with 150 ms between them, because tmux owns a
-    /// named-key table and because text+Enter in one `send-keys` is read as a
-    /// bracketed paste. Neither applies here: this transport carries raw bytes
-    /// and has no key table yet (the child-as-contract-party design,
+    /// The whole send is `ESC`, then `interKeyPause`, then
+    /// `holderContinuePayload`, which is the tmux arm's Escape/pause/text
+    /// timing expressed in raw bytes. There is no named-key table on this
+    /// transport (the child-as-contract-party design,
     /// `docs/specs/2026-09-05-child-as-contract-party-design.md`, is where one
-    /// comes from — it needs the child's cursor-key mode to choose a byte
-    /// sequence for a named key), and a
-    /// message split across several courier calls can be split across a routing
-    /// decision — `HolderInjectionCourier` picks the viewer or the daemon per
-    /// call, so two calls are two independent routings. `performHolderSend`
-    /// composes its whole send as one write for exactly that reason.
+    /// comes from: choosing bytes for a named key needs the child's cursor-key
+    /// mode), so the two keys this rail needs are written as the bytes a
+    /// terminal delivers for them — `0x1B` for Escape, `0x0D` for Return.
     ///
-    /// **Why no bracketed-paste wrapper.** Claude Code's stdin tokenizer
+    /// **Why `ESC` gets a write and a pause of its own.** An ink-style input
+    /// parser reads `ESC` immediately followed by a printable byte as a meta
+    /// key, so `ESC` and the text arriving in one read compose Alt-c and then
+    /// "ontinue" — deterministically, on every attempt, which is why the retry
+    /// in `actuate` could not recover it. The pause goes through the same
+    /// `waiter` seam as the tmux arm's, so tests advance it virtually and only
+    /// production sleeps.
+    static let holderEscapePayload = Data([0x1B])
+
+    /// The second of the holder arm's two writes: the literal and the carriage
+    /// return that submits it — 9 bytes, one write.
+    ///
+    /// **Text and carriage return together, unlike Escape.** Nothing composes
+    /// them into a different key, and a message split across two courier calls
+    /// can be split across a routing decision — `HolderInjectionCourier` picks
+    /// the viewer or the daemon per call, so two calls are two independent
+    /// routings. `performHolderSend` composes its own body and `\r` as one
+    /// write for exactly that reason.
+    ///
+    /// **And no bracketed-paste wrapper.** Claude Code's stdin tokenizer
     /// swallows the trailing `\r` of any single *unwrapped* write of 64 bytes
-    /// or more (measured on 2.1.261: 63 bytes submits, 64 does not); the
+    /// or more (measured on 2.1.261: 63 bytes submits, 64 does not). The
     /// wrappers are the fix, and they are correct only when the child has
     /// bracketed-paste mode on, which the daemon's emulator does not yet
-    /// expose. At 10 bytes this payload is far under that threshold, so it
+    /// expose. At 9 bytes this write is far under that threshold, so it
     /// submits as bare bytes and needs no wrapper.
-    ///
-    /// **What one write costs.** ESC and the text land in the same read, so a
-    /// child that reads `ESC`+char as a meta-key composes Alt-c and types
-    /// "ontinue" — the same defect the tmux arm's inter-key pause exists to
-    /// prevent, and a pause cannot be expressed inside a single write. The
-    /// retry in `actuate` covers a first attempt that composes wrongly, and the
-    /// whole arm is behind the default-off holder-hibernation flag while that
-    /// is soaked.
-    static let holderContinuePayload = Data(("\u{1B}" + continueMessage + "\r").utf8)
+    static let holderContinuePayload = Data((continueMessage + "\r").utf8)
 
     static let verifyPollInterval: Duration = .seconds(1)
     static let verifyPolls = 20   // ~20s window
@@ -285,8 +291,9 @@ public struct LimitResumeActuator: LimitResumeActuating {
                 // courier has already exhausted its own routes by the time it
                 // answers no — viewer, then the daemon's own descriptor — so a
                 // second identical write would take the same route to the same
-                // answer, ~20s of verification later.
-                guard await send(context.terminalID, Self.holderContinuePayload) else {
+                // answer, ~20s of verification later. Either write answering no
+                // ends the actuation the same way: half a send is not a send.
+                guard await sendHolderContinue(send: send, terminalID: context.terminalID) else {
                     await actuationLog.appendOutcome(
                         confirms: actuationID, result: .transportFailed,
                         error: Self.holderWriteRefused)
@@ -634,7 +641,7 @@ public struct LimitResumeActuator: LimitResumeActuating {
     }
 
     /// The exact production send sequence for the tmux arm (spec §Actuation 5);
-    /// the holder arm's single-write equivalent is `holderContinuePayload`:
+    /// the holder arm's raw-bytes equivalent is `sendHolderContinue`:
     /// Escape first — at the limit, newer Claude Code opens the
     /// `/rate-limit-options` menu whose highlighted default can be "Upgrade
     /// your plan"; a blind Enter can confirm a paid upgrade. Escape
@@ -653,6 +660,27 @@ public struct LimitResumeActuator: LimitResumeActuating {
         try await tmux.sendKeys(server: server, paneID: paneID, text: continueMessage)
         await waiter(interKeyPause)
         try await tmux.sendKey(server: server, paneID: paneID, key: "Enter")
+    }
+
+    /// The holder arm's counterpart to `sendContinueSequence`: the same
+    /// Escape/pause/text-and-submit shape, written as bytes.
+    ///
+    /// Two writes with `interKeyPause` between them — `holderEscapePayload`
+    /// says why the pause is load-bearing rather than cosmetic here, and
+    /// `holderContinuePayload` says why the literal and its carriage return
+    /// stay together. The pause runs on the same injected `waiter` the tmux arm
+    /// uses, so a test advances it and only production sleeps.
+    ///
+    /// Answers whether the whole sequence was delivered. A `false` from the
+    /// first write skips the second: nothing is gained by typing "continue" at
+    /// a session that did not take the Escape, and the caller reports one named
+    /// failure either way.
+    private func sendHolderContinue(
+        send: @Sendable (UUID, Data) async -> Bool, terminalID: UUID
+    ) async -> Bool {
+        guard await send(terminalID, Self.holderEscapePayload) else { return false }
+        await waiter(Self.interKeyPause)
+        return await send(terminalID, Self.holderContinuePayload)
     }
 
     /// Success signal within ~20s: the activity hook reports `working`, or

--- a/Sources/TBDDaemon/Claude/LimitResumeActuator.swift
+++ b/Sources/TBDDaemon/Claude/LimitResumeActuator.swift
@@ -565,11 +565,13 @@ public struct LimitResumeActuator: LimitResumeActuating {
         // session that is over.
         //
         // The evidence has to be positive, which is why the seam asks about the
-        // holder's reported STATUS rather than about the daemon's reader. On
-        // this transport a session with no daemon reader is usually a session a
-        // viewer is holding — the most ordinary live state there is — so
-        // `reader(for:) == nil` would cancel the auto-resume of every session
-        // with a tab open on it.
+        // holder's reported STATUS rather than about the daemon's reader.
+        // `reader(for:)` answers which emulator is this session's, not whether
+        // the session is alive: the registry keeps that reader across an attach
+        // and hands out none while a slot is mid-adoption or mid-release. So
+        // `reader(for:) == nil` names a transition as often as a death, and a
+        // rail keyed on it would cancel auto-resumes on sessions that are
+        // running.
         if let sessionEnded = self.holderSessionEnded, await sessionEnded(terminal.id) {
             logger.info("""
                 actuate: terminal \(terminal.id.uuidString, privacy: .public) is holder-backed \

--- a/Sources/TBDDaemon/Claude/LimitResumeActuator.swift
+++ b/Sources/TBDDaemon/Claude/LimitResumeActuator.swift
@@ -162,9 +162,24 @@ public struct LimitResumeActuator: LimitResumeActuating {
     /// yes/no out — so the actuator neither imports the holder subsystem nor
     /// has to fake an actor to be tested.
     private let holderSend: (@Sendable (UUID, Data) async -> Bool)?
+    /// Whether the holder session behind a terminal has ended, as the daemon's
+    /// registry last heard it — this transport's answer to `windowExists`.
+    ///
+    /// Production passes "the last status this registry recorded is `.exited`
+    /// or `.exitedStatusUnknown`", which is a POSITIVE report from the holder
+    /// that its job is over. Nothing weaker is admissible here: in particular
+    /// **the absence of a daemon reader is not evidence**, because a viewer
+    /// holding the pty is the ordinary live state on this transport and would
+    /// cancel every armed resume on a session the user is looking at.
+    ///
+    /// `nil` — mock mode, or no registry — behaves exactly as before: the rail
+    /// asks nobody and proceeds to the courier, which fails by name if the
+    /// session really is gone.
+    private let holderSessionEnded: (@Sendable (UUID) async -> Bool)?
 
-    /// `holderSend` defaults to `nil` so every existing call site — and every
-    /// test that has no holder row in it — constructs the actuator unchanged.
+    /// `holderSend` and `holderSessionEnded` default to `nil` so every existing
+    /// call site — and every test that has no holder row in it — constructs the
+    /// actuator unchanged.
     public init(
         db: TBDDatabase,
         tmux: any ResumeSendingTmux,
@@ -173,7 +188,8 @@ public struct LimitResumeActuator: LimitResumeActuating {
         transcriptModifiedAt: @escaping @Sendable (String) -> Date?,
         waiter: @escaping @Sendable (Duration) async -> Void,
         actuationLog: ActuationLog,
-        holderSend: (@Sendable (UUID, Data) async -> Bool)? = nil
+        holderSend: (@Sendable (UUID, Data) async -> Bool)? = nil,
+        holderSessionEnded: (@Sendable (UUID) async -> Bool)? = nil
     ) {
         self.db = db
         self.tmux = tmux
@@ -183,6 +199,7 @@ public struct LimitResumeActuator: LimitResumeActuating {
         self.waiter = waiter
         self.actuationLog = actuationLog
         self.holderSend = holderSend
+        self.holderSessionEnded = holderSessionEnded
     }
 
     /// Early-cancel probe (see `LimitResumeActuating.userAlreadyContinued`).
@@ -499,7 +516,10 @@ public struct LimitResumeActuator: LimitResumeActuating {
     ///
     /// - **`windowExists` and the worktree lookup.** Both name a tmux server
     ///   and window this row does not have. A holder session's liveness is its
-    ///   child process, and the courier addresses it by terminal id.
+    ///   child process, and the courier addresses it by terminal id — so the
+    ///   liveness question is not dropped, it is asked of a different oracle:
+    ///   `holderSessionEnded`, in the same position and with the same silent
+    ///   `.terminalGone` cancel.
     /// - **The pane-identity consultation (step 1a).** It exists because tmux
     ///   reuses pane ids, so a stale coordinate can name a live stranger. There
     ///   is no coordinate here to go stale: a holder row's pane id is `""` by
@@ -536,6 +556,27 @@ public struct LimitResumeActuator: LimitResumeActuating {
         // silent cancel. Parking already cancels the pending row; this catches
         // a park that raced the scheduler.
         guard !terminal.isParked else { return .notEligible(.terminalGone) }
+
+        // Liveness, in the position `windowExists` occupies on the tmux arm and
+        // with the same silent `.terminalGone` cancel. Without it the holder
+        // arm had no liveness answer at all: a row whose child exited without
+        // anything parking it would be typed at, and the write would land on a
+        // pty nobody is reading — an armed resume reported as delivered on a
+        // session that is over.
+        //
+        // The evidence has to be positive, which is why the seam asks about the
+        // holder's reported STATUS rather than about the daemon's reader. On
+        // this transport a session with no daemon reader is usually a session a
+        // viewer is holding — the most ordinary live state there is — so
+        // `reader(for:) == nil` would cancel the auto-resume of every session
+        // with a tab open on it.
+        if let sessionEnded = self.holderSessionEnded, await sessionEnded(terminal.id) {
+            logger.info("""
+                actuate: terminal \(terminal.id.uuidString, privacy: .public) is holder-backed \
+                and its holder reported the session over — cancelling
+                """)
+            return .notEligible(.terminalGone)
+        }
 
         // 1b, unchanged: the row itself can be cancelled while a prior
         // attempt's ~20s verify window runs.

--- a/Sources/TBDDaemon/Claude/LimitResumeActuator.swift
+++ b/Sources/TBDDaemon/Claude/LimitResumeActuator.swift
@@ -57,8 +57,11 @@ public struct ProductionPaneProcessInspector: PaneProcessInspecting {
     }
 }
 
-/// Runs one actuation attempt for a scheduled resume: eligibility checks,
-/// the Escape/continue/Enter send sequence, and post-send verification.
+/// Runs one actuation attempt for a scheduled resume: eligibility checks, the
+/// send — tmux's Escape/continue/Enter key sequence, or the holder transport's
+/// single write of the same three things — and post-send verification, which is
+/// the same for both because it reads hook-fed state and the transcript rather
+/// than anything the transport can see.
 public struct LimitResumeActuator: LimitResumeActuating {
 
     // MARK: - Timing constants (spec §Actuation 5-6)
@@ -67,17 +70,66 @@ public struct LimitResumeActuator: LimitResumeActuating {
     /// The literal typed into the pane, recorded verbatim in the rail's row.
     static let continueMessage = "continue"
 
-    /// The one refusal text this rail returns for a holder-backed row, so the
-    /// notification, the log line and this file's tests all name the same
-    /// reason rather than three near-misses.
+    /// The one refusal text this rail returns for a holder-backed row while
+    /// holder hibernation is off, so the notification, the log line and this
+    /// file's tests all name the same reason rather than three near-misses.
+    /// Same fact and the same repair as
+    /// `HibernationCoordinator.holderTransportRefusal`, which is the other half
+    /// of what that flag gates.
     ///
     /// Written to complete the daemon's sentence: the notification reads
     /// "Auto-resume failed — \(reason). Claude may still be parked at the
     /// limit screen."
     static let holderTransportRefusal =
-        "this session runs on the pty-holder transport, whose input path carries raw "
-        + "bytes and has no named-key table yet, so the Escape and Enter this rail "
-        + "sends cannot be expressed and nothing was typed"
+        "this session runs on the pty-holder transport and holder hibernation is off "
+        + "(Settings → Hibernate pty-holder sessions, or `tbd config "
+        + "holder-hibernation on`), so nothing was typed"
+
+    /// The refusal for a daemon that has no way to write to a holder's pty at
+    /// all — mock mode, or a daemon whose registry (and so whose injection
+    /// courier) was never built. Kept apart from `holderTransportRefusal`
+    /// because the two are different repairs: one is a flag the user can turn
+    /// on, the other is a daemon that cannot serve this transport at all.
+    static let holderInputPathMissing = "this daemon has no holder input path"
+
+    /// The failure for a write the holder input path took and could not
+    /// deliver. Distinct from the two refusals above: the rail tried.
+    static let holderWriteRefused =
+        "the resume could not be written to the holder-backed session"
+
+    /// The single message the holder arm writes: `ESC`, the literal, carriage
+    /// return — 10 bytes.
+    ///
+    /// **One write, not three.** The tmux arm sends Escape, the text and Enter
+    /// as three `send-keys` calls with 150 ms between them, because tmux owns a
+    /// named-key table and because text+Enter in one `send-keys` is read as a
+    /// bracketed paste. Neither applies here: this transport carries raw bytes
+    /// and has no key table yet (the child-as-contract-party design,
+    /// `docs/specs/2026-09-05-child-as-contract-party-design.md`, is where one
+    /// comes from — it needs the child's cursor-key mode to choose a byte
+    /// sequence for a named key), and a
+    /// message split across several courier calls can be split across a routing
+    /// decision — `HolderInjectionCourier` picks the viewer or the daemon per
+    /// call, so two calls are two independent routings. `performHolderSend`
+    /// composes its whole send as one write for exactly that reason.
+    ///
+    /// **Why no bracketed-paste wrapper.** Claude Code's stdin tokenizer
+    /// swallows the trailing `\r` of any single *unwrapped* write of 64 bytes
+    /// or more (measured on 2.1.261: 63 bytes submits, 64 does not); the
+    /// wrappers are the fix, and they are correct only when the child has
+    /// bracketed-paste mode on, which the daemon's emulator does not yet
+    /// expose. At 10 bytes this payload is far under that threshold, so it
+    /// submits as bare bytes and needs no wrapper.
+    ///
+    /// **What one write costs.** ESC and the text land in the same read, so a
+    /// child that reads `ESC`+char as a meta-key composes Alt-c and types
+    /// "ontinue" — the same defect the tmux arm's inter-key pause exists to
+    /// prevent, and a pause cannot be expressed inside a single write. The
+    /// retry in `actuate` covers a first attempt that composes wrongly, and the
+    /// whole arm is behind the default-off holder-hibernation flag while that
+    /// is soaked.
+    static let holderContinuePayload = Data(("\u{1B}" + continueMessage + "\r").utf8)
+
     static let verifyPollInterval: Duration = .seconds(1)
     static let verifyPolls = 20   // ~20s window
 
@@ -93,7 +145,20 @@ public struct LimitResumeActuator: LimitResumeActuating {
     /// The daemon's actuation record. This rail bypasses the RPC router, so it
     /// writes its own row — with no `method`, and an actor naming the rail.
     private let actuationLog: ActuationLog
+    /// Writes bytes to one holder-backed session's pty, answering whether they
+    /// were delivered. Production passes `HolderInjectionCourier.deliver`,
+    /// which routes by who owns the pty; `nil` means this daemon has no holder
+    /// input path at all (mock mode, or no holder registry), which the holder
+    /// arm refuses by name rather than by pretending the transport is the
+    /// problem.
+    ///
+    /// The seam is the courier reduced to what this rail needs — bytes in, a
+    /// yes/no out — so the actuator neither imports the holder subsystem nor
+    /// has to fake an actor to be tested.
+    private let holderSend: (@Sendable (UUID, Data) async -> Bool)?
 
+    /// `holderSend` defaults to `nil` so every existing call site — and every
+    /// test that has no holder row in it — constructs the actuator unchanged.
     public init(
         db: TBDDatabase,
         tmux: any ResumeSendingTmux,
@@ -101,7 +166,8 @@ public struct LimitResumeActuator: LimitResumeActuating {
         readTranscript: @escaping @Sendable (String) -> Data?,
         transcriptModifiedAt: @escaping @Sendable (String) -> Date?,
         waiter: @escaping @Sendable (Duration) async -> Void,
-        actuationLog: ActuationLog
+        actuationLog: ActuationLog,
+        holderSend: (@Sendable (UUID, Data) async -> Bool)? = nil
     ) {
         self.db = db
         self.tmux = tmux
@@ -110,6 +176,7 @@ public struct LimitResumeActuator: LimitResumeActuating {
         self.transcriptModifiedAt = transcriptModifiedAt
         self.waiter = waiter
         self.actuationLog = actuationLog
+        self.holderSend = holderSend
     }
 
     /// Early-cancel probe (see `LimitResumeActuating.userAlreadyContinued`).
@@ -197,18 +264,39 @@ public struct LimitResumeActuator: LimitResumeActuating {
                 return .failed("could not record the resume in the actuation log")
             }
 
-            do {
-                try await Self.sendContinueSequence(
-                    tmux: tmux, server: context.server, paneID: context.paneID, waiter: waiter)
+            switch context.delivery {
+            case .tmux(let server, let paneID):
+                do {
+                    try await Self.sendContinueSequence(
+                        tmux: tmux, server: server, paneID: paneID, waiter: waiter)
+                    await actuationLog.appendOutcome(confirms: actuationID, result: .dispatched)
+                } catch {
+                    await actuationLog.appendOutcome(
+                        confirms: actuationID, result: .transportFailed, error: "\(error)")
+                    // Treat a thrown send like a failed verification: retry
+                    // (with a fresh eligibility re-check) rather than failing
+                    // instantly — only give up after attempt 2 also fails.
+                    logger.warning("actuate: send threw on attempt \(attempt, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                    continue
+                }
+            case .holder(let send):
+                // Not retried, unlike a thrown tmux send. A wedged tmux server
+                // is a transient the next attempt may find recovered; the
+                // courier has already exhausted its own routes by the time it
+                // answers no — viewer, then the daemon's own descriptor — so a
+                // second identical write would take the same route to the same
+                // answer, ~20s of verification later.
+                guard await send(context.terminalID, Self.holderContinuePayload) else {
+                    await actuationLog.appendOutcome(
+                        confirms: actuationID, result: .transportFailed,
+                        error: Self.holderWriteRefused)
+                    logger.warning("""
+                        actuate: the holder input path took nothing for terminal \
+                        \(context.terminalID.uuidString, privacy: .public)
+                        """)
+                    return .failed(Self.holderWriteRefused)
+                }
                 await actuationLog.appendOutcome(confirms: actuationID, result: .dispatched)
-            } catch {
-                await actuationLog.appendOutcome(
-                    confirms: actuationID, result: .transportFailed, error: "\(error)")
-                // Treat a thrown send like a failed verification: retry
-                // (with a fresh eligibility re-check) rather than failing
-                // instantly — only give up after attempt 2 also fails.
-                logger.warning("actuate: send threw on attempt \(attempt, privacy: .public): \(error.localizedDescription, privacy: .public)")
-                continue
             }
             if await verifyResumed(terminalID: context.terminalID,
                                    transcriptPath: context.transcriptPath,
@@ -228,9 +316,19 @@ public struct LimitResumeActuator: LimitResumeActuating {
         case notEligible(ResumeActuationOutcome)
     }
 
+    /// How an eligible pass will put the resume into the session.
+    ///
+    /// Typed rather than a transport flag plus optional coordinates, so the
+    /// holder arm cannot reach for a pane id that a holder row does not have
+    /// and the tmux arm cannot reach for a seam that may be nil: whichever
+    /// case a pass produced carries exactly what its send needs.
+    private enum ResumeDelivery {
+        case tmux(server: String, paneID: String)
+        case holder(send: @Sendable (UUID, Data) async -> Bool)
+    }
+
     private struct EligibilityContext {
-        let server: String
-        let paneID: String
+        let delivery: ResumeDelivery
         let terminalID: UUID
         let worktreeID: UUID
         let transcriptPath: String?
@@ -242,9 +340,10 @@ public struct LimitResumeActuator: LimitResumeActuating {
 
     /// Runs eligibility steps 1-4 (spec §Actuation), in order: terminal
     /// alive → user-already-continued → Claude foreground → copy-mode.
-    /// A transport guard runs between the terminal lookup and everything else,
+    /// The transport branches between the terminal lookup and everything else,
     /// because every one of those steps addresses a tmux pane and a
-    /// holder-backed row has none.
+    /// holder-backed row has none — see `holderEligibility` for what that arm
+    /// keeps and what it drops.
     /// Foreground is checked before copy-mode so a dead/backgrounded shell
     /// classifies `.failed` rather than endlessly rescheduling on a stale
     /// copy-mode flag. Two additional checks (0a the row's own limitType-aware toggle, 1b row
@@ -260,7 +359,12 @@ public struct LimitResumeActuator: LimitResumeActuating {
         //     EVERY call to `checkEligibility` (the initial pass and every
         //     attempt>1 re-check in `actuate`), so attempt 2 never fires
         //     after the user turns the row's gate off mid-flight.
-        guard ((try? await db.config.get())?.autoResumeEnabled(forLimitType: resume.limitType)) ?? false else {
+        //
+        //     One config read serves both this gate and the holder arm's
+        //     below, so a single pass cannot act on two different snapshots of
+        //     the same row.
+        guard let config = try? await db.config.get(),
+              config.autoResumeEnabled(forLimitType: resume.limitType) else {
             return .notEligible(.cancelledExternally)
         }
 
@@ -281,7 +385,7 @@ public struct LimitResumeActuator: LimitResumeActuating {
         // `windowExists`, the pane-identity consultation, `panePID`, copy-mode,
         // and finally the keys themselves. A holder row's `tmuxWindowID` and
         // `tmuxPaneID` are the empty string by construction, so without this
-        // guard the rail exited at step 1 with `.terminalGone` — silently
+        // branch the rail exited at step 1 with `.terminalGone` — silently
         // cancelling the user's armed auto-resume on a session that is
         // perfectly alive, and recording "the terminal is gone" for a row that
         // is not.
@@ -292,19 +396,17 @@ public struct LimitResumeActuator: LimitResumeActuating {
         // would have sent this rail on to type "continue" at whatever pane the
         // empty coordinate resolved to.
         //
-        // Refused rather than served, because Milestone A wires no input path
-        // for the holder transport: the registry can render a session's screen
-        // and report its child's last known status, but nothing writes to a
-        // holder's pty. `.failed` rather than a silent cancel, because a user
-        // who armed auto-resume and will not get it should be told once, not
-        // left watching a limit screen behind an "auto-resume scheduled" badge
-        // that quietly expired.
-        guard terminal.transport != .holder else {
-            logger.info("""
-                actuate: terminal \(terminal.id.uuidString, privacy: .public) runs on the \
-                pty-holder transport — typing nothing
-                """)
-            return .notEligible(.failed(Self.holderTransportRefusal))
+        // Served rather than refused when holder hibernation is on: the
+        // transport now has an input path (`holderSend`), and this rail is
+        // gated by that same flag because a resume it delivers is the other
+        // half of a park it can undo.
+        if terminal.transport == .holder {
+            // Off the same snapshot step 0a read, and already carrying the
+            // shipped default for an install where nobody has chosen
+            // (`ConfigRecord.toModel` applies it).
+            return await holderEligibility(
+                resume, terminal: terminal,
+                hibernationEnabled: config.holderHibernationEnabled)
         }
 
         guard !terminal.isParked,
@@ -377,9 +479,86 @@ public struct LimitResumeActuator: LimitResumeActuating {
         }
 
         return .eligible(EligibilityContext(
-            server: server, paneID: terminal.tmuxPaneID, terminalID: terminal.id,
+            delivery: .tmux(server: server, paneID: terminal.tmuxPaneID),
+            terminalID: terminal.id,
             worktreeID: terminal.worktreeID,
             transcriptPath: terminal.transcriptPath, preSendTranscriptData: preSendTranscriptData))
+    }
+
+    /// Eligibility for a holder-backed row: the transport-agnostic rails of
+    /// `checkEligibility`, with every tmux-shaped step dropped.
+    ///
+    /// Dropped, and why each one is tmux's alone:
+    ///
+    /// - **`windowExists` and the worktree lookup.** Both name a tmux server
+    ///   and window this row does not have. A holder session's liveness is its
+    ///   child process, and the courier addresses it by terminal id.
+    /// - **The pane-identity consultation (step 1a).** It exists because tmux
+    ///   reuses pane ids, so a stale coordinate can name a live stranger. There
+    ///   is no coordinate here to go stale: a holder row's pane id is `""` by
+    ///   construction, and the write is addressed to the terminal id itself,
+    ///   which nothing reuses.
+    /// - **`panePID` and the foreground check (step 3).** Both walk the process
+    ///   tree under a pane's shell. The holder's child IS the agent — there is
+    ///   no shell in front of it to be foreground instead of it.
+    /// - **Copy-mode (step 4).** tmux's scrollback mode. A holder session's
+    ///   scrollback belongs to whichever emulator is reading it, and there is
+    ///   no mode for typing to land in.
+    ///
+    /// Kept, because none of them was ever about tmux: the flag, the parked
+    /// backstop, the row's own cancellation status (1b), and the
+    /// user-already-continued check (2) — which also produces the pre-send
+    /// growth baseline `verifyResumed` compares against, so skipping it would
+    /// leave `preSize == 0` and make any later read look like a resume.
+    private func holderEligibility(
+        _ resume: ScheduledResume, terminal: Terminal, hibernationEnabled: Bool
+    ) async -> EligibilityCheckResult {
+        // The flag. Off, this rail refuses by name and `.failed` rather than
+        // silently cancelling, because a user who armed auto-resume and will
+        // not get it should be told once, not left watching a limit screen
+        // behind an "auto-resume scheduled" badge that quietly expired.
+        guard hibernationEnabled else {
+            logger.info("""
+                actuate: terminal \(terminal.id.uuidString, privacy: .public) runs on the \
+                pty-holder transport and holder hibernation is off — typing nothing
+                """)
+            return .notEligible(.failed(Self.holderTransportRefusal))
+        }
+
+        // Parked: the same fire-time backstop as the tmux path, and the same
+        // silent cancel. Parking already cancels the pending row; this catches
+        // a park that raced the scheduler.
+        guard !terminal.isParked else { return .notEligible(.terminalGone) }
+
+        // 1b, unchanged: the row itself can be cancelled while a prior
+        // attempt's ~20s verify window runs.
+        guard ((try? await db.scheduledResumes.get(id: resume.id)) ?? nil)?.status == .pending else {
+            return .notEligible(.cancelledExternally)
+        }
+
+        // 2, unchanged — and ahead of the input-path check below on purpose:
+        // a session that has already moved on wants the silent cancel, not a
+        // notification saying auto-resume failed on it.
+        let continuation = transcriptContinuation(
+            path: terminal.transcriptPath, since: resume.createdAt, mtimeGated: false)
+        if continuation.alreadyContinued {
+            return .notEligible(.userAlreadyContinued)
+        }
+
+        guard let send = self.holderSend else {
+            logger.warning("""
+                actuate: terminal \(terminal.id.uuidString, privacy: .public) is holder-backed \
+                and this daemon has no holder input path — typing nothing
+                """)
+            return .notEligible(.failed(Self.holderInputPathMissing))
+        }
+
+        return .eligible(EligibilityContext(
+            delivery: .holder(send: send),
+            terminalID: terminal.id,
+            worktreeID: terminal.worktreeID,
+            transcriptPath: terminal.transcriptPath,
+            preSendTranscriptData: continuation.data))
     }
 
     /// What the pane consultation concluded for step 1a.
@@ -454,7 +633,8 @@ public struct LimitResumeActuator: LimitResumeActuating {
         }
     }
 
-    /// The exact production send sequence (spec §Actuation 5):
+    /// The exact production send sequence for the tmux arm (spec §Actuation 5);
+    /// the holder arm's single-write equivalent is `holderContinuePayload`:
     /// Escape first — at the limit, newer Claude Code opens the
     /// `/rate-limit-options` menu whose highlighted default can be "Upgrade
     /// your plan"; a blind Enter can confirm a paid upgrade. Escape

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -908,7 +908,7 @@ public final class Daemon: Sendable {
                 viewerAttachment: { terminalID in
                     await registry.viewerAttachment(for: terminalID)
                 },
-                writeDirectly: { terminalID, bytes in
+                writeDirectly: { [inputActivity] terminalID, bytes in
                     // The daemon's own reader is the only descriptor it has —
                     // but it keeps that reader across an attach, suspended
                     // rather than stopped, so this fallback has a target in
@@ -920,6 +920,14 @@ public final class Daemon: Sendable {
                             terminalID: terminalID)
                     }
                     try await reader.write(bytes)
+                    // The pending-input veto's holder leg. A daemon-side write
+                    // is the ONLY input into a holder session the daemon can
+                    // see — a viewer types on its own descriptor and tells
+                    // nobody — so this is what there is to record, and it is
+                    // recorded only after the write actually landed. Keyed by
+                    // terminal id, matching `InputActivityTracker.key(for:)`
+                    // for a holder row.
+                    inputActivity.recordInput(paneID: terminalID.uuidString)
                 })
         }
 
@@ -1050,6 +1058,10 @@ public final class Daemon: Sendable {
         )
         // Wire the shared input activity tracker to the coordinator
         await rpcRouter.hibernationCoordinator.setInputActivity(inputActivity)
+        // And the holder registry, for the same reason and on the same terms:
+        // the park path reads a holder session's screen through the reader the
+        // spawn path registered, so all three must hold ONE registry.
+        await rpcRouter.hibernationCoordinator.setHolderRegistry(holderRegistry)
         // Queued prompt, second half: route the parking RPC and the readiness
         // and confirmation hooks to the coordinator, and give it the paste
         // path's send seam.

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -1697,7 +1697,24 @@ public final class Daemon: Sendable {
                 },
                 // swiftlint:disable:next no_raw_task_sleep - already seamed: this closure IS the production value of `LimitResumeActuator`'s non-defaulted `waiter:` parameter (the seam itself), exercised by Tests/TBDDaemonTests/LimitResumeActuatorTests.swift which injects `waiter: { _ in }` at 5 construction sites; see docs/specs/2026-07-24-test-hardening-design.md
                 waiter: { duration in _ = try? await Task.sleep(for: duration) },
-                actuationLog: actuationLog
+                actuationLog: actuationLog,
+                // The rail's input path for a holder-backed row: the same
+                // courier `terminal.send` writes through, so an auto-resume is
+                // routed by who owns the pty exactly as a human's send is, and
+                // reduced to the yes/no this rail acts on. Both write answers
+                // are a delivery — `daemonWrote` names a fallback route, not a
+                // failure. Nil with no courier (mock mode, or no holder
+                // registry to build one on): the actuator then refuses a holder
+                // row by name instead of typing at coordinates it does not have.
+                holderSend: holderInjectionCourier.map { courier in
+                    let send: @Sendable (UUID, Data) async -> Bool = { terminalID, bytes in
+                        switch await courier.deliver(terminalID: terminalID, bytes: bytes) {
+                        case .viewerWrote, .daemonWrote: return true
+                        case .notDelivered: return false
+                        }
+                    }
+                    return send
+                }
             )
             let resumeScheduler = LimitResumeScheduler(
                 store: database.scheduledResumes,

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -1732,9 +1732,10 @@ public final class Daemon: Sendable {
                 // The rail's liveness answer for a holder-backed row, and this
                 // transport's counterpart to `windowExists`. A positive exit
                 // report from the holder is the only evidence admitted: the
-                // absence of a daemon reader means a viewer owns the pty, which
-                // is the ordinary live state and would cancel the auto-resume of
-                // every session with a tab open on it.
+                // absence of a daemon reader says nothing about the child, since
+                // the registry keeps its reader across an attach and hands out
+                // none while a slot is mid-adoption or mid-release — so a rail
+                // keyed on it would cancel the auto-resume of live sessions.
                 holderSessionEnded: holderRegistry.map { registry in
                     let ended: @Sendable (UUID) async -> Bool = { terminalID in
                         switch await registry.lastKnownStatus(for: terminalID) {

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -1369,7 +1369,15 @@ public final class Daemon: Sendable {
                         terminalID: terminal.id,
                         holderPID: terminal.holderPID,
                         childPID: childPID,
-                        createdAt: terminal.createdAt)
+                        // The identity anchor, not the row's birthday. A row
+                        // woken from a park carries a child younger than
+                        // itself, and anchoring on `createdAt` there would make
+                        // every such session read as `.startTimeMismatch` —
+                        // which this leg spells "keep", so the orphan it exists
+                        // to reclaim would survive every sweep. NULL means the
+                        // row has never been parked, and there the two are the
+                        // same instant.
+                        createdAt: terminal.holderChildStartedAt ?? terminal.createdAt)
                 }
             }
             let reaper = AgentReaper(

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -908,26 +908,29 @@ public final class Daemon: Sendable {
                 viewerAttachment: { terminalID in
                     await registry.viewerAttachment(for: terminalID)
                 },
-                writeDirectly: { [inputActivity] terminalID, bytes in
+                writeDirectly: { terminalID, bytes in
                     // The daemon's own reader is the only descriptor it has —
                     // but it keeps that reader across an attach, suspended
                     // rather than stopped, so this fallback has a target in
                     // every attached state. No reader means the session is gone
                     // or was never adopted, which is the one case with nothing
                     // to write to.
+                    //
+                    // Deliberately NOT recorded as input activity. The veto's
+                    // fact source is the app's keystroke stream, and a write
+                    // that starts here is the daemon's own — an auto-resume, a
+                    // peer's `terminal.send` — never something a person typed
+                    // and has not sent. Recording it would leave the merge
+                    // rail's `activityStateObservedAt` anchor behind a
+                    // "keystroke" that will never be consumed, vetoing every
+                    // park of that row forever. See `InputActivityTracker`'s
+                    // holder key for why the veto is vacuous on this transport
+                    // anyway.
                     guard let reader = await registry.reader(for: terminalID) else {
                         throw HolderInjectionCourier.Error.noDaemonDescriptor(
                             terminalID: terminalID)
                     }
                     try await reader.write(bytes)
-                    // The pending-input veto's holder leg. A daemon-side write
-                    // is the ONLY input into a holder session the daemon can
-                    // see — a viewer types on its own descriptor and tells
-                    // nobody — so this is what there is to record, and it is
-                    // recorded only after the write actually landed. Keyed by
-                    // terminal id, matching `InputActivityTracker.key(for:)`
-                    // for a holder row.
-                    inputActivity.recordInput(paneID: terminalID.uuidString)
                 })
         }
 
@@ -1706,6 +1709,17 @@ public final class Daemon: Sendable {
                 // failure. Nil with no courier (mock mode, or no holder
                 // registry to build one on): the actuator then refuses a holder
                 // row by name instead of typing at coordinates it does not have.
+                //
+                // **`.daemonWrote(.ackDeadlineElapsed)` is counted as delivered
+                // with its eyes open.** It is the one branch that can duplicate:
+                // the app was holding the pty, never answered inside the ack
+                // deadline, and may yet write the bytes it was given — so the
+                // daemon's own write can land a second "continue". That trade is
+                // made deliberately in this direction. A doubled continue lands
+                // in a session that is working again, as a stray message the
+                // user can see and undo; a missed resume is the silent failure
+                // this whole rail exists to prevent, and it is discovered hours
+                // later by a limit screen nobody continued.
                 holderSend: holderInjectionCourier.map { courier in
                     let send: @Sendable (UUID, Data) async -> Bool = { terminalID, bytes in
                         switch await courier.deliver(terminalID: terminalID, bytes: bytes) {
@@ -1714,6 +1728,21 @@ public final class Daemon: Sendable {
                         }
                     }
                     return send
+                },
+                // The rail's liveness answer for a holder-backed row, and this
+                // transport's counterpart to `windowExists`. A positive exit
+                // report from the holder is the only evidence admitted: the
+                // absence of a daemon reader means a viewer owns the pty, which
+                // is the ordinary live state and would cancel the auto-resume of
+                // every session with a tab open on it.
+                holderSessionEnded: holderRegistry.map { registry in
+                    let ended: @Sendable (UUID) async -> Bool = { terminalID in
+                        switch await registry.lastKnownStatus(for: terminalID) {
+                        case .exited, .exitedStatusUnknown: return true
+                        case .alive, nil: return false
+                        }
+                    }
+                    return ended
                 }
             )
             let resumeScheduler = LimitResumeScheduler(

--- a/Sources/TBDDaemon/Database/ConfigStore.swift
+++ b/Sources/TBDDaemon/Database/ConfigStore.swift
@@ -138,6 +138,14 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     /// through `Config.holderRowReconcileEnabledDefault`, never through
     /// `?? false`.
     var holder_row_reconcile_enabled: Bool?
+    /// Gate for parking, waking and limit-resuming Claude sessions on the
+    /// pty-holder transport. **Genuinely tri-state**, same shape as
+    /// `holder_row_reconcile_enabled`: the
+    /// `20260905213000_config_holder_hibernation` migration carries no SQL
+    /// default, so `nil` here means "never chose" rather than "off". Resolve
+    /// it through `Config.holderHibernationEnabledDefault`, never through
+    /// `?? false`.
+    var holder_hibernation_enabled: Bool?
     /// The update mode: 'off', 'check' or 'auto'
     /// (design 2026-09-04 §6). **Genuinely tri-state**, same shape as
     /// `gc_retained_transcripts_enabled`: the
@@ -206,6 +214,11 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     ///   `holder_row_reconcile_enabled` — the holder row sweep's soak gate,
     ///   which is a separate opt-in from both because it deletes database rows
     ///   rather than files or processes.
+    /// - Parameter holderHibernationDefault: same shape once more, for
+    ///   `holder_hibernation_enabled` — the pty-holder transport's
+    ///   auto-hibernation gate, a separate opt-in from `holderRowReconcileDefault`
+    ///   because it kills a live agent process rather than reclaiming a
+    ///   already-dead row.
     /// - Parameter updateModeDefault: and truly, finally the last, for
     ///   `update_mode` — the only one of these that is not a Bool, so the
     ///   parameter proves both properties at once: a NULL row follows a changed
@@ -226,6 +239,7 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         remoteDeleteDefault: Bool = Config.remoteDeleteEnabledDefault,
         gcRetainedTranscriptsDefault: Bool = Config.gcRetainedTranscriptsEnabledDefault,
         holderRowReconcileDefault: Bool = Config.holderRowReconcileEnabledDefault,
+        holderHibernationDefault: Bool = Config.holderHibernationEnabledDefault,
         updateModeDefault: UpdateMode = Config.updateModeDefault
     ) -> Config {
         Config(
@@ -306,6 +320,9 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             // NOT `?? false`.
             holderRowReconcileEnabled:
                 holder_row_reconcile_enabled ?? holderRowReconcileDefault,
+            // And once more, for holder hibernation's gate — NOT `?? false`.
+            holderHibernationEnabled:
+                holder_hibernation_enabled ?? holderHibernationDefault,
             // Same reasoning once more, for the update mode — NOT `?? .off`.
             // The `flatMap` covers the second way a value can be absent: a
             // string no `UpdateMode` case matches is as unusable as NULL, so it
@@ -825,6 +842,23 @@ public struct ConfigStore: Sendable {
         try await writer.write { db in
             try db.execute(
                 sql: "UPDATE config SET holder_row_reconcile_enabled = ? WHERE id = ?",
+                arguments: [enabled, Self.singletonID]
+            )
+        }
+    }
+
+    /// Persist the pty-holder transport's auto-hibernation gate (default OFF,
+    /// soaking) — whether idle holder-backed sessions get parked, woken and
+    /// limit-resumed by the same sweep and rails as tmux sessions. Separate
+    /// from `setHolderRowReconcileEnabled` on purpose: that gate reclaims a
+    /// session row whose holder is already gone, this one parks (and can kill)
+    /// a holder whose child process is still very much alive. The column is
+    /// written on every call, because writing either value is the explicit
+    /// gesture that lifts it out of NULL forever after.
+    public func setHolderHibernationEnabled(_ enabled: Bool) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE config SET holder_hibernation_enabled = ? WHERE id = ?",
                 arguments: [enabled, Self.singletonID]
             )
         }

--- a/Sources/TBDDaemon/Database/Migrations/20260905213000_config_holder_hibernation.sql
+++ b/Sources/TBDDaemon/Database/Migrations/20260905213000_config_holder_hibernation.sql
@@ -1,0 +1,18 @@
+-- Gate for parking, waking and limit-resuming Claude sessions on the
+-- pty-holder transport — auto-hibernation's holder leg
+-- (docs/specs/2026-08-30-pty-holder-session-transport-design.md). A background
+-- sweep kills a live holder-owned agent process, and wake spawns a fresh
+-- holder running `claude --resume` rather than reattaching to anything, so
+-- this soaks behind its own switch rather than riding pty_holder_enabled —
+-- that outer gate has to be ON for a holder row to exist at all, so it cannot
+-- express "transport on, hibernation not yet", which is the whole protocol the
+-- sibling holder gates (gc_holder_rendezvous_enabled, reap_holder_children_enabled,
+-- holder_row_reconcile_enabled) exist for.
+--
+-- No DEFAULT clause, deliberately. ADD COLUMN ... DEFAULT would backfill every
+-- existing row, destroying the distinction between "nobody has chosen" (NULL)
+-- and "chose off" (0) — which is what made auto_hibernate_enabled impossible to
+-- graduate without a forcing UPDATE that also reset deliberate opt-ins.
+-- The shipped default lives in exactly one place:
+-- Config.holderHibernationEnabledDefault.
+ALTER TABLE config ADD COLUMN holder_hibernation_enabled INTEGER;

--- a/Sources/TBDDaemon/Database/Migrations/20260905220000_terminal_holder_child_started_at.sql
+++ b/Sources/TBDDaemon/Database/Migrations/20260905220000_terminal_holder_child_started_at.sql
@@ -1,0 +1,16 @@
+-- When the job behind a holder-transport row was last started.
+--
+-- The reaper's holder leg and the wake path both verify a recorded child pid
+-- through ProcessIdentityCheck, and that check anchors on a start time. Until
+-- this column existed the only anchor available was the row's `createdAt`,
+-- which is the same instant only while the row still holds its FIRST child. A
+-- woken session's child is younger than its row by however long it was parked,
+-- so the anchor has to move with the child rather than with the row —
+-- otherwise every woken session reads as `.startTimeMismatch`, which the
+-- reaper spells "keep" (a leak) and the wake path spells "not gone" (a lie).
+--
+-- NULL means the row has never been through a park/wake cycle, so `createdAt`
+-- is still the right anchor; every reader spells that `holderChildStartedAt ??
+-- createdAt`. Park clears it back to NULL along with the two pid columns,
+-- because a parked row names no child at all.
+ALTER TABLE terminal ADD COLUMN holder_child_started_at DATETIME;

--- a/Sources/TBDDaemon/Database/TerminalStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalStore.swift
@@ -63,6 +63,10 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var holder_pid: Int32?
     /// PID of the job the holder `forkpty()`d, for holder-transport rows only.
     var child_pid: Int32?
+    /// When the job named by `child_pid` was started. NULL on a row that has
+    /// never been through a park/wake cycle, where `createdAt` is still the
+    /// right identity anchor — see `Terminal.holderChildStartedAt`.
+    var holder_child_started_at: Date?
 
     init(from terminal: Terminal) {
         self.id = terminal.id.uuidString
@@ -96,6 +100,7 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         self.transport = terminal.transport.rawValue
         self.holder_pid = terminal.holderPID
         self.child_pid = terminal.childPID
+        self.holder_child_started_at = terminal.holderChildStartedAt
     }
 
     /// Failable decode: skips (returns nil after a logged warning) rather than
@@ -145,7 +150,8 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             // a newer daemon both degrade to tmux rather than throwing.
             transport: transport.flatMap(TerminalTransport.init(rawValue:)) ?? .tmux,
             holderPID: holder_pid,
-            childPID: child_pid
+            childPID: child_pid,
+            holderChildStartedAt: holder_child_started_at
         )
     }
 }
@@ -674,7 +680,8 @@ public struct TerminalStore: Sendable {
         watchDeskRole: WatchDeskRole? = nil,
         transport: TerminalTransport = .tmux,
         holderPID: Int32? = nil,
-        childPID: Int32? = nil
+        childPID: Int32? = nil,
+        holderChildStartedAt: Date? = nil
     ) async throws -> Terminal {
         let terminal = Terminal(
             id: id,
@@ -688,7 +695,8 @@ public struct TerminalStore: Sendable {
             watchDeskRole: watchDeskRole,
             transport: transport,
             holderPID: holderPID,
-            childPID: childPID
+            childPID: childPID,
+            holderChildStartedAt: holderChildStartedAt
         )
         let record = TerminalRecord(from: terminal)
         try await writer.write { db in
@@ -1766,6 +1774,30 @@ public struct TerminalStore: Sendable {
                 at: date)
             try record.update(db)
             return incarnationID
+        }
+    }
+
+    /// Record — or clear — which processes carry a holder-transport row, in one
+    /// write.
+    ///
+    /// The three facts move together on purpose. A pid without the start time
+    /// that identifies it is a pid nothing may signal (`ProcessIdentityCheck`
+    /// reads a missing start time as "not the same process"), and a start time
+    /// without a pid names nothing at all, so a caller that could set one and
+    /// forget another would leave the row saying something no reader can act
+    /// on. Wake passes all three; park passes `nil` for all three, which is
+    /// what a parked row means — no holder, no job, no anchor.
+    public func setHolderProcess(
+        id: UUID, holderPID: Int32?, childPID: Int32?, startedAt: Date?
+    ) async throws {
+        try await writer.write { db in
+            guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
+                throw DatabaseError(message: "Terminal not found")
+            }
+            record.holder_pid = holderPID
+            record.child_pid = childPID
+            record.holder_child_started_at = startedAt
+            try record.update(db)
         }
     }
 

--- a/Sources/TBDDaemon/Holder/HolderRegistry.swift
+++ b/Sources/TBDDaemon/Holder/HolderRegistry.swift
@@ -118,13 +118,39 @@ actor HolderRegistry {
         }
     }
 
-    /// A reader and the description the hand-over rode with.
+    /// A reader, the description the hand-over rode with, and the pid of the
+    /// holder that answered it.
     ///
     /// The description is not decoration: it is the one place a job that
     /// finished while no daemon was listening reports how it ended.
+    ///
+    /// The holder pid is read off the socket rather than off the wire — see
+    /// `HolderClient.peerPID` — so it is known for every adoption, including
+    /// one this daemon inherited from a previous one. It is optional because
+    /// the kernel may decline to answer, and because nothing here depends on
+    /// having it: the child pid is the anchor every reclaimer uses.
     private struct Adoption: Sendable {
         let reader: HolderReader
         let description: HolderChildDescription
+        let holderPID: Int32?
+    }
+
+    /// The processes behind a session this registry currently holds a reader
+    /// for.
+    ///
+    /// First-hand rather than inferred: both numbers come from the hand-over
+    /// that produced the reader, so a caller holding one of these is holding
+    /// what the *registry* observed, not what a row happens to say. That is
+    /// what makes it usable to repair a row whose pids were lost — a wake
+    /// interrupted between `spawn` publishing its reader and the row recording
+    /// its pids leaves exactly that, and after a restart `adoptAll` re-adopts
+    /// the holder anyway, so the reader is back while the row still names
+    /// nothing.
+    struct HolderAdoptedProcess: Sendable, Equatable {
+        /// The holder process, when the kernel would name it.
+        let holderPID: Int32?
+        /// The job the holder forked. The anchor every reclaimer sweeps by.
+        let childPID: Int32
     }
 
     /// What the registry knows about one session.
@@ -273,6 +299,13 @@ actor HolderRegistry {
     private var lastAttachGeneration: UInt64 = 0
 
     private var slots: [UUID: Slot] = [:]
+
+    /// What the hand-over said about each published session's processes.
+    ///
+    /// Keyed and cleared exactly like `slots`' `.adopted` case, in `publish`
+    /// and `release`, so it cannot outlive the reader it describes and point a
+    /// caller at pids this daemon stopped observing.
+    private var adoptedProcesses: [UUID: HolderAdoptedProcess] = [:]
     /// The last status a holder reported for a session, and the only home it
     /// has: no `terminal` column records an exit status, and the row's fate
     /// belongs to the holder reconciler Milestone B adds. Recorded here so a
@@ -452,6 +485,17 @@ actor HolderRegistry {
         return reader
     }
 
+    /// The processes behind a session this registry holds a published reader
+    /// for, or nil when it holds none.
+    ///
+    /// Answers for exactly the sessions `reader(for:)` answers for, because it
+    /// is written and cleared in the same two places. A caller that has just
+    /// seen a live reader can therefore rely on this answering, and one that
+    /// has not must be prepared for nil.
+    func adoptedProcess(for terminalID: UUID) -> HolderAdoptedProcess? {
+        adoptedProcesses[terminalID]
+    }
+
     /// The last status a holder reported for a session, if one ever has.
     func lastKnownStatus(for terminalID: UUID) -> HolderChildStatus? {
         statuses[terminalID]
@@ -539,7 +583,7 @@ actor HolderRegistry {
             throw error
         }
 
-        publish(reader: adoption.reader, status: adoption.description.status, for: terminalID)
+        publish(adoption, for: terminalID)
         Self.logger.info(
             """
             spawned and adopted a holder for session \(terminalID.uuidString, privacy: .public): \
@@ -898,7 +942,7 @@ actor HolderRegistry {
                 """)
             throw Error.superseded(terminalID: terminalID)
         }
-        publish(reader: adoption.reader, status: adoption.description.status, for: terminalID)
+        publish(adoption, for: terminalID)
         Self.logger.info(
             """
             adopted the holder for session \(terminalID.uuidString, privacy: .public): child \
@@ -1229,6 +1273,10 @@ actor HolderRegistry {
             await client.close()
             throw error
         }
+        // Read while the connection is still open — `LOCAL_PEERPID` is a
+        // property of the socket, not of the path — and after a verb has been
+        // answered, so it names a peer that has provably spoken the protocol.
+        let holderPID = await client.peerPID()
         await client.close()
 
         guard description.owner == owner else {
@@ -1279,7 +1327,7 @@ actor HolderRegistry {
             await reader.stop()
             throw error
         }
-        return Adoption(reader: reader, description: description)
+        return Adoption(reader: reader, description: description, holderPID: holderPID)
     }
 
     // MARK: - Handing a session to a viewer
@@ -2189,6 +2237,10 @@ actor HolderRegistry {
         // ID that no longer means anything.
         pendingAttaches[terminalID] = nil
         viewerAttachments[terminalID] = nil
+        // The processes are named only for as long as this daemon is reading
+        // them. A session it has let go of is one whose pids it has no
+        // first-hand claim about any more.
+        adoptedProcesses[terminalID] = nil
         switch slots[terminalID] {
         case nil:
             return
@@ -2220,11 +2272,14 @@ actor HolderRegistry {
     /// `liveDrainLoops` negative for a spawned session, and
     /// `peakLiveDrainLoops` could not see a second loop running beside a
     /// spawned one — the exact byte theft that counter exists to catch.
-    private func publish(
-        reader: HolderReader, status: HolderChildStatus, for terminalID: UUID
-    ) {
-        slots[terminalID] = .adopted(reader)
-        statuses[terminalID] = status
+    private func publish(_ adoption: Adoption, for terminalID: UUID) {
+        slots[terminalID] = .adopted(adoption.reader)
+        statuses[terminalID] = adoption.description.status
+        // Recorded with the reader and cleared with it, so "the registry holds
+        // a reader for this session" and "the registry can name that session's
+        // processes" are the same fact rather than two that can disagree.
+        adoptedProcesses[terminalID] = HolderAdoptedProcess(
+            holderPID: adoption.holderPID, childPID: adoption.description.childPID)
         drainLoopsStarted += 1
         liveDrainLoops += 1
         peakLiveDrainLoops = max(peakLiveDrainLoops, liveDrainLoops)

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator+Holder.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator+Holder.swift
@@ -308,6 +308,17 @@ extension HibernationCoordinator {
     /// Everything else — an unreadable start time, a mismatch, a foreign
     /// executable — is an uncertain identity, and an uncertain identity is not
     /// evidence in either direction.
+    ///
+    /// **It is deliberately ungated, and that is not an oversight.**
+    /// `holder_hibernation_enabled` decides whether a row may be parked; this
+    /// arm judges rows that already are, including the ones the soak parked
+    /// before the flag was turned off. Gating it would make turning the flag
+    /// off strand exactly the rows an abort most needs healed. Both of its
+    /// mutations are safety-only in the direction a disabled feature wants:
+    /// one un-parks a row over a child that is verifiably alive, the other
+    /// clears pids that verifiably name nothing. Neither ends a process,
+    /// neither parks anything, and neither can be undone into a worse state
+    /// than the row was already in.
     func reconcileParkedHolderRow(_ terminal: Terminal) async {
         guard let childPID = terminal.childPID, childPID > 1 else { return }
         let verdict = ProcessIdentityCheck.verify(

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator+Holder.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator+Holder.swift
@@ -266,15 +266,22 @@ extension HibernationCoordinator {
     private func childIsGone(
         childPID: Int32, terminalID: UUID, registry: HolderRegistry
     ) async -> Bool {
-        if let status = await registry.lastKnownStatus(for: terminalID) {
-            switch status {
-            case .exited, .exitedStatusUnknown: return true
-            case .alive: break
-            }
+        let status = await registry.lastKnownStatus(for: terminalID)
+        switch status {
+        case .exited, .exitedStatusUnknown: return true
+        case .alive, nil: break
         }
+        let statusAlive = (status == .alive)
         // A pid of 0 or below names nothing this daemon may signal or wait on,
-        // and a row that never recorded a child pid has nothing to outlive.
-        guard childPID > 1 else { return true }
+        // so the process table has no answer to give and the registry's is the
+        // only evidence there is. An explicit `.alive` is a positive report
+        // from the holder that its job is still running, and it must not be
+        // thrown away because the row's `child_pid` column happened to be
+        // NULL — that reading would let a park finalize over a live child,
+        // which is the one thing this whole path exists to prevent. With no
+        // report either way, a row that never recorded a child pid has nothing
+        // to outlive.
+        guard childPID > 1 else { return !statusAlive }
         guard signaller.isAlive(childPID) else { return true }
         // `ps -o stat=` reports a corpse as `Z...`. It answers `kill(pid, 0)`,
         // so liveness alone cannot tell it from a running process — and the

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator+Holder.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator+Holder.swift
@@ -4,6 +4,18 @@ import os
 
 private let logger = Logger(subsystem: "com.tbd.daemon", category: "Hibernation")
 
+/// What the park's pending-input rail got when it asked for a holder session's
+/// screen: a screen it may judge, or the refusal that stands in its place.
+///
+/// A type rather than an optional because the three ways to have no judgeable
+/// screen — no reader, a source the daemon is not the live store for, a
+/// projection that refused — carry different remedies and so different words,
+/// and collapsing them would hand the user a sentence that fits none of them.
+enum HolderScreenReading: Sendable {
+    case readable(TerminalScreen)
+    case refused(String)
+}
+
 /// Park and wake for the pty-holder transport.
 ///
 /// Split from `HibernationCoordinator` so the diff to that file is a set of
@@ -22,23 +34,44 @@ private let logger = Logger(subsystem: "com.tbd.daemon", category: "Hibernation"
 /// invisible to every reconciler that reads rows.
 extension HibernationCoordinator {
 
-    /// The refusal for a holder session whose pty a viewer is holding.
+    /// How deep a tail of a holder session's screen the pending-input rail
+    /// judges.
     ///
-    /// Fail-closed, per the transport design's two-store rule: while a viewer
-    /// owns the pty the daemon's emulator is frozen at the moment of that
-    /// attach, so the pending-input rail would be asking a stale screen whether
-    /// there is unsent typed input — and answering that question wrongly is
-    /// exactly the harm the rail exists to prevent. Refusing is recoverable;
-    /// eating a half-composed prompt is not.
+    /// The depth `terminal.output` answers by default, and about a screen's
+    /// worth. The rail scans upward for the composer and stops at the first
+    /// prompt line it finds, so what it needs is the tail; asking for the whole
+    /// retained scrollback would put lines nobody is looking at under a check
+    /// that reads only the last of them.
+    static let holderScreenLines = 50
+
+    /// The refusal for a holder session whose screen the daemon is not the
+    /// live source of.
+    ///
+    /// Fail-closed, per the transport design's two-store rule, and decided from
+    /// the typed screen's own `source` rather than from a second question about
+    /// who holds the pty. A viewer's attach suspends the daemon's drain, and a
+    /// suspended reader's screen answers `.staleDaemon` — the daemon's emulator
+    /// frozen at the moment of that attach. Asking a frozen screen whether
+    /// there is unsent typed input is exactly the wrong answer the rail exists
+    /// to prevent. Refusing is recoverable; eating a half-composed prompt is
+    /// not.
+    ///
+    /// `.viewer` — a screen the viewer itself answered a pull with — refuses
+    /// here for a different reason that lands in the same place: that screen is
+    /// live, but somebody is sitting at the keyboard of the session about to be
+    /// parked. It is not reachable from a `HolderReader`, which answers only
+    /// `.daemon` or `.staleDaemon`; the arm exists because a source is the
+    /// question this rail asks, and a new source must be answered rather than
+    /// defaulted.
     ///
     /// It names an action the user can take, which is why it is a separate
     /// string from `holderNoReaderRefusal` below: closing the tab makes this
     /// park possible, and telling somebody to close a tab they have not got
     /// would be worse than saying nothing.
     static let holderViewerAttachedRefusal =
-        "A viewer is attached to this session, so the daemon cannot read its "
-        + "screen to check for unsent input; close the tab or wait for it to "
-        + "leave the viewer before hibernating"
+        "The daemon's screen for this session is not the live one — a viewer "
+        + "holds its pty — so it cannot check for unsent input; close the tab "
+        + "or wait for it to leave the viewer before hibernating"
 
     /// The refusal for a holder session this daemon is not reading at all.
     ///
@@ -53,23 +86,122 @@ extension HibernationCoordinator {
         "The daemon is not reading this session's terminal, so it cannot check "
         + "for unsent input before hibernating"
 
+    /// The refusal for a screen that could not be projected at all.
+    ///
+    /// `TerminalScreen` refuses a line carrying a control character, and its
+    /// own documentation argues why that is a bug in whatever rendered the line
+    /// rather than a state a session can put itself in. This rail cannot repair
+    /// it and must not guess past it: a screen it could not read is a screen it
+    /// cannot clear of unsent input, so it fails closed like every other half
+    /// of this rail. The third string exists because the remedy is neither a
+    /// tab to close nor a session to re-adopt — it is a defect to fix, and a
+    /// refusal that said "close the tab" would send somebody chasing the wrong
+    /// thing.
+    static let holderScreenProjectionRefusal =
+        "The daemon could not read this session's screen to check for unsent "
+        + "input before hibernating"
+
+    /// The refusal a screen's `source` implies, or nil when the daemon may
+    /// judge it.
+    ///
+    /// The whole policy, in one place, so the park and the idle sweep cannot
+    /// hold different opinions about which sources are judgeable. Both ask this
+    /// question; they differ only in how much of the screen they pay for to get
+    /// the answer.
+    static func holderRefusal(forScreenSource source: TerminalScreen.Source) -> String? {
+        switch source {
+        case .daemon: return nil
+        case .staleDaemon, .viewer: return holderViewerAttachedRefusal
+        }
+    }
+
+    /// The typed screen the park's rail judges, or the refusal that stands in
+    /// its place.
+    ///
+    /// One method so the two fail-closed halves and the projection failure are
+    /// stated once and the park reads a single answer.
+    func holderScreenReading(
+        terminalID: UUID, registry: HolderRegistry
+    ) async -> HolderScreenReading {
+        let screen: TerminalScreen?
+        do {
+            screen = try await holderScreen(terminalID: terminalID, registry: registry)
+        } catch {
+            logger.error(
+                """
+                hibernate: could not project \(terminalID, privacy: .public)'s screen for the \
+                pending-input rail: \(error.localizedDescription, privacy: .public)
+                """)
+            return .refused(Self.holderScreenProjectionRefusal)
+        }
+        guard let screen else { return .refused(Self.holderNoReaderRefusal) }
+        if let refusal = Self.holderRefusal(forScreenSource: screen.source) {
+            return .refused(refusal)
+        }
+        return .readable(screen)
+    }
+
     /// Whether the screen the park's pending-input rail would have to judge is
-    /// one this daemon cannot read — a viewer owns the pty, or no reader was
+    /// one this daemon may not judge — a viewer holds the pty, or no reader was
     /// ever adopted for the session.
     ///
-    /// The same question `performHolderHibernate` asks before its two
-    /// fail-closed refusals, lifted out so the sweep can ask it *first*.
+    /// The same question `performHolderHibernate` asks before its fail-closed
+    /// refusals, lifted out so the sweep can ask it *first*.
     /// `HibernationGate` is pure — it decides from the row, the config and the
     /// clock, and has no way to see who holds a pty — so the sweep is the only
     /// place with the registry in hand.
+    ///
+    /// **It reads the mode half of the oracle, not the whole screen.** `source`
+    /// is one fact taken from one reader under one lock, and
+    /// `HolderReader.modeReading` carries it without the whole-buffer walk that
+    /// `screen(maxLines:)` pays for — the same trade the send path's oracle
+    /// makes, and for the same reason: this runs on every sweep, for every idle
+    /// holder row, and the walk holds the emulator lock a live session's drain
+    /// thread needs. The two therefore agree on the question that decides the
+    /// refusal. They can differ on exactly one thing, a screen that will not
+    /// project at all: the sweep cannot foresee it, so such a row is armed here
+    /// and refused at the park. That is a producer bug rather than a session
+    /// state, and paying a request-and-refusal pair per sweep for one is better
+    /// than hiding it.
     ///
     /// A daemon with no registry at all answers false: that is the tmux-only
     /// configuration, where a holder row is a leftover and the park's own
     /// no-registry refusal is the right place to say so once.
     func holderScreenIsUnreadable(terminalID: UUID) async -> Bool {
         guard let registry = holderRegistry else { return false }
-        if await registry.viewerAttachment(for: terminalID) != nil { return true }
-        return await registry.reader(for: terminalID) == nil
+        if let oracle = holderScreenOracle {
+            do {
+                guard let screen = try await oracle(terminalID) else { return true }
+                return Self.holderRefusal(forScreenSource: screen.source) != nil
+            } catch {
+                // A refused projection, and the seam answers it the way the
+                // production path below does rather than better: that path
+                // reads only the source and never walks a line, so it cannot
+                // see one. The sweep arms, the park refuses. A seam that
+                // answered `true` here would make a test agree where the
+                // shipped code does not.
+                return false
+            }
+        }
+        guard let reader = await registry.reader(for: terminalID) else { return true }
+        let source = await reader.modeReading().source
+        return Self.holderRefusal(forScreenSource: source) != nil
+    }
+
+    /// The screen this daemon holds for a session, or nil when it holds none.
+    ///
+    /// The test seam first, so a park can be driven against each source without
+    /// a real holder, a real pty and a real attach; otherwise the registry's
+    /// own reader, which is the single source the design names. Both throw only
+    /// what `TerminalScreen`'s construction refuses.
+    private func holderScreen(
+        terminalID: UUID, registry: HolderRegistry
+    ) async throws -> TerminalScreen? {
+        if let holderScreenOracle {
+            return try await holderScreenOracle(terminalID)
+        }
+        guard let reader = await registry.reader(for: terminalID) else { return nil }
+        return try await reader.screen(maxLines: Self.holderScreenLines)
     }
 
     // MARK: - Park
@@ -115,13 +247,14 @@ extension HibernationCoordinator {
             return refusal
         }
 
-        // The three refusals below clear `idleSince` and `pendingKillSince`
-        // like every other refusal in this method. Each one names a condition
-        // that will still hold on the next sweep — no registry on this daemon,
-        // a viewer that owns the pty until its tab closes, a session this
-        // daemon never adopted — so leaving the markers armed would re-fire the
-        // identical refusal every pass. Clearing them makes the row start its
-        // idle clock again from the moment the condition clears.
+        // Every refusal below clears `idleSince` and `pendingKillSince` like
+        // every other refusal in this method. Each names a condition that will
+        // still hold on the next sweep — no registry on this daemon, a viewer
+        // that owns the pty until its tab closes, a session this daemon never
+        // adopted, a screen whose projection is broken — so leaving the markers
+        // armed would re-fire the identical refusal every pass. Clearing them
+        // makes the row start its idle clock again from the moment the
+        // condition clears.
 
         // No registry means no reader, no way to write `/exit`, and no way to
         // abandon the holder afterwards. Say so by name rather than parking a
@@ -132,29 +265,38 @@ extension HibernationCoordinator {
             return .notEligible(reason: "this daemon has no holder registry")
         }
 
-        // Rail: typed-but-unsent input, read off the daemon's own emulator.
-        // Fail-closed on both halves — a viewer holding the pty, or no reader
-        // at all — because either one means the screen this rail would judge is
-        // not the screen the session is showing. Each half answers with its own
-        // name: they differ in what the person reading the refusal can do next.
-        if await registry.viewerAttachment(for: terminal.id) != nil {
+        // Rail: typed-but-unsent input, read off the typed screen oracle.
+        // Fail-closed on every answer that is not a live daemon-rendered
+        // screen — a source the daemon is not the live store for, no reader at
+        // all, a projection that refused — because each one means the screen
+        // this rail would judge is not the screen the session is showing. Each
+        // answers with its own name: they differ in what the person reading the
+        // refusal can do next.
+        let capturedSnapshot: String?
+        switch await holderScreenReading(terminalID: terminal.id, registry: registry) {
+        case .refused(let refusal):
             idleSince[terminal.id] = nil
             pendingKillSince[terminal.id] = nil
-            logger.debug("hibernate: refusing \(terminal.id, privacy: .public) — a viewer holds this session's pty")
-            return .notEligible(reason: Self.holderViewerAttachedRefusal)
+            logger.debug("hibernate: refusing \(terminal.id, privacy: .public) — \(refusal, privacy: .public)")
+            return .notEligible(reason: refusal)
+        case .readable(let screen):
+            if HibernationSafetyChecks.hasPendingInput(paneCapture: screen.output) {
+                logger.debug("hibernate: skipping \(terminal.id, privacy: .public) — pending typed input in prompt")
+                return .notEligible(reason: "Terminal has unsent typed input")
+            }
+            capturedSnapshot = screen.output.isEmpty ? nil : screen.output
         }
+
+        // The reader the polite `/exit` below is written through. Read after
+        // the rail rather than inside it: the rail's subject is the screen, and
+        // a reader that answered a live screen a moment ago is the one this
+        // park writes to.
         guard let reader = await registry.reader(for: terminal.id) else {
             idleSince[terminal.id] = nil
             pendingKillSince[terminal.id] = nil
             logger.debug("hibernate: refusing \(terminal.id, privacy: .public) — the daemon holds no reader for this session")
             return .notEligible(reason: Self.holderNoReaderRefusal)
         }
-        let screen = await reader.renderScreen()
-        if HibernationSafetyChecks.hasPendingInput(paneCapture: screen) {
-            logger.debug("hibernate: skipping \(terminal.id, privacy: .public) — pending typed input in prompt")
-            return .notEligible(reason: "Terminal has unsent typed input")
-        }
-        let capturedSnapshot: String? = screen.isEmpty ? nil : screen
 
         // Rail: transcript-tail validity, identical to the tmux path. Killing
         // mid-write can leave an unresumable jsonl.

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator+Holder.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator+Holder.swift
@@ -487,7 +487,19 @@ extension HibernationCoordinator {
     /// same reason: the pids are persisted BEFORE the row stops being parked,
     /// so a failure in between leaves a parked row that names live processes —
     /// which `reconcileOnStartup` un-parks — rather than an awake row that
-    /// names nothing, which nothing would ever reconcile.
+    /// names nothing, which nothing would ever reconcile. Both orders can fail
+    /// in the middle; only this one fails into a state something owns.
+    ///
+    /// **What makes that order converge rather than compound is the adopt
+    /// guard below.** Without it, the window between the pid write and the
+    /// cleared park marker is not merely untidy, it multiplies: the row still
+    /// reads parked, so the app's next focus-wake re-enters this method,
+    /// `registry.spawn` runs unconditionally, `setHolderProcess` overwrites the
+    /// pids with a third generation, and the second generation — live, and no
+    /// longer named by any row — is beyond every reconciler, because the
+    /// reaper's holder leg sweeps by the pids a row carries. Healing the row
+    /// instead means the retry that used to widen the damage is now what
+    /// repairs it, and `reconcileOnStartup` stops being the only cure.
     func wakeHolderSection(
         terminal: Terminal,
         worktree: LocalWorktree,
@@ -503,17 +515,33 @@ extension HibernationCoordinator {
             return .respawnFailed(
                 reason: "this daemon has no holder registry, so the session cannot be resumed on the pty-holder transport")
         }
-        // "Registry present" is not "can spawn": a daemon whose `TBDHolder`
-        // binary has moved still builds a registry, because adoption of a
-        // running holder needs no executable. Only this fact may gate a spawn.
-        guard registry.canSpawn else {
-            return .respawnFailed(
-                reason: "the TBDHolder helper is missing beside the daemon, so no holder can be started for this session; the row stays parked")
-        }
 
         guard let currentTerminal = try? await db.terminals.get(id: terminal.id),
               expectedReplacementState.matches(currentTerminal) else {
             return .respawnFailed(reason: "terminal changed while wake was preparing; retry")
+        }
+
+        // The row said parked, but its holder may already be running — an
+        // earlier wake of this same row that got as far as the pids. Heal it
+        // rather than starting a second one.
+        if let adopted = await adoptLiveHolderInsteadOfRespawning(
+            currentTerminal, registry: registry) {
+            return adopted
+        }
+
+        // "Registry present" is not "can spawn": a daemon whose `TBDHolder`
+        // binary has moved still builds a registry, because adoption of a
+        // running holder needs no executable. Only this fact may gate a spawn.
+        //
+        // Asked here rather than at the top of the method because it gates a
+        // SPAWN, and the branch above does not spawn: a daemon whose helper has
+        // moved can still un-park a row over the holder it already adopted, and
+        // refusing that would strand exactly the row this method just proved is
+        // healthy. Everything between here and the guard is read-only, so
+        // moving the question down costs the refusal nothing.
+        guard registry.canSpawn else {
+            return .respawnFailed(
+                reason: "the TBDHolder helper is missing beside the daemon, so no holder can be started for this session; the row stays parked")
         }
 
         let incarnationID: UUID
@@ -589,6 +617,83 @@ extension HibernationCoordinator {
         // pane's screen, and this row has no pane. A holder session's resumed
         // id is recaptured the way every other fact about it is — from hooks.
         logger.info("woke holder-backed terminal \(terminal.id, privacy: .public) (resume \(sessionID, privacy: .public), holder \(handle.holderPID, privacy: .public), child \(handle.childPID, privacy: .public))")
+        return .ok
+    }
+
+    /// Un-park a parked row whose holder is already running, or answer nil so
+    /// the wake spawns as usual.
+    ///
+    /// The state this recognizes is a wake that half-finished: `setHolderProcess`
+    /// landed and `clearHibernated` did not, so the row names a live holder and
+    /// a live child while still claiming parked. `reconcileOnStartup` heals it,
+    /// but only at the next daemon start, and the periodic reconcile sweep skips
+    /// parked rows by design — so between those two events every retry used to
+    /// spawn again and abandon the generation before it.
+    ///
+    /// Two independent facts count as "already running", because they answer
+    /// from opposite ends and either one alone is enough:
+    ///
+    /// - **The registry still holds a reader for the session.** That reader
+    ///   exists only because a `spawn` on this daemon adopted the holder it
+    ///   started, which makes it first-hand evidence rather than an inference
+    ///   about a number. It is also what makes this a guard rather than a
+    ///   nicety: `HolderRegistry.spawn` refuses a session that already occupies
+    ///   a slot (`sessionAlreadyRegistered`), so without the guard the retry's
+    ///   spawn throws and the row stays parked forever — the guard is what turns
+    ///   that throw into a heal.
+    /// - **The recorded child pid is identity-verified alive**, through the same
+    ///   `ProcessIdentityCheck` the reaper's holder leg consults before it
+    ///   signals anything: alive, started within
+    ///   `AgentReaper.defaultHolderIdentityWindow` of the row's recorded child
+    ///   start, and running an executable a holder's job could be. This is the
+    ///   half that survives a daemon restart, where no reader exists but the
+    ///   child does. A pid the kernel has recycled fails it exactly as it fails
+    ///   there.
+    ///
+    /// Every other verdict — `.notRunning`, an unreadable start time or command
+    /// line, a mismatch, a foreign executable — returns nil and lets the spawn
+    /// proceed. That is the safe direction on this side: an uncertain identity
+    /// must not silently un-park a row over a session nobody is running, and a
+    /// spawn that turns out to be unnecessary is refused by the registry rather
+    /// than duplicated.
+    private func adoptLiveHolderInsteadOfRespawning(
+        _ terminal: Terminal, registry: HolderRegistry
+    ) async -> WakeResult? {
+        let evidence: String
+        if await registry.reader(for: terminal.id) != nil {
+            evidence = "this daemon is still reading its holder"
+        } else if let childPID = terminal.childPID, childPID > 1,
+                  ProcessIdentityCheck.verify(
+                    pid: childPID,
+                    startedWithin: AgentReaper.defaultHolderIdentityWindow,
+                    of: terminal.holderChildStartedAt ?? terminal.createdAt,
+                    executableIsAcceptable: AgentReaper.isHolderChildExecutable,
+                    signaller: signaller) == .same {
+            evidence = "its recorded child \(childPID) is identity-verified alive"
+        } else {
+            return nil
+        }
+
+        do {
+            try await db.terminals.clearHibernated(id: terminal.id)
+        } catch {
+            // Nothing was started and nothing is abandoned: the row is exactly
+            // as it was, still parked over its own live holder, and the next
+            // retry or the next daemon start reaches this same branch again.
+            logger.error("wake: \(terminal.id, privacy: .public) is parked over a holder that is already running, but the parked marker could not be cleared: \(error.localizedDescription, privacy: .public)")
+            return .respawnFailed(
+                reason: "this session's holder is already running, but clearing its parked "
+                    + "marker failed: \(error.localizedDescription)")
+        }
+
+        idleSince[terminal.id] = nil
+        // The same empty tmux coordinates the spawn path broadcasts, for the
+        // same reason: a holder row carries none, and a non-empty pair would
+        // send the terminal view looking for a window that does not exist.
+        broadcastHibernation(
+            terminal: terminal, hibernated: false, keepWarm: terminal.keepWarm,
+            tmuxWindowID: "", tmuxPaneID: "")
+        logger.info("wake: adopted the holder already running for \(terminal.id, privacy: .public) instead of spawning a second one — \(evidence, privacy: .public); the row was parked over it")
         return .ok
     }
 }

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator+Holder.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator+Holder.swift
@@ -22,7 +22,7 @@ private let logger = Logger(subsystem: "com.tbd.daemon", category: "Hibernation"
 /// invisible to every reconciler that reads rows.
 extension HibernationCoordinator {
 
-    /// The refusal for a holder session the daemon cannot read the screen of.
+    /// The refusal for a holder session whose pty a viewer is holding.
     ///
     /// Fail-closed, per the transport design's two-store rule: while a viewer
     /// owns the pty the daemon's emulator is frozen at the moment of that
@@ -30,10 +30,28 @@ extension HibernationCoordinator {
     /// there is unsent typed input — and answering that question wrongly is
     /// exactly the harm the rail exists to prevent. Refusing is recoverable;
     /// eating a half-composed prompt is not.
+    ///
+    /// It names an action the user can take, which is why it is a separate
+    /// string from `holderNoReaderRefusal` below: closing the tab makes this
+    /// park possible, and telling somebody to close a tab they have not got
+    /// would be worse than saying nothing.
     static let holderViewerAttachedRefusal =
         "A viewer is attached to this session, so the daemon cannot read its "
         + "screen to check for unsent input; close the tab or wait for it to "
         + "leave the viewer before hibernating"
+
+    /// The refusal for a holder session this daemon is not reading at all.
+    ///
+    /// The same fail-closed rail, reached from the opposite direction: nobody
+    /// holds the pty, and the daemon still has no emulator to judge — the
+    /// session was never adopted, or its reader is gone. Nothing the user does
+    /// to a tab changes that, so the text says what is true rather than
+    /// prescribing a gesture that would not help. The distinction is worth a
+    /// string of its own precisely because the remedies differ: one is a tab
+    /// to close, the other is a session the daemon has lost track of.
+    static let holderNoReaderRefusal =
+        "The daemon is not reading this session's terminal, so it cannot check "
+        + "for unsent input before hibernating"
 
     // MARK: - Park
 
@@ -88,11 +106,15 @@ extension HibernationCoordinator {
         // Rail: typed-but-unsent input, read off the daemon's own emulator.
         // Fail-closed on both halves — a viewer holding the pty, or no reader
         // at all — because either one means the screen this rail would judge is
-        // not the screen the session is showing.
-        guard await registry.viewerAttachment(for: terminal.id) == nil,
-              let reader = await registry.reader(for: terminal.id) else {
-            logger.debug("hibernate: refusing \(terminal.id, privacy: .public) — the daemon is not this session's reader")
+        // not the screen the session is showing. Each half answers with its own
+        // name: they differ in what the person reading the refusal can do next.
+        if await registry.viewerAttachment(for: terminal.id) != nil {
+            logger.debug("hibernate: refusing \(terminal.id, privacy: .public) — a viewer holds this session's pty")
             return .notEligible(reason: Self.holderViewerAttachedRefusal)
+        }
+        guard let reader = await registry.reader(for: terminal.id) else {
+            logger.debug("hibernate: refusing \(terminal.id, privacy: .public) — the daemon holds no reader for this session")
+            return .notEligible(reason: Self.holderNoReaderRefusal)
         }
         let screen = await reader.renderScreen()
         if HibernationSafetyChecks.hasPendingInput(paneCapture: screen) {
@@ -174,8 +196,22 @@ extension HibernationCoordinator {
                         childPID: 0,
                         socketPath: socketPath))
             } catch {
-                // Nothing is leaked by skipping it: the job is confirmed gone
-                // and its holder exits when its child does.
+                // The processes are not the concern: the job is confirmed gone
+                // and a holder whose child has exited winds itself down. What
+                // does outlive this call is bookkeeping `abandon` would have
+                // cleared — this session's registry slot and its remembered
+                // status — and the collector for that is
+                // `reclaimIfSessionEnded`, which the reader's end-of-output
+                // notifier fires once the drain runs dry.
+                //
+                // Worth naming rather than glossing: that reclaimer derives the
+                // SAME rendezvous path, and the only thing that makes this
+                // throw is a path over `sun_path` — a persistent fact about
+                // this install's `TBD_HOME` and this session's id, not a
+                // transient. So the pairing is real but not a guarantee here;
+                // it is also the reason this branch is close to unreachable,
+                // since a session whose path cannot be represented could
+                // neither have been spawned nor adopted by this daemon.
                 logger.warning("hibernate: could not derive the rendezvous path for \(terminal.id, privacy: .public), so its holder was not told to let go: \(error.localizedDescription, privacy: .public)")
             }
         }
@@ -186,6 +222,15 @@ extension HibernationCoordinator {
             // spawn a second agent onto the same session. Roll the intent back
             // — `clearHibernated` nils both park columns and the pending
             // incarnation — and report the pid so an operator can act.
+            //
+            // "Left awake" is the row's state, not the session's, and the
+            // difference matters to whoever reads this. Reaching here means the
+            // escalation already ran: the holder was torn down and the job was
+            // signalled, so what is left is a child that survived `SIGKILL` or
+            // could not be confirmed gone. Leaving the row awake is the only
+            // honest record of that — it names live pids, so the reconcile arm
+            // and the reaper's holder leg can both judge it — but it is not a
+            // claim that the session is still usable.
             do {
                 try await db.terminals.clearHibernated(id: terminal.id)
             } catch {
@@ -193,9 +238,10 @@ extension HibernationCoordinator {
             }
             idleSince[terminal.id] = nil
             pendingKillSince[terminal.id] = nil
-            logger.error("hibernate: holder child \(childPID, privacy: .public) for terminal \(terminal.id, privacy: .public) did not exit; the row was left awake")
+            logger.error("hibernate: holder child \(childPID, privacy: .public) for terminal \(terminal.id, privacy: .public) survived the escalation; its holder was torn down and the row is left awake for reconciliation to judge")
             return .notEligible(
-                reason: "holder child \(childPID) did not exit; the session was left running")
+                reason: "holder child \(childPID) survived the escalation; its holder was torn "
+                    + "down and this session is left awake for reconciliation to judge")
         }
 
         do {

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator+Holder.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator+Holder.swift
@@ -993,14 +993,18 @@ extension HibernationCoordinator {
     /// Two independent facts count as "already running", because they answer
     /// from opposite ends and either one alone is enough:
     ///
-    /// - **The registry still holds a reader for the session.** That reader
-    ///   exists only because a `spawn` on this daemon adopted the holder it
-    ///   started, which makes it first-hand evidence rather than an inference
-    ///   about a number. It is also what makes this a guard rather than a
-    ///   nicety: `HolderRegistry.spawn` refuses a session that already occupies
-    ///   a slot (`sessionAlreadyRegistered`), so without the guard the retry's
-    ///   spawn throws and the row stays parked forever — the guard is what turns
-    ///   that throw into a heal.
+    /// - **The registry still holds a reader for the session.** That means this
+    ///   daemon is draining that session's pty right now — whichever daemon
+    ///   started the holder, since `adoptAll` adopts rows this one never
+    ///   spawned — which is first-hand evidence that the holder is alive rather
+    ///   than an inference about a number. A re-adopted row may carry no pids
+    ///   at all, so this leg restores them from what the registry itself
+    ///   observed before the park marker is cleared; that is what
+    ///   `restoreHolderPIDsFromRegistry` is doing here. It is also what makes
+    ///   this a guard rather than a nicety: `HolderRegistry.spawn` refuses a
+    ///   session that already occupies a slot (`sessionAlreadyRegistered`), so
+    ///   without the guard the retry's spawn throws and the row stays parked
+    ///   forever — the guard is what turns that throw into a heal.
     /// - **The recorded child pid is identity-verified alive**, through the same
     ///   `ProcessIdentityCheck` the reaper's holder leg consults before it
     ///   signals anything: alive, started within

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator+Holder.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator+Holder.swift
@@ -16,6 +16,46 @@ enum HolderScreenReading: Sendable {
     case refused(String)
 }
 
+/// What the park's escalation ladder may do to the pid a holder row records —
+/// the whole decision table, in one type, because each rung asks the same
+/// question and the answers must not drift between them.
+///
+/// Three facts feed it: whether the row named a pid at all, whether that pid is
+/// a corpse, and `ProcessIdentityCheck` — the check every other signalling site
+/// in this daemon consults. The mapping is deliberately asymmetric, because the
+/// two mistakes are not: a refused park is recoverable on the next sweep, and a
+/// signal sent to a stranger's process is not.
+///
+/// - a corpse (`ps` says `Z…`) → `.gone`. Past its last instruction, and its
+///   number cannot be reissued while the entry stands.
+/// - `.same` → `.ours`. The one verdict that licenses a signal.
+/// - `.notRunning` → `.gone`. Nothing holds the pid, so the child this park set
+///   out to end is already past its last instruction. This is a *positive*
+///   answer about a real pid and may therefore lead to a finalize, exactly like
+///   the registry's `.exited`.
+/// - `.startTimeMismatch` / `.foreignExecutable` → `.unverifiable`. The pid
+///   names a stranger. In the narrow sense our child IS gone — nothing that
+///   survives is ours — but "gone" here would mean finalizing a park whose
+///   child this daemon never saw exit, over a row it can no longer describe. So
+///   the park refuses instead, and only `.notRunning` (and the registry's own
+///   `.exited`) are allowed to complete one.
+/// - `.startTimeUnreadable` / `.commandUnreadable` → `.unverifiable`. The
+///   kernel would not say. "Keep when uncertain" is the doctrine every
+///   signalling site here follows, and an unreadable answer is uncertainty, not
+///   absence.
+/// - no recorded pid → `.unrecorded`. There is nothing to verify and nothing to
+///   signal by number, but the holder is still reachable over its socket.
+enum HolderChildDisposition: Sendable, Equatable {
+    /// A live process this daemon verified as this session's own child.
+    case ours
+    /// The recorded pid names nothing.
+    case gone
+    /// The row records no usable child pid.
+    case unrecorded
+    /// Alive, and not provably this session's child.
+    case unverifiable(ProcessIdentityVerdict)
+}
+
 /// Park and wake for the pty-holder transport.
 ///
 /// Split from `HibernationCoordinator` so the diff to that file is a set of
@@ -272,6 +312,14 @@ extension HibernationCoordinator {
         // this rail would judge is not the screen the session is showing. Each
         // answers with its own name: they differ in what the person reading the
         // refusal can do next.
+        //
+        // One dependency this rail has and cannot check: after a daemon restart
+        // the emulator it reads is one that has seen only what arrived since
+        // re-adoption, so what it shows of the composer is whatever the
+        // attach-edge jiggle's repaint produced. The rail is relying on a real
+        // geometry change forcing an Ink-style TUI to redraw its composer, and
+        // so on a half-composed prompt being visible again. That is inferred
+        // from how such TUIs redraw on `SIGWINCH`, not measured.
         let capturedSnapshot: String?
         switch await holderScreenReading(terminalID: terminal.id, registry: registry) {
         case .refused(let refusal):
@@ -333,62 +381,94 @@ extension HibernationCoordinator {
         }
 
         let childPID = currentTerminal.childPID ?? 0
-        // Polite park: `/exit` in band, so Claude flushes its transcript, shuts
-        // down MCP children and fires Stop hooks. Written to the pty the daemon
-        // is already reading — the same descriptor `terminal.send` uses — rather
-        // than through tmux `send-keys`, which addresses a pane this row has
-        // not got.
-        try? await reader.write(Data("/exit\r".utf8))
+        // Rung 1 — polite park: `/exit` in band, so Claude flushes its
+        // transcript, shuts down MCP children and fires Stop hooks. Written to
+        // the pty the daemon is already reading — the same descriptor
+        // `terminal.send` uses — rather than through tmux `send-keys`, which
+        // addresses a pane this row has not got.
+        //
+        // A refused write is not a failure of the park; it is the reason the
+        // ladder below exists. It is logged rather than swallowed because it
+        // names the one thing the rungs after it cannot: that the session never
+        // got the chance to shut itself down, so a `SIGTERM` it did not deserve
+        // is about to arrive. `HolderReader.write` is all-or-nothing — it
+        // either delivers the whole buffer within its budget or throws — so
+        // there is no partial-write value to inspect here; if that ever becomes
+        // a short count, it belongs in this same log line.
+        do {
+            try await reader.write(Data("/exit\r".utf8))
+        } catch {
+            logger.warning("hibernate: could not write the polite /exit for \(terminal.id, privacy: .public), so the escalation is what will end its job: \(error.localizedDescription, privacy: .public)")
+        }
         var gone = await pollUntilChildIsGone(
             childPID: childPID, terminalID: terminal.id, registry: registry,
             attempts: exitPollAttempts)
+        // Whether the holder has already been told to let go. Only the forced
+        // rung does that, and only as part of killing the job; every other way
+        // out of the ladder still owes the holder its `forget`.
+        var abandoned = false
 
         if !gone {
-            // The polite exit did not take. `abandon` is the escalation: the
-            // holder is told to let go (closing the pty master), the job is
-            // killed by process group, and the holder's corpse is collected.
-            logger.debug("hibernate: /exit did not end the job for \(terminal.id, privacy: .public) within the poll window — abandoning the holder")
-            if let unfinished = await registry.abandon(terminal: currentTerminal) {
-                logger.warning("hibernate: holder teardown for \(terminal.id, privacy: .public) was incomplete: \(unfinished, privacy: .public)")
+            // Rung 2 — `SIGTERM` to the child, and to the child alone.
+            //
+            // The tmux ladder is `/exit` → Escape → C-c C-c → SIGTERM →
+            // forced replacement, and this is the rung the holder park was
+            // missing: without it a session whose Stop hooks or MCP teardown
+            // outlast the three-second polite window went straight to a
+            // `SIGKILL` of its process group, which is where a transcript gets
+            // cut mid-write. `terminateProcessOnly` is deliberate — widening to
+            // the group is the forced rung's job, and on a recycled pid
+            // `getpgid` resolves to a stranger's group entirely.
+            switch holderChildDisposition(childPID: childPID, terminal: currentTerminal) {
+            case .gone:
+                gone = true
+            case .unverifiable(let verdict):
+                return await refuseUnverifiableHolderChild(
+                    currentTerminal, childPID: childPID, verdict: verdict, registry: registry)
+            case .ours:
+                logger.debug("hibernate: /exit did not end the job for \(terminal.id, privacy: .public) within the poll window — sending SIGTERM to child \(childPID, privacy: .public)")
+                signaller.terminateProcessOnly(childPID)
+                gone = await pollUntilChildIsGone(
+                    childPID: childPID, terminalID: terminal.id, registry: registry,
+                    attempts: holderTerminateAttempts)
+            case .unrecorded:
+                // Nothing to signal by pid, so this rung has nothing to do.
+                // The forced rung still does: it reaches the holder over its
+                // socket, which needs no pid at all.
+                break
             }
-            gone = await pollUntilChildIsGone(
-                childPID: childPID, terminalID: terminal.id, registry: registry,
-                attempts: holderEscalationAttempts)
-        } else {
-            // Gone politely, so the holder was never told to let go — and a
-            // holder whose child has exited winds itself down, which is a race
-            // this call does not need to win. `childPID: 0` is the sentinel
-            // `dispose` refuses to signal, and that is the point: the recorded
-            // pid is now free and the next process to take that number is
-            // somebody else's.
-            do {
-                let socketPath = try HolderRendezvous.socketPath(
-                    sessionID: terminal.id, environment: registry.environment)
-                await registry.abandon(
-                    terminalID: terminal.id,
-                    handle: HolderHandle(
-                        holderPID: currentTerminal.holderPID ?? 0,
-                        childPID: 0,
-                        socketPath: socketPath))
-            } catch {
-                // The processes are not the concern: the job is confirmed gone
-                // and a holder whose child has exited winds itself down. What
-                // does outlive this call is bookkeeping `abandon` would have
-                // cleared — this session's registry slot and its remembered
-                // status — and the collector for that is
-                // `reclaimIfSessionEnded`, which the reader's end-of-output
-                // notifier fires once the drain runs dry.
-                //
-                // Worth naming rather than glossing: that reclaimer derives the
-                // SAME rendezvous path, and the only thing that makes this
-                // throw is a path over `sun_path` — a persistent fact about
-                // this install's `TBD_HOME` and this session's id, not a
-                // transient. So the pairing is real but not a guarantee here;
-                // it is also the reason this branch is close to unreachable,
-                // since a session whose path cannot be represented could
-                // neither have been spawned nor adopted by this daemon.
-                logger.warning("hibernate: could not derive the rendezvous path for \(terminal.id, privacy: .public), so its holder was not told to let go: \(error.localizedDescription, privacy: .public)")
+        }
+
+        if !gone {
+            // Rung 3 — forced. `abandon` is the escalation: the holder is told
+            // to let go (closing the pty master), the job is killed by process
+            // group, and the holder's corpse is collected. Identity-checked
+            // again rather than on the strength of the check above, because the
+            // `SIGTERM` rung's own poll window sits between them and a pid
+            // freed inside it is a pid the kernel may already have reissued.
+            switch holderChildDisposition(childPID: childPID, terminal: currentTerminal) {
+            case .gone:
+                gone = true
+            case .unverifiable(let verdict):
+                return await refuseUnverifiableHolderChild(
+                    currentTerminal, childPID: childPID, verdict: verdict, registry: registry)
+            case .ours, .unrecorded:
+                logger.debug("hibernate: SIGTERM did not end the job for \(terminal.id, privacy: .public) within the poll window — abandoning the holder")
+                if let unfinished = await registry.abandon(terminal: currentTerminal) {
+                    logger.warning("hibernate: holder teardown for \(terminal.id, privacy: .public) was incomplete: \(unfinished, privacy: .public)")
+                }
+                abandoned = true
+                gone = await pollUntilChildIsGone(
+                    childPID: childPID, terminalID: terminal.id, registry: registry,
+                    attempts: holderEscalationAttempts)
             }
+        }
+
+        if gone, !abandoned {
+            // The job ended without the forced rung, so the holder was never
+            // told to let go — and a holder whose child has exited winds itself
+            // down, which is a race this call does not need to win.
+            await letHolderGoWithoutKilling(currentTerminal, registry: registry)
         }
 
         guard gone else {
@@ -417,6 +497,22 @@ extension HibernationCoordinator {
             return .notEligible(
                 reason: "holder child \(childPID) survived the escalation; its holder was torn "
                     + "down and this session is left awake for reconciliation to judge")
+        }
+
+        // The transcript rail, asked a second time now that the child is gone.
+        //
+        // The first ask was before `/exit`, which is the only moment it can
+        // stop a park; this one cannot and must not. The process is gone, and
+        // the row parked is the truthful record of that — rolling back here
+        // would leave an awake row over a session that no longer exists, which
+        // is a worse lie than a transcript that needs repair. So it reports and
+        // continues: a tail that was parseable before the shutdown and is not
+        // parseable after it means the write was cut, and the resume that finds
+        // it will need to know why.
+        if let transcriptPath = currentTerminal.transcriptPath,
+           let body = try? String(contentsOfFile: transcriptPath, encoding: .utf8),
+           !HibernationSafetyChecks.isTranscriptTailValid(jsonlBody: body) {
+            logger.warning("hibernate: the transcript for \(terminal.id, privacy: .public) is not parseable after its child exited — it may have been cut mid-write; parking anyway, because the process is gone")
         }
 
         do {
@@ -496,6 +592,13 @@ extension HibernationCoordinator {
     /// not signal — and treating that silence as an exit is precisely how a row
     /// finalizes parked over a live child.
     ///
+    /// **It answers "did our child exit", not "who holds this number now".**
+    /// The second question is `holderChildDisposition`'s, and the two agree
+    /// where they overlap: both read a `Z…` stat as gone, and neither lets a
+    /// stranger on a recycled pid complete a park — this one because the
+    /// stranger is alive, that one because it refuses to signal what it cannot
+    /// identify. The full table is on `HolderChildDisposition`.
+    ///
     /// So when the pid is unusable, only a POSITIVE `.exited` /
     /// `.exitedStatusUnknown` from the registry counts as gone; nil and
     /// `.alive` alike answer "not gone". The consequence is that a NULL-pid
@@ -521,6 +624,121 @@ extension HibernationCoordinator {
         // distinction matters here: the job has finished, and the `waitpid`
         // still owed to it belongs to the holder, not to this park.
         return signaller.stat(childPID)?.hasPrefix("Z") ?? false
+    }
+
+    /// What the escalation ladder may do to this row's recorded child pid.
+    ///
+    /// Asked before every signal, and asked again between rungs, because the
+    /// poll window between them is exactly long enough for a pid to be freed
+    /// and reissued. The verdict-to-disposition mapping and the reasoning for
+    /// each arm live on `HolderChildDisposition`.
+    ///
+    /// The anchor is the row's own `holderChildStartedAt`, falling back to
+    /// `createdAt` for a row written before that column existed — the same pair
+    /// the reaper's holder leg and the wake's adopt guard measure against, so a
+    /// pid that passes here passes there.
+    func holderChildDisposition(
+        childPID: Int32, terminal: Terminal
+    ) -> HolderChildDisposition {
+        guard childPID > 1 else { return .unrecorded }
+        // A corpse is gone, and it is asked about FIRST so this agrees with
+        // `childIsGone`, which reads the same fact. It also has to come first
+        // to be right: `ps` prints a zombie's command in parentheses, which the
+        // executable check below would read as a stranger's — so a child that
+        // exited a moment after the poll gave up would be refused as a foreign
+        // process rather than recognized as the exit it is. A zombie is past
+        // its last instruction and its number cannot be reissued while the
+        // entry stands, so this is a positive answer either way: if some
+        // stranger's corpse holds the number, our child left it long ago.
+        if signaller.stat(childPID)?.hasPrefix("Z") == true { return .gone }
+        let verdict = ProcessIdentityCheck.verify(
+            pid: childPID,
+            startedWithin: AgentReaper.defaultHolderIdentityWindow,
+            of: terminal.holderChildStartedAt ?? terminal.createdAt,
+            executableIsAcceptable: AgentReaper.isHolderChildExecutable,
+            signaller: signaller)
+        switch verdict {
+        case .same: return .ours
+        case .notRunning: return .gone
+        case .startTimeUnreadable, .startTimeMismatch, .commandUnreadable, .foreignExecutable:
+            return .unverifiable(verdict)
+        }
+    }
+
+    /// Abandon a park whose child pid this daemon cannot prove is its own.
+    ///
+    /// "Keep when uncertain", spelled out on the park path: nothing is
+    /// signalled — not the pid, not its group — because the process at that
+    /// number may be a stranger's work on a machine running dozens of agent
+    /// sessions, and a wrong kill there is unrecoverable while a refused park
+    /// is not.
+    ///
+    /// The holder is still told to let go, without a kill. That is not a
+    /// contradiction: the `forget` addresses the holder over its own socket and
+    /// signals nothing, and leaving the daemon reading a pty whose job it can
+    /// no longer identify would keep a reader alive over a session nobody can
+    /// describe. What is left behind is a row that is awake and still names its
+    /// pids — the state the reconcile arm and the reaper's holder leg are built
+    /// to judge, both of which apply the same identity check and will keep for
+    /// the same reason.
+    private func refuseUnverifiableHolderChild(
+        _ terminal: Terminal,
+        childPID: Int32,
+        verdict: ProcessIdentityVerdict,
+        registry: HolderRegistry
+    ) async -> HibernateResult {
+        await letHolderGoWithoutKilling(terminal, registry: registry)
+        do {
+            try await db.terminals.clearHibernated(id: terminal.id)
+        } catch {
+            logger.error("hibernate: could not verify the child of \(terminal.id, privacy: .public) and could not roll the park intent back either: \(error.localizedDescription, privacy: .public)")
+        }
+        idleSince[terminal.id] = nil
+        pendingKillSince[terminal.id] = nil
+        logger.warning("hibernate: refusing to signal child \(childPID, privacy: .public) for terminal \(terminal.id, privacy: .public) — its identity is \(String(describing: verdict), privacy: .public); the row is left awake with its pids intact")
+        return .notEligible(
+            reason: "the process holding child pid \(childPID) could not be verified as this "
+                + "session's own (\(verdict)), so nothing was signalled and this session is "
+                + "left awake")
+    }
+
+    /// Tell the holder to let go of the pty without killing anything.
+    ///
+    /// `childPID: 0` is the sentinel `dispose` refuses to signal, and that is
+    /// the point on both paths that reach here: after a confirmed exit the
+    /// recorded pid is free and the next process to take that number is
+    /// somebody else's, and after an unverifiable identity the number was never
+    /// ours to signal in the first place.
+    private func letHolderGoWithoutKilling(
+        _ terminal: Terminal, registry: HolderRegistry
+    ) async {
+        do {
+            let socketPath = try HolderRendezvous.socketPath(
+                sessionID: terminal.id, environment: registry.environment)
+            await registry.abandon(
+                terminalID: terminal.id,
+                handle: HolderHandle(
+                    holderPID: terminal.holderPID ?? 0,
+                    childPID: 0,
+                    socketPath: socketPath))
+        } catch {
+            // The processes are not the concern: nothing here was going to be
+            // signalled anyway. What does outlive this call is bookkeeping
+            // `abandon` would have cleared — this session's registry slot and
+            // its remembered status — and the collector for that is
+            // `reclaimIfSessionEnded`, which the reader's end-of-output
+            // notifier fires once the drain runs dry.
+            //
+            // Worth naming rather than glossing: that reclaimer derives the
+            // SAME rendezvous path, and the only thing that makes this throw is
+            // a path over `sun_path` — a persistent fact about this install's
+            // `TBD_HOME` and this session's id, not a transient. So the pairing
+            // is real but not a guarantee here; it is also the reason this
+            // branch is close to unreachable, since a session whose path cannot
+            // be represented could neither have been spawned nor adopted by
+            // this daemon.
+            logger.warning("hibernate: could not derive the rendezvous path for \(terminal.id, privacy: .public), so its holder was not told to let go: \(error.localizedDescription, privacy: .public)")
+        }
     }
 
     // MARK: - Startup reconciliation
@@ -787,10 +1005,21 @@ extension HibernationCoordinator {
     ///   `ProcessIdentityCheck` the reaper's holder leg consults before it
     ///   signals anything: alive, started within
     ///   `AgentReaper.defaultHolderIdentityWindow` of the row's recorded child
-    ///   start, and running an executable a holder's job could be. This is the
-    ///   half that survives a daemon restart, where no reader exists but the
-    ///   child does. A pid the kernel has recycled fails it exactly as it fails
-    ///   there.
+    ///   start, and running an executable a holder's job could be. A pid the
+    ///   kernel has recycled fails it exactly as it fails there.
+    ///
+    /// **What the second leg is actually for**, since the obvious answer is
+    /// wrong: it is not "a daemon restart, where no reader exists". `adoptAll`
+    /// filters on transport alone and adopts parked rows too, so after a
+    /// restart such a session normally *does* get a reader and the first leg
+    /// fires. The second leg is what is left when adoption itself failed — a
+    /// holder that would not answer the hand-over — and the recorded pid is
+    /// nonetheless certain. When identity is uncertain as well, this returns
+    /// nil, the wake proceeds to `registry.spawn`, and the holder's creation
+    /// lock refuses a second holder for a session that already has one: the row
+    /// then stays parked until that holder dies. Fail-safe, in that no second
+    /// agent is ever started, but the outcome is a session stuck parked, and it
+    /// is named here rather than left to be rediscovered.
     ///
     /// Every other verdict — `.notRunning`, an unreadable start time or command
     /// line, a mismatch, a foreign executable — returns nil and lets the spawn
@@ -804,6 +1033,11 @@ extension HibernationCoordinator {
         let evidence: String
         if await registry.reader(for: terminal.id) != nil {
             evidence = "this daemon is still reading its holder"
+            // Before the row stops being parked, and this is the ordering that
+            // matters: a row un-parked without pids on it is invisible to every
+            // reclaimer this transport has, all of which sweep by the numbers a
+            // row carries.
+            await restoreHolderPIDsFromRegistry(terminal, registry: registry)
         } else if let childPID = terminal.childPID, childPID > 1,
                   ProcessIdentityCheck.verify(
                     pid: childPID,
@@ -837,5 +1071,78 @@ extension HibernationCoordinator {
             tmuxWindowID: "", tmuxPaneID: "")
         logger.info("wake: adopted the holder already running for \(terminal.id, privacy: .public) instead of spawning a second one — \(evidence, privacy: .public); the row was parked over it")
         return .ok
+    }
+
+    /// Put the registry's own view of a session's processes back onto its row.
+    ///
+    /// The state this repairs is narrow and real: `HolderRegistry.spawn`
+    /// publishes its reader before `wakeHolderSection` persists the pids, and a
+    /// daemon that dies in that window — SIGKILL, OOM, a panic; not a thrown
+    /// error, which the spawn path already undoes itself — leaves a parked row
+    /// naming no processes behind a holder that is alive. `reconcileParkedHolderRow`
+    /// cannot repair it, because it has no pid to verify. `adoptAll` re-adopts
+    /// the holder regardless, so the next wake reaches the reader leg above and
+    /// would un-park the row with no pid on it — and from then on the reaper's
+    /// holder leg, the startup arm, and any later park's own escalation are all
+    /// blind to that session, permanently.
+    ///
+    /// The registry is the right source precisely because it is first-hand: the
+    /// child pid comes from the hand-over that produced the live reader, and
+    /// the holder pid from the socket that carried it. A registry that answers
+    /// nothing is logged and left alone rather than guessed at — this runs
+    /// under a live reader, so it should always answer, and inventing a pid
+    /// would be worse than recording none.
+    ///
+    /// The start time is the identity anchor every reclaimer measures that pid
+    /// against, so it is taken from the most trustworthy source available and
+    /// the log says which one: the row's own value when it still describes this
+    /// child, else the kernel's start time for the pid, else the current time —
+    /// which is a fallback rather than a fact, and is honest in the direction
+    /// that matters, since a wrong anchor makes the identity check refuse to
+    /// signal rather than signal wrongly.
+    private func restoreHolderPIDsFromRegistry(
+        _ terminal: Terminal, registry: HolderRegistry
+    ) async {
+        guard let observed = await registry.adoptedProcess(for: terminal.id) else {
+            logger.warning("wake: \(terminal.id, privacy: .public) is parked over a holder this daemon is reading, but the registry names no processes for it, so the row's pids cannot be repaired")
+            return
+        }
+        // A holder pid the kernel would not name is recorded as nil rather than
+        // faked. Nothing needs it: the child pid is the anchor every reclaimer
+        // sweeps by, `HolderRegistry.abandon(terminal:)` reaches the holder over
+        // its socket, and `AgentReaper.decideHolderChild` keeps — never kills —
+        // when the holder pid is missing.
+        let holderPID = observed.holderPID ?? terminal.holderPID
+        let startedAt: Date
+        let anchorSource: String
+        if let recorded = terminal.holderChildStartedAt, terminal.childPID == observed.childPID {
+            startedAt = recorded
+            anchorSource = "the row's own recorded start"
+        } else if let measured = signaller.startTime(observed.childPID) {
+            startedAt = measured
+            anchorSource = "the kernel's start time for the child"
+        } else {
+            startedAt = now()
+            anchorSource = "this moment, because the kernel would not say when the child started"
+        }
+        guard terminal.childPID != observed.childPID
+                || terminal.holderPID != holderPID
+                || terminal.holderChildStartedAt != startedAt else { return }
+        do {
+            try await db.terminals.setHolderProcess(
+                id: terminal.id, holderPID: holderPID, childPID: observed.childPID,
+                startedAt: startedAt)
+            // Hoisted rather than folded into the interpolation: `0` here is
+            // "the kernel would not name the holder", not a pid.
+            let loggedHolderPID = holderPID ?? 0
+            logger.info("wake: restored the holder pids on \(terminal.id, privacy: .public) from the registry — holder \(loggedHolderPID, privacy: .public), child \(observed.childPID, privacy: .public), anchored on \(anchorSource, privacy: .public)")
+        } catch {
+            // The un-park below still proceeds. A row that is awake and pid-less
+            // is the state this method exists to prevent, but refusing the wake
+            // over it would leave the session parked over a holder that is
+            // already running — which nothing else repairs either, and which the
+            // user cannot get out of.
+            logger.error("wake: could not restore the holder pids on \(terminal.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
+        }
     }
 }

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator+Holder.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator+Holder.swift
@@ -53,6 +53,25 @@ extension HibernationCoordinator {
         "The daemon is not reading this session's terminal, so it cannot check "
         + "for unsent input before hibernating"
 
+    /// Whether the screen the park's pending-input rail would have to judge is
+    /// one this daemon cannot read — a viewer owns the pty, or no reader was
+    /// ever adopted for the session.
+    ///
+    /// The same question `performHolderHibernate` asks before its two
+    /// fail-closed refusals, lifted out so the sweep can ask it *first*.
+    /// `HibernationGate` is pure — it decides from the row, the config and the
+    /// clock, and has no way to see who holds a pty — so the sweep is the only
+    /// place with the registry in hand.
+    ///
+    /// A daemon with no registry at all answers false: that is the tmux-only
+    /// configuration, where a holder row is a leftover and the park's own
+    /// no-registry refusal is the right place to say so once.
+    func holderScreenIsUnreadable(terminalID: UUID) async -> Bool {
+        guard let registry = holderRegistry else { return false }
+        if await registry.viewerAttachment(for: terminalID) != nil { return true }
+        return await registry.reader(for: terminalID) == nil
+    }
+
     // MARK: - Park
 
     /// Park a holder-backed session: end the job its holder forked, then record
@@ -96,10 +115,20 @@ extension HibernationCoordinator {
             return refusal
         }
 
+        // The three refusals below clear `idleSince` and `pendingKillSince`
+        // like every other refusal in this method. Each one names a condition
+        // that will still hold on the next sweep — no registry on this daemon,
+        // a viewer that owns the pty until its tab closes, a session this
+        // daemon never adopted — so leaving the markers armed would re-fire the
+        // identical refusal every pass. Clearing them makes the row start its
+        // idle clock again from the moment the condition clears.
+
         // No registry means no reader, no way to write `/exit`, and no way to
         // abandon the holder afterwards. Say so by name rather than parking a
         // row whose process nothing in this daemon can end.
         guard let registry = holderRegistry else {
+            idleSince[terminal.id] = nil
+            pendingKillSince[terminal.id] = nil
             return .notEligible(reason: "this daemon has no holder registry")
         }
 
@@ -109,10 +138,14 @@ extension HibernationCoordinator {
         // not the screen the session is showing. Each half answers with its own
         // name: they differ in what the person reading the refusal can do next.
         if await registry.viewerAttachment(for: terminal.id) != nil {
+            idleSince[terminal.id] = nil
+            pendingKillSince[terminal.id] = nil
             logger.debug("hibernate: refusing \(terminal.id, privacy: .public) — a viewer holds this session's pty")
             return .notEligible(reason: Self.holderViewerAttachedRefusal)
         }
         guard let reader = await registry.reader(for: terminal.id) else {
+            idleSince[terminal.id] = nil
+            pendingKillSince[terminal.id] = nil
             logger.debug("hibernate: refusing \(terminal.id, privacy: .public) — the daemon holds no reader for this session")
             return .notEligible(reason: Self.holderNoReaderRefusal)
         }
@@ -309,25 +342,37 @@ extension HibernationCoordinator {
             childPID: childPID, terminalID: terminalID, registry: registry)
     }
 
+    /// Whether the holder's job can be treated as gone.
+    ///
+    /// Two positive facts count as gone, and one silence deliberately does not.
+    ///
+    /// **A verdict must never rest on evidence the escalation itself erased.**
+    /// `abandon(terminal:)` sets this session's remembered status back to nil,
+    /// so the poll that runs *after* the escalation reads no status at all. On
+    /// a row whose `child_pid` column is NULL there is then nothing else to
+    /// read — the process table has no answer to give for a pid this daemon may
+    /// not signal — and treating that silence as an exit is precisely how a row
+    /// finalizes parked over a live child.
+    ///
+    /// So when the pid is unusable, only a POSITIVE `.exited` /
+    /// `.exitedStatusUnknown` from the registry counts as gone; nil and
+    /// `.alive` alike answer "not gone". The consequence is that a NULL-pid
+    /// park rolls back after its escalation rather than completing, which is
+    /// the safe direction: the row is left awake, where the reconcile arm and
+    /// the reaper's holder leg can judge it. Every path that recorded a real
+    /// child pid is unchanged, because the process table answers there.
     private func childIsGone(
         childPID: Int32, terminalID: UUID, registry: HolderRegistry
     ) async -> Bool {
-        let status = await registry.lastKnownStatus(for: terminalID)
-        switch status {
+        switch await registry.lastKnownStatus(for: terminalID) {
         case .exited, .exitedStatusUnknown: return true
         case .alive, nil: break
         }
-        let statusAlive = (status == .alive)
-        // A pid of 0 or below names nothing this daemon may signal or wait on,
-        // so the process table has no answer to give and the registry's is the
-        // only evidence there is. An explicit `.alive` is a positive report
-        // from the holder that its job is still running, and it must not be
-        // thrown away because the row's `child_pid` column happened to be
-        // NULL — that reading would let a park finalize over a live child,
-        // which is the one thing this whole path exists to prevent. With no
-        // report either way, a row that never recorded a child pid has nothing
-        // to outlive.
-        guard childPID > 1 else { return !statusAlive }
+        // Reaching here means the registry reported the job alive, or has
+        // nothing to report because the escalation cleared what it knew.
+        // Neither is evidence of an exit, and with no pid to check there is no
+        // second source to ask.
+        guard childPID > 1 else { return false }
         guard signaller.isAlive(childPID) else { return true }
         // `ps -o stat=` reports a corpse as `Z...`. It answers `kill(pid, 0)`,
         // so liveness alone cannot tell it from a running process — and the

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator+Holder.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator+Holder.swift
@@ -1,0 +1,493 @@
+import Foundation
+import TBDShared
+import os
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "Hibernation")
+
+/// Park and wake for the pty-holder transport.
+///
+/// Split from `HibernationCoordinator` so the diff to that file is a set of
+/// branch points rather than a second mechanic interleaved with the first. The
+/// two transports share every decision about WHETHER to act — the singleflight
+/// claim, the refusal cascade, the transcript rail, the resume argv — and share
+/// nothing about HOW: tmux parks by `respawn-window`ing a pane it owns, while a
+/// holder session is parked by ending the job the holder forked and clearing
+/// the pids that named it.
+///
+/// **The invariant the whole feature is judged on: a row never finalizes parked
+/// while its child is still running.** Every failure below rolls the park
+/// intent back rather than completing it, because a row that claims parked over
+/// a live process is unreclaimable — nothing sweeps it, the app offers a wake
+/// that would spawn a second agent onto the same session, and the process is
+/// invisible to every reconciler that reads rows.
+extension HibernationCoordinator {
+
+    /// How many times the escalation poll re-checks the child after
+    /// `abandon` has signalled it. Five at the production `exitPollInterval` of
+    /// 200 ms is one second — the budget a `SIGKILL`ed process needs to leave
+    /// the process table, not a budget for it to shut down politely, which is
+    /// what the poll before it was for. It rides `exitPollInterval` rather than
+    /// carrying its own so a test that shrinks the polite poll shrinks this too.
+    static var holderEscalationAttempts: Int { 5 }
+
+    /// The refusal for a holder session the daemon cannot read the screen of.
+    ///
+    /// Fail-closed, per the transport design's two-store rule: while a viewer
+    /// owns the pty the daemon's emulator is frozen at the moment of that
+    /// attach, so the pending-input rail would be asking a stale screen whether
+    /// there is unsent typed input — and answering that question wrongly is
+    /// exactly the harm the rail exists to prevent. Refusing is recoverable;
+    /// eating a half-composed prompt is not.
+    static let holderViewerAttachedRefusal =
+        "A viewer is attached to this session, so the daemon cannot read its "
+        + "screen to check for unsent input; close the tab or wait for it to "
+        + "leave the viewer before hibernating"
+
+    // MARK: - Park
+
+    /// Park a holder-backed session: end the job its holder forked, then record
+    /// the row as parked with no pids on it.
+    ///
+    /// Entered from `performHibernate` with `hibernatesInFlight` already
+    /// claimed, and with NO tmux server lock — a holder session has no server,
+    /// so there is nothing for a server lock to exclude. `hibernatesInFlight`
+    /// is the whole exclusion here, and it is enough: every mutation below
+    /// addresses one terminal row and one holder.
+    func performHolderHibernate(
+        terminal: Terminal,
+        worktree: LocalWorktree,
+        reason: HibernateReason,
+        policy: HibernateEligibilityPolicy
+    ) async -> HibernateResult {
+        // Re-read and re-check, in the same order and with the same refusal
+        // strings the tmux path uses under its server lock. This method is
+        // actor-reentrant across the polite-exit poll below, so the row it
+        // decided on must be the row it acts on.
+        guard let currentTerminal = try? await db.terminals.get(id: terminal.id) else {
+            return .notFound
+        }
+        guard TerminalReplacementSnapshot(terminal: terminal).matches(currentTerminal) else {
+            idleSince[terminal.id] = nil
+            pendingKillSince[terminal.id] = nil
+            return .notEligible(reason: "Terminal process changed before hibernation")
+        }
+        if case .automatic = policy,
+           !TerminalHibernationSnapshot(terminal: terminal).matchesActivity(currentTerminal) {
+            idleSince[terminal.id] = nil
+            pendingKillSince[terminal.id] = nil
+            return .notEligible(reason: "Session activity changed before hibernation")
+        }
+        guard let sessionID = currentTerminal.claudeSessionID else {
+            return .notEligible(reason: "No session id to resume later")
+        }
+        if let refusal = hibernationRefusal(terminal: currentTerminal, policy: policy) {
+            idleSince[terminal.id] = nil
+            pendingKillSince[terminal.id] = nil
+            return refusal
+        }
+
+        // No registry means no reader, no way to write `/exit`, and no way to
+        // abandon the holder afterwards. Say so by name rather than parking a
+        // row whose process nothing in this daemon can end.
+        guard let registry = holderRegistry else {
+            return .notEligible(reason: "this daemon has no holder registry")
+        }
+
+        // Rail: typed-but-unsent input, read off the daemon's own emulator.
+        // Fail-closed on both halves — a viewer holding the pty, or no reader
+        // at all — because either one means the screen this rail would judge is
+        // not the screen the session is showing.
+        guard await registry.viewerAttachment(for: terminal.id) == nil,
+              let reader = await registry.reader(for: terminal.id) else {
+            logger.debug("hibernate: refusing \(terminal.id, privacy: .public) — the daemon is not this session's reader")
+            return .notEligible(reason: Self.holderViewerAttachedRefusal)
+        }
+        let screen = await reader.renderScreen()
+        if HibernationSafetyChecks.hasPendingInput(paneCapture: screen) {
+            logger.debug("hibernate: skipping \(terminal.id, privacy: .public) — pending typed input in prompt")
+            return .notEligible(reason: "Terminal has unsent typed input")
+        }
+        let capturedSnapshot: String? = screen.isEmpty ? nil : screen
+
+        // Rail: transcript-tail validity, identical to the tmux path. Killing
+        // mid-write can leave an unresumable jsonl.
+        if let transcriptPath = currentTerminal.transcriptPath,
+           let body = try? String(contentsOfFile: transcriptPath, encoding: .utf8),
+           !HibernationSafetyChecks.isTranscriptTailValid(jsonlBody: body) {
+            logger.warning("hibernate: skipping \(terminal.id, privacy: .public) — transcript tail not parseable, would be unresumable")
+            return .notEligible(reason: "Transcript is mid-write; try again shortly")
+        }
+
+        // Park INTENT, before anything touches the process. A crash between
+        // here and the finalize below leaves a parked row that still names its
+        // pids, which `reconcileOnStartup` un-parks on the next start after
+        // proving the child is alive.
+        let expectedState = TerminalHibernationSnapshot(terminal: currentTerminal)
+        let inertIncarnation: TerminalSessionIncarnation
+        do {
+            guard let prepared = try await db.terminals.beginHibernatedShellRespawn(
+                id: terminal.id,
+                expectedState: expectedState,
+                snapshot: capturedSnapshot,
+                reason: reason,
+                at: now()) else {
+                idleSince[terminal.id] = nil
+                pendingKillSince[terminal.id] = nil
+                return .notEligible(reason: "Terminal process changed before hibernation")
+            }
+            inertIncarnation = prepared
+        } catch {
+            logger.warning("hibernate: failed to prepare parked state for \(terminal.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            idleSince[terminal.id] = nil
+            pendingKillSince[terminal.id] = nil
+            return .notEligible(reason: "Failed to persist hibernation")
+        }
+
+        let childPID = currentTerminal.childPID ?? 0
+        // Polite park: `/exit` in band, so Claude flushes its transcript, shuts
+        // down MCP children and fires Stop hooks. Written to the pty the daemon
+        // is already reading — the same descriptor `terminal.send` uses — rather
+        // than through tmux `send-keys`, which addresses a pane this row has
+        // not got.
+        try? await reader.write(Data("/exit\r".utf8))
+        var gone = await pollUntilChildIsGone(
+            childPID: childPID, terminalID: terminal.id, registry: registry,
+            attempts: exitPollAttempts)
+
+        if !gone {
+            // The polite exit did not take. `abandon` is the escalation: the
+            // holder is told to let go (closing the pty master), the job is
+            // killed by process group, and the holder's corpse is collected.
+            logger.debug("hibernate: /exit did not end the job for \(terminal.id, privacy: .public) within the poll window — abandoning the holder")
+            if let unfinished = await registry.abandon(terminal: currentTerminal) {
+                logger.warning("hibernate: holder teardown for \(terminal.id, privacy: .public) was incomplete: \(unfinished, privacy: .public)")
+            }
+            gone = await pollUntilChildIsGone(
+                childPID: childPID, terminalID: terminal.id, registry: registry,
+                attempts: Self.holderEscalationAttempts)
+        } else {
+            // Gone politely, so the holder was never told to let go — and a
+            // holder whose child has exited winds itself down, which is a race
+            // this call does not need to win. `childPID: 0` is the sentinel
+            // `dispose` refuses to signal, and that is the point: the recorded
+            // pid is now free and the next process to take that number is
+            // somebody else's.
+            do {
+                let socketPath = try HolderRendezvous.socketPath(
+                    sessionID: terminal.id, environment: registry.environment)
+                await registry.abandon(
+                    terminalID: terminal.id,
+                    handle: HolderHandle(
+                        holderPID: currentTerminal.holderPID ?? 0,
+                        childPID: 0,
+                        socketPath: socketPath))
+            } catch {
+                // Nothing is leaked by skipping it: the job is confirmed gone
+                // and its holder exits when its child does.
+                logger.warning("hibernate: could not derive the rendezvous path for \(terminal.id, privacy: .public), so its holder was not told to let go: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+
+        guard gone else {
+            // THE invariant. The row must not claim parked over a process that
+            // is still running: nothing would ever reclaim it, and a wake would
+            // spawn a second agent onto the same session. Roll the intent back
+            // — `clearHibernated` nils both park columns and the pending
+            // incarnation — and report the pid so an operator can act.
+            do {
+                try await db.terminals.clearHibernated(id: terminal.id)
+            } catch {
+                logger.error("hibernate: the job for \(terminal.id, privacy: .public) survived and the park intent could not be rolled back: \(error.localizedDescription, privacy: .public)")
+            }
+            idleSince[terminal.id] = nil
+            pendingKillSince[terminal.id] = nil
+            logger.error("hibernate: holder child \(childPID, privacy: .public) for terminal \(terminal.id, privacy: .public) did not exit; the row was left awake")
+            return .notEligible(
+                reason: "holder child \(childPID) did not exit; the session was left running")
+        }
+
+        do {
+            guard try await db.terminals.finalizeHibernatedShellRespawn(
+                id: terminal.id,
+                expectedIncarnation: inertIncarnation,
+                at: now()) != nil else {
+                idleSince[terminal.id] = nil
+                pendingKillSince[terminal.id] = nil
+                return .notEligible(reason: "Terminal process changed during hibernation")
+            }
+        } catch {
+            logger.warning("hibernate: failed to fence replaced agent for \(terminal.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            idleSince[terminal.id] = nil
+            pendingKillSince[terminal.id] = nil
+            return .notEligible(reason: "Failed to finalize hibernation")
+        }
+
+        // A parked holder row names no processes. Leaving the pids on it would
+        // point `AgentReaper`'s holder leg and every identity check at numbers
+        // the kernel has already handed to somebody else.
+        do {
+            try await db.terminals.setHolderProcess(
+                id: terminal.id, holderPID: nil, childPID: nil, startedAt: nil)
+        } catch {
+            logger.warning("hibernate: parked \(terminal.id, privacy: .public) but failed to clear its holder pids: \(error.localizedDescription, privacy: .public)")
+        }
+        inputActivity.forget(paneID: InputActivityTracker.key(for: currentTerminal))
+
+        guard let persisted = try? await db.terminals.get(id: terminal.id),
+              persisted.isParked else {
+            logger.warning("hibernate: prepared row disappeared or changed during the holder park for \(terminal.id, privacy: .public)")
+            idleSince[terminal.id] = nil
+            pendingKillSince[terminal.id] = nil
+            return .notEligible(reason: "Failed to verify hibernation")
+        }
+        idleSince[terminal.id] = nil
+        pendingKillSince[terminal.id] = nil
+        broadcastHibernation(
+            terminal: currentTerminal, hibernated: true, keepWarm: currentTerminal.keepWarm,
+            suspendedSnapshot: capturedSnapshot, hibernateReason: reason)
+        logger.info("hibernated holder-backed terminal \(terminal.id, privacy: .public) in worktree \(worktree.id, privacy: .public) (session \(sessionID, privacy: .public))")
+        return .ok
+    }
+
+    /// Poll `attempts` times, sleeping `exitPollInterval` on the injected clock
+    /// between checks, for the holder's job to be gone.
+    ///
+    /// Two independent facts count as gone, because they answer from opposite
+    /// ends. The process table says the pid names nothing, or names a corpse
+    /// nobody has collected — a zombie is past its last instruction, and only
+    /// its parent's `waitpid` is outstanding. And the holder itself may have
+    /// already reported the exit, which is the one answer that survives a pid
+    /// the kernel has already recycled.
+    private func pollUntilChildIsGone(
+        childPID: Int32, terminalID: UUID, registry: HolderRegistry, attempts: Int
+    ) async -> Bool {
+        for _ in 0..<max(0, attempts) {
+            try? await clock.sleep(for: exitPollInterval)
+            if await childIsGone(childPID: childPID, terminalID: terminalID, registry: registry) {
+                return true
+            }
+        }
+        return await childIsGone(
+            childPID: childPID, terminalID: terminalID, registry: registry)
+    }
+
+    private func childIsGone(
+        childPID: Int32, terminalID: UUID, registry: HolderRegistry
+    ) async -> Bool {
+        if let status = await registry.lastKnownStatus(for: terminalID) {
+            switch status {
+            case .exited, .exitedStatusUnknown: return true
+            case .alive: break
+            }
+        }
+        // A pid of 0 or below names nothing this daemon may signal or wait on,
+        // and a row that never recorded a child pid has nothing to outlive.
+        guard childPID > 1 else { return true }
+        guard signaller.isAlive(childPID) else { return true }
+        // `ps -o stat=` reports a corpse as `Z...`. It answers `kill(pid, 0)`,
+        // so liveness alone cannot tell it from a running process — and the
+        // distinction matters here: the job has finished, and the `waitpid`
+        // still owed to it belongs to the holder, not to this park.
+        return signaller.stat(childPID)?.hasPrefix("Z") ?? false
+    }
+
+    // MARK: - Startup reconciliation
+
+    /// Reconcile one PARKED holder row against the process table.
+    ///
+    /// **It must not consult the registry, and that is a startup-ordering
+    /// fact rather than a preference**: `reconcileOnStartup` runs before
+    /// `HolderRegistry.adoptAll`, so at this moment the registry holds no
+    /// readers and knows no statuses — asking it would answer "gone" for every
+    /// session on the machine and un-park nothing while looking authoritative.
+    /// The recorded child pid is the only ground truth available this early,
+    /// read through the same `ProcessIdentityCheck` the reaper's holder leg
+    /// consults.
+    ///
+    /// Two verdicts move the row and every other one leaves it alone:
+    ///
+    /// - `.same` — the daemon died mid-park, after the intent was written and
+    ///   before the child was confirmed gone. The child is alive and is this
+    ///   row's; un-park it, and adoption will pick the session up moments later.
+    ///   The tmux recovery in the same method has exactly this shape.
+    /// - `.notRunning` — the child is gone but the row still names it. Clear the
+    ///   pids so nothing later signals a number the kernel has recycled.
+    ///
+    /// Everything else — an unreadable start time, a mismatch, a foreign
+    /// executable — is an uncertain identity, and an uncertain identity is not
+    /// evidence in either direction.
+    func reconcileParkedHolderRow(_ terminal: Terminal) async {
+        guard let childPID = terminal.childPID, childPID > 1 else { return }
+        let verdict = ProcessIdentityCheck.verify(
+            pid: childPID,
+            startedWithin: AgentReaper.defaultHolderIdentityWindow,
+            of: terminal.holderChildStartedAt ?? terminal.createdAt,
+            executableIsAcceptable: AgentReaper.isHolderChildExecutable,
+            signaller: signaller)
+        switch verdict {
+        case .same:
+            do {
+                try await db.terminals.clearHibernated(id: terminal.id)
+                logger.info("startup: holder-backed terminal \(terminal.id, privacy: .public) was parked while its child \(childPID, privacy: .public) was still running — un-parking; adoption will pick it up")
+            } catch {
+                logger.warning("startup: failed to un-park holder-backed terminal \(terminal.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            }
+        case .notRunning:
+            do {
+                try await db.terminals.setHolderProcess(
+                    id: terminal.id, holderPID: nil, childPID: nil, startedAt: nil)
+                logger.info("startup: cleared the stale holder pids on parked terminal \(terminal.id, privacy: .public) — its recorded child \(childPID, privacy: .public) is gone")
+            } catch {
+                logger.warning("startup: failed to clear the stale holder pids on \(terminal.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            }
+        case .startTimeUnreadable, .startTimeMismatch, .commandUnreadable, .foreignExecutable:
+            logger.debug("startup: leaving parked holder-backed terminal \(terminal.id, privacy: .public) alone — child identity is uncertain (\(String(describing: verdict), privacy: .public))")
+        }
+    }
+
+    // MARK: - Wake
+
+    /// What a wake aimed at an UNPARKED holder row should answer.
+    ///
+    /// The tmux answer to this question probes a pane; a holder row has none.
+    /// The equivalent evidence is the recorded child pid, read through the same
+    /// `ProcessIdentityCheck` the reaper's holder leg consults before it
+    /// signals anything — so a pid the kernel has recycled is recognized here
+    /// the same way it is there.
+    ///
+    /// Only `.notRunning` downgrades the answer. Every other verdict is an
+    /// uncertain identity, and an uncertain identity is not evidence that a
+    /// session died — the same asymmetry the tmux classification applies to a
+    /// probe that merely threw. Like it, this reports and does not repair.
+    func classifyUnparkedHolderWake(_ terminal: Terminal) async -> WakeResult {
+        guard let childPID = terminal.childPID, childPID > 1 else { return .notHibernated }
+        let verdict = ProcessIdentityCheck.verify(
+            pid: childPID,
+            startedWithin: AgentReaper.defaultHolderIdentityWindow,
+            of: terminal.holderChildStartedAt ?? terminal.createdAt,
+            executableIsAcceptable: AgentReaper.isHolderChildExecutable,
+            signaller: signaller)
+        guard verdict == .notRunning else { return .notHibernated }
+        logger.warning("""
+            wake: terminal \(terminal.id, privacy: .public) is unparked but the job its \
+            holder forked (pid \(childPID, privacy: .public)) is gone — reporting sessionGone \
+            instead of "already awake"
+            """)
+        // No pane id to name, and the empty string is what the row carries.
+        // `RPCRouter.unparkedWakeMessage` phrases an empty one as "its
+        // holder-backed session" rather than as a pane that does not exist.
+        return .sessionGone(paneID: "", detail: .processExited)
+    }
+
+    /// The mutate half of a holder wake: spawn a fresh holder running the
+    /// resume command, record what it started, then un-park the row.
+    ///
+    /// The ordering is the same one `WorktreeLifecycle+Create` uses and for the
+    /// same reason: the pids are persisted BEFORE the row stops being parked,
+    /// so a failure in between leaves a parked row that names live processes —
+    /// which `reconcileOnStartup` un-parks — rather than an awake row that
+    /// names nothing, which nothing would ever reconcile.
+    func wakeHolderSection(
+        terminal: Terminal,
+        worktree: LocalWorktree,
+        sessionID: String,
+        expectedReplacementState: TerminalReplacementSnapshot,
+        spawnCommand: String,
+        env: [String: String],
+        sensitiveEnv: [String: String],
+        cols: Int?,
+        rows: Int?
+    ) async -> WakeResult {
+        guard let registry = holderRegistry else {
+            return .respawnFailed(
+                reason: "this daemon has no holder registry, so the session cannot be resumed on the pty-holder transport")
+        }
+        // "Registry present" is not "can spawn": a daemon whose `TBDHolder`
+        // binary has moved still builds a registry, because adoption of a
+        // running holder needs no executable. Only this fact may gate a spawn.
+        guard registry.canSpawn else {
+            return .respawnFailed(
+                reason: "the TBDHolder helper is missing beside the daemon, so no holder can be started for this session; the row stays parked")
+        }
+
+        guard let currentTerminal = try? await db.terminals.get(id: terminal.id),
+              expectedReplacementState.matches(currentTerminal) else {
+            return .respawnFailed(reason: "terminal changed while wake was preparing; retry")
+        }
+
+        let incarnationID: UUID
+        do {
+            guard let prepared = try await db.terminals.prepareHibernatedAgentRespawn(
+                id: terminal.id,
+                expectedState: expectedReplacementState,
+                at: now()) else {
+                return .respawnFailed(reason: "terminal changed before wake could launch; retry")
+            }
+            incarnationID = prepared
+        } catch {
+            logger.warning("wake: failed to prepare the replacement agent for \(terminal.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            return .respawnFailed(
+                reason: "preparing the replacement agent failed: \(error.localizedDescription)")
+        }
+        let replacementEnv = AgentProcessEnvironment.replacement(
+            base: env, incarnationID: incarnationID)
+
+        let handle: HolderHandle
+        do {
+            handle = try await registry.spawn(
+                terminalID: terminal.id,
+                launch: WorktreeLifecycle.holderLaunch(
+                    shellCommand: spawnCommand,
+                    env: replacementEnv,
+                    sensitiveEnv: sensitiveEnv,
+                    workingDirectory: worktree.path,
+                    cols: cols ?? TmuxManager.defaultCols,
+                    rows: rows ?? TmuxManager.defaultRows,
+                    environment: registry.environment))
+        } catch {
+            // The row stays parked, so the next focus or menu retry can wake it.
+            logger.warning("wake: could not start a holder for \(terminal.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            return .respawnFailed(
+                reason: "starting a holder for this session failed: \(error.localizedDescription)")
+        }
+
+        do {
+            try await db.terminals.setHolderProcess(
+                id: terminal.id,
+                holderPID: handle.holderPID,
+                childPID: handle.childPID,
+                startedAt: now())
+        } catch {
+            // A holder and a job no row names would be reclaimable by nothing,
+            // so undo the spawn from the failing call itself.
+            await registry.abandon(terminalID: terminal.id, handle: handle)
+            logger.warning("wake: started a holder for \(terminal.id, privacy: .public) but could not record its pids, so it was abandoned: \(error.localizedDescription, privacy: .public)")
+            return .respawnFailed(
+                reason: "the replacement agent started, but recording its process ids failed: \(error.localizedDescription)")
+        }
+
+        do {
+            try await db.terminals.clearHibernated(id: terminal.id)
+        } catch {
+            // Keep the live replacement parked. The row names live pids, and
+            // startup reconciliation clears the marker off a parked row whose
+            // child is identity-verified alive.
+            logger.error("wake: launched the replacement agent for \(terminal.id, privacy: .public), but failed to clear its parked marker: \(error.localizedDescription, privacy: .public)")
+            return .respawnFailed(
+                reason: "replacement agent launched, but clearing the parked marker failed: \(error.localizedDescription)")
+        }
+
+        idleSince[terminal.id] = nil
+        // Empty tmux coordinates, because that is what a holder row carries and
+        // what the app's cached row must keep: a non-empty pair here would send
+        // the terminal view looking for a window that does not exist.
+        broadcastHibernation(
+            terminal: currentTerminal, hibernated: false, keepWarm: currentTerminal.keepWarm,
+            tmuxWindowID: "", tmuxPaneID: "")
+        // No `SessionRecaptureScheduler`: it re-reads the session id off a tmux
+        // pane's screen, and this row has no pane. A holder session's resumed
+        // id is recaptured the way every other fact about it is — from hooks.
+        logger.info("woke holder-backed terminal \(terminal.id, privacy: .public) (resume \(sessionID, privacy: .public), holder \(handle.holderPID, privacy: .public), child \(handle.childPID, privacy: .public))")
+        return .ok
+    }
+}

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator+Holder.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator+Holder.swift
@@ -22,14 +22,6 @@ private let logger = Logger(subsystem: "com.tbd.daemon", category: "Hibernation"
 /// invisible to every reconciler that reads rows.
 extension HibernationCoordinator {
 
-    /// How many times the escalation poll re-checks the child after
-    /// `abandon` has signalled it. Five at the production `exitPollInterval` of
-    /// 200 ms is one second — the budget a `SIGKILL`ed process needs to leave
-    /// the process table, not a budget for it to shut down politely, which is
-    /// what the poll before it was for. It rides `exitPollInterval` rather than
-    /// carrying its own so a test that shrinks the polite poll shrinks this too.
-    static var holderEscalationAttempts: Int { 5 }
-
     /// The refusal for a holder session the daemon cannot read the screen of.
     ///
     /// Fail-closed, per the transport design's two-store rule: while a viewer
@@ -164,7 +156,7 @@ extension HibernationCoordinator {
             }
             gone = await pollUntilChildIsGone(
                 childPID: childPID, terminalID: terminal.id, registry: registry,
-                attempts: Self.holderEscalationAttempts)
+                attempts: holderEscalationAttempts)
         } else {
             // Gone politely, so the holder was never told to let go — and a
             // holder whose child has exited winds itself down, which is a race

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
@@ -11,12 +11,18 @@ public enum HibernateResult: Equatable, Sendable {
     case notFound
 }
 
+/// Which rails a park attempt is judged by, and the config facts those rails
+/// need. Every case carries `holderHibernationEnabled` because the park
+/// mechanic for the pty-holder transport is behind a soak gate whatever
+/// triggered it — the property the soak validates (a row never claims parked
+/// while its child runs) does not depend on who asked.
 private enum HibernateEligibilityPolicy: Sendable {
-    case manual
-    case merge(inputVetoEnabled: Bool)
+    case manual(holderHibernationEnabled: Bool)
+    case merge(inputVetoEnabled: Bool, holderHibernationEnabled: Bool)
     case automatic(
         enabled: Bool,
         inputVetoEnabled: Bool,
+        holderHibernationEnabled: Bool,
         idleTimeout: TimeInterval,
         idleSince: Date?)
 }
@@ -66,10 +72,11 @@ public enum WakeResult: Equatable, Sendable {
     /// default-profile fallback; the row stays parked and resumable. Carries
     /// the missing profile id for the message.
     case profileMissing(profileID: UUID)
-    /// The row runs on the pty-holder transport. Every branch below this point
-    /// — the unparked pane classification as much as the respawn — addresses a
-    /// tmux pane the row does not have, so wake refuses before reaching any of
-    /// them and leaves the row exactly as it found it.
+    /// The row runs on the pty-holder transport and
+    /// `holder_hibernation_enabled` is off. The transport has a wake mechanic —
+    /// spawn a fresh holder running `claude --resume` — and this soak gate says
+    /// it may not run here yet, so wake refuses before touching anything and
+    /// leaves the row exactly as it found it.
     case holderTransport
 }
 
@@ -263,18 +270,37 @@ public actor HibernationCoordinator {
             return .notFound
         }
         guard terminal.hibernatedAt == nil else { return .alreadyHibernated }
-        guard terminal.isManuallyHibernatable else {
-            return .notEligible(reason: manualBlockReason(terminal))
+        // One read, carried into the policy so the rail re-checked under the
+        // lock cannot disagree with the one checked here. A config read that
+        // fails takes the shipped default, which refuses a holder row.
+        let holderHibernationEnabled = await resolvedHolderHibernationEnabled()
+        guard terminal.isManuallyHibernatable(
+            holderHibernationEnabled: holderHibernationEnabled) else {
+            return .notEligible(reason: manualBlockReason(
+                terminal, holderHibernationEnabled: holderHibernationEnabled))
         }
         return await performHibernate(
             terminal: terminal,
             reason: .manual,
-            policy: .manual)
+            policy: .manual(holderHibernationEnabled: holderHibernationEnabled))
+    }
+
+    /// `config.holderHibernationEnabled`, resolved through the shipped default
+    /// when the config row cannot be read. Failing toward the default is
+    /// failing toward refusal, which is the safe direction for a mechanic that
+    /// kills a live process.
+    private func resolvedHolderHibernationEnabled() async -> Bool {
+        (try? await db.config.get())?.holderHibernationEnabled
+            ?? Config.holderHibernationEnabledDefault
     }
 
     /// The reason a manual hibernate was refused, for the RPC error string.
-    private func manualBlockReason(_ terminal: Terminal) -> String {
-        if terminal.transport == .holder { return Self.holderTransportRefusal }
+    private func manualBlockReason(
+        _ terminal: Terminal, holderHibernationEnabled: Bool
+    ) -> String {
+        if terminal.transport == .holder, !holderHibernationEnabled {
+            return Self.holderTransportRefusal
+        }
         if !terminal.isClaudeResumable { return "Not a resumable Claude session" }
         if terminal.suspendedAt != nil { return "Terminal is suspended" }
         switch terminal.activityState {
@@ -301,7 +327,9 @@ public actor HibernationCoordinator {
     /// rails above, so — like the idle sweep — the row goes after the gate, at
     /// the moment this rail is actually about to act on a session.
     public func hibernateForMerge(
-        terminalID: UUID, inputVetoEnabled: Bool
+        terminalID: UUID,
+        inputVetoEnabled: Bool,
+        holderHibernationEnabled: Bool = Config.holderHibernationEnabledDefault
     ) async -> HibernateResult {
         guard let terminal = try? await db.terminals.get(id: terminalID) else {
             return .notFound
@@ -310,7 +338,9 @@ public actor HibernationCoordinator {
         let decision = HibernationGate.decideForMerge(
             terminal: terminal,
             inputVetoEnabled: inputVetoEnabled,
-            lastInputAt: inputActivity.lastInput(paneID: terminal.tmuxPaneID))
+            holderHibernationEnabled: holderHibernationEnabled,
+            lastInputAt: inputActivity.lastInput(
+                paneID: InputActivityTracker.key(for: terminal)))
         guard decision == .eligible else {
             return .notEligible(reason: Self.mergeBlockReason(decision))
         }
@@ -332,7 +362,9 @@ public actor HibernationCoordinator {
         let result = await performHibernate(
             terminal: terminal,
             reason: .merged,
-            policy: .merge(inputVetoEnabled: inputVetoEnabled))
+            policy: .merge(
+                inputVetoEnabled: inputVetoEnabled,
+                holderHibernationEnabled: holderHibernationEnabled))
         await actuationLog.appendOutcome(
             confirms: actuationID,
             result: ActuationOutcome.classify(result),
@@ -348,8 +380,9 @@ public actor HibernationCoordinator {
     /// The one refusal text every park/wake path uses for a holder-backed row,
     /// so the CLI, the app and the actuation record all name the same reason.
     static let holderTransportRefusal =
-        "Session runs on the pty-holder transport, which has no tmux window to "
-        + "park or wake. Parking is not supported for it yet."
+        "Session runs on the pty-holder transport and holder hibernation is off "
+        + "(Settings → Hibernate pty-holder sessions, or `tbd config "
+        + "holder-hibernation on`)"
 
     private static func mergeBlockReason(_ decision: HibernationGate.Decision) -> String {
         switch decision {
@@ -645,31 +678,38 @@ public actor HibernationCoordinator {
         policy: HibernateEligibilityPolicy
     ) -> HibernateResult? {
         switch policy {
-        case .manual:
+        case let .manual(holderHibernationEnabled):
             guard terminal.hibernatedAt == nil else { return .alreadyHibernated }
-            guard terminal.isManuallyHibernatable else {
-                return .notEligible(reason: manualBlockReason(terminal))
+            guard terminal.isManuallyHibernatable(
+                holderHibernationEnabled: holderHibernationEnabled) else {
+                return .notEligible(reason: manualBlockReason(
+                    terminal, holderHibernationEnabled: holderHibernationEnabled))
             }
             return nil
 
-        case let .merge(inputVetoEnabled):
+        case let .merge(inputVetoEnabled, holderHibernationEnabled):
             let decision = HibernationGate.decideForMerge(
                 terminal: terminal,
                 inputVetoEnabled: inputVetoEnabled,
-                lastInputAt: inputActivity.lastInput(paneID: terminal.tmuxPaneID))
+                holderHibernationEnabled: holderHibernationEnabled,
+                lastInputAt: inputActivity.lastInput(
+                    paneID: InputActivityTracker.key(for: terminal)))
             guard decision == .eligible else {
                 return .notEligible(reason: Self.mergeBlockReason(decision))
             }
             return nil
 
-        case let .automatic(enabled, inputVetoEnabled, idleTimeout, idleSince):
+        case let .automatic(
+            enabled, inputVetoEnabled, holderHibernationEnabled, idleTimeout, idleSince):
             let decision = HibernationGate.decide(
                 terminal: terminal,
                 autoHibernateEnabled: enabled,
                 inputVetoEnabled: inputVetoEnabled,
+                holderHibernationEnabled: holderHibernationEnabled,
                 idleTimeout: idleTimeout,
                 idleSince: idleSince,
-                lastInputAt: inputActivity.lastInput(paneID: terminal.tmuxPaneID),
+                lastInputAt: inputActivity.lastInput(
+                    paneID: InputActivityTracker.key(for: terminal)),
                 now: now())
             guard decision == .eligible else {
                 return .notEligible(reason: Self.mergeBlockReason(decision))
@@ -1325,17 +1365,22 @@ public actor HibernationCoordinator {
 
         // Prune markers for terminals that vanished.
         let liveIDs = Set(terminals.map { $0.id })
-        let livePaneIDs = Set(terminals.compactMap { $0.tmuxPaneID })
+        // The tracker's own keys, so a holder row's entry (keyed by its
+        // terminal id) survives a prune that a pane-id-only set would drop on
+        // the very first sweep.
+        let liveKeys = Set(terminals.map { InputActivityTracker.key(for: $0) })
         idleSince = idleSince.filter { liveIDs.contains($0.key) }
         pendingKillSince = pendingKillSince.filter { liveIDs.contains($0.key) }
-        inputActivity.prune(keeping: livePaneIDs)
+        inputActivity.prune(keeping: liveKeys)
 
         for terminal in terminals {
-            let lastInputAt = inputActivity.lastInput(paneID: terminal.tmuxPaneID)
+            let lastInputAt = inputActivity.lastInput(
+                paneID: InputActivityTracker.key(for: terminal))
             let decision = HibernationGate.decide(
                 terminal: terminal,
                 autoHibernateEnabled: config.autoHibernateEnabled,
                 inputVetoEnabled: config.hibernateInputVetoEnabled,
+                holderHibernationEnabled: config.holderHibernationEnabled,
                 idleTimeout: timeout,
                 idleSince: idleSince[terminal.id],
                 lastInputAt: lastInputAt,
@@ -1371,6 +1416,7 @@ public actor HibernationCoordinator {
                             policy: .automatic(
                                 enabled: config.autoHibernateEnabled,
                                 inputVetoEnabled: config.hibernateInputVetoEnabled,
+                                holderHibernationEnabled: config.holderHibernationEnabled,
                                 idleTimeout: timeout,
                                 idleSince: idleSince[terminal.id]))
                         await actuationLog.appendOutcome(

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
@@ -365,10 +365,18 @@ public actor HibernationCoordinator {
     /// fans out over every terminal in the worktree and most are refused by the
     /// rails above, so — like the idle sweep — the row goes after the gate, at
     /// the moment this rail is actually about to act on a session.
+    ///
+    /// `holderHibernationEnabled` is not defaulted, for the reason
+    /// `Terminal.isManuallyHibernatable(holderHibernationEnabled:)` gives: the
+    /// flag reaches several call sites across the daemon and the app, and a
+    /// missing argument should be a compile error rather than a rail that
+    /// quietly disagrees with the menu the user is looking at. A default that
+    /// leaned on "forgetting refuses, which is safe" would invert the day the
+    /// shipped constant flips, which is this flag's whole graduation plan.
     public func hibernateForMerge(
         terminalID: UUID,
         inputVetoEnabled: Bool,
-        holderHibernationEnabled: Bool = Config.holderHibernationEnabledDefault
+        holderHibernationEnabled: Bool
     ) async -> HibernateResult {
         guard let terminal = try? await db.terminals.get(id: terminalID) else {
             return .notFound
@@ -1483,6 +1491,30 @@ public actor HibernationCoordinator {
                 lastInputAt: lastInputAt,
                 now: reference
             )
+
+            // A holder row whose screen this daemon cannot read is not a
+            // candidate, however idle it is. `performHolderHibernate` fails
+            // closed on exactly this — a viewer owns the pty, or no reader was
+            // ever adopted — but it only reaches that refusal after the sweep
+            // has written a request row and its refused outcome. On a tab the
+            // user is looking at the condition holds for as long as the tab is
+            // open, so without this check an open tab costs one
+            // request+refusal pair per sweep, forever, for a park that could
+            // never have happened.
+            //
+            // The gate cannot make this call: it is pure, and the registry is
+            // only available here. So the sweep asks, and treats the answer the
+            // way it treats the `.running` family — reset the idle clock and
+            // any armed debounce, write nothing — which restarts the full idle
+            // window from the moment the viewer leaves.
+            if terminal.transport == .holder,
+               decision == .eligible || decision == .notIdleLongEnough,
+               await holderScreenIsUnreadable(terminalID: terminal.id) {
+                logger.debug("hibernate: not arming \(terminal.id, privacy: .public) — the daemon cannot read this holder session's screen")
+                idleSince[terminal.id] = nil
+                pendingKillSince[terminal.id] = nil
+                continue
+            }
 
             switch decision {
             case .eligible:

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
@@ -201,6 +201,22 @@ public actor HibernationCoordinator {
     /// a screen.
     var holderRegistry: HolderRegistry?
 
+    /// Answers a holder-backed session's screen, for the park's pending-input
+    /// rail to judge. A **test seam only** — production leaves it nil and
+    /// `holderScreenReading` falls through to the registry's own reader, which
+    /// is the single source the design names.
+    ///
+    /// It exists for the same reason the send path's `holderModeOracle` does:
+    /// reaching the rail's answers (`daemon`, `staleDaemon`, a screen that will
+    /// not project, and no screen at all) through a real registry means a real
+    /// holder, a real pty and a real attach for what is a pure question about
+    /// whether a park may proceed. The registry-backed path is exercised live;
+    /// this is how the rail's own branches are pinned.
+    ///
+    /// `nil` from the seam means the same thing as no reader: nothing answered.
+    /// A throw means the same thing as a refused projection.
+    var holderScreenOracle: (@Sendable (UUID) async throws -> TerminalScreen?)?
+
     /// How the holder park observes and ends a child process. Injected so a
     /// test can state "the job declined `/exit`" in one line instead of
     /// arranging a real one.
@@ -277,6 +293,13 @@ public actor HibernationCoordinator {
     /// must share the one actor that holds the daemon's readers.
     func setHolderRegistry(_ registry: HolderRegistry?) {
         holderRegistry = registry
+    }
+
+    /// Wire the park rail's screen seam. Tests only — see `holderScreenOracle`.
+    func setHolderScreenOracle(
+        _ oracle: (@Sendable (UUID) async throws -> TerminalScreen?)?
+    ) {
+        holderScreenOracle = oracle
     }
 
     func setInputActivity(_ tracker: InputActivityTracker) {

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
@@ -16,7 +16,7 @@ public enum HibernateResult: Equatable, Sendable {
 /// mechanic for the pty-holder transport is behind a soak gate whatever
 /// triggered it — the property the soak validates (a row never claims parked
 /// while its child runs) does not depend on who asked.
-private enum HibernateEligibilityPolicy: Sendable {
+enum HibernateEligibilityPolicy: Sendable {
     case manual(holderHibernationEnabled: Bool)
     case merge(inputVetoEnabled: Bool, holderHibernationEnabled: Bool)
     case automatic(
@@ -112,7 +112,7 @@ public enum WakeResult: Equatable, Sendable {
 /// full uncached input on its next message whether or not the process stayed
 /// alive — parking an idle session is therefore nearly free.
 public actor HibernationCoordinator {
-    private let db: TBDDatabase
+    let db: TBDDatabase
     private let tmux: TmuxManager
     private let modelProfileResolver: ModelProfileResolver?
     private let subscriptions: StateSubscriptionManager?
@@ -122,14 +122,14 @@ public actor HibernationCoordinator {
     private let configDirManager: ClaudeProfileConfigDirManager
     /// Default input activity tracker. Wired post-construction by Daemon.swift
     /// to the shared instance from the input router so both use the same tracker.
-    private var inputActivity: InputActivityTracker
-    private let now: @Sendable () -> Date
+    var inputActivity: InputActivityTracker
+    let now: @Sendable () -> Date
 
     /// Per-terminal "first time we observed it idle-at-rest" marker, maintained
     /// by `sweep`. In-memory only: a daemon restart clears it, so a freshly
     /// started daemon won't instantly hibernate long-idle sessions — it waits a
     /// full idle window first, which is the safe behavior.
-    private var idleSince: [UUID: Date] = [:]
+    var idleSince: [UUID: Date] = [:]
 
     /// Terminal ids with an in-flight wake respawn, so a double-focus can't
     /// spawn two `claude --resume` processes into the same window.
@@ -153,7 +153,7 @@ public actor HibernationCoordinator {
     /// holds. State can flip in the final instant (a turn starts, a permission
     /// prompt appears), so the kill decision is re-verified here, not at
     /// arm-time. (Knative/KEDA poll-cheaply / decide-against-window pattern.)
-    private var pendingKillSince: [UUID: Date] = [:]
+    var pendingKillSince: [UUID: Date] = [:]
 
     /// Settle window between crossing the idle threshold and the actual kill.
     static let killDebounce: TimeInterval = 20
@@ -177,7 +177,22 @@ public actor HibernationCoordinator {
     /// Delay seam for the verify-exit poll (`Duration` is behavior). Tests
     /// inject a `TestClock` so the poll's pacing is virtual and the
     /// "escalate after exactly N attempts" boundary is exact.
-    private let clock: any Clock<Duration>
+    let clock: any Clock<Duration>
+
+    /// The pty-holder registry, wired post-construction by Daemon.swift the way
+    /// `inputActivity` is — the registry is built before the RPC router that
+    /// owns this coordinator, and both must reach the SAME actor: the park path
+    /// reads a session's screen through the reader the spawn path registered.
+    ///
+    /// Nil in mock mode and in any composition with no holder transport, where
+    /// the park path refuses by name rather than pretending it could have read
+    /// a screen.
+    var holderRegistry: HolderRegistry?
+
+    /// How the holder park observes and ends a child process. Injected so a
+    /// test can state "the job declined `/exit`" in one line instead of
+    /// arranging a real one.
+    let signaller: any ProcessSignaller
 
     /// The daemon's actuation record. The idle sweep and the merge-park rail
     /// are daemon-internal actuation sites — they bypass the router, so each
@@ -200,6 +215,7 @@ public actor HibernationCoordinator {
         exitPollAttempts: Int = 15,
         exitPollInterval: Duration = .milliseconds(200),
         clock: any Clock<Duration> = ContinuousClock(),
+        signaller: any ProcessSignaller = ProductionProcessSignaller(),
         actuationLog: ActuationLog
     ) {
         self.db = db
@@ -212,6 +228,7 @@ public actor HibernationCoordinator {
         self.exitPollAttempts = exitPollAttempts
         self.exitPollInterval = exitPollInterval
         self.clock = clock
+        self.signaller = signaller
         self.actuationLog = actuationLog
     }
 
@@ -240,6 +257,14 @@ public actor HibernationCoordinator {
     /// Wire the input activity tracker so the sweep can veto parks based on
     /// pending typed input. Set once by Daemon.swift after construction so the
     /// shared tracker is used across the input router and coordinator.
+    /// Wire the pty-holder registry. Set once by Daemon.swift after
+    /// construction, for the same reason `setInputActivity` is: the registry
+    /// exists before the router that owns this coordinator, and every consumer
+    /// must share the one actor that holds the daemon's readers.
+    func setHolderRegistry(_ registry: HolderRegistry?) {
+        holderRegistry = registry
+    }
+
     func setInputActivity(_ tracker: InputActivityTracker) {
         // Replace the default tracker with the shared one from the input router.
         // This is safe because nothing has accessed inputActivity yet at wiring time.
@@ -426,6 +451,17 @@ public actor HibernationCoordinator {
         guard let worktree = try? await db.worktrees.getLocal(id: terminal.worktreeID) else {
             return .notFound
         }
+        // The two transports diverge here, ahead of the first tmux call. A
+        // holder-backed row has no tmux server to lock and no pane to capture:
+        // its park writes to the holder's pty, confirms the child is gone, and
+        // clears the row's pids. Everything above this line — the singleflight
+        // claim, the session-id and worktree lookups — is shared, and
+        // everything below it is the tmux mechanic, unchanged.
+        if terminal.transport == .holder {
+            return await performHolderHibernate(
+                terminal: terminal, worktree: worktree, reason: reason, policy: policy)
+        }
+
         let server = worktree.tmuxServer
         let paneID = terminal.tmuxPaneID
 
@@ -673,7 +709,7 @@ public actor HibernationCoordinator {
         return .ok
     }
 
-    private func hibernationRefusal(
+    func hibernationRefusal(
         terminal: Terminal,
         policy: HibernateEligibilityPolicy
     ) -> HibernateResult? {
@@ -876,17 +912,27 @@ public actor HibernationCoordinator {
             return .notFound
         }
         // Ahead of the parked check, and therefore ahead of BOTH downstream
-        // paths: `classifyUnparkedWake` probes the pane, and the parked branch
-        // respawns into it. A holder row's pane id is the empty string, which
-        // tmux answers for by reporting the pane gone — so the unparked path
-        // would report a live session as `.sessionGone` and the parked path
-        // would respawn a second `claude --resume` for a session whose original
-        // process is still alive on the holder's pty. Refuse, mutating nothing.
-        guard terminal.transport != .holder else { return .holderTransport }
+        // paths. Read once, before anything is mutated: a holder row whose soak
+        // gate is off is refused here, mutating nothing, rather than reaching
+        // either branch below.
+        let holderHibernationEnabled = await resolvedHolderHibernationEnabled()
+        if terminal.transport == .holder, !holderHibernationEnabled {
+            return .holderTransport
+        }
         // Wake ANY parked row, not just `hibernatedAt`-marked ones: legacy rows
         // and the reconcile / recreate-window paths may carry only `suspendedAt`.
         // `clearHibernated` nils both columns, so this fully un-parks either.
-        guard terminal.isParked else { return await classifyUnparkedWake(terminal) }
+        //
+        // The unparked answer is per-transport: `classifyUnparkedWake` probes a
+        // tmux pane, and a holder row's pane id is the empty string, which tmux
+        // answers for by reporting the pane gone — a live session reported as
+        // `.sessionGone`. The holder classification asks the process table
+        // instead.
+        guard terminal.isParked else {
+            return terminal.transport == .holder
+                ? await classifyUnparkedHolderWake(terminal)
+                : await classifyUnparkedWake(terminal)
+        }
         guard let sessionID = terminal.claudeSessionID else { return .noSessionID }
         let expectedReplacementState = TerminalReplacementSnapshot(terminal: terminal)
         guard let worktree = try? await db.worktrees.getLocal(id: terminal.worktreeID) else {
@@ -903,10 +949,17 @@ public actor HibernationCoordinator {
         let server = worktree.tmuxServer
         let paneID = terminal.tmuxPaneID
 
-        // `claude --resume` is cwd-scoped (session lookup is per-directory).
-        // Respawning inside the existing window already runs in the worktree,
-        // but assert it so a moved/relocated worktree can't silently resume in
-        // the wrong directory (or fail to find the session).
+        // Assert that the process about to be resumed will run in THIS
+        // worktree. Not a lookup concern: `claude --resume <id>` is not
+        // cwd-scoped — measured on claude 2.1.261, a resume from another
+        // directory succeeds and appends to the original project directory's
+        // JSONL. What the check is for is belonging: a session resumed outside
+        // its worktree would edit the wrong tree while writing to the right
+        // transcript, which is the harder failure to notice. The respawn `-c`s
+        // into the worktree path regardless, so this only reports.
+        //
+        // tmux-only, because it reads a pane's cwd. A holder row has no pane
+        // and takes the branch above.
         if let paneCwd = try? await tmux.paneCurrentPath(server: server, paneID: paneID),
            paneCwd != worktree.path {
             logger.warning("wake: pane cwd \(paneCwd, privacy: .public) != worktree path \(worktree.path, privacy: .public) for terminal \(terminal.id, privacy: .public); respawn will -c into the worktree path")
@@ -1041,6 +1094,24 @@ public actor HibernationCoordinator {
             "TBD_TERMINAL_ID": terminal.id.uuidString,
         ]
         let sensitiveEnv = mergedEnvOverrides.merging(spawn.sensitiveEnv) { _, builder in builder }
+
+        // The transports diverge again, and for the last time. Everything above
+        // — profile, env, overlay, trust seed, transcript sync, the resume
+        // argv with its queued prompt — is shared verbatim, because it decides
+        // WHAT to resume and that is transport-independent. Below is the tmux
+        // mechanic.
+        if terminal.transport == .holder {
+            return await wakeHolderSection(
+                terminal: terminal,
+                worktree: worktree,
+                sessionID: sessionID,
+                expectedReplacementState: expectedReplacementState,
+                spawnCommand: spawn.command,
+                env: env,
+                sensitiveEnv: sensitiveEnv,
+                cols: cols,
+                rows: rows)
+        }
 
         // The window/pane the rest of wake must reference: the original ones
         // when the window survived, or the recreated window's fresh ones.
@@ -1468,6 +1539,10 @@ public actor HibernationCoordinator {
         guard let allTerminals = try? await db.terminals.list() else { return }
 
         for terminal in allTerminals where terminal.isParked {
+            if terminal.transport == .holder {
+                await reconcileParkedHolderRow(terminal)
+                continue
+            }
             guard let worktree = try? await db.worktrees.getLocal(id: terminal.worktreeID) else { continue }
             let server = worktree.tmuxServer
 
@@ -1577,7 +1652,7 @@ public actor HibernationCoordinator {
     /// `hibernated` flip and reads the row's snapshot once, and wake-on-focus
     /// reads the row's reason — a later refetch is too late. Wake broadcasts
     /// leave them nil.
-    private func broadcastHibernation(
+    func broadcastHibernation(
         terminal: Terminal, hibernated: Bool, keepWarm: Bool,
         tmuxWindowID: String? = nil, tmuxPaneID: String? = nil,
         suspendedSnapshot: String? = nil, hibernateReason: HibernateReason? = nil

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
@@ -174,6 +174,20 @@ public actor HibernationCoordinator {
     nonisolated let exitPollAttempts: Int
     nonisolated let exitPollInterval: Duration
 
+    /// How many times the holder park re-checks its child after sending it
+    /// `SIGTERM`, before escalating to the forced teardown.
+    ///
+    /// 25 at the production `exitPollInterval` of 200 ms is five seconds, and
+    /// the number is sized against what a Claude session actually does with a
+    /// `SIGTERM` it means to honour: run its Stop hooks, tear down its MCP
+    /// children, and flush the transcript it is mid-write on. Three seconds of
+    /// polite `/exit` has already passed by the time this rung is reached, so a
+    /// session that is shutting down cleanly and slowly gets eight seconds in
+    /// total before anything is killed — which is the whole reason this rung
+    /// exists, since the alternative it replaced was a `SIGKILL` of the process
+    /// group at three seconds. Injectable on the same terms as the pair above.
+    nonisolated let holderTerminateAttempts: Int
+
     /// How many times the holder park re-checks its child AFTER escalating to
     /// `HolderRegistry.abandon` — which forgets the holder, kills the job by
     /// process group and reaps the corpse.
@@ -242,6 +256,7 @@ public actor HibernationCoordinator {
         now: @escaping @Sendable () -> Date = { Date() },
         exitPollAttempts: Int = 15,
         exitPollInterval: Duration = .milliseconds(200),
+        holderTerminateAttempts: Int = 25,
         holderEscalationAttempts: Int = 5,
         clock: any Clock<Duration> = ContinuousClock(),
         signaller: any ProcessSignaller = ProductionProcessSignaller(),
@@ -256,6 +271,7 @@ public actor HibernationCoordinator {
         self.now = now
         self.exitPollAttempts = exitPollAttempts
         self.exitPollInterval = exitPollInterval
+        self.holderTerminateAttempts = holderTerminateAttempts
         self.holderEscalationAttempts = holderEscalationAttempts
         self.clock = clock
         self.signaller = signaller

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
@@ -174,6 +174,18 @@ public actor HibernationCoordinator {
     nonisolated let exitPollAttempts: Int
     nonisolated let exitPollInterval: Duration
 
+    /// How many times the holder park re-checks its child AFTER escalating to
+    /// `HolderRegistry.abandon` — which forgets the holder, kills the job by
+    /// process group and reaps the corpse.
+    ///
+    /// Five at the production `exitPollInterval` of 200 ms is one second, and
+    /// it is a different budget from the poll before it: that one waits for a
+    /// session to shut itself down politely, this one waits for a `SIGKILL`ed
+    /// process to leave the process table. Injectable on the same terms as the
+    /// pair above, and for the same reason — a test proving the "the child
+    /// survived everything" branch must not pay a real second to do it.
+    nonisolated let holderEscalationAttempts: Int
+
     /// Delay seam for the verify-exit poll (`Duration` is behavior). Tests
     /// inject a `TestClock` so the poll's pacing is virtual and the
     /// "escalate after exactly N attempts" boundary is exact.
@@ -214,6 +226,7 @@ public actor HibernationCoordinator {
         now: @escaping @Sendable () -> Date = { Date() },
         exitPollAttempts: Int = 15,
         exitPollInterval: Duration = .milliseconds(200),
+        holderEscalationAttempts: Int = 5,
         clock: any Clock<Duration> = ContinuousClock(),
         signaller: any ProcessSignaller = ProductionProcessSignaller(),
         actuationLog: ActuationLog
@@ -227,6 +240,7 @@ public actor HibernationCoordinator {
         self.now = now
         self.exitPollAttempts = exitPollAttempts
         self.exitPollInterval = exitPollInterval
+        self.holderEscalationAttempts = holderEscalationAttempts
         self.clock = clock
         self.signaller = signaller
         self.actuationLog = actuationLog
@@ -958,9 +972,12 @@ public actor HibernationCoordinator {
         // transcript, which is the harder failure to notice. The respawn `-c`s
         // into the worktree path regardless, so this only reports.
         //
-        // tmux-only, because it reads a pane's cwd. A holder row has no pane
-        // and takes the branch above.
-        if let paneCwd = try? await tmux.paneCurrentPath(server: server, paneID: paneID),
+        // tmux-only, and the guard is not decoration: a holder row's pane id is
+        // the empty string, so this would ask a tmux server — starting one, on
+        // a worktree whose sessions deliberately have none — about a
+        // coordinate that names nothing.
+        if terminal.transport != .holder,
+           let paneCwd = try? await tmux.paneCurrentPath(server: server, paneID: paneID),
            paneCwd != worktree.path {
             logger.warning("wake: pane cwd \(paneCwd, privacy: .public) != worktree path \(worktree.path, privacy: .public) for terminal \(terminal.id, privacy: .public); respawn will -c into the worktree path")
         }

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
@@ -416,8 +416,10 @@ public actor HibernationCoordinator {
     /// keep-warm, which merge-park honors but manual bypasses — plus the
     /// pending-input veto, whose wording matches the backup TUI scrape's so a
     /// reader cannot tell which of the two rails fired and does not need to.
-    /// The one refusal text every park/wake path uses for a holder-backed row,
-    /// so the CLI, the app and the actuation record all name the same reason.
+    /// The one refusal text every gated path uses for a holder-backed row, so
+    /// the CLI, the app and the actuation record all name the same reason. What
+    /// the flag gates is a new park and the classification of an UNPARKED
+    /// holder row; a row that is already parked wakes without consulting it.
     static let holderTransportRefusal =
         "Session runs on the pty-holder transport and holder hibernation is off "
         + "(Settings → Hibernate pty-holder sessions, or `tbd config "
@@ -907,6 +909,14 @@ public actor HibernationCoordinator {
     /// That recovery covers parked rows ONLY, because it lives downstream of
     /// the parked check below. An UNPARKED row whose session died is reported
     /// (`.sessionGone`) but not repaired — see `classifyUnparkedWake`.
+    ///
+    /// **An already-parked holder row wakes whatever `holder_hibernation_enabled`
+    /// says.** The flag gates new parks and the classification of an UNPARKED
+    /// holder row; it does not gate the wake of a row the feature has already
+    /// parked. Turning the flag off is the soak's abort gesture, and an abort
+    /// that stranded everything the soak parked would be no abort at all — the
+    /// app's focus-wake would fire a failing RPC on every focus, forever, with
+    /// no way back to a live session.
     public func wake(terminalID: UUID, cols: Int? = nil, rows: Int? = nil, allowDefaultProfileFallback: Bool = false, initialPrompt: String? = nil) async -> WakeResult {
         // Claim synchronously, before the first suspension. Otherwise two wake
         // calls can both read the parked row, then each pass the in-flight check
@@ -925,14 +935,6 @@ public actor HibernationCoordinator {
         guard let terminal = try? await db.terminals.get(id: terminalID) else {
             return .notFound
         }
-        // Ahead of the parked check, and therefore ahead of BOTH downstream
-        // paths. Read once, before anything is mutated: a holder row whose soak
-        // gate is off is refused here, mutating nothing, rather than reaching
-        // either branch below.
-        let holderHibernationEnabled = await resolvedHolderHibernationEnabled()
-        if terminal.transport == .holder, !holderHibernationEnabled {
-            return .holderTransport
-        }
         // Wake ANY parked row, not just `hibernatedAt`-marked ones: legacy rows
         // and the reconcile / recreate-window paths may carry only `suspendedAt`.
         // `clearHibernated` nils both columns, so this fully un-parks either.
@@ -943,9 +945,16 @@ public actor HibernationCoordinator {
         // `.sessionGone`. The holder classification asks the process table
         // instead.
         guard terminal.isParked else {
-            return terminal.transport == .holder
-                ? await classifyUnparkedHolderWake(terminal)
-                : await classifyUnparkedWake(terminal)
+            guard terminal.transport == .holder else {
+                return await classifyUnparkedWake(terminal)
+            }
+            // The soak gate belongs HERE and not above the parked check: it
+            // decides whether this install classifies an unparked holder row
+            // at all, and an install that has not armed the feature is told so
+            // rather than being handed a process-table verdict it never asked
+            // for. Nothing is mutated on the way out.
+            guard await resolvedHolderHibernationEnabled() else { return .holderTransport }
+            return await classifyUnparkedHolderWake(terminal)
         }
         guard let sessionID = terminal.claudeSessionID else { return .noSessionID }
         let expectedReplacementState = TerminalReplacementSnapshot(terminal: terminal)

--- a/Sources/TBDDaemon/Lifecycle/HibernationGate.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationGate.swift
@@ -40,11 +40,14 @@ public enum HibernationGate {
     ///   - autoHibernateEnabled: the global master switch.
     ///   - inputVetoEnabled: soak flag for the input-pipeline pending-input veto.
     ///   - holderHibernationEnabled: `config.holderHibernationEnabled`, the soak
-    ///     gate for park/wake on the pty-holder transport. Defaulted — unlike
-    ///     `decideForMerge`'s `inputVetoEnabled` — because forgetting it fails
-    ///     toward REFUSING a holder row, which is the safe direction: a session
-    ///     that is wrongly left awake is recoverable, one parked by a mechanic
-    ///     nobody armed is not.
+    ///     gate for park/wake on the pty-holder transport. Not defaulted, for
+    ///     the reason `Terminal.isManuallyHibernatable(holderHibernationEnabled:)`
+    ///     gives: the flag reaches several call sites across the daemon and the
+    ///     app, and a missing argument should be a compile error rather than a
+    ///     rail that quietly disagrees with the menu the user is looking at.
+    ///     "Forgetting fails toward refusing" would be an argument with a
+    ///     shelf life — it inverts the day the shipped constant flips, which is
+    ///     the whole graduation plan for this flag.
     ///   - idleTimeout: how long a terminal must be idle before it qualifies.
     ///   - idleSince: when the terminal last went idle (its `hibernationIdleSince`
     ///     marker). `nil` means "no idle marker yet" — treated as not-yet-idle,
@@ -57,7 +60,7 @@ public enum HibernationGate {
         terminal: Terminal,
         autoHibernateEnabled: Bool,
         inputVetoEnabled: Bool = false,
-        holderHibernationEnabled: Bool = Config.holderHibernationEnabledDefault,
+        holderHibernationEnabled: Bool,
         idleTimeout: TimeInterval,
         idleSince: Date?,
         lastInputAt: Date? = nil,
@@ -146,17 +149,18 @@ public enum HibernationGate {
     ///     path that silently forgets to arm this rail is the exact defect this
     ///     parameter exists to prevent.
     ///   - holderHibernationEnabled: `config.holderHibernationEnabled`, the
-    ///     soak gate for park/wake on the pty-holder transport. Defaulted for
-    ///     the same reason it is on `decide`: forgetting it refuses a holder
-    ///     row, and a session left awake is recoverable where one parked by an
-    ///     unarmed mechanic is not.
+    ///     soak gate for park/wake on the pty-holder transport. Not defaulted,
+    ///     for the same reason it is not on `decide`: a missing argument should be
+    ///     a compile error, not a rail that silently disagrees with the app's
+    ///     menu — and any "forgetting fails safe" reading inverts the day the
+    ///     shipped constant flips.
     ///   - lastInputAt: the timestamp of the last keystroke/paste routed to
     ///     this terminal's pane (from `InputActivityTracker`) — the same fact
     ///     the sweep passes. `nil` means no input was recorded for the pane.
     public static func decideForMerge(
         terminal: Terminal,
         inputVetoEnabled: Bool,
-        holderHibernationEnabled: Bool = Config.holderHibernationEnabledDefault,
+        holderHibernationEnabled: Bool,
         lastInputAt: Date?
     ) -> Decision {
         if let blocked = blockingRail(

--- a/Sources/TBDDaemon/Lifecycle/HibernationGate.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationGate.swift
@@ -7,9 +7,10 @@ import TBDShared
 /// safety rails plus the idle-duration check — is unit-testable without an
 /// actor, a tmux server, or a database. The rails themselves (running turn,
 /// permission prompt, keep-warm, already-hibernated/suspended, resumable
-/// Claude) live on `Terminal.isAutoHibernationEligible`; this adds the two
-/// inputs that pure property can't see: whether the feature is enabled and how
-/// long the terminal has been idle relative to the configured timeout.
+/// Claude) live on `Terminal.isAutoHibernationEligible(holderHibernationEnabled:)`;
+/// this adds the two inputs that pure method can't see: whether the feature is
+/// enabled and how long the terminal has been idle relative to the configured
+/// timeout.
 public enum HibernationGate {
     /// Why a terminal was or wasn't selected for auto-hibernation. `.eligible`
     /// is the only go; every other case names the rail that blocked it, so the
@@ -18,9 +19,9 @@ public enum HibernationGate {
     public enum Decision: Equatable, Sendable {
         case eligible
         case featureDisabled
-        /// The session's pty is owned by a `TBDHolder`, not a tmux pane, so the
-        /// respawn-window park mechanic has no coordinate to act on. Refused
-        /// outright rather than parked against an empty window id.
+        /// The session runs on the pty-holder transport and
+        /// `holder_hibernation_enabled` is off. The park and wake mechanic for
+        /// that transport exists; this soak gate says it may not run here yet.
         case holderTransport
         case notClaudeResumable
         case alreadyHibernated
@@ -38,6 +39,12 @@ public enum HibernationGate {
     ///   - terminal: the candidate.
     ///   - autoHibernateEnabled: the global master switch.
     ///   - inputVetoEnabled: soak flag for the input-pipeline pending-input veto.
+    ///   - holderHibernationEnabled: `config.holderHibernationEnabled`, the soak
+    ///     gate for park/wake on the pty-holder transport. Defaulted — unlike
+    ///     `decideForMerge`'s `inputVetoEnabled` — because forgetting it fails
+    ///     toward REFUSING a holder row, which is the safe direction: a session
+    ///     that is wrongly left awake is recoverable, one parked by a mechanic
+    ///     nobody armed is not.
     ///   - idleTimeout: how long a terminal must be idle before it qualifies.
     ///   - idleSince: when the terminal last went idle (its `hibernationIdleSince`
     ///     marker). `nil` means "no idle marker yet" — treated as not-yet-idle,
@@ -50,6 +57,7 @@ public enum HibernationGate {
         terminal: Terminal,
         autoHibernateEnabled: Bool,
         inputVetoEnabled: Bool = false,
+        holderHibernationEnabled: Bool = Config.holderHibernationEnabledDefault,
         idleTimeout: TimeInterval,
         idleSince: Date?,
         lastInputAt: Date? = nil,
@@ -58,7 +66,9 @@ public enum HibernationGate {
         guard autoHibernateEnabled else { return .featureDisabled }
         // Hard safety rails that don't depend on idle duration (returns the most
         // specific blocker, or nil when all pass).
-        if let blocked = blockingRail(terminal: terminal) { return blocked }
+        if let blocked = blockingRail(
+            terminal: terminal, holderHibernationEnabled: holderHibernationEnabled
+        ) { return blocked }
         // Idle-duration rail: needs a marker and enough elapsed time.
         guard let idleSince, now.timeIntervalSince(idleSince) >= idleTimeout else {
             return .notIdleLongEnough
@@ -80,14 +90,19 @@ public enum HibernationGate {
     /// on this exact precedence (e.g. an already-hibernated running terminal
     /// reports `.alreadyHibernated`, not `.running`). Kept identical to the cascade
     /// that used to be inlined in `decide` so existing behavior is preserved.
-    static func blockingRail(terminal: Terminal) -> Decision? {
-        // First, and ahead of `isClaudeResumable`: a holder-backed session is
-        // refused for a reason that has nothing to do with the Claude rails,
-        // and naming it precisely is what keeps a future reader from "fixing"
-        // the resumable check. Mirrors the same guard on
-        // `Terminal.isManuallyHibernatable`, which this cascade deliberately
-        // re-implements rather than calls (it needs per-rail reasons).
-        guard terminal.transport != .holder else { return .holderTransport }
+    static func blockingRail(
+        terminal: Terminal, holderHibernationEnabled: Bool
+    ) -> Decision? {
+        // First, and ahead of `isClaudeResumable`: a holder-backed session
+        // whose soak gate is off is refused for a reason that has nothing to do
+        // with the Claude rails, and naming it precisely is what keeps a future
+        // reader from "fixing" the resumable check. Mirrors the same guard on
+        // `Terminal.isManuallyHibernatable(holderHibernationEnabled:)`, which
+        // this cascade deliberately re-implements rather than calls (it needs
+        // per-rail reasons).
+        if terminal.transport == .holder, !holderHibernationEnabled {
+            return .holderTransport
+        }
         guard terminal.isClaudeResumable else { return .notClaudeResumable }
         guard terminal.hibernatedAt == nil else { return .alreadyHibernated }
         guard terminal.suspendedAt == nil else { return .suspended }
@@ -130,15 +145,23 @@ public enum HibernationGate {
     ///     veto (`config.hibernateInputVetoEnabled`). Not defaulted: a park
     ///     path that silently forgets to arm this rail is the exact defect this
     ///     parameter exists to prevent.
+    ///   - holderHibernationEnabled: `config.holderHibernationEnabled`, the
+    ///     soak gate for park/wake on the pty-holder transport. Defaulted for
+    ///     the same reason it is on `decide`: forgetting it refuses a holder
+    ///     row, and a session left awake is recoverable where one parked by an
+    ///     unarmed mechanic is not.
     ///   - lastInputAt: the timestamp of the last keystroke/paste routed to
     ///     this terminal's pane (from `InputActivityTracker`) — the same fact
     ///     the sweep passes. `nil` means no input was recorded for the pane.
     public static func decideForMerge(
         terminal: Terminal,
         inputVetoEnabled: Bool,
+        holderHibernationEnabled: Bool = Config.holderHibernationEnabledDefault,
         lastInputAt: Date?
     ) -> Decision {
-        if let blocked = blockingRail(terminal: terminal) { return blocked }
+        if let blocked = blockingRail(
+            terminal: terminal, holderHibernationEnabled: holderHibernationEnabled
+        ) { return blocked }
         guard inputVetoEnabled, let lastInputAt else { return .eligible }
         // The sweep compares `lastInputAt` against its own `idleSince` marker.
         // Merge-park has no such marker to compare against: it does not run the

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -1622,7 +1622,12 @@ extension WorktreeLifecycle {
                 watchDeskRole: watchDeskRole,
                 transport: primaryTransport,
                 holderPID: holderHandle?.holderPID,
-                childPID: holderHandle?.childPID
+                childPID: holderHandle?.childPID,
+                // The identity anchor for the job just spawned. `createdAt`
+                // would say the same thing today and stop being true the first
+                // time this row is parked and woken, so it is recorded from the
+                // start rather than only on the wake path.
+                holderChildStartedAt: holderHandle == nil ? nil : Date()
             )
         } catch {
             // Best-effort creation-time cleanup on both transports: a resource

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -1626,8 +1626,12 @@ extension WorktreeLifecycle {
                 // The identity anchor for the job just spawned. `createdAt`
                 // would say the same thing today and stop being true the first
                 // time this row is parked and woken, so it is recorded from the
-                // start rather than only on the wake path.
-                holderChildStartedAt: holderHandle == nil ? nil : Date()
+                // start rather than only on the wake path. Off this type's
+                // injected date seam, not a bare `Date()`: the stamp is
+                // persisted and later compared against a process start time by
+                // `ProcessIdentityCheck`, which is exactly the kind of fact a
+                // test has to be able to pin end to end.
+                holderChildStartedAt: holderHandle == nil ? nil : now()
             )
         } catch {
             // Best-effort creation-time cleanup on both transports: a resource

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -646,6 +646,13 @@ extension WorktreeLifecycle {
         let holderArmEnabled =
             (try? await db.config.get().holderRowReconcileEnabled)
             ?? Config.holderRowReconcileEnabledDefault
+        // Read beside the arm's own gate and for the same reason: what a
+        // finished holder session's row BECOMES is one judgement per pass, and
+        // a flip landing between two rows would park one and delete its sibling
+        // for no reason a reader could reconstruct.
+        let holderHibernationEnabled =
+            (try? await db.config.get().holderHibernationEnabled)
+            ?? Config.holderHibernationEnabledDefault
         // The budget covers the pass, not one server: the arm is serial across
         // every server this call reconciles, so a per-server budget would
         // multiply by the server count exactly the way a per-probe timeout
@@ -661,7 +668,8 @@ extension WorktreeLifecycle {
         do {
             try await reconcileTerminalsWhileLockedPerServer(
                 in: worktrees, actuationLog: actuationLog,
-                holderArmEnabled: holderArmEnabled)
+                holderArmEnabled: holderArmEnabled,
+                holderHibernationEnabled: holderHibernationEnabled)
         } catch {
             await holderProbeBudget.end()
             throw error
@@ -672,7 +680,8 @@ extension WorktreeLifecycle {
     /// The per-server half of `reconcileTerminals`, split out only so its
     /// caller can bracket it with the pass's probe budget.
     private func reconcileTerminalsWhileLockedPerServer(
-        in worktrees: [LocalWorktree], actuationLog: ActuationLog, holderArmEnabled: Bool
+        in worktrees: [LocalWorktree], actuationLog: ActuationLog, holderArmEnabled: Bool,
+        holderHibernationEnabled: Bool
     ) async throws {
         let grouped = Dictionary(grouping: worktrees, by: \.tmuxServer)
         for server in grouped.keys.sorted() {
@@ -686,7 +695,8 @@ extension WorktreeLifecycle {
                 }
                 try await reconcileTerminalsWhileLocked(
                     in: currentWorktrees, actuationLog: actuationLog,
-                    holderArmEnabled: holderArmEnabled)
+                    holderArmEnabled: holderArmEnabled,
+                    holderHibernationEnabled: holderHibernationEnabled)
             }
         }
     }
@@ -698,7 +708,8 @@ extension WorktreeLifecycle {
     /// holding this lock neither protects nor delays it.
     private func reconcileTerminalsWhileLocked(
         in worktrees: [LocalWorktree], actuationLog: ActuationLog,
-        holderArmEnabled: Bool
+        holderArmEnabled: Bool,
+        holderHibernationEnabled: Bool
     ) async throws {
         // Probe the server each worktree row actually stores, not a canonical
         // name. Promoted scratch worktrees keep their inherited scratch server.
@@ -823,22 +834,26 @@ extension WorktreeLifecycle {
                     disposal = "window \(terminal.tmuxWindowID) gone or reassigned"
                 }
 
-                // **Parking is a tmux-transport outcome, and only that.** A
-                // holder-backed row is deleted even when it names a resumable
-                // Claude session, because a parked holder row is inert and
-                // noisy rather than recoverable: `HibernationCoordinator.wake`
-                // refuses `transport == .holder` ahead of its "wake any parked
-                // row" branch, and this sweep skips parked rows, so nothing
-                // would ever judge it again — while the app's focus-wake
-                // selects exactly `isParked && isClaudeResumable &&
+                // **What a finished session's row becomes is one rule with one
+                // per-transport condition.** A resumable Claude row is PARKED,
+                // preserving its session id for a later wake; anything else is
+                // deleted, because there is nothing to preserve.
+                //
+                // The holder transport joins that rule only when
+                // `holder_hibernation_enabled` is on, and the reason is that a
+                // parked row is only worth having if something can wake it.
+                // With the gate off `HibernationCoordinator.wake` refuses a
+                // holder row, and this sweep skips parked rows, so a parked
+                // holder row would never be judged again — while the app's
+                // focus-wake selects exactly `isParked && isClaudeResumable &&
                 // hibernateReason != .manual` and would fire a failing wake RPC
                 // on every focus of that worktree, forever. Deleting says the
-                // true thing instead. The cost is real and named in the PR: a
-                // holder-backed resumable Claude session that ends loses the
-                // park a tmux one would get, until a holder wake path lands —
-                // which is a feature, not a reconciler's job.
-                if terminal.transport != .holder, terminal.isClaudeResumable,
-                   let sessionID = terminal.claudeSessionID {
+                // true thing in that state. With the gate on, the wake path
+                // exists and the park is worth exactly what it is worth on
+                // tmux.
+                let parkable = terminal.isClaudeResumable
+                    && (terminal.transport != .holder || holderHibernationEnabled)
+                if parkable, let sessionID = terminal.claudeSessionID {
                     // This park bypasses `HibernationCoordinator`, so the
                     // reconcile rail records its own independent actuation.
                     // Fail closed if that authoritative record cannot be made.
@@ -852,6 +867,15 @@ extension WorktreeLifecycle {
                     do {
                         try await db.terminals.setHibernated(
                             id: terminal.id, sessionID: sessionID, reason: .recovery)
+                        // A parked holder row names no processes. The holder
+                        // and its job are already gone — that is what
+                        // `.sessionOver` established — so leaving their pids on
+                        // the row would point the reaper's holder leg and every
+                        // identity check at numbers the kernel has recycled.
+                        if terminal.transport == .holder {
+                            try await db.terminals.setHolderProcess(
+                                id: terminal.id, holderPID: nil, childPID: nil, startedAt: nil)
+                        }
                         await actuationLog.appendOutcome(
                             confirms: actuationID, result: .dispatched)
                     } catch {
@@ -861,7 +885,7 @@ extension WorktreeLifecycle {
                     logger.info("reconcile: parked terminal \(terminal.id, privacy: .public) — \(disposal, privacy: .public), session \(sessionID, privacy: .public) preserved, wakeable via the unified resume path")
                 } else {
                     try? await db.deleteTerminalAndTab(id: terminal.id)
-                    logger.info("reconcile: deleted terminal \(terminal.id, privacy: .public) — \(disposal, privacy: .public), \(Self.deletionRationale(for: terminal), privacy: .public)")
+                    logger.info("reconcile: deleted terminal \(terminal.id, privacy: .public) — \(disposal, privacy: .public), \(Self.deletionRationale(for: terminal, holderHibernationEnabled: holderHibernationEnabled), privacy: .public)")
                 }
                 await pendingQuestions.clear(terminalID: terminal.id)
                 await subscriptions?.broadcastPendingQuestions(
@@ -920,12 +944,15 @@ extension WorktreeLifecycle {
     /// Composed by a named function so a test can pin the text: the two
     /// deletions are not the same event, and a line that told a
     /// holder-transport Claude row it had "no session to preserve" would be
-    /// false about the one row shape whose park was deliberately withheld.
-    static func deletionRationale(for terminal: Terminal) -> String {
-        guard terminal.transport == .holder, terminal.isClaudeResumable,
-            terminal.claudeSessionID != nil
+    /// false about the one row shape whose park was withheld by a soak gate
+    /// rather than by having nothing worth keeping.
+    static func deletionRationale(
+        for terminal: Terminal, holderHibernationEnabled: Bool
+    ) -> String {
+        guard terminal.transport == .holder, !holderHibernationEnabled,
+            terminal.isClaudeResumable, terminal.claudeSessionID != nil
         else { return "no session to preserve" }
-        return "its Claude session is not resumable from a park on the holder transport"
+        return "holder hibernation is off, so a parked holder row would have nothing to wake it"
     }
 
     /// How a finished session's job ended, in words, for the one log line that

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -640,19 +640,19 @@ extension WorktreeLifecycle {
     private func reconcileTerminals(
         in worktrees: [LocalWorktree], actuationLog: ActuationLog
     ) async throws {
-        // Read once per pass, not per row: the gate decides what this whole
-        // sweep is allowed to do, and re-reading it mid-pass would let a flip
-        // land between two rows of one judgement.
+        // ONE read for both gates, once per pass rather than per row. They
+        // decide what this whole sweep may do — whether it judges holder rows
+        // at all, and what a finished holder session's row BECOMES — and both
+        // are one judgement for the pass: a flip landing between two rows would
+        // park one and delete its sibling for no reason a reader could
+        // reconstruct. Reading the row twice could also straddle a write and
+        // take the two answers from different configurations, which is the one
+        // way this could disagree with itself inside a single pass.
+        let config = try? await db.config.get()
         let holderArmEnabled =
-            (try? await db.config.get().holderRowReconcileEnabled)
-            ?? Config.holderRowReconcileEnabledDefault
-        // Read beside the arm's own gate and for the same reason: what a
-        // finished holder session's row BECOMES is one judgement per pass, and
-        // a flip landing between two rows would park one and delete its sibling
-        // for no reason a reader could reconstruct.
+            config?.holderRowReconcileEnabled ?? Config.holderRowReconcileEnabledDefault
         let holderHibernationEnabled =
-            (try? await db.config.get().holderHibernationEnabled)
-            ?? Config.holderHibernationEnabledDefault
+            config?.holderHibernationEnabled ?? Config.holderHibernationEnabledDefault
         // The budget covers the pass, not one server: the arm is serial across
         // every server this call reconciles, so a per-server budget would
         // multiply by the server count exactly the way a per-probe timeout

--- a/Sources/TBDDaemon/PR/AutoHibernateOnMergeCoordinator.swift
+++ b/Sources/TBDDaemon/PR/AutoHibernateOnMergeCoordinator.swift
@@ -48,7 +48,10 @@ public struct AutoHibernateOnMergeCoordinator: Sendable {
                 // an idle timeout is.
                 let result = await hibernation.hibernateForMerge(
                     terminalID: terminal.id,
-                    inputVetoEnabled: config.hibernateInputVetoEnabled)
+                    inputVetoEnabled: config.hibernateInputVetoEnabled,
+                    // The holder soak gate rides the same snapshot, for the
+                    // same reason: one config read decides the whole fan-out.
+                    holderHibernationEnabled: config.holderHibernationEnabled)
                 switch result {
                 case .ok:
                     parked += 1

--- a/Sources/TBDDaemon/Process/AgentReaper.swift
+++ b/Sources/TBDDaemon/Process/AgentReaper.swift
@@ -26,8 +26,21 @@ public struct HolderChildRecord: Sendable, Equatable {
     public var holderPID: Int32?
     /// The job the holder `forkpty`'d, as recorded on the row.
     public var childPID: Int32
-    /// When the session row was written. The anchor for the start-time half of
-    /// the identity check — see `decideHolderChild`.
+    /// **The child-identity anchor**: when the job this record names is
+    /// believed to have started. The start-time half of the identity check
+    /// measures against it — see `decideHolderChild`.
+    ///
+    /// It is no longer simply the session row's birthday, and the name has been
+    /// kept only because renaming a field costs every call site and buys
+    /// nothing this comment cannot say. `Daemon.start` fills it with
+    /// `holderChildStartedAt ?? createdAt`: a row that has never been parked
+    /// records no child start, and there the two are the same instant, because
+    /// the job is forked within milliseconds of the row being written. A row
+    /// woken from a park is the case that separates them — its child is younger
+    /// than the row, sometimes by days — and anchoring on the row's own
+    /// `createdAt` there would read every such job as `.startTimeMismatch`,
+    /// which this leg spells "keep". The orphan the leg exists to reclaim would
+    /// then survive every sweep it ever ran.
     public var createdAt: Date
 
     public init(terminalID: UUID, holderPID: Int32?, childPID: Int32, createdAt: Date) {
@@ -61,8 +74,9 @@ public struct AgentReaper: Sendable {
     /// `OrphanGC`. Defaulted to empty so every existing call site and test is
     /// unchanged by the leg's arrival.
     let holderSessions: @Sendable () async -> [HolderChildRecord]
-    /// How far a child's start time may sit from its session row's `createdAt`
-    /// and still be believed to be that session's job.
+    /// How far a child's start time may sit from its record's identity anchor
+    /// (`HolderChildRecord.createdAt`) and still be believed to be that
+    /// session's job.
     let holderIdentityWindow: TimeInterval
 
     public init(
@@ -230,7 +244,7 @@ public struct AgentReaper: Sendable {
     ///    also what the app-liveness arbitration consults, so a reused pid is
     ///    recognized the same way on both paths. A pid naming nothing is not
     ///    killed blindly; the process now holding it must have started within
-    ///    `holderIdentityWindow` of the row's `createdAt` and must present an
+    ///    `holderIdentityWindow` of the record's identity anchor and must present an
     ///    executable a holder's job could have; and an unreadable start time or
     ///    command line is an uncertain identity, which keeps. **Every one of
     ///    that check's answers except `.same` is a keep here**, and that

--- a/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
@@ -309,6 +309,22 @@ extension RPCRouter {
         return .ok()
     }
 
+    /// Persist the pty-holder auto-hibernation gate — the default-off soak
+    /// switch for parking, waking and limit-resuming holder-backed sessions.
+    ///
+    /// This is how the soak is turned on. It is a separate verb from the
+    /// holder row reconcile gate above: that one reclaims a row whose holder
+    /// is already gone, this one parks (and can kill) a holder whose child
+    /// process is still running.
+    func handleConfigSetHolderHibernationEnabled(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(
+            ConfigSetHolderHibernationEnabledParams.self, from: paramsData)
+        try await db.config.setHolderHibernationEnabled(params.enabled)
+        // Reuse the existing config-change channel so the app reloads Config.
+        subscriptions.broadcast(delta: .modelProfilesChanged)
+        return .ok()
+    }
+
     /// Persist the orphaned-process collector gate — the default-off soak
     /// switch for reclaiming processes that outlived the worktree they were
     /// rooted in, read on top of the GC master switch.

--- a/Sources/TBDDaemon/Server/RPCRouter+HibernationHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+HibernationHandlers.swift
@@ -8,17 +8,30 @@ extension RPCRouter {
     /// describe the same state differently. Always names
     /// `tbd terminal conversation`, which still reads a dead session's messages
     /// — context can be rebuilt before the terminal is closed.
+    ///
+    /// An empty `paneID` is a holder-backed row rather than a nameless pane:
+    /// those carry `tmuxPaneID == ""` by construction, and the classification
+    /// that produced this result asked the process table, not tmux. Naming "its
+    /// tmux pane ()" there would send a reader looking for a coordinate that
+    /// was never supposed to exist.
     static func unparkedWakeMessage(
         paneID: String, detail: UnparkedPaneDisagreement
     ) -> String {
+        let subject = paneID.isEmpty
+            ? "its holder-backed session"
+            : "its tmux pane (\(paneID))"
         let cause: String
         switch detail {
         case .paneMissing:
-            cause = "its tmux pane (\(paneID)) is gone"
+            cause = "\(subject) is gone"
         case .processExited:
-            cause = "its tmux pane (\(paneID)) is still there but its process has exited"
+            cause = paneID.isEmpty
+                ? "\(subject) has exited"
+                : "\(subject) is still there but its process has exited"
         case .paneBelongsToAnotherTerminal(let actual):
-            cause = "its pane coordinate (\(paneID)) now points at a different terminal (\(actual))"
+            cause = paneID.isEmpty
+                ? "\(subject) now belongs to a different terminal (\(actual))"
+                : "its pane coordinate (\(paneID)) now points at a different terminal (\(actual))"
         }
         return """
             TBD's row says this terminal is awake, but \(cause) — so nothing was woken and any \

--- a/Sources/TBDDaemon/Server/RPCRouter+ManualSuspendHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ManualSuspendHandlers.swift
@@ -102,7 +102,16 @@ extension RPCRouter {
         }
         await limitResumeScheduler?.wake()
 
-        let eligible = terminals.filter { $0.isManuallyHibernatable }
+        // One config read for the whole fan-out: every terminal in this
+        // worktree is judged by the same soak gate, and a per-row read could
+        // straddle a toggle mid-loop. A read that fails takes the shipped
+        // default, which refuses a holder row.
+        let holderHibernationEnabled =
+            (try? await db.config.get())?.holderHibernationEnabled
+            ?? Config.holderHibernationEnabledDefault
+        let eligible = terminals.filter {
+            $0.isManuallyHibernatable(holderHibernationEnabled: holderHibernationEnabled)
+        }
 
         // Fire in background — RPC returns immediately so the app can show
         // the parking overlay while the daemon does its work.

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -727,6 +727,8 @@ public final class RPCRouter: Sendable {
                 return try await handleConfigSetRemoteDeleteEnabled(request.paramsData)
             case RPCMethod.configSetHolderRowReconcileEnabled:
                 return try await handleConfigSetHolderRowReconcileEnabled(request.paramsData)
+            case RPCMethod.configSetHolderHibernationEnabled:
+                return try await handleConfigSetHolderHibernationEnabled(request.paramsData)
             case RPCMethod.configSetSupervisionEnabled:
                 return try await handleConfigSetSupervisionEnabled(request.paramsData)
             case RPCMethod.remoteProviders:
@@ -861,7 +863,8 @@ public final class RPCRouter: Sendable {
             // unable to start a holder, and with the flag on that combination
             // falls back to tmux silently. Reported so Settings can say so
             // instead of offering a switch that would change nothing.
-            ptyHolderSupported: holderRegistry?.canSpawn == true))
+            ptyHolderSupported: holderRegistry?.canSpawn == true,
+            holderHibernationEnabled: config.holderHibernationEnabled))
     }
 
     // MARK: - PR Status

--- a/Sources/TBDDaemon/Tmux/InputActivityTracker.swift
+++ b/Sources/TBDDaemon/Tmux/InputActivityTracker.swift
@@ -1,4 +1,5 @@
 import Foundation
+import TBDShared
 import os
 
 /// Tracks the timestamp of the last keystroke recorded for each tmux pane,
@@ -46,6 +47,22 @@ final class InputActivityTracker: @unchecked Sendable {
         lock.lock()
         lastInputByPane.removeValue(forKey: paneID)
         lock.unlock()
+    }
+
+    /// The tracker key for one terminal.
+    ///
+    /// The map is keyed by tmux pane id because the input router speaks pane
+    /// ids — but a holder-backed row has no pane, and its `tmuxPaneID` is the
+    /// empty string by construction. Keying every holder row on `""` would put
+    /// them all in ONE bucket: input typed into any one of them would veto a
+    /// park on every other, and forgetting one would forget them all. Their id
+    /// is the discriminator instead. The two namespaces cannot collide — a tmux
+    /// pane id is `%<n>` and a UUID string is neither.
+    static func key(for terminal: Terminal) -> String {
+        switch terminal.transport {
+        case .holder: return terminal.id.uuidString
+        case .tmux: return terminal.tmuxPaneID
+        }
     }
 
     /// Drop recorded entries for panes not in `livePaneIDs`. Called during the

--- a/Sources/TBDDaemon/Tmux/InputActivityTracker.swift
+++ b/Sources/TBDDaemon/Tmux/InputActivityTracker.swift
@@ -58,6 +58,20 @@ final class InputActivityTracker: @unchecked Sendable {
     /// park on every other, and forgetting one would forget them all. Their id
     /// is the discriminator instead. The two namespaces cannot collide — a tmux
     /// pane id is `%<n>` and a UUID string is neither.
+    ///
+    /// **Nothing records under a holder key today, and that is the design, not
+    /// a gap.** This veto's fact source is the app's keystroke stream, and on
+    /// the holder transport those keystrokes go straight down the pty the
+    /// viewer holds — which is precisely the state the park refuses anyway, on
+    /// its own fail-closed screen rail. So the veto is vacuous for holder rows,
+    /// and the pending-input question is answered there by the screen rail
+    /// instead. Recording the daemon's own writes in its place would be worse
+    /// than recording nothing: an auto-resume or a peer's `terminal.send` would
+    /// read as typed-but-unsent input forever against the merge rail's
+    /// `activityStateObservedAt` anchor, vetoing every park of that row. The
+    /// key stays because it is the thing that keeps holder rows out of the
+    /// empty-pane-id bucket the moment anything does have a keystroke to
+    /// record — #816's viewer-side input reporting is the candidate.
     static func key(for terminal: Terminal) -> String {
         switch terminal.transport {
         case .holder: return terminal.id.uuidString

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -724,6 +724,16 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
     public var holderPID: Int32?
     /// PID of the job the holder `forkpty()`d. Nil for tmux rows.
     public var childPID: Int32?
+    /// When the job named by `childPID` was started, for the identity checks
+    /// that guard against pid reuse.
+    ///
+    /// Nil means this row has never been through a park/wake cycle, so its
+    /// `createdAt` is still the moment its child was born and remains the right
+    /// anchor — every reader spells that `holderChildStartedAt ?? createdAt`. A
+    /// woken session's child is younger than its row by however long the
+    /// session was parked, which is exactly the case `createdAt` alone cannot
+    /// describe. Cleared with the two pid columns when a row parks.
+    public var holderChildStartedAt: Date?
 
     /// `activityState` as a fact — value, source, observed-at — or nil.
     ///
@@ -787,7 +797,8 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
                 awaitingInputObservedAt: Date? = nil,
                 transport: TerminalTransport = .tmux,
                 holderPID: Int32? = nil,
-                childPID: Int32? = nil) {
+                childPID: Int32? = nil,
+                holderChildStartedAt: Date? = nil) {
         self.id = id
         self.worktreeID = worktreeID
         self.tmuxWindowID = tmuxWindowID
@@ -821,6 +832,7 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
         self.transport = transport
         self.holderPID = holderPID
         self.childPID = childPID
+        self.holderChildStartedAt = holderChildStartedAt
     }
 
     enum CodingKeys: String, CodingKey {
@@ -832,7 +844,7 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
         case hibernatedAt, hibernateReason, keepWarm, pendingResumeAt, watchDeskRole
         case activityStateSource, activityStateObservedAt, activityStateOrderObservedAt
         case awaitingInputReason, awaitingInputObservedAt
-        case transport, holderPID, childPID
+        case transport, holderPID, childPID, holderChildStartedAt
     }
 
     public init(from decoder: Decoder) throws {
@@ -886,6 +898,7 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
             .flatMap(TerminalTransport.init(rawValue:)) ?? .tmux
         holderPID = try c.decodeIfPresent(Int32.self, forKey: .holderPID)
         childPID = try c.decodeIfPresent(Int32.self, forKey: .childPID)
+        holderChildStartedAt = try c.decodeIfPresent(Date.self, forKey: .holderChildStartedAt)
     }
 }
 

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -1592,6 +1592,24 @@ public struct Config: Codable, Sendable, Equatable {
     /// NULL means "never chose" and follows the shipped default wherever it
     /// goes; `0`/`1` is an explicit gesture and is honored forever.
     public var holderRowReconcileEnabled: Bool
+    /// Gate for parking, waking and limit-resuming Claude sessions on the
+    /// pty-holder transport — auto-hibernation's holder leg. It ships OFF and
+    /// soaks behind its own switch rather than riding `ptyHolderEnabled`: that
+    /// outer gate has to be ON for a holder row to exist at all, so it cannot
+    /// express "transport on, hibernation not yet" — the same reason
+    /// `holderRowReconcileEnabled` is not folded into `ptyHolderEnabled`
+    /// either. What it gates is destructive in a way tmux hibernation is not:
+    /// a background sweep kills a live holder-owned agent process, and wake
+    /// starts a fresh holder running `claude --resume` rather than reattaching
+    /// to anything.
+    ///
+    /// **Resolved, not stored**, like `holderRowReconcileEnabled`: the backing
+    /// column carries no SQL default and stays NULL until somebody touches the
+    /// toggle, so this property is
+    /// `holder_hibernation_enabled ?? Config.holderHibernationEnabledDefault`.
+    /// NULL means "never chose" and follows the shipped default wherever it
+    /// goes; `0`/`1` is an explicit gesture and is honored forever.
+    public var holderHibernationEnabled: Bool
     /// The single opt-in for remote peer messaging
     /// (`docs/specs/2026-08-29-remote-peer-messaging-design.md`, "Flag and
     /// rollout"): publishing a shadow peer for each remote session and carrying
@@ -1750,6 +1768,13 @@ public struct Config: Codable, Sendable, Equatable {
     /// reachable — is a change to this constant, with no forcing `UPDATE`
     /// migration and every explicit opt-out left alone.
     public static let holderRowReconcileEnabledDefault = false
+    /// The shipped default for `holderHibernationEnabled`, and the single
+    /// place it lives. Holder hibernation ships off; graduation — after a soak
+    /// in which no park ever finalized while its child was still running and
+    /// no wake ever left a holder without a row — is a change to this
+    /// constant, with no forcing `UPDATE` migration and every explicit opt-out
+    /// left alone.
+    public static let holderHibernationEnabledDefault = false
     /// The shipped default for `updateMode`, and the single place it lives.
     /// Updating ships off; graduation to `check` — after a soak in which the
     /// notice was accurate and the hourly `ls-remote` cost nothing anyone
@@ -1799,6 +1824,7 @@ public struct Config: Codable, Sendable, Equatable {
                 gcRetainedTranscriptsEnabled: Bool =
                     Config.gcRetainedTranscriptsEnabledDefault,
                 holderRowReconcileEnabled: Bool = Config.holderRowReconcileEnabledDefault,
+                holderHibernationEnabled: Bool = Config.holderHibernationEnabledDefault,
                 updateMode: UpdateMode = Config.updateModeDefault,
                 remoteCreateDefaults: [String: String] = [:],
                 holderOwnerToken: String? = nil) {
@@ -1841,6 +1867,7 @@ public struct Config: Codable, Sendable, Equatable {
         self.remoteDeleteEnabled = remoteDeleteEnabled
         self.gcRetainedTranscriptsEnabled = gcRetainedTranscriptsEnabled
         self.holderRowReconcileEnabled = holderRowReconcileEnabled
+        self.holderHibernationEnabled = holderHibernationEnabled
         self.updateMode = updateMode
         self.remoteCreateDefaults = remoteCreateDefaults
         self.holderOwnerToken = holderOwnerToken
@@ -1963,6 +1990,10 @@ public struct Config: Codable, Sendable, Equatable {
         holderRowReconcileEnabled = try c.decodeIfPresent(
             Bool.self, forKey: .holderRowReconcileEnabled)
             ?? Config.holderRowReconcileEnabledDefault
+        // Same shape once more, for holder hibernation's gate.
+        holderHibernationEnabled = try c.decodeIfPresent(
+            Bool.self, forKey: .holderHibernationEnabled)
+            ?? Config.holderHibernationEnabledDefault
         // Same shape for the update mode, with one addition: an unrecognised
         // NAME from a newer daemon (a fourth mode) is as unusable as an absent
         // key, so it resolves to the shipped default instead of failing the

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -961,25 +961,36 @@ public extension Terminal {
     ///     hand; hibernating would eat it).
     /// Manual "Hibernate now" bypasses the keep-warm and idle checks but keeps
     /// the running/permission rails (see `isManuallyHibernatable`).
-    var isAutoHibernationEligible: Bool {
-        isManuallyHibernatable && !keepWarm
+    ///
+    /// `holderHibernationEnabled` is `Config.holderHibernationEnabled` — see
+    /// `isManuallyHibernatable(holderHibernationEnabled:)`, which this defers
+    /// the whole transport question to.
+    func isAutoHibernationEligible(holderHibernationEnabled: Bool) -> Bool {
+        isManuallyHibernatable(holderHibernationEnabled: holderHibernationEnabled) && !keepWarm
     }
 
     /// Whether a MANUAL "Hibernate now" may act on this terminal. Same rails as
     /// auto except keep-warm and idle-time don't apply — the user asked
     /// explicitly. Still refuses to hibernate an in-flight turn or a raised
     /// permission hand.
-    var isManuallyHibernatable: Bool {
-        // Parking is a tmux mechanic end to end: it `respawn-window`s the pane
-        // to a bare shell and wake respawns `claude --resume` back into that
-        // same pane. A holder row has no pane — its `tmuxWindowID`/`tmuxPaneID`
-        // are empty strings by construction — so every step would address the
-        // empty coordinate, which tmux answers for by reporting the window
-        // gone. The row would flip to parked while the holder and its child
-        // kept running, unreclaimed. Until parking learns the holder transport,
-        // refuse: an ineligible session is recoverable, a row that lies about a
-        // live process is not.
-        guard transport != .holder else { return false }
+    ///
+    /// - Parameter holderHibernationEnabled: `Config.holderHibernationEnabled`,
+    ///   the soak gate for park and wake on the pty-holder transport. A
+    ///   holder-backed row IS parkable — the mechanic terminates the holder's
+    ///   child and wake spawns a fresh holder running `claude --resume` — and
+    ///   this flag decides only whether that mechanic has soaked long enough to
+    ///   run on this install. Not defaulted, deliberately: the flag reaches
+    ///   five call sites across the daemon and the app, and a missing argument
+    ///   is a compile error rather than a rail that quietly disagrees with the
+    ///   menu the user is looking at.
+    func isManuallyHibernatable(holderHibernationEnabled: Bool) -> Bool {
+        // Park and wake on the holder transport do not go through tmux at all:
+        // the park writes `/exit` to the holder's pty, confirms the child is
+        // gone, and clears the row's pids; the wake spawns a fresh holder. A
+        // holder row's `tmuxWindowID`/`tmuxPaneID` are empty strings by
+        // construction and neither path reads them. What this guard gates is
+        // the soak, not the capability.
+        if transport == .holder, !holderHibernationEnabled { return false }
         guard isClaudeResumable else { return false }
         guard hibernatedAt == nil, suspendedAt == nil else { return false }
         switch activityState {

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -311,6 +311,11 @@ public enum RPCMethod {
     /// method of its own: `config.get` already carries the resolved value.
     public static let configSetRemoteDeleteEnabled = "config.setRemoteDeleteEnabled"
     public static let configSetHolderRowReconcileEnabled = "config.setHolderRowReconcileEnabled"
+    /// The pty-holder auto-hibernation gate (`holder_hibernation_enabled`) —
+    /// the soak switch on parking, waking and limit-resuming holder-backed
+    /// sessions. Reading needs no method of its own: `config.get` already
+    /// carries the resolved value.
+    public static let configSetHolderHibernationEnabled = "config.setHolderHibernationEnabled"
     public static let remoteProviders = "remote.providers"
     public static let remoteSessions = "remote.sessions"
     public static let remoteCreate = "remote.create"
@@ -3263,6 +3268,17 @@ public struct ConfigSetHolderRowReconcileEnabledParams: Codable, Sendable {
     public init(enabled: Bool) { self.enabled = enabled }
 }
 
+/// Params for `config.setHolderHibernationEnabled` — the gate on parking,
+/// waking and limit-resuming Claude sessions on the pty-holder transport
+/// (default OFF during soak). This is how the soak is turned on: without it
+/// the sweep that kills a live holder-owned process would be reachable only by
+/// hand-editing `~/tbd/state.db`. Design:
+/// `docs/specs/2026-08-30-pty-holder-session-transport-design.md`.
+public struct ConfigSetHolderHibernationEnabledParams: Codable, Sendable {
+    public let enabled: Bool
+    public init(enabled: Bool) { self.enabled = enabled }
+}
+
 /// Params for `config.setGCOrphanProcessesEnabled` — the gate for the
 /// orphaned-process collector, which reclaims processes that outlived the
 /// worktree they were rooted in (default OFF during soak, on top of the GC
@@ -3571,6 +3587,10 @@ public struct DaemonCapabilitiesResult: Codable, Sendable {
     /// tmux — so Settings disables the toggle and says why rather than offering
     /// a switch that would change nothing.
     public let ptyHolderSupported: Bool
+    /// Whether the pty-holder auto-hibernation gate (`holder_hibernation_enabled`)
+    /// is set. Default OFF while it soaks. Read at sweep time, so the Settings
+    /// toggle reads it back from here rather than from a local guess.
+    public let holderHibernationEnabled: Bool
 
     public init(controlModeEnabled: Bool,
                 tmuxVersion: String? = nil,
@@ -3588,7 +3608,8 @@ public struct DaemonCapabilitiesResult: Codable, Sendable {
                 remoteDeleteEnabled: Bool = Config.remoteDeleteEnabledDefault,
                 updateMode: UpdateMode = Config.updateModeDefault,
                 ptyHolderEnabled: Bool = Config.ptyHolderDefault,
-                ptyHolderSupported: Bool = false) {
+                ptyHolderSupported: Bool = false,
+                holderHibernationEnabled: Bool = false) {
         self.controlModeEnabled = controlModeEnabled
         self.tmuxVersion = tmuxVersion
         self.controlModeSupported = controlModeSupported
@@ -3606,6 +3627,7 @@ public struct DaemonCapabilitiesResult: Codable, Sendable {
         self.updateMode = updateMode
         self.ptyHolderEnabled = ptyHolderEnabled
         self.ptyHolderSupported = ptyHolderSupported
+        self.holderHibernationEnabled = holderHibernationEnabled
     }
 
     public init(from decoder: Decoder) throws {
@@ -3664,6 +3686,11 @@ public struct DaemonCapabilitiesResult: Codable, Sendable {
             Bool.self, forKey: .ptyHolderEnabled) ?? Config.ptyHolderDefault
         ptyHolderSupported = try c.decodeIfPresent(
             Bool.self, forKey: .ptyHolderSupported) ?? false
+        // New field for holder auto-hibernation. A daemon that does not send
+        // it runs no such sweep leg either, so an absent value is honestly
+        // false rather than assuming the gate is live.
+        holderHibernationEnabled = try c.decodeIfPresent(
+            Bool.self, forKey: .holderHibernationEnabled) ?? false
     }
 }
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -3609,7 +3609,7 @@ public struct DaemonCapabilitiesResult: Codable, Sendable {
                 updateMode: UpdateMode = Config.updateModeDefault,
                 ptyHolderEnabled: Bool = Config.ptyHolderDefault,
                 ptyHolderSupported: Bool = false,
-                holderHibernationEnabled: Bool = false) {
+                holderHibernationEnabled: Bool = Config.holderHibernationEnabledDefault) {
         self.controlModeEnabled = controlModeEnabled
         self.tmuxVersion = tmuxVersion
         self.controlModeSupported = controlModeSupported
@@ -3687,10 +3687,12 @@ public struct DaemonCapabilitiesResult: Codable, Sendable {
         ptyHolderSupported = try c.decodeIfPresent(
             Bool.self, forKey: .ptyHolderSupported) ?? false
         // New field for holder auto-hibernation. A daemon that does not send
-        // it runs no such sweep leg either, so an absent value is honestly
-        // false rather than assuming the gate is live.
+        // it runs no such sweep leg either, so fall through to the shipped
+        // default — one constant with the memberwise init above and with
+        // `ConfigRecord.toModel`, so a graduation moves all three at once —
+        // rather than assuming the gate is live.
         holderHibernationEnabled = try c.decodeIfPresent(
-            Bool.self, forKey: .holderHibernationEnabled) ?? false
+            Bool.self, forKey: .holderHibernationEnabled) ?? Config.holderHibernationEnabledDefault
     }
 }
 

--- a/Sources/TBDShared/TerminalScreen.swift
+++ b/Sources/TBDShared/TerminalScreen.swift
@@ -101,14 +101,13 @@ public struct TerminalScreen: Codable, Sendable, Equatable {
     /// Which of the transport's two stores answered.
     ///
     /// A consumer's policy is keyed on this field, so the policy cannot be
-    /// applied by accident. Of the consumers the design names, two are on the
-    /// contract today: the input-path oracle proceeds on `staleDaemon` modes
-    /// and records the source on the actuation row, and a person reading `tbd
-    /// terminal output` is shown the source and the age on stderr. The
-    /// hibernation pending-input check is still on its own screen read; the
-    /// policy it is to apply when it moves onto this contract is to fail closed
-    /// on `staleDaemon`, because a frozen screen cannot prove the composer is
-    /// empty.
+    /// applied by accident. The consumers the design names read it as follows:
+    /// the input-path oracle proceeds on `staleDaemon` modes and records the
+    /// source on the actuation row; the hibernation pending-input rail refuses
+    /// on anything but `daemon`, because a frozen screen cannot prove the
+    /// composer is empty and a live one a viewer answered has somebody at its
+    /// keyboard; and a person reading `tbd terminal output` is shown the source
+    /// and the age on stderr.
     ///
     /// **The raw values must stay identical to `ActuationModeSource`'s.** A
     /// supervisor correlates the `screen.source` it read from `tbd terminal

--- a/Tests/TBDAppTests/PtyHolderSettingsTests.swift
+++ b/Tests/TBDAppTests/PtyHolderSettingsTests.swift
@@ -79,6 +79,46 @@ struct PtyHolderSettingsTests {
         }
     }
 
+    // MARK: - The holder-hibernation setter, both directions
+
+    @Test func holderHibernationSetterPersistsOnAndRefreshesCapabilities() async {
+        await withAppState { state in
+            var written: [Bool] = []
+            var refreshes = 0
+            state.holderHibernationFlagSetter = { @MainActor enabled in written.append(enabled) }
+            state.daemonCapabilitiesFetcher = { @MainActor in
+                refreshes += 1
+                return DaemonCapabilitiesResult(
+                    controlModeEnabled: false, holderHibernationEnabled: true)
+            }
+
+            await state.setHolderHibernationEnabled(true)
+
+            #expect(written == [true])
+            #expect(refreshes == 1)
+            #expect(state.daemonCapabilities?.holderHibernationEnabled == true)
+        }
+    }
+
+    /// The off branch is its own test rather than a second assertion, for the
+    /// same reason as `setterPersistsOffAndRefreshesCapabilities` above: a
+    /// setter that ignored its argument would pass the on-only test.
+    @Test func holderHibernationSetterPersistsOffAndRefreshesCapabilities() async {
+        await withAppState { state in
+            var written: [Bool] = []
+            state.holderHibernationFlagSetter = { @MainActor enabled in written.append(enabled) }
+            state.daemonCapabilitiesFetcher = { @MainActor in
+                DaemonCapabilitiesResult(
+                    controlModeEnabled: false, holderHibernationEnabled: false)
+            }
+
+            await state.setHolderHibernationEnabled(false)
+
+            #expect(written == [false])
+            #expect(state.daemonCapabilities?.holderHibernationEnabled == false)
+        }
+    }
+
     // MARK: - The help text
 
     /// The one claim the design spec forbids. Its §"why" is explicit that the

--- a/Tests/TBDAppTests/RowActionMenuTests.swift
+++ b/Tests/TBDAppTests/RowActionMenuTests.swift
@@ -856,4 +856,67 @@ struct RowActionMenuCallSiteTests {
             #expect(built.location == .remote(provider: "fake", sessionID: "s1"))
         }
     }
+
+    private func localWorktree() -> Worktree {
+        Worktree(
+            repoID: UUID(), name: "acme", displayName: "acme",
+            branch: "b", path: "/tmp/acme", tmuxServer: "t")
+    }
+
+    private func holderTerminal(worktreeID: UUID) -> Terminal {
+        Terminal(
+            id: UUID(), worktreeID: worktreeID, tmuxWindowID: "", tmuxPaneID: "",
+            claudeSessionID: "session-1", kind: .claude, activityState: .idle,
+            transport: .holder)
+    }
+
+    /// A holder-backed session whose panel currently owns the pty is not
+    /// offered a park by the row menu either.
+    ///
+    /// This is the call-site half of `ManualParkAffordance`: the pure model is
+    /// exercised in `TabParkMenuModelTests`, and what this pins is that the row
+    /// menu asks the same question of the same registry. The daemon would
+    /// refuse such a park — its pending-input rail cannot read a screen it no
+    /// longer has — so an item offered here is one that always errors.
+    @Test("a holder session whose panel holds the pty is not offered a park")
+    func attachedHolderSessionIsNotOfferedAPark() {
+        withState { state in
+            let worktree = localWorktree()
+            let terminal = holderTerminal(worktreeID: worktree.id)
+            state.terminals[worktree.id] = [terminal]
+            state.daemonCapabilities = DaemonCapabilitiesResult(
+                controlModeEnabled: false, ptyHolderEnabled: true,
+                holderHibernationEnabled: true)
+            // The claim a panel takes the instant `attach.ready` is accepted.
+            let registration = state.terminalInjections.register(
+                terminalID: terminal.id) { _, _ in true }
+
+            #expect(!actions(state, worktree).context().hasHibernatableClaude)
+
+            // The discriminating half: release the claim and the same row, the
+            // same flag and the same terminal offer the park.
+            state.terminalInjections.unregister(registration)
+            #expect(actions(state, worktree).context().hasHibernatableClaude)
+        }
+    }
+
+    /// The same claim on a tmux session changes nothing — the daemon reads a
+    /// pane's screen with `capture-pane` whoever is looking at it — so the test
+    /// above is about the transport, not about an attached panel alone.
+    @Test("a tmux session with an attached panel is still offered a park")
+    func attachedTmuxSessionIsStillOfferedAPark() {
+        withState { state in
+            let worktree = localWorktree()
+            let terminal = Terminal(
+                id: UUID(), worktreeID: worktree.id, tmuxWindowID: "@1",
+                tmuxPaneID: "%1", claudeSessionID: "session-1", kind: .claude,
+                activityState: .idle)
+            state.terminals[worktree.id] = [terminal]
+            state.daemonCapabilities = DaemonCapabilitiesResult(
+                controlModeEnabled: false, holderHibernationEnabled: true)
+            _ = state.terminalInjections.register(terminalID: terminal.id) { _, _ in true }
+
+            #expect(actions(state, worktree).context().hasHibernatableClaude)
+        }
+    }
 }

--- a/Tests/TBDAppTests/TabParkMenuModelTests.swift
+++ b/Tests/TBDAppTests/TabParkMenuModelTests.swift
@@ -5,7 +5,7 @@ import TBDShared
 
 /// The per-tab Hibernate/Wake context-menu affordance (the park control that
 /// returned to the tab after PR #362 retired the play/pause Suspend button).
-/// Tests the pure decision `TabParkMenuModel.action(for:)` across every
+/// Tests the pure decision `TabParkMenuModel.action(for:holderHibernationEnabled:)` across every
 /// branch without SwiftUI: hibernate for a live manually-hibernatable Claude
 /// session, wake for a parked one (authoritative `hibernatedAt` AND legacy
 /// `suspendedAt`), and neither for busy/nil/non-Claude terminals.
@@ -28,14 +28,14 @@ struct TabParkMenuModelTests {
     /// hibernatable → offer Hibernate.
     @Test func manuallyHibernatableTerminalOffersHibernate() {
         let terminal = claudeTerminal()
-        #expect(terminal.isManuallyHibernatable)
-        #expect(TabParkMenuModel.action(for: terminal) == .hibernate)
+        #expect(terminal.isManuallyHibernatable(holderHibernationEnabled: false))
+        #expect(TabParkMenuModel.action(for: terminal, holderHibernationEnabled: false) == .hibernate)
     }
 
     /// Branch 2: a parked session (authoritative `hibernatedAt`) → offer Wake.
     @Test func parkedTerminalOffersWake() {
         let terminal = claudeTerminal(hibernatedAt: Date())
-        #expect(TabParkMenuModel.action(for: terminal) == .wake)
+        #expect(TabParkMenuModel.action(for: terminal, holderHibernationEnabled: false) == .wake)
     }
 
     /// Branch 2 (legacy): a row parked by the pre-merge Suspend feature has
@@ -43,26 +43,26 @@ struct TabParkMenuModelTests {
     @Test func legacySuspendedOnlyTerminalOffersWake() {
         let terminal = claudeTerminal(suspendedAt: Date())
         #expect(terminal.hibernatedAt == nil)
-        #expect(TabParkMenuModel.action(for: terminal) == .wake)
+        #expect(TabParkMenuModel.action(for: terminal, holderHibernationEnabled: false) == .wake)
     }
 
     /// Branch 3: a Claude session mid-turn (`.working`) is neither parked nor
     /// manually hibernatable → no item.
     @Test func workingTerminalOffersNothing() {
         let terminal = claudeTerminal(activityState: .working)
-        #expect(TabParkMenuModel.action(for: terminal) == nil)
+        #expect(TabParkMenuModel.action(for: terminal, holderHibernationEnabled: false) == nil)
     }
 
     /// Branch 3: a Claude session waiting on a permission prompt — hibernating
     /// would eat the raised hand → no item.
     @Test func waitingForUserTerminalOffersNothing() {
         let terminal = claudeTerminal(activityState: .waitingForUser)
-        #expect(TabParkMenuModel.action(for: terminal) == nil)
+        #expect(TabParkMenuModel.action(for: terminal, holderHibernationEnabled: false) == nil)
     }
 
     /// Branch 3: no terminal backing the tab → no item.
     @Test func nilTerminalOffersNothing() {
-        #expect(TabParkMenuModel.action(for: nil) == nil)
+        #expect(TabParkMenuModel.action(for: nil, holderHibernationEnabled: false) == nil)
     }
 
     /// Branch 3: non-Claude terminals (plain shell, Codex) are never
@@ -72,7 +72,7 @@ struct TabParkMenuModelTests {
                              tmuxPaneID: "%1", kind: .shell, activityState: .idle)
         let codex = Terminal(id: UUID(), worktreeID: UUID(), tmuxWindowID: "@2",
                              tmuxPaneID: "%2", kind: .codex, activityState: .idle)
-        #expect(TabParkMenuModel.action(for: shell) == nil)
-        #expect(TabParkMenuModel.action(for: codex) == nil)
+        #expect(TabParkMenuModel.action(for: shell, holderHibernationEnabled: false) == nil)
+        #expect(TabParkMenuModel.action(for: codex, holderHibernationEnabled: false) == nil)
     }
 }

--- a/Tests/TBDAppTests/TabParkMenuModelTests.swift
+++ b/Tests/TBDAppTests/TabParkMenuModelTests.swift
@@ -5,10 +5,12 @@ import TBDShared
 
 /// The per-tab Hibernate/Wake context-menu affordance (the park control that
 /// returned to the tab after PR #362 retired the play/pause Suspend button).
-/// Tests the pure decision `TabParkMenuModel.action(for:holderHibernationEnabled:)` across every
-/// branch without SwiftUI: hibernate for a live manually-hibernatable Claude
-/// session, wake for a parked one (authoritative `hibernatedAt` AND legacy
-/// `suspendedAt`), and neither for busy/nil/non-Claude terminals.
+/// Tests the pure decision
+/// `TabParkMenuModel.action(for:holderHibernationEnabled:panelHoldsPTY:)`
+/// across every branch without SwiftUI: hibernate for a live
+/// manually-hibernatable Claude session, wake for a parked one (authoritative
+/// `hibernatedAt` AND legacy `suspendedAt`), and neither for
+/// busy/nil/non-Claude terminals or a holder tab whose panel owns the pty.
 @Suite("Tab park menu decision (per-tab Hibernate/Wake)")
 struct TabParkMenuModelTests {
     /// A live, resumable Claude terminal — the shape `isManuallyHibernatable`
@@ -29,13 +31,13 @@ struct TabParkMenuModelTests {
     @Test func manuallyHibernatableTerminalOffersHibernate() {
         let terminal = claudeTerminal()
         #expect(terminal.isManuallyHibernatable(holderHibernationEnabled: false))
-        #expect(TabParkMenuModel.action(for: terminal, holderHibernationEnabled: false) == .hibernate)
+        #expect(TabParkMenuModel.action(for: terminal, holderHibernationEnabled: false, panelHoldsPTY: false) == .hibernate)
     }
 
     /// Branch 2: a parked session (authoritative `hibernatedAt`) → offer Wake.
     @Test func parkedTerminalOffersWake() {
         let terminal = claudeTerminal(hibernatedAt: Date())
-        #expect(TabParkMenuModel.action(for: terminal, holderHibernationEnabled: false) == .wake)
+        #expect(TabParkMenuModel.action(for: terminal, holderHibernationEnabled: false, panelHoldsPTY: false) == .wake)
     }
 
     /// Branch 2 (legacy): a row parked by the pre-merge Suspend feature has
@@ -43,26 +45,26 @@ struct TabParkMenuModelTests {
     @Test func legacySuspendedOnlyTerminalOffersWake() {
         let terminal = claudeTerminal(suspendedAt: Date())
         #expect(terminal.hibernatedAt == nil)
-        #expect(TabParkMenuModel.action(for: terminal, holderHibernationEnabled: false) == .wake)
+        #expect(TabParkMenuModel.action(for: terminal, holderHibernationEnabled: false, panelHoldsPTY: false) == .wake)
     }
 
     /// Branch 3: a Claude session mid-turn (`.working`) is neither parked nor
     /// manually hibernatable → no item.
     @Test func workingTerminalOffersNothing() {
         let terminal = claudeTerminal(activityState: .working)
-        #expect(TabParkMenuModel.action(for: terminal, holderHibernationEnabled: false) == nil)
+        #expect(TabParkMenuModel.action(for: terminal, holderHibernationEnabled: false, panelHoldsPTY: false) == nil)
     }
 
     /// Branch 3: a Claude session waiting on a permission prompt — hibernating
     /// would eat the raised hand → no item.
     @Test func waitingForUserTerminalOffersNothing() {
         let terminal = claudeTerminal(activityState: .waitingForUser)
-        #expect(TabParkMenuModel.action(for: terminal, holderHibernationEnabled: false) == nil)
+        #expect(TabParkMenuModel.action(for: terminal, holderHibernationEnabled: false, panelHoldsPTY: false) == nil)
     }
 
     /// Branch 3: no terminal backing the tab → no item.
     @Test func nilTerminalOffersNothing() {
-        #expect(TabParkMenuModel.action(for: nil, holderHibernationEnabled: false) == nil)
+        #expect(TabParkMenuModel.action(for: nil, holderHibernationEnabled: false, panelHoldsPTY: false) == nil)
     }
 
     /// Branch 3: non-Claude terminals (plain shell, Codex) are never
@@ -72,8 +74,8 @@ struct TabParkMenuModelTests {
                              tmuxPaneID: "%1", kind: .shell, activityState: .idle)
         let codex = Terminal(id: UUID(), worktreeID: UUID(), tmuxWindowID: "@2",
                              tmuxPaneID: "%2", kind: .codex, activityState: .idle)
-        #expect(TabParkMenuModel.action(for: shell, holderHibernationEnabled: false) == nil)
-        #expect(TabParkMenuModel.action(for: codex, holderHibernationEnabled: false) == nil)
+        #expect(TabParkMenuModel.action(for: shell, holderHibernationEnabled: false, panelHoldsPTY: false) == nil)
+        #expect(TabParkMenuModel.action(for: codex, holderHibernationEnabled: false, panelHoldsPTY: false) == nil)
     }
 
     /// Both branches of the holder soak gate. The menu must agree with the rail
@@ -85,9 +87,9 @@ struct TabParkMenuModelTests {
             id: UUID(), worktreeID: UUID(), tmuxWindowID: "", tmuxPaneID: "",
             claudeSessionID: "session-1", kind: .claude, activityState: .idle,
             transport: .holder)
-        #expect(TabParkMenuModel.action(for: holder, holderHibernationEnabled: false) == nil)
+        #expect(TabParkMenuModel.action(for: holder, holderHibernationEnabled: false, panelHoldsPTY: false) == nil)
         #expect(
-            TabParkMenuModel.action(for: holder, holderHibernationEnabled: true) == .hibernate)
+            TabParkMenuModel.action(for: holder, holderHibernationEnabled: true, panelHoldsPTY: false) == .hibernate)
     }
 
     /// A PARKED holder tab offers Wake under both values: the gate decides
@@ -98,8 +100,8 @@ struct TabParkMenuModelTests {
             id: UUID(), worktreeID: UUID(), tmuxWindowID: "", tmuxPaneID: "",
             claudeSessionID: "session-1", kind: .claude, activityState: .idle,
             hibernatedAt: Date(), transport: .holder)
-        #expect(TabParkMenuModel.action(for: parked, holderHibernationEnabled: false) == .wake)
-        #expect(TabParkMenuModel.action(for: parked, holderHibernationEnabled: true) == .wake)
+        #expect(TabParkMenuModel.action(for: parked, holderHibernationEnabled: false, panelHoldsPTY: false) == .wake)
+        #expect(TabParkMenuModel.action(for: parked, holderHibernationEnabled: true, panelHoldsPTY: false) == .wake)
     }
 
     /// A tmux tab is unaffected by either value, which is what makes the two
@@ -108,8 +110,56 @@ struct TabParkMenuModelTests {
         let terminal = claudeTerminal()
         for enabled in [false, true] {
             #expect(
-                TabParkMenuModel.action(for: terminal, holderHibernationEnabled: enabled)
+                TabParkMenuModel.action(for: terminal, holderHibernationEnabled: enabled, panelHoldsPTY: false)
                     == .hibernate)
         }
+    }
+
+    /// Both branches of the viewer suppression, on a holder tab with the soak
+    /// gate ON — so the only thing moving is whether this app's panel owns the
+    /// pty.
+    ///
+    /// The daemon fail-closes a park while a viewer holds the pty: its
+    /// pending-input rail judges its own emulator, which is frozen for the
+    /// duration of the attach. A Hibernate item offered there errors every
+    /// single time, which is worse than no item at all.
+    @Test func holderTabWithAnAttachedPanelOffersNothing() {
+        let holder = Terminal(
+            id: UUID(), worktreeID: UUID(), tmuxWindowID: "", tmuxPaneID: "",
+            claudeSessionID: "session-1", kind: .claude, activityState: .idle,
+            transport: .holder)
+        #expect(
+            TabParkMenuModel.action(
+                for: holder, holderHibernationEnabled: true, panelHoldsPTY: true) == nil)
+        #expect(
+            TabParkMenuModel.action(
+                for: holder, holderHibernationEnabled: true, panelHoldsPTY: false)
+                == .hibernate)
+    }
+
+    /// A tmux tab is unaffected by the same input, which is what makes the test
+    /// above about the transport rather than about an attached panel alone: the
+    /// daemon reads a tmux pane's screen with `capture-pane` whoever is looking
+    /// at it.
+    @Test func tmuxTabIsUnaffectedByAnAttachedPanel() {
+        let terminal = claudeTerminal()
+        for held in [false, true] {
+            #expect(
+                TabParkMenuModel.action(
+                    for: terminal, holderHibernationEnabled: true, panelHoldsPTY: held)
+                    == .hibernate)
+        }
+    }
+
+    /// A PARKED holder tab still offers Wake with a panel attached: a parked
+    /// row has no pty for anything to hold, and the wake path reads no screen.
+    @Test func parkedHolderTabOffersWakeEvenWithAnAttachedPanel() {
+        let parked = Terminal(
+            id: UUID(), worktreeID: UUID(), tmuxWindowID: "", tmuxPaneID: "",
+            claudeSessionID: "session-1", kind: .claude, activityState: .idle,
+            hibernatedAt: Date(), transport: .holder)
+        #expect(
+            TabParkMenuModel.action(
+                for: parked, holderHibernationEnabled: true, panelHoldsPTY: true) == .wake)
     }
 }

--- a/Tests/TBDAppTests/TabParkMenuModelTests.swift
+++ b/Tests/TBDAppTests/TabParkMenuModelTests.swift
@@ -75,4 +75,41 @@ struct TabParkMenuModelTests {
         #expect(TabParkMenuModel.action(for: shell, holderHibernationEnabled: false) == nil)
         #expect(TabParkMenuModel.action(for: codex, holderHibernationEnabled: false) == nil)
     }
+
+    /// Both branches of the holder soak gate. The menu must agree with the rail
+    /// the daemon will apply: with the gate off a holder tab offers nothing,
+    /// because a Hibernate item there could only ever produce a refusal the
+    /// user cannot act on; with it on the same tab offers Hibernate.
+    @Test func holderTabFollowsTheSoakGate() {
+        let holder = Terminal(
+            id: UUID(), worktreeID: UUID(), tmuxWindowID: "", tmuxPaneID: "",
+            claudeSessionID: "session-1", kind: .claude, activityState: .idle,
+            transport: .holder)
+        #expect(TabParkMenuModel.action(for: holder, holderHibernationEnabled: false) == nil)
+        #expect(
+            TabParkMenuModel.action(for: holder, holderHibernationEnabled: true) == .hibernate)
+    }
+
+    /// A PARKED holder tab offers Wake under both values: the gate decides
+    /// whether a park may happen, and a row that is already parked has to be
+    /// wakeable however it got there — an older daemon, or the reconcile rail.
+    @Test func parkedHolderTabAlwaysOffersWake() {
+        let parked = Terminal(
+            id: UUID(), worktreeID: UUID(), tmuxWindowID: "", tmuxPaneID: "",
+            claudeSessionID: "session-1", kind: .claude, activityState: .idle,
+            hibernatedAt: Date(), transport: .holder)
+        #expect(TabParkMenuModel.action(for: parked, holderHibernationEnabled: false) == .wake)
+        #expect(TabParkMenuModel.action(for: parked, holderHibernationEnabled: true) == .wake)
+    }
+
+    /// A tmux tab is unaffected by either value, which is what makes the two
+    /// tests above about the transport rather than about the flag alone.
+    @Test func tmuxTabIsUnaffectedByTheSoakGate() {
+        let terminal = claudeTerminal()
+        for enabled in [false, true] {
+            #expect(
+                TabParkMenuModel.action(for: terminal, holderHibernationEnabled: enabled)
+                    == .hibernate)
+        }
+    }
 }

--- a/Tests/TBDCLITests/ConfigCommandsTests.swift
+++ b/Tests/TBDCLITests/ConfigCommandsTests.swift
@@ -1,3 +1,4 @@
+import ArgumentParser
 import Foundation
 import Testing
 
@@ -112,5 +113,22 @@ struct ConfigCommandsTests {
         let rendered = ConfigGet.render(config)
         #expect(rendered.contains("update-mode: check"))
         #expect(rendered.contains("auto-archive-on-merge: off"))
+    }
+
+    // MARK: - tbd config holder-hibernation
+
+    /// The soak switch for a background sweep that can kill a live holder-owned
+    /// agent process needs a hand-reachable CLI leg, or "enable it for the
+    /// soak" means hand-editing `state.db` — which this project's rules put
+    /// out of bounds.
+    @Test func holderHibernationIsRegisteredOnTheConfigGroup() {
+        let names = ConfigCommand.configuration.subcommands.map { $0._commandName }
+        #expect(names.contains("holder-hibernation"))
+    }
+
+    @Test func holderHibernationTakesTheStateWordAsARequiredPositional() throws {
+        #expect(try ConfigHolderHibernation.parse(["on"]).state == "on")
+        #expect(try ConfigHolderHibernation.parse(["off"]).state == "off")
+        #expect(throws: (any Error).self) { try ConfigHolderHibernation.parse([]) }
     }
 }

--- a/Tests/TBDDaemonLiveTests/Holder/HolderHibernationLiveTests.swift
+++ b/Tests/TBDDaemonLiveTests/Holder/HolderHibernationLiveTests.swift
@@ -97,6 +97,38 @@ struct HolderHibernationLiveTests {
         #expect(await fixture.registry.reader(for: terminal.id) != nil,
                 "nothing is draining the woken session's pty")
 
+        // WHAT it launched. Every assertion above is satisfied by a holder
+        // running the wrong command entirely — a fresh session instead of a
+        // resume, or one attributed to another terminal — because a row and a
+        // pid cannot see an argv. The stub can.
+        //
+        // Waiting on the env file is what makes the argv file safe to read:
+        // the stub writes the argv first and the environment last.
+        let launched = await pollUntil("the woken session to reach its claude stub") {
+            (try? String(contentsOfFile: fixture.launchEnvPath, encoding: .utf8))?
+                .contains("TBD_TERMINAL_ID=") ?? false
+        }
+        #expect(launched, "the wake never launched anything through the pinned shell")
+        let argv = ((try? String(contentsOfFile: fixture.launchArgvPath, encoding: .utf8)) ?? "")
+            .split(separator: "\n").map(String.init)
+        let resumeIndex = argv.firstIndex(of: "--resume")
+        #expect(resumeIndex != nil, "the wake did not resume anything: \(argv)")
+        if let resumeIndex, resumeIndex + 1 < argv.count {
+            // Adjacency, not mere presence: `--resume` and the session id have
+            // to be one flag, or a resume of some OTHER session would pass.
+            #expect(argv[resumeIndex + 1] == HibernationFixture.sessionID,
+                    "resumed the wrong session: \(argv)")
+        }
+        let launchEnv = (try? String(contentsOfFile: fixture.launchEnvPath, encoding: .utf8)) ?? ""
+        // The two ids every hook, notification and transcript write is
+        // attributed by. Delivered as inline exports ahead of the command, so
+        // reading them back OUT of the process environment is what proves the
+        // delivery, not just the composition.
+        #expect(launchEnv.contains("TBD_WORKTREE_ID=\(fixture.worktree.id.uuidString)"),
+                "the woken agent is attributed to the wrong worktree: \(launchEnv)")
+        #expect(launchEnv.contains("TBD_TERMINAL_ID=\(terminal.id.uuidString)"),
+                "the woken agent is attributed to the wrong terminal: \(launchEnv)")
+
         // Tear the woken session down through the same door the delete path
         // uses, so neither the holder nor its job outlives the test.
         _ = await fixture.registry.abandon(terminal: woken)
@@ -161,6 +193,13 @@ private final class HibernationFixture {
     let coordinator: HibernationCoordinator
     let environment: [String: String]
     let worktree: Worktree
+
+    /// Where the `claude` stub records the argv it was launched with, one
+    /// argument per line, and the `TBD_` environment it saw. Neither exists
+    /// until a wake has actually launched something.
+    var launchArgvPath: String { "\(home)/launch-argv" }
+    var launchEnvPath: String { "\(home)/launch-env" }
+
     private let home: String
     private let tempDir: URL
     private var torndown = false
@@ -172,17 +211,50 @@ private final class HibernationFixture {
         fencedScratchRoot(prefix: "tbdhib")
     }
 
-    /// The stand-in login shell the WAKE spawn runs. It ignores the
-    /// `-i -l -c <command>` argv the production composition hands it, which is
-    /// the point: the resumed "agent" is a controlled two-line program.
+    /// The stand-in login shell the WAKE spawn runs, plus the `claude` stub it
+    /// puts ahead of everything else on PATH.
+    ///
+    /// The shell HONOURS its `-i -l -c <command>` argv rather than ignoring it,
+    /// because that argv is the artifact under test. Evaluating it is what
+    /// turns the composition's inline `export TBD_…` statements into real
+    /// environment variables and what launches "claude" — so the stub can
+    /// record the argv and the environment the resumed agent would actually
+    /// have been given. Nothing here can reach a real agent: `claude` resolves
+    /// to the stub, which is a four-line script.
+    ///
+    /// The stub returns instead of blocking, so the shell reaches its
+    /// `exec sleep` and the job stays exactly one pid — the one the row names
+    /// and the one teardown kills. A stub that blocked would leave a grandchild
+    /// no row names.
     private static func writeGateShell(in home: String) throws -> String {
         try FileManager.default.createDirectory(
             atPath: home, withIntermediateDirectories: true,
             attributes: [.posixPermissions: 0o700])
-        let path = "\(home)/gate-shell"
+        let binDir = "\(home)/bin"
+        try FileManager.default.createDirectory(
+            atPath: binDir, withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700])
+
+        // The argv file is written first and the env file last, so a reader
+        // that waits for the env file has a complete argv file to read.
         try """
         #!/bin/sh
+        printf '%s\\n' "$@" > "\(home)/launch-argv"
         printf 'WOKE-OK\\n'
+        env | grep '^TBD_' > "\(home)/launch-env"
+        """.write(toFile: "\(binDir)/claude", atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o700], ofItemAtPath: "\(binDir)/claude")
+
+        let path = "\(home)/gate-shell"
+        // The command is the LAST argument whatever flags precede it, which is
+        // what keeps this shell honest about a `shellFlags` change.
+        try """
+        #!/bin/sh
+        PATH="\(binDir):$PATH"
+        export PATH
+        for tbd_arg in "$@"; do tbd_command="$tbd_arg"; done
+        eval "$tbd_command"
         exec sleep 30
         """.write(toFile: path, atomically: true, encoding: .utf8)
         try FileManager.default.setAttributes(
@@ -322,18 +394,29 @@ private final class HibernationFixture {
         try? FileManager.default.removeItem(at: tempDir)
     }
 
-    /// Reads the terminal rows from a non-async `tearDown`. Bounded, and a
-    /// timeout simply means the sweep above has nothing to kill by pid — the
-    /// suite would rather report that than hang.
+    /// Reads the terminal rows from a non-async `tearDown`.
+    ///
+    /// `tearDown` runs from a `defer` in the test body, so the thread this
+    /// blocks belongs to the cooperative pool and cannot be moved from here.
+    /// What CAN be moved is the side that releases the gate: started with
+    /// `gateHoldingTask` it runs on a thread these tests own — and the
+    /// executor preference carries into the store actor it hops through — so
+    /// the read can always reach `signal()` however saturated the pool is.
+    /// `Task.detached` took no preference at all and queued the release behind
+    /// the very pool this wait is starving.
+    ///
+    /// `waitForGate` supplies the bound and names the gate if it ever expires,
+    /// which is all a teardown can usefully do about one: a timeout simply
+    /// means the sweep above has nothing to kill by pid.
     private func blockingTerminals() throws -> [Terminal] {
         let box = ResultBox()
         let done = DispatchSemaphore(value: 0)
         let db = self.db
-        Task.detached {
+        _ = gateHoldingTask {
             box.value = try? await db.terminals.list()
             done.signal()
         }
-        _ = done.wait(timeout: .now() + 5)
+        done.waitForGate("HibernationFixture.tearDown reading the terminal rows")
         return box.value ?? []
     }
 

--- a/Tests/TBDDaemonLiveTests/Holder/HolderHibernationLiveTests.swift
+++ b/Tests/TBDDaemonLiveTests/Holder/HolderHibernationLiveTests.swift
@@ -21,12 +21,17 @@ import Testing
 @Suite(.serialized)
 struct HolderHibernationLiveTests {
 
-    /// The park's whole point, against a job that cannot cooperate.
+    /// The park's whole point, against a job that cannot cooperate — and the
+    /// middle rung of the ladder, proved by the job's own hand.
     ///
-    /// `while :; do sleep 1; done` never reads its terminal, so the polite
-    /// `/exit` cannot possibly work and the escalation is what has to end it.
-    /// That is deliberately the harder half: a test whose job exited on `/exit`
-    /// would pass without the escalation ever running.
+    /// The job never reads its terminal, so the polite `/exit` cannot possibly
+    /// work and something further down has to end it. That is deliberately the
+    /// harder half: a test whose job exited on `/exit` would pass without any
+    /// escalation ever running. What ends it here is the `SIGTERM` rung, and
+    /// the marker file is what says so rather than leaving it to be inferred
+    /// from a dead pid — a `SIGKILL` cannot run a handler, so a park that
+    /// skipped the `SIGTERM` rung and went straight to the forced one would
+    /// leave that file absent while every other assertion below still passed.
     @Test func parkEndsTheJobAndClearsTheRow() async throws {
         let fixture = try await HibernationFixture.make()
         defer { fixture.tearDown() }
@@ -76,6 +81,43 @@ struct HolderHibernationLiveTests {
         // off the pty.
         #expect(await fixture.registry.reader(for: terminal.id) == nil,
                 "the registry still holds a reader for a parked session")
+        // WHICH rung ended it. The job wrote this from its own `SIGTERM`
+        // handler, so its existence is the one fact that separates the polite
+        // rung's successor from the forced teardown after it.
+        #expect(FileManager.default.fileExists(atPath: fixture.jobTermMarkerPath),
+                "the job never caught a SIGTERM, so the park skipped the rung between /exit and the forced teardown")
+    }
+
+    /// The rung after that one, on a job that declines `SIGTERM`.
+    ///
+    /// `trap '' TERM` is what makes this a test of the forced teardown rather
+    /// than of the ladder generally: the polite `/exit` is unread, the
+    /// `SIGTERM` is ignored, and the only thing left that can end this process
+    /// is the `SIGKILL` `HolderRegistry.abandon` sends to its group. A park
+    /// that stopped at the middle rung would report the child survived and roll
+    /// itself back.
+    @Test func parkEscalatesToTheForcedRungWhenTheJobIgnoresSIGTERM() async throws {
+        // Three attempts rather than the fixture default: this poll is
+        // guaranteed to fail every time, so its budget is pure wall time.
+        let fixture = try await HibernationFixture.make(holderTerminateAttempts: 3)
+        defer { fixture.tearDown() }
+        let terminal = try await fixture.spawnHolderRow(job: HibernationFixture.signalDeafJob)
+        let childPID = try #require(terminal.childPID)
+        let holderPID = try #require(terminal.holderPID)
+
+        let result = await fixture.coordinator.manualHibernate(terminalID: terminal.id)
+        #expect(result == .ok, "park refused: \(result)")
+
+        let parked = try #require(try await fixture.db.terminals.get(id: terminal.id))
+        #expect(parked.isParked)
+        #expect(parked.childPID == nil)
+        let signalled = kill(childPID, 0)
+        let signalErrno = errno
+        #expect(signalled == -1 && signalErrno == ESRCH,
+                "a job that ignores SIGTERM survived the park (kill returned \(signalled), errno \(signalErrno))")
+        #expect(!holderProcessIsAlive(holderPID), "the holder outlived the park")
+        #expect(!FileManager.default.fileExists(atPath: fixture.jobTermMarkerPath),
+                "this job has no SIGTERM handler, so a marker here means the fixture wrote it")
     }
 
     /// Wake after that park: a fresh holder, a fresh job, and a row that names
@@ -209,7 +251,8 @@ struct HolderHibernationLiveTests {
     /// that claims parked over a live child.
     @Test func parkRollsBackWhenTheChildOutlivesTheEscalation() async throws {
         let fixture = try await HibernationFixture.make(
-            holderEscalationAttempts: 3, signaller: AlwaysAliveSignaller())
+            holderTerminateAttempts: 3, holderEscalationAttempts: 3,
+            signaller: AlwaysAliveSignaller())
         defer { fixture.tearDown() }
         let terminal = try await fixture.spawnHolderRow()
         let childPID = try #require(terminal.childPID)
@@ -300,33 +343,192 @@ struct HolderHibernationLiveTests {
         try await fixture.db.terminals.setHolderProcess(
             id: terminal.id, holderPID: nil, childPID: nil, startedAt: nil)
     }
+
+    /// "Keep when uncertain", on the park path: a recorded pid that now names a
+    /// stranger is signalled by nothing at all.
+    ///
+    /// The stranger is arranged through the signaller rather than through the
+    /// process table, because a real pid reissued to somebody else's work is
+    /// the one condition a test cannot ask a kernel for. Everything else is
+    /// real: a real holder, a real job, and a real teardown afterwards.
+    ///
+    /// The job declines `SIGHUP` and nothing else, which is what makes its
+    /// survival mean something. Telling the holder to let go — which this
+    /// refusal still does, since a daemon reading a pty whose job it cannot
+    /// identify is worse than one that has let go — closes the pty master and
+    /// hangs the job up, so a default-disposition job would die of that and the
+    /// assertion below could not tell it from a park that signalled. This one
+    /// survives the hangup and would not survive either signal.
+    @Test func parkRefusesToSignalAChildItCannotVerify() async throws {
+        let stranger = StrangerSignaller()
+        let fixture = try await HibernationFixture.make(signaller: stranger)
+        defer { fixture.tearDown() }
+        let terminal = try await fixture.spawnHolderRow(job: HibernationFixture.hangupDeafJob)
+        let childPID = try #require(terminal.childPID)
+        let startedAt = try #require(terminal.holderChildStartedAt)
+
+        let result = await fixture.coordinator.manualHibernate(terminalID: terminal.id)
+
+        guard case .notEligible(let reason) = result else {
+            Issue.record("the park reported \(result) for a pid it could not verify")
+            return
+        }
+        #expect(reason.contains("\(childPID)"),
+                "the refusal does not name the pid it declined to signal: \(reason)")
+        #expect(reason.contains("could not be verified"),
+                "the refusal does not say why it stopped: \(reason)")
+
+        // Nothing was asked of the process table, which is the whole claim.
+        // Asserting on the request rather than on the survivor is what makes
+        // this independent of what a signal would have done.
+        #expect(stranger.signalsRequested().isEmpty,
+                "the park signalled a pid it could not verify: \(stranger.signalsRequested())")
+        // And the job really is still there. A `SIGTERM` or a `SIGKILL` would
+        // have ended it; the hangup the holder's forget delivered did not.
+        #expect(holderProcessIsAlive(childPID),
+                "the job died, so something ended it after the identity check refused")
+
+        let after = try #require(try await fixture.db.terminals.get(id: terminal.id))
+        #expect(!after.isParked, "a refused park still parked the row")
+        #expect(after.pendingSessionIncarnationID == nil,
+                "the park intent's pending incarnation outlived the rollback")
+        // The pids stay, because the row left awake is the last record of a
+        // session the reconcile arm and the reaper's holder leg now have to
+        // judge — both of which apply this same identity check and will keep
+        // for this same reason.
+        #expect(after.childPID == childPID, "the refusal erased the child pid")
+        #expect(after.holderChildStartedAt == startedAt,
+                "the refusal erased the child's identity anchor")
+        // The holder was told to let go, so the daemon is off this pty.
+        #expect(await fixture.registry.reader(for: terminal.id) == nil,
+                "the daemon is still reading a session whose job it cannot identify")
+    }
+
+    /// The wake's adopt guard, on the row shape that made it necessary: parked,
+    /// naming no processes, behind a holder that is alive and adopted.
+    ///
+    /// That row is what a daemon killed between `HolderRegistry.spawn`
+    /// publishing its reader and `wakeHolderSection` persisting the pids leaves
+    /// behind, and `adoptAll` re-adopts the holder on the next start regardless
+    /// of park state — so the reader is back while the row still names nothing.
+    /// Un-parking it without restoring the pids would put that session beyond
+    /// every reclaimer this transport has, permanently and silently.
+    ///
+    /// The nil pids are written directly rather than produced by killing a
+    /// daemon, and that is the whole of the simulation: the state under test is
+    /// the row, and the registry either holds a live reader for the session or
+    /// it does not.
+    @Test func wakeRestoresThePidsOfARowThatLostThemMidSpawn() async throws {
+        let fixture = try await HibernationFixture.make()
+        defer { fixture.tearDown() }
+        let terminal = try await fixture.spawnHolderRow()
+        let childPID = try #require(terminal.childPID)
+        let holderPID = try #require(terminal.holderPID)
+
+        // The crash window, reproduced as state: the row is parked and names
+        // nothing, while the registry is still reading the session's holder.
+        try await fixture.db.terminals.setHolderProcess(
+            id: terminal.id, holderPID: nil, childPID: nil, startedAt: nil)
+        try await fixture.db.terminals.setHibernated(
+            id: terminal.id, sessionID: HibernationFixture.sessionID)
+        #expect(await fixture.registry.reader(for: terminal.id) != nil,
+                "the fixture lost its reader, so this test would exercise the wrong branch")
+
+        let result = await fixture.coordinator.wake(terminalID: terminal.id)
+        #expect(result == .ok, "wake refused: \(result)")
+
+        let woken = try #require(try await fixture.db.terminals.get(id: terminal.id))
+        #expect(!woken.isParked)
+        // The pid anchor, restored from what the registry itself observed.
+        #expect(woken.childPID == childPID,
+                "the woken row names \(String(describing: woken.childPID)) rather than the child the registry is reading")
+        #expect(woken.holderPID == holderPID,
+                "the woken row names \(String(describing: woken.holderPID)) rather than the holder the registry is reading")
+        #expect(woken.holderChildStartedAt != nil,
+                "the row was un-parked with no identity anchor for its child")
+        // Asked of the process table rather than of the row: the number is only
+        // an anchor if it still names this session's job.
+        #expect(holderProcessIsAlive(childPID), "the restored child pid names nothing")
+        let command = ProductionProcessSignaller().commandLine(childPID) ?? ""
+        #expect(AgentReaper.isHolderChildExecutable(command),
+                "the restored pid names something no holder would have forked: \(command)")
+
+        // And nothing was spawned. Two independent facts: the registry is still
+        // reading the ORIGINAL session (a spawn would have been refused by the
+        // creation lock, or would have replaced these pids with a second
+        // generation's), and the wake's pinned shell — which every spawned
+        // holder runs and this session's job does not — never ran.
+        #expect(await fixture.registry.reader(for: terminal.id) != nil,
+                "the wake released the reader it was supposed to adopt")
+        #expect(!FileManager.default.fileExists(atPath: fixture.launchArgvPath),
+                "the wake spawned a second holder instead of adopting the live one")
+    }
 }
 
 // MARK: - A process table that never concedes
 
-/// Answers "alive, and not a corpse" for every pid, forever.
+/// Answers "alive, this session's own child, and not a corpse" for every pid,
+/// forever.
 ///
-/// The two members that matter are `isAlive` and `stat`: `childIsGone` treats a
-/// `Z…` stat as gone (a zombie is past its last instruction) and everything
-/// else as running, so a fake that answered nil for `stat` would be relying on
-/// that branch's nil handling rather than stating the case. Answering `"S"`
-/// states it.
+/// Two questions have to be answered together, because the park asks both. The
+/// liveness pair — `isAlive` and `stat` — is what `childIsGone` reads: a `Z…`
+/// stat is gone (a zombie is past its last instruction) and everything else is
+/// running, so a fake that answered nil for `stat` would be relying on that
+/// branch's nil handling rather than stating the case. Answering `"S"` states
+/// it.
 ///
-/// The rest are stubs because the park path never reaches them — it signals
-/// through the registry, not through this seam — and stubbing them is
-/// deliberate rather than lazy: a signaller that quietly swallowed a real
-/// `kill` would turn "the escalation ran" into an untestable claim.
+/// The identity pair — `startTime` and `commandLine` — is what every rung of
+/// the ladder verifies before it signals, and it must pass here or this test
+/// would measure the identity refusal instead of the rollback it is named for.
+/// `Date()` sits well inside `AgentReaper.defaultHolderIdentityWindow` of the
+/// row's own anchor, and `/bin/sh` is what this fixture's job really is.
+///
+/// The signal members are no-ops, which is deliberate rather than lazy: the
+/// escalation the test is about reaches the job through the REGISTRY, not
+/// through this seam, so a fake that quietly swallowed a real `kill` would turn
+/// "the escalation ran" into an untestable claim — and a `SIGTERM` rung that
+/// went through here must land nowhere, or the job would die and the branch
+/// under test would never be reached.
 private struct AlwaysAliveSignaller: ProcessSignaller {
     func isAlive(_ pid: Int32) -> Bool { true }
     func terminate(_ pid: Int32) {}
     func forceKill(_ pid: Int32) {}
     func children(ofServerPID serverPID: Int32) -> [Int32] { [] }
-    func commandLine(_ pid: Int32) -> String? { nil }
+    func commandLine(_ pid: Int32) -> String? { "/bin/sh" }
     func stat(_ pid: Int32) -> String? { "S" }
-    /// Nil, which every identity check must read as "not the same process".
-    /// Nothing on the park path asks, and a fake that invented a start time
-    /// would be answering a question it cannot know.
-    func startTime(_ pid: Int32) -> Date? { nil }
+    func startTime(_ pid: Int32) -> Date? { Date() }
+}
+
+/// A process table on which every pid is a stranger: alive, and started long
+/// before the row that names it.
+///
+/// The one shape the identity check exists for — a pid the kernel has reissued
+/// to somebody else's work — and the only one no real process table can be
+/// asked to produce on demand. Every signal it is asked for is RECORDED and
+/// none is delivered, so a test can assert what the park tried to do
+/// independently of what survived.
+private final class StrangerSignaller: ProcessSignaller, @unchecked Sendable {
+    private let lock = NSLock()
+    private var calls: [String] = []
+
+    /// Every signal this seam was asked to deliver, in order.
+    func signalsRequested() -> [String] { lock.withLock { calls } }
+
+    func isAlive(_ pid: Int32) -> Bool { true }
+    func terminate(_ pid: Int32) { lock.withLock { calls.append("terminate(\(pid))") } }
+    func forceKill(_ pid: Int32) { lock.withLock { calls.append("forceKill(\(pid))") } }
+    func terminateProcessOnly(_ pid: Int32) {
+        lock.withLock { calls.append("terminateProcessOnly(\(pid))") }
+    }
+    func forceKillProcessOnly(_ pid: Int32) {
+        lock.withLock { calls.append("forceKillProcessOnly(\(pid))") }
+    }
+    func children(ofServerPID serverPID: Int32) -> [Int32] { [] }
+    func commandLine(_ pid: Int32) -> String? { "/bin/sh" }
+    func stat(_ pid: Int32) -> String? { "S" }
+    /// Two hours before any row in this suite was written — far outside
+    /// `AgentReaper.defaultHolderIdentityWindow`, which is five minutes.
+    func startTime(_ pid: Int32) -> Date? { Date(timeIntervalSinceNow: -7200) }
 }
 
 // MARK: - Fixture
@@ -338,9 +540,35 @@ private final class HibernationFixture {
     /// real Claude: the pinned shell ignores the argv it is handed.
     static let sessionID = "sess-holder-hibernation"
 
-    /// A job that cannot cooperate with `/exit`: it never reads its terminal,
-    /// so the polite poll must fail and the escalation must be what ends it.
-    private static let uncooperativeJob = "while :; do sleep 1; done"
+    /// The default job: deaf to `/exit`, and honest about `SIGTERM`.
+    ///
+    /// It never reads its terminal, so the polite rung cannot possibly work and
+    /// something further down the ladder has to end it. What it *does* do is
+    /// catch `SIGTERM` and leave a mark before exiting — which is what makes
+    /// "the SIGTERM rung ended this job" an observable claim rather than an
+    /// inference from a dead pid: a `SIGKILL` cannot run a handler, so the
+    /// marker exists if and only if the middle rung is what worked.
+    ///
+    /// The loop sleeps in fifths of a second because a POSIX shell runs a trap
+    /// only after the foreground command it was waiting on completes; a
+    /// one-second sleep would put up to a second of the poll window between the
+    /// signal and the handler for no benefit.
+    static func termAwareJob(markerPath: String) -> String {
+        "trap 'printf term > \"\(markerPath)\"; exit 0' TERM; while :; do sleep 0.2; done"
+    }
+
+    /// A job that ignores `SIGTERM` outright, so only the forced rung — the
+    /// holder let go of, the process group `SIGKILL`ed — can end it.
+    static let signalDeafJob = "trap '' TERM; while :; do sleep 0.2; done"
+
+    /// A job that ignores `SIGHUP` and nothing else.
+    ///
+    /// For the one test that must distinguish "the park signalled this pid"
+    /// from "the pty master closed underneath it": telling a holder to let go
+    /// hangs its job up, which a default-disposition job dies of, so a job that
+    /// declines the hangup is the only one whose survival proves nothing was
+    /// signalled. `SIGTERM` and `SIGKILL` both still end it.
+    static let hangupDeafJob = "trap '' HUP; while :; do sleep 0.2; done"
 
     let db: TBDDatabase
     let registry: HolderRegistry
@@ -353,6 +581,10 @@ private final class HibernationFixture {
     /// until a wake has actually launched something.
     var launchArgvPath: String { "\(home)/launch-argv" }
     var launchEnvPath: String { "\(home)/launch-env" }
+
+    /// Where `termAwareJob` records that it caught a `SIGTERM`. Absent until
+    /// one is actually delivered and handled.
+    var jobTermMarkerPath: String { "\(home)/job-caught-term" }
 
     private let home: String
     private let tempDir: URL
@@ -417,6 +649,12 @@ private final class HibernationFixture {
     }
 
     /// - Parameters:
+    ///   - holderTerminateAttempts: how many times the poll after the `SIGTERM`
+    ///     rung asks whether the job is gone. 25 at this fixture's 100 ms
+    ///     interval is 2.5 s, which is generous next to the fifth of a second a
+    ///     cooperating job takes to reach its trap and mean next to the shipped
+    ///     five seconds. A test that has arranged for that poll to NEVER
+    ///     succeed passes a small number and buys back the wall time.
     ///   - holderEscalationAttempts: how many times the post-escalation poll
     ///     asks whether the job is gone. The shipped default is generous
     ///     because a real `SIGKILL` lands on a real process table; a test that
@@ -428,6 +666,7 @@ private final class HibernationFixture {
     ///     real process can reach.
     static func make(
         holderHibernationEnabled: Bool = true,
+        holderTerminateAttempts: Int = 25,
         holderEscalationAttempts: Int = 100,
         signaller: any ProcessSignaller = ProductionProcessSignaller()
     ) async throws -> HibernationFixture {
@@ -484,6 +723,7 @@ private final class HibernationFixture {
             // there the generosity is pure wall time.
             exitPollAttempts: 2,
             exitPollInterval: .milliseconds(100),
+            holderTerminateAttempts: holderTerminateAttempts,
             holderEscalationAttempts: holderEscalationAttempts,
             signaller: signaller,
             actuationLog: makeTestActuationLog())
@@ -510,13 +750,13 @@ private final class HibernationFixture {
     /// A real holder supervising a real job, plus the row that names both —
     /// created in the order `WorktreeLifecycle+Create` creates them, so the
     /// registry has adopted the session before anything reads its screen.
-    func spawnHolderRow() async throws -> Terminal {
+    func spawnHolderRow(job: String? = nil) async throws -> Terminal {
         let terminalID = UUID()
         let handle = try await registry.spawn(
             terminalID: terminalID,
             launch: HolderLaunchRequest(
                 executable: "/bin/sh",
-                arguments: ["-c", Self.uncooperativeJob],
+                arguments: ["-c", job ?? Self.termAwareJob(markerPath: jobTermMarkerPath)],
                 workingDirectory: "/tmp",
                 environment: ["PATH": "/usr/bin:/bin", "TERM": "xterm-256color"],
                 columns: 80,

--- a/Tests/TBDDaemonLiveTests/Holder/HolderHibernationLiveTests.swift
+++ b/Tests/TBDDaemonLiveTests/Holder/HolderHibernationLiveTests.swift
@@ -173,6 +173,145 @@ struct HolderHibernationLiveTests {
         #expect(await fixture.coordinator.wake(terminalID: terminal.id) == .holderTransport)
         #expect(holderProcessIsAlive(childPID))
     }
+
+    /// The safety rollback: the park's own invariant, on the one path that
+    /// reaches it.
+    ///
+    /// A real job cannot survive the `SIGKILL` the escalation sends, so this
+    /// branch is unreachable against a real process table — which is why it
+    /// shipped untested. The verdict does not come from the process table
+    /// directly, though: it comes from `childIsGone`, whose two sources are the
+    /// registry's remembered status and the coordinator's injected
+    /// `signaller`. `abandon(terminal:)` nils the first as part of the
+    /// escalation, by design, so a signaller that answers "alive" with a
+    /// non-zombie `stat` is enough to make the poll say "still running" for as
+    /// long as it is asked — whatever the kernel thinks.
+    ///
+    /// The escalation still really runs: the holder is torn down and the job is
+    /// killed for real, through the registry, which the fake cannot reach. What
+    /// is under test is only what the coordinator does with a verdict it cannot
+    /// turn into "gone" — roll the park intent back rather than finalize a row
+    /// that claims parked over a live child.
+    @Test func parkRollsBackWhenTheChildOutlivesTheEscalation() async throws {
+        let fixture = try await HibernationFixture.make(
+            holderEscalationAttempts: 3, signaller: AlwaysAliveSignaller())
+        defer { fixture.tearDown() }
+        let terminal = try await fixture.spawnHolderRow()
+        let childPID = try #require(terminal.childPID)
+        let holderPID = try #require(terminal.holderPID)
+        let startedAt = try #require(terminal.holderChildStartedAt)
+        let incarnationBefore = terminal.sessionIncarnationID
+
+        // Arm the idle marker through the real sweep before parking, so the
+        // "the refusal cleared its markers" assertion below has something to
+        // clear. Without this the markers are nil going in and nil coming out,
+        // and the assertion passes whether or not the branch resets them.
+        //
+        // One sweep is all it takes and all that is wanted: the row is at rest
+        // but nowhere near a one-minute window, so the gate answers
+        // `.notIdleLongEnough`, which seeds `idleSince` and fires nothing.
+        try await fixture.db.config.setAutoHibernate(enabled: true, idleMinutes: 1)
+        await fixture.coordinator.sweep()
+        let armed = await fixture.coordinator.idleSince[terminal.id]
+        #expect(armed != nil,
+                "the sweep never armed the idle marker, so nothing below discriminates")
+
+        let result = await fixture.coordinator.manualHibernate(terminalID: terminal.id)
+
+        guard case .notEligible(let reason) = result else {
+            Issue.record(
+                "the park reported \(result) for a child it could never confirm gone")
+            return
+        }
+        // The pid is the whole operational value of this refusal — it is the
+        // only handle anybody has on a process whose holder has just been torn
+        // down — and "survived" is what stops the text reading like a park that
+        // worked.
+        #expect(reason.contains("\(childPID)"),
+                "the refusal does not name the child that outlived it: \(reason)")
+        #expect(reason.contains("survived"),
+                "the refusal does not say what happened: \(reason)")
+
+        let after = try #require(try await fixture.db.terminals.get(id: terminal.id))
+        // THE invariant. All three, because `isParked` is a disjunction and a
+        // rollback that nilled only one of the two columns would still satisfy
+        // the column assertion it happened to clear.
+        #expect(after.hibernatedAt == nil, "the row claims parked over a live child")
+        #expect(after.suspendedAt == nil, "the row claims suspended over a live child")
+        #expect(!after.isParked, "the row claims parked over a live child")
+        // The park intent is two writes, not one: the columns above and the
+        // pending incarnation `beginHibernatedShellRespawn` rotated in. A
+        // rollback that left the latter behind would fence the next legitimate
+        // replacement against an incarnation no launch will ever confirm.
+        #expect(after.pendingSessionIncarnationID == nil,
+                "the park intent's pending incarnation outlived the rollback")
+        #expect(after.sessionIncarnationID == incarnationBefore,
+                "the rollback promoted or rotated the durable incarnation")
+
+        // And the other half of "left awake for reconciliation to judge": the
+        // row must still name the processes. These three are the last record of
+        // a child whose holder is gone, so erasing them here would hide it from
+        // the reconcile arm and from the reaper's holder leg — the two things
+        // the refusal explicitly hands it to.
+        #expect(after.holderPID == holderPID, "the rollback erased the holder pid")
+        #expect(after.childPID == childPID, "the rollback erased the child pid")
+        #expect(after.holderChildStartedAt == startedAt,
+                "the rollback erased the child's identity anchor")
+
+        // The markers, cleared like every other refusal in the method. Leaving
+        // them armed would re-fire this identical doomed park on every sweep.
+        let idleMarker = await fixture.coordinator.idleSince[terminal.id]
+        let killMarker = await fixture.coordinator.pendingKillSince[terminal.id]
+        #expect(idleMarker == nil, "the rollback left the idle marker armed")
+        #expect(killMarker == nil, "the rollback left the kill debounce armed")
+
+        // Asked again, the coordinator refuses rather than reporting the
+        // session already parked — the state it would report if the rollback
+        // had left the row claiming a park. It refuses for the reader the
+        // escalation destroyed, which is the honest description of what this
+        // session now is.
+        let asked = await fixture.coordinator.manualHibernate(terminalID: terminal.id)
+        #expect(asked == .notEligible(reason: HibernationCoordinator.holderNoReaderRefusal),
+                "a second park did not refuse on the torn-down holder: \(asked)")
+
+        // The escalation was not a dry run, and this is what makes the pid
+        // assertions above safe to leave standing: the numbers on that row name
+        // nothing now. Teardown reads the row, so clear them here rather than
+        // letting it signal pids the kernel is free to hand to somebody else.
+        let reclaimed = await pollUntil("the escalation to reclaim the job and the holder") {
+            !holderProcessIsAlive(childPID) && !holderProcessIsAlive(holderPID)
+        }
+        #expect(reclaimed, "the escalation did not tear down what the refusal says it did")
+        try await fixture.db.terminals.setHolderProcess(
+            id: terminal.id, holderPID: nil, childPID: nil, startedAt: nil)
+    }
+}
+
+// MARK: - A process table that never concedes
+
+/// Answers "alive, and not a corpse" for every pid, forever.
+///
+/// The two members that matter are `isAlive` and `stat`: `childIsGone` treats a
+/// `Z…` stat as gone (a zombie is past its last instruction) and everything
+/// else as running, so a fake that answered nil for `stat` would be relying on
+/// that branch's nil handling rather than stating the case. Answering `"S"`
+/// states it.
+///
+/// The rest are stubs because the park path never reaches them — it signals
+/// through the registry, not through this seam — and stubbing them is
+/// deliberate rather than lazy: a signaller that quietly swallowed a real
+/// `kill` would turn "the escalation ran" into an untestable claim.
+private struct AlwaysAliveSignaller: ProcessSignaller {
+    func isAlive(_ pid: Int32) -> Bool { true }
+    func terminate(_ pid: Int32) {}
+    func forceKill(_ pid: Int32) {}
+    func children(ofServerPID serverPID: Int32) -> [Int32] { [] }
+    func commandLine(_ pid: Int32) -> String? { nil }
+    func stat(_ pid: Int32) -> String? { "S" }
+    /// Nil, which every identity check must read as "not the same process".
+    /// Nothing on the park path asks, and a fake that invented a start time
+    /// would be answering a question it cannot know.
+    func startTime(_ pid: Int32) -> Date? { nil }
 }
 
 // MARK: - Fixture
@@ -262,7 +401,21 @@ private final class HibernationFixture {
         return path
     }
 
-    static func make(holderHibernationEnabled: Bool = true) async throws -> HibernationFixture {
+    /// - Parameters:
+    ///   - holderEscalationAttempts: how many times the post-escalation poll
+    ///     asks whether the job is gone. The shipped default is generous
+    ///     because a real `SIGKILL` lands on a real process table; a test that
+    ///     has arranged for the poll to NEVER succeed pays every attempt, so it
+    ///     passes a small number and buys back the wall time.
+    ///   - signaller: the process table the park's liveness poll reads. The
+    ///     real one by default — the whole point of this suite is the kernel's
+    ///     own answers — overridden only where the branch under test is one no
+    ///     real process can reach.
+    static func make(
+        holderHibernationEnabled: Bool = true,
+        holderEscalationAttempts: Int = 100,
+        signaller: any ProcessSignaller = ProductionProcessSignaller()
+    ) async throws -> HibernationFixture {
         let home = scratchHome()
         let shell = try writeGateShell(in: home)
         let environment = [
@@ -309,12 +462,15 @@ private final class HibernationFixture {
             // Two attempts at 100 ms is the polite window; the job cannot use
             // it, so the run pays 200 ms to reach the escalation rather than
             // the shipped three seconds. The escalation budget is generous by
-            // contrast — it is a real `SIGKILL` leaving a real process table on
+            // default — it is a real `SIGKILL` leaving a real process table on
             // a machine that may be loaded, and a short budget there would fail
-            // this test for scheduling rather than for behaviour.
+            // this test for scheduling rather than for behaviour. A caller that
+            // has arranged for that poll to fail every time overrides it, since
+            // there the generosity is pure wall time.
             exitPollAttempts: 2,
             exitPollInterval: .milliseconds(100),
-            holderEscalationAttempts: 100,
+            holderEscalationAttempts: holderEscalationAttempts,
+            signaller: signaller,
             actuationLog: makeTestActuationLog())
         await coordinator.setHolderRegistry(registry)
 

--- a/Tests/TBDDaemonLiveTests/Holder/HolderHibernationLiveTests.swift
+++ b/Tests/TBDDaemonLiveTests/Holder/HolderHibernationLiveTests.swift
@@ -129,9 +129,15 @@ struct HolderHibernationLiveTests {
         #expect(after.childPID == childPID, "a refused park still cleared the row's pids")
         #expect(holderProcessIsAlive(childPID), "a refused park still ended the job")
 
-        // And the wake half of the same gate, on a row parked out of band.
-        try await fixture.db.terminals.setHibernated(
-            id: terminal.id, sessionID: HibernationFixture.sessionID, reason: .manual)
+        // And the wake half of the same gate, on the same UNPARKED row: the
+        // flag decides whether this install classifies a holder row at all.
+        //
+        // The row is deliberately NOT parked out of band first. A row that is
+        // already parked wakes whatever the flag says — turning the flag off is
+        // the soak's abort gesture, not a way to strand what the soak parked —
+        // so parking it here would spawn a real replacement holder, which is
+        // the opposite of what this test asserts. That half is covered
+        // scripted, in `HolderTmuxAssumptionGateTests`.
         #expect(await fixture.coordinator.wake(terminalID: terminal.id) == .holderTransport)
         #expect(holderProcessIsAlive(childPID))
     }

--- a/Tests/TBDDaemonLiveTests/Holder/HolderHibernationLiveTests.swift
+++ b/Tests/TBDDaemonLiveTests/Holder/HolderHibernationLiveTests.swift
@@ -1,0 +1,337 @@
+import Darwin
+import Foundation
+import TestSupport
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Park and wake against a **real** holder and a **real** job.
+///
+/// The scripted suites state the rules; this one proves them against the
+/// kernel's own answers, because the property the soak is for is not a return
+/// value: it is that the process is actually gone when the row says parked, and
+/// actually running when the row says awake. Nothing but a real pid can say
+/// either.
+///
+/// Tier 3, and every rule the holder fixtures carry applies here: a scratch
+/// `TBD_HOME` under the run root the wrapper reclaims, rc-free `/bin/sh` jobs, a
+/// pinned `SHELL` and `PATH` so no developer profile and no real agent binary is
+/// ever reached, bounded waits everywhere, and a teardown that kills the holder
+/// AND the job — holder death is deliberately not child death.
+@Suite(.serialized)
+struct HolderHibernationLiveTests {
+
+    /// The park's whole point, against a job that cannot cooperate.
+    ///
+    /// `while :; do sleep 1; done` never reads its terminal, so the polite
+    /// `/exit` cannot possibly work and the escalation is what has to end it.
+    /// That is deliberately the harder half: a test whose job exited on `/exit`
+    /// would pass without the escalation ever running.
+    @Test func parkEndsTheJobAndClearsTheRow() async throws {
+        let fixture = try await HibernationFixture.make()
+        defer { fixture.tearDown() }
+        let terminal = try await fixture.spawnHolderRow()
+        let childPID = try #require(terminal.childPID)
+        let holderPID = try #require(terminal.holderPID)
+
+        let result = await fixture.coordinator.manualHibernate(terminalID: terminal.id)
+        #expect(result == .ok, "park refused: \(result)")
+
+        let parked = try #require(try await fixture.db.terminals.get(id: terminal.id))
+        #expect(parked.isParked)
+        #expect(parked.claudeSessionID == HibernationFixture.sessionID)
+        // A parked row names no processes. These three move together: a pid
+        // without its start time is a pid nothing may signal, and either one
+        // left behind points the reaper at a number the kernel has recycled.
+        #expect(parked.holderPID == nil)
+        #expect(parked.childPID == nil)
+        #expect(parked.holderChildStartedAt == nil)
+
+        // The invariant, asked of the kernel rather than of the row. ESRCH is
+        // the only answer that means gone: EPERM would mean alive and owned by
+        // somebody else, which on a shared box is a real possibility for a
+        // recycled pid.
+        // `errno` is captured on the next line rather than read inside the
+        // expectation: the message is an autoclosure, evaluated only on
+        // failure, by which time any intervening libc call has clobbered it.
+        let signalled = kill(childPID, 0)
+        let signalErrno = errno
+        #expect(signalled == -1 && signalErrno == ESRCH,
+                "the job survived a park that reported .ok (kill returned \(signalled), errno \(signalErrno))")
+        #expect(!holderProcessIsAlive(holderPID), "the holder outlived the park")
+        #expect(await fixture.registry.reader(for: terminal.id) == nil,
+                "the daemon is still draining a pty for a parked session")
+    }
+
+    /// Wake after that park: a fresh holder, a fresh job, and a row that names
+    /// both and is no longer parked.
+    ///
+    /// The command the wake builds is `claude --resume …`, and nothing here
+    /// runs it: `WorktreeLifecycle.holderLaunch` hands it to the registry's
+    /// pinned `SHELL`, which is a two-line script that ignores its argv. That
+    /// is the same lever `HolderSpawnGateTests` uses, and it is what keeps a
+    /// live-process test off both the developer's login shell and a real agent.
+    @Test func wakeStartsAFreshHolderAndUnparksTheRow() async throws {
+        let fixture = try await HibernationFixture.make()
+        defer { fixture.tearDown() }
+        let terminal = try await fixture.spawnHolderRow()
+
+        #expect(await fixture.coordinator.manualHibernate(terminalID: terminal.id) == .ok)
+
+        let result = await fixture.coordinator.wake(terminalID: terminal.id)
+        #expect(result == .ok, "wake refused: \(result)")
+
+        let woken = try #require(try await fixture.db.terminals.get(id: terminal.id))
+        #expect(!woken.isParked)
+        let holderPID = try #require(woken.holderPID, "the woken row records no holder")
+        let childPID = try #require(woken.childPID, "the woken row records no child")
+        #expect(holderPID != childPID, "one pid was recorded twice")
+        #expect(holderProcessIsAlive(holderPID))
+        #expect(holderProcessIsAlive(childPID))
+        // The identity anchor for the NEW child. Without it the reaper would
+        // measure this process against a row created before the park and read
+        // it as a stranger.
+        let startedAt = try #require(
+            woken.holderChildStartedAt, "the woken row records no child start time")
+        #expect(abs(startedAt.timeIntervalSince(Date())) < 300)
+        #expect(await fixture.registry.reader(for: terminal.id) != nil,
+                "nothing is draining the woken session's pty")
+
+        // Tear the woken session down through the same door the delete path
+        // uses, so neither the holder nor its job outlives the test.
+        _ = await fixture.registry.abandon(terminal: woken)
+        _ = await pollUntil("the woken job to be reclaimed") {
+            !holderProcessIsAlive(childPID)
+        }
+        // Row-driven teardown must not signal these numbers afterwards: they
+        // are free now, and the next process to take one is somebody else's.
+        try await fixture.db.terminals.setHolderProcess(
+            id: terminal.id, holderPID: nil, childPID: nil, startedAt: nil)
+    }
+
+    /// The gate's OFF branch, on the same live fixture: the park is refused by
+    /// name and the job is still there afterwards.
+    ///
+    /// Asserting on the surviving pid is what makes this a test of the gate
+    /// rather than of a string — a refusal that had already written `/exit` or
+    /// killed the job would return the same value.
+    @Test func withTheFlagOffTheParkIsRefusedAndTheJobSurvives() async throws {
+        let fixture = try await HibernationFixture.make(holderHibernationEnabled: false)
+        defer { fixture.tearDown() }
+        let terminal = try await fixture.spawnHolderRow()
+        let childPID = try #require(terminal.childPID)
+
+        let result = await fixture.coordinator.manualHibernate(terminalID: terminal.id)
+        #expect(result == .notEligible(reason: HibernationCoordinator.holderTransportRefusal))
+
+        let after = try #require(try await fixture.db.terminals.get(id: terminal.id))
+        #expect(!after.isParked, "a refused park still parked the row")
+        #expect(after.childPID == childPID, "a refused park still cleared the row's pids")
+        #expect(holderProcessIsAlive(childPID), "a refused park still ended the job")
+
+        // And the wake half of the same gate, on a row parked out of band.
+        try await fixture.db.terminals.setHibernated(
+            id: terminal.id, sessionID: HibernationFixture.sessionID, reason: .manual)
+        #expect(await fixture.coordinator.wake(terminalID: terminal.id) == .holderTransport)
+        #expect(holderProcessIsAlive(childPID))
+    }
+}
+
+// MARK: - Fixture
+
+/// A database, a worktree, a real `HolderRegistry` with a real spawner, and a
+/// coordinator wired to both — assembled the way `Daemon.swift` assembles them.
+private final class HibernationFixture {
+    /// The session id the row carries and the wake resumes. Never reaches a
+    /// real Claude: the pinned shell ignores the argv it is handed.
+    static let sessionID = "sess-holder-hibernation"
+
+    /// A job that cannot cooperate with `/exit`: it never reads its terminal,
+    /// so the polite poll must fail and the escalation must be what ends it.
+    private static let uncooperativeJob = "while :; do sleep 1; done"
+
+    let db: TBDDatabase
+    let registry: HolderRegistry
+    let coordinator: HibernationCoordinator
+    let environment: [String: String]
+    let worktree: Worktree
+    private let home: String
+    private let tempDir: URL
+    private var torndown = false
+
+    /// A short scratch root under the run root `scripts/test.sh` reclaims: the
+    /// rendezvous socket lives under it and `sun_path` is 104 bytes, so a deeper
+    /// root fails the bind rather than the assertion.
+    private static func scratchHome() -> String {
+        fencedScratchRoot(prefix: "tbdhib")
+    }
+
+    /// The stand-in login shell the WAKE spawn runs. It ignores the
+    /// `-i -l -c <command>` argv the production composition hands it, which is
+    /// the point: the resumed "agent" is a controlled two-line program.
+    private static func writeGateShell(in home: String) throws -> String {
+        try FileManager.default.createDirectory(
+            atPath: home, withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700])
+        let path = "\(home)/gate-shell"
+        try """
+        #!/bin/sh
+        printf 'WOKE-OK\\n'
+        exec sleep 30
+        """.write(toFile: path, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o700], ofItemAtPath: path)
+        return path
+    }
+
+    static func make(holderHibernationEnabled: Bool = true) async throws -> HibernationFixture {
+        let home = scratchHome()
+        let shell = try writeGateShell(in: home)
+        let environment = [
+            "TBD_HOME": home,
+            "PATH": "/usr/bin:/bin",
+            "SHELL": shell,
+        ]
+
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setPtyHolderEnabled(true)
+        try await db.config.setHolderHibernationEnabled(holderHibernationEnabled)
+
+        let executable = try #require(
+            HolderProcessFixture.locateExecutable(),
+            "TBDHolder must be built beside the test bundle")
+        let registry = HolderRegistry(
+            owner: HolderOwnerToken(rawValue: "acme-installation"),
+            environment: environment,
+            listTerminals: { [] },
+            spawner: HolderSpawner(executableURL: executable))
+
+        let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
+        let repo = try await db.repos.create(
+            path: repoDir.path, displayName: "acme", defaultBranch: "main")
+        let worktree = try await db.worktrees.createMain(
+            repoID: repo.id, name: "main", branch: "main", path: repoDir.path,
+            tmuxServer: TmuxManager.serverName(forRepoPath: repoDir.path))
+
+        let coordinator = HibernationCoordinator(
+            db: db,
+            // Dry-run and never reached: both branches under test fork away
+            // from tmux before the first call. A recorder is not needed here —
+            // `HolderTmuxAssumptionGateTests` asserts the "no tmux was touched"
+            // half without spawning anything.
+            tmux: TmuxManager(dryRun: true),
+            // The profile/host stores the wake preamble seeds folder trust and
+            // resolves a projects root through, kept inside this fixture's own
+            // scratch root.
+            configDirManager: ClaudeProfileConfigDirManager(
+                baseDirectory: URL(fileURLWithPath: home)
+                    .appendingPathComponent("profiles", isDirectory: true),
+                hostBaseDirectory: URL(fileURLWithPath: home)
+                    .appendingPathComponent("claude", isDirectory: true)),
+            // Two attempts at 100 ms is the polite window; the job cannot use
+            // it, so the run pays 200 ms to reach the escalation rather than
+            // the shipped three seconds. The escalation budget is generous by
+            // contrast — it is a real `SIGKILL` leaving a real process table on
+            // a machine that may be loaded, and a short budget there would fail
+            // this test for scheduling rather than for behaviour.
+            exitPollAttempts: 2,
+            exitPollInterval: .milliseconds(100),
+            holderEscalationAttempts: 100,
+            actuationLog: makeTestActuationLog())
+        await coordinator.setHolderRegistry(registry)
+
+        return HibernationFixture(
+            db: db, registry: registry, coordinator: coordinator, environment: environment,
+            worktree: worktree, home: home, tempDir: tempDir)
+    }
+
+    private init(
+        db: TBDDatabase, registry: HolderRegistry, coordinator: HibernationCoordinator,
+        environment: [String: String], worktree: Worktree, home: String, tempDir: URL
+    ) {
+        self.db = db
+        self.registry = registry
+        self.coordinator = coordinator
+        self.environment = environment
+        self.worktree = worktree
+        self.home = home
+        self.tempDir = tempDir
+    }
+
+    /// A real holder supervising a real job, plus the row that names both —
+    /// created in the order `WorktreeLifecycle+Create` creates them, so the
+    /// registry has adopted the session before anything reads its screen.
+    func spawnHolderRow() async throws -> Terminal {
+        let terminalID = UUID()
+        let handle = try await registry.spawn(
+            terminalID: terminalID,
+            launch: HolderLaunchRequest(
+                executable: "/bin/sh",
+                arguments: ["-c", Self.uncooperativeJob],
+                workingDirectory: "/tmp",
+                environment: ["PATH": "/usr/bin:/bin", "TERM": "xterm-256color"],
+                columns: 80,
+                rows: 24))
+        _ = try await db.terminals.create(
+            id: terminalID,
+            worktreeID: worktree.id,
+            tmuxWindowID: "",
+            tmuxPaneID: "",
+            label: TerminalLabel.claudeCode,
+            claudeSessionID: Self.sessionID,
+            kind: .claude,
+            transport: .holder,
+            holderPID: handle.holderPID,
+            childPID: handle.childPID,
+            holderChildStartedAt: Date())
+        return try #require(try await db.terminals.get(id: terminalID))
+    }
+
+    /// Kills whatever the ROWS still name, then clears the scratch roots.
+    ///
+    /// Reading the rows rather than a list of everything ever spawned is the
+    /// safety property: a park clears the pids off its row precisely because
+    /// those processes are gone, and a teardown working from a remembered list
+    /// would signal numbers the kernel has already handed to somebody else — on
+    /// a box running dozens of agent sessions, to somebody else's work.
+    func tearDown() {
+        guard !torndown else { return }
+        torndown = true
+
+        for row in (try? blockingTerminals()) ?? [] where row.transport == .holder {
+            if let holderPID = row.holderPID, holderPID > 1 {
+                kill(holderPID, SIGKILL)
+                var ignored: Int32 = 0
+                _ = waitpid(holderPID, &ignored, 0)
+            }
+            if let childPID = row.childPID, childPID > 1, holderProcessIsAlive(childPID) {
+                kill(childPID, SIGKILL)
+            }
+        }
+        // Whatever a reader is still draining is named only by the registry, so
+        // release them all. Detached because teardown is not async.
+        let registry = self.registry
+        Task.detached { await registry.releaseAll() }
+        try? FileManager.default.removeItem(atPath: home)
+        try? FileManager.default.removeItem(at: tempDir)
+    }
+
+    /// Reads the terminal rows from a non-async `tearDown`. Bounded, and a
+    /// timeout simply means the sweep above has nothing to kill by pid — the
+    /// suite would rather report that than hang.
+    private func blockingTerminals() throws -> [Terminal] {
+        let box = ResultBox()
+        let done = DispatchSemaphore(value: 0)
+        let db = self.db
+        Task.detached {
+            box.value = try? await db.terminals.list()
+            done.signal()
+        }
+        _ = done.wait(timeout: .now() + 5)
+        return box.value ?? []
+    }
+
+    private final class ResultBox: @unchecked Sendable {
+        var value: [Terminal]?
+    }
+}

--- a/Tests/TBDDaemonLiveTests/Holder/HolderHibernationLiveTests.swift
+++ b/Tests/TBDDaemonLiveTests/Holder/HolderHibernationLiveTests.swift
@@ -34,6 +34,17 @@ struct HolderHibernationLiveTests {
         let childPID = try #require(terminal.childPID)
         let holderPID = try #require(terminal.holderPID)
 
+        // The rail's own precondition, asked of the registry this park will
+        // ask. `.daemon` is the only source the park may act on, and it is a
+        // fact about a real adopted reader draining a real pty — the scripted
+        // suites can state the other sources, but only a live holder can prove
+        // this one is what an ordinary detached session actually answers.
+        let reader = try #require(await fixture.registry.reader(for: terminal.id))
+        let observed = try await reader.screen(
+            maxLines: HibernationCoordinator.holderScreenLines)
+        #expect(observed.source == .daemon,
+                "a detached live session answered \(observed.source) rather than .daemon")
+
         let result = await fixture.coordinator.manualHibernate(terminalID: terminal.id)
         #expect(result == .ok, "park refused: \(result)")
 
@@ -59,8 +70,12 @@ struct HolderHibernationLiveTests {
         #expect(signalled == -1 && signalErrno == ESRCH,
                 "the job survived a park that reported .ok (kill returned \(signalled), errno \(signalErrno))")
         #expect(!holderProcessIsAlive(holderPID), "the holder outlived the park")
+        // A released slot, not merely a suspended reader: `reader(for:)` answers
+        // for an adopted slot and keeps answering across an attach, so nil here
+        // means the registry let this session go rather than that the daemon is
+        // off the pty.
         #expect(await fixture.registry.reader(for: terminal.id) == nil,
-                "the daemon is still draining a pty for a parked session")
+                "the registry still holds a reader for a parked session")
     }
 
     /// Wake after that park: a fresh holder, a fresh job, and a row that names
@@ -95,7 +110,7 @@ struct HolderHibernationLiveTests {
             woken.holderChildStartedAt, "the woken row records no child start time")
         #expect(abs(startedAt.timeIntervalSince(Date())) < 300)
         #expect(await fixture.registry.reader(for: terminal.id) != nil,
-                "nothing is draining the woken session's pty")
+                "the registry did not adopt the woken session's holder")
 
         // WHAT it launched. Every assertion above is satisfied by a holder
         // running the wrong command entirely — a fresh session instead of a

--- a/Tests/TBDDaemonTests/ActuationLogSpawnWiringTests.swift
+++ b/Tests/TBDDaemonTests/ActuationLogSpawnWiringTests.swift
@@ -262,7 +262,8 @@ struct ActuationLogSpawnWiringTests {
         let coordinator = makeCoordinator(db: fixture.db, logPath: logPath)
 
         let result = await coordinator.hibernateForMerge(
-            terminalID: fixture.terminalID, inputVetoEnabled: false)
+            terminalID: fixture.terminalID, inputVetoEnabled: false,
+            holderHibernationEnabled: false)
         #expect(result == .ok)
 
         let written = try rows(at: logPath)
@@ -287,7 +288,8 @@ struct ActuationLogSpawnWiringTests {
         let coordinator = makeCoordinator(db: fixture.db, logPath: logPath)
 
         let result = await coordinator.hibernateForMerge(
-            terminalID: fixture.terminalID, inputVetoEnabled: false)
+            terminalID: fixture.terminalID, inputVetoEnabled: false,
+            holderHibernationEnabled: false)
         #expect(result == .notEligible(reason: "Terminal is pinned keep-warm"))
         #expect(try rows(at: logPath).isEmpty)
     }
@@ -311,7 +313,8 @@ struct ActuationLogSpawnWiringTests {
         await coordinator.setInputActivity(tracker)
 
         let result = await coordinator.hibernateForMerge(
-            terminalID: fixture.terminalID, inputVetoEnabled: true)
+            terminalID: fixture.terminalID, inputVetoEnabled: true,
+            holderHibernationEnabled: false)
         #expect(result == .notEligible(reason: "Terminal has unsent typed input"))
         #expect(try rows(at: logPath).isEmpty)
         #expect(try await fixture.db.terminals.get(id: fixture.terminalID)?.hibernatedAt == nil)
@@ -333,7 +336,8 @@ struct ActuationLogSpawnWiringTests {
         await coordinator.setInputActivity(tracker)
 
         let result = await coordinator.hibernateForMerge(
-            terminalID: fixture.terminalID, inputVetoEnabled: false)
+            terminalID: fixture.terminalID, inputVetoEnabled: false,
+            holderHibernationEnabled: false)
         #expect(result == .ok)
         #expect(try rows(at: logPath).count == 2)
         #expect(try await fixture.db.terminals.get(id: fixture.terminalID)?.hibernatedAt != nil)
@@ -345,7 +349,8 @@ struct ActuationLogSpawnWiringTests {
         let coordinator = makeCoordinator(db: fixture.db, logPath: try makeUnwritablePath())
 
         let result = await coordinator.hibernateForMerge(
-            terminalID: fixture.terminalID, inputVetoEnabled: false)
+            terminalID: fixture.terminalID, inputVetoEnabled: false,
+            holderHibernationEnabled: false)
         guard case .notEligible(let reason) = result else {
             Issue.record("expected the park to be skipped, got \(result)")
             return

--- a/Tests/TBDDaemonTests/Config/HolderHibernationFlagTests.swift
+++ b/Tests/TBDDaemonTests/Config/HolderHibernationFlagTests.swift
@@ -1,0 +1,189 @@
+import Foundation
+import GRDB
+import Testing
+
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Schema and resolution guards for `config.holder_hibernation_enabled`, the
+/// soak gate on parking, waking and limit-resuming Claude sessions on the
+/// pty-holder transport.
+///
+/// The column is added by `20260905213000_config_holder_hibernation` with **no
+/// SQL default**, so "never chose" (NULL) stays distinguishable from
+/// "explicitly off" (0). If someone adds a `DEFAULT` clause to that migration,
+/// `nullBeforeAnyGesture` and `rowWrittenBeforeTheMigrationStillReadsNull` go
+/// red — that is their only job. The distinction earns its keep because this
+/// gate can kill a live agent process: somebody who turned it off did so
+/// deliberately and must stay opted out through graduation.
+@Suite("HolderHibernationFlag")
+struct HolderHibernationFlagTests {
+
+    /// The last migration identifier that predates the flag's column. Migrating
+    /// only this far reproduces the schema a real pre-flag daemon ran on.
+    private static let lastIdentifierBeforeTheFlag = "20260904172536_config_update_mode"
+
+    private func fetchConfigRecord(_ db: TBDDatabase) async throws -> ConfigRecord? {
+        try await db.writerForTests.read { conn in
+            try ConfigRecord.fetchOne(conn, key: ConfigStore.singletonID)
+        }
+    }
+
+    // MARK: - Storage: the column is genuinely NULL until somebody chooses
+
+    /// **The load-bearing test.** The `config` singleton row is inserted by v1,
+    /// so every install has a row that predates this column. After the
+    /// migration that row must read NULL, not `0`.
+    @Test func nullBeforeAnyGesture() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let record = try #require(try await fetchConfigRecord(db))
+        #expect(
+            record.holder_hibernation_enabled == nil,
+            """
+            config.holder_hibernation_enabled must be NULL until the toggle is \
+            touched — read back \
+            \(String(describing: record.holder_hibernation_enabled)). A non-nil \
+            value here means 20260905213000_config_holder_hibernation grew a \
+            DEFAULT clause; remove it.
+            """)
+    }
+
+    /// The same guard against a row written by a real pre-flag daemon: migrate
+    /// only as far as the last identifier that predates the column, write to the
+    /// config row, then finish migrating.
+    @Test func rowWrittenBeforeTheMigrationStillReadsNull() throws {
+        let queue = try DatabaseQueue()
+        let migrator = TBDDatabase.buildMigratorForTests()
+        try migrator.migrate(queue, upTo: Self.lastIdentifierBeforeTheFlag)
+
+        try queue.write { db in
+            try db.execute(
+                sql: "UPDATE config SET auto_create_notes_enabled = 1 WHERE id = ?",
+                arguments: [ConfigStore.singletonID])
+        }
+
+        try migrator.migrate(queue)
+
+        try queue.read { db in
+            let row = try #require(try Row.fetchOne(
+                db, sql: "SELECT * FROM config WHERE id = ?",
+                arguments: [ConfigStore.singletonID]))
+            let raw: DatabaseValue = row["holder_hibernation_enabled"]
+            #expect(
+                raw.isNull,
+                "a config row written before the migration must read NULL, not \(raw)")
+            // The pre-existing write survived — the migration is purely additive.
+            #expect(row["auto_create_notes_enabled"] == true)
+        }
+    }
+
+    // MARK: - Resolution: the three states are distinguishable
+
+    /// NULL follows `Config.holderHibernationEnabledDefault` wherever it goes;
+    /// an explicit `false` does not. That property is what makes graduation a
+    /// one-line constant change with no forcing `UPDATE` migration. Exercised
+    /// against BOTH possible default values, so it fails if the resolution is
+    /// ever wired as `?? false`.
+    @Test func explicitFalseSurvivesADefaultFlipWhileNullFollowsIt() async throws {
+        let db = try TBDDatabase(inMemory: true)
+
+        let untouched = try #require(try await fetchConfigRecord(db))
+        #expect(untouched.holder_hibernation_enabled == nil)
+        #expect(
+            untouched.toModel(holderHibernationDefault: false).holderHibernationEnabled == false)
+        #expect(
+            untouched.toModel(holderHibernationDefault: true).holderHibernationEnabled == true,
+            "a never-chosen row must pick up a changed shipped default")
+
+        try await db.config.setHolderHibernationEnabled(false)
+        let explicitlyOff = try #require(try await fetchConfigRecord(db))
+        #expect(explicitlyOff.holder_hibernation_enabled == false)
+        #expect(
+            explicitlyOff.toModel(holderHibernationDefault: false)
+                .holderHibernationEnabled == false)
+        #expect(
+            explicitlyOff.toModel(holderHibernationDefault: true)
+                .holderHibernationEnabled == false,
+            "an explicit opt-out must be honored forever, whatever the shipped default becomes")
+    }
+
+    /// Mirrored for an explicit `true`: an operator who opted into the soak
+    /// stays opted in even if the shipped default never moves.
+    @Test func explicitTrueSticks() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setHolderHibernationEnabled(true)
+        let explicitlyOn = try #require(try await fetchConfigRecord(db))
+        #expect(explicitlyOn.holder_hibernation_enabled == true)
+        #expect(
+            explicitlyOn.toModel(holderHibernationDefault: false)
+                .holderHibernationEnabled == true)
+        #expect(
+            explicitlyOn.toModel(holderHibernationDefault: true)
+                .holderHibernationEnabled == true)
+    }
+
+    /// Isolates the RESOLUTION guard (`toModel()`'s `?? holderHibernationDefault`)
+    /// from the STORAGE guard (the migration's missing SQL default) by
+    /// constructing a `ConfigRecord` directly — no database, no migration.
+    @Test func toModelResolvesNullThroughTheInjectedDefault() {
+        let record = ConfigRecord(id: "unstored", holder_hibernation_enabled: nil)
+        #expect(record.toModel(holderHibernationDefault: false).holderHibernationEnabled == false)
+        #expect(
+            record.toModel(holderHibernationDefault: true).holderHibernationEnabled == true,
+            "a NULL record must pick up whatever default is injected, not a hardcoded false")
+    }
+
+    // MARK: - The shipped default, and the wire
+
+    /// The shipped default today: OFF. A background sweep that can kill a live
+    /// holder-owned agent process soaks behind its own switch, and it cannot
+    /// borrow `ptyHolderEnabled` for that — that gate has to be ON for a holder
+    /// row to exist at all.
+    @Test func shippedDefaultIsOff() async throws {
+        #expect(Config.holderHibernationEnabledDefault == false)
+        let db = try TBDDatabase(inMemory: true)
+        #expect(try await db.config.get().holderHibernationEnabled == false)
+    }
+
+    /// Hibernation is its own opt-in, not a rider on any sibling holder gate:
+    /// enabling the file sweep, the process reaper, or the row reconciler must
+    /// leave it off.
+    @Test func theSiblingHolderGatesDoNotEnableIt() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setPtyHolderEnabled(true)
+        try await db.config.setGCHolderRendezvousEnabled(true)
+        try await db.config.setReapHolderChildrenEnabled(true)
+        try await db.config.setGCRowlessHoldersEnabled(true)
+        try await db.config.setHolderRowReconcileEnabled(true)
+        #expect(
+            try await db.config.get().holderHibernationEnabled == false,
+            "enabling the transport or any sibling holder sweep must not enable hibernation")
+    }
+
+    @Test func setterRoundtrips() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setHolderHibernationEnabled(true)
+        #expect(try await db.config.get().holderHibernationEnabled == true)
+        try await db.config.setHolderHibernationEnabled(false)
+        #expect(try await db.config.get().holderHibernationEnabled == false)
+    }
+
+    /// JSON from a daemon that predates the flag still decodes, and the absent
+    /// key means the sender knew nothing about it — the NULL column's situation,
+    /// so it follows the shipped default rather than a hardcoded `false`.
+    @Test func configJSONWithoutTheKeyFollowsTheShippedDefault() throws {
+        let json = #"{"primaryAgentPreference":"claude"}"#
+        let config = try JSONDecoder().decode(Config.self, from: Data(json.utf8))
+        #expect(config.holderHibernationEnabled == Config.holderHibernationEnabledDefault)
+    }
+
+    /// An explicit `true` on the wire is carried, so the app and the CLI see the
+    /// same state the daemon resolved rather than re-deriving it.
+    @Test func configJSONRoundTripsAnExplicitChoice() throws {
+        var config = Config()
+        config.holderHibernationEnabled = true
+        let decoded = try JSONDecoder().decode(
+            Config.self, from: JSONEncoder().encode(config))
+        #expect(decoded.holderHibernationEnabled == true)
+    }
+}

--- a/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
@@ -900,6 +900,13 @@ struct HibernationCoordinatorTests {
         #expect(coord.exitPollInterval == .milliseconds(200))
         #expect(coord.exitPollInterval * coord.exitPollAttempts == .seconds(3),
                 "the shipped verify-exit window must stay ~3s")
+        // The holder park's escalation budget rides the same interval: five
+        // more checks after `abandon` has SIGKILLed the job, i.e. one second
+        // for a dead process to leave the process table. A different budget
+        // from the three seconds above, which waits for a polite shutdown.
+        #expect(coord.holderEscalationAttempts == 5)
+        #expect(coord.exitPollInterval * coord.holderEscalationAttempts == .seconds(1),
+                "the shipped holder escalation window must stay ~1s")
     }
 
     /// The ANSI pane snapshot captured before the kill is persisted into

--- a/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
@@ -655,7 +655,8 @@ struct HibernationCoordinatorTests {
         let hibernate = gateHoldingTask {
             await coord.hibernateForMerge(
                 terminalID: terminalID,
-                inputVetoEnabled: true)
+                inputVetoEnabled: true,
+                holderHibernationEnabled: false)
         }
         await capture.waitForFirstCapture()
         inputActivity.recordInput(paneID: before.tmuxPaneID)

--- a/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
@@ -890,10 +890,12 @@ struct HibernationCoordinatorTests {
                 "must escalate once all \(attempts) attempts observed claude; got: \(recorded.snapshot())")
     }
 
-    /// Pins the SHIPPED poll window, which the two injected-pacing tests above
-    /// deliberately no longer run: 15 × 200ms ≈ 3s. Making the pacing
-    /// injectable must not quietly change what production waits before it
-    /// SIGTERMs a claude that is still shutting down.
+    /// Pins the SHIPPED poll windows, which the two injected-pacing tests above
+    /// deliberately no longer run: 15 × 200ms ≈ 3s for the polite rung, and the
+    /// two holder-park budgets that ride the same interval after it. Making the
+    /// pacing injectable must not quietly change what production waits before
+    /// it SIGTERMs a claude that is still shutting down, nor how long it then
+    /// waits before killing one.
     @Test func defaultPollPacingIsFifteenTimesTwoHundredMillis() async throws {
         let (db, _, _) = try await setup()
         let coord = coordinator(db)
@@ -901,10 +903,19 @@ struct HibernationCoordinatorTests {
         #expect(coord.exitPollInterval == .milliseconds(200))
         #expect(coord.exitPollInterval * coord.exitPollAttempts == .seconds(3),
                 "the shipped verify-exit window must stay ~3s")
-        // The holder park's escalation budget rides the same interval: five
-        // more checks after `abandon` has SIGKILLed the job, i.e. one second
-        // for a dead process to leave the process table. A different budget
-        // from the three seconds above, which waits for a polite shutdown.
+        // The holder park's middle rung rides the same interval: 25 checks
+        // after a `SIGTERM`, i.e. five seconds for a session to run its Stop
+        // hooks, tear down its MCP children and flush the transcript it is
+        // mid-write on. It is the rung that keeps the holder park from being
+        // harsher than the tmux one, so shortening it is a behaviour change
+        // rather than a tuning nudge.
+        #expect(coord.holderTerminateAttempts == 25)
+        #expect(coord.exitPollInterval * coord.holderTerminateAttempts == .seconds(5),
+                "the shipped SIGTERM window must stay ~5s")
+        // The escalation budget after it is a different budget again: five
+        // more checks once `abandon` has SIGKILLed the job, i.e. one second for
+        // a dead process to leave the process table. Neither of the two above
+        // waits for that, and it waits for neither of them.
         #expect(coord.holderEscalationAttempts == 5)
         #expect(coord.exitPollInterval * coord.holderEscalationAttempts == .seconds(1),
                 "the shipped holder escalation window must stay ~1s")

--- a/Tests/TBDDaemonTests/HibernationGateMergeTests.swift
+++ b/Tests/TBDDaemonTests/HibernationGateMergeTests.swift
@@ -37,8 +37,13 @@ struct HibernationGateMergeTests {
         inputVetoEnabled: Bool = false,
         lastInputAt: Date? = nil
     ) -> HibernationGate.Decision {
+        // Every terminal in this suite is a tmux row, so the soak gate is
+        // passed off and named. The production signature has no default for
+        // it, and the tests that are about the gate live beside the holder
+        // fixtures in HolderTmuxAssumptionGateTests.
         HibernationGate.decideForMerge(
-            terminal: terminal, inputVetoEnabled: inputVetoEnabled, lastInputAt: lastInputAt)
+            terminal: terminal, inputVetoEnabled: inputVetoEnabled,
+            holderHibernationEnabled: false, lastInputAt: lastInputAt)
     }
 
     // MARK: - The go path: no idle window at all
@@ -67,6 +72,7 @@ struct HibernationGateMergeTests {
         let t = claudeTerminal(activityState: .idle)
         let sweepWithSwitchOff = HibernationGate.decide(
             terminal: t, autoHibernateEnabled: false,
+            holderHibernationEnabled: false,
             idleTimeout: 30 * 60,
             idleSince: Date(timeIntervalSince1970: 0), now: Date()
         )
@@ -215,6 +221,9 @@ struct HibernationGateMergeTests {
             transport: .holder)
     }
 
+    /// The argument cannot be omitted: `decideForMerge` carries no default for
+    /// it, the same as `decide`, so a park path that forgets the flag is a
+    /// compile error rather than a rail that silently disagrees with the app.
     @Test func mergeParkRefusesAHolderRowWhileTheSoakGateIsOff() {
         #expect(HibernationGate.decideForMerge(
             terminal: holderTerminal(), inputVetoEnabled: false,
@@ -225,13 +234,6 @@ struct HibernationGateMergeTests {
         #expect(HibernationGate.decideForMerge(
             terminal: holderTerminal(), inputVetoEnabled: false,
             holderHibernationEnabled: true, lastInputAt: nil) == .eligible)
-    }
-
-    /// Omitting the argument refuses, the same safe direction `decide` takes.
-    @Test func theOmittedArgumentRefusesAHolderMergePark() {
-        #expect(HibernationGate.decideForMerge(
-            terminal: holderTerminal(), inputVetoEnabled: false,
-            lastInputAt: nil) == .holderTransport)
     }
 
     /// With the gate on, a holder row still answers to every other rail — the

--- a/Tests/TBDDaemonTests/HibernationGateMergeTests.swift
+++ b/Tests/TBDDaemonTests/HibernationGateMergeTests.swift
@@ -200,4 +200,58 @@ struct HibernationGateMergeTests {
             activityStateObservedAt: now.addingTimeInterval(-10 * 60))
         #expect(decideForMerge(t, inputVetoEnabled: true, lastInputAt: now) == .alreadyHibernated)
     }
+
+    // MARK: - The holder-transport soak gate, both branches
+
+    /// A holder-backed row that passes every other merge rail — including the
+    /// input veto's `activityStateObservedAt` requirement, so the only thing
+    /// these two tests vary is the flag.
+    private func holderTerminal() -> Terminal {
+        Terminal(
+            worktreeID: UUID(), tmuxWindowID: "", tmuxPaneID: "",
+            label: "claude", claudeSessionID: "sess-1", kind: .claude,
+            activityState: .idle,
+            activityStateObservedAt: now.addingTimeInterval(-10 * 60),
+            transport: .holder)
+    }
+
+    @Test func mergeParkRefusesAHolderRowWhileTheSoakGateIsOff() {
+        #expect(HibernationGate.decideForMerge(
+            terminal: holderTerminal(), inputVetoEnabled: false,
+            holderHibernationEnabled: false, lastInputAt: nil) == .holderTransport)
+    }
+
+    @Test func mergeParkElectsAHolderRowOnceTheSoakGateIsOn() {
+        #expect(HibernationGate.decideForMerge(
+            terminal: holderTerminal(), inputVetoEnabled: false,
+            holderHibernationEnabled: true, lastInputAt: nil) == .eligible)
+    }
+
+    /// Omitting the argument refuses, the same safe direction `decide` takes.
+    @Test func theOmittedArgumentRefusesAHolderMergePark() {
+        #expect(HibernationGate.decideForMerge(
+            terminal: holderTerminal(), inputVetoEnabled: false,
+            lastInputAt: nil) == .holderTransport)
+    }
+
+    /// With the gate on, a holder row still answers to every other rail — the
+    /// input veto included. The flag lifts one refusal, not all of them.
+    @Test func theSoakGateDoesNotLiftTheInputVetoOnAHolderRow() {
+        #expect(HibernationGate.decideForMerge(
+            terminal: holderTerminal(), inputVetoEnabled: true,
+            holderHibernationEnabled: true, lastInputAt: now) == .pendingTypedInput)
+    }
+
+    /// A tmux row is unaffected by either value, which is what makes the two
+    /// assertions above about the transport rather than about the flag alone.
+    @Test func aTmuxRowIsUnaffectedByTheSoakGate() {
+        for enabled in [false, true] {
+            #expect(HibernationGate.decideForMerge(
+                terminal: claudeTerminal(), inputVetoEnabled: false,
+                holderHibernationEnabled: enabled, lastInputAt: nil) == .eligible)
+            #expect(HibernationGate.decideForMerge(
+                terminal: claudeTerminal(keepWarm: true), inputVetoEnabled: false,
+                holderHibernationEnabled: enabled, lastInputAt: nil) == .keepWarm)
+        }
+    }
 }

--- a/Tests/TBDDaemonTests/HibernationGateTests.swift
+++ b/Tests/TBDDaemonTests/HibernationGateTests.swift
@@ -236,4 +236,59 @@ struct HibernationGateTests {
         #expect(decision == .pendingTypedInput)
         // The gate alone blocks, so even if the scrape is broken the park is safe.
     }
+
+    // MARK: - The holder-transport soak gate, both branches
+
+    /// A holder-backed row that passes every other rail. Only `transport`
+    /// differs from the baseline above, so the two tests below are about the
+    /// flag and nothing else.
+    private func holderTerminal() -> Terminal {
+        Terminal(
+            worktreeID: UUID(), tmuxWindowID: "", tmuxPaneID: "",
+            label: "claude", claudeSessionID: "sess-1", kind: .claude,
+            activityState: .idle, transport: .holder)
+    }
+
+    @Test func holderRowIsRefusedWhileTheSoakGateIsOff() {
+        let idleSince = now.addingTimeInterval(-31 * 60)
+        #expect(HibernationGate.decide(
+            terminal: holderTerminal(), autoHibernateEnabled: true,
+            holderHibernationEnabled: false, idleTimeout: 30 * 60,
+            idleSince: idleSince, now: now) == .holderTransport)
+    }
+
+    @Test func holderRowIsEligibleOnceTheSoakGateIsOn() {
+        let idleSince = now.addingTimeInterval(-31 * 60)
+        #expect(HibernationGate.decide(
+            terminal: holderTerminal(), autoHibernateEnabled: true,
+            holderHibernationEnabled: true, idleTimeout: 30 * 60,
+            idleSince: idleSince, now: now) == .eligible)
+    }
+
+    /// Omitting the argument must fail toward refusal, which is the safe
+    /// direction and the whole reason the parameter carries a default at all.
+    @Test func theOmittedArgumentRefusesAHolderRow() {
+        let idleSince = now.addingTimeInterval(-31 * 60)
+        #expect(HibernationGate.decide(
+            terminal: holderTerminal(), autoHibernateEnabled: true,
+            idleTimeout: 30 * 60, idleSince: idleSince, now: now) == .holderTransport)
+    }
+
+    /// The flag decides what a HOLDER row gets and must not reach a tmux one:
+    /// a condition written on the flag alone rather than on the flag AND the
+    /// transport would still pass every assertion above.
+    @Test func aTmuxRowIsUnaffectedByTheSoakGate() {
+        let idleSince = now.addingTimeInterval(-31 * 60)
+        for enabled in [false, true] {
+            #expect(HibernationGate.decide(
+                terminal: claudeTerminal(), autoHibernateEnabled: true,
+                holderHibernationEnabled: enabled, idleTimeout: 30 * 60,
+                idleSince: idleSince, now: now) == .eligible)
+            #expect(HibernationGate.decide(
+                terminal: claudeTerminal(activityState: .working),
+                autoHibernateEnabled: true,
+                holderHibernationEnabled: enabled, idleTimeout: 30 * 60,
+                idleSince: idleSince, now: now) == .running)
+        }
+    }
 }

--- a/Tests/TBDDaemonTests/HibernationGateTests.swift
+++ b/Tests/TBDDaemonTests/HibernationGateTests.swift
@@ -292,10 +292,22 @@ struct HibernationGateTests {
     ///
     /// - `blockingRail == nil` ⇔ `isAutoHibernationEligible`. Both are "every
     ///   hard rail passes, keep-warm included".
-    /// - `blockingRail == nil || blockingRail == .keepWarm` ⇔
-    ///   `isManuallyHibernatable`. A manual park is allowed to override
-    ///   keep-warm and nothing else, so keep-warm is the one blocker the
-    ///   manual predicate forgives.
+    /// - `blockingRail(the same row with keep-warm cleared) == nil` ⇔
+    ///   `isManuallyHibernatable`. A manual park overrides keep-warm and
+    ///   nothing else, so the honest way to say that is to ask the cascade the
+    ///   question with keep-warm taken out of it.
+    ///
+    /// **Not** `rail == nil || rail == .keepWarm`, which is the obvious
+    /// spelling and is wrong: `blockingRail` returns the most specific blocker
+    /// in ITS order, and keep-warm sits ahead of the activity rails — so a
+    /// keep-warm row that is mid-turn answers `.keepWarm`, and forgiving that
+    /// answer would read as "only keep-warm blocks this" while
+    /// `isManuallyHibernatable` correctly refuses it for running a turn. This
+    /// test was written with that spelling and found the twelve rows where it
+    /// disagrees, which is the whole argument for having it. Nothing in
+    /// production computes manual eligibility from `blockingRail` — the manual
+    /// path calls the predicate directly — so those rows were a defect in the
+    /// assertion rather than in the daemon.
     ///
     /// The structural fix — `isManuallyHibernatable` becoming
     /// `blockingRail(...) == nil`, with the reason-bearing cascade moved into
@@ -324,14 +336,19 @@ struct HibernationGateTests {
                                         let rail = HibernationGate.blockingRail(
                                             terminal: terminal,
                                             holderHibernationEnabled: holderHibernationEnabled)
+                                        var withoutKeepWarm = terminal
+                                        withoutKeepWarm.keepWarm = false
+                                        let railIgnoringKeepWarm = HibernationGate.blockingRail(
+                                            terminal: withoutKeepWarm,
+                                            holderHibernationEnabled: holderHibernationEnabled)
                                         let auto = terminal.isAutoHibernationEligible(
                                             holderHibernationEnabled: holderHibernationEnabled)
                                         let manual = terminal.isManuallyHibernatable(
                                             holderHibernationEnabled: holderHibernationEnabled)
                                         #expect((rail == nil) == auto,
                                                 "blockingRail said \(String(describing: rail)) while isAutoHibernationEligible said \(auto) for \(transport) flag=\(holderHibernationEnabled) session=\(String(describing: sessionID)) kind=\(String(describing: kind)) hibernated=\(hibernatedAt != nil) suspended=\(suspendedAt != nil) keepWarm=\(keepWarm) activity=\(activity)")
-                                        #expect((rail == nil || rail == .keepWarm) == manual,
-                                                "blockingRail said \(String(describing: rail)) while isManuallyHibernatable said \(manual) for \(transport) flag=\(holderHibernationEnabled) session=\(String(describing: sessionID)) kind=\(String(describing: kind)) hibernated=\(hibernatedAt != nil) suspended=\(suspendedAt != nil) keepWarm=\(keepWarm) activity=\(activity)")
+                                        #expect((railIgnoringKeepWarm == nil) == manual,
+                                                "blockingRail with keep-warm cleared said \(String(describing: railIgnoringKeepWarm)) while isManuallyHibernatable said \(manual) for \(transport) flag=\(holderHibernationEnabled) session=\(String(describing: sessionID)) kind=\(String(describing: kind)) hibernated=\(hibernatedAt != nil) suspended=\(suspendedAt != nil) keepWarm=\(keepWarm) activity=\(activity)")
                                         rows += 1
                                         if rail == nil { passedEveryRail += 1 }
                                     }

--- a/Tests/TBDDaemonTests/HibernationGateTests.swift
+++ b/Tests/TBDDaemonTests/HibernationGateTests.swift
@@ -275,6 +275,83 @@ struct HibernationGateTests {
             idleSince: idleSince, now: now) == .eligible)
     }
 
+    // MARK: - Parity with the predicate the app reads
+
+    /// `blockingRail` and `Terminal.isManuallyHibernatable` are two cascades
+    /// over the same rails, and this is what stops them drifting.
+    ///
+    /// They are duplicated on purpose — the gate needs a per-rail *reason* and
+    /// the model needs a yes or no — but nothing in the compiler notices when
+    /// one grows a rail the other has not got, and the two are read by
+    /// different halves of the product: the daemon refuses a park by the first
+    /// and the app decides whether to offer one by the second. A row they
+    /// disagree about is a menu item that fails when the user clicks it, or a
+    /// park the daemon performs that the app said was impossible.
+    ///
+    /// The equivalences, and why they are what they are:
+    ///
+    /// - `blockingRail == nil` ⇔ `isAutoHibernationEligible`. Both are "every
+    ///   hard rail passes, keep-warm included".
+    /// - `blockingRail == nil || blockingRail == .keepWarm` ⇔
+    ///   `isManuallyHibernatable`. A manual park is allowed to override
+    ///   keep-warm and nothing else, so keep-warm is the one blocker the
+    ///   manual predicate forgives.
+    ///
+    /// The structural fix — `isManuallyHibernatable` becoming
+    /// `blockingRail(...) == nil`, with the reason-bearing cascade moved into
+    /// `TBDShared` — is better than this test and larger than this change; it
+    /// is a follow-up. Until then this matrix is the ratchet.
+    @Test func blockingRailAgreesWithTheModelPredicateOverEveryRow() {
+        var rows = 0
+        var passedEveryRail = 0
+        for transport in [TerminalTransport.tmux, .holder] {
+            for holderHibernationEnabled in [false, true] {
+                for sessionID in [String?.none, "sess-1"] {
+                    for kind in [TerminalKind?.none, .claude, .codex, .shell] {
+                        for hibernatedAt in [Date?.none, now] {
+                            for suspendedAt in [Date?.none, now] {
+                                for keepWarm in [false, true] {
+                                    for activity in [TerminalActivityState.idle, .unknown,
+                                                     .working, .waitingForUser] {
+                                        let terminal = Terminal(
+                                            worktreeID: UUID(),
+                                            tmuxWindowID: transport == .holder ? "" : "@0",
+                                            tmuxPaneID: transport == .holder ? "" : "%0",
+                                            label: "claude", claudeSessionID: sessionID,
+                                            suspendedAt: suspendedAt, kind: kind,
+                                            activityState: activity, hibernatedAt: hibernatedAt,
+                                            keepWarm: keepWarm, transport: transport)
+                                        let rail = HibernationGate.blockingRail(
+                                            terminal: terminal,
+                                            holderHibernationEnabled: holderHibernationEnabled)
+                                        let auto = terminal.isAutoHibernationEligible(
+                                            holderHibernationEnabled: holderHibernationEnabled)
+                                        let manual = terminal.isManuallyHibernatable(
+                                            holderHibernationEnabled: holderHibernationEnabled)
+                                        #expect((rail == nil) == auto,
+                                                "blockingRail said \(String(describing: rail)) while isAutoHibernationEligible said \(auto) for \(transport) flag=\(holderHibernationEnabled) session=\(String(describing: sessionID)) kind=\(String(describing: kind)) hibernated=\(hibernatedAt != nil) suspended=\(suspendedAt != nil) keepWarm=\(keepWarm) activity=\(activity)")
+                                        #expect((rail == nil || rail == .keepWarm) == manual,
+                                                "blockingRail said \(String(describing: rail)) while isManuallyHibernatable said \(manual) for \(transport) flag=\(holderHibernationEnabled) session=\(String(describing: sessionID)) kind=\(String(describing: kind)) hibernated=\(hibernatedAt != nil) suspended=\(suspendedAt != nil) keepWarm=\(keepWarm) activity=\(activity)")
+                                        rows += 1
+                                        if rail == nil { passedEveryRail += 1 }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        // The matrix has to have actually run, and it has to contain both
+        // answers: a loop that produced only blocked rows would agree with any
+        // predicate that refuses everything.
+        #expect(rows == 2 * 2 * 2 * 4 * 2 * 2 * 2 * 4)
+        #expect(passedEveryRail > 0,
+                "no row in the matrix passed every rail, so the parity above agrees with any predicate that refuses everything")
+        #expect(passedEveryRail < rows,
+                "every row in the matrix passed every rail, so the parity above agrees with any predicate that allows everything")
+    }
+
     /// The flag decides what a HOLDER row gets and must not reach a tmux one:
     /// a condition written on the flag alone rather than on the flag AND the
     /// transport would still pass every assertion above.

--- a/Tests/TBDDaemonTests/HibernationGateTests.swift
+++ b/Tests/TBDDaemonTests/HibernationGateTests.swift
@@ -28,6 +28,10 @@ struct HibernationGateTests {
         )
     }
 
+    /// Every terminal this helper is called with is a tmux row, so the soak
+    /// gate is passed off and named rather than defaulted: the production
+    /// signature has no default, and the tests that are ABOUT the gate call it
+    /// directly with both answers.
     private func decide(
         _ terminal: Terminal,
         enabled: Bool = true,
@@ -39,6 +43,7 @@ struct HibernationGateTests {
         HibernationGate.decide(
             terminal: terminal, autoHibernateEnabled: enabled,
             inputVetoEnabled: inputVetoEnabled,
+            holderHibernationEnabled: false,
             idleTimeout: timeout, idleSince: idleSince, lastInputAt: lastInputAt, now: now
         )
     }
@@ -249,6 +254,11 @@ struct HibernationGateTests {
             activityState: .idle, transport: .holder)
     }
 
+    /// The argument cannot be omitted: `decide` carries no default for it, so
+    /// a call site that forgets the flag is a compile error rather than a rail
+    /// that silently disagrees with the app's menu. That is what replaced the
+    /// old "forgetting fails toward refusing" reading, which would have
+    /// inverted the day the shipped constant flips.
     @Test func holderRowIsRefusedWhileTheSoakGateIsOff() {
         let idleSince = now.addingTimeInterval(-31 * 60)
         #expect(HibernationGate.decide(
@@ -263,15 +273,6 @@ struct HibernationGateTests {
             terminal: holderTerminal(), autoHibernateEnabled: true,
             holderHibernationEnabled: true, idleTimeout: 30 * 60,
             idleSince: idleSince, now: now) == .eligible)
-    }
-
-    /// Omitting the argument must fail toward refusal, which is the safe
-    /// direction and the whole reason the parameter carries a default at all.
-    @Test func theOmittedArgumentRefusesAHolderRow() {
-        let idleSince = now.addingTimeInterval(-31 * 60)
-        #expect(HibernationGate.decide(
-            terminal: holderTerminal(), autoHibernateEnabled: true,
-            idleTimeout: 30 * 60, idleSince: idleSince, now: now) == .holderTransport)
     }
 
     /// The flag decides what a HOLDER row gets and must not reach a tmux one:

--- a/Tests/TBDDaemonTests/Holder/HolderReconcileExemptionTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HolderReconcileExemptionTests.swift
@@ -95,12 +95,19 @@ struct HolderReconcileExemptionTests {
             "the sweep deleted a holder-backed shell row")
     }
 
-    @Test("a tmux-backed row whose window is gone is still parked or deleted")
-    func tmuxRowStillReconciledNormally() async throws {
+    /// Both values of `holder_hibernation_enabled`, because the tmux arm must
+    /// be blind to it: the flag decides what a HOLDER row becomes, and a
+    /// condition written to test the flag alone rather than the flag AND the
+    /// transport would change this outcome too.
+    @Test(
+        "a tmux-backed row whose window is gone is still parked or deleted",
+        arguments: [false, true])
+    func tmuxRowStillReconciledNormally(holderHibernationEnabled: Bool) async throws {
         let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
         let db = try TBDDatabase(inMemory: true)
+        try await db.config.setHolderHibernationEnabled(holderHibernationEnabled)
         let lifecycle = makeLifecycle(db: db, tmux: deadWindowTmux())
         let (repo, main) = try await seedRepo(db: db, at: repoDir.path)
 

--- a/Tests/TBDDaemonTests/Holder/HolderReconcileInventoryTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HolderReconcileInventoryTests.swift
@@ -103,7 +103,7 @@ struct HolderReconcileInventoryTests {
 
     // MARK: - The sweep
 
-    @Test("a holder-backed row whose holder is gone is deleted, never parked")
+    @Test("with holder hibernation off, a row whose holder is gone is deleted, never parked")
     func vanishedHolderRowsAreDeleted() async throws {
         let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
         defer { try? FileManager.default.removeItem(at: tempDir) }
@@ -129,19 +129,75 @@ struct HolderReconcileInventoryTests {
             actuationLog: makeTestActuationLog(),
             reapSharedScratchTmuxResources: true)
 
-        // **The park is withheld on purpose.** `HibernationCoordinator.wake`
-        // refuses `transport == .holder` before its "wake any parked row"
-        // branch and this sweep skips parked rows, so a parked holder row could
-        // never be woken and never be re-judged — while the app's focus-wake
-        // selects exactly `isParked && isClaudeResumable && hibernateReason !=
-        // .manual` and would fire a failing wake RPC on every focus of the
-        // worktree, forever.
+        // **The park is withheld while the soak gate is off, on purpose.**
+        // `HibernationCoordinator.wake` refuses a holder row with the gate off,
+        // and this sweep skips parked rows, so a parked holder row could never
+        // be woken and never be re-judged — while the app's focus-wake selects
+        // exactly `isParked && isClaudeResumable && hibernateReason != .manual`
+        // and would fire a failing wake RPC on every focus of the worktree,
+        // forever.
+        #expect(
+            try await db.config.get().holderHibernationEnabled == false,
+            "this test asserts the gate's off branch; it must not have been touched")
         #expect(
             try await db.terminals.get(id: claude.id) == nil,
-            "a holder-backed resumable Claude row was parked instead of deleted; a parked holder row is unwakeable and re-fires focus-wake forever")
+            "a holder-backed resumable Claude row was parked instead of deleted; with holder hibernation off a parked holder row is unwakeable and re-fires focus-wake forever")
         #expect(
             try await db.terminals.get(id: shell.id) == nil,
             "a holder-backed shell row whose holder is gone was left in the inventory")
+    }
+
+    /// The same fixture with `holder_hibernation_enabled` ON: the resumable
+    /// Claude row is PARKED rather than deleted, exactly as the tmux arm parks
+    /// its equivalent, and the shell row is still deleted because there is
+    /// nothing about it to preserve.
+    ///
+    /// Deliberately identical input to the test above — only the gesture
+    /// differs — so a gate that stopped being read shows up as two tests
+    /// asserting opposite outcomes on the same rows.
+    @Test("with holder hibernation on, a resumable holder row is parked instead of deleted")
+    func holderHibernationOnParksResumableRows() async throws {
+        let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        try await enableTheHolderArm(db)
+        try await db.config.setHolderHibernationEnabled(true)
+        let lifecycle = makeLifecycle(
+            db: db,
+            signaller: deadJobs([4243, 4245]),
+            registry: registry(environment: vanishedHolderEnvironment()))
+        let (repo, main) = try await seedRepo(db: db, at: repoDir.path)
+
+        let claude = try await db.terminals.create(
+            worktreeID: main.id, tmuxWindowID: "", tmuxPaneID: "",
+            label: TerminalLabel.claudeCode, claudeSessionID: "sess-holder",
+            kind: .claude, transport: .holder, holderPID: 4242, childPID: 4243)
+        let shell = try await db.terminals.create(
+            worktreeID: main.id, tmuxWindowID: "", tmuxPaneID: "",
+            kind: .shell, transport: .holder, holderPID: 4244, childPID: 4245)
+
+        try await lifecycle.reconcile(
+            repoID: repo.id,
+            actuationLog: makeTestActuationLog(),
+            reapSharedScratchTmuxResources: true)
+
+        let parked = try #require(
+            try await db.terminals.get(id: claude.id),
+            "a resumable holder row was deleted with holder hibernation on")
+        #expect(parked.isParked)
+        #expect(parked.hibernateReason == .recovery)
+        #expect(parked.claudeSessionID == "sess-holder", "the session id must survive the park")
+        // A parked holder row names no processes: the holder and its job are
+        // already gone, and pids left on the row point every identity check at
+        // numbers the kernel has recycled.
+        #expect(parked.holderPID == nil)
+        #expect(parked.childPID == nil)
+        #expect(parked.holderChildStartedAt == nil)
+
+        #expect(
+            try await db.terminals.get(id: shell.id) == nil,
+            "a holder-backed shell row has no session to preserve and must still be deleted")
     }
 
     /// The gate's off branch, which is the shipped default: the arm judges
@@ -597,7 +653,8 @@ struct HolderReconcileInventoryTests {
 
     /// The two deletions are different events and the log must not conflate
     /// them. A holder-transport Claude row *has* a session to preserve; what it
-    /// does not have is a park it could be woken from.
+    /// does not have, while the soak gate is off, is anything that could wake
+    /// the park.
     @Test("a withheld park says so rather than claiming there was no session")
     func theDeletionRationaleNamesTheWithheldPark() {
         let holderClaude = Terminal(
@@ -605,13 +662,23 @@ struct HolderReconcileInventoryTests {
             label: TerminalLabel.claudeCode, claudeSessionID: "sess-holder",
             kind: .claude, transport: .holder)
         #expect(
-            WorktreeLifecycle.deletionRationale(for: holderClaude)
-                == "its Claude session is not resumable from a park on the holder transport")
+            WorktreeLifecycle.deletionRationale(
+                for: holderClaude, holderHibernationEnabled: false)
+                == "holder hibernation is off, so a parked holder row would have nothing to wake it")
 
         let holderShell = Terminal(
             worktreeID: UUID(), tmuxWindowID: "", tmuxPaneID: "",
             kind: .shell, transport: .holder)
-        #expect(WorktreeLifecycle.deletionRationale(for: holderShell) == "no session to preserve")
+        #expect(
+            WorktreeLifecycle.deletionRationale(
+                for: holderShell, holderHibernationEnabled: false) == "no session to preserve")
+        // With the gate ON this Claude row is not deleted at all, so the only
+        // rationale it could carry would be a lie. The function says the
+        // generic thing rather than repeating the withheld-park sentence for a
+        // park that was not withheld.
+        #expect(
+            WorktreeLifecycle.deletionRationale(
+                for: holderClaude, holderHibernationEnabled: true) == "no session to preserve")
     }
 }
 

--- a/Tests/TBDDaemonTests/Holder/HolderStartupReconcileTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HolderStartupReconcileTests.swift
@@ -170,6 +170,50 @@ struct HolderStartupReconcileTests {
         #expect(after.holderPID == 8101)
     }
 
+    /// This arm is deliberately ungated, and the flag-off branch is the one
+    /// worth pinning: turning `holder_hibernation_enabled` off is the soak's
+    /// abort gesture, and the rows most needing reconciliation afterwards are
+    /// exactly the ones the soak parked. Gating the arm would strand them.
+    ///
+    /// Both verdicts are asserted in the same run, with the flag written
+    /// EXPLICITLY false rather than left NULL, so a future `guard` on the flag
+    /// fails here whichever of the tri-state's two off-values it reads.
+    @Test("both verdicts still move their row with holder hibernation turned off")
+    func bothVerdictsMoveTheirRowWithTheFlagOff() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setHolderHibernationEnabled(false)
+        #expect(try await db.config.get().holderHibernationEnabled == false)
+        let (wt, dir) = try await seedWorktree(db)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let childStartedAt = Date().addingTimeInterval(-3600)
+        let signaller = FakeProcessSignaller()
+        // 8102: alive, identity verified → `.same` → un-park.
+        signaller.behaviors[8102] = .init(aliveInitially: true)
+        signaller.startTimes[8102] = childStartedAt
+        signaller.cmdlines[8102] = Self.holderChildCommand
+        // 8103: names nothing → `.notRunning` → clear the stale pids.
+        signaller.behaviors[8103] = .init(aliveInitially: false)
+
+        let live = try await seedParkedHolderRow(
+            db, worktreeID: wt.id, childStartedAt: childStartedAt, childPID: 8102)
+        let dead = try await seedParkedHolderRow(
+            db, worktreeID: wt.id, childStartedAt: childStartedAt, childPID: 8103)
+
+        await coordinator(db, signaller: signaller).reconcileOnStartup()
+
+        let afterLive = try #require(try await db.terminals.get(id: live.id))
+        #expect(!afterLive.isParked,
+                "the flag-off branch left a row parked over a verifiably live child")
+        #expect(afterLive.childPID == 8102, "un-parking must not forget the live child")
+
+        let afterDead = try #require(try await db.terminals.get(id: dead.id))
+        #expect(afterDead.isParked, "a parked row whose child is gone was un-parked")
+        #expect(afterDead.childPID == nil,
+                "the flag-off branch left pids naming a process the kernel has recycled")
+        #expect(afterDead.holderPID == nil)
+    }
+
     /// The tmux branch is untouched: its evidence is the window and the pane,
     /// and a dead window leaves a parked row exactly as it found it — whatever
     /// the process table says about pids the row does not carry.

--- a/Tests/TBDDaemonTests/Holder/HolderStartupReconcileTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HolderStartupReconcileTests.swift
@@ -1,0 +1,201 @@
+import Foundation
+import TestSupport
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// What startup reconciliation does with a PARKED holder-backed row.
+///
+/// `reconcileOnStartup` runs before `HolderRegistry.adoptAll`, so this arm must
+/// reach a verdict without the registry: at that moment it holds no readers and
+/// remembers no statuses, and asking it would answer "gone" for every session on
+/// the machine while looking authoritative. The recorded child pid, read through
+/// `ProcessIdentityCheck`, is the only ground truth available that early — which
+/// is why every case here is scripted on a `FakeProcessSignaller` rather than
+/// arranged with real processes.
+///
+/// Tier 1: no tmux server, no spawned process, no `~/tbd`.
+@Suite("Parked holder rows at startup")
+struct HolderStartupReconcileTests {
+
+    /// The shape a holder's job presents: the login shell the holder forked, or
+    /// the agent binary that shell `exec`d itself into.
+    private static let holderChildCommand = "/bin/zsh -i -l -c claude"
+
+    private func seedWorktree(_ db: TBDDatabase) async throws -> (Worktree, URL) {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-holderstartup-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let repo = try await db.repos.create(
+            path: dir.path, displayName: "acme", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "wt", branch: "main", path: dir.path,
+            tmuxServer: "tbd-holderstartup")
+        return (wt, dir)
+    }
+
+    private func coordinator(
+        _ db: TBDDatabase, signaller: FakeProcessSignaller
+    ) -> HibernationCoordinator {
+        HibernationCoordinator(
+            db: db,
+            // Every window dead, which is what a holder row's empty coordinate
+            // gets from a real server. The holder branch must not consult it at
+            // all, and the tmux parity test below relies on this answer.
+            tmux: TmuxManager(dryRun: true, dryRunWindowIsDead: { _ in true }),
+            signaller: signaller,
+            actuationLog: makeTestActuationLog())
+    }
+
+    /// A parked holder row that names a child pid, with the identity anchor an
+    /// hour behind the row's own `createdAt` — the shape a woken session has,
+    /// and the one that tells the two anchors apart.
+    private func seedParkedHolderRow(
+        _ db: TBDDatabase, worktreeID: UUID, childStartedAt: Date?, childPID: Int32
+    ) async throws -> Terminal {
+        let terminal = try await db.terminals.create(
+            worktreeID: worktreeID, tmuxWindowID: "", tmuxPaneID: "",
+            label: TerminalLabel.claudeCode, claudeSessionID: "sess-startup",
+            kind: .claude, transport: .holder,
+            holderPID: 8101, childPID: childPID,
+            holderChildStartedAt: childStartedAt)
+        try await db.terminals.setHibernated(
+            id: terminal.id, sessionID: "sess-startup", reason: .auto)
+        return try #require(try await db.terminals.get(id: terminal.id))
+    }
+
+    /// The daemon died mid-park: the intent landed, the child never went. The
+    /// row is un-parked so adoption can pick the live session up.
+    @Test("a parked row whose child is verifiably alive is un-parked")
+    func aLiveChildUnparksItsRow() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let (wt, dir) = try await seedWorktree(db)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let childStartedAt = Date().addingTimeInterval(-3600)
+        let signaller = FakeProcessSignaller()
+        signaller.behaviors[8102] = .init(aliveInitially: true)
+        signaller.startTimes[8102] = childStartedAt
+        signaller.cmdlines[8102] = Self.holderChildCommand
+
+        let terminal = try await seedParkedHolderRow(
+            db, worktreeID: wt.id, childStartedAt: childStartedAt, childPID: 8102)
+        #expect(terminal.isParked)
+
+        await coordinator(db, signaller: signaller).reconcileOnStartup()
+
+        let after = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(!after.isParked, "a parked row whose child is alive was left parked")
+        #expect(after.childPID == 8102, "un-parking must not forget the live child")
+        #expect(after.holderPID == 8101)
+    }
+
+    /// The anchor is the child's start, not the row's birthday — and an hour of
+    /// park is far outside `defaultHolderIdentityWindow`, so a reconciler that
+    /// still anchored on `createdAt` would read this same live child as a
+    /// stranger and leave the row parked over it.
+    @Test("the identity anchor is the recorded child start, not the row's createdAt")
+    func theAnchorIsTheChildStart() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let (wt, dir) = try await seedWorktree(db)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let childStartedAt = Date().addingTimeInterval(-3600)
+        let signaller = FakeProcessSignaller()
+        signaller.behaviors[8102] = .init(aliveInitially: true)
+        signaller.startTimes[8102] = childStartedAt
+        signaller.cmdlines[8102] = Self.holderChildCommand
+
+        // Same scripted process, same row — except the row records no anchor,
+        // so `createdAt` (now) is used and the hour-old child reads as a
+        // different process.
+        let anchored = try await seedParkedHolderRow(
+            db, worktreeID: wt.id, childStartedAt: childStartedAt, childPID: 8102)
+        let unanchored = try await seedParkedHolderRow(
+            db, worktreeID: wt.id, childStartedAt: nil, childPID: 8102)
+
+        await coordinator(db, signaller: signaller).reconcileOnStartup()
+
+        #expect(try await db.terminals.get(id: anchored.id)?.isParked == false)
+        #expect(
+            try await db.terminals.get(id: unanchored.id)?.isParked == true,
+            "a start-time mismatch is an uncertain identity and must move nothing")
+    }
+
+    /// The child is gone but the row still names it. Clear the pids so nothing
+    /// later signals a number the kernel has already handed to somebody else.
+    @Test("a parked row whose child is gone keeps its park and loses its pids")
+    func aDeadChildLosesItsPids() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let (wt, dir) = try await seedWorktree(db)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let signaller = FakeProcessSignaller()
+        signaller.behaviors[8102] = .init(aliveInitially: false)
+
+        let terminal = try await seedParkedHolderRow(
+            db, worktreeID: wt.id, childStartedAt: Date().addingTimeInterval(-3600),
+            childPID: 8102)
+
+        await coordinator(db, signaller: signaller).reconcileOnStartup()
+
+        let after = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(after.isParked, "a parked row whose child is gone was un-parked")
+        #expect(after.childPID == nil)
+        #expect(after.holderPID == nil)
+        #expect(after.holderChildStartedAt == nil)
+    }
+
+    /// Every verdict but `.same` and `.notRunning` is an uncertain identity,
+    /// and an uncertain identity is not evidence in either direction. A missing
+    /// start time is how that case is stated.
+    @Test("an unreadable child identity moves nothing")
+    func anUncertainIdentityMovesNothing() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let (wt, dir) = try await seedWorktree(db)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let signaller = FakeProcessSignaller()
+        signaller.behaviors[8102] = .init(aliveInitially: true)
+        // No `startTimes` entry: the start time could not be read.
+
+        let terminal = try await seedParkedHolderRow(
+            db, worktreeID: wt.id, childStartedAt: Date(), childPID: 8102)
+
+        await coordinator(db, signaller: signaller).reconcileOnStartup()
+
+        let after = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(after.isParked)
+        #expect(after.childPID == 8102)
+        #expect(after.holderPID == 8101)
+    }
+
+    /// The tmux branch is untouched: its evidence is the window and the pane,
+    /// and a dead window leaves a parked row exactly as it found it — whatever
+    /// the process table says about pids the row does not carry.
+    @Test("a parked tmux row is judged by tmux, not by the process table")
+    func aParkedTmuxRowIsUnaffected() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let (wt, dir) = try await seedWorktree(db)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        // Scripted as alive with a perfect identity. If the holder branch ever
+        // stopped discriminating on transport, this row would be un-parked.
+        let signaller = FakeProcessSignaller()
+        signaller.behaviors[8102] = .init(aliveInitially: true)
+        signaller.startTimes[8102] = Date()
+        signaller.cmdlines[8102] = Self.holderChildCommand
+
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@7", tmuxPaneID: "%7",
+            label: TerminalLabel.claudeCode, claudeSessionID: "sess-tmux", kind: .claude)
+        try await db.terminals.setHibernated(
+            id: terminal.id, sessionID: "sess-tmux", reason: .auto)
+
+        await coordinator(db, signaller: signaller).reconcileOnStartup()
+
+        #expect(
+            try await db.terminals.get(id: terminal.id)?.isParked == true,
+            "the holder branch judged a tmux row")
+    }
+}

--- a/Tests/TBDDaemonTests/Holder/HolderTmuxAssumptionGateTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HolderTmuxAssumptionGateTests.swift
@@ -472,11 +472,12 @@ struct HolderTmuxAssumptionGateTests {
         // Idle for an hour with the sweep armed: every other rail passes, so
         // `.eligible` is what this row gets without the transport gate.
         #expect(HibernationGate.decide(
-            terminal: terminal, autoHibernateEnabled: true, idleTimeout: 60,
+            terminal: terminal, autoHibernateEnabled: true,
+            holderHibernationEnabled: false, idleTimeout: 60,
             idleSince: now.addingTimeInterval(-3600), now: now) == .holderTransport)
         #expect(HibernationGate.decideForMerge(
             terminal: terminal, inputVetoEnabled: false,
-            lastInputAt: nil) == .holderTransport)
+            holderHibernationEnabled: false, lastInputAt: nil) == .holderTransport)
     }
 
     /// The same two rails with the flag on: a holder row that passes every
@@ -510,10 +511,12 @@ struct HolderTmuxAssumptionGateTests {
 
         let now = Date()
         #expect(HibernationGate.decide(
-            terminal: terminal, autoHibernateEnabled: true, idleTimeout: 60,
+            terminal: terminal, autoHibernateEnabled: true,
+            holderHibernationEnabled: false, idleTimeout: 60,
             idleSince: now.addingTimeInterval(-3600), now: now) == .eligible)
         #expect(HibernationGate.decideForMerge(
-            terminal: terminal, inputVetoEnabled: false, lastInputAt: nil) == .eligible)
+            terminal: terminal, inputVetoEnabled: false,
+            holderHibernationEnabled: false, lastInputAt: nil) == .eligible)
     }
 
     // MARK: - Gate 3: wake
@@ -1643,9 +1646,14 @@ struct HolderTmuxAssumptionGateTests {
     /// registry wires, so the flag-off tests below assert the flag and not an
     /// absent seam. `waiter` defaults to a no-op, so only the test that asserts
     /// on the pause between the holder arm's two writes records them.
+    ///
+    /// `holderSessionEnded` defaults to nil for the same reason `holderSend`
+    /// does: that is what a daemon with no holder registry wires, so a test
+    /// that says nothing about liveness is asserting on today's behaviour.
     private func resumeActuator(
         _ db: TBDDatabase, tmux: FakeResumeTmux,
         holderSend: (@Sendable (UUID, Data) async -> Bool)? = nil,
+        holderSessionEnded: (@Sendable (UUID) async -> Bool)? = nil,
         waiter: @escaping @Sendable (Duration) async -> Void = { _ in }
     ) -> LimitResumeActuator {
         LimitResumeActuator(
@@ -1653,7 +1661,8 @@ struct HolderTmuxAssumptionGateTests {
             readTranscript: { _ in nil },
             transcriptModifiedAt: { _ in nil },
             waiter: waiter, actuationLog: makeTestActuationLog(),
-            holderSend: holderSend)
+            holderSend: holderSend,
+            holderSessionEnded: holderSessionEnded)
     }
 
     /// The reproduction, on the answer a real tmux gives — and the shipped
@@ -1819,6 +1828,100 @@ struct HolderTmuxAssumptionGateTests {
         #expect(tmux.sends.isEmpty)
     }
 
+    /// The holder arm's liveness answer, in the position `windowExists`
+    /// occupies on the tmux arm and with the same silent cancel.
+    ///
+    /// Nothing had parked this row: its child simply ended. Without the seam
+    /// the arm has no liveness question at all and types "continue" onto a pty
+    /// nobody is reading, reporting an armed resume as delivered into a session
+    /// that is over.
+    @Test("auto-resume cancels silently when the holder reports the session over")
+    func autoResumeCancelsWhenTheHolderSessionHasEnded() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let (wt, dir) = try await seedWorktree(db)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try await db.config.setHolderHibernationEnabled(true)
+        let terminal = try await seedClaudeTerminal(
+            db, worktreeID: wt.id, transport: .holder)
+        try await db.terminals.setActivityState(
+            id: terminal.id, activityState: .working, source: .derived)
+        let resume = try await armedResume(db, terminal: terminal)
+
+        let tmux = FakeResumeTmux()
+        tmux.windowAlive = true
+        let holder = RecordedHolderWrites()
+        let outcome = await resumeActuator(
+            db, tmux: tmux, holderSend: holder.send,
+            holderSessionEnded: { _ in true }
+        ).actuate(resume)
+
+        #expect(outcome == .terminalGone, "expected .terminalGone, got \(outcome)")
+        #expect(holder.writes().isEmpty,
+                "auto-resume typed into a session its holder had reported over")
+        #expect(tmux.sends.isEmpty)
+    }
+
+    /// The other answer. A seam that answered "ended" for everything would pass
+    /// the test above while cancelling every armed resume on the transport, so
+    /// this leg is what makes that one about the answer rather than about the
+    /// seam's presence.
+    @Test("auto-resume still sends when the holder reports the session live")
+    func autoResumeSendsWhenTheHolderSessionIsLive() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let (wt, dir) = try await seedWorktree(db)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try await db.config.setHolderHibernationEnabled(true)
+        let terminal = try await seedClaudeTerminal(
+            db, worktreeID: wt.id, transport: .holder)
+        try await db.terminals.setActivityState(
+            id: terminal.id, activityState: .working, source: .derived)
+        let resume = try await armedResume(db, terminal: terminal)
+
+        let tmux = FakeResumeTmux()
+        tmux.windowAlive = true
+        let holder = RecordedHolderWrites()
+        let outcome = await resumeActuator(
+            db, tmux: tmux, holderSend: holder.send,
+            holderSessionEnded: { _ in false }
+        ).actuate(resume)
+
+        #expect(outcome == .sent, "expected .sent, got \(outcome)")
+        #expect(holder.writes() == [
+            .write(terminalID: terminal.id, bytes: Data([0x1B])),
+            .write(terminalID: terminal.id, bytes: Data("continue".utf8) + Data([0x0D])),
+        ], "the holder arm's send was \(holder.snapshot())")
+    }
+
+    /// The seam absent. A daemon with no holder registry wires nil, and that
+    /// must behave exactly as it did before the seam existed — asking nobody
+    /// and proceeding to the courier, which fails by name if the session really
+    /// is gone.
+    @Test("auto-resume with no liveness seam sends exactly as it did before")
+    func autoResumeWithoutALivenessSeamIsUnchanged() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let (wt, dir) = try await seedWorktree(db)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try await db.config.setHolderHibernationEnabled(true)
+        let terminal = try await seedClaudeTerminal(
+            db, worktreeID: wt.id, transport: .holder)
+        try await db.terminals.setActivityState(
+            id: terminal.id, activityState: .working, source: .derived)
+        let resume = try await armedResume(db, terminal: terminal)
+
+        let tmux = FakeResumeTmux()
+        tmux.windowAlive = true
+        let holder = RecordedHolderWrites()
+        let outcome = await resumeActuator(
+            db, tmux: tmux, holderSend: holder.send, holderSessionEnded: nil
+        ).actuate(resume)
+
+        #expect(outcome == .sent, "expected .sent, got \(outcome)")
+        #expect(holder.writes() == [
+            .write(terminalID: terminal.id, bytes: Data([0x1B])),
+            .write(terminalID: terminal.id, bytes: Data("continue".utf8) + Data([0x0D])),
+        ], "the holder arm's send was \(holder.snapshot())")
+    }
+
     /// A courier that found no route answers no, and the rail says so by name
     /// rather than reporting the generic "no activity after 2 sends" — and it
     /// does not try again, because the courier has already exhausted its own
@@ -1955,5 +2058,165 @@ struct HolderTmuxAssumptionGateTests {
         #expect(tmux.sends == ["key:Escape", "text:continue", "key:Enter"])
         #expect(holder.writes().isEmpty,
                 "a tmux row was routed through the holder input path")
+    }
+
+    // MARK: - Gate 11: the idle sweep and a screen the daemon cannot read
+
+    private func sweepLogPath() throws -> String {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-holdergate-sweep-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory, withIntermediateDirectories: true)
+        return directory.appendingPathComponent("actuations.jsonl").path
+    }
+
+    private func logRows(at path: String) throws -> [[String: Any]] {
+        guard let contents = try? String(contentsOfFile: path, encoding: .utf8) else { return [] }
+        return try contents
+            .split(separator: "\n", omittingEmptySubsequences: true)
+            .map { line in
+                try #require(
+                    try JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any])
+            }
+    }
+
+    /// A coordinator whose actuation record is a real file this test can count
+    /// rows in, and whose date seam the test drives — the sweep's poll/decide
+    /// sequence needs three passes and two elapsed windows, and none of that
+    /// may cost wall time.
+    private func sweepCoordinator(
+        _ db: TBDDatabase, logPath: String, dates: TestDateSource,
+        registry: HolderRegistry?
+    ) async -> HibernationCoordinator {
+        let coordinator = HibernationCoordinator(
+            db: db, tmux: TmuxManager(dryRun: true),
+            configDirManager: isolatedConfigDirManager(),
+            now: dates.provider,
+            exitPollAttempts: 1, exitPollInterval: .milliseconds(1),
+            actuationLog: ActuationLog(path: logPath))
+        await coordinator.setHolderRegistry(registry)
+        return coordinator
+    }
+
+    /// Seed the idle marker, cross the idle window to arm the debounce, then
+    /// let the settle window elapse so the rail reaches its act moment.
+    private func sweepToTheActMoment(
+        _ coord: HibernationCoordinator, dates: TestDateSource, idleMinutes: Int = 1
+    ) async {
+        await coord.sweep()
+        dates.advance(by: TimeInterval(idleMinutes) * 60 + 1)
+        await coord.sweep()
+        dates.advance(by: HibernationCoordinator.killDebounce + 1)
+        await coord.sweep()
+    }
+
+    /// The registry check the sweep makes before it arms or fires a holder row.
+    ///
+    /// `HibernationGate` is pure and cannot see who holds a pty, so a holder
+    /// row whose screen the daemon cannot read still reaches `.eligible` — and
+    /// `performHolderHibernate` then fails closed, but only after the sweep has
+    /// written a request row and its refused outcome. On a tab the user is
+    /// looking at that condition holds for as long as the tab is open, so the
+    /// pair would be paid on every sweep forever. The assertion is therefore on
+    /// the RECORD being empty, not on the row being unparked: the row is
+    /// unparked either way, and only the record can tell "refused" from "never
+    /// asked".
+    @Test("the sweep neither arms nor fires a holder row whose screen it cannot read")
+    func sweepSkipsAHolderRowTheDaemonIsNotReading() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setHolderHibernationEnabled(true)
+        try await db.config.setAutoHibernate(enabled: true, idleMinutes: 1)
+        let (wt, dir) = try await seedWorktree(db)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let terminal = try await seedClaudeTerminal(
+            db, worktreeID: wt.id, transport: .holder)
+        let before = RowFingerprint(terminal)
+        let logPath = try sweepLogPath()
+        let dates = TestDateSource()
+        // This registry adopted nothing, so it holds no reader for the session
+        // — the same state a daemon is in while a viewer owns the pty, reached
+        // without a live holder.
+        let coord = await sweepCoordinator(
+            db, logPath: logPath, dates: dates,
+            registry: holderRegistry(listing: [terminal]))
+
+        await sweepToTheActMoment(coord, dates: dates)
+        // A fourth pass a whole window later. Resetting the markers must mean
+        // "never fires while this holds", not "fires one sweep later".
+        dates.advance(by: 61 + HibernationCoordinator.killDebounce + 1)
+        await coord.sweep()
+
+        let written = try logRows(at: logPath)
+        #expect(written.isEmpty,
+                "the sweep asked for a park it could never have completed: \(written)")
+        let after = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(RowFingerprint(after) == before)
+    }
+
+    /// The other side of that check, and the marker half of the same fix.
+    ///
+    /// With no registry wired at all the sweep has nothing to ask, so it does
+    /// arm and fire — which is what makes the assertion above about the
+    /// registry answer rather than about holder rows being skipped wholesale.
+    /// The park then refuses by name, and that refusal clears `idleSince` and
+    /// `pendingKillSince` like every other refusal in the method: the next
+    /// sweep, at the same instant with the debounce still long past, writes
+    /// nothing. Leaving the markers armed would re-fire the identical refusal
+    /// on every pass.
+    @Test("with no registry the sweep fires once and the refusal clears its markers")
+    func sweepFiresOnceWhenNoRegistryCanAnswer() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setHolderHibernationEnabled(true)
+        try await db.config.setAutoHibernate(enabled: true, idleMinutes: 1)
+        let (wt, dir) = try await seedWorktree(db)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let terminal = try await seedClaudeTerminal(
+            db, worktreeID: wt.id, transport: .holder)
+        let logPath = try sweepLogPath()
+        let dates = TestDateSource()
+        let coord = await sweepCoordinator(
+            db, logPath: logPath, dates: dates, registry: nil)
+
+        await sweepToTheActMoment(coord, dates: dates)
+
+        let afterAct = try logRows(at: logPath)
+        #expect(afterAct.count == 2, "expected one request row and its outcome, got \(afterAct)")
+        #expect(afterAct.first?["kind"] as? String == "hibernate")
+        // The outcome's free-text slot is `error`, which is where
+        // `ActuationOutcome.detail` puts a refusal reason.
+        #expect(afterAct.last?["error"] as? String == "this daemon has no holder registry")
+
+        await coord.sweep()
+        let afterASecondPass = try logRows(at: logPath)
+        #expect(afterASecondPass.count == 2,
+                "the refusal left its markers armed, so the next sweep re-fired it: "
+                    + "\(afterASecondPass)")
+        #expect(try await db.terminals.get(id: terminal.id)?.isParked == false)
+    }
+
+    /// The transport leg. The registry question is asked of holder rows only —
+    /// an inverted comparison would stop the idle sweep parking tmux sessions
+    /// on any daemon that happens to have a registry wired.
+    @Test("the sweep still parks an identical tmux row on a daemon with a registry")
+    func sweepStillParksATmuxRowWithARegistryWired() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setHolderHibernationEnabled(true)
+        try await db.config.setAutoHibernate(enabled: true, idleMinutes: 1)
+        let (wt, dir) = try await seedWorktree(db)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let terminal = try await seedClaudeTerminal(
+            db, worktreeID: wt.id, transport: .tmux)
+        let logPath = try sweepLogPath()
+        let dates = TestDateSource()
+        let coord = await sweepCoordinator(
+            db, logPath: logPath, dates: dates,
+            registry: holderRegistry(listing: [terminal]))
+
+        await sweepToTheActMoment(coord, dates: dates)
+
+        #expect(try await db.terminals.get(id: terminal.id)?.isParked == true)
+        let written = try logRows(at: logPath)
+        #expect(written.count == 2, "expected one request row and its outcome, got \(written)")
+        #expect(written.last?["result"] as? String == "dispatched")
     }
 }

--- a/Tests/TBDDaemonTests/Holder/HolderTmuxAssumptionGateTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HolderTmuxAssumptionGateTests.swift
@@ -126,10 +126,14 @@ struct HolderTmuxAssumptionGateTests {
             listTerminals: { terminals })
     }
 
-    private func coordinator(_ db: TBDDatabase, tmux: TmuxManager) -> HibernationCoordinator {
-        HibernationCoordinator(
+    private func coordinator(
+        _ db: TBDDatabase, tmux: TmuxManager, registry: HolderRegistry? = nil
+    ) async -> HibernationCoordinator {
+        let coordinator = HibernationCoordinator(
             db: db, tmux: tmux, configDirManager: isolatedConfigDirManager(),
             actuationLog: makeTestActuationLog())
+        await coordinator.setHolderRegistry(registry)
+        return coordinator
     }
 
     /// Dry-run tmux that reports every window dead, recording every argv.
@@ -292,6 +296,94 @@ struct HolderTmuxAssumptionGateTests {
         #expect(try await db.terminals.get(id: terminal.id)?.hibernatedAt != nil)
     }
 
+    /// The flag's untouched state is a refusal, and that is asserted against
+    /// the column rather than against the Swift constant: a migration that
+    /// backfilled `0`, or a `toModel` that resolved NULL through something
+    /// other than `Config.holderHibernationEnabledDefault`, would both still
+    /// read `false` here — but so would a default that had been flipped without
+    /// anyone noticing, which is what this pins.
+    @Test("an untouched install refuses to park a holder row")
+    func theShippedDefaultRefusesAHolderPark() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let (wt, dir) = try await seedWorktree(db)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let terminal = try await seedClaudeTerminal(
+            db, worktreeID: wt.id, transport: .holder)
+        let before = RowFingerprint(terminal)
+
+        #expect(
+            try await db.config.get().holderHibernationEnabled == false,
+            "the shipped default must be off; nothing here touched the column")
+
+        let result = await coordinator(
+            db, tmux: TmuxManager(dryRun: true),
+            registry: holderRegistry(listing: [terminal])
+        ).manualHibernate(terminalID: terminal.id)
+        #expect(result == .notEligible(reason: HibernationCoordinator.holderTransportRefusal))
+
+        let after = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(RowFingerprint(after) == before,
+                "a park refused by the shipped default still mutated the holder row")
+    }
+
+    /// The gate's ON branch. The park is reached — which is the point — and
+    /// stops at the fail-closed screen rail, because this registry adopted
+    /// nothing and so is not this session's reader.
+    ///
+    /// That refusal is the whole rail stated without a live holder: it is the
+    /// answer a session whose viewer holds the pty gets too, and both mean the
+    /// same thing — the daemon cannot see the screen it would have to judge.
+    /// The row fingerprint is what proves the park stopped BEFORE the intent
+    /// was written rather than after.
+    @Test("with the flag on a holder row is hibernatable and reaches the screen rail")
+    func flagOnMakesAHolderRowHibernatable() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setHolderHibernationEnabled(true)
+        let (wt, dir) = try await seedWorktree(db)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let terminal = try await seedClaudeTerminal(
+            db, worktreeID: wt.id, transport: .holder)
+        let before = RowFingerprint(terminal)
+
+        #expect(terminal.isManuallyHibernatable(holderHibernationEnabled: true))
+        #expect(terminal.isAutoHibernationEligible(holderHibernationEnabled: true))
+
+        let result = await coordinator(
+            db, tmux: TmuxManager(dryRun: true),
+            registry: holderRegistry(listing: [terminal])
+        ).manualHibernate(terminalID: terminal.id)
+        #expect(
+            result == .notEligible(
+                reason: HibernationCoordinator.holderViewerAttachedRefusal),
+            "the park did not reach the screen rail: \(result)")
+
+        let after = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(RowFingerprint(after) == before,
+                "a park refused at the screen rail still wrote its intent to the row")
+    }
+
+    /// The registry is not optional decoration: with none wired there is no
+    /// reader to write `/exit` to and no way to abandon the holder afterwards,
+    /// so the park says so by name rather than parking a row whose process
+    /// nothing in this daemon could end.
+    @Test("with the flag on and no registry the park refuses by name")
+    func flagOnWithoutARegistryRefusesByName() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setHolderHibernationEnabled(true)
+        let (wt, dir) = try await seedWorktree(db)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let terminal = try await seedClaudeTerminal(
+            db, worktreeID: wt.id, transport: .holder)
+        let before = RowFingerprint(terminal)
+
+        let result = await coordinator(db, tmux: TmuxManager(dryRun: true))
+            .manualHibernate(terminalID: terminal.id)
+        #expect(result == .notEligible(reason: "this daemon has no holder registry"))
+
+        let after = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(RowFingerprint(after) == before)
+    }
+
     @Test("the auto and merge rails both name the holder transport as the blocker")
     func autoAndMergeRailsRefuseHolderRow() async throws {
         let db = try TBDDatabase(inMemory: true)
@@ -309,6 +401,27 @@ struct HolderTmuxAssumptionGateTests {
         #expect(HibernationGate.decideForMerge(
             terminal: terminal, inputVetoEnabled: false,
             lastInputAt: nil) == .holderTransport)
+    }
+
+    /// The same two rails with the flag on: a holder row that passes every
+    /// other rail is `.eligible`, which is what makes the flag-off assertions
+    /// above about the flag rather than about some unrelated blocker.
+    @Test("with the flag on the auto and merge rails elect a holder row")
+    func autoAndMergeRailsElectAHolderRowWithTheFlagOn() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let (wt, dir) = try await seedWorktree(db)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let terminal = try await seedClaudeTerminal(
+            db, worktreeID: wt.id, transport: .holder)
+
+        let now = Date()
+        #expect(HibernationGate.decide(
+            terminal: terminal, autoHibernateEnabled: true,
+            holderHibernationEnabled: true, idleTimeout: 60,
+            idleSince: now.addingTimeInterval(-3600), now: now) == .eligible)
+        #expect(HibernationGate.decideForMerge(
+            terminal: terminal, inputVetoEnabled: false,
+            holderHibernationEnabled: true, lastInputAt: nil) == .eligible)
     }
 
     @Test("the auto and merge rails still elect an identical tmux row")
@@ -373,6 +486,47 @@ struct HolderTmuxAssumptionGateTests {
         #expect(result == .ok)
         #expect(try await db.terminals.get(id: terminal.id)?.isParked == false)
         #expect(!recorded.snapshot().isEmpty, "the tmux leg must still drive tmux")
+    }
+
+    /// The wake gate's ON branch, stopped at the one refusal a fixture can
+    /// state without a live `TBDHolder`: this registry has no spawner, which is
+    /// the shape a daemon has when its helper binary has moved.
+    ///
+    /// "Registry present" is not "can spawn" — a daemon whose helper is missing
+    /// still builds a registry, because adopting a running holder needs no
+    /// executable — and the row staying parked is what proves the wake refused
+    /// rather than half-ran.
+    @Test("with the flag on a wake that cannot spawn a holder leaves the row parked")
+    func flagOnWakeWithoutASpawnerLeavesTheRowParked() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setHolderHibernationEnabled(true)
+        let recorded = RecordedTmuxArgs()
+        let tmux = deadWindowTmux(recorded)
+        let (wt, dir) = try await seedWorktree(db)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let terminal = try await seedClaudeTerminal(
+            db, worktreeID: wt.id, transport: .holder)
+        try await db.terminals.setHibernated(
+            id: terminal.id, sessionID: "sess-holdergate", reason: .manual)
+        let before = RowFingerprint(try #require(try await db.terminals.get(id: terminal.id)))
+
+        let registry = holderRegistry(listing: [terminal])
+        #expect(registry.canSpawn == false, "the fixture wired a spawner it was not meant to")
+
+        let result = await coordinator(db, tmux: tmux, registry: registry)
+            .wake(terminalID: terminal.id)
+        guard case .respawnFailed(let reason) = result else {
+            Issue.record("expected .respawnFailed, got \(result)")
+            return
+        }
+        #expect(reason.contains("TBDHolder"))
+
+        let after = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(after.isParked, "a refused wake un-parked the row")
+        #expect(RowFingerprint(after) == before,
+                "a refused wake mutated the holder row")
+        #expect(recorded.snapshot().isEmpty,
+                "the holder wake path reached tmux: \(recorded.snapshot())")
     }
 
     // MARK: - Gate 4: terminal.swapProfile, .inPlace

--- a/Tests/TBDDaemonTests/Holder/HolderTmuxAssumptionGateTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HolderTmuxAssumptionGateTests.swift
@@ -398,11 +398,15 @@ struct HolderTmuxAssumptionGateTests {
     /// stops at the fail-closed screen rail, because this registry adopted
     /// nothing and so is not this session's reader.
     ///
-    /// That refusal is the whole rail stated without a live holder: it is the
-    /// answer a session whose viewer holds the pty gets too, and both mean the
-    /// same thing — the daemon cannot see the screen it would have to judge.
-    /// The row fingerprint is what proves the park stopped BEFORE the intent
-    /// was written rather than after.
+    /// That refusal is the whole rail stated without a live holder. It is the
+    /// no-reader half: this registry has adopted nothing, so the daemon holds
+    /// no emulator to judge. The viewer half answers with its own name
+    /// (`holderViewerAttachedRefusal`) because the remedies differ — one is a
+    /// tab to close, the other is a session the daemon has lost track of —
+    /// while the underlying rule is one rule: the daemon cannot see the screen
+    /// it would have to judge, so it fails closed. The row fingerprint is what
+    /// proves the park stopped BEFORE the intent was written rather than
+    /// after.
     @Test("with the flag on a holder row is hibernatable and reaches the screen rail")
     func flagOnMakesAHolderRowHibernatable() async throws {
         let db = try TBDDatabase(inMemory: true)
@@ -422,8 +426,12 @@ struct HolderTmuxAssumptionGateTests {
         ).manualHibernate(terminalID: terminal.id)
         #expect(
             result == .notEligible(
-                reason: HibernationCoordinator.holderViewerAttachedRefusal),
+                reason: HibernationCoordinator.holderNoReaderRefusal),
             "the park did not reach the screen rail: \(result)")
+        #expect(
+            HibernationCoordinator.holderNoReaderRefusal
+                != HibernationCoordinator.holderViewerAttachedRefusal,
+            "the two halves of the screen rail collapsed back into one string")
 
         let after = try #require(try await db.terminals.get(id: terminal.id))
         #expect(RowFingerprint(after) == before,

--- a/Tests/TBDDaemonTests/Holder/HolderTmuxAssumptionGateTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HolderTmuxAssumptionGateTests.swift
@@ -25,32 +25,63 @@ final class RecordedTmuxArgs: @unchecked Sendable {
     }
 }
 
-/// Every payload a rail handed the holder input seam, and the answer it got.
+/// Every payload a rail handed the holder input seam, every pause it took
+/// between them, and the answer the seam gave back — in one ordered log,
+/// because on this transport the ORDER of "Escape, pause, text" is the
+/// property under test and two separate recorders could not express it.
 ///
-/// Shaped exactly like the closure `Daemon.start` builds over
+/// `send` is shaped exactly like the closure `Daemon.start` builds over
 /// `HolderInjectionCourier.deliver` — bytes in, delivered-or-not out — so a
 /// test asserts on the bytes production would put on a pty rather than on a
-/// mock of the courier's internals.
+/// mock of the courier's internals. `waiter` is the actuator's own sleep seam,
+/// recording instead of sleeping (the same trick
+/// `LimitResumeActuatorTests.toggleFlippedOffBetweenAttemptsCancelsAfterOneSend`
+/// uses to act between an actuation's steps).
 private final class RecordedHolderWrites: @unchecked Sendable {
+    enum Event: Equatable {
+        case write(terminalID: UUID, bytes: Data)
+        case pause(Duration)
+    }
+
     private let lock = NSLock()
-    private var writes: [(terminalID: UUID, bytes: Data)] = []
-    /// What the seam answers: `true` for delivered, `false` for a courier that
-    /// found no route at all.
-    private let accepts: Bool
+    private var events: [Event] = []
+    private var writeCount = 0
+    /// How many writes the seam answers `true` to before it starts answering
+    /// `false` — a courier that found no route at all. Default: every one.
+    /// `0` refuses the first write, `1` the second, which is how the two
+    /// halves of the holder arm's send are failed independently.
+    private let acceptedWrites: Int
 
-    init(accepts: Bool = true) { self.accepts = accepts }
+    init(acceptedWrites: Int = .max) { self.acceptedWrites = acceptedWrites }
 
-    func snapshot() -> [(terminalID: UUID, bytes: Data)] {
+    /// Writes and pauses interleaved, in the order they happened.
+    func snapshot() -> [Event] {
         lock.lock(); defer { lock.unlock() }
-        return writes
+        return events
+    }
+
+    /// Just the writes, for the tests whose whole assertion is that there were
+    /// none.
+    func writes() -> [Event] {
+        snapshot().filter { if case .write = $0 { return true } else { return false } }
     }
 
     var send: @Sendable (UUID, Data) async -> Bool {
         { [self] terminalID, bytes in
             lock.lock()
-            writes.append((terminalID: terminalID, bytes: bytes))
+            events.append(.write(terminalID: terminalID, bytes: bytes))
+            writeCount += 1
+            let accepted = writeCount <= acceptedWrites
             lock.unlock()
-            return accepts
+            return accepted
+        }
+    }
+
+    var waiter: @Sendable (Duration) async -> Void {
+        { [self] duration in
+            lock.lock()
+            events.append(.pause(duration))
+            lock.unlock()
         }
     }
 }
@@ -1552,16 +1583,18 @@ struct HolderTmuxAssumptionGateTests {
     ///
     /// `holderSend` defaults to nil, which is also what a daemon with no holder
     /// registry wires, so the flag-off tests below assert the flag and not an
-    /// absent seam.
+    /// absent seam. `waiter` defaults to a no-op, so only the test that asserts
+    /// on the pause between the holder arm's two writes records them.
     private func resumeActuator(
         _ db: TBDDatabase, tmux: FakeResumeTmux,
-        holderSend: (@Sendable (UUID, Data) async -> Bool)? = nil
+        holderSend: (@Sendable (UUID, Data) async -> Bool)? = nil,
+        waiter: @escaping @Sendable (Duration) async -> Void = { _ in }
     ) -> LimitResumeActuator {
         LimitResumeActuator(
             db: db, tmux: tmux, inspector: FakeInspector(claudePID: 4242),
             readTranscript: { _ in nil },
             transcriptModifiedAt: { _ in nil },
-            waiter: { _ in }, actuationLog: makeTestActuationLog(),
+            waiter: waiter, actuationLog: makeTestActuationLog(),
             holderSend: holderSend)
     }
 
@@ -1601,7 +1634,7 @@ struct HolderTmuxAssumptionGateTests {
         #expect(outcome == .failed(LimitResumeActuator.holderTransportRefusal),
                 "expected the named refusal, got \(outcome)")
         #expect(tmux.sends.isEmpty)
-        #expect(holder.snapshot().isEmpty,
+        #expect(holder.writes().isEmpty,
                 "the flag is off and the rail still wrote to the holder's pty")
         let after = try #require(try await db.terminals.get(id: terminal.id))
         #expect(RowFingerprint(after) == before,
@@ -1641,7 +1674,7 @@ struct HolderTmuxAssumptionGateTests {
                 "expected the named refusal, got \(outcome)")
         #expect(tmux.sends.isEmpty,
                 "auto-resume typed into a holder row: \(tmux.sends)")
-        #expect(holder.snapshot().isEmpty,
+        #expect(holder.writes().isEmpty,
                 "the flag is off and the rail still wrote to the holder's pty")
         let after = try #require(try await db.terminals.get(id: terminal.id))
         #expect(RowFingerprint(after) == before)
@@ -1650,12 +1683,18 @@ struct HolderTmuxAssumptionGateTests {
     /// The other branch of the same gate: with the flag on, the rail delivers
     /// the resume through the holder input path instead of refusing.
     ///
-    /// The bytes are asserted whole rather than against the actuator's own
-    /// constant, because the constant is what this test exists to pin: ESC,
-    /// the literal `continue`, carriage return — one write, ten bytes, no
-    /// bracketed-paste wrapper (Claude Code's stdin tokenizer swallows the
-    /// `\r` only at 64 bytes and up).
-    @Test("auto-resume writes ESC + continue + CR to a holder session with the flag on")
+    /// Two writes with the tmux arm's 150 ms pause between them, asserted as
+    /// one ordered log because the order is the property. ESC has to arrive in
+    /// a read of its own: an ink-style parser reads ESC followed immediately by
+    /// a printable byte as a meta key, so a single `ESC`+`continue`+`\r` write
+    /// composes Alt-c and then "ontinue" every time, which no retry recovers.
+    /// The second write keeps its carriage return — 9 bytes, under the 64 at
+    /// which Claude Code's stdin tokenizer swallows an unwrapped `\r`.
+    ///
+    /// The bytes are spelled out here rather than compared against the
+    /// actuator's own constants, because those constants are what this test
+    /// exists to pin.
+    @Test("auto-resume writes ESC, a pause, then continue + CR to a holder session with the flag on")
     func autoResumeWritesTheContinueMessageToHolderRowWithFlagOn() async throws {
         let db = try TBDDatabase(inMemory: true)
         let (wt, dir) = try await seedWorktree(db)
@@ -1666,7 +1705,9 @@ struct HolderTmuxAssumptionGateTests {
         // The activity hook already reports working, so the first verification
         // poll succeeds without a transcript on disk — the same fixture the
         // tmux leg uses, because verification reads hook-fed state and the
-        // transcript and so is the same code for both transports.
+        // transcript and so is the same code for both transports. It also
+        // means verification never reaches its own `waiter` call, so every
+        // pause in the log below belongs to the send.
         try await db.terminals.setActivityState(
             id: terminal.id, activityState: .working, source: .derived)
         let resume = try await armedResume(db, terminal: terminal)
@@ -1676,19 +1717,16 @@ struct HolderTmuxAssumptionGateTests {
         // makes that a real assertion rather than a refusal in disguise.
         tmux.windowAlive = true
         let holder = RecordedHolderWrites()
-        let outcome = await resumeActuator(db, tmux: tmux, holderSend: holder.send)
-            .actuate(resume)
+        let outcome = await resumeActuator(
+            db, tmux: tmux, holderSend: holder.send, waiter: holder.waiter
+        ).actuate(resume)
 
         #expect(outcome == .sent, "expected .sent, got \(outcome)")
-        let writes = holder.snapshot()
-        #expect(writes.count == 1, "expected one write, got \(writes.count)")
-        let write = try #require(writes.first)
-        #expect(write.terminalID == terminal.id,
-                "the write was addressed to \(write.terminalID), not the scheduled terminal")
-        #expect(write.bytes == Data([0x1B]) + Data("continue".utf8) + Data([0x0D]),
-                "wrote \(Array(write.bytes))")
-        #expect(write.bytes.count == 10,
-                "the payload must stay under the 64-byte threshold that eats an unwrapped \\r")
+        #expect(holder.snapshot() == [
+            .write(terminalID: terminal.id, bytes: Data([0x1B])),
+            .pause(.milliseconds(150)),
+            .write(terminalID: terminal.id, bytes: Data("continue".utf8) + Data([0x0D])),
+        ], "the holder arm's send was \(holder.snapshot())")
         #expect(tmux.sends.isEmpty,
                 "the holder arm reached tmux: \(tmux.sends)")
     }
@@ -1718,7 +1756,7 @@ struct HolderTmuxAssumptionGateTests {
             .actuate(resume)
 
         #expect(outcome == .terminalGone, "expected .terminalGone, got \(outcome)")
-        #expect(holder.snapshot().isEmpty,
+        #expect(holder.writes().isEmpty,
                 "auto-resume wrote into a parked holder session")
         #expect(tmux.sends.isEmpty)
     }
@@ -1727,7 +1765,10 @@ struct HolderTmuxAssumptionGateTests {
     /// rather than reporting the generic "no activity after 2 sends" — and it
     /// does not try again, because the courier has already exhausted its own
     /// routes by the time it answers.
-    @Test("auto-resume fails by name when the holder input path takes nothing")
+    ///
+    /// A refused Escape also stops the sequence there: no pause, and no
+    /// "continue" typed at a session that did not take the Escape.
+    @Test("auto-resume fails by name when the holder input path refuses the Escape")
     func autoResumeFailsByNameWhenHolderWriteIsRefused() async throws {
         let db = try TBDDatabase(inMemory: true)
         let (wt, dir) = try await seedWorktree(db)
@@ -1738,14 +1779,45 @@ struct HolderTmuxAssumptionGateTests {
         let resume = try await armedResume(db, terminal: terminal)
 
         let tmux = FakeResumeTmux()
-        let holder = RecordedHolderWrites(accepts: false)
-        let outcome = await resumeActuator(db, tmux: tmux, holderSend: holder.send)
-            .actuate(resume)
+        let holder = RecordedHolderWrites(acceptedWrites: 0)
+        let outcome = await resumeActuator(
+            db, tmux: tmux, holderSend: holder.send, waiter: holder.waiter
+        ).actuate(resume)
 
         #expect(outcome == .failed(LimitResumeActuator.holderWriteRefused),
                 "expected the named write failure, got \(outcome)")
-        #expect(holder.snapshot().count == 1,
-                "an undeliverable write was retried: \(holder.snapshot().count) attempts")
+        #expect(holder.snapshot() == [.write(terminalID: terminal.id, bytes: Data([0x1B]))],
+                "a refused Escape was followed by more: \(holder.snapshot())")
+        #expect(tmux.sends.isEmpty)
+    }
+
+    /// The other half of the same failure: the Escape lands, the text does not.
+    /// Same named failure, and still no retry — a half-delivered send is not a
+    /// send, and the courier that refused the second write would refuse it
+    /// again by the same route.
+    @Test("auto-resume fails by name when the holder input path refuses the continue text")
+    func autoResumeFailsByNameWhenHolderSecondWriteIsRefused() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let (wt, dir) = try await seedWorktree(db)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try await db.config.setHolderHibernationEnabled(true)
+        let terminal = try await seedClaudeTerminal(
+            db, worktreeID: wt.id, transport: .holder)
+        let resume = try await armedResume(db, terminal: terminal)
+
+        let tmux = FakeResumeTmux()
+        let holder = RecordedHolderWrites(acceptedWrites: 1)
+        let outcome = await resumeActuator(
+            db, tmux: tmux, holderSend: holder.send, waiter: holder.waiter
+        ).actuate(resume)
+
+        #expect(outcome == .failed(LimitResumeActuator.holderWriteRefused),
+                "expected the named write failure, got \(outcome)")
+        #expect(holder.snapshot() == [
+            .write(terminalID: terminal.id, bytes: Data([0x1B])),
+            .pause(.milliseconds(150)),
+            .write(terminalID: terminal.id, bytes: Data("continue".utf8) + Data([0x0D])),
+        ], "the send was retried or reshaped: \(holder.snapshot())")
         #expect(tmux.sends.isEmpty)
     }
 
@@ -1823,7 +1895,7 @@ struct HolderTmuxAssumptionGateTests {
 
         #expect(outcome == .sent, "expected .sent, got \(outcome)")
         #expect(tmux.sends == ["key:Escape", "text:continue", "key:Enter"])
-        #expect(holder.snapshot().isEmpty,
+        #expect(holder.writes().isEmpty,
                 "a tmux row was routed through the holder input path")
     }
 }

--- a/Tests/TBDDaemonTests/Holder/HolderTmuxAssumptionGateTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HolderTmuxAssumptionGateTests.swift
@@ -510,8 +510,18 @@ struct HolderTmuxAssumptionGateTests {
 
     // MARK: - Gate 3: wake
 
-    @Test("wake refuses a parked holder row without touching tmux or the row")
-    func wakeRefusesParkedHolderRow() async throws {
+    /// The flag gates new parks, not the wake of a row that is already parked.
+    ///
+    /// Turning the flag off is the soak's abort gesture, and an abort that
+    /// stranded what the soak parked would be no abort at all: the app's
+    /// focus-wake would fire a failing RPC on every focus, forever. So a parked
+    /// holder row must reach the holder wake mechanic with the flag OFF — and
+    /// the way to state that without a live `TBDHolder` is the same refusal the
+    /// flag-on test uses, a registry that cannot spawn. `.respawnFailed` is
+    /// therefore the PROOF: `.holderTransport` here would mean the gate is
+    /// still above the parked check.
+    @Test("with the flag off a wake of a parked holder row still reaches the holder mechanic")
+    func flagOffWakeOfAParkedHolderRowProceedsPastTheGate() async throws {
         let db = try TBDDatabase(inMemory: true)
         let recorded = RecordedTmuxArgs()
         let tmux = deadWindowTmux(recorded)
@@ -519,14 +529,47 @@ struct HolderTmuxAssumptionGateTests {
         defer { try? FileManager.default.removeItem(at: dir) }
         let terminal = try await seedClaudeTerminal(
             db, worktreeID: wt.id, transport: .holder)
-        // Park the row through the store directly. The coordinator now refuses
-        // to park it, but a row parked by an older daemon — or by a path this
-        // milestone has not yet gated — still has to survive a wake, and the
-        // parked branch is where the damage would be done.
+        #expect(try await db.config.get().holderHibernationEnabled == false,
+                "the fixture armed the flag it was meant to leave off")
         try await db.terminals.setHibernated(
             id: terminal.id, sessionID: "sess-holdergate", reason: .manual)
         let before = RowFingerprint(try #require(try await db.terminals.get(id: terminal.id)))
         #expect(before.hibernatedAt != nil)
+
+        let registry = holderRegistry(listing: [terminal])
+        #expect(registry.canSpawn == false, "the fixture wired a spawner it was not meant to")
+
+        let result = await coordinator(db, tmux: tmux, registry: registry)
+            .wake(terminalID: terminal.id)
+        guard case .respawnFailed(let reason) = result else {
+            Issue.record("expected .respawnFailed — the flag still gates a parked wake, got \(result)")
+            return
+        }
+        #expect(reason.contains("TBDHolder"))
+
+        let after = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(after.isParked, "a failed wake un-parked the row")
+        #expect(RowFingerprint(after) == before,
+                "a failed wake mutated the holder row")
+        #expect(recorded.snapshot().isEmpty,
+                "the holder wake path reached tmux: \(recorded.snapshot())")
+    }
+
+    /// The other side of the same gate: an UNPARKED holder row with the flag
+    /// off is refused by name, mutating nothing and asking the process table
+    /// nothing. This is what keeps the move above from being a removal — the
+    /// flag still decides whether this install classifies a holder row at all.
+    @Test("with the flag off a wake of an unparked holder row is refused by name")
+    func flagOffWakeOfAnUnparkedHolderRowIsRefused() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let recorded = RecordedTmuxArgs()
+        let tmux = deadWindowTmux(recorded)
+        let (wt, dir) = try await seedWorktree(db)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let terminal = try await seedClaudeTerminal(
+            db, worktreeID: wt.id, transport: .holder)
+        let before = RowFingerprint(terminal)
+        #expect(before.hibernatedAt == nil && before.suspendedAt == nil)
 
         let result = await coordinator(db, tmux: tmux).wake(terminalID: terminal.id)
         #expect(result == .holderTransport)

--- a/Tests/TBDDaemonTests/Holder/HolderTmuxAssumptionGateTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HolderTmuxAssumptionGateTests.swift
@@ -263,8 +263,8 @@ struct HolderTmuxAssumptionGateTests {
 
         // The pure property first: it is what the app's tab menu reads, so a
         // holder tab must not even offer Hibernate.
-        #expect(!terminal.isManuallyHibernatable)
-        #expect(!terminal.isAutoHibernationEligible)
+        #expect(!terminal.isManuallyHibernatable(holderHibernationEnabled: false))
+        #expect(!terminal.isAutoHibernationEligible(holderHibernationEnabled: false))
 
         let result = await coordinator(db, tmux: TmuxManager(dryRun: true))
             .manualHibernate(terminalID: terminal.id)
@@ -283,8 +283,8 @@ struct HolderTmuxAssumptionGateTests {
         let terminal = try await seedClaudeTerminal(
             db, worktreeID: wt.id, transport: .tmux)
 
-        #expect(terminal.isManuallyHibernatable)
-        #expect(terminal.isAutoHibernationEligible)
+        #expect(terminal.isManuallyHibernatable(holderHibernationEnabled: false))
+        #expect(terminal.isAutoHibernationEligible(holderHibernationEnabled: false))
 
         let result = await coordinator(db, tmux: TmuxManager(dryRun: true))
             .manualHibernate(terminalID: terminal.id)

--- a/Tests/TBDDaemonTests/Holder/HolderTmuxAssumptionGateTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HolderTmuxAssumptionGateTests.swift
@@ -424,17 +424,18 @@ struct HolderTmuxAssumptionGateTests {
 
     /// The gate's ON branch. The park is reached — which is the point — and
     /// stops at the fail-closed screen rail, because this registry adopted
-    /// nothing and so is not this session's reader.
+    /// nothing and so holds no screen for this session.
     ///
     /// That refusal is the whole rail stated without a live holder. It is the
-    /// no-reader half: this registry has adopted nothing, so the daemon holds
-    /// no emulator to judge. The viewer half answers with its own name
-    /// (`holderViewerAttachedRefusal`) because the remedies differ — one is a
-    /// tab to close, the other is a session the daemon has lost track of —
-    /// while the underlying rule is one rule: the daemon cannot see the screen
-    /// it would have to judge, so it fails closed. The row fingerprint is what
-    /// proves the park stopped BEFORE the intent was written rather than
-    /// after.
+    /// no-screen half: this registry has adopted nothing, so the oracle answers
+    /// nothing at all. The other halves answer with their own names — a source
+    /// the daemon is not the live store for gets
+    /// `holderViewerAttachedRefusal`, a screen that will not project gets
+    /// `holderScreenProjectionRefusal` — because the remedies differ: a tab to
+    /// close, a session the daemon has lost track of, a defect to fix. The
+    /// underlying rule is one rule: the daemon cannot judge the screen, so it
+    /// fails closed. The row fingerprint is what proves the park stopped BEFORE
+    /// the intent was written rather than after.
     @Test("with the flag on a holder row is hibernatable and reaches the screen rail")
     func flagOnMakesAHolderRowHibernatable() async throws {
         let db = try TBDDatabase(inMemory: true)
@@ -459,11 +460,200 @@ struct HolderTmuxAssumptionGateTests {
         #expect(
             HibernationCoordinator.holderNoReaderRefusal
                 != HibernationCoordinator.holderViewerAttachedRefusal,
-            "the two halves of the screen rail collapsed back into one string")
+            "two halves of the screen rail collapsed back into one string")
+        #expect(
+            HibernationCoordinator.holderScreenProjectionRefusal
+                != HibernationCoordinator.holderNoReaderRefusal,
+            "two halves of the screen rail collapsed back into one string")
 
         let after = try #require(try await db.terminals.get(id: terminal.id))
         #expect(RowFingerprint(after) == before,
                 "a park refused at the screen rail still wrote its intent to the row")
+    }
+
+    // MARK: - Gate 2a: the pending-input rail reads the typed screen
+
+    /// A screen the rail can judge, without a holder, a pty or an attach.
+    ///
+    /// The two facts these tests vary are the ones the rail turns on: the
+    /// `lines`, which `HibernationSafetyChecks.hasPendingInput` reads, and the
+    /// `source`, which decides whether the daemon may read them at all.
+    /// Everything else is a plausible constant, constructed through
+    /// `TerminalScreen`'s own initializer so a fixture cannot state a screen
+    /// the type would refuse.
+    private static func screen(
+        lines: [String], source: TerminalScreen.Source = .daemon
+    ) throws -> TerminalScreen {
+        try TerminalScreen(
+            lines: lines,
+            viewportStart: 0,
+            cursor: TerminalScreen.Cursor(row: 0, column: 0, visible: true),
+            size: TerminalScreen.Size(columns: 80, rows: 24),
+            modes: TerminalScreen.ChildModes(
+                bracketedPaste: true, applicationCursor: false, alternateScreen: false),
+            source: source,
+            ageMilliseconds: 0)
+    }
+
+    /// The composer as Claude draws it when nobody has typed anything.
+    private static let emptyComposer = [
+        "╭──────────────────────────────────────╮",
+        "│ > Try \"fix the failing test\"         │",
+        "╰──────────────────────────────────────╯",
+    ]
+
+    /// The same composer with a half-composed prompt in it.
+    private static let typedComposer = [
+        "╭──────────────────────────────────────╮",
+        "│ > refactor the auth module and add    │",
+        "╰──────────────────────────────────────╯",
+    ]
+
+    /// The park's screen seam, standing in for a registry-backed reader.
+    private static func screenOracle(
+        _ answer: @escaping @Sendable () throws -> TerminalScreen?
+    ) -> @Sendable (UUID) async throws -> TerminalScreen? {
+        { _ in try answer() }
+    }
+
+    /// A park driven against a screen this suite states, with a registry that
+    /// adopted nothing behind it.
+    ///
+    /// The registry's own reader is therefore never the answer — the seam is —
+    /// which is what lets each `source` be reached without a real attach. The
+    /// consequence is that a park which CLEARS the rail then stops at the
+    /// reader lookup the polite `/exit` needs, and `holderNoReaderRefusal` is
+    /// how "the rail passed" is stated here.
+    private func parkAgainst(
+        _ answer: @escaping @Sendable () throws -> TerminalScreen?,
+        db: TBDDatabase, terminal: Terminal
+    ) async -> HibernateResult {
+        let coord = await coordinator(
+            db, tmux: TmuxManager(dryRun: true),
+            registry: holderRegistry(listing: [terminal]))
+        await coord.setHolderScreenOracle(Self.screenOracle(answer))
+        return await coord.manualHibernate(terminalID: terminal.id)
+    }
+
+    /// The whole point of reading the typed screen rather than a string: a
+    /// screen the daemon did not render live is refused, and it is refused on
+    /// the `source` field rather than on a second question about who holds the
+    /// pty. A viewer's attach suspends the daemon's drain, so its retained
+    /// emulator answers `staleDaemon` — a screen frozen at the moment of that
+    /// attach, which cannot prove a composer is empty however empty it looks.
+    @Test("a park refuses a screen the daemon is not the live store for")
+    func parkRefusesAStaleScreen() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setHolderHibernationEnabled(true)
+        let (wt, dir) = try await seedWorktree(db)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let terminal = try await seedClaudeTerminal(
+            db, worktreeID: wt.id, transport: .holder)
+        let before = RowFingerprint(terminal)
+        // An EMPTY composer, deliberately: the refusal must come from the
+        // source, not from anything the lines say. A stale screen showing a
+        // clear prompt is exactly the screen that would otherwise be parked
+        // over a person's half-typed message.
+        let stale = try Self.screen(lines: Self.emptyComposer, source: .staleDaemon)
+
+        let result = await parkAgainst({ stale }, db: db, terminal: terminal)
+        #expect(
+            result == .notEligible(reason: HibernationCoordinator.holderViewerAttachedRefusal),
+            "a stale screen did not fail the rail closed: \(result)")
+
+        let after = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(RowFingerprint(after) == before,
+                "a park refused on a stale screen still wrote its intent to the row")
+    }
+
+    /// The `viewer` arm. Not reachable from a `HolderReader`, which answers only
+    /// `daemon` or `staleDaemon` — but the rail's policy is a switch over every
+    /// source, and this pins that a live screen somebody else is typing into is
+    /// still not one this park may act on.
+    @Test("a park refuses a screen a viewer answered")
+    func parkRefusesAViewerScreen() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setHolderHibernationEnabled(true)
+        let (wt, dir) = try await seedWorktree(db)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let terminal = try await seedClaudeTerminal(
+            db, worktreeID: wt.id, transport: .holder)
+        let viewer = try Self.screen(lines: Self.emptyComposer, source: .viewer)
+
+        let result = await parkAgainst({ viewer }, db: db, terminal: terminal)
+        #expect(result == .notEligible(reason: HibernationCoordinator.holderViewerAttachedRefusal))
+    }
+
+    /// The `daemon` arm, with something typed. This is the rail doing the job
+    /// it exists for, and the refusal is the input one rather than any of the
+    /// fail-closed ones — which is what makes the tests above about the source.
+    @Test("a park refuses a live screen with a half-composed prompt on it")
+    func parkRefusesTypedInputOnALiveScreen() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setHolderHibernationEnabled(true)
+        let (wt, dir) = try await seedWorktree(db)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let terminal = try await seedClaudeTerminal(
+            db, worktreeID: wt.id, transport: .holder)
+        let before = RowFingerprint(terminal)
+        let typed = try Self.screen(lines: Self.typedComposer, source: .daemon)
+
+        let result = await parkAgainst({ typed }, db: db, terminal: terminal)
+        #expect(result == .notEligible(reason: "Terminal has unsent typed input"))
+
+        let after = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(RowFingerprint(after) == before)
+    }
+
+    /// The `daemon` arm with a clear composer: the rail PASSES, and the park
+    /// goes on to the reader it would write `/exit` through.
+    ///
+    /// `holderNoReaderRefusal` is the proof, and it is a different string from
+    /// every refusal above: reaching it means the source was accepted and the
+    /// lines were judged empty. Without a live holder there is no further to
+    /// get, and inventing one for a question about a screen is what the seam
+    /// exists to avoid.
+    @Test("a live screen with a clear composer passes the rail")
+    func parkPassesTheRailOnALiveClearScreen() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setHolderHibernationEnabled(true)
+        let (wt, dir) = try await seedWorktree(db)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let terminal = try await seedClaudeTerminal(
+            db, worktreeID: wt.id, transport: .holder)
+        let live = try Self.screen(lines: Self.emptyComposer, source: .daemon)
+
+        let result = await parkAgainst({ live }, db: db, terminal: terminal)
+        #expect(
+            result == .notEligible(reason: HibernationCoordinator.holderNoReaderRefusal),
+            "the rail refused a live screen with an empty composer: \(result)")
+    }
+
+    /// A screen that will not project at all. `TerminalScreen` refuses a line
+    /// carrying a control character, and the rail cannot read past that: it
+    /// fails closed with a name of its own, because the remedy is a defect to
+    /// fix rather than a tab to close.
+    @Test("a park refuses a screen that will not project")
+    func parkRefusesAScreenThatWillNotProject() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setHolderHibernationEnabled(true)
+        let (wt, dir) = try await seedWorktree(db)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let terminal = try await seedClaudeTerminal(
+            db, worktreeID: wt.id, transport: .holder)
+        let before = RowFingerprint(terminal)
+
+        // Thrown by the type itself rather than by a hand-rolled error, so the
+        // test states the real failure a broken render produces.
+        let result = await parkAgainst(
+            { try Self.screen(lines: ["> \u{7}"], source: .daemon) },
+            db: db, terminal: terminal)
+        #expect(
+            result == .notEligible(reason: HibernationCoordinator.holderScreenProjectionRefusal),
+            "a refused projection did not fail the rail closed: \(result)")
+
+        let after = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(RowFingerprint(after) == before)
     }
 
     /// The registry is not optional decoration: with none wired there is no
@@ -2256,7 +2446,8 @@ struct HolderTmuxAssumptionGateTests {
     /// may cost wall time.
     private func sweepCoordinator(
         _ db: TBDDatabase, logPath: String, dates: TestDateSource,
-        registry: HolderRegistry?
+        registry: HolderRegistry?,
+        screen: (@Sendable () throws -> TerminalScreen?)? = nil
     ) async -> HibernationCoordinator {
         let coordinator = HibernationCoordinator(
             db: db, tmux: TmuxManager(dryRun: true),
@@ -2265,6 +2456,9 @@ struct HolderTmuxAssumptionGateTests {
             exitPollAttempts: 1, exitPollInterval: .milliseconds(1),
             actuationLog: ActuationLog(path: logPath))
         await coordinator.setHolderRegistry(registry)
+        if let screen {
+            await coordinator.setHolderScreenOracle(Self.screenOracle(screen))
+        }
         return coordinator
     }
 
@@ -2303,9 +2497,11 @@ struct HolderTmuxAssumptionGateTests {
         let before = RowFingerprint(terminal)
         let logPath = try sweepLogPath()
         let dates = TestDateSource()
-        // This registry adopted nothing, so it holds no reader for the session
-        // — the same state a daemon is in while a viewer owns the pty, reached
-        // without a live holder.
+        // This registry adopted nothing, so the oracle has no screen to answer
+        // with at all — the no-reader half of the rail, reached without a live
+        // holder. (A viewer-held session is the *other* half and answers a
+        // stale screen rather than none; `sweepSkipsAHolderRowWithAStaleScreen`
+        // states that one.)
         let coord = await sweepCoordinator(
             db, logPath: logPath, dates: dates,
             registry: holderRegistry(listing: [terminal]))
@@ -2387,5 +2583,80 @@ struct HolderTmuxAssumptionGateTests {
         let written = try logRows(at: logPath)
         #expect(written.count == 2, "expected one request row and its outcome, got \(written)")
         #expect(written.last?["result"] as? String == "dispatched")
+    }
+
+    /// The sweep and the park ask the same question of the same oracle, so a
+    /// screen the park would refuse is one the sweep never arms.
+    ///
+    /// A viewer holding the pty is exactly that state: the daemon's retained
+    /// emulator answers `staleDaemon`, the park fails closed on it, and a tab
+    /// somebody has open holds that condition for as long as it is open — so
+    /// arming would buy a request-and-refusal pair on every sweep, forever.
+    /// The assertion is on the RECORD being empty, because only the record can
+    /// tell "refused" from "never asked".
+    @Test("the sweep neither arms nor fires a holder row whose screen is stale")
+    func sweepSkipsAHolderRowWithAStaleScreen() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setHolderHibernationEnabled(true)
+        try await db.config.setAutoHibernate(enabled: true, idleMinutes: 1)
+        let (wt, dir) = try await seedWorktree(db)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let terminal = try await seedClaudeTerminal(
+            db, worktreeID: wt.id, transport: .holder)
+        let before = RowFingerprint(terminal)
+        let logPath = try sweepLogPath()
+        let dates = TestDateSource()
+        // A clear composer, so nothing but the source can be what stops this.
+        let stale = try Self.screen(lines: Self.emptyComposer, source: .staleDaemon)
+        let coord = await sweepCoordinator(
+            db, logPath: logPath, dates: dates,
+            registry: holderRegistry(listing: [terminal]),
+            screen: { stale })
+
+        await sweepToTheActMoment(coord, dates: dates)
+        dates.advance(by: 61 + HibernationCoordinator.killDebounce + 1)
+        await coord.sweep()
+
+        let written = try logRows(at: logPath)
+        #expect(written.isEmpty,
+                "the sweep asked for a park it could never have completed: \(written)")
+        let after = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(RowFingerprint(after) == before)
+    }
+
+    /// The other side of the source check, and what makes the test above about
+    /// the source rather than about holder rows being skipped wholesale.
+    ///
+    /// The same fixture with a `daemon` screen arms and fires. The park then
+    /// refuses at the reader lookup the polite `/exit` needs — this registry
+    /// adopted nothing — so what the record shows is a request and its refusal
+    /// rather than a park, and `holderNoReaderRefusal` is the proof the sweep
+    /// got past its own screen check.
+    @Test("the sweep arms a holder row whose screen the daemon renders live")
+    func sweepArmsAHolderRowWithALiveScreen() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setHolderHibernationEnabled(true)
+        try await db.config.setAutoHibernate(enabled: true, idleMinutes: 1)
+        let (wt, dir) = try await seedWorktree(db)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let terminal = try await seedClaudeTerminal(
+            db, worktreeID: wt.id, transport: .holder)
+        let logPath = try sweepLogPath()
+        let dates = TestDateSource()
+        let live = try Self.screen(lines: Self.emptyComposer, source: .daemon)
+        let coord = await sweepCoordinator(
+            db, logPath: logPath, dates: dates,
+            registry: holderRegistry(listing: [terminal]),
+            screen: { live })
+
+        await sweepToTheActMoment(coord, dates: dates)
+
+        let written = try logRows(at: logPath)
+        #expect(written.count == 2, "expected one request row and its outcome, got \(written)")
+        #expect(written.first?["kind"] as? String == "hibernate")
+        #expect(
+            written.last?["error"] as? String == HibernationCoordinator.holderNoReaderRefusal,
+            "the sweep fired, but not past its own screen check: \(written)")
+        #expect(try await db.terminals.get(id: terminal.id)?.isParked == false)
     }
 }

--- a/Tests/TBDDaemonTests/Holder/HolderTmuxAssumptionGateTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HolderTmuxAssumptionGateTests.swift
@@ -2189,8 +2189,7 @@ struct HolderTmuxAssumptionGateTests {
         await coord.sweep()
         let afterASecondPass = try logRows(at: logPath)
         #expect(afterASecondPass.count == 2,
-                "the refusal left its markers armed, so the next sweep re-fired it: "
-                    + "\(afterASecondPass)")
+                "the refusal left its markers armed, so the next sweep re-fired it: \(afterASecondPass)")
         #expect(try await db.terminals.get(id: terminal.id)?.isParked == false)
     }
 

--- a/Tests/TBDDaemonTests/Holder/HolderTmuxAssumptionGateTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HolderTmuxAssumptionGateTests.swift
@@ -160,9 +160,14 @@ struct HolderTmuxAssumptionGateTests {
     /// test here that reaches code which would `kill()` it, and no fixture on a
     /// shared box may name a pid that could really exist. See
     /// `deleteDisposesHolderInsteadOfKillingAWindow`.
+    ///
+    /// `holderChildStartedAt` is the identity anchor `ProcessIdentityCheck`
+    /// measures a live pid's start time against. Left nil by default, which is
+    /// what a row that never recorded one carries; the wake tests that script a
+    /// living child set it, because a verdict of `.same` needs both halves.
     private func seedClaudeTerminal(
         _ db: TBDDatabase, worktreeID: UUID, transport: TerminalTransport,
-        childPID: Int32 = 9102
+        childPID: Int32 = 9102, holderChildStartedAt: Date? = nil
     ) async throws -> Terminal {
         let holder = transport == .holder
         let terminal = try await db.terminals.create(
@@ -174,7 +179,8 @@ struct HolderTmuxAssumptionGateTests {
             kind: .claude,
             transport: transport,
             holderPID: holder ? 9101 : nil,
-            childPID: holder ? childPID : nil)
+            childPID: holder ? childPID : nil,
+            holderChildStartedAt: holder ? holderChildStartedAt : nil)
         try await db.terminals.setActivityState(
             id: terminal.id, activityState: .idle, source: .derived)
         return try #require(try await db.terminals.get(id: terminal.id))
@@ -194,14 +200,36 @@ struct HolderTmuxAssumptionGateTests {
             listTerminals: { terminals })
     }
 
+    /// `signaller` is defaulted so every call site that does not care about the
+    /// process table keeps compiling unchanged — but the wake path now reads it
+    /// on holder rows, so a test whose verdict depends on whether a recorded
+    /// child is alive must script one rather than let the production signaller
+    /// ask the real kernel about a fixture pid.
     private func coordinator(
-        _ db: TBDDatabase, tmux: TmuxManager, registry: HolderRegistry? = nil
+        _ db: TBDDatabase, tmux: TmuxManager, registry: HolderRegistry? = nil,
+        signaller: any ProcessSignaller = ProductionProcessSignaller()
     ) async -> HibernationCoordinator {
         let coordinator = HibernationCoordinator(
             db: db, tmux: tmux, configDirManager: isolatedConfigDirManager(),
-            actuationLog: makeTestActuationLog())
+            signaller: signaller, actuationLog: makeTestActuationLog())
         await coordinator.setHolderRegistry(registry)
         return coordinator
+    }
+
+    /// The shape a holder's job presents to an identity check: the login shell
+    /// the holder forked, or the agent binary that shell `exec`d itself into.
+    private static let holderChildCommand = "/bin/zsh -i -l -c claude"
+
+    /// A process table in which the fixture's recorded child pid names nothing.
+    ///
+    /// The wake path asks about that pid before it spawns, and a fixture pid is
+    /// a number the kernel may well have handed to a real process on this box.
+    /// Scripting the answer is what keeps "the wake went on to spawn" a fact
+    /// about the code rather than about what happens to be running.
+    private func deadChildSignaller(_ childPID: Int32 = 9102) -> FakeProcessSignaller {
+        let signaller = FakeProcessSignaller()
+        signaller.behaviors[childPID] = .init(aliveInitially: false)
+        return signaller
     }
 
     /// Dry-run tmux that reports every window dead, recording every argv.
@@ -550,7 +578,10 @@ struct HolderTmuxAssumptionGateTests {
         let registry = holderRegistry(listing: [terminal])
         #expect(registry.canSpawn == false, "the fixture wired a spawner it was not meant to")
 
-        let result = await coordinator(db, tmux: tmux, registry: registry)
+        // The recorded child names nothing, so the wake goes on to spawn — and
+        // then refuses for the one reason this fixture can state.
+        let result = await coordinator(
+            db, tmux: tmux, registry: registry, signaller: deadChildSignaller())
             .wake(terminalID: terminal.id)
         guard case .respawnFailed(let reason) = result else {
             Issue.record("expected .respawnFailed — the flag still gates a parked wake, got \(result)")
@@ -635,7 +666,8 @@ struct HolderTmuxAssumptionGateTests {
         let registry = holderRegistry(listing: [terminal])
         #expect(registry.canSpawn == false, "the fixture wired a spawner it was not meant to")
 
-        let result = await coordinator(db, tmux: tmux, registry: registry)
+        let result = await coordinator(
+            db, tmux: tmux, registry: registry, signaller: deadChildSignaller())
             .wake(terminalID: terminal.id)
         guard case .respawnFailed(let reason) = result else {
             Issue.record("expected .respawnFailed, got \(result)")
@@ -649,6 +681,144 @@ struct HolderTmuxAssumptionGateTests {
                 "a refused wake mutated the holder row")
         #expect(recorded.snapshot().isEmpty,
                 "the holder wake path reached tmux: \(recorded.snapshot())")
+    }
+
+    /// A retried wake of a row whose holder is ALREADY running adopts it.
+    ///
+    /// The state under test is the one a wake leaves behind when its pid write
+    /// lands and its `clearHibernated` does not: the row reads parked while
+    /// naming a live holder and a live child. The periodic reconcile sweep
+    /// skips parked rows and `reconcileOnStartup` only runs at daemon boot, so
+    /// until this guard existed every retry in between spawned a SECOND agent
+    /// onto the same session and abandoned the first, which no reconciler could
+    /// then reach — the reaper's holder leg sweeps by the pids a row carries,
+    /// and the row had just been made to carry the third generation's.
+    ///
+    /// The registry deliberately cannot spawn, and that is the discriminator
+    /// rather than a limitation of the fixture: a wake that reached the spawn
+    /// would answer `.respawnFailed` here, so `.ok` can only mean it stopped
+    /// short of one. The pids surviving unchanged says the same thing from the
+    /// row's side.
+    @Test("a wake of a row parked over a live holder adopts it instead of spawning again")
+    func wakeAdoptsAHolderThatIsAlreadyRunning() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setHolderHibernationEnabled(true)
+        let recorded = RecordedTmuxArgs()
+        let tmux = deadWindowTmux(recorded)
+        let (wt, dir) = try await seedWorktree(db)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        // An hour-old child, anchored on the row's recorded start rather than
+        // on `createdAt`: the shape a session woken a while ago has.
+        let childStartedAt = Date().addingTimeInterval(-3600)
+        let signaller = FakeProcessSignaller()
+        signaller.behaviors[9109] = .init(aliveInitially: true)
+        signaller.startTimes[9109] = childStartedAt
+        signaller.cmdlines[9109] = Self.holderChildCommand
+
+        let terminal = try await seedClaudeTerminal(
+            db, worktreeID: wt.id, transport: .holder,
+            childPID: 9109, holderChildStartedAt: childStartedAt)
+        try await db.terminals.setHibernated(
+            id: terminal.id, sessionID: "sess-holdergate", reason: .manual)
+
+        let registry = holderRegistry(listing: [terminal])
+        #expect(registry.canSpawn == false, "the fixture wired a spawner it was not meant to")
+
+        let result = await coordinator(
+            db, tmux: tmux, registry: registry, signaller: signaller)
+            .wake(terminalID: terminal.id)
+        #expect(result == .ok,
+                "a row parked over a live holder was not adopted")
+
+        let after = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(!after.isParked, "the adopted row was left parked")
+        #expect(after.holderPID == 9101, "adoption re-identified the holder")
+        #expect(after.childPID == 9109, "adoption re-identified the child")
+        #expect(after.holderChildStartedAt != nil,
+                "adoption forgot the identity anchor the next check needs")
+        #expect(recorded.snapshot().isEmpty,
+                "the holder wake path reached tmux: \(recorded.snapshot())")
+    }
+
+    /// The other verdict on the same row: a recorded child that names nothing
+    /// is not a holder to adopt, so the wake goes on to spawn one — and this
+    /// fixture's registry cannot, which leaves the row parked.
+    ///
+    /// Without this leg the guard above would be indistinguishable from one
+    /// that un-parks every parked holder row it is handed.
+    @Test("a wake whose recorded child is gone still spawns, and the row stays parked")
+    func wakeWithADeadChildStillSpawns() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setHolderHibernationEnabled(true)
+        let recorded = RecordedTmuxArgs()
+        let tmux = deadWindowTmux(recorded)
+        let (wt, dir) = try await seedWorktree(db)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let childStartedAt = Date().addingTimeInterval(-3600)
+        let terminal = try await seedClaudeTerminal(
+            db, worktreeID: wt.id, transport: .holder,
+            childPID: 9109, holderChildStartedAt: childStartedAt)
+        try await db.terminals.setHibernated(
+            id: terminal.id, sessionID: "sess-holdergate", reason: .manual)
+        let before = RowFingerprint(try #require(try await db.terminals.get(id: terminal.id)))
+
+        let registry = holderRegistry(listing: [terminal])
+        let result = await coordinator(
+            db, tmux: tmux, registry: registry, signaller: deadChildSignaller(9109))
+            .wake(terminalID: terminal.id)
+        guard case .respawnFailed(let reason) = result else {
+            Issue.record("expected .respawnFailed — a dead child must not be adopted, got \(result)")
+            return
+        }
+        #expect(reason.contains("TBDHolder"))
+
+        let after = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(after.isParked, "a wake that could not spawn un-parked the row")
+        #expect(RowFingerprint(after) == before, "a failed wake mutated the holder row")
+        #expect(recorded.snapshot().isEmpty,
+                "the holder wake path reached tmux: \(recorded.snapshot())")
+    }
+
+    /// The tmux leg of the same guard: a parked tmux row is judged by its
+    /// window, never by the process table, so a signaller scripted to report a
+    /// perfect identity changes nothing about how it wakes.
+    @Test("a parked tmux row still wakes through tmux whatever the process table says")
+    func parkedTmuxRowIsUnaffectedByTheAdoptGuard() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setHolderHibernationEnabled(true)
+        let recorded = RecordedTmuxArgs()
+        let tmux = deadWindowTmux(recorded)
+        let (wt, dir) = try await seedWorktree(db)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        // Scripted alive with an unimpeachable identity, and the row is given
+        // the pids to match — a shape a tmux row would never really carry, and
+        // deliberately so: without them the process table says nothing about
+        // this row and the test could not tell a transport-blind guard from a
+        // correct one. With them, a guard that stopped discriminating on
+        // transport would adopt this row and drive no tmux at all.
+        let childStartedAt = Date()
+        let signaller = FakeProcessSignaller()
+        signaller.behaviors[9109] = .init(aliveInitially: true)
+        signaller.startTimes[9109] = childStartedAt
+        signaller.cmdlines[9109] = Self.holderChildCommand
+
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@7", tmuxPaneID: "%7",
+            label: TerminalLabel.claudeCode, claudeSessionID: "sess-holdergate",
+            kind: .claude, transport: .tmux,
+            holderPID: 9101, childPID: 9109, holderChildStartedAt: childStartedAt)
+        try await db.terminals.setHibernated(
+            id: terminal.id, sessionID: "sess-holdergate", reason: .manual)
+
+        let result = await coordinator(db, tmux: tmux, signaller: signaller)
+            .wake(terminalID: terminal.id)
+        #expect(result == .ok)
+        #expect(try await db.terminals.get(id: terminal.id)?.isParked == false)
+        #expect(!recorded.snapshot().isEmpty,
+                "the tmux leg must still drive tmux to wake a parked row")
     }
 
     // MARK: - Gate 4: terminal.swapProfile, .inPlace

--- a/Tests/TBDDaemonTests/Holder/HolderTmuxAssumptionGateTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HolderTmuxAssumptionGateTests.swift
@@ -66,22 +66,29 @@ private final class RecordedHolderWrites: @unchecked Sendable {
         snapshot().filter { if case .write = $0 { return true } else { return false } }
     }
 
+    private func recordWrite(terminalID: UUID, bytes: Data) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        events.append(.write(terminalID: terminalID, bytes: bytes))
+        writeCount += 1
+        return writeCount <= acceptedWrites
+    }
+
+    private func recordPause(_ duration: Duration) {
+        lock.lock()
+        defer { lock.unlock() }
+        events.append(.pause(duration))
+    }
+
     var send: @Sendable (UUID, Data) async -> Bool {
         { [self] terminalID, bytes in
-            lock.lock()
-            events.append(.write(terminalID: terminalID, bytes: bytes))
-            writeCount += 1
-            let accepted = writeCount <= acceptedWrites
-            lock.unlock()
-            return accepted
+            recordWrite(terminalID: terminalID, bytes: bytes)
         }
     }
 
     var waiter: @Sendable (Duration) async -> Void {
         { [self] duration in
-            lock.lock()
-            events.append(.pause(duration))
-            lock.unlock()
+            recordPause(duration)
         }
     }
 }

--- a/Tests/TBDDaemonTests/Holder/HolderTmuxAssumptionGateTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HolderTmuxAssumptionGateTests.swift
@@ -25,6 +25,36 @@ final class RecordedTmuxArgs: @unchecked Sendable {
     }
 }
 
+/// Every payload a rail handed the holder input seam, and the answer it got.
+///
+/// Shaped exactly like the closure `Daemon.start` builds over
+/// `HolderInjectionCourier.deliver` — bytes in, delivered-or-not out — so a
+/// test asserts on the bytes production would put on a pty rather than on a
+/// mock of the courier's internals.
+private final class RecordedHolderWrites: @unchecked Sendable {
+    private let lock = NSLock()
+    private var writes: [(terminalID: UUID, bytes: Data)] = []
+    /// What the seam answers: `true` for delivered, `false` for a courier that
+    /// found no route at all.
+    private let accepts: Bool
+
+    init(accepts: Bool = true) { self.accepts = accepts }
+
+    func snapshot() -> [(terminalID: UUID, bytes: Data)] {
+        lock.lock(); defer { lock.unlock() }
+        return writes
+    }
+
+    var send: @Sendable (UUID, Data) async -> Bool {
+        { [self] terminalID, bytes in
+            lock.lock()
+            writes.append((terminalID: terminalID, bytes: bytes))
+            lock.unlock()
+            return accepts
+        }
+    }
+}
+
 /// The subsystems that assumed every terminal has a live tmux window, and what
 /// each of them now does with a holder-backed row instead.
 ///
@@ -1516,30 +1546,47 @@ struct HolderTmuxAssumptionGateTests {
     }
 
     /// An actuator whose every side effect is observable: no real sleeping, no
-    /// transcript on disk, and a tmux double that records the keys it is asked
-    /// to type.
+    /// transcript on disk, a tmux double that records the keys it is asked to
+    /// type, and — when the caller passes one — a holder input path that
+    /// records the bytes it is handed.
+    ///
+    /// `holderSend` defaults to nil, which is also what a daemon with no holder
+    /// registry wires, so the flag-off tests below assert the flag and not an
+    /// absent seam.
     private func resumeActuator(
-        _ db: TBDDatabase, tmux: FakeResumeTmux
+        _ db: TBDDatabase, tmux: FakeResumeTmux,
+        holderSend: (@Sendable (UUID, Data) async -> Bool)? = nil
     ) -> LimitResumeActuator {
         LimitResumeActuator(
             db: db, tmux: tmux, inspector: FakeInspector(claudePID: 4242),
             readTranscript: { _ in nil },
             transcriptModifiedAt: { _ in nil },
-            waiter: { _ in }, actuationLog: makeTestActuationLog())
+            waiter: { _ in }, actuationLog: makeTestActuationLog(),
+            holderSend: holderSend)
     }
 
-    /// The reproduction, on the answer a real tmux gives.
+    /// The reproduction, on the answer a real tmux gives — and the shipped
+    /// default, untouched.
     ///
     /// `windowExists(windowID: "")` is `false`, so the rail cancelled the
     /// user's armed auto-resume as `.terminalGone` — a silent cancel that
     /// records "the terminal is gone" for a session that is perfectly alive,
     /// and leaves nobody told. The refusal is now named, and `.failed` so the
     /// daemon's notification says so once.
-    @Test("auto-resume refuses a holder row by name instead of cancelling it as gone")
+    ///
+    /// Nothing here sets `holder_hibernation_enabled`: the column is NULL,
+    /// nobody has chosen, and `Config.holderHibernationEnabledDefault` decides
+    /// — which is the state every install is in until someone opts into the
+    /// soak. A holder input path is wired all the same, so what refuses is the
+    /// flag and not an absent seam.
+    @Test("auto-resume refuses a holder row by name under the shipped default")
     func autoResumeRefusesHolderRow() async throws {
         let db = try TBDDatabase(inMemory: true)
         let (wt, dir) = try await seedWorktree(db)
         defer { try? FileManager.default.removeItem(at: dir) }
+        let shipped = try await db.config.get()
+        #expect(shipped.holderHibernationEnabled == false,
+                "the fixture is not in the default-off state this test is about")
         let terminal = try await seedClaudeTerminal(
             db, worktreeID: wt.id, transport: .holder)
         let before = RowFingerprint(terminal)
@@ -1547,11 +1594,15 @@ struct HolderTmuxAssumptionGateTests {
 
         let tmux = FakeResumeTmux()
         tmux.windowAlive = false   // what a real server answers for ""
-        let outcome = await resumeActuator(db, tmux: tmux).actuate(resume)
+        let holder = RecordedHolderWrites()
+        let outcome = await resumeActuator(db, tmux: tmux, holderSend: holder.send)
+            .actuate(resume)
 
         #expect(outcome == .failed(LimitResumeActuator.holderTransportRefusal),
                 "expected the named refusal, got \(outcome)")
         #expect(tmux.sends.isEmpty)
+        #expect(holder.snapshot().isEmpty,
+                "the flag is off and the rail still wrote to the holder's pty")
         let after = try #require(try await db.terminals.get(id: terminal.id))
         #expect(RowFingerprint(after) == before,
                 "a refused auto-resume mutated the holder row")
@@ -1566,11 +1617,15 @@ struct HolderTmuxAssumptionGateTests {
     /// typed at whatever the empty pane id resolves to. That is what makes the
     /// old behavior an accident rather than a safe default: it depended on
     /// `TmuxManager.windowExists` swallowing its error.
-    @Test("auto-resume types nothing at a holder row even when tmux claims the window is alive")
+    @Test("auto-resume types nothing at a holder row with the flag explicitly off, even when tmux claims the window is alive")
     func autoResumeTypesNothingAtHolderRowWithLiveWindowAnswer() async throws {
         let db = try TBDDatabase(inMemory: true)
         let (wt, dir) = try await seedWorktree(db)
         defer { try? FileManager.default.removeItem(at: dir) }
+        // Explicitly off: a chosen `0` rather than the NULL the test above
+        // covers, which is the state a user who tried the soak and turned it
+        // back off is in.
+        try await db.config.setHolderHibernationEnabled(false)
         let terminal = try await seedClaudeTerminal(
             db, worktreeID: wt.id, transport: .holder)
         let before = RowFingerprint(terminal)
@@ -1578,12 +1633,145 @@ struct HolderTmuxAssumptionGateTests {
 
         let tmux = FakeResumeTmux()
         tmux.windowAlive = true
-        let outcome = await resumeActuator(db, tmux: tmux).actuate(resume)
+        let holder = RecordedHolderWrites()
+        let outcome = await resumeActuator(db, tmux: tmux, holderSend: holder.send)
+            .actuate(resume)
 
         #expect(outcome == .failed(LimitResumeActuator.holderTransportRefusal),
                 "expected the named refusal, got \(outcome)")
         #expect(tmux.sends.isEmpty,
                 "auto-resume typed into a holder row: \(tmux.sends)")
+        #expect(holder.snapshot().isEmpty,
+                "the flag is off and the rail still wrote to the holder's pty")
+        let after = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(RowFingerprint(after) == before)
+    }
+
+    /// The other branch of the same gate: with the flag on, the rail delivers
+    /// the resume through the holder input path instead of refusing.
+    ///
+    /// The bytes are asserted whole rather than against the actuator's own
+    /// constant, because the constant is what this test exists to pin: ESC,
+    /// the literal `continue`, carriage return — one write, ten bytes, no
+    /// bracketed-paste wrapper (Claude Code's stdin tokenizer swallows the
+    /// `\r` only at 64 bytes and up).
+    @Test("auto-resume writes ESC + continue + CR to a holder session with the flag on")
+    func autoResumeWritesTheContinueMessageToHolderRowWithFlagOn() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let (wt, dir) = try await seedWorktree(db)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try await db.config.setHolderHibernationEnabled(true)
+        let terminal = try await seedClaudeTerminal(
+            db, worktreeID: wt.id, transport: .holder)
+        // The activity hook already reports working, so the first verification
+        // poll succeeds without a transcript on disk — the same fixture the
+        // tmux leg uses, because verification reads hook-fed state and the
+        // transcript and so is the same code for both transports.
+        try await db.terminals.setActivityState(
+            id: terminal.id, activityState: .working, source: .derived)
+        let resume = try await armedResume(db, terminal: terminal)
+
+        let tmux = FakeResumeTmux()
+        // A holder row must not consult tmux either way; answering "alive"
+        // makes that a real assertion rather than a refusal in disguise.
+        tmux.windowAlive = true
+        let holder = RecordedHolderWrites()
+        let outcome = await resumeActuator(db, tmux: tmux, holderSend: holder.send)
+            .actuate(resume)
+
+        #expect(outcome == .sent, "expected .sent, got \(outcome)")
+        let writes = holder.snapshot()
+        #expect(writes.count == 1, "expected one write, got \(writes.count)")
+        let write = try #require(writes.first)
+        #expect(write.terminalID == terminal.id,
+                "the write was addressed to \(write.terminalID), not the scheduled terminal")
+        #expect(write.bytes == Data([0x1B]) + Data("continue".utf8) + Data([0x0D]),
+                "wrote \(Array(write.bytes))")
+        #expect(write.bytes.count == 10,
+                "the payload must stay under the 64-byte threshold that eats an unwrapped \\r")
+        #expect(tmux.sends.isEmpty,
+                "the holder arm reached tmux: \(tmux.sends)")
+    }
+
+    /// Parking cancels the pending row, so this is the fire-time backstop for a
+    /// park that raced the scheduler — and with the flag on, parking a holder
+    /// row is something that can now happen. Same silent cancel as the tmux
+    /// path: `.terminalGone`, nothing written.
+    @Test("auto-resume writes nothing to a parked holder row with the flag on")
+    func autoResumeLeavesParkedHolderRowAloneWithFlagOn() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let (wt, dir) = try await seedWorktree(db)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try await db.config.setHolderHibernationEnabled(true)
+        let terminal = try await seedClaudeTerminal(
+            db, worktreeID: wt.id, transport: .holder)
+        // Armed first, then parked: the order a park that raced the scheduler
+        // actually happens in.
+        let resume = try await armedResume(db, terminal: terminal)
+        try await db.terminals.setHibernated(
+            id: terminal.id, sessionID: "sess-holdergate", snapshot: nil)
+
+        let tmux = FakeResumeTmux()
+        tmux.windowAlive = true
+        let holder = RecordedHolderWrites()
+        let outcome = await resumeActuator(db, tmux: tmux, holderSend: holder.send)
+            .actuate(resume)
+
+        #expect(outcome == .terminalGone, "expected .terminalGone, got \(outcome)")
+        #expect(holder.snapshot().isEmpty,
+                "auto-resume wrote into a parked holder session")
+        #expect(tmux.sends.isEmpty)
+    }
+
+    /// A courier that found no route answers no, and the rail says so by name
+    /// rather than reporting the generic "no activity after 2 sends" — and it
+    /// does not try again, because the courier has already exhausted its own
+    /// routes by the time it answers.
+    @Test("auto-resume fails by name when the holder input path takes nothing")
+    func autoResumeFailsByNameWhenHolderWriteIsRefused() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let (wt, dir) = try await seedWorktree(db)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try await db.config.setHolderHibernationEnabled(true)
+        let terminal = try await seedClaudeTerminal(
+            db, worktreeID: wt.id, transport: .holder)
+        let resume = try await armedResume(db, terminal: terminal)
+
+        let tmux = FakeResumeTmux()
+        let holder = RecordedHolderWrites(accepts: false)
+        let outcome = await resumeActuator(db, tmux: tmux, holderSend: holder.send)
+            .actuate(resume)
+
+        #expect(outcome == .failed(LimitResumeActuator.holderWriteRefused),
+                "expected the named write failure, got \(outcome)")
+        #expect(holder.snapshot().count == 1,
+                "an undeliverable write was retried: \(holder.snapshot().count) attempts")
+        #expect(tmux.sends.isEmpty)
+    }
+
+    /// The flag is on, the row is a holder row, and this daemon has no way to
+    /// write to a holder's pty at all (mock mode, or no registry to build a
+    /// courier on). A different refusal from the flag's, because it is a
+    /// different repair.
+    @Test("auto-resume fails by name when the daemon has no holder input path")
+    func autoResumeFailsByNameWithNoHolderInputPath() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let (wt, dir) = try await seedWorktree(db)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try await db.config.setHolderHibernationEnabled(true)
+        let terminal = try await seedClaudeTerminal(
+            db, worktreeID: wt.id, transport: .holder)
+        let before = RowFingerprint(terminal)
+        let resume = try await armedResume(db, terminal: terminal)
+
+        let tmux = FakeResumeTmux()
+        tmux.windowAlive = true
+        let outcome = await resumeActuator(db, tmux: tmux, holderSend: nil).actuate(resume)
+
+        #expect(outcome == .failed(LimitResumeActuator.holderInputPathMissing),
+                "expected the named missing-path failure, got \(outcome)")
+        #expect(tmux.sends.isEmpty,
+                "a daemon with no holder input path fell back to typing at tmux: \(tmux.sends)")
         let after = try #require(try await db.terminals.get(id: terminal.id))
         #expect(RowFingerprint(after) == before)
     }
@@ -1609,5 +1797,33 @@ struct HolderTmuxAssumptionGateTests {
 
         #expect(outcome == .sent, "expected .sent, got \(outcome)")
         #expect(tmux.sends == ["key:Escape", "text:continue", "key:Enter"])
+    }
+
+    /// The tmux leg of the flag itself. `holder_hibernation_enabled` decides
+    /// how a HOLDER row is resumed and nothing about a tmux one: with it on, a
+    /// tmux row still gets the three-key sequence through `send-keys` and the
+    /// holder input path is never touched.
+    @Test("auto-resume still types the continue sequence into a tmux row with holder hibernation on")
+    func autoResumeStillActsOnTmuxRowWithHolderHibernationOn() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let (wt, dir) = try await seedWorktree(db)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try await db.config.setHolderHibernationEnabled(true)
+        let terminal = try await seedClaudeTerminal(
+            db, worktreeID: wt.id, transport: .tmux)
+        try await db.terminals.setActivityState(
+            id: terminal.id, activityState: .working, source: .derived)
+        let resume = try await armedResume(db, terminal: terminal)
+
+        let tmux = FakeResumeTmux()
+        tmux.windowAlive = true
+        let holder = RecordedHolderWrites()
+        let outcome = await resumeActuator(db, tmux: tmux, holderSend: holder.send)
+            .actuate(resume)
+
+        #expect(outcome == .sent, "expected .sent, got \(outcome)")
+        #expect(tmux.sends == ["key:Escape", "text:continue", "key:Enter"])
+        #expect(holder.snapshot().isEmpty,
+                "a tmux row was routed through the holder input path")
     }
 }

--- a/Tests/TBDDaemonTests/InputActivityTrackerTests.swift
+++ b/Tests/TBDDaemonTests/InputActivityTrackerTests.swift
@@ -1,6 +1,7 @@
 import Testing
 import Foundation
 @testable import TBDDaemonLib
+@testable import TBDShared
 
 /// Tests for the InputActivityTracker: timestamp recording, query, forget, and
 /// pruning. Pure: no DB, no tmux, no actor. One test per method/path.
@@ -119,5 +120,50 @@ struct InputActivityTrackerTests {
         #expect(time2 >= time1)
         // pane1's time should not have changed
         #expect(tracker.lastInput(paneID: pane1) == time1)
+    }
+
+    // MARK: - The per-transport key
+
+    /// A tmux row is keyed by its pane id, unchanged.
+    @Test func aTmuxRowIsKeyedByItsPaneID() {
+        let terminal = Terminal(
+            worktreeID: UUID(), tmuxWindowID: "@1", tmuxPaneID: "%7", kind: .claude)
+        #expect(InputActivityTracker.key(for: terminal) == "%7")
+    }
+
+    /// A holder row has no pane, so its `tmuxPaneID` is the empty string by
+    /// construction. Keying on that would put EVERY holder session in one
+    /// bucket: input typed into any of them would veto a park on all the
+    /// others, and forgetting one would forget them all. Two rows, two keys, is
+    /// the assertion — the empty string is not.
+    @Test func holderRowsGetDistinctKeys() {
+        let first = Terminal(
+            worktreeID: UUID(), tmuxWindowID: "", tmuxPaneID: "", kind: .claude,
+            transport: .holder)
+        let second = Terminal(
+            worktreeID: UUID(), tmuxWindowID: "", tmuxPaneID: "", kind: .claude,
+            transport: .holder)
+        #expect(InputActivityTracker.key(for: first) == first.id.uuidString)
+        #expect(InputActivityTracker.key(for: first) != InputActivityTracker.key(for: second))
+        #expect(!InputActivityTracker.key(for: first).isEmpty)
+    }
+
+    /// The keys are what the two transports' entries actually live under, so a
+    /// veto recorded for one holder session cannot be read for another.
+    @Test func aHolderVetoIsNotVisibleToAnotherHolderSession() {
+        let tracker = InputActivityTracker()
+        let first = Terminal(
+            worktreeID: UUID(), tmuxWindowID: "", tmuxPaneID: "", kind: .claude,
+            transport: .holder)
+        let second = Terminal(
+            worktreeID: UUID(), tmuxWindowID: "", tmuxPaneID: "", kind: .claude,
+            transport: .holder)
+
+        tracker.recordInput(paneID: InputActivityTracker.key(for: first))
+        #expect(tracker.lastInput(paneID: InputActivityTracker.key(for: first)) != nil)
+        #expect(tracker.lastInput(paneID: InputActivityTracker.key(for: second)) == nil)
+
+        tracker.forget(paneID: InputActivityTracker.key(for: first))
+        #expect(tracker.lastInput(paneID: InputActivityTracker.key(for: first)) == nil)
     }
 }

--- a/Tests/TBDDaemonTests/NotificationHookRPCTests.swift
+++ b/Tests/TBDDaemonTests/NotificationHookRPCTests.swift
@@ -151,6 +151,9 @@ import TestSupport
         HibernationGate.decide(
             terminal: terminal,
             autoHibernateEnabled: true,
+            // A tmux fixture; the gate takes no default for this, so it is
+            // named rather than omitted.
+            holderHibernationEnabled: false,
             idleTimeout: 60,
             idleSince: Self.baselineActivityAt,
             now: Self.baselineActivityAt.addingTimeInterval(3600))

--- a/Tests/TBDDaemonTests/NotificationHookRPCTests.swift
+++ b/Tests/TBDDaemonTests/NotificationHookRPCTests.swift
@@ -217,7 +217,7 @@ import TestSupport
         // rather than assumed.
         #expect(parkDecision(after) == parkDecision(before))
         #expect(parkDecision(after) == .eligible)
-        #expect(HibernationGate.blockingRail(terminal: after) == nil)
+        #expect(HibernationGate.blockingRail(terminal: after, holderHibernationEnabled: false) == nil)
 
         // A prompt on screen is the one class a human has to act on now, so
         // it, and only it, raises the attention notification behind the macOS

--- a/Tests/TBDDaemonTests/PtyHolderSettingsRPCTests.swift
+++ b/Tests/TBDDaemonTests/PtyHolderSettingsRPCTests.swift
@@ -194,4 +194,86 @@ struct PtyHolderSettingsRPCTests {
             #expect(decoded.enabled == value)
         }
     }
+
+    // MARK: - config.setHolderHibernationEnabled
+
+    private func setHolderHibernation(_ router: RPCRouter, enabled: Bool) async throws {
+        let request = try RPCRequest(
+            method: RPCMethod.configSetHolderHibernationEnabled,
+            params: ConfigSetHolderHibernationEnabledParams(enabled: enabled))
+        let response = await router.handle(request)
+        #expect(response.success, "error: \(response.error ?? "nil")")
+    }
+
+    /// The RPC persists on and off through the router — the round trip the
+    /// Settings toggle actually performs.
+    @Test("config.setHolderHibernationEnabled persists on and off through the router")
+    func setHolderHibernationPersistsBothDirections() async throws {
+        let (router, db) = try makeRouterAndDB()
+
+        try await setHolderHibernation(router, enabled: true)
+        #expect(try await db.config.get().holderHibernationEnabled == true)
+
+        try await setHolderHibernation(router, enabled: false)
+        #expect(try await db.config.get().holderHibernationEnabled == false)
+        let stored = try await db.writerForTests.read { conn in
+            try ConfigRecord.fetchOne(conn, key: ConfigStore.singletonID)?.holder_hibernation_enabled
+        }
+        #expect(stored == false, "an explicit off must be a stored 0, not a NULL")
+    }
+
+    /// An untouched install stores NULL, not a 0 — the third state, same shape
+    /// as the pty-holder transport gate above.
+    @Test("an untouched install stores NULL for holder hibernation")
+    func untouchedStoresNullForHolderHibernation() async throws {
+        let (_, db) = try makeRouterAndDB()
+        let stored = try await db.writerForTests.read { conn in
+            try ConfigRecord.fetchOne(conn, key: ConfigStore.singletonID)?.holder_hibernation_enabled
+        }
+        #expect(stored == nil)
+    }
+
+    @Test("capabilities reports holder hibernation OFF by default")
+    func capabilitiesHolderHibernationDefaultsOff() async throws {
+        let (router, _) = try makeRouterAndDB()
+        #expect(
+            try await capabilities(router).holderHibernationEnabled
+                == Config.holderHibernationEnabledDefault)
+        #expect(
+            Config.holderHibernationEnabledDefault == false,
+            "the shipped default is still OFF during the soak")
+    }
+
+    /// Capabilities re-evaluates the flag on every call, exactly like the
+    /// pty-holder transport gate — no daemon restart needed.
+    @Test("capabilities re-evaluates holder hibernation without a restart")
+    func capabilitiesReEvaluatesHolderHibernation() async throws {
+        let (router, _) = try makeRouterAndDB()
+
+        try await setHolderHibernation(router, enabled: true)
+        #expect(try await capabilities(router).holderHibernationEnabled == true)
+
+        try await setHolderHibernation(router, enabled: false)
+        #expect(try await capabilities(router).holderHibernationEnabled == false)
+    }
+
+    /// An older daemon sends no such field; the decoder falls through to
+    /// `false` rather than assuming the gate is live.
+    @Test("capabilities JSON without holder hibernation decodes to false")
+    func capabilitiesHolderHibernationDecodeBackCompat() throws {
+        let json = Data(#"{"controlModeEnabled":true,"controlModeSupported":false}"#.utf8)
+        let result = try JSONDecoder().decode(DaemonCapabilitiesResult.self, from: json)
+        #expect(result.holderHibernationEnabled == false)
+    }
+
+    @Test("ConfigSetHolderHibernationEnabledParams round-trips both values")
+    func holderHibernationParamsRoundTrip() throws {
+        for value in [true, false] {
+            let decoded = try JSONDecoder().decode(
+                ConfigSetHolderHibernationEnabledParams.self,
+                from: try JSONEncoder().encode(
+                    ConfigSetHolderHibernationEnabledParams(enabled: value)))
+            #expect(decoded.enabled == value)
+        }
+    }
 }

--- a/Tests/TBDDaemonTests/SQLMigrationLoaderTests.swift
+++ b/Tests/TBDDaemonTests/SQLMigrationLoaderTests.swift
@@ -504,6 +504,7 @@ import Testing
             "20260902140000_config_gc_retained_transcripts",
             "20260903193500_config_holder_row_reconcile",
             "20260904172536_config_update_mode",
+            "20260905213000_config_holder_hibernation",
         ]
         let found = try SQLMigrationLoader.bundled.get()
         #expect(found.files.map(\.identifier) == expected)

--- a/Tests/TBDDaemonTests/SQLMigrationLoaderTests.swift
+++ b/Tests/TBDDaemonTests/SQLMigrationLoaderTests.swift
@@ -505,6 +505,7 @@ import Testing
             "20260903193500_config_holder_row_reconcile",
             "20260904172536_config_update_mode",
             "20260905213000_config_holder_hibernation",
+            "20260905220000_terminal_holder_child_started_at",
         ]
         let found = try SQLMigrationLoader.bundled.get()
         #expect(found.files.map(\.identifier) == expected)

--- a/Tests/TBDSharedTests/ModelsTests.swift
+++ b/Tests/TBDSharedTests/ModelsTests.swift
@@ -331,6 +331,40 @@ func testTerminalCodexTranscriptBoundaryRoundTrip(_ boundary: Int64?) throws {
     #expect(!t(.idle, suspendedAt: Date()).isManuallyHibernatable(holderHibernationEnabled: false))   // suspended
 }
 
+/// The pty-holder soak gate, both branches, on both eligibility methods.
+///
+/// The gate is the ONLY thing separating the two arms here: the row is the same
+/// idle, resumable Claude session either way, and a tmux twin of it is asserted
+/// alongside so a condition written on the flag alone — rather than on the flag
+/// AND the transport — fails rather than passing both arms.
+@Test func testHolderHibernationGateOnBothEligibilityMethods() {
+    let holder = Terminal(
+        worktreeID: UUID(), tmuxWindowID: "", tmuxPaneID: "",
+        claudeSessionID: "s", kind: .claude, activityState: .idle, transport: .holder)
+    #expect(!holder.isManuallyHibernatable(holderHibernationEnabled: false))
+    #expect(!holder.isAutoHibernationEligible(holderHibernationEnabled: false))
+    #expect(holder.isManuallyHibernatable(holderHibernationEnabled: true))
+    #expect(holder.isAutoHibernationEligible(holderHibernationEnabled: true))
+
+    // With the gate on, the holder row still answers to every other rail: the
+    // flag lifts one refusal, not all of them.
+    var busy = holder
+    busy.activityState = .working
+    #expect(!busy.isManuallyHibernatable(holderHibernationEnabled: true))
+    var warm = holder
+    warm.keepWarm = true
+    #expect(!warm.isAutoHibernationEligible(holderHibernationEnabled: true))
+    #expect(warm.isManuallyHibernatable(holderHibernationEnabled: true))
+
+    let tmux = Terminal(
+        worktreeID: UUID(), tmuxWindowID: "@1", tmuxPaneID: "%1",
+        claudeSessionID: "s", kind: .claude, activityState: .idle)
+    for enabled in [false, true] {
+        #expect(tmux.isManuallyHibernatable(holderHibernationEnabled: enabled))
+        #expect(tmux.isAutoHibernationEligible(holderHibernationEnabled: enabled))
+    }
+}
+
 @Test func testAutoHibernationEligibilityAddsKeepWarmRail() {
     let base = Terminal(worktreeID: UUID(), tmuxWindowID: "@1", tmuxPaneID: "%1",
                         claudeSessionID: "s", kind: .claude, activityState: .idle)

--- a/Tests/TBDSharedTests/ModelsTests.swift
+++ b/Tests/TBDSharedTests/ModelsTests.swift
@@ -320,25 +320,25 @@ func testTerminalCodexTranscriptBoundaryRoundTrip(_ boundary: Int64?) throws {
     }
     // Manual-hibernatable: idle/unknown resumable Claude, not running/waiting/
     // hibernated/suspended. keep-warm does NOT block manual.
-    #expect(t(.idle).isManuallyHibernatable)
-    #expect(t(.unknown).isManuallyHibernatable)
-    #expect(t(.idle, keepWarm: true).isManuallyHibernatable)          // manual bypasses keep-warm
-    #expect(!t(.working).isManuallyHibernatable)                      // running rail
-    #expect(!t(.waitingForUser).isManuallyHibernatable)              // permission rail
-    #expect(!t(.idle, session: nil, kind: .shell).isManuallyHibernatable)  // not Claude
-    #expect(!t(.idle, kind: .codex).isManuallyHibernatable)          // Codex excluded
-    #expect(!t(.idle, hibernatedAt: Date()).isManuallyHibernatable)  // already hibernated
-    #expect(!t(.idle, suspendedAt: Date()).isManuallyHibernatable)   // suspended
+    #expect(t(.idle).isManuallyHibernatable(holderHibernationEnabled: false))
+    #expect(t(.unknown).isManuallyHibernatable(holderHibernationEnabled: false))
+    #expect(t(.idle, keepWarm: true).isManuallyHibernatable(holderHibernationEnabled: false))          // manual bypasses keep-warm
+    #expect(!t(.working).isManuallyHibernatable(holderHibernationEnabled: false))                      // running rail
+    #expect(!t(.waitingForUser).isManuallyHibernatable(holderHibernationEnabled: false))              // permission rail
+    #expect(!t(.idle, session: nil, kind: .shell).isManuallyHibernatable(holderHibernationEnabled: false))  // not Claude
+    #expect(!t(.idle, kind: .codex).isManuallyHibernatable(holderHibernationEnabled: false))          // Codex excluded
+    #expect(!t(.idle, hibernatedAt: Date()).isManuallyHibernatable(holderHibernationEnabled: false))  // already hibernated
+    #expect(!t(.idle, suspendedAt: Date()).isManuallyHibernatable(holderHibernationEnabled: false))   // suspended
 }
 
 @Test func testAutoHibernationEligibilityAddsKeepWarmRail() {
     let base = Terminal(worktreeID: UUID(), tmuxWindowID: "@1", tmuxPaneID: "%1",
                         claudeSessionID: "s", kind: .claude, activityState: .idle)
-    #expect(base.isAutoHibernationEligible)
+    #expect(base.isAutoHibernationEligible(holderHibernationEnabled: false))
     var warm = base; warm.keepWarm = true
     // Auto adds the keep-warm rail that manual bypasses.
-    #expect(!warm.isAutoHibernationEligible)
-    #expect(warm.isManuallyHibernatable)
+    #expect(!warm.isAutoHibernationEligible(holderHibernationEnabled: false))
+    #expect(warm.isManuallyHibernatable(holderHibernationEnabled: false))
 }
 
 @Test func testConfigDecodesWithoutHibernationFields() throws {

--- a/docs/specs/2026-08-30-pty-holder-session-transport-design.md
+++ b/docs/specs/2026-08-30-pty-holder-session-transport-design.md
@@ -548,10 +548,11 @@ it reads back to the daemon:
   macOS App Nap coalesces a backgrounded app's work, and an app being wedged
   or busy correlates with exactly the moments supervision most wants a
   screen, so "quiet" is not the rare case it looks like.
-  Safety-critical consumers fail closed: the hibernation input-veto check
-  treats no-answer as unsafe and refuses to hibernate, never risking typed
-  input. Best-effort consumers fall back to the daemon's frozen-at-attach
-  emulator, labeled stale, rather than blocking on an unresponsive app.
+  Safety-critical consumers fail closed: the hibernation pending-input rail
+  acts only on a screen the daemon rendered live, and its refusals are set out
+  under "Feature parity" below. Best-effort consumers fall back to the
+  daemon's frozen-at-attach emulator, labeled stale, rather than blocking on
+  an unresponsive app.
 - Terminal scrollback history has a hole across each attached period (minus
   whatever the kernel buffer held at the edges). This is the accepted cost,
   and it is cheap here specifically: the artifact users actually mine history
@@ -600,9 +601,13 @@ Everything TBD does through tmux today, and its replacement:
 - **Machine reads** (`tbd terminal read`, the interactive-login driver, the
   hibernation pending-input rail, the embedded supervision babysitter) — the
   daemon renders its own emulator when it is the reader and pulls a snapshot
-  from the app when a viewer is attached. This replaces `capture-pane` with a
-  first-party interface, which the no-TUI-scraping rule already pushes
-  toward; the three sanctioned scrapers migrate onto it as part of this work.
+  from the app when a viewer is attached. Every such read answers with a
+  typed screen that names which store answered and how stale it is, so a
+  consumer can hold a policy rather than a hope
+  ([`2026-09-05-child-as-contract-party-design.md`](2026-09-05-child-as-contract-party-design.md)).
+  This replaces `capture-pane` with a first-party interface, which the
+  no-TUI-scraping rule already pushes toward; the three sanctioned scrapers
+  migrate onto it as part of this work.
 - **Hibernation and revive** — hibernate instructs the holder to terminate its
   child (the holder reports status and exits); revive spawns a fresh holder.
   The queued-prompt flag keeps its semantics, now gating daemon writes to the
@@ -624,11 +629,18 @@ Everything TBD does through tmux today, and its replacement:
     the session awake, because a row that claims parked over a live process is
     reclaimable by nothing: no sweep reads it, and a wake would put a second
     agent on the same session.
-  - **The pending-input rail fails closed when the daemon is not the reader.**
-    It judges the daemon's own emulator, which is frozen for the duration of a
-    viewer's attach (see "Two stores, reconciled on demand"), so a park asked
-    for while a viewer holds the pty is refused by name. Refusing is
-    recoverable; eating a half-composed prompt is not.
+  - **The pending-input rail acts only on a screen the daemon rendered live.**
+    It reads the typed screen the machine-read contract answers with and
+    branches on that answer's `source`. A `daemon` screen is judged for a
+    half-composed prompt; every other answer is refused, each by a name of its
+    own, because the remedies differ — a `staleDaemon` or `viewer` screen
+    means somebody has the session open and the tab is what to close, a
+    session with no reader is one the daemon has lost track of, and a screen
+    that will not project is a defect to fix. Refusing is recoverable; eating
+    a half-composed prompt is not. The idle sweep asks the same question
+    before it arms a row, reading the source alone rather than paying for the
+    lines, so a session the park could never complete costs no
+    request-and-refusal pair on every pass.
   - **Revive re-anchors the identity check.** The row records when its current
     child started, because a woken session's child is younger than its row and
     every reclaimer that verifies a recorded pid against a start time would

--- a/docs/specs/2026-08-30-pty-holder-session-transport-design.md
+++ b/docs/specs/2026-08-30-pty-holder-session-transport-design.md
@@ -629,6 +629,16 @@ Everything TBD does through tmux today, and its replacement:
     the session awake, because a row that claims parked over a live process is
     reclaimable by nothing: no sweep reads it, and a wake would put a second
     agent on the same session.
+  - **The park escalates in rungs, and each rung is identity-checked.** An
+    in-band `/exit`, then `SIGTERM` to the child pid alone, then telling the
+    holder to forget the pty and killing the job by process group — each with
+    its own bounded window, so a session whose Stop hooks and MCP teardown
+    outlast the polite one still gets to shut itself down rather than being
+    killed mid-write. Before any signal the recorded pid is verified as this
+    session's own child, the way every other signalling site in the daemon
+    verifies one; an identity that cannot be established signals nothing, lets
+    the holder go without a kill, and leaves the row awake for a reconciler to
+    judge.
   - **The pending-input rail acts only on a screen the daemon rendered live.**
     It reads the typed screen the machine-read contract answers with and
     branches on that answer's `source`. A `daemon` screen is judged for a

--- a/docs/specs/2026-08-30-pty-holder-session-transport-design.md
+++ b/docs/specs/2026-08-30-pty-holder-session-transport-design.md
@@ -606,7 +606,32 @@ Everything TBD does through tmux today, and its replacement:
 - **Hibernation and revive** — hibernate instructs the holder to terminate its
   child (the holder reports status and exits); revive spawns a fresh holder.
   The input-veto and queued-prompt flags keep their semantics, now gating
-  daemon writes to the master instead of tmux `send-keys`.
+  daemon writes to the master instead of tmux `send-keys`. Three properties
+  of the park are load-bearing rather than incidental:
+
+  - **The row never finalizes parked while the child is still running.** The
+    park writes its intent, ends the child, confirms the exit, and only then
+    finalizes and clears the row's holder and child pids. A child that survives
+    both the polite `/exit` and the escalation rolls the intent back and leaves
+    the session awake, because a row that claims parked over a live process is
+    reclaimable by nothing: no sweep reads it, and a wake would put a second
+    agent on the same session.
+  - **The pending-input rail fails closed when the daemon is not the reader.**
+    It judges the daemon's own emulator, which is frozen for the duration of a
+    viewer's attach (see "Two stores, reconciled on demand"), so a park asked
+    for while a viewer holds the pty is refused by name. Refusing is
+    recoverable; eating a half-composed prompt is not.
+  - **Revive re-anchors the identity check.** The row records when its current
+    child started, because a woken session's child is younger than its row and
+    every reclaimer that verifies a recorded pid against a start time would
+    otherwise read it as a stranger.
+
+  Park and wake on this transport ship behind `holder_hibernation_enabled`,
+  which is separate from `pty_holder_enabled` because that outer gate has to be
+  on for a holder row to exist at all and so cannot express "transport on,
+  hibernation not yet". With it off, every park and wake path refuses a holder
+  row and the reconcile arm deletes a finished holder session rather than
+  parking it — a park is only worth having where something can wake it.
 - **Scrollback** — bounded emulator history while detached, SwiftTerm's own
   history while attached, transcripts as the durable record. tmux's 50k-line
   retention is not matched and deliberately so.

--- a/docs/specs/2026-08-30-pty-holder-session-transport-design.md
+++ b/docs/specs/2026-08-30-pty-holder-session-transport-design.md
@@ -629,9 +629,20 @@ Everything TBD does through tmux today, and its replacement:
   Park and wake on this transport ship behind `holder_hibernation_enabled`,
   which is separate from `pty_holder_enabled` because that outer gate has to be
   on for a holder row to exist at all and so cannot express "transport on,
-  hibernation not yet". With it off, every park and wake path refuses a holder
-  row and the reconcile arm deletes a finished holder session rather than
+  hibernation not yet". With it off, every path that would newly park a holder
+  row refuses it, an unparked holder row asked to wake is refused by the same
+  name, and the reconcile arm deletes a finished holder session rather than
   parking it — a park is only worth having where something can wake it.
+
+  What the flag deliberately does **not** gate is the wake of a row that is
+  already parked. Turning it off is the soak's abort gesture, and an abort that
+  stranded every session the soak had parked would be no abort at all: those
+  rows would answer the app's focus-wake with a failing RPC on every focus,
+  forever, with no route back to a live session. So the gate sits below the
+  parked check — new parks and the unparked classification consult it, an
+  already-parked row wakes regardless. For the same reason the startup arm that
+  heals parked holder rows is ungated: both of its verdicts are safety-only,
+  and a row parked before the flag was turned off still needs reconciling.
 
   The same flag decides the **limit-resume rail**, which types "continue" into
   a session whose usage limit has reset. On this transport it writes through

--- a/docs/specs/2026-08-30-pty-holder-session-transport-design.md
+++ b/docs/specs/2026-08-30-pty-holder-session-transport-design.md
@@ -605,9 +605,17 @@ Everything TBD does through tmux today, and its replacement:
   toward; the three sanctioned scrapers migrate onto it as part of this work.
 - **Hibernation and revive** — hibernate instructs the holder to terminate its
   child (the holder reports status and exits); revive spawns a fresh holder.
-  The input-veto and queued-prompt flags keep their semantics, now gating
-  daemon writes to the master instead of tmux `send-keys`. Three properties
-  of the park are load-bearing rather than incidental:
+  The queued-prompt flag keeps its semantics, now gating daemon writes to the
+  master instead of tmux `send-keys`. The **input veto does not carry over**:
+  its fact source is the app's keystroke stream, and on this transport those
+  keystrokes go straight down the pty the viewer holds — which is exactly the
+  state a park refuses anyway — so the veto is vacuous for a holder row and
+  the screen rail below is the pending-input rail there. Recording the
+  daemon's own writes in its place would be strictly worse than recording
+  nothing: an auto-resume or a peer's `terminal.send` would then read as
+  unsent typed input forever against the merge rail's
+  `activityStateObservedAt` anchor, vetoing every park of that row. Three
+  properties of the park are load-bearing rather than incidental:
 
   - **The row never finalizes parked while the child is still running.** The
     park writes its intent, ends the child, confirms the exit, and only then

--- a/docs/specs/2026-08-30-pty-holder-session-transport-design.md
+++ b/docs/specs/2026-08-30-pty-holder-session-transport-design.md
@@ -635,9 +635,14 @@ Everything TBD does through tmux today, and its replacement:
 
   The same flag decides the **limit-resume rail**, which types "continue" into
   a session whose usage limit has reset. On this transport it writes through
-  `HolderInjectionCourier` rather than tmux `send-keys` — one message of ESC,
-  the literal and a carriage return, ten bytes, far under the size at which an
-  unwrapped write loses its trailing `\r`. Its pane-identity, pane-PID and
+  `HolderInjectionCourier` rather than tmux `send-keys`, in the tmux sequence's
+  own shape and timing: one write of `ESC`, the same 150 ms pause, then one
+  write of the literal and its carriage return. The Escape needs a read of its
+  own because an ink-style input parser reads `ESC` followed immediately by a
+  printable byte as a meta key, so a single combined write would compose Alt-c
+  and then "ontinue" on every attempt. The second write keeps its `\r` — nine
+  bytes, under the size at which an unwrapped write loses its trailing `\r`, so
+  no bracketed-paste wrapper is needed. Its pane-identity, pane-PID and
   copy-mode rails are tmux's alone and are skipped; the verification that
   follows the send reads hook-fed activity state and transcript growth, so it
   is the same code for both transports. It belongs under this flag rather than

--- a/docs/specs/2026-08-30-pty-holder-session-transport-design.md
+++ b/docs/specs/2026-08-30-pty-holder-session-transport-design.md
@@ -632,6 +632,20 @@ Everything TBD does through tmux today, and its replacement:
   hibernation not yet". With it off, every park and wake path refuses a holder
   row and the reconcile arm deletes a finished holder session rather than
   parking it — a park is only worth having where something can wake it.
+
+  The same flag decides the **limit-resume rail**, which types "continue" into
+  a session whose usage limit has reset. On this transport it writes through
+  `HolderInjectionCourier` rather than tmux `send-keys` — one message of ESC,
+  the literal and a carriage return, ten bytes, far under the size at which an
+  unwrapped write loses its trailing `\r`. Its pane-identity, pane-PID and
+  copy-mode rails are tmux's alone and are skipped; the verification that
+  follows the send reads hook-fed activity state and transcript growth, so it
+  is the same code for both transports. It belongs under this flag rather than
+  a flag of its own for the same reason as the park: a rail that resumes a
+  session is the counterpart of one that parks it, and soaking them apart
+  would leave a fleet where an auto-resume can fire at a session no sweep may
+  park. With the flag off it refuses a holder row by name, so a user who armed
+  auto-resume is told once rather than left watching a limit screen.
 - **Scrollback** — bounded emulator history while detached, SwiftTerm's own
   history while attached, transcripts as the durable record. tmux's 50k-line
   retention is not matched and deliberately so.


### PR DESCRIPTION
## Summary

Sessions on the pty-holder transport can now be hibernated and woken. Until now every park path (idle sweep, merge-park, manual "Hibernate now", the retired suspend RPCs), the wake path, and the usage-limit auto-resume refused a holder-backed row outright, and the reconcile arm deleted a finished holder Claude session rather than parking it. For anyone running with `pty_holder_enabled` on, that meant idle sessions stayed resident forever, the tab menu never offered Hibernate, and a session that ended while nobody was looking was gone rather than resumable.

That refusal was the unbuilt half of a design that is already committed (`docs/specs/2026-08-30-pty-holder-session-transport-design.md`, "Hibernation and revive"): hibernate ends the holder's child and the holder winds down; revive spawns a fresh holder; the input-veto and queued-prompt flags keep their meaning against daemon writes to the pty. This PR builds that half.

## Why this shape

No brainstorming round: the design is the transport spec's, and `Terminal.isManuallyHibernatable` said in as many words that the refusal stood only "until parking learns the holder transport". The decisions this PR had to make on top of it:

- **The row never finalizes parked while the child still runs.** Park writes its intent first (pending incarnation and `hibernatedAt`, so hooks from the dying agent are fenced and a crash in this window is healed by startup reconciliation rather than left ambiguous), then ends the child on a ladder that mirrors the tmux one: `/exit` written to the pty the daemon is reading, then SIGTERM, then the registry's teardown (forget, SIGKILL the job's group, reap the holder), each rung with its own poll on the injected clock, and each signal sent only to a child whose identity verifies against the row's recorded start time and executable. Only then does the park finalize and clear the row's pids. A child that survives the ladder, or whose identity cannot be verified, rolls the intent back and the session is left awake with a named reason. A parked row over a live process is the one state nothing reclaims and a wake would double.
- **The pending-input rail fails closed when the daemon is not the reader**, exactly as the spec's "Two stores" section requires. The rail reads the typed screen the transport now exposes and branches on its source: a screen the daemon is draining right now is judged with the existing sanctioned pending-input check; a stale daemon copy (a viewer holds the pty) or a screen that will not project is refused by name. The idle sweep asks the same source question through the cheaper mode reading before it arms a holder row. Consequence during the soak: a holder session still open in a viewer does not auto-park, until the viewer can answer a screen request.
- **No new holder wire verb.** The spec's "instructs the holder to terminate its child" is met with the verbs that exist; nothing under `Sources/TBDDaemon/Holder/` changed, because a sibling PR is restructuring those files.
- **Manual "Hibernate now" is behind the same flag** as the sweep. The park mechanic is one code path whatever triggers it, and the property the soak validates does not depend on who asked. The app's menus read the flag from daemon capabilities, and they also withhold Hibernate from a holder tab while the app's own viewer holds its pty, because the daemon would refuse that park for the fail-closed reason above; the menu and the rail agree. During the soak that means Hibernate is offered on holder tabs the app is not currently displaying, and the tmux tabs are unchanged. The attached case opens up when the viewer can answer a screen request.
- **The flag gates new parks, never the wake of a row already parked.** Turning the flag off is the soak-abort gesture, and it must not strand what the soak parked: a parked holder row wakes whatever the flag says, and startup reconciliation still heals a parked holder row whose child is verifiably alive or gone. `.holderTransport` on a wake now means only an unparked holder row with the flag off.
- **The reconcile arm parks instead of deleting** a finished holder Claude session when the flag is on, matching the tmux arm. With the flag off it deletes as before, since a park nothing can wake is noise.
- **The row records when its current child started.** Every reclaimer that verifies a recorded pid anchors on a start time; after a wake the child is younger than the row, so anchoring on `createdAt` would read every woken session's child as a stranger.

## What this PR does

- New tri-state config column `holder_hibernation_enabled` (no SQL default) with record, model, RPC setter, `daemon.capabilities` field, a Settings toggle under the pty-holder toggle, and `tbd config holder-hibernation on|off`.
- New nullable column `terminal.holder_child_started_at`, written at holder spawn and wake, cleared at park; the reaper's holder leg anchors on it.
- `Terminal.isManuallyHibernatable` and `isAutoHibernationEligible` become methods taking `holderHibernationEnabled:`, so every caller in the daemon and the app passes the flag and the compiler enforces that the five refusal sites move together.
- `HibernationGate.blockingRail`, `decide` and `decideForMerge` take the flag; `.holderTransport` now means "the soak flag is off".
- `HibernationCoordinator+Holder.swift`: the holder park and wake bodies, a startup-reconciliation branch for parked holder rows (child verified alive un-parks; child verified gone clears stale pids), and a transport-aware input-activity key. The input-veto rail keeps its meaning: its fact source is the app's keystroke stream, and on the holder transport those keystrokes go straight to the pty the viewer holds, which is the state the park already refuses, so the daemon's own emulator plus the fail-closed viewer check is the pending-input rail there. Daemon-originated writes (peer sends, queued prompts, the auto-resume) are deliberately not recorded as typed input.
- `wake` on a parked holder row runs the same preamble as tmux (pinned profile via `loadByID`, env overrides, settings overlay, trust seed, transcript mirror, `ClaudeSpawnCommandBuilder` with the queued prompt on argv), then spawns a fresh holder with `TBD_WORKTREE_ID`/`TBD_TERMINAL_ID` and the rotated incarnation, records its pids, and clears the park.
- `LimitResumeActuator` delivers the auto-resume to a holder row through the injection courier when the flag is on: an Escape write, the same 150 ms pause the tmux arm keeps between Escape and its text (an escape byte followed by a printable in one read parses as a meta key and would type "ontinue"), then `continue` plus a carriage return as one 9-byte write, under the 64-byte tokenizer threshold that stalls unwrapped holder writes.
- Corrected the wake comment that claimed `claude --resume` is cwd-scoped (measured false on claude 2.1.261); `TranscriptProjectDirSync` stays, because TBD reads transcripts from the mirrored project dir itself.

Refusal sites changed, all five: `HibernationGate.blockingRail`, `Terminal.isManuallyHibernatable`, `HibernationCoordinator` (`manualBlockReason`, `wake`), `RPCRouter+ManualSuspendHandlers`, `LimitResumeActuator`.

## Flag & rollout

`holder_hibernation_enabled`, default OFF. Enable for the soak with the Settings toggle "Hibernate pty-holder sessions" or:

```
tbd config holder-hibernation on
```

Both `pty_holder_enabled` and this flag must be on for a holder session to park; the flag alone changes nothing on tmux rows. Graduation: flip `Config.holderHibernationEnabledDefault` after a soak in which no park finalized while its child was still running, no wake left a holder without a row, and the reaper's holder leg never mis-anchored a woken session; an explicit off survives the flip because the column is NULL until touched.

## Assumptions

- A holder row that reaches the park with no recorded child pid (a crash-era or legacy row) can only park through the polite `/exit` window. Once the escalation runs, the registry's own teardown erases the status the verdict would need, and silence is not treated as "gone", so the row is left awake with its holder torn down for reconciliation to judge. Every row written by this daemon records its child pid, so this is the rare shape, and it fails toward leaving a row awake rather than parking over a live process.
- The idle sweep never accrues idle time for a holder row while a viewer holds its pty, so during the soak the auto-park leg exercises only sessions with no open tab. That is the fail-closed rule stated above, and it lifts when the viewer can answer a screen request.

## Orphans

Wake is a new creation path for a holder process, and park is a new teardown path. Who reclaims:

- **A park that half-completes** (daemon dies after the intent, before the child is confirmed gone) leaves a parked row that still names its pids. On the next start `HibernationCoordinator.reconcileOnStartup` un-parks a row whose recorded child is identity-verified alive, and `HolderRegistry.adoptAll` re-adopts its holder. If the holder is gone and the child outlived the hangup, `AgentReaper.sweepHolderChildren` reaps it by the recorded pid with its existing identity check, which the new start-time anchor keeps correct after a wake. The rendezvous files are `HolderRendezvousCollector`'s as before.
- **A wake that half-completes**: the pids are written before the park is cleared. A failed pid write abandons the holder from the failing call itself (the create-time cleanup `WorktreeLifecycle+Create` already does); a failed clear leaves a parked row with live pids, which startup reconciliation un-parks, and which a retried wake adopts rather than respawns: before spawning, the wake checks whether the registry still holds the earlier reader (after a daemon restart, adoption normally re-establishes one for such a row) or the recorded child is identity-verified alive, and if so it only clears the park marker. That is what makes a retry converge instead of stacking a second holder that no row names. The one shape neither leg answers is a live holder that adoption could not take and whose child's identity is uncertain: the wake then proceeds to spawn, the holder's creation lock refuses a second holder, and the row stays parked until that holder dies. Fail-safe, and named here so nobody reads it as a leak.

## Evidence & verification

- The idle sweep skips a holder row whose pty a viewer holds before arming it, so an open tab costs no actuation rows per pass; the holder-specific refusals clear the sweep's idle markers like every other refusal.
- The limit-resume holder arm answers a session the registry has seen end with the same silent cancel the tmux arm gives a dead window.

- Every gate has a test for both branches: the shipped NULL default and an explicit off refuse holder rows exactly as before with the row unmutated and no registry or tmux call; on, the gate elects, manual park reaches the fail-closed screen rail, wake without a spawner leaves the row parked, the reconcile arm parks, startup reconciliation un-parks a live child and clears a dead one. Identical tmux rows pass unchanged under both values.
- A live suite (`HolderHibernationLiveTests`) spawns a real `TBDHolder` with a real job, parks it (the job ignores `/exit`, so the escalation runs), and proves the row is parked with its pids cleared, the child pid answers ESRCH, the holder is gone and the daemon holds no reader; then wakes it and proves a new live holder and child are recorded; and proves the flag-off park leaves the job running. A fourth case drives the rollback itself: with a signaller that reports the child alive whatever the process table says, the park escalates, tears the holder down, and then refuses to finalize, leaving the row awake with its pids intact, its pending incarnation rolled back, and the sweep's idle markers cleared.
- Flag storage tests prove a pre-migration row reads NULL, an explicit false survives a default flip, and NULL follows it.
- CI is the verdict; the local build slot on the development machine is contended. Full suite green on the current head after the rebase onto #819. Two fresh-context review passes, the merge gate's three rounds, and an independent design review all fed fixes into the branch: the SIGTERM rung, identity checks before every signal, the wake-adopt guard and its pid restoration, the polite-write result handling, and the rail-parity matrix. The one item outside this PR's territory is filed as #820.

https://claude.ai/code/session_01MSDmW2YUht9nBzkQaSiouJ

[holder-hibernation](https://cheapsteak.github.io/tbd/open/?worktree=CF66C231-05C1-4E2D-9C7E-41C165A3CAB2)
