### PR TITLE
Fix: Stop holder sends landing in the composer and never submitting (six silent stalls in one day)

### DIFF
--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -2483,13 +2483,20 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
                 // Holder path: **this panel owns `TIOCSWINSZ` for as long as it
                 // owns the pty**, and makes the same ioctl the arm above makes,
                 // on the write-only duplicate it took at attach. It is not left
-                // to the daemon: the daemon deliberately does not issue
-                // `TIOCSWINSZ` for a session a viewer holds (see
-                // `HolderRegistry.applyViewerResize`), because two ioctls for
-                // one resize signal the child twice and, in the window where
-                // they disagree, at a geometry nobody is painting. So a resize
-                // routed only through the RPC below would reach the emulator's
-                // grid and never the child.
+                // to the daemon: once the attach is acknowledged — or has timed
+                // out unacknowledged — `HolderRegistry.applyViewerResize` sees
+                // a `viewerAttachment` and resizes only the emulator's grid,
+                // leaving the tty size to whoever is painting it. So a resize
+                // routed only through the RPC below would reach the grid and
+                // never the child.
+                //
+                // The exception is the vended-but-not-yet-acked window, where
+                // there is no `viewerAttachment` yet and the daemon's arm still
+                // calls `reader.resize()` — the same narrow window
+                // `HolderInjectionCourier.deliver` names for writes, and for
+                // the same reason. Both sides may set the size for one RPC
+                // round trip; two ioctls signal the child twice and, until they
+                // agree, at a geometry nobody is painting. Narrow, not zero.
                 setHolderWindowSize(cols: newCols, rows: newRows)
                 // The daemon is told either way, and for a different reason per
                 // transport: for a control-mode window it is the sole size

--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -2483,10 +2483,13 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
                 // Holder path: **this panel owns `TIOCSWINSZ` for as long as it
                 // owns the pty**, and makes the same ioctl the arm above makes,
                 // on the write-only duplicate it took at attach. It is not left
-                // to the daemon because the daemon has no descriptor to make it
-                // on — it released its reader when it handed the pty over — so
-                // a resize routed only through the RPC below would reach the
-                // emulator and never the child.
+                // to the daemon: the daemon deliberately does not issue
+                // `TIOCSWINSZ` for a session a viewer holds (see
+                // `HolderRegistry.applyViewerResize`), because two ioctls for
+                // one resize signal the child twice and, in the window where
+                // they disagree, at a geometry nobody is painting. So a resize
+                // routed only through the RPC below would reach the emulator's
+                // grid and never the child.
                 setHolderWindowSize(cols: newCols, rows: newRows)
                 // The daemon is told either way, and for a different reason per
                 // transport: for a control-mode window it is the sole size

--- a/Sources/TBDCLI/Commands/TerminalCommands.swift
+++ b/Sources/TBDCLI/Commands/TerminalCommands.swift
@@ -487,8 +487,60 @@ struct TerminalOutput: AsyncParsableCommand {
         if json {
             printJSON(result)
         } else {
+            // stdout stays exactly the screen text — scripts pipe it, diff it
+            // and match on it — so the provenance goes to stderr, where a
+            // human and a supervising agent both see it and no pipeline does.
+            if let screen = result.screen, let note = Self.stalenessNote(for: screen) {
+                FileHandle.standardError.write(Data("\(note)\n".utf8))
+            }
             print(result.output)
         }
+    }
+
+    /// What to tell a reader about a screen that did not come from the live
+    /// store, or `nil` when it did.
+    ///
+    /// `tbd terminal output` is one of the consumers the screen contract makes
+    /// declare a policy for `.staleDaemon`, and its declared policy is *accept
+    /// and surface*: the answer is still the best one available, and a reader
+    /// told which store produced it and how old it is has learned something the
+    /// bare string could never tell them. Before the typed screen this call
+    /// simply failed on a session a viewer held; answering with a frozen screen
+    /// and saying nothing would be the worse of the two, because a supervisor
+    /// reading a three-hour-old composer sees a live one.
+    ///
+    /// The source is spelled with the enum's own raw value, so the note and the
+    /// `--json` field a script correlates against can never drift apart.
+    static func stalenessNote(for screen: TerminalScreen) -> String? {
+        let age = humaneAge(milliseconds: screen.ageMilliseconds)
+        switch screen.source {
+        case .daemon:
+            return nil
+        case .viewer:
+            return """
+                note: screen came from the viewer holding this session's pty \
+                (source \(screen.source.rawValue), age \(age))
+                """
+        case .staleDaemon:
+            return """
+                note: screen is the daemon's emulator as it stood when a viewer attached \
+                (source \(screen.source.rawValue), age \(age))
+                """
+        }
+    }
+
+    /// An age a person can judge at a glance: seconds under a minute, minutes
+    /// and seconds under an hour, hours and minutes above it.
+    ///
+    /// Milliseconds are the wire's unit because a threshold is compared in
+    /// them; nobody reading a note decides anything on the difference between
+    /// 2,460,000 and 2,461,000.
+    private static func humaneAge(milliseconds: Int) -> String {
+        let seconds = max(0, milliseconds) / 1_000
+        if seconds < 60 { return "\(seconds)s" }
+        let minutes = seconds / 60
+        if minutes < 60 { return "\(minutes)m \(seconds % 60)s" }
+        return "\(minutes / 60)h \(minutes % 60)m"
     }
 }
 

--- a/Sources/TBDDaemon/Actuation/ActuationLog.swift
+++ b/Sources/TBDDaemon/Actuation/ActuationLog.swift
@@ -174,12 +174,25 @@ public actor ActuationLog {
     /// not merely forbidden here, it is unspellable: the observed vocabulary
     /// lives in a type this signature does not accept (`ObservedResult`), and
     /// reaches the file only through `appendObservation`.
-    func appendOutcome(confirms: String, result: ActuationOutcome, error: String? = nil) {
+    ///
+    /// `modeSource` and `modeAgeMilliseconds` are defaulted to nil because only
+    /// one caller has them: a holder send, which composed its bytes against a
+    /// mode oracle and records what it composed against. Every other act passes
+    /// nothing and writes neither key.
+    func appendOutcome(
+        confirms: String,
+        result: ActuationOutcome,
+        error: String? = nil,
+        modeSource: ActuationModeSource? = nil,
+        modeAgeMilliseconds: Int? = nil
+    ) {
         var row = ActuationRow(actor: .daemon(), kind: .outcome)
         row.id = Self.mintID()
         row.confirms = confirms
         row.result = .synchronous(result.result)
         row.reason = result.reason
+        row.modeSource = modeSource
+        row.modeAgeMilliseconds = modeAgeMilliseconds
         row.error = error
         try? appendWithOneRetry(row, failClosed: false)
     }

--- a/Sources/TBDDaemon/Actuation/ActuationRow.swift
+++ b/Sources/TBDDaemon/Actuation/ActuationRow.swift
@@ -316,9 +316,11 @@ struct ActuationRow: Codable, Sendable, Equatable {
     ///
     /// Set on holder-send outcome rows and nowhere else — the tmux arm has no
     /// oracle (tmux tracks the pane's mode itself and pastes accordingly), and
-    /// no other act composes bytes against a child's modes. Absent on a row
-    /// where nothing was composed, which is what the empty-payload send is: it
-    /// wrote nothing, so it guessed nothing.
+    /// no other act composes bytes against a child's modes. Within that, it is
+    /// written whenever the send composed anything against the oracle's answer:
+    /// the caller's text was non-empty, or a submitting `\r` was written. The
+    /// one holder send without it is `--text ""` with no `--submit`, which
+    /// composed nothing, so it guessed nothing.
     ///
     /// **Per dispatch, not per act.** A verified send that is re-delivered
     /// recomposes against the modes as they are then, and each dispatch writes

--- a/Sources/TBDDaemon/Actuation/ActuationRow.swift
+++ b/Sources/TBDDaemon/Actuation/ActuationRow.swift
@@ -185,6 +185,49 @@ enum ActuationOutcome: Sendable, Equatable {
     }
 }
 
+/// Which store answered when a holder send asked what modes the child was in.
+///
+/// The same vocabulary as `TerminalScreen.Source` plus `unavailable`, and the
+/// extra case is the point: a send composed against *no* answer at all is a
+/// different fact from one composed against a frozen emulator, and the record
+/// has to be able to say which.
+///
+/// This is the guard on the one place this design knowingly proceeds on
+/// information that may be wrong. A message composed against `staleDaemon`
+/// modes can mis-paste — the markers printed by a child that never asked for
+/// them, or absorbed by one that did — and that is accepted, because refusing
+/// would make every supervision send fail closed exactly when the app is
+/// napping or wedged, which is when supervision most needs to send. What makes
+/// it honest rather than merely optimistic is that the guess is recorded: a row
+/// reading `dispatched, modeSource: staleDaemon` tells whoever reads the record
+/// afterwards that the composition was a guess, and the age says how old.
+///
+/// New raw values are additive, like every other closed vocabulary here.
+enum ActuationModeSource: String, Codable, Sendable, CaseIterable, Equatable {
+    /// The daemon is the session's reader and answered from its live emulator.
+    case daemon
+    /// A viewer holds the pty and answered a pull from its own terminal.
+    case viewer
+    /// A viewer holds the pty and did not answer; the daemon's retained
+    /// emulator answered instead, as of its last byte.
+    case staleDaemon = "stale-daemon"
+    /// Nothing answered. No registry, or no reader for this session — it is
+    /// gone or was never adopted, in which case the write is about to fail
+    /// anyway. Composed bare, and carries no age, because there is no store
+    /// whose age it could be.
+    case unavailable
+
+    /// The record's name for the store a screen reading came from. Total, so a
+    /// new `TerminalScreen.Source` cannot reach the record unmapped.
+    init(_ source: TerminalScreen.Source) {
+        switch source {
+        case .daemon: self = .daemon
+        case .viewer: self = .viewer
+        case .staleDaemon: self = .staleDaemon
+        }
+    }
+}
+
 /// The thing an actuation acted on. Local sessions carry `worktree`/`terminal`
 /// (full uppercase UUID strings, matching the DB); remote sessions carry
 /// `provider` and, once known, `session`.
@@ -259,5 +302,28 @@ struct ActuationRow: Codable, Sendable, Equatable {
     /// Set on — and only on — a `refused` outcome, by `appendOutcome` from the
     /// same `ActuationOutcome` that decided `result`.
     var reason: RefusedReason?
+    /// Which store answered the mode oracle that a holder send was composed
+    /// against.
+    ///
+    /// Set on holder-send outcome rows and nowhere else — the tmux arm has no
+    /// oracle (tmux tracks the pane's mode itself and pastes accordingly), and
+    /// no other act composes bytes against a child's modes. Absent on a row
+    /// where nothing was composed, which is what the empty-payload send is: it
+    /// wrote nothing, so it guessed nothing.
+    ///
+    /// **Per dispatch, not per act.** A verified send that is re-delivered
+    /// recomposes against the modes as they are then, and each dispatch writes
+    /// its own outcome row, so every attempt carries its own immutable
+    /// provenance and nothing is overwritten.
+    var modeSource: ActuationModeSource?
+    /// How long ago the answering emulator had last consumed a byte from the
+    /// pty when it was asked, in milliseconds.
+    ///
+    /// Rides with `modeSource` and is absent whenever that is `unavailable`:
+    /// nothing answered, so there is no store whose age this could be. It is
+    /// what turns "stale" from an adjective into a number — a row reading
+    /// `staleDaemon` at 41 minutes and one at 200 milliseconds describe very
+    /// different amounts of guessing.
+    var modeAgeMilliseconds: Int?
     var error: String?
 }

--- a/Sources/TBDDaemon/Actuation/ActuationRow.swift
+++ b/Sources/TBDDaemon/Actuation/ActuationRow.swift
@@ -202,6 +202,15 @@ enum ActuationOutcome: Sendable, Equatable {
 /// reading `dispatched, modeSource: staleDaemon` tells whoever reads the record
 /// afterwards that the composition was a guess, and the age says how old.
 ///
+/// **The three shared raw values must stay identical to
+/// `TerminalScreen.Source`'s.** A supervisor correlates the `screen.source` it
+/// read from `tbd terminal output --json` against the `modeSource` on the row
+/// its send produced, by string comparison — so a second spelling of
+/// `staleDaemon` would defeat exactly the case worth correlating. The default
+/// synthesised raw values are the wire spellings on both sides; do not write
+/// one out here without writing the same one there. `ActuationLogTests` pins
+/// the correspondence over `TerminalScreen.Source.allCases`.
+///
 /// New raw values are additive, like every other closed vocabulary here.
 enum ActuationModeSource: String, Codable, Sendable, CaseIterable, Equatable {
     /// The daemon is the session's reader and answered from its live emulator.
@@ -210,7 +219,7 @@ enum ActuationModeSource: String, Codable, Sendable, CaseIterable, Equatable {
     case viewer
     /// A viewer holds the pty and did not answer; the daemon's retained
     /// emulator answered instead, as of its last byte.
-    case staleDaemon = "stale-daemon"
+    case staleDaemon
     /// Nothing answered. No registry, or no reader for this session — it is
     /// gone or was never adopted, in which case the write is about to fail
     /// anyway. Composed bare, and carries no age, because there is no store

--- a/Sources/TBDDaemon/Actuation/RPCRouter+Actuation.swift
+++ b/Sources/TBDDaemon/Actuation/RPCRouter+Actuation.swift
@@ -83,10 +83,20 @@ extension RPCRouter {
     /// Append the synchronous outcome row for a request. Never fails the call:
     /// the act already ran, so a lost outcome row leaves the request
     /// unconfirmed rather than retroactively refused.
+    ///
+    /// The two mode parameters are defaulted so no existing call site changes.
+    /// Only a holder send passes them, and only for a row written after it
+    /// composed something — see `ActuationRow.modeSource`.
     func finishActuation(
-        _ id: String, _ result: ActuationOutcome, error: String? = nil
+        _ id: String,
+        _ result: ActuationOutcome,
+        error: String? = nil,
+        modeSource: ActuationModeSource? = nil,
+        modeAgeMilliseconds: Int? = nil
     ) async {
-        await actuationLog.appendOutcome(confirms: id, result: result, error: error)
+        await actuationLog.appendOutcome(
+            confirms: id, result: result, error: error,
+            modeSource: modeSource, modeAgeMilliseconds: modeAgeMilliseconds)
     }
 
     /// Convenience for handlers whose only post-row failure mode is the daemon

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -1234,7 +1234,8 @@ public final class Daemon: Sendable {
         // stopped accepting — independent of how badly any one of them is.
         // Binding first would instead open a window in which the socket answers while holder
         // sessions have no readers — `terminal.output` fails a live session
-        // with "its session is gone or was never adopted", a sentence no caller
+        // with "its session is gone, was never adopted, or is mid-transition", a
+        // sentence no caller
         // can tell apart from the truth about a genuinely dead one, and the
         // app's `attach.request` throws `noLiveReader` for the same session —
         // and it would not even make the daemon answerable, because steps 8b-8d

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -909,8 +909,12 @@ public final class Daemon: Sendable {
                     await registry.viewerAttachment(for: terminalID)
                 },
                 writeDirectly: { terminalID, bytes in
-                    // The daemon's own reader is the only descriptor it has,
-                    // and it has one only while nobody else owns the pty.
+                    // The daemon's own reader is the only descriptor it has —
+                    // but it keeps that reader across an attach, suspended
+                    // rather than stopped, so this fallback has a target in
+                    // every attached state. No reader means the session is gone
+                    // or was never adopted, which is the one case with nothing
+                    // to write to.
                     guard let reader = await registry.reader(for: terminalID) else {
                         throw HolderInjectionCourier.Error.noDaemonDescriptor(
                             terminalID: terminalID)

--- a/Sources/TBDDaemon/Holder/HolderInjectionCourier.swift
+++ b/Sources/TBDDaemon/Holder/HolderInjectionCourier.swift
@@ -62,9 +62,12 @@ actor HolderInjectionCourier {
     private static let logger = Logger(subsystem: "com.tbd.daemon", category: "holderInjection")
 
     enum Error: LocalizedError, Equatable {
-        /// The daemon holds no descriptor for this session's pty. Ordinary
-        /// while a viewer is attached — the attach acknowledgement releases the
-        /// daemon's reader, which closes it — and a genuine fault otherwise.
+        /// The daemon holds no descriptor for this session's pty. **Not an
+        /// attached session's ordinary state** — the daemon keeps its reader,
+        /// suspended, across an attach, and a suspended reader's descriptor is
+        /// open. It means the registry has no reader for this session at all:
+        /// the session is gone, was never adopted, or is mid-release. A genuine
+        /// fault in every case.
         case noDaemonDescriptor(terminalID: UUID)
 
         var errorDescription: String? {
@@ -175,36 +178,24 @@ actor HolderInjectionCourier {
     /// per-terminal send serializer upstream is what keeps two callers'
     /// messages apart.
     ///
-    /// **Known gap, and the honest statement of it.** Once a viewer has
-    /// *acknowledged* an attach the daemon has released its reader and closed
-    /// its descriptor (`HolderRegistry.confirmAttach` → `HolderReader.stop`),
-    /// so `writeDirectly` has nothing to write to and the fail-open fallback
-    /// reports `.notDelivered` instead of writing. Nothing is lost silently —
-    /// the caller is told, and the actuation row records a transport failure —
-    /// but in that state the fallback is not yet the fail-open the spec
-    /// describes. Closing it means the daemon keeping a **write-only** dup
-    /// across an attach (the one-reader invariant is about readers; multiple
-    /// writers to a pty master are fine), which is an ownership change
-    /// belonging to the detach and app-death work, not here.
+    /// **The fallback really writes, in every attached state.** The daemon
+    /// keeps its reader across an attach — suspended, never stopped, whether or
+    /// not the viewer acknowledged (`HolderRegistry.confirmAttach`) — so its
+    /// descriptor stays open and `HolderReader.write` guards only on
+    /// `.stopped`. That is what makes `ackDeadlineElapsed`,
+    /// `viewerReportedNothingWritten` and `viewerFrameUndeliverable` genuinely
+    /// fail *open* rather than reporting `.notDelivered` for the very sessions
+    /// the fallback exists to serve: a viewer that is napping, wedged, or gone
+    /// without telling anyone. The one-reader invariant is untouched by this —
+    /// it is about readers, and several writers on a pty master are fine.
     ///
-    /// **The gap is not every attached state, and the exceptions matter.**
-    /// `viewerAttachment` means "a viewer *may* hold this pty", and two states
-    /// leave the daemon's descriptor open underneath it:
-    ///
-    /// - **A timed-out attach.** `HolderRegistry.cancelPendingAttach`'s
-    ///   `.unacknowledged` arm records the claim and deliberately leaves the
-    ///   slot `.adopted` with its reader merely `.suspended` — the descriptor
-    ///   is still open, and `HolderReader.write` guards only on `.stopped`. So
-    ///   `viewerAttachment != nil` **and** `reader(for:) != nil`, and the
-    ///   fallback really fires and really writes. That is the case fail-open
-    ///   exists for above all others: the app is presumed hung or dead.
-    /// - **The vended-but-not-yet-acked window.** `beginAttach` records a
-    ///   pending attach but no `viewerAttachment`, so this method takes the
-    ///   *detached* branch and writes through that same suspended reader —
-    ///   while the app already holds its `dup` of the descriptor
-    ///   (`TerminalPanelView.startHolderClient` takes it before
-    ///   `attach.ready`) and may already be writing keystrokes. Two writers,
-    ///   for one RPC round trip. Narrow, not zero.
+    /// **The vended-but-not-yet-acked window is the one state with two live
+    /// writers.** `beginAttach` records a pending attach but no
+    /// `viewerAttachment`, so this method takes the *detached* branch and
+    /// writes through the suspended reader — while the app already holds its
+    /// `dup` of the descriptor (`TerminalPanelView.startHolderClient` takes it
+    /// before `attach.ready`) and may already be writing keystrokes. Two
+    /// writers, for one RPC round trip. Narrow, not zero, and unchanged.
     func deliver(terminalID: UUID, bytes: Data) async -> Delivery {
         guard await viewerAttachment(terminalID) != nil else {
             return await writeFromDaemon(terminalID: terminalID, bytes: bytes, because: .detached)

--- a/Sources/TBDDaemon/Holder/HolderReader.swift
+++ b/Sources/TBDDaemon/Holder/HolderReader.swift
@@ -1,6 +1,12 @@
 import Darwin
 import Foundation
 import SwiftTerm
+// Scoped, not a whole-module import: `TBDShared.Terminal` is the DB row model
+// and `SwiftTerm.Terminal` is the emulator, and this file is full of the
+// second. Naming the two types it needs keeps every bare `Terminal` here
+// meaning the emulator.
+import struct TBDShared.TerminalModeReading
+import struct TBDShared.TerminalScreen
 import TBDTerminalSerialization
 import os
 
@@ -131,6 +137,15 @@ actor HolderReader {
     ///   session's output is exhausted — see `hasReachedEndOfOutput`. It must
     ///   not block, and must not stop this reader inline; the registry's
     ///   reclaimer hops onto the actor instead.
+    /// - Parameter monotonicNow: reads the monotonic clock, for the two
+    ///   instants the emulator stamps — its adoption and its last consumed
+    ///   byte — whose difference is a screen's `age`. It sits *before* `clock`
+    ///   so `clock` stays the last parameter, per the repo's clock-seam rule,
+    ///   and it is a separate seam because `any Clock<Duration>` pins
+    ///   `Duration` and not `Instant`: it can express a delay but cannot do the
+    ///   instant arithmetic an age is. `ContinuousClock.Instant` can, which is
+    ///   what lets a test hand back `base + .minutes(41)` and assert an exact
+    ///   age rather than a tolerance window.
     init(
         sessionID: UUID,
         ptyFD: Int32,
@@ -140,6 +155,7 @@ actor HolderReader {
         stopTimeout: Duration = HolderReader.defaultStopTimeout,
         readFault: HolderReadFault? = nil,
         onEndOfOutput: (@Sendable () -> Void)? = nil,
+        monotonicNow: @escaping @Sendable () -> ContinuousClock.Instant = { ContinuousClock.now },
         clock: any Clock<Duration> = ContinuousClock()
     ) {
         self.sessionID = sessionID
@@ -156,6 +172,7 @@ actor HolderReader {
             columns: columns,
             rows: rows,
             scrollback: scrollbackLines,
+            monotonicNow: monotonicNow,
             reply: { [descriptor] bytes in descriptor.replyBestEffort(bytes) })
     }
 
@@ -473,6 +490,41 @@ actor HolderReader {
     /// The tail of the scrollback plus the viewport, at most `maxLines` lines.
     func renderScreenWithScrollback(maxLines: Int) -> String {
         emulator.renderScreenWithScrollback(maxLines: maxLines)
+    }
+
+    /// The typed screen `terminal.output` answers with: the same lines
+    /// `renderScreenWithScrollback` produces, plus the facts a string cannot
+    /// carry — where the viewport starts, where the cursor is, what modes the
+    /// child is in, which store answered, and how stale that store is.
+    ///
+    /// **`source` is read from this reader's own drain state**, which is the
+    /// only place it can be read honestly. A reader that is draining is on the
+    /// pty and its emulator is live, so it answers `.daemon`. A reader in any
+    /// other state — suspended for an attach, idle, stopped — is holding a
+    /// screen it is no longer updating, and a consumer told `.daemon` about it
+    /// would apply a live-screen policy to a frozen one. `.viewer` never comes
+    /// from here: it is the app's answer to a pull, on a path this reader is
+    /// not part of.
+    ///
+    /// Throws only what `TerminalScreen`'s construction refuses. That is a
+    /// projection bug rather than a session state, and the handler above turns
+    /// it into an error naming the offending line rather than an empty screen.
+    func screen(maxLines: Int) throws -> TerminalScreen {
+        try emulator.screen(maxLines: maxLines, source: currentSource)
+    }
+
+    /// The child's modes, their provenance and their age, with no line walk.
+    ///
+    /// What the send path's oracle asks. A whole screen would be the same
+    /// answer at the price of walking the retained scrollback on every message
+    /// composed.
+    func modeReading() -> TerminalModeReading {
+        emulator.modeReading(source: currentSource)
+    }
+
+    /// Whether this reader's emulator is live or frozen — see `screen`.
+    private var currentSource: TerminalScreen.Source {
+        state == .draining ? .daemon : .staleDaemon
     }
 
     /// The session's whole screen — modes, scrollback, viewport, cursor — as a
@@ -1163,10 +1215,33 @@ private final class HolderEmulator: @unchecked Sendable {
     /// Held strongly: `Terminal.tdel` is `weak`, so a delegate nobody else
     /// retains is deallocated and the child's terminal queries go unanswered.
     private let delegate: ReplyForwardingDelegate
+    private let monotonicNow: @Sendable () -> ContinuousClock.Instant
+    /// When this emulator started existing — the floor for a screen's age.
+    ///
+    /// A store that has never consumed a byte reports its own age rather than
+    /// no age at all, so a fresh, silent session reads as exactly as old as it
+    /// is instead of as instantly current.
+    private let adoptedAt: ContinuousClock.Instant
+    /// When this emulator last consumed a byte **from the pty**.
+    ///
+    /// Under `terminalLock` like everything else here, and stamped in `feed`
+    /// only. That placement is the whole definition: `snapshotPreamble`'s
+    /// `DECRQM` probes and `screen`'s cursor-visibility probe feed the
+    /// `Terminal` directly rather than through this method, so the daemon
+    /// asking its own emulator a question can never make a stale screen look
+    /// fresh. Keep it that way — routing a probe through `feed` would make
+    /// every read reset the age it was taken to measure.
+    private var lastByteAt: ContinuousClock.Instant?
 
-    init(columns: Int, rows: Int, scrollback: Int, reply: @escaping @Sendable (ArraySlice<UInt8>) -> Void) {
+    init(
+        columns: Int, rows: Int, scrollback: Int,
+        monotonicNow: @escaping @Sendable () -> ContinuousClock.Instant,
+        reply: @escaping @Sendable (ArraySlice<UInt8>) -> Void
+    ) {
         let delegate = ReplyForwardingDelegate(reply: reply)
         self.delegate = delegate
+        self.monotonicNow = monotonicNow
+        self.adoptedAt = monotonicNow()
         self.terminal = Terminal(
             delegate: delegate,
             options: TerminalOptions(
@@ -1177,6 +1252,7 @@ private final class HolderEmulator: @unchecked Sendable {
 
     func feed(_ bytes: ArraySlice<UInt8>) {
         terminal.terminalLock.withLock {
+            lastByteAt = monotonicNow()
             terminal.feed(buffer: bytes)
         }
     }
@@ -1213,6 +1289,119 @@ private final class HolderEmulator: @unchecked Sendable {
         }
     }
 
+    /// The typed screen, taken as **one observation** under a single
+    /// `terminalLock` hold.
+    ///
+    /// The lock is what makes lines, cursor, modes and size one fact rather
+    /// than four. Taken separately, a drain-thread feed between two of them
+    /// would produce a screen that never existed — modes from after a mode
+    /// change beside lines from before it, which is exactly the pairing the
+    /// input path must not compose against.
+    ///
+    /// The line walk is `renderScreenWithScrollback`'s: enumerate from
+    /// `totalLinesTrimmed` until `getScrollInvariantLine` returns nil, because
+    /// there is no public line count and `Buffer.lines` is internal.
+    ///
+    /// Two probes run inside the hold and neither touches `lastByteAt`. The
+    /// cursor's visibility is a `DECRQM` 25 answer, because `cursorHidden` is
+    /// not public, and it is read the way `snapshotPreamble` reads its modes —
+    /// through `DelegateModeReader` with the delegate switched to collecting,
+    /// so the answer reaches this method instead of arriving at the child as if
+    /// somebody had typed it.
+    func screen(maxLines: Int, source: TerminalScreen.Source) throws -> TerminalScreen {
+        try terminal.terminalLock.withLock {
+            var enumerated: [String] = []
+            var row = terminal.buffer.totalLinesTrimmed
+            while let line = terminal.getScrollInvariantLine(row: row) {
+                enumerated.append(Self.rowText(line))
+                row += 1
+            }
+            let enumeratedCount = enumerated.count
+
+            var lines = enumerated
+            if maxLines <= 0 {
+                lines = []
+            } else if lines.count > maxLines {
+                lines.removeFirst(lines.count - maxLines)
+            }
+            let droppedFromFront = enumeratedCount - lines.count
+            while let last = lines.last, last.isEmpty { lines.removeLast() }
+
+            // SwiftTerm's line list is always `yBase + rows` long, so the
+            // viewport is its tail — but `yBase` is not public, so the index of
+            // the viewport's first row is derived from the length instead. The
+            // tail cut then shifts it, which is why `droppedFromFront` comes
+            // off it: the result is an index into `lines`, not into the buffer.
+            // It can land outside `lines` in both directions, which the type's
+            // own documentation states and callers must bounds check.
+            let viewportStart = enumeratedCount - terminal.rows - droppedFromFront
+
+            let cursor = TerminalScreen.Cursor(
+                row: terminal.buffer.y,
+                column: terminal.buffer.x,
+                visible: cursorIsVisible())
+
+            return try TerminalScreen(
+                lines: lines,
+                viewportStart: viewportStart,
+                cursor: cursor,
+                size: TerminalScreen.Size(columns: terminal.cols, rows: terminal.rows),
+                modes: currentModes(),
+                source: source,
+                ageMilliseconds: ageMilliseconds())
+        }
+    }
+
+    /// The modes, their provenance and their age, without the line walk.
+    func modeReading(source: TerminalScreen.Source) -> TerminalModeReading {
+        terminal.terminalLock.withLock {
+            TerminalModeReading(
+                modes: currentModes(), source: source, ageMilliseconds: ageMilliseconds())
+        }
+    }
+
+    /// The three child modes, all readable from public properties.
+    ///
+    /// `TerminalModeCapture` reads these same three the same way, and its
+    /// comment records why 1049 in particular must come from the property:
+    /// `cmdDecRqm`'s switch does not carry it, so a `DECRQM` query answers
+    /// "unknown". Caller holds `terminalLock`.
+    private func currentModes() -> TerminalScreen.ChildModes {
+        TerminalScreen.ChildModes(
+            bracketedPaste: terminal.bracketedPasteMode,
+            applicationCursor: terminal.applicationCursor,
+            alternateScreen: terminal.isCurrentBufferAlternate)
+    }
+
+    /// `DECTCEM` (mode 25) through the collecting delegate. Caller holds
+    /// `terminalLock`.
+    ///
+    /// A terminal that does not answer is read as a visible cursor, which is
+    /// the state a terminal is in until a program hides it — the same default
+    /// the mode itself has.
+    private func cursorIsVisible() -> Bool {
+        let reader = DelegateModeReader(terminal: terminal, delegate: delegate)
+        delegate.beginCollectingReplies()
+        defer { delegate.endCollectingReplies() }
+        guard let answer = reader.requestMode(25, decPrivate: true) else { return true }
+        return answer == 1
+    }
+
+    /// How long ago this emulator last consumed a byte, in milliseconds, never
+    /// negative. Caller holds `terminalLock`.
+    ///
+    /// Clamped at zero rather than trusted: the clock is injected, and a seam
+    /// that ever moved backwards would otherwise produce an age the screen type
+    /// refuses — turning a test double's mistake into a failed machine read.
+    private func ageMilliseconds() -> Int {
+        let since = lastByteAt ?? adoptedAt
+        let elapsed = since.duration(to: monotonicNow())
+        let milliseconds =
+            elapsed.components.seconds * 1_000
+            + elapsed.components.attoseconds / 1_000_000_000_000_000
+        return Int(max(0, milliseconds))
+    }
+
     /// Serializes the whole terminal — modes, scrollback, viewport, cursor —
     /// into bytes that reconstruct it elsewhere.
     ///
@@ -1231,6 +1420,10 @@ private final class HolderEmulator: @unchecked Sendable {
     /// switched from forwarding to collecting for the duration, which is also
     /// how `DelegateModeReader` reads the answers at all. This is the
     /// daemon-side twin of the app's quiet ingest, in the opposite direction.
+    ///
+    /// Those queries feed the `Terminal` directly rather than through `feed`,
+    /// so they do not stamp `lastByteAt` — an attach must not make a session
+    /// that has been silent for an hour report an age of zero.
     func snapshotPreamble(maxScrollbackLines: Int) -> Data {
         terminal.terminalLock.withLock {
             let reader = DelegateModeReader(terminal: terminal, delegate: delegate)

--- a/Sources/TBDDaemon/Holder/HolderReader.swift
+++ b/Sources/TBDDaemon/Holder/HolderReader.swift
@@ -1554,22 +1554,22 @@ private final class ReplyForwardingDelegate: TerminalDelegate {
     /// delegate from inside a parse, which always runs under `terminalLock`,
     /// and `HolderEmulator.screen` reads the flag under that same lock.
     ///
-    /// **One residual, and it is `DECSTR`.** A soft reset (`CSI ! p`,
-    /// `Terminal.cmdSoftReset`) clears `cursorHidden` by assignment, with no
-    /// delegate call, so a soft reset arriving while the cursor is hidden
-    /// leaves this reading hidden while the terminal is showing. `RIS` (`ESC
-    /// c`) does **not** have this problem, though its `setup(isReset:)` clears
-    /// the same field: `resetToInitialState` saves `cursorHidden` around the
-    /// call and restores it afterwards, so a full reset leaves the flag exactly
-    /// as it found it and this reading stays true.
+    /// **Both resets leave it true, by different mechanisms**, and each is
+    /// worth stating because a reset that moved the cursor silently would leave
+    /// this reading wrong for the rest of the session. A soft reset (`DECSTR`,
+    /// `CSI ! p`, `Terminal.cmdSoftReset`) shows the cursor and calls
+    /// `showCursor` on the delegate as its last act, so the flag follows it out
+    /// of hidden. A full reset (`RIS`, `ESC c`) makes no cursor call at all and
+    /// needs none: `resetToInitialState` saves `cursorHidden` around the
+    /// `setup(isReset:)` that clears it and restores it afterwards, so the
+    /// terminal ends where the flag already is.
     ///
-    /// The `DECSTR` residual self-corrects on the child's next
-    /// *hide-then-show* pair, not on a bare `DECSET 25`: `Terminal.showCursor`
-    /// returns early when `cursorHidden` is already false, so the call the flag
-    /// needs never happens until something has set it true again. A TUI hides
-    /// its cursor for a repaint and shows it afterwards, so in practice that is
-    /// the next repaint — but a child that soft-resets and only ever shows
-    /// reads hidden until it does hide once.
+    /// What a silent change *would* cost is why both are pinned in
+    /// `HolderScreenContractTests` rather than assumed. A divergence here does
+    /// not self-correct on a bare `DECSET 25`: `Terminal.showCursor` returns
+    /// early when `cursorHidden` is already false, so the delegate call the
+    /// flag needs never happens until something sets it true again, and only a
+    /// hide-then-show pair puts it back.
     private(set) var cursorVisible = true
 
     init(reply: @escaping @Sendable (ArraySlice<UInt8>) -> Void) {

--- a/Sources/TBDDaemon/Holder/HolderReader.swift
+++ b/Sources/TBDDaemon/Holder/HolderReader.swift
@@ -524,6 +524,22 @@ actor HolderReader {
     }
 
     /// Whether this reader's emulator is live or frozen — see `screen`.
+    ///
+    /// Three states answer `.staleDaemon`, but **only one of them is reachable
+    /// in production**, and that is what makes the answer mean what the type
+    /// says it does. `HolderRegistry` publishes a reader into its `.adopted`
+    /// slot only after `start()` has returned, and `reader(for:)` reads no
+    /// other slot — so no caller can reach an `.idle` reader — while a stopped
+    /// reader has been through `.releasing` and been dropped from the slot, so
+    /// no caller can reach one of those either. What a consumer can reach is a
+    /// reader suspended for an attach, which is exactly the case `staleDaemon`
+    /// describes: a viewer holds the pty, and this emulator has been frozen
+    /// since it did.
+    ///
+    /// A test harness *can* hold an `.idle` reader, and one answers
+    /// `staleDaemon` there. That is not a special case to be excused: an idle
+    /// reader's emulator is by definition not being fed, so a screen taken from
+    /// it is a frozen one and saying so is the truthful answer.
     private var currentSource: TerminalScreen.Source {
         state == .draining ? .daemon : .staleDaemon
     }
@@ -1223,14 +1239,25 @@ private final class HolderEmulator: @unchecked Sendable {
     /// no age at all, so a fresh, silent session reads as exactly as old as it
     /// is instead of as instantly current.
     private let adoptedAt: ContinuousClock.Instant
-    /// When this emulator last consumed a byte **from the pty**.
+    /// When this emulator last took in bytes that came from outside the daemon.
     ///
     /// Under `terminalLock` like everything else here, and stamped in `feed`
-    /// only. That placement is the whole definition: `snapshotPreamble`'s
-    /// `DECRQM` probes feed the `Terminal` directly rather than through this
-    /// method, so the daemon asking its own emulator a question can never make
-    /// a stale screen look fresh. Keep it that way — routing a probe through
-    /// `feed` would make every read reset the age it was taken to measure.
+    /// only — which is the whole definition, because it is what decides the
+    /// answer for each of the three things that reach `feed` and the one that
+    /// does not:
+    ///
+    /// - **The drain loop's reads** and **the quiesce remainder** stamp it.
+    ///   They are the child's own output; this is the measurement's subject.
+    /// - **A handback preamble** (`ingest(preamble:)`) stamps it, deliberately.
+    ///   A returning viewer hands back the screen as it stood a moment ago, so
+    ///   the emulator's view really is fresh again, and reporting it as an hour
+    ///   old would make a take-back look like a session nobody had watched.
+    /// - **`snapshotPreamble`'s `DECRQM` probes** do not, because they feed the
+    ///   `Terminal` directly rather than through this method. The daemon asking
+    ///   its own emulator a question must never make a stale screen look fresh.
+    ///   Keep it that way — routing a probe through `feed` would make every
+    ///   read reset the age it was taken to measure.
+    ///
     /// `screen` asks nothing at all: it reads the delegate's `DECTCEM` flag.
     private var lastByteAt: ContinuousClock.Instant?
 
@@ -1527,17 +1554,22 @@ private final class ReplyForwardingDelegate: TerminalDelegate {
     /// delegate from inside a parse, which always runs under `terminalLock`,
     /// and `HolderEmulator.screen` reads the flag under that same lock.
     ///
-    /// **One residual, and it is a reset.** `RIS` (`ESC c`, via SwiftTerm's
-    /// `resetToInitialState`) and `DECSTR` (`CSI ! p`) both clear
-    /// `cursorHidden` by assignment, with no delegate call. So a reset arriving
-    /// while the cursor is hidden leaves this reading hidden while the terminal
-    /// is showing. It self-corrects on the child's next *hide-then-show* pair,
-    /// not on a bare `DECSET 25`: `Terminal.showCursor` returns early when
-    /// `cursorHidden` is already false, so the call the flag needs never
-    /// happens until something has set it true again. A TUI hides its cursor
-    /// for a repaint and shows it afterwards, so in practice that is the next
-    /// repaint — but a child that resets and only ever shows reads hidden until
-    /// it does hide once.
+    /// **One residual, and it is `DECSTR`.** A soft reset (`CSI ! p`,
+    /// `Terminal.cmdSoftReset`) clears `cursorHidden` by assignment, with no
+    /// delegate call, so a soft reset arriving while the cursor is hidden
+    /// leaves this reading hidden while the terminal is showing. `RIS` (`ESC
+    /// c`) does **not** have this problem, though its `setup(isReset:)` clears
+    /// the same field: `resetToInitialState` saves `cursorHidden` around the
+    /// call and restores it afterwards, so a full reset leaves the flag exactly
+    /// as it found it and this reading stays true.
+    ///
+    /// The `DECSTR` residual self-corrects on the child's next
+    /// *hide-then-show* pair, not on a bare `DECSET 25`: `Terminal.showCursor`
+    /// returns early when `cursorHidden` is already false, so the call the flag
+    /// needs never happens until something has set it true again. A TUI hides
+    /// its cursor for a repaint and shows it afterwards, so in practice that is
+    /// the next repaint — but a child that soft-resets and only ever shows
+    /// reads hidden until it does hide once.
     private(set) var cursorVisible = true
 
     init(reply: @escaping @Sendable (ArraySlice<UInt8>) -> Void) {

--- a/Sources/TBDDaemon/Holder/HolderReader.swift
+++ b/Sources/TBDDaemon/Holder/HolderReader.swift
@@ -1465,13 +1465,35 @@ private final class HolderEmulator: @unchecked Sendable {
     /// every emoji. Trimming is unaffected — `trimRight` is computed from
     /// `getTrimmedLength()` before the projection runs, so a row nobody wrote
     /// still renders empty rather than as a row of spaces.
+    ///
+    /// **`U+0000` is not the only cell a screen line may not hold.** SwiftTerm's
+    /// printable-run inserter takes every byte from `0x20` through `0x7f`
+    /// without consulting a width, so a `printf '\x7f'` leaves a `DEL` in a cell
+    /// — legal for a child to emit, and refused by `TerminalScreen`'s
+    /// whitelist. Mapping only the NUL would therefore let one such byte break
+    /// *every* later read of that session until the line left the scrollback: a
+    /// session-wide outage caused by the session's own output.
+    ///
+    /// `DEL` is the only one reachable today — a C1 control is dropped before
+    /// insertion, because non-ASCII goes through a width table and nothing of
+    /// width zero is inserted. The projection is written against
+    /// `TerminalScreen.isDisallowed` anyway, rather than against the list of
+    /// scalars currently known to get through: the render and the whitelist
+    /// cannot disagree if they read the same predicate, and a width table that
+    /// changes its mind cannot reopen the outage. `U+FFFD` rather than a space
+    /// for these, because unlike a never-written cell something *was* written
+    /// and a reader should see that something is there.
     private static func rowText(_ line: BufferLine) -> String {
         line.translateToString(
             trimRight: true,
             skipNullCellsFollowingWide: true,
             characterProvider: { cell in
                 let character = cell.getCharacter()
-                return character == Character(Unicode.Scalar(0)) ? " " : character
+                if character == Character(Unicode.Scalar(0)) { return " " }
+                guard character.unicodeScalars.contains(where: TerminalScreen.isDisallowed) else {
+                    return character
+                }
+                return "\u{FFFD}"
             })
     }
 

--- a/Sources/TBDDaemon/Holder/HolderReader.swift
+++ b/Sources/TBDDaemon/Holder/HolderReader.swift
@@ -487,15 +487,16 @@ actor HolderReader {
         emulator.renderScreen()
     }
 
-    /// The tail of the scrollback plus the viewport, at most `maxLines` lines.
-    func renderScreenWithScrollback(maxLines: Int) -> String {
-        emulator.renderScreenWithScrollback(maxLines: maxLines)
-    }
-
-    /// The typed screen `terminal.output` answers with: the same lines
-    /// `renderScreenWithScrollback` produces, plus the facts a string cannot
-    /// carry — where the viewport starts, where the cursor is, what modes the
-    /// child is in, which store answered, and how stale that store is.
+    /// The typed screen `terminal.output` answers with: the tail of the
+    /// scrollback plus the viewport at most `maxLines` long, plus the facts a
+    /// string cannot carry — where the viewport starts, where the cursor is,
+    /// what modes the child is in, which store answered, and how stale that
+    /// store is.
+    ///
+    /// The one whole-buffer walk. A second one existed while `terminal.output`
+    /// was migrating and produced the same lines with none of the facts; it is
+    /// gone, because two walks over one buffer are two chances for a
+    /// projection fix to land in only one of them.
     ///
     /// **`source` is read from this reader's own drain state**, which is the
     /// only place it can be read honestly. A reader that is draining is on the
@@ -1268,27 +1269,6 @@ private final class HolderEmulator: @unchecked Sendable {
         }
     }
 
-    /// The tail of the whole buffer — scrollback and viewport together.
-    ///
-    /// Enumeration starts at `totalLinesTrimmed`, the absolute index of the
-    /// oldest line still held, and runs until `getScrollInvariantLine` returns
-    /// nil: there is no public line count, and `Buffer.lines` is internal.
-    func renderScreenWithScrollback(maxLines: Int) -> String {
-        guard maxLines > 0 else { return "" }
-        return terminal.terminalLock.withLock {
-            var lines: [String] = []
-            var row = terminal.buffer.totalLinesTrimmed
-            while let line = terminal.getScrollInvariantLine(row: row) {
-                lines.append(Self.rowText(line))
-                row += 1
-            }
-            if lines.count > maxLines {
-                lines.removeFirst(lines.count - maxLines)
-            }
-            return Self.joined(lines)
-        }
-    }
-
     /// The typed screen, taken as **one observation** under a single
     /// `terminalLock` hold.
     ///
@@ -1298,9 +1278,12 @@ private final class HolderEmulator: @unchecked Sendable {
     /// change beside lines from before it, which is exactly the pairing the
     /// input path must not compose against.
     ///
-    /// The line walk is `renderScreenWithScrollback`'s: enumerate from
-    /// `totalLinesTrimmed` until `getScrollInvariantLine` returns nil, because
-    /// there is no public line count and `Buffer.lines` is internal.
+    /// The line walk enumerates from `totalLinesTrimmed`, the absolute index of
+    /// the oldest line still held, until `getScrollInvariantLine` returns nil —
+    /// because there is no public line count and `Buffer.lines` is internal.
+    /// It is the only whole-buffer walk in this type: the string-returning twin
+    /// that answered `terminal.output` before the screen contract is gone, so a
+    /// change to the projection cannot land in one walk and miss the other.
     ///
     /// **Nothing here feeds the terminal**, which is why the cursor's
     /// visibility is read from a flag the delegate keeps rather than probed

--- a/Sources/TBDDaemon/Holder/HolderReader.swift
+++ b/Sources/TBDDaemon/Holder/HolderReader.swift
@@ -1226,11 +1226,11 @@ private final class HolderEmulator: @unchecked Sendable {
     ///
     /// Under `terminalLock` like everything else here, and stamped in `feed`
     /// only. That placement is the whole definition: `snapshotPreamble`'s
-    /// `DECRQM` probes and `screen`'s cursor-visibility probe feed the
-    /// `Terminal` directly rather than through this method, so the daemon
-    /// asking its own emulator a question can never make a stale screen look
-    /// fresh. Keep it that way — routing a probe through `feed` would make
-    /// every read reset the age it was taken to measure.
+    /// `DECRQM` probes feed the `Terminal` directly rather than through this
+    /// method, so the daemon asking its own emulator a question can never make
+    /// a stale screen look fresh. Keep it that way — routing a probe through
+    /// `feed` would make every read reset the age it was taken to measure.
+    /// `screen` asks nothing at all: it reads the delegate's `DECTCEM` flag.
     private var lastByteAt: ContinuousClock.Instant?
 
     init(
@@ -1302,12 +1302,24 @@ private final class HolderEmulator: @unchecked Sendable {
     /// `totalLinesTrimmed` until `getScrollInvariantLine` returns nil, because
     /// there is no public line count and `Buffer.lines` is internal.
     ///
-    /// Two probes run inside the hold and neither touches `lastByteAt`. The
-    /// cursor's visibility is a `DECRQM` 25 answer, because `cursorHidden` is
-    /// not public, and it is read the way `snapshotPreamble` reads its modes —
-    /// through `DelegateModeReader` with the delegate switched to collecting,
-    /// so the answer reaches this method instead of arriving at the child as if
-    /// somebody had typed it.
+    /// **Nothing here feeds the terminal**, which is why the cursor's
+    /// visibility is read from a flag the delegate keeps rather than probed
+    /// with a `DECRQM` 25 query. `Terminal.cursorHidden` is not public, but
+    /// SwiftTerm calls `showCursor`/`hideCursor` on its delegate every time the
+    /// child sets or resets `DECTCEM`, so the fact arrives without asking.
+    ///
+    /// A probe here would be fed into a live parser: this method runs on every
+    /// `terminal.output`, including against a reader whose drain thread is
+    /// mid-stream, and SwiftTerm's parser carries its state across `feed` calls
+    /// while an `ESC` in any state aborts whatever sequence is pending. A read
+    /// whose last chunk ended mid-sequence — routine when a TUI repaint exceeds
+    /// the pty buffer — would therefore truncate the child's sequence, print
+    /// its remainder into the screen model as literal text, and swallow the
+    /// reply to a query the child was in the middle of asking. `snapshotPreamble`
+    /// still probes, once per attach; its own doc argues that case.
+    ///
+    /// It does not touch `lastByteAt` either — a daemon reading its own
+    /// emulator must not make a stale screen look fresh.
     func screen(maxLines: Int, source: TerminalScreen.Source) throws -> TerminalScreen {
         try terminal.terminalLock.withLock {
             var enumerated: [String] = []
@@ -1339,7 +1351,7 @@ private final class HolderEmulator: @unchecked Sendable {
             let cursor = TerminalScreen.Cursor(
                 row: terminal.buffer.y,
                 column: terminal.buffer.x,
-                visible: cursorIsVisible())
+                visible: delegate.cursorVisible)
 
             return try TerminalScreen(
                 lines: lines,
@@ -1371,20 +1383,6 @@ private final class HolderEmulator: @unchecked Sendable {
             bracketedPaste: terminal.bracketedPasteMode,
             applicationCursor: terminal.applicationCursor,
             alternateScreen: terminal.isCurrentBufferAlternate)
-    }
-
-    /// `DECTCEM` (mode 25) through the collecting delegate. Caller holds
-    /// `terminalLock`.
-    ///
-    /// A terminal that does not answer is read as a visible cursor, which is
-    /// the state a terminal is in until a program hides it — the same default
-    /// the mode itself has.
-    private func cursorIsVisible() -> Bool {
-        let reader = DelegateModeReader(terminal: terminal, delegate: delegate)
-        delegate.beginCollectingReplies()
-        defer { delegate.endCollectingReplies() }
-        guard let answer = reader.requestMode(25, decPrivate: true) else { return true }
-        return answer == 1
     }
 
     /// How long ago this emulator last consumed a byte, in milliseconds, never
@@ -1486,11 +1484,19 @@ private final class HolderEmulator: @unchecked Sendable {
     }
 }
 
-/// The emulator's only required delegate hook: bytes the terminal itself wants
-/// to send back — device-status replies, cursor-position reports, the answers
-/// to `DECRQM`. `TerminalDelegate` declares 31 methods and a public extension
-/// defaults 30 of them; this is the one that has no default, and routing it
-/// anywhere but the child would turn every terminal query into a hang.
+/// The emulator's delegate: the terminal's outbound wire, plus the one piece of
+/// its state that is not readable from a public property.
+///
+/// `send` is the required hook — bytes the terminal itself wants to send back:
+/// device-status replies, cursor-position reports, the answers to `DECRQM`.
+/// `TerminalDelegate` declares 31 methods and a public extension defaults 30 of
+/// them; `send` is the one that has no default, and routing it anywhere but the
+/// child would turn every terminal query into a hang.
+///
+/// `showCursor`/`hideCursor` are overridden from that default set, because
+/// being *told* about `DECTCEM` is the only way to know the cursor's visibility
+/// without asking the terminal — and asking is what `HolderEmulator.screen`
+/// must never do.
 private final class ReplyForwardingDelegate: TerminalDelegate {
     private let reply: @Sendable (ArraySlice<UInt8>) -> Void
     /// While true, replies are kept here instead of being written to the pty.
@@ -1502,8 +1508,43 @@ private final class ReplyForwardingDelegate: TerminalDelegate {
     private var collecting = false
     private var collected: [UInt8] = []
 
+    /// Whether the child's cursor is currently visible — `DECTCEM`, mode 25.
+    ///
+    /// `Terminal.cursorHidden` is not public, and the emulator must not ask for
+    /// it: a `DECRQM` probe fed into a parser that is mid-sequence aborts the
+    /// child's sequence (see `HolderEmulator.screen`). So the fact is taken
+    /// where SwiftTerm volunteers it instead — `showCursor`/`hideCursor` are
+    /// called on the delegate whenever the child sets or resets the mode.
+    /// Starts `true`, the mode's own default: a terminal shows its cursor until
+    /// a program hides it.
+    ///
+    /// Like `collecting`, this needs no lock of its own. The terminal calls its
+    /// delegate from inside a parse, which always runs under `terminalLock`,
+    /// and `HolderEmulator.screen` reads the flag under that same lock.
+    ///
+    /// **One residual, and it is a reset.** `RIS` (`ESC c`, via SwiftTerm's
+    /// `resetToInitialState`) and `DECSTR` (`CSI ! p`) both clear
+    /// `cursorHidden` by assignment, with no delegate call. So a reset arriving
+    /// while the cursor is hidden leaves this reading hidden while the terminal
+    /// is showing. It self-corrects on the child's next *hide-then-show* pair,
+    /// not on a bare `DECSET 25`: `Terminal.showCursor` returns early when
+    /// `cursorHidden` is already false, so the call the flag needs never
+    /// happens until something has set it true again. A TUI hides its cursor
+    /// for a repaint and shows it afterwards, so in practice that is the next
+    /// repaint — but a child that resets and only ever shows reads hidden until
+    /// it does hide once.
+    private(set) var cursorVisible = true
+
     init(reply: @escaping @Sendable (ArraySlice<UInt8>) -> Void) {
         self.reply = reply
+    }
+
+    func showCursor(source: Terminal) {
+        cursorVisible = true
+    }
+
+    func hideCursor(source: Terminal) {
+        cursorVisible = false
     }
 
     func send(source: Terminal, data: ArraySlice<UInt8>) {
@@ -1547,9 +1588,13 @@ private final class ReplyForwardingDelegate: TerminalDelegate {
 /// rather than a suppressing one: the same switch that keeps the answers away
 /// from the child is what makes them readable here.
 ///
-/// The caller must hold `terminal.terminalLock` and must have put the delegate
-/// in collecting mode; `HolderEmulator.snapshotPreamble` is the only construction
-/// site and does both.
+/// The caller must hold `terminal.terminalLock` — the lock every parse, and so
+/// every `send`, arrives under — and must have put the delegate in collecting
+/// mode with `beginCollectingReplies`, or the answers go to the child and this
+/// reads nothing. `HolderEmulator.snapshotPreamble` is the only construction
+/// site, and it does both. Deliberately only that one: a probe is safe there
+/// because it runs once per attach, and unsafe on the per-`terminal.output`
+/// path, where it would abort a sequence the child is mid-way through sending.
 private struct DelegateModeReader: ModeReplyReader {
     let terminal: Terminal
     let delegate: ReplyForwardingDelegate

--- a/Sources/TBDDaemon/Holder/HolderRegistry.swift
+++ b/Sources/TBDDaemon/Holder/HolderRegistry.swift
@@ -251,9 +251,13 @@ actor HolderRegistry {
     ///
     /// Unreachability arguments elsewhere in this type rest on it — notably
     /// `confirmAttach`'s second guard, which is argued dead by enumerating the
-    /// writers of `slots`. **A new writer of `slots` or of either map has to
-    /// keep this true**, because the next reader will reach the guard long
-    /// before reaching the chain that makes it unreachable.
+    /// writers of `slots`. That enumeration is `spawn`, `beginAdoption` (which
+    /// `adopt` and the take-back's no-reader arm both reach), `release` and its
+    /// `clearIfStillReleasing`, and it does **not** include `confirmAttach`:
+    /// an acknowledgement leaves the slot exactly as it found it, `.adopted`
+    /// with a suspended reader. **A new writer of `slots` or of
+    /// either map has to keep this true**, because the next reader will reach
+    /// the guard long before reaching the chain that makes it unreachable.
     private var pendingAttaches: [UUID: PendingAttach] = [:]
     /// Sessions whose pty a viewer owns, and the attach generation that owns
     /// it. **The daemon reads none of these**, and `adopt` refuses them, which
@@ -294,6 +298,16 @@ actor HolderRegistry {
     /// The decrement happens inside the releasing task, before anything awaiting
     /// that task resumes, so an adoption queued behind a release can never see
     /// its own publish overlap the reader it waited for.
+    ///
+    /// **A suspended reader stays counted, and both suspending paths agree on
+    /// that.** An attach that timed out unacknowledged keeps its reader
+    /// suspended and its loop counted; so does an attach that was
+    /// acknowledged, which retains the same reader for the same reason. Only a
+    /// release decrements. The number therefore means "loops this registry is
+    /// on the hook for", which is what the one-reader invariant needs it to
+    /// mean — a suspended reader is one this registry may put back on a pty,
+    /// and a second one built beside it would be the byte theft `peakLiveDrainLoops`
+    /// exists to see.
     private var liveDrainLoops = 0
     /// The most drain loops that have ever been live at one time.
     ///
@@ -418,10 +432,20 @@ actor HolderRegistry {
 
     // MARK: - Reading
 
-    /// The live reader for a session, or nil if none has been adopted.
+    /// The reader this registry holds for a session, or nil if it holds none.
     ///
-    /// A session still being adopted answers nil: there is no drain loop yet.
-    /// So does one being released — its reader may still be draining, but it is
+    /// **A returned reader may be suspended**, and most attached sessions'
+    /// readers are: `beginAttach` suspends the drain, and neither the
+    /// acknowledgement nor a timed-out attach resumes or discards it. So this
+    /// answers "which emulator is this session's" rather than "who is on the
+    /// pty". Writing through a suspended reader is fine — the one-reader
+    /// invariant is about readers, and several writers on a pty master are not
+    /// a hazard. Anything that needs the *drain* must ask `isDraining`, and
+    /// anything that needs to know who owns the pty must ask
+    /// `viewerAttachment(for:)`.
+    ///
+    /// A session still being adopted answers nil: there is no reader yet. So
+    /// does one being released — its reader may still be draining, but it is
     /// on its way out and nothing new should be routed to it.
     func reader(for terminalID: UUID) -> HolderReader? {
         guard case .adopted(let reader) = slots[terminalID] else { return nil }
@@ -455,11 +479,16 @@ actor HolderRegistry {
     /// defect the adoption path was fixed for once already, seen from the other
     /// side.
     ///
+    /// **The grid tracks the viewer for the whole of an attach**, confirmed or
+    /// not, because the reader is retained across both. So a session a viewer
+    /// is resizing keeps a daemon-side emulator at the width the viewer is
+    /// painting at, which is what makes the fallback screen (`staleDaemon`) and
+    /// the next adoption's re-render read correctly instead of wrapping every
+    /// later line at a width nobody is looking at.
+    ///
     /// A session with no reader is skipped silently: there is no grid to
-    /// reshape and no descriptor to size. That is the ordinary state of a
-    /// *confirmed* attach — the daemon released its reader at the
-    /// acknowledgement — and there the viewer's own ioctl is the whole resize,
-    /// with the pty itself carrying the geometry into the next adoption.
+    /// reshape and no descriptor to size. That is a session being adopted or
+    /// released, not an attached one.
     func applyViewerResize(terminalID: UUID, columns: Int, rows: Int) async {
         guard let reader = reader(for: terminalID) else { return }
         if viewerAttachment(for: terminalID) != nil {
@@ -1349,7 +1378,7 @@ actor HolderRegistry {
         Self.logger.info(
             """
             vended the pty for session \(terminalID.uuidString, privacy: .public) to a viewer as \
-            attach \(generation, privacy: .public); the daemon has stopped reading it and will not \
+            attach \(generation, privacy: .public); the daemon's reader is suspended and will not \
             resume without an answer about that viewer
             """)
         return HolderAttachVend(
@@ -1357,16 +1386,34 @@ actor HolderRegistry {
     }
 
     /// The viewer's acknowledgement: it is reading the descriptor, so this
-    /// session is now its to read and the daemon's reader is released for good.
+    /// session is now the viewer's to read, and the daemon's reader stays
+    /// suspended and retained.
+    ///
+    /// **Suspended, not stopped, and that is the whole of what an
+    /// acknowledgement decides.** `beginAttach` already took the daemon off the
+    /// pty; what is left to settle is whether the emulator it built goes with
+    /// it. It does not. That emulator holds the session's screen as it stood at
+    /// the attach, and it is the only store there is whenever the viewer cannot
+    /// answer for itself — a machine read of an open session falls back to it
+    /// (`source: .staleDaemon`), the input path asks it what modes the child is
+    /// in, and a take-back resumes it instead of opening a second hand-over.
+    /// Stopping it would make every one of those answers an empty screen or an
+    /// error naming the wrong cause. The cost is one emulator per attached
+    /// session, which is what the transport budgets for every session anyway.
+    ///
+    /// A suspended reader still holds its descriptor, so the daemon can still
+    /// *write* to the pty — the one-reader invariant is about readers, and
+    /// several writers on a pty master are fine. What it must never do is
+    /// resume the drain without evidence the viewer is gone; `acceptHandback`
+    /// and `seizeFromDeadApp` are the only two callers that carry it.
     ///
     /// The jiggle goes here rather than at the vend, and that ordering is the
     /// point of it: a program repaints on `SIGWINCH` into the tty, and the ack
     /// is the first moment anybody is certainly there to receive the repaint.
-    /// It happens before the reader is stopped because the reader owns the
-    /// descriptor the ioctl rides on.
+    /// The reader owns the descriptor the ioctl rides on, and keeps owning it.
     ///
     /// Generation-checked. A stale ack — a superseded viewer's, or a duplicate
-    /// — is refused rather than allowed to release a reader a live attach is
+    /// — is refused rather than allowed to hand away a pty a live attach is
     /// relying on.
     ///
     /// **A refused ack records no claim, and that is examined rather than
@@ -1380,7 +1427,9 @@ actor HolderRegistry {
     ///   is unreachable. Every writer of `slots` that can change the reader
     ///   under a live pending entry clears `pendingAttaches` first (`release`),
     ///   and the two that would install a different reader refuse outright
-    ///   while a pending entry exists (`adopt`, `beginAttach`).
+    ///   while a pending entry exists (`adopt`, `beginAttach`). This method
+    ///   does not write `slots` at all — it leaves the slot exactly as it
+    ///   found it — so it is not itself one of the writers to enumerate.
     /// - The **first** guard (the pending entry is already gone) is reachable
     ///   only through a clearer that has itself settled the question:
     ///   `cancelPendingAttach(.unacknowledged)` records the claim,
@@ -1403,25 +1452,24 @@ actor HolderRegistry {
         }
         clearPendingAttach(terminalID: terminalID, generation: generation)
         // Recorded BEFORE anything that suspends — the jiggle below is a
-        // deliberate 10 ms sleep, and the stop after it is longer again. Two
-        // callers resume inside that window and both must find the session
-        // already marked as the viewer's: an `adopt` waiting on the release,
-        // and a `beginAttach` parked between its quiesce and its guard, which
-        // would otherwise hand out a second live descriptor for a pty this
-        // acknowledgement has just given away.
+        // deliberate 10 ms sleep. Two callers resume inside that window and
+        // both must find the session already marked as the viewer's: an
+        // `adopt` waiting on this actor, and a `beginAttach` parked between its
+        // quiesce and its guard, which would otherwise hand out a second live
+        // descriptor for a pty this acknowledgement has just given away.
         viewerAttachments[terminalID] = generation
 
         await reader.jiggle()
 
-        let task = Task<Void, Never> { await self.stopPublished(reader) }
-        slots[terminalID] = .releasing(task)
-        await task.value
-        clearIfStillReleasing(task, for: terminalID)
+        // The slot is left as it was found: `.adopted(reader)`, with the reader
+        // suspended since `beginAttach` and nothing here resuming it. Nothing
+        // decrements `liveDrainLoops` either, which is deliberate and matches
+        // the `.unacknowledged` arm — see the counter's own comment.
         Self.logger.info(
             """
             attach \(generation, privacy: .public) for session \
             \(terminalID.uuidString, privacy: .public) was acknowledged; the daemon's reader is \
-            released and the viewer owns the pty
+            suspended and retained, and the viewer owns the pty
             """)
     }
 
@@ -1596,16 +1644,13 @@ actor HolderRegistry {
     /// last `read()` is still outstanding, which is the double-reader
     /// corruption in miniature.
     ///
-    /// Two states arrive here, and they differ in what "resume" means:
-    ///
-    /// - **An acknowledged attach** released the daemon's reader for good
-    ///   (`confirmAttach`), so the slot is empty and the session is taken back
-    ///   through a fresh hand-over from its holder. The holder `dup`s on every
-    ///   `handOverPTY`, so there is always another descriptor to be had.
-    /// - **An attach that timed out unacknowledged** kept its reader, suspended
-    ///   (`AttachCancelReason.unacknowledged`) — the viewer may have been
-    ///   reading all along, and it evidently was, because it is detaching. That
-    ///   reader is put back on the pty it never let go of.
+    /// **Every attach keeps its reader**, suspended, whether or not it was
+    /// acknowledged — an acknowledgement decides who reads the pty, not who
+    /// owns the emulator. So the ordinary take-back ingests the viewer's screen
+    /// into that reader and resumes the drain it never restarted, rather than
+    /// opening a second hand-over against a master this registry already holds.
+    /// The reader kept its descriptor throughout, so the resume needs nothing
+    /// from the holder — not even a reachable rendezvous socket.
     ///
     /// **The claim is held across the resume and cleared only after it lands**,
     /// the same invariant `cancelPendingAttach`'s resuming arm states: no window
@@ -1638,9 +1683,23 @@ actor HolderRegistry {
     /// rot.
     ///
     /// With no preamble there is simply nothing to ingest: the suspended reader
-    /// still holds the screen it had before the attach, a fresh adoption seeds
-    /// from the holder's hand-over as any adoption does, and the jiggle is what
+    /// still holds the screen it had before the attach, and the jiggle is what
     /// gets a repainting program to redraw the rest.
+    ///
+    /// **The `.adopted` arm serves every attach**, acknowledged or timed out,
+    /// because both keep their reader suspended on a descriptor they never let
+    /// go of. It is the ordinary path, and the strictly better one: no holder
+    /// round trip, no second `dup`, no second drain loop, and the screen the
+    /// daemon had at the attach is still underneath whatever the preamble puts
+    /// on top of it.
+    ///
+    /// **The `nil` arm is defensive and expected to be dead.** A claim can only
+    /// outlive its reader if something emptied the slot while the claim stood,
+    /// and the one writer that empties a slot — `release` — clears the claim
+    /// first. It is kept rather than turned into a `throw` because the
+    /// alternative to a fresh adoption here is a session bricked for the
+    /// daemon's whole life, and a hand-over from the holder is a legitimate
+    /// recovery whenever that state is somehow reached.
     private func takeBackFromViewer(
         terminalID: UUID, generation: UInt64, preamble: Data?
     ) async throws {
@@ -1652,13 +1711,15 @@ actor HolderRegistry {
         do {
             switch slots[terminalID] {
             case .adopted(let suspended):
-                // The unacknowledged-attach arm. The reader never left the
-                // descriptor, so the screen goes in before the drain restarts
-                // and the resume is a restart of its thread.
+                // Every attach's arm. The reader never left the descriptor, so
+                // the screen goes in before the drain restarts and the resume is
+                // a restart of its thread.
                 if let preamble { await suspended.ingest(preamble: preamble) }
                 try await suspended.resumeDraining()
                 reader = suspended
             case nil:
+                // Defensive; see the header. A claim with no reader under it
+                // means something emptied the slot without clearing the claim.
                 reader = try await beginAdoption(
                     of: terminalID, seedingScreenWith: preamble ?? Data())
             case .adopting, .releasing:

--- a/Sources/TBDDaemon/Holder/HolderRegistry.swift
+++ b/Sources/TBDDaemon/Holder/HolderRegistry.swift
@@ -539,9 +539,7 @@ actor HolderRegistry {
             throw error
         }
 
-        slots[terminalID] = .adopted(adoption.reader)
-        statuses[terminalID] = adoption.description.status
-        drainLoopsStarted += 1
+        publish(reader: adoption.reader, status: adoption.description.status, for: terminalID)
         Self.logger.info(
             """
             spawned and adopted a holder for session \(terminalID.uuidString, privacy: .public): \
@@ -900,11 +898,7 @@ actor HolderRegistry {
                 """)
             throw Error.superseded(terminalID: terminalID)
         }
-        slots[terminalID] = .adopted(adoption.reader)
-        statuses[terminalID] = adoption.description.status
-        drainLoopsStarted += 1
-        liveDrainLoops += 1
-        peakLiveDrainLoops = max(peakLiveDrainLoops, liveDrainLoops)
+        publish(reader: adoption.reader, status: adoption.description.status, for: terminalID)
         Self.logger.info(
             """
             adopted the holder for session \(terminalID.uuidString, privacy: .public): child \
@@ -2214,6 +2208,26 @@ actor HolderRegistry {
             await task.value
             clearIfStillReleasing(task, for: terminalID)
         }
+    }
+
+    /// Publishes an adopted reader into its slot, records the status that came
+    /// with it, and counts the drain loop it carries.
+    ///
+    /// The one publish site for both callers — `spawn` and `beginAdoption` —
+    /// because the counters only mean anything if *every* publish touches all
+    /// three. They diverged once: `spawn` incremented `drainLoopsStarted`
+    /// alone, so `stopPublished`'s unconditional decrement drove
+    /// `liveDrainLoops` negative for a spawned session, and
+    /// `peakLiveDrainLoops` could not see a second loop running beside a
+    /// spawned one — the exact byte theft that counter exists to catch.
+    private func publish(
+        reader: HolderReader, status: HolderChildStatus, for terminalID: UUID
+    ) {
+        slots[terminalID] = .adopted(reader)
+        statuses[terminalID] = status
+        drainLoopsStarted += 1
+        liveDrainLoops += 1
+        peakLiveDrainLoops = max(peakLiveDrainLoops, liveDrainLoops)
     }
 
     /// Stops a reader this registry published, and drops it from the live count

--- a/Sources/TBDDaemon/Server/HolderSendComposition.swift
+++ b/Sources/TBDDaemon/Server/HolderSendComposition.swift
@@ -23,6 +23,18 @@ import Foundation
 /// **An empty body is never wrapped.** `--text "" --submit` is a real way to
 /// press Enter, and a bracketed paste of nothing is a pair of markers the child
 /// has to interpret for no reason — a shell at its prompt would show them.
+///
+/// **A wrapped body carries no end marker of its own.** `ESC[201~` inside the
+/// paste closes it early, so everything after it — the rest of the body and the
+/// submitting `\r` — arrives as keystrokes instead of text, which is precisely
+/// the failure the wrapping exists to prevent, reached by content rather than by
+/// chunk shape. `--text "$(cat some-file)"` is all it takes. An end marker
+/// inside a paste can only ever be a break-out: there is nothing a child could
+/// display for it, so removing it loses nothing a caller meant to send, and
+/// removal is done bytewise on the composed body so a marker cannot re-form
+/// across a removal. Only the wrapped path touches the body; an unwrapped send
+/// is delivered verbatim, because with no paste open there is nothing to break
+/// out of and the bytes are the caller's to send.
 enum HolderSendComposition {
     /// `ESC [ 2 0 0 ~` — the start of a bracketed paste.
     static let pasteStart = Data([0x1b, 0x5b, 0x32, 0x30, 0x30, 0x7e])
@@ -43,17 +55,40 @@ enum HolderSendComposition {
     /// - Returns: one `Data`, written in one call, so the message is never
     ///   interleaved with another writer's.
     static func compose(body: String, submit: Bool, bracketedPaste: Bool) -> Data {
+        // Stripped before the emptiness test, not after, so the two rules
+        // compose: a body that was nothing but an end marker has nothing left
+        // to paste, and wrapping it would put the markers the empty-body rule
+        // exists to avoid in front of the Enter.
+        let payload = bracketedPaste ? removingEndMarkers(from: Data(body.utf8)) : Data(body.utf8)
         var message = Data()
-        if !body.isEmpty {
-            if bracketedPaste {
-                message.append(pasteStart)
-                message.append(Data(body.utf8))
-                message.append(pasteEnd)
-            } else {
-                message.append(Data(body.utf8))
-            }
+        if !payload.isEmpty {
+            if bracketedPaste { message.append(pasteStart) }
+            message.append(payload)
+            if bracketedPaste { message.append(pasteEnd) }
         }
         if submit { message.append(submitByte) }
         return message
+    }
+
+    /// `body` with every `ESC[201~` taken out, so the only end marker in the
+    /// composed message is the one this type puts there.
+    ///
+    /// Written as an append-and-retract scan rather than a search-and-replace
+    /// because a single replacing pass is not enough: removing the marker from
+    /// `ESC[2` + `ESC[201~` + `01~` joins its neighbours into a fresh one. Here
+    /// a marker is retracted the moment the byte that completes it is appended,
+    /// so the invariant holds after every step and the output provably contains
+    /// none — in one pass over the body.
+    static func removingEndMarkers(from body: Data) -> Data {
+        let pattern = [UInt8](pasteEnd)
+        var kept: [UInt8] = []
+        kept.reserveCapacity(body.count)
+        for byte in body {
+            kept.append(byte)
+            if kept.count >= pattern.count, Array(kept.suffix(pattern.count)) == pattern {
+                kept.removeLast(pattern.count)
+            }
+        }
+        return Data(kept)
     }
 }

--- a/Sources/TBDDaemon/Server/HolderSendComposition.swift
+++ b/Sources/TBDDaemon/Server/HolderSendComposition.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Turns one `terminal.send` into the exact bytes the holder transport writes.
+///
+/// Split out of `performHolderSend` because it is the whole of the decision and
+/// none of the plumbing: given a body, whether the send submits, and what the
+/// child's bracketed-paste mode is, there is exactly one right answer in bytes.
+/// A pure function is testable on whole `Data` values, and whole `Data` values
+/// are the only assertion worth making here — a substring check would pass on a
+/// message with the submitting `\r` *inside* the paste, which is the defect
+/// this composition exists to fix.
+///
+/// **Why the wrapping matters.** An agent TUI's paste-burst heuristic keys on
+/// the *shape* of a chunk, not its byte count, so a `\r` arriving in the same
+/// read as a multi-line body gets absorbed into the pasted text and nothing
+/// submits — measured at ~230 bytes and again at 4 KB, which is what shows it
+/// is not a size effect. Wrapping the body in `ESC[200~`…`ESC[201~` and putting
+/// the `\r` after the end marker makes the Enter provably outside the paste.
+/// That is the property the tmux arm had, by pasting and pressing Enter as two
+/// separate acts; this gets it without splitting the message, so a payload is
+/// still never split across a routing decision.
+///
+/// **An empty body is never wrapped.** `--text "" --submit` is a real way to
+/// press Enter, and a bracketed paste of nothing is a pair of markers the child
+/// has to interpret for no reason — a shell at its prompt would show them.
+enum HolderSendComposition {
+    /// `ESC [ 2 0 0 ~` — the start of a bracketed paste.
+    static let pasteStart = Data([0x1b, 0x5b, 0x32, 0x30, 0x30, 0x7e])
+    /// `ESC [ 2 0 1 ~` — the end of a bracketed paste.
+    static let pasteEnd = Data([0x1b, 0x5b, 0x32, 0x30, 0x31, 0x7e])
+    /// Carriage return, not newline: what a terminal delivers when Return is
+    /// pressed, and what tmux's `send-keys Enter` sends.
+    static let submitByte: UInt8 = 0x0d
+
+    /// - Parameter body: everything the message says, envelope included. The
+    ///   envelope goes *inside* the paste, because it is part of the text the
+    ///   child is being handed and splitting it out would be a second chunk.
+    /// - Parameter submit: whether a Return follows.
+    /// - Parameter bracketedPaste: what the child's mode is, as the oracle
+    ///   answered. `false` when the oracle could not answer at all — bare bytes
+    ///   are what every child understood before this existed, and markers a
+    ///   child never asked for are printed rather than obeyed.
+    /// - Returns: one `Data`, written in one call, so the message is never
+    ///   interleaved with another writer's.
+    static func compose(body: String, submit: Bool, bracketedPaste: Bool) -> Data {
+        var message = Data()
+        if !body.isEmpty {
+            if bracketedPaste {
+                message.append(pasteStart)
+                message.append(Data(body.utf8))
+                message.append(pasteEnd)
+            } else {
+                message.append(Data(body.utf8))
+            }
+        }
+        if submit { message.append(submitByte) }
+        return message
+    }
+}

--- a/Sources/TBDDaemon/Server/HolderSendComposition.swift
+++ b/Sources/TBDDaemon/Server/HolderSendComposition.swift
@@ -24,8 +24,9 @@ import Foundation
 /// press Enter, and a bracketed paste of nothing is a pair of markers the child
 /// has to interpret for no reason — a shell at its prompt would show them.
 ///
-/// **A wrapped body carries no paste marker of its own.** Both markers are
-/// taken out, for reasons that differ. `ESC[201~` inside the paste closes it
+/// **A send carries no paste marker of its own, in either mode.** Both markers
+/// are taken out of every body, wrapped or bare. Inside a wrapping they break
+/// it, for reasons that differ. `ESC[201~` inside the paste closes it
 /// early, so everything after it — the rest of the body and the submitting
 /// `\r` — arrives as keystrokes instead of text, which is precisely the failure
 /// the wrapping exists to prevent, reached by content rather than by chunk
@@ -37,9 +38,20 @@ import Foundation
 /// marker inside a paste can only ever be a break-out or a restart: there is
 /// nothing a child could display for one, so removing it loses nothing a caller
 /// meant to send, and removal is done bytewise on the composed body so a marker
-/// cannot re-form across a removal. Only the wrapped path touches the body; an
-/// unwrapped send is delivered verbatim, because with no paste open there is
-/// nothing to break out of and the bytes are the caller's to send.
+/// cannot re-form across a removal.
+///
+/// **The bare path strips too, and that is not symmetry for its own sake.** A
+/// paste marker in a text send is never content a child can display, whichever
+/// mode the composition read: with bracketing off the child prints the six
+/// bytes or misreads them, so delivering them verbatim serves no caller. And
+/// the mode this composition reads can be *stale* — `staleDaemon` is a reading
+/// from an emulator that stopped consuming bytes when a viewer took the pty,
+/// possibly hours ago — so "bracketing is off" is a guess about a child that
+/// may well have turned it on since. An unstripped `ESC[200~` delivered bare to
+/// such a child opens a paste nothing closes, and the submitting `\r` and every
+/// keystroke after it are swallowed as pasted text. Stripping unconditionally
+/// costs a caller nothing it could have meant and removes that failure from
+/// both branches.
 enum HolderSendComposition {
     /// `ESC [ 2 0 0 ~` — the start of a bracketed paste.
     static let pasteStart = Data([0x1b, 0x5b, 0x32, 0x30, 0x30, 0x7e])
@@ -60,11 +72,11 @@ enum HolderSendComposition {
     /// - Returns: one `Data`, written in one call, so the message is never
     ///   interleaved with another writer's.
     static func compose(body: String, submit: Bool, bracketedPaste: Bool) -> Data {
-        // Stripped before the emptiness test, not after, so the two rules
-        // compose: a body that was nothing but paste markers has nothing left
-        // to paste, and wrapping it would put the markers the empty-body rule
-        // exists to avoid in front of the Enter.
-        let payload = bracketedPaste ? removingPasteMarkers(from: Data(body.utf8)) : Data(body.utf8)
+        // Stripped in both modes, and before the emptiness test rather than
+        // after, so the two rules compose: a body that was nothing but paste
+        // markers has nothing left to paste, and wrapping it would put the
+        // markers the empty-body rule exists to avoid in front of the Enter.
+        let payload = removingPasteMarkers(from: Data(body.utf8))
         var message = Data()
         if !payload.isEmpty {
             if bracketedPaste { message.append(pasteStart) }
@@ -76,7 +88,8 @@ enum HolderSendComposition {
     }
 
     /// `body` with every `ESC[200~` and `ESC[201~` taken out, so the only paste
-    /// markers in the composed message are the pair this type puts there.
+    /// markers in the composed message are the pair this type puts there — and
+    /// on the bare path, where it puts none, there are none at all.
     ///
     /// Written as an append-and-retract scan rather than a search-and-replace
     /// because a single replacing pass is not enough: removing the marker from

--- a/Sources/TBDDaemon/Server/HolderSendComposition.swift
+++ b/Sources/TBDDaemon/Server/HolderSendComposition.swift
@@ -24,17 +24,22 @@ import Foundation
 /// press Enter, and a bracketed paste of nothing is a pair of markers the child
 /// has to interpret for no reason — a shell at its prompt would show them.
 ///
-/// **A wrapped body carries no end marker of its own.** `ESC[201~` inside the
-/// paste closes it early, so everything after it — the rest of the body and the
-/// submitting `\r` — arrives as keystrokes instead of text, which is precisely
-/// the failure the wrapping exists to prevent, reached by content rather than by
-/// chunk shape. `--text "$(cat some-file)"` is all it takes. An end marker
-/// inside a paste can only ever be a break-out: there is nothing a child could
-/// display for it, so removing it loses nothing a caller meant to send, and
-/// removal is done bytewise on the composed body so a marker cannot re-form
-/// across a removal. Only the wrapped path touches the body; an unwrapped send
-/// is delivered verbatim, because with no paste open there is nothing to break
-/// out of and the bytes are the caller's to send.
+/// **A wrapped body carries no paste marker of its own.** Both markers are
+/// taken out, for reasons that differ. `ESC[201~` inside the paste closes it
+/// early, so everything after it — the rest of the body and the submitting
+/// `\r` — arrives as keystrokes instead of text, which is precisely the failure
+/// the wrapping exists to prevent, reached by content rather than by chunk
+/// shape. `ESC[200~` inside the paste restarts it in a child whose reader takes
+/// a nested start marker as the beginning of a new paste, discarding everything
+/// before it — the dispatch envelope included — so what the child acts on is
+/// not what the caller sent. `--text "$(cat some-file)"` is all either takes: a
+/// log or a transcript that recorded raw terminal input holds both. A paste
+/// marker inside a paste can only ever be a break-out or a restart: there is
+/// nothing a child could display for one, so removing it loses nothing a caller
+/// meant to send, and removal is done bytewise on the composed body so a marker
+/// cannot re-form across a removal. Only the wrapped path touches the body; an
+/// unwrapped send is delivered verbatim, because with no paste open there is
+/// nothing to break out of and the bytes are the caller's to send.
 enum HolderSendComposition {
     /// `ESC [ 2 0 0 ~` — the start of a bracketed paste.
     static let pasteStart = Data([0x1b, 0x5b, 0x32, 0x30, 0x30, 0x7e])
@@ -56,10 +61,10 @@ enum HolderSendComposition {
     ///   interleaved with another writer's.
     static func compose(body: String, submit: Bool, bracketedPaste: Bool) -> Data {
         // Stripped before the emptiness test, not after, so the two rules
-        // compose: a body that was nothing but an end marker has nothing left
+        // compose: a body that was nothing but paste markers has nothing left
         // to paste, and wrapping it would put the markers the empty-body rule
         // exists to avoid in front of the Enter.
-        let payload = bracketedPaste ? removingEndMarkers(from: Data(body.utf8)) : Data(body.utf8)
+        let payload = bracketedPaste ? removingPasteMarkers(from: Data(body.utf8)) : Data(body.utf8)
         var message = Data()
         if !payload.isEmpty {
             if bracketedPaste { message.append(pasteStart) }
@@ -70,34 +75,59 @@ enum HolderSendComposition {
         return message
     }
 
-    /// `body` with every `ESC[201~` taken out, so the only end marker in the
-    /// composed message is the one this type puts there.
+    /// `body` with every `ESC[200~` and `ESC[201~` taken out, so the only paste
+    /// markers in the composed message are the pair this type puts there.
     ///
     /// Written as an append-and-retract scan rather than a search-and-replace
     /// because a single replacing pass is not enough: removing the marker from
-    /// `ESC[2` + `ESC[201~` + `01~` joins its neighbours into a fresh one. Here
-    /// a marker is retracted the moment the byte that completes it is appended,
-    /// so the invariant holds after every step and the output provably contains
-    /// none — in one pass over the body.
+    /// `ESC[2` + `ESC[201~` + `01~` joins its neighbours into a fresh one, and
+    /// the same holds for `ESC[200~`. Here a marker is retracted the moment the
+    /// byte that completes it is appended, and the retraction is followed by a
+    /// re-check, so neither pattern can leave a suffix that completes the other
+    /// unnoticed — the invariant holds after every step and the output provably
+    /// contains neither marker, in one pass over the body.
     ///
-    /// The suffix is compared **in place**, and the last byte of the pattern is
-    /// checked first. This runs inside the per-terminal send serializer on a
-    /// body with no size cap, and the obvious spelling — materialising
-    /// `kept.suffix(pattern.count)` into an `Array` — allocates once per input
-    /// byte for a comparison that ordinary text loses on its first byte.
-    static func removingEndMarkers(from body: Data) -> Data {
-        let pattern = [UInt8](pasteEnd)
-        guard let terminator = pattern.last else { return body }
+    /// The suffix is compared **in place**, and only when the byte just
+    /// appended is the `~` both markers end in. This runs inside the
+    /// per-terminal send serializer on a body with no size cap, and the obvious
+    /// spelling — materialising `kept.suffix(pattern.count)` into an `Array` —
+    /// allocates once per input byte for a comparison that ordinary text loses
+    /// on its first byte.
+    static func removingPasteMarkers(from body: Data) -> Data {
+        let patterns = [[UInt8](pasteStart), [UInt8](pasteEnd)]
+        // The shared last byte is what makes one cheap test enough to skip the
+        // suffix scan on every byte of ordinary text.
+        guard let terminator = pasteEnd.last, pasteStart.last == terminator else { return body }
         var kept: [UInt8] = []
         kept.reserveCapacity(body.count)
         for byte in body {
             kept.append(byte)
-            guard byte == terminator, kept.count >= pattern.count else { continue }
-            let start = kept.count - pattern.count
-            var index = 0
-            while index < pattern.count, kept[start + index] == pattern[index] { index += 1 }
-            if index == pattern.count { kept.removeLast(pattern.count) }
+            guard byte == terminator else { continue }
+            while retractTrailingMarker(from: &kept, patterns: patterns) {}
         }
         return Data(kept)
+    }
+
+    /// Removes one trailing marker from `kept`, answering whether it removed
+    /// one so the caller can look again: a retraction rejoins the bytes on
+    /// either side of what it took out, and the re-check is what keeps a
+    /// removal of one pattern from leaving the other's bytes touching.
+    ///
+    /// The comparison runs from the end of the pattern backwards, which is
+    /// where the two markers differ — they agree on everything but their
+    /// second-to-last byte.
+    private static func retractTrailingMarker(
+        from kept: inout [UInt8], patterns: [[UInt8]]
+    ) -> Bool {
+        for pattern in patterns where kept.count >= pattern.count {
+            let start = kept.count - pattern.count
+            var index = pattern.count - 1
+            while index >= 0, kept[start + index] == pattern[index] { index -= 1 }
+            if index < 0 {
+                kept.removeLast(pattern.count)
+                return true
+            }
+        }
+        return false
     }
 }

--- a/Sources/TBDDaemon/Server/HolderSendComposition.swift
+++ b/Sources/TBDDaemon/Server/HolderSendComposition.swift
@@ -79,15 +79,24 @@ enum HolderSendComposition {
     /// a marker is retracted the moment the byte that completes it is appended,
     /// so the invariant holds after every step and the output provably contains
     /// none — in one pass over the body.
+    ///
+    /// The suffix is compared **in place**, and the last byte of the pattern is
+    /// checked first. This runs inside the per-terminal send serializer on a
+    /// body with no size cap, and the obvious spelling — materialising
+    /// `kept.suffix(pattern.count)` into an `Array` — allocates once per input
+    /// byte for a comparison that ordinary text loses on its first byte.
     static func removingEndMarkers(from body: Data) -> Data {
         let pattern = [UInt8](pasteEnd)
+        guard let terminator = pattern.last else { return body }
         var kept: [UInt8] = []
         kept.reserveCapacity(body.count)
         for byte in body {
             kept.append(byte)
-            if kept.count >= pattern.count, Array(kept.suffix(pattern.count)) == pattern {
-                kept.removeLast(pattern.count)
-            }
+            guard byte == terminator, kept.count >= pattern.count else { continue }
+            let start = kept.count - pattern.count
+            var index = 0
+            while index < pattern.count, kept[start + index] == pattern[index] { index += 1 }
+            if index == pattern.count { kept.removeLast(pattern.count) }
         }
         return Data(kept)
     }

--- a/Sources/TBDDaemon/Server/RPCRouter+AttachHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+AttachHandlers.swift
@@ -350,9 +350,10 @@ extension RPCRouter {
         return .descriptorNeverDelivered
     }
 
-    /// The holder half of `attach.ready`: the viewer is on the pty, so the
-    /// daemon's reader is released for good and the session becomes the
-    /// viewer's.
+    /// The holder half of `attach.ready`: the viewer is on the pty, so the pty
+    /// becomes the viewer's and the daemon's reader stays suspended and
+    /// retained — it is the session's screen and its mode oracle for as long as
+    /// the viewer holds the descriptor.
     ///
     /// There is no replay sequence to run here — the screen went out with the
     /// request, as the snapshot preamble — so this is only the ownership edge,

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -3298,9 +3298,10 @@ extension RPCRouter {
             // Nothing to write, reached two ways. `--text ""` with no
             // `--submit` is a well-formed act that names nothing — the tmux arm
             // reaches the same outcome by skipping both of its sub-steps. A
-            // body that was nothing but end markers reaches it too, because the
-            // composition strips those before it tests for emptiness, and a
-            // caller's `ESC[201~` cannot be allowed to leave an open paste.
+            // body that was nothing but paste markers reaches it too, because
+            // the composition strips those before it tests for emptiness, and a
+            // caller's `ESC[201~` cannot be allowed to leave an open paste nor
+            // its `ESC[200~` to restart one.
             //
             // Provenance is recorded whenever the caller's text was non-empty:
             // a composition did happen, against a store this asked, and what it

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -1912,10 +1912,12 @@ extension RPCRouter {
     /// possible wrong answer.
     ///
     /// A missing reader is still reported rather than papered over. It means
-    /// the registry has no reader at all — the holder is gone, or startup
-    /// adoption found it unreachable — and an empty screen would read as "the
-    /// session is quiet", which is a different and much more comfortable claim
-    /// than the true one.
+    /// the registry has no reader to hand out: the holder is gone, startup
+    /// adoption found it unreachable, or the slot is mid-transition — an attach
+    /// in flight, or a release running — since `reader(for:)` answers only for
+    /// an adopted slot. The error names all three and says which of them a
+    /// retry helps, because an empty screen would read as "the session is
+    /// quiet", a different and much more comfortable claim than the true one.
     ///
     /// **A refused projection is an error, never an empty screen.** The screen
     /// type refuses a row carrying a control character, and such a row is a bug
@@ -1932,7 +1934,9 @@ extension RPCRouter {
         guard let reader = await holderRegistry.reader(for: terminal.id) else {
             return RPCResponse(
                 error: "No live holder reader for terminal \(terminal.id); "
-                    + "its session is gone or was never adopted")
+                    + "its session is gone, was never adopted, or is mid-transition "
+                    + "(being adopted or released); retry if it was just created "
+                    + "or is being closed")
         }
         let lines = params.lines ?? 50
         // Rendered to the requested depth directly. The tmux path asks for a
@@ -3208,15 +3212,33 @@ extension RPCRouter {
     /// non-empty body in `ESC[200~`…`ESC[201~` exactly when the child has
     /// bracketed paste on, and the submitting `\r` follows the end marker — so
     /// the Enter is provably outside the paste, which is the property the tmux
-    /// arm gets from delivering in two acts and this arm used to lack. A child
+    /// arm gets from delivering in two acts and a mode-blind composition cannot
+    /// have at all. A child
     /// that never asked for bracketing gets bare bytes, because markers it does
     /// not understand are markers it prints.
     ///
     /// The oracle is consulted at composition time, which is a moment, and the
-    /// child can change a mode between that moment and the write. tmux has the
-    /// same window — the server reads the pane's mode when it pastes, not when
-    /// the bytes land — and it is accepted for the same reason: a mode that
-    /// flips mid-send produces a visible mis-paste, not a silent loss.
+    /// child can change a mode between that moment and the write. **How wide
+    /// that window is depends on which store answered.** A live store — the
+    /// daemon's own emulator, or a viewer that answered the pull — leaves only
+    /// the moment between the read and the write, which is the window tmux has
+    /// too: its server reads the pane's mode when it pastes, not when the bytes
+    /// land. A `staleDaemon` reading leaves the whole attach, because that
+    /// emulator stopped consuming bytes when the viewer took the pty, so a mode
+    /// the child changed since then is invisible here for as long as the viewer
+    /// holds it — possibly hours.
+    ///
+    /// Both windows are accepted, and the wide one is accepted by ruling: the
+    /// design's "Proceeding on stale modes" section weighs a rare wrong
+    /// composition against rails that fail closed exactly when supervision most
+    /// needs to send. What a wrong reading costs is a wrong composition, and a
+    /// wrong composition is visible in the composer or diagnosable from the
+    /// row's `modeSource` and its age — never a send that vanished. Read as on
+    /// when it is off, a shell that has bracketing off prints the `ESC[200~` and
+    /// `ESC[201~` markers around the text and runs the line it made of them.
+    /// Read as off when it is on, a multi-line body goes bare to a TUI that
+    /// turned bracketing on after the attach, and its paste-burst heuristic can
+    /// absorb the submitting `\r` into the text.
     private func performHolderSend(
         payload: TerminalSendPayload, terminal: Terminal, actuationID: String,
         actor: ActuationActor?, envelope: DispatchEnvelopeDisposition

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -1900,14 +1900,27 @@ extension RPCRouter {
         return try RPCResponse(result: TerminalOutputResult(output: trimmed))
     }
 
-    /// The holder half of `terminal.output`: render the daemon's own emulator
-    /// for a session whose pty master it is draining.
+    /// The holder half of `terminal.output`: the typed screen, from the
+    /// daemon's own emulator.
     ///
-    /// A missing reader is reported rather than papered over. It means the
-    /// registry never adopted this session — the holder is gone, or startup
+    /// **A session a person has open is answerable.** The daemon's reader is
+    /// retained across an attach — suspended, holding the screen as it stood
+    /// when the viewer arrived — so this reads it and labels the answer
+    /// `staleDaemon` with an age rather than failing. Before the reader was
+    /// retained, a machine read of any open session returned an error saying
+    /// the session was gone, which was both wrong and the most comfortable
+    /// possible wrong answer.
+    ///
+    /// A missing reader is still reported rather than papered over. It means
+    /// the registry has no reader at all — the holder is gone, or startup
     /// adoption found it unreachable — and an empty screen would read as "the
     /// session is quiet", which is a different and much more comfortable claim
     /// than the true one.
+    ///
+    /// **A refused projection is an error, never an empty screen.** The screen
+    /// type refuses a row carrying a control character, and such a row is a bug
+    /// in the render rather than a state a session can be in; the caller is
+    /// told which line, so the bug is findable.
     private func holderTerminalOutput(
         terminal: Terminal,
         params: TerminalOutputParams
@@ -1926,8 +1939,14 @@ extension RPCRouter {
         // whole pane and trims afterwards because `capture-pane` has no such
         // knob; the emulator does, and going through it means the scrollback
         // above the viewport is available rather than discarded.
-        let output = await reader.renderScreenWithScrollback(maxLines: lines)
-        return try RPCResponse(result: TerminalOutputResult(output: output))
+        let screen: TerminalScreen
+        do {
+            screen = try await reader.screen(maxLines: lines)
+        } catch {
+            return RPCResponse(
+                error: "Could not project terminal \(terminal.id)'s screen: \(error)")
+        }
+        return try RPCResponse(result: TerminalOutputResult(screen: screen))
     }
 
     func handleTerminalConversation(_ paramsData: Data) async throws -> RPCResponse {

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -3188,31 +3188,35 @@ extension RPCRouter {
     /// actuation row, the same dispatch envelope, the same per-terminal
     /// serializer lane (this runs inside it). What changes is the destination —
     /// `HolderInjectionCourier` routes by whether a viewer owns the pty — and
-    /// three things this transport cannot do yet, each refused by name rather
+    /// two things this transport cannot do yet, each refused by name rather
     /// than by "the holder transport", so a caller learns which capability is
     /// missing:
     ///
-    /// - `--verify` has no delivery observation here (the verifier re-reads a
-    ///   tmux pane, and there is none).
+    /// - `--verify` has no delivery observation here.
     /// - `--keys` has no named-key → bytes mapping here (tmux owns that table).
-    /// - A daemon with no courier has no input path at all.
     ///
-    /// **The whole send is one message.** The body, its envelope and the
-    /// carriage return that submits it are composed here and handed to the
-    /// courier in a single call, because a payload split across two writes can
-    /// be split across a routing decision — and because `HolderReader.write`
-    /// completes partial writes in a loop, so one call is one uninterrupted
-    /// write. That is a deliberate divergence from the tmux arm, which pastes
-    /// the body and presses Enter as two separate acts.
+    /// A daemon with no courier has no input path at all, and says so.
     ///
-    /// The cost of that divergence is worth naming: the tmux arm wraps the
-    /// body in an *explicit* bracketed paste so a payload larger than the pty
-    /// buffer cannot have its trailing Enter absorbed by a TUI's paste-burst
-    /// detection. This arm cannot do the same, because the wrappers are correct
-    /// only when the child has bracketed-paste mode on and the daemon's holder
-    /// emulator does not expose that mode to callers. So a very large `--text
-    /// --submit` here can leave its Enter unpressed. Exposing the mode from the
-    /// emulator is what closes it.
+    /// **The whole send is one message.** The body, its envelope, its paste
+    /// markers and the carriage return that submits it are composed here and
+    /// handed to the courier in a single call, because a payload split across
+    /// two writes can be split across a routing decision — and because
+    /// `HolderReader.write` completes partial writes in a loop, so one call is
+    /// one uninterrupted write.
+    ///
+    /// **The child's modes decide the bytes.** `HolderSendComposition` wraps a
+    /// non-empty body in `ESC[200~`…`ESC[201~` exactly when the child has
+    /// bracketed paste on, and the submitting `\r` follows the end marker — so
+    /// the Enter is provably outside the paste, which is the property the tmux
+    /// arm gets from delivering in two acts and this arm used to lack. A child
+    /// that never asked for bracketing gets bare bytes, because markers it does
+    /// not understand are markers it prints.
+    ///
+    /// The oracle is consulted at composition time, which is a moment, and the
+    /// child can change a mode between that moment and the write. tmux has the
+    /// same window — the server reads the pane's mode when it pastes, not when
+    /// the bytes land — and it is accepted for the same reason: a mode that
+    /// flips mid-send produces a visible mis-paste, not a silent loss.
     private func performHolderSend(
         payload: TerminalSendPayload, terminal: Terminal, actuationID: String,
         actor: ActuationActor?, envelope: DispatchEnvelopeDisposition
@@ -3236,40 +3240,78 @@ extension RPCRouter {
                 actuationID, Self.holderKeysRefusal(terminalID: terminal.id))
         }
 
+        // Asked BEFORE anything is composed, because the answer decides the
+        // bytes. Two sources, in order: the test seam if one is installed, then
+        // the registry's own reader for this session.
+        //
+        // **A `nil` answer proceeds; it never refuses.** There is no reader,
+        // which means the session is gone or was never adopted — in which case
+        // the courier's write is about to fail and say so with the right cause.
+        // Refusing here would put a second, wronger refusal in front of that,
+        // and more importantly it would make every rail's send fail closed
+        // whenever the daemon cannot see a store: the moments that correlate
+        // exactly with supervision needing to send. The composition step's job
+        // is to record what it composed against, not to decide whether delivery
+        // is possible — the courier decides that, and it fails open.
+        let reading = await holderModeReading(terminalID: terminal.id)
+        let modeSource = reading.map { ActuationModeSource($0.source) } ?? .unavailable
+        // Absent for `unavailable`: nothing answered, so there is no store
+        // whose age this could be.
+        let modeAge = reading?.ageMilliseconds
+
         // Same envelope rule as the tmux arm, and for the same reasons — see
         // the long comment there. Empty text stays empty: `--text "" --submit`
         // is a real way to press Enter and must not start pasting a tag.
-        var message = Data()
-        if !text.isEmpty {
-            let composed = envelope == .attached && Self.carriesDispatchEnvelope(terminal)
+        let body = text.isEmpty
+            ? ""
+            : (envelope == .attached && Self.carriesDispatchEnvelope(terminal)
                 ? Self.dispatchEnvelope(
                     id: actuationID, from: (actor ?? .anonymous).dispatchLabel) + "\n" + text
-                : text
-            message.append(Data(composed.utf8))
-        }
-        // Carriage return, not newline: this is what a terminal delivers when
-        // Return is pressed, and what tmux's `send-keys Enter` sends.
-        if submit { message.append(0x0d) }
+                : text)
+        let message = HolderSendComposition.compose(
+            body: body, submit: submit,
+            bracketedPaste: reading?.modes.bracketedPaste ?? false)
 
         guard !message.isEmpty else {
             // `--text ""` with no `--submit`: a well-formed act that names
             // nothing to write. The tmux arm reaches the same outcome by
-            // skipping both of its sub-steps.
+            // skipping both of its sub-steps. No mode provenance is recorded,
+            // because nothing was composed — there is no guess to disclose.
             await finishActuation(actuationID, .dispatched)
             return .ok()
         }
 
         switch await courier.deliver(terminalID: terminal.id, bytes: message) {
         case .viewerWrote, .daemonWrote:
-            await finishActuation(actuationID, .dispatched)
+            await finishActuation(
+                actuationID, .dispatched,
+                modeSource: modeSource, modeAgeMilliseconds: modeAge)
             return .ok()
         case .notDelivered(let reason):
             // The transport, not a decision: the daemon tried to write and
             // could not. Classified as such so the record does not read like a
-            // rail that declined.
-            await finishActuation(actuationID, .transportFailed, error: reason)
+            // rail that declined. The provenance rides here too — what was
+            // composed is a fact about the attempt, not about its success.
+            await finishActuation(
+                actuationID, .transportFailed, error: reason,
+                modeSource: modeSource, modeAgeMilliseconds: modeAge)
             return RPCResponse(error: reason)
         }
+    }
+
+    /// What the child's modes are, as best this daemon can say.
+    ///
+    /// The seam first so a test can pin all three answers without a real
+    /// holder; otherwise the registry's reader for this session, which is
+    /// retained across an attach and so answers for an open session as well as
+    /// a detached one — `.daemon` while the daemon is draining, `.staleDaemon`
+    /// while a viewer holds the pty.
+    private func holderModeReading(terminalID: UUID) async -> TerminalModeReading? {
+        if let holderModeOracle {
+            return await holderModeOracle(terminalID)
+        }
+        guard let reader = await holderRegistry?.reader(for: terminalID) else { return nil }
+        return await reader.modeReading()
     }
 
     /// Close a holder send that never touched the transport. One helper because

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -3295,11 +3295,23 @@ extension RPCRouter {
             bracketedPaste: reading?.modes.bracketedPaste ?? false)
 
         guard !message.isEmpty else {
-            // `--text ""` with no `--submit`: a well-formed act that names
-            // nothing to write. The tmux arm reaches the same outcome by
-            // skipping both of its sub-steps. No mode provenance is recorded,
-            // because nothing was composed — there is no guess to disclose.
-            await finishActuation(actuationID, .dispatched)
+            // Nothing to write, reached two ways. `--text ""` with no
+            // `--submit` is a well-formed act that names nothing — the tmux arm
+            // reaches the same outcome by skipping both of its sub-steps. A
+            // body that was nothing but end markers reaches it too, because the
+            // composition strips those before it tests for emptiness, and a
+            // caller's `ESC[201~` cannot be allowed to leave an open paste.
+            //
+            // Provenance is recorded whenever the caller's text was non-empty:
+            // a composition did happen, against a store this asked, and what it
+            // composed against is a fact about the attempt however little the
+            // attempt came to. An empty text composed against nothing, so there
+            // is no guess to disclose.
+            let composed = !text.isEmpty
+            await finishActuation(
+                actuationID, .dispatched,
+                modeSource: composed ? modeSource : nil,
+                modeAgeMilliseconds: composed ? modeAge : nil)
             return .ok()
         }
 

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -241,6 +241,20 @@ public final class RPCRouter: Sendable {
     /// input path in this daemon rather than being silently dropped.
     nonisolated(unsafe) var holderInjectionCourier: HolderInjectionCourier?
 
+    /// Answers what modes a holder-backed session's child is in, for the send
+    /// path to compose against. A **test seam only** — production leaves it
+    /// nil and `performHolderSend` falls through to the registry's own reader,
+    /// which is the single source the design names.
+    ///
+    /// It exists because the alternative is worse: reaching the three answers
+    /// (`daemon`, `staleDaemon`, and no answer at all) through a real registry
+    /// means a real holder, a real pty and a real attach for what is a pure
+    /// question about which bytes get composed. The registry-backed path is
+    /// exercised live; this is how the composition's own branches are pinned.
+    ///
+    /// `nil` from the seam means the same thing as no reader: nothing answered.
+    nonisolated(unsafe) var holderModeOracle: (@Sendable (UUID) async -> TerminalModeReading?)?
+
     let decoder = JSONDecoder()
     let encoder = JSONEncoder()
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -3834,7 +3834,9 @@ public struct TerminalOutputResult: Codable, Sendable {
     }
 
     /// The holder arm. `output` is derived from the screen, so the two can
-    /// never disagree.
+    /// never disagree — and this is the only place the joined string crosses
+    /// the wire, since `TerminalScreen` encodes its `lines` and no copy of
+    /// them.
     public init(screen: TerminalScreen) {
         self.output = screen.output
         self.screen = screen

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -3805,9 +3805,40 @@ public struct TerminalOutputParams: Codable, Sendable {
     }
 }
 
+/// The answer to `terminal.output`, on both transports.
+///
+/// `output` is the string every existing consumer already reads, and it is
+/// always the same string they read before — the CLI prints it, scripts match
+/// on it, and nothing about it changed when `screen` appeared beside it. That
+/// is what let the typed screen land in place rather than as a sibling method:
+/// a second method would have left this one answering wrongly for every
+/// attached session until the last consumer migrated.
+///
+/// **`screen` is present on the holder transport and absent on tmux**, and the
+/// asymmetry is honest rather than an omission. The screen contract is the
+/// holder transport's: `source` names which of that transport's two stores
+/// answered, `modes` come from the emulator that produced the lines, and
+/// `ageMilliseconds` is measured on the daemon's monotonic clock against that
+/// emulator's last byte. `capture-pane` supplies none of them — it returns text
+/// from a server that keeps no such record — so a `screen` on the tmux arm
+/// could only be fabricated, and a fabricated `source` is worse than an absent
+/// one, because a consumer's policy is keyed on exactly that field.
 public struct TerminalOutputResult: Codable, Sendable {
     public let output: String
-    public init(output: String) { self.output = output }
+    public let screen: TerminalScreen?
+
+    /// The tmux arm: text and nothing else.
+    public init(output: String) {
+        self.output = output
+        self.screen = nil
+    }
+
+    /// The holder arm. `output` is derived from the screen, so the two can
+    /// never disagree.
+    public init(screen: TerminalScreen) {
+        self.output = screen.output
+        self.screen = screen
+    }
 }
 
 // MARK: - Terminal Conversation

--- a/Sources/TBDShared/TBDSkillContent.swift
+++ b/Sources/TBDShared/TBDSkillContent.swift
@@ -101,13 +101,18 @@ tbd terminal output <id> [--lines N]
 ```
 
 **A session someone has open answers from a frozen screen.** While a viewer
-holds a session's pty, `tbd terminal output` no longer fails — it answers with
-the daemon's emulator as it stood when that viewer attached, and announces that
+holds a session's pty, `tbd terminal output` still answers: with the daemon's
+emulator as it stood when that viewer attached, and it announces that
 on stderr. Stdout stays exactly the screen text, so a reader that captures only
 stdout cannot tell a live screen from one that stopped updating hours ago. Read
 the stderr note, or pass `--json` and check `screen.source` (`daemon` is the
 live store, `staleDaemon` the at-attach one) and `screen.ageMilliseconds`,
 before acting on what you read.
+
+`screen` is there only for sessions on the pty-holder transport. A tmux-backed
+session answers with `output` alone, so a missing `screen` key means a tmux
+session rather than an error, and there is no staleness question to ask about
+one — tmux captures its pane live.
 
 ### Message a sibling session
 

--- a/Sources/TBDShared/TBDSkillContent.swift
+++ b/Sources/TBDShared/TBDSkillContent.swift
@@ -100,6 +100,15 @@ tbd terminal send --terminal <id> --text "..." [--submit]
 tbd terminal output <id> [--lines N]
 ```
 
+**A session someone has open answers from a frozen screen.** While a viewer
+holds a session's pty, `tbd terminal output` no longer fails — it answers with
+the daemon's emulator as it stood when that viewer attached, and announces that
+on stderr. Stdout stays exactly the screen text, so a reader that captures only
+stdout cannot tell a live screen from one that stopped updating hours ago. Read
+the stderr note, or pass `--json` and check `screen.source` (`daemon` is the
+live store, `staleDaemon` the at-attach one) and `screen.ageMilliseconds`,
+before acting on what you read.
+
 ### Message a sibling session
 
 Two channels reach another TBD session.

--- a/Sources/TBDShared/TerminalScreen.swift
+++ b/Sources/TBDShared/TerminalScreen.swift
@@ -166,10 +166,16 @@ public struct TerminalScreen: Codable, Sendable, Equatable {
     /// The lines joined with `\n`.
     ///
     /// Derived, carrying no information of its own, and kept for exactly one
-    /// reason: scripts and skills read `tbd terminal output` today, and it is
-    /// what lets the in-place change to this RPC result be invisible to every
-    /// consumer that has not migrated. It is written to the wire by
-    /// `encode(to:)` and ignored on the way back in.
+    /// reason: scripts and skills read `tbd terminal output` today, and the
+    /// string is what lets the in-place change to this RPC result be invisible
+    /// to every consumer that has not migrated.
+    ///
+    /// **Swift-side only; the screen's wire form carries no `output`.** The
+    /// compatibility string a script reads is `TerminalOutputResult.output`, at
+    /// the top level of the answer, and it is this property — so the text
+    /// crosses the socket as the lines plus that one string, rather than as a
+    /// third copy nobody reads. Decoding re-derives the field from `lines`,
+    /// which is why a payload that carries an `output` anyway loses nothing.
     public var output: String { lines.joined(separator: "\n") }
 
     /// The three modes, their provenance, and their age — everything the input
@@ -265,12 +271,14 @@ public struct TerminalScreen: Codable, Sendable, Equatable {
     // MARK: - Coding
 
     private enum CodingKeys: String, CodingKey {
-        case lines, viewportStart, cursor, size, modes, source, ageMilliseconds, output
+        case lines, viewportStart, cursor, size, modes, source, ageMilliseconds
     }
 
-    /// Writes `output` beside `lines`, because it is a field a script reads out
-    /// of `tbd terminal output --json` and a computed property would otherwise
-    /// never reach the wire.
+    /// Written out field by field rather than synthesised, so the wire form is
+    /// stated in one readable place — and so `output` is provably not on it.
+    /// The lines are the text; `TerminalOutputResult` carries the joined string
+    /// for the consumers that read one, and a third copy inside the screen
+    /// would only make the answer longer.
     public func encode(to encoder: any Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(lines, forKey: .lines)
@@ -280,13 +288,12 @@ public struct TerminalScreen: Codable, Sendable, Equatable {
         try container.encode(modes, forKey: .modes)
         try container.encode(source, forKey: .source)
         try container.encode(ageMilliseconds, forKey: .ageMilliseconds)
-        try container.encode(output, forKey: .output)
     }
 
     /// **Any `output` on the wire is ignored** and the field is re-derived from
-    /// `lines`, so the two can never disagree in a decoded value — including
-    /// for a payload that carries no `output` at all, which is what a future
-    /// producer that stopped writing it would send.
+    /// `lines`, so the two can never disagree in a decoded value. This producer
+    /// writes none; a payload from anywhere that carries one — an older
+    /// producer, a hand-written fixture — decodes to exactly the same value.
     ///
     /// Decoding runs the same validation construction does. A screen that
     /// arrives with a control character in it is refused at the boundary rather

--- a/Sources/TBDShared/TerminalScreen.swift
+++ b/Sources/TBDShared/TerminalScreen.swift
@@ -131,10 +131,12 @@ public struct TerminalScreen: Codable, Sendable, Equatable {
     ///
     /// **It may be negative**, when the requested tail cut inside the viewport
     /// — ask for 6 lines of a 24-row screen and the first four rows of that
-    /// viewport are simply not in `lines`. **It may also equal `lines.count`**,
-    /// when the whole viewport was blank rows that the trim dropped. Both are
-    /// well-formed answers, and a consumer indexing `lines` with it must bounds
-    /// check rather than assume.
+    /// viewport are simply not in `lines`. **It may also exceed `lines.count`**,
+    /// because the trailing-blank trim does not stop at the viewport's first
+    /// row: a blank viewport over scrollback whose own last row is blank has
+    /// both trimmed away, and the index is left past the end rather than at it.
+    /// Both are well-formed answers, and a consumer indexing `lines` with it
+    /// must bounds check rather than assume.
     public let viewportStart: Int
     public let cursor: Cursor
     public let size: Size

--- a/Sources/TBDShared/TerminalScreen.swift
+++ b/Sources/TBDShared/TerminalScreen.swift
@@ -42,6 +42,17 @@ public struct TerminalScreen: Codable, Sendable, Equatable {
         /// Whether the child has asked for a visible cursor (`DECTCEM`, mode
         /// 25). A composer waiting for input and a program that has hidden the
         /// cursor to repaint look identical without it.
+        ///
+        /// **A tracked fact, not a probed one.** The holder producer keeps it
+        /// from the emulator's own notifications, because probing a parser that
+        /// may be mid-sequence would abort the child's sequence — so what this
+        /// field can promise is bounded by which changes the emulator
+        /// announces. Both resets stay inside that bound: a soft reset
+        /// (`DECSTR`, `CSI ! p`) shows the cursor and says so, and a full reset
+        /// (`RIS`) restores the visibility it found. A change made without a
+        /// notification would sit here undetected, and a bare `DECSET 25` would
+        /// not repair it, since an already-shown cursor is shown again silently
+        /// — the mechanism, and the bound, are `HolderReader`'s `cursorVisible`.
         public let visible: Bool
 
         public init(row: Int, column: Int, visible: Bool) {

--- a/Sources/TBDShared/TerminalScreen.swift
+++ b/Sources/TBDShared/TerminalScreen.swift
@@ -11,14 +11,23 @@ import Foundation
 ///
 /// The second reason is the whitelist. Every cell that reaches `lines` is
 /// printable or a tab: a never-written cell is projected as a space by the
-/// render, the trailing half of a wide glyph is omitted, and anything else — a
-/// stray control character, a `U+0000` that slipped through — is refused at
-/// construction. That refusal is deliberately *not* delegated to each render
-/// site remembering to sanitize: a row carrying a control character is a bug in
-/// the projection, and a bug is better raised at the boundary than shipped to a
-/// consumer that matches on text and silently fails to find the characters on
-/// either side of the hole. (1,595 such `U+0000` cells were measured across
-/// five of nine live sessions in one sweep, and no consumer had noticed.)
+/// render, the trailing half of a wide glyph is omitted, and every other
+/// disallowed scalar is projected as `U+FFFD`. The render does that against
+/// `isDisallowed`, the same predicate the initializer checks with, so the two
+/// cannot disagree about what a screen line may hold.
+///
+/// **The render substitutes; the initializer refuses.** A child may legitimately
+/// store a `DEL` or a C1 byte in a cell — SwiftTerm's ground-state fast path
+/// keeps them verbatim — so refusing those at construction would make one
+/// `printf '\x7f'` break every later read of the session until the line left
+/// scrollback. Substituting at the render keeps the whitelist true without
+/// making a session's own output able to silence it. What survives to the
+/// initializer is therefore a *projection bug* rather than anything a session
+/// can do: a render that forgot the predicate, or a producer that never ran
+/// one. A bug is better raised at the boundary than shipped to a consumer that
+/// matches on text and silently fails to find the characters on either side of
+/// the hole. (1,595 `U+0000` cells were measured across five of nine live
+/// sessions in one sweep, and no consumer had noticed.)
 ///
 /// Plain data, in `TBDShared`, with no emulator in it. The projection from a
 /// grid to these lines belongs to whichever store did the rendering; this is
@@ -159,9 +168,13 @@ public struct TerminalScreen: Codable, Sendable, Equatable {
     /// means whoever measured it subtracted the wrong way round.
     public enum ValidationError: LocalizedError, Equatable, CustomStringConvertible {
         /// A row carried a character no screen line may contain: any C0 control
-        /// but tab, `DEL`, or a C1 control. `U+0000` is included — a
-        /// never-written cell is the render's job to project as a space, and
-        /// one arriving here means it did not.
+        /// but tab, `DEL`, or a C1 control.
+        ///
+        /// **Not something a child can cause.** A render substitutes every one
+        /// of these — `U+0000` as a space, the rest as `U+FFFD` — using the
+        /// same `isDisallowed` predicate checked here, so a session that prints
+        /// a `DEL` produces a replacement character rather than an unreadable
+        /// session. One arriving here means a render skipped the predicate.
         case disallowedCharacter(lineIndex: Int, scalar: UInt32)
         /// An age measured as a negative interval.
         case negativeAge(milliseconds: Int)
@@ -214,10 +227,18 @@ public struct TerminalScreen: Codable, Sendable, Equatable {
         self.ageMilliseconds = ageMilliseconds
     }
 
+    /// Whether a scalar is one a screen line may not hold.
+    ///
+    /// Public and static because it has **two** call sites that must agree: the
+    /// initializer below, which refuses, and each render's character provider,
+    /// which substitutes. Two copies of this rule would drift, and the shape of
+    /// the drift is a render that lets through exactly what the initializer
+    /// throws on — a session whose every read fails.
+    ///
     /// Tab is the one control a line may hold: a program that lays a screen out
     /// with tabs is doing something a reader can see, and stripping them would
     /// move every column after one.
-    private static func isDisallowed(_ scalar: Unicode.Scalar) -> Bool {
+    public static func isDisallowed(_ scalar: Unicode.Scalar) -> Bool {
         if scalar == "\t" { return false }
         let value = scalar.value
         return value < 0x20 || value == 0x7f || (0x80...0x9f).contains(value)

--- a/Sources/TBDShared/TerminalScreen.swift
+++ b/Sources/TBDShared/TerminalScreen.swift
@@ -1,0 +1,275 @@
+import Foundation
+
+/// What a machine reader is told when it asks a session what is on its screen.
+///
+/// `terminal.output` used to answer with a bare `String`, and a string cannot
+/// carry the two facts every consumer's policy turns on: **which store
+/// answered**, and **how stale that store's view is**. A consumer reading text
+/// alone cannot tell a live render from a frozen one, so it cannot have a
+/// policy at all — it can only hope. Those two facts are `source` and
+/// `ageMilliseconds`, and they are why this is a type rather than a string.
+///
+/// The second reason is the whitelist. Every cell that reaches `lines` is
+/// printable or a tab: a never-written cell is projected as a space by the
+/// render, the trailing half of a wide glyph is omitted, and anything else — a
+/// stray control character, a `U+0000` that slipped through — is refused at
+/// construction. That refusal is deliberately *not* delegated to each render
+/// site remembering to sanitize: a row carrying a control character is a bug in
+/// the projection, and a bug is better raised at the boundary than shipped to a
+/// consumer that matches on text and silently fails to find the characters on
+/// either side of the hole. (1,595 such `U+0000` cells were measured across
+/// five of nine live sessions in one sweep, and no consumer had noticed.)
+///
+/// Plain data, in `TBDShared`, with no emulator in it. The projection from a
+/// grid to these lines belongs to whichever store did the rendering; this is
+/// only what comes out.
+public struct TerminalScreen: Codable, Sendable, Equatable {
+    /// Where the cursor sits, in **viewport** coordinates — so
+    /// `lines[viewportStart + cursor.row]` is the cursor's line whenever that
+    /// row survived the trailing-blank trim.
+    public struct Cursor: Codable, Sendable, Equatable {
+        public let row: Int
+        public let column: Int
+        /// Whether the child has asked for a visible cursor (`DECTCEM`, mode
+        /// 25). A composer waiting for input and a program that has hidden the
+        /// cursor to repaint look identical without it.
+        public let visible: Bool
+
+        public init(row: Int, column: Int, visible: Bool) {
+            self.row = row
+            self.column = column
+            self.visible = visible
+        }
+    }
+
+    /// The grid the lines were rendered from. A consumer that compares this
+    /// against the pty's own size can see an emulator that disagrees with the
+    /// child — which is how a session ends up wrapping every line at a width
+    /// nobody is painting at.
+    public struct Size: Codable, Sendable, Equatable {
+        public let columns: Int
+        public let rows: Int
+
+        public init(columns: Int, rows: Int) {
+            self.columns = columns
+            self.rows = rows
+        }
+    }
+
+    /// The child-facing modes a writer needs before it composes input.
+    ///
+    /// Read from the same emulator that produced the lines, in the same
+    /// observation, so a caller can never pair one store's modes with another
+    /// store's screen.
+    public struct ChildModes: Codable, Sendable, Equatable {
+        /// `DECSET 2004`. Decides whether a pasted body is wrapped in
+        /// `ESC[200~`…`ESC[201~`, which is what puts a submitting `\r`
+        /// provably outside the paste.
+        public let bracketedPaste: Bool
+        /// `DECCKM`, mode 1. Decides `ESCOA` over `ESC[A` for the arrows.
+        public let applicationCursor: Bool
+        /// Whether the child is on the alternate screen buffer (`1049`).
+        public let alternateScreen: Bool
+
+        public init(bracketedPaste: Bool, applicationCursor: Bool, alternateScreen: Bool) {
+            self.bracketedPaste = bracketedPaste
+            self.applicationCursor = applicationCursor
+            self.alternateScreen = alternateScreen
+        }
+    }
+
+    /// Which of the transport's two stores answered.
+    ///
+    /// A consumer's policy is keyed on this field, so the policy cannot be
+    /// applied by accident: the hibernation pending-input check fails closed on
+    /// `staleDaemon`, the input-path oracle proceeds and records it, and a
+    /// person reading `tbd terminal output` is shown it.
+    public enum Source: String, Codable, Sendable {
+        /// The daemon is this session's reader and rendered its live emulator.
+        case daemon
+        /// A viewer holds the pty and answered a pull from its own terminal.
+        case viewer
+        /// A viewer holds the pty and did not answer, so this is the daemon's
+        /// emulator — retained and suspended since the attach.
+        case staleDaemon
+    }
+
+    /// The requested tail of scrollback plus the viewport, one entry per row,
+    /// right-trimmed, with trailing blank rows dropped.
+    public let lines: [String]
+    /// The index in `lines` of the viewport's first row; everything before it
+    /// is scrollback.
+    ///
+    /// Carried explicitly because it cannot be derived: trailing blank rows are
+    /// dropped, so `lines.count` is not `scrollback + size.rows` and a consumer
+    /// that subtracted would land in the wrong row.
+    ///
+    /// **It may be negative**, when the requested tail cut inside the viewport
+    /// — ask for 6 lines of a 24-row screen and the first four rows of that
+    /// viewport are simply not in `lines`. **It may also equal `lines.count`**,
+    /// when the whole viewport was blank rows that the trim dropped. Both are
+    /// well-formed answers, and a consumer indexing `lines` with it must bounds
+    /// check rather than assume.
+    public let viewportStart: Int
+    public let cursor: Cursor
+    public let size: Size
+    public let modes: ChildModes
+    public let source: Source
+    /// How long ago the answering store's emulator last consumed a byte from
+    /// the pty, in milliseconds, on a monotonic clock — never wall time, so no
+    /// clock adjustment can defeat a staleness threshold.
+    ///
+    /// One rule for every source. A store that has never consumed a byte
+    /// reports its own age, counted from adoption, so the field is never absent
+    /// and a fresh silent session reads as exactly as old as it is. Always
+    /// non-negative: the producer clamps and this type refuses the rest.
+    public let ageMilliseconds: Int
+
+    /// The lines joined with `\n`.
+    ///
+    /// Derived, carrying no information of its own, and kept for exactly one
+    /// reason: scripts and skills read `tbd terminal output` today, and it is
+    /// what lets the in-place change to this RPC result be invisible to every
+    /// consumer that has not migrated. It is written to the wire by
+    /// `encode(to:)` and ignored on the way back in.
+    public var output: String { lines.joined(separator: "\n") }
+
+    /// The three modes, their provenance, and their age — everything the input
+    /// path needs and nothing it does not.
+    public var modeReading: TerminalModeReading {
+        TerminalModeReading(modes: modes, source: source, ageMilliseconds: ageMilliseconds)
+    }
+
+    /// Why a screen could not be constructed.
+    ///
+    /// Both cases are producer bugs rather than conditions a session can be in,
+    /// which is why they are thrown rather than represented: a control
+    /// character in a row means the projection is wrong, and a negative age
+    /// means whoever measured it subtracted the wrong way round.
+    public enum ValidationError: LocalizedError, Equatable, CustomStringConvertible {
+        /// A row carried a character no screen line may contain: any C0 control
+        /// but tab, `DEL`, or a C1 control. `U+0000` is included — a
+        /// never-written cell is the render's job to project as a space, and
+        /// one arriving here means it did not.
+        case disallowedCharacter(lineIndex: Int, scalar: UInt32)
+        /// An age measured as a negative interval.
+        case negativeAge(milliseconds: Int)
+
+        public var description: String {
+            switch self {
+            case .disallowedCharacter(let lineIndex, let scalar):
+                let hex = String(format: "%04X", scalar)
+                return """
+                    screen line \(lineIndex) carries the disallowed control character U+\(hex); \
+                    a screen line may hold only printable characters and tabs
+                    """
+            case .negativeAge(let milliseconds):
+                return "a screen's age cannot be negative, and this one is \(milliseconds)ms"
+            }
+        }
+
+        /// `localizedDescription` consults only this, and the whole value of
+        /// either message is the payload it names — the offending line, or the
+        /// number that was measured. Forwarded so a log or an RPC error carries
+        /// it rather than the `NSError` bridge string.
+        public var errorDescription: String? { description }
+    }
+
+    /// The one construction site. Everything the type promises is checked here,
+    /// so no caller can produce a screen that breaks it.
+    public init(
+        lines: [String],
+        viewportStart: Int,
+        cursor: Cursor,
+        size: Size,
+        modes: ChildModes,
+        source: Source,
+        ageMilliseconds: Int
+    ) throws {
+        guard ageMilliseconds >= 0 else {
+            throw ValidationError.negativeAge(milliseconds: ageMilliseconds)
+        }
+        for (index, line) in lines.enumerated() {
+            for scalar in line.unicodeScalars where Self.isDisallowed(scalar) {
+                throw ValidationError.disallowedCharacter(lineIndex: index, scalar: scalar.value)
+            }
+        }
+        self.lines = lines
+        self.viewportStart = viewportStart
+        self.cursor = cursor
+        self.size = size
+        self.modes = modes
+        self.source = source
+        self.ageMilliseconds = ageMilliseconds
+    }
+
+    /// Tab is the one control a line may hold: a program that lays a screen out
+    /// with tabs is doing something a reader can see, and stripping them would
+    /// move every column after one.
+    private static func isDisallowed(_ scalar: Unicode.Scalar) -> Bool {
+        if scalar == "\t" { return false }
+        let value = scalar.value
+        return value < 0x20 || value == 0x7f || (0x80...0x9f).contains(value)
+    }
+
+    // MARK: - Coding
+
+    private enum CodingKeys: String, CodingKey {
+        case lines, viewportStart, cursor, size, modes, source, ageMilliseconds, output
+    }
+
+    /// Writes `output` beside `lines`, because it is a field a script reads out
+    /// of `tbd terminal output --json` and a computed property would otherwise
+    /// never reach the wire.
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(lines, forKey: .lines)
+        try container.encode(viewportStart, forKey: .viewportStart)
+        try container.encode(cursor, forKey: .cursor)
+        try container.encode(size, forKey: .size)
+        try container.encode(modes, forKey: .modes)
+        try container.encode(source, forKey: .source)
+        try container.encode(ageMilliseconds, forKey: .ageMilliseconds)
+        try container.encode(output, forKey: .output)
+    }
+
+    /// **Any `output` on the wire is ignored** and the field is re-derived from
+    /// `lines`, so the two can never disagree in a decoded value — including
+    /// for a payload that carries no `output` at all, which is what a future
+    /// producer that stopped writing it would send.
+    ///
+    /// Decoding runs the same validation construction does. A screen that
+    /// arrives with a control character in it is refused at the boundary rather
+    /// than handed on, for the same reason it is refused at the producer.
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        try self.init(
+            lines: container.decode([String].self, forKey: .lines),
+            viewportStart: container.decode(Int.self, forKey: .viewportStart),
+            cursor: container.decode(Cursor.self, forKey: .cursor),
+            size: container.decode(Size.self, forKey: .size),
+            modes: container.decode(ChildModes.self, forKey: .modes),
+            source: container.decode(Source.self, forKey: .source),
+            ageMilliseconds: container.decode(Int.self, forKey: .ageMilliseconds))
+    }
+}
+
+/// The mode oracle's answer: what the child is in, who says so, and how old
+/// that answer is.
+///
+/// A `TerminalScreen` without the line walk. The input path needs the three
+/// modes and their provenance and nothing else, and asking for a whole screen
+/// to compose one message would walk the scrollback on every send.
+public struct TerminalModeReading: Sendable, Equatable {
+    public let modes: TerminalScreen.ChildModes
+    public let source: TerminalScreen.Source
+    public let ageMilliseconds: Int
+
+    public init(
+        modes: TerminalScreen.ChildModes, source: TerminalScreen.Source, ageMilliseconds: Int
+    ) {
+        self.modes = modes
+        self.source = source
+        self.ageMilliseconds = ageMilliseconds
+    }
+}

--- a/Sources/TBDShared/TerminalScreen.swift
+++ b/Sources/TBDShared/TerminalScreen.swift
@@ -84,7 +84,18 @@ public struct TerminalScreen: Codable, Sendable, Equatable {
     /// applied by accident: the hibernation pending-input check fails closed on
     /// `staleDaemon`, the input-path oracle proceeds and records it, and a
     /// person reading `tbd terminal output` is shown it.
-    public enum Source: String, Codable, Sendable {
+    ///
+    /// **The raw values must stay identical to `ActuationModeSource`'s.** A
+    /// supervisor correlates the `screen.source` it read from `tbd terminal
+    /// output --json` against the `modeSource` on the actuation row its send
+    /// produced, and it does that by string comparison — so two spellings of
+    /// one fact make exactly the case that matters, `staleDaemon`, fail to
+    /// match. The default synthesised raw values are the wire spellings
+    /// (`daemon`, `viewer`, `staleDaemon`); there is nothing to write out, and
+    /// a case added here must be added there with the same name.
+    /// `ActuationLogTests` pins the correspondence over `allCases`, which is
+    /// what `CaseIterable` is here for.
+    public enum Source: String, Codable, Sendable, CaseIterable {
         /// The daemon is this session's reader and rendered its live emulator.
         case daemon
         /// A viewer holds the pty and answered a pull from its own terminal.

--- a/Sources/TBDShared/TerminalScreen.swift
+++ b/Sources/TBDShared/TerminalScreen.swift
@@ -90,9 +90,14 @@ public struct TerminalScreen: Codable, Sendable, Equatable {
     /// Which of the transport's two stores answered.
     ///
     /// A consumer's policy is keyed on this field, so the policy cannot be
-    /// applied by accident: the hibernation pending-input check fails closed on
-    /// `staleDaemon`, the input-path oracle proceeds and records it, and a
-    /// person reading `tbd terminal output` is shown it.
+    /// applied by accident. Of the consumers the design names, two are on the
+    /// contract today: the input-path oracle proceeds on `staleDaemon` modes
+    /// and records the source on the actuation row, and a person reading `tbd
+    /// terminal output` is shown the source and the age on stderr. The
+    /// hibernation pending-input check is still on its own screen read; the
+    /// policy it is to apply when it moves onto this contract is to fail closed
+    /// on `staleDaemon`, because a frozen screen cannot prove the composer is
+    /// empty.
     ///
     /// **The raw values must stay identical to `ActuationModeSource`'s.** A
     /// supervisor correlates the `screen.source` it read from `tbd terminal

--- a/Tests/TBDCLITests/TerminalOutputStalenessNoteTests.swift
+++ b/Tests/TBDCLITests/TerminalOutputStalenessNoteTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import TBDShared
+import Testing
+
+@testable import TBDCLI
+
+/// What `tbd terminal output` tells a reader about a screen it did not read
+/// live.
+///
+/// The contract makes every consumer of `TerminalScreen` declare what it does
+/// with `.staleDaemon`; this consumer's declaration is *accept and surface*.
+/// Before the typed screen, asking a session a viewer held simply failed, so a
+/// reader could not mistake a frozen screen for a live one. Answering with the
+/// frozen screen and saying nothing would remove that protection without
+/// replacing it — a supervisor would read a three-hour-old composer as the
+/// session's present state — which is why the note exists and why it carries
+/// both facts a string cannot: which store answered, and how old its view is.
+///
+/// Asserted on the composed line rather than on a formatter in isolation: the
+/// line is what a person and a supervising agent read, and a correct age
+/// pasted into the wrong sentence is still the wrong answer.
+@Suite("tbd terminal output staleness note")
+struct TerminalOutputStalenessNoteTests {
+
+    private static func screen(
+        source: TerminalScreen.Source, ageMilliseconds: Int
+    ) throws -> TerminalScreen {
+        try TerminalScreen(
+            lines: ["composer"],
+            viewportStart: 0,
+            cursor: TerminalScreen.Cursor(row: 0, column: 0, visible: true),
+            size: TerminalScreen.Size(columns: 80, rows: 24),
+            modes: TerminalScreen.ChildModes(
+                bracketedPaste: false, applicationCursor: false, alternateScreen: false),
+            source: source,
+            ageMilliseconds: ageMilliseconds)
+    }
+
+    /// The live store needs no note, and adding one would put a line on stderr
+    /// for every ordinary read — noise a reader would learn to ignore, which is
+    /// how the notes that matter stop being read.
+    @Test("a live daemon screen produces no note at all")
+    func liveScreenIsSilent() throws {
+        let live = try Self.screen(source: .daemon, ageMilliseconds: 12)
+        #expect(TerminalOutput.stalenessNote(for: live) == nil)
+    }
+
+    /// The spec's own worked example: a screen frozen at an attach 41 minutes
+    /// ago. Both facts are in the line, and the source is spelled the way the
+    /// `--json` field spells it so a script can correlate the two.
+    @Test("a stale daemon screen names the store, why it is frozen, and its age")
+    func staleDaemonNoteCarriesSourceAndAge() throws {
+        let stale = try Self.screen(source: .staleDaemon, ageMilliseconds: 41 * 60_000 + 3_000)
+        let note = try #require(TerminalOutput.stalenessNote(for: stale))
+
+        #expect(
+            note == """
+                note: screen is the daemon's emulator as it stood when a viewer attached \
+                (source staleDaemon, age 41m 3s)
+                """,
+            "composed note was: \(note)")
+        #expect(note.contains(TerminalScreen.Source.staleDaemon.rawValue))
+    }
+
+    /// A viewer's own answer is fresh, not frozen — but it still came from the
+    /// other store, and a reader correlating it against an actuation row needs
+    /// to be told which.
+    @Test("a viewer screen is surfaced as the viewer's, not as the daemon's")
+    func viewerNoteNamesTheViewer() throws {
+        let viewer = try Self.screen(source: .viewer, ageMilliseconds: 250)
+        let note = try #require(TerminalOutput.stalenessNote(for: viewer))
+
+        #expect(
+            note == """
+                note: screen came from the viewer holding this session's pty \
+                (source viewer, age 0s)
+                """,
+            "composed note was: \(note)")
+        #expect(!note.contains("staleDaemon"))
+    }
+
+    /// The three bands of the age format, read off the composed line. Under a
+    /// minute is seconds alone; an hour and above drops seconds entirely,
+    /// because nobody deciding anything about a two-hour-old screen cares.
+    @Test(
+        "the age reads humanely in each band",
+        arguments: [
+            (0, "0s"),
+            (999, "0s"),
+            (1_000, "1s"),
+            (59_000, "59s"),
+            (60_000, "1m 0s"),
+            (3_599_000, "59m 59s"),
+            (3_600_000, "1h 0m"),
+            (2_460_000, "41m 0s"),
+            (9_000_000, "2h 30m"),
+        ])
+    func ageBands(milliseconds: Int, rendered: String) throws {
+        let stale = try Self.screen(source: .staleDaemon, ageMilliseconds: milliseconds)
+        let note = try #require(TerminalOutput.stalenessNote(for: stale))
+        #expect(note.hasSuffix("(source staleDaemon, age \(rendered))"), "composed: \(note)")
+    }
+}

--- a/Tests/TBDDaemonLiveTests/Holder/HolderAppDeathSeizureTests.swift
+++ b/Tests/TBDDaemonLiveTests/Holder/HolderAppDeathSeizureTests.swift
@@ -32,16 +32,24 @@ struct HolderAppDeathSeizureTests {
 
     /// The whole task, at the far end. An app died holding an acknowledged
     /// attach: no detach arrived, no preamble came back, and no cooperation
-    /// from it is possible. The daemon takes the session back through a fresh
-    /// hand-over from the holder, and the session is *live* again — not merely
-    /// unclaimed.
+    /// from it is possible. The daemon puts its own suspended reader back on
+    /// the pty, and the session is *live* again — not merely unclaimed.
+    ///
+    /// **One reader, throughout.** The reader the seizure resumes is the very
+    /// one the attach suspended, so no second hand-over is opened and no second
+    /// drain loop is started against a master this registry already holds. The
+    /// two counters say that in the only way object identity cannot: a
+    /// `drainLoopsStarted` unchanged across the seizure, and a
+    /// `peakLiveDrainLoops` that never reached two.
     @Test func aConfirmedDeadAppsSessionRevertsToDaemonRead() async throws {
         let fixture = try await HandbackFixture.start(command: Self.echoJob)
         defer { fixture.tearDown() }
 
         let viewer = try await fixture.attachAViewer()
-        #expect(await fixture.registry.reader(for: fixture.terminalID) == nil,
-                "an acknowledged attach releases the daemon's reader for good")
+        let suspended = try #require(await fixture.registry.reader(for: fixture.terminalID))
+        #expect(await !suspended.isDraining,
+                "the daemon is still draining a pty a viewer acknowledged owning")
+        let loopsBefore = await fixture.registry.drainLoopsStarted
         // Exactly what a dying app does, and nothing else: its descriptors
         // close with the process, and no detach follows.
         viewer.close()
@@ -54,6 +62,16 @@ struct HolderAppDeathSeizureTests {
             refused by every re-open for the daemon's whole life
             """)
         let resumed = try #require(await fixture.registry.reader(for: fixture.terminalID))
+        #expect(resumed === suspended, """
+            the seizure opened a second hand-over for a session whose own reader had never left \
+            the descriptor
+            """)
+        #expect(await fixture.registry.drainLoopsStarted == loopsBefore, """
+            the seizure published a second drain loop for a pty this registry was already \
+            holding a reader for
+            """)
+        #expect(await fixture.registry.peakLiveDrainLoops == 1,
+                "two drain loops were live at once, which is byte theft seen after the fact")
         #expect(await resumed.isDraining, "the daemon took the session back without reading it")
 
         // Live again, not merely claimed: the daemon writes, the job answers,
@@ -127,20 +145,37 @@ struct HolderAppDeathSeizureTests {
         }
         #expect(await fixture.registry.viewerAttachment(for: fixture.terminalID) == viewer.generation,
                 "a stale seizure took the pty from the attach that holds it")
-        #expect(await fixture.registry.reader(for: fixture.terminalID) == nil,
+        // The reader is retained across an attach, so its presence proves
+        // nothing here; `isDraining` reads the drain thread's own flag.
+        let stillSuspended = try #require(await fixture.registry.reader(for: fixture.terminalID))
+        #expect(await !stillSuspended.isDraining,
                 "a stale seizure put the daemon back on a pty a viewer is reading")
     }
 
-    /// A seizure whose take-back **fails** must still drop the claim, for the
-    /// reason the failed handback does: the app is gone, no second verdict is
-    /// coming for it, and a claim left standing is the permanent brick this
-    /// path exists to clear. Reachable without a race — here, a rendezvous
-    /// socket a `connect` can no longer find.
-    @Test func aFailedSeizureDoesNotLeaveTheSessionClaimed() async throws {
+    /// **A seizure no longer needs the holder to be reachable**, which is the
+    /// strictly better outcome the retained reader buys — and it is what used
+    /// to make this case a failure at all.
+    ///
+    /// Before the emulator was retained, an acknowledged attach left the slot
+    /// empty, so a seizure had to open a fresh hand-over from the holder; a
+    /// rendezvous socket a `connect` could no longer find was then a way for a
+    /// crashed app to brick every session it had open. The reader now never
+    /// leaves the descriptor, so the resume is a restart of its own thread and
+    /// asks the holder nothing.
+    ///
+    /// **The failing take-back is no longer reachable by a test on this arm,
+    /// and no failure is fabricated to stand in for it.** All that is left that
+    /// can throw is `HolderReader.resumeDraining`, which fails only when
+    /// `pipe()` does — an out-of-descriptors condition a test on a shared box
+    /// must not induce. `takeBackFromViewer` still drops the claim on its error
+    /// path, and that behaviour is still correct; it is simply unreachable from
+    /// here now.
+    @Test func aFailedSeizureIsNoLongerReachableThroughAMissingSocket() async throws {
         let fixture = try await HandbackFixture.start(command: Self.echoJob)
         defer { fixture.tearDown() }
 
         let viewer = try await fixture.attachAViewer()
+        let suspended = try #require(await fixture.registry.reader(for: fixture.terminalID))
         viewer.close()
         try FileManager.default.removeItem(
             atPath: try HolderRendezvous.socketPath(
@@ -148,10 +183,16 @@ struct HolderAppDeathSeizureTests {
                 environment: HolderProcessFixture.environment(home: fixture.process.home)))
 
         let reclaimed = await fixture.registry.reclaimSessionsFromADeadApp()
-        #expect(reclaimed.isEmpty, "a take-back that failed was reported as a session reclaimed")
-        #expect(await fixture.registry.viewerAttachment(for: fixture.terminalID) == nil, """
-            a seizure that could not take the session back left the dead app's claim standing, so \
-            nothing drains this pty and every re-open is refused
+        #expect(reclaimed == [fixture.terminalID], """
+            the seizure could not take the session back with the rendezvous socket gone, so it \
+            still depends on a hand-over from the holder
             """)
+        #expect(await fixture.registry.viewerAttachment(for: fixture.terminalID) == nil, """
+            the seizure left the dead app's claim standing, so nothing drains this pty and every \
+            re-open is refused
+            """)
+        let resumed = try #require(await fixture.registry.reader(for: fixture.terminalID))
+        #expect(resumed === suspended, "the seizure opened a second hand-over")
+        #expect(await resumed.isDraining, "the suspended reader was not put back on the pty")
     }
 }

--- a/Tests/TBDDaemonLiveTests/Holder/HolderAttachHandoffTests.swift
+++ b/Tests/TBDDaemonLiveTests/Holder/HolderAttachHandoffTests.swift
@@ -194,9 +194,27 @@ struct HolderAttachHandoffTests {
 
     // MARK: - Ownership
 
+    /// What an acknowledgement decides, and what it deliberately does not.
+    ///
+    /// It decides **who reads the pty**: the viewer, and the daemon neither
+    /// drains it nor duplicates it again. It does not decide who owns the
+    /// *emulator*. That reader stays in the slot, suspended, because it holds
+    /// the session's screen as it stood at the attach and is the only store
+    /// there is whenever the viewer cannot answer for itself.
+    ///
+    /// `reader(for:) != nil` is therefore not evidence the daemon is on the
+    /// pty, and this suite no longer uses it as such. `isDraining` is the
+    /// honest instrument: it reads the drain thread's own flag.
     @Test func acknowledgingAnAttachHandsTheSessionToTheViewer() async throws {
         let fixture = try await AttachFixture.start(command: Self.echoJob)
         defer { fixture.tearDown() }
+
+        // Something on the screen before the hand-over, so "the emulator was
+        // retained" is a claim about content and not only about a pointer.
+        try await fixture.reader.write(Data("BEFORE-ATTACH\n".utf8))
+        #expect(await pollUntil("the job's answer before the attach") {
+            await fixture.reader.renderScreen().contains("GOT:BEFORE-ATTACH")
+        })
 
         let vend = try await fixture.registry.beginAttach(terminalID: fixture.terminalID)
         defer { close(vend.ptyFD) }
@@ -212,10 +230,23 @@ struct HolderAttachHandoffTests {
             terminalID: fixture.terminalID, generation: vend.generation)
 
         #expect(await fixture.registry.viewerAttachment(for: fixture.terminalID) == vend.generation)
+        let retained = try #require(
+            await fixture.registry.reader(for: fixture.terminalID),
+            """
+            the acknowledgement discarded the daemon's emulator, so this session has no screen \
+            to answer a machine read with and no modes to compose input against
+            """)
+        #expect(retained === fixture.reader, "the acknowledgement built a second reader")
         #expect(
-            await fixture.registry.reader(for: fixture.terminalID) == nil,
-            "the daemon kept a reader for a session it no longer reads")
-        #expect(await !fixture.reader.isDraining)
+            await !retained.isDraining,
+            "the daemon is still draining a pty it handed to a viewer")
+
+        // Retained with its contents, not merely retained: the screen the
+        // daemon was holding at the attach is still there to answer with.
+        let held = await retained.renderScreen()
+        #expect(held.contains("GOT:BEFORE-ATTACH"), """
+            the retained emulator lost the screen it was holding: \(held)
+            """)
 
         // And the session belongs to the viewer: an adoption must refuse it
         // rather than build the second reader that would steal its bytes.

--- a/Tests/TBDDaemonLiveTests/Holder/HolderAttachHandoffTests.swift
+++ b/Tests/TBDDaemonLiveTests/Holder/HolderAttachHandoffTests.swift
@@ -205,6 +205,11 @@ struct HolderAttachHandoffTests {
     /// `reader(for:) != nil` is therefore not evidence the daemon is on the
     /// pty, and this suite no longer uses it as such. `isDraining` is the
     /// honest instrument: it reads the drain thread's own flag.
+    ///
+    /// **This is where `staleDaemon` comes from**, and it is asserted here
+    /// because it is the only place the state is real: a suspended reader
+    /// holding the screen it had at the attach, answering a machine read that
+    /// used to get an error saying the session was gone.
     @Test func acknowledgingAnAttachHandsTheSessionToTheViewer() async throws {
         let fixture = try await AttachFixture.start(command: Self.echoJob)
         defer { fixture.tearDown() }
@@ -215,6 +220,8 @@ struct HolderAttachHandoffTests {
         #expect(await pollUntil("the job's answer before the attach") {
             await fixture.reader.renderScreen().contains("GOT:BEFORE-ATTACH")
         })
+        // And the live store says so while it is still live.
+        #expect(try await fixture.reader.screen(maxLines: 50).source == .daemon)
 
         let vend = try await fixture.registry.beginAttach(terminalID: fixture.terminalID)
         defer { close(vend.ptyFD) }
@@ -241,12 +248,15 @@ struct HolderAttachHandoffTests {
             await !retained.isDraining,
             "the daemon is still draining a pty it handed to a viewer")
 
-        // Retained with its contents, not merely retained: the screen the
-        // daemon was holding at the attach is still there to answer with.
-        let held = await retained.renderScreen()
-        #expect(held.contains("GOT:BEFORE-ATTACH"), """
-            the retained emulator lost the screen it was holding: \(held)
+        // The machine read a person's open session now gets: labelled as the
+        // frozen store it is, and carrying the screen as it stood at the
+        // attach rather than an error naming the wrong cause.
+        let screen = try await retained.screen(maxLines: 50)
+        #expect(screen.source == .staleDaemon)
+        #expect(screen.output.contains("GOT:BEFORE-ATTACH"), """
+            the retained emulator lost the screen it was holding: \(screen.output)
             """)
+        #expect(await retained.modeReading().source == .staleDaemon)
 
         // And the session belongs to the viewer: an adoption must refuse it
         // rather than build the second reader that would steal its bytes.

--- a/Tests/TBDDaemonLiveTests/Holder/HolderAttachRPCTests.swift
+++ b/Tests/TBDDaemonLiveTests/Holder/HolderAttachRPCTests.swift
@@ -367,7 +367,12 @@ struct HolderAttachRPCTests {
                     generation: vend.generation, terminalID: harness.terminalID)))
         #expect(response.success)
         #expect(await harness.registry.viewerAttachment(for: harness.terminalID) == vend.generation)
-        #expect(await harness.registry.reader(for: harness.terminalID) == nil)
+        // The reader is retained across the acknowledgement — suspended, so it
+        // holds the session's screen without being on the pty. `isDraining` is
+        // the instrument for "the daemon is not reading"; the reader's presence
+        // is not.
+        let suspended = try #require(await harness.registry.reader(for: harness.terminalID))
+        #expect(await !suspended.isDraining)
 
         // The viewer's descriptor outlives the daemon's, which is the point of
         // handing over a dup rather than the reader's own.
@@ -437,7 +442,8 @@ struct HolderAttachRPCTests {
         // refusal — but the claim stands.
         #expect(response.success)
         #expect(await harness.registry.viewerAttachment(for: harness.terminalID) == vend.generation)
-        #expect(await harness.registry.reader(for: harness.terminalID) == nil,
+        let suspended = try #require(await harness.registry.reader(for: harness.terminalID))
+        #expect(await !suspended.isDraining,
                 "a detach the daemon could not check put it back on a pty a viewer holds")
     }
 

--- a/Tests/TBDDaemonLiveTests/Holder/HolderDetachHandbackTests.swift
+++ b/Tests/TBDDaemonLiveTests/Holder/HolderDetachHandbackTests.swift
@@ -23,6 +23,13 @@ import Testing
 /// daemon's model frozen at the instant the viewer arrived, because the jiggle
 /// heals only programs that repaint and a shell repaints essentially nothing.
 ///
+/// **`reader(for:) == nil` is not the instrument for "the daemon is off the
+/// pty", and this suite does not use it as one.** An attach suspends the
+/// daemon's reader and retains it — the emulator is the session's only screen
+/// while a viewer holds the descriptor, and the only source of the child's
+/// modes — so an attached session has a reader and is not being read. The
+/// honest instrument is `isDraining`, which reads the drain thread's own flag.
+///
 /// **Tier 3.** A real `TBDHolder`, a real pty, a real job.
 @Suite(.serialized)
 struct HolderDetachHandbackTests {
@@ -53,8 +60,9 @@ struct HolderDetachHandbackTests {
         let seen = readPTYUntil(fd: viewer.ptyFD, contains: "GOT:WHILE-ATTACHED")
         #expect(seen != nil, "the viewer never saw its own job's answer")
         viewer.terminal.feed(Data((seen ?? "").utf8))
-        #expect(await fixture.registry.reader(for: fixture.terminalID) == nil,
-                "an acknowledged attach releases the daemon's reader for good")
+        let suspended = try #require(await fixture.registry.reader(for: fixture.terminalID))
+        #expect(await !suspended.isDraining,
+                "the daemon is still draining a pty a viewer acknowledged owning")
 
         // The order the app keeps, and the reason it keeps it: nothing may read
         // this pty between the close and the daemon's resume.
@@ -146,52 +154,70 @@ struct HolderDetachHandbackTests {
         }
         #expect(await fixture.registry.viewerAttachment(for: fixture.terminalID) == viewer.generation,
                 "a stale detach took the pty from the attach that holds it")
-        #expect(await fixture.registry.reader(for: fixture.terminalID) == nil,
+        let stillSuspended = try #require(await fixture.registry.reader(for: fixture.terminalID))
+        #expect(await !stillSuspended.isDraining,
                 "a stale detach put the daemon back on a pty a viewer is reading")
     }
 
-    /// A handback whose take-back **fails** must still drop the claim, or the
-    /// error path re-creates the exact brick this method exists to prevent: the
-    /// session undrained, unwritable, and refused by `beginAttach` until it is
-    /// torn down, with no second detach ever coming — the app closed its
-    /// descriptors before it sent this one. Reachable without a race: a holder
-    /// busy past the retry budget, an adoption that times out, or (here) a
-    /// rendezvous socket that has gone.
-    @Test func aFailedHandbackDoesNotLeaveTheSessionClaimed() async throws {
+    /// **The take-back no longer depends on the holder being reachable**, and
+    /// that is the strictly better outcome the retained reader buys.
+    ///
+    /// Before the emulator was retained, an acknowledged attach left the slot
+    /// empty, so a detach had to open a fresh hand-over — a connect to the
+    /// session's rendezvous socket, a second `dup`, a second drain loop. Every
+    /// way that round trip could fail (a holder busy past the retry budget, an
+    /// adoption that timed out, a socket that had gone) was a way for a closed
+    /// tab to brick its session. The reader now never leaves the descriptor, so
+    /// the resume is a restart of its own thread and asks the holder nothing.
+    ///
+    /// This unlinks the rendezvous socket — the failure that used to be fatal
+    /// here — and asserts the handback succeeds through it: the claim is
+    /// cleared, the same reader is draining again, and the session is live.
+    ///
+    /// **The failing take-back is no longer reachable by a test on this arm,
+    /// and no failure is fabricated to stand in for it.** What is left that can
+    /// throw is `HolderReader.resumeDraining`, which fails only when `pipe()`
+    /// does — an out-of-descriptors condition a test on a shared box must not
+    /// induce. The claim-dropping behaviour on the error path is still there
+    /// and still correct; it is simply unreachable from here now. Its sibling
+    /// `HolderAppDeathSeizureTests.aFailedSeizureIsNoLongerReachableThroughAMissingSocket`
+    /// records the same for the seizure.
+    @Test func aHandbackSucceedsWithoutTheHoldersSocket() async throws {
         let fixture = try await HandbackFixture.start(command: Self.echoJob)
         defer { fixture.tearDown() }
 
         let viewer = try await fixture.attachAViewer()
+        let suspended = try #require(await fixture.registry.reader(for: fixture.terminalID))
         viewer.close()
         // The holder is still alive and still bound to this socket; unlinking
-        // the path is what a connect can no longer find, so `beginAdoption`
-        // fails on its first attempt rather than spending the busy budget.
+        // the path is what a connect can no longer find, so any adoption would
+        // fail on its first attempt rather than spending the busy budget.
         try FileManager.default.removeItem(
             atPath: try HolderRendezvous.socketPath(
                 sessionID: fixture.terminalID,
                 environment: HolderProcessFixture.environment(home: fixture.process.home)))
 
-        await #expect(throws: (any Swift.Error).self) {
-            try await fixture.registry.acceptHandback(
-                terminal: fixture.terminalRow, generation: viewer.generation,
-                preamble: Data("PREAMBLE".utf8))
-        }
+        try await fixture.registry.acceptHandback(
+            terminal: fixture.terminalRow, generation: viewer.generation,
+            preamble: viewer.terminal.snapshot())
 
         #expect(await fixture.registry.viewerAttachment(for: fixture.terminalID) == nil, """
-            a handback that could not take the session back left the viewer's claim standing, so \
-            nothing drains this pty, no injection can reach it, and every re-open is refused
+            the handback left the viewer's claim standing, so nothing drains this pty, no \
+            injection can reach it, and every re-open is refused
             """)
-        // And the claim is not merely absent from the map: the guard that reads
-        // it no longer refuses a recovery. This adopt fails too — the socket is
-        // gone — but it must fail on the socket, not on the claim.
-        do {
-            _ = try await fixture.registry.adopt(terminal: fixture.terminalRow)
-        } catch {
-            #expect(
-                (error as? HolderRegistry.Error)
-                    != .attachedToViewer(terminalID: fixture.terminalID),
-                "a recovery attach is still refused on the claim the failed handback left behind")
-        }
+        let resumed = try #require(await fixture.registry.reader(for: fixture.terminalID))
+        #expect(resumed === suspended, """
+            the handback opened a hand-over for a session whose own reader had never left the \
+            descriptor — and with the rendezvous socket gone it could not have succeeded
+            """)
+        #expect(await resumed.isDraining, "the suspended reader was not put back on the pty")
+
+        // Live again, not merely claimed: the daemon writes, the job answers,
+        // and the answer lands on the screen it is keeping.
+        try await resumed.write(Data("AFTER-SOCKETLESS-HANDBACK\n".utf8))
+        #expect(await pollUntil("the job's answer after the socketless handback") {
+            await resumed.renderScreen().contains("GOT:AFTER-SOCKETLESS-HANDBACK")
+        })
     }
 
     /// The negative that scopes this task: **an app that dies mid-detach needs
@@ -211,7 +237,9 @@ struct HolderDetachHandbackTests {
 
         #expect(await fixture.registry.viewerAttachment(for: fixture.terminalID) == viewer.generation,
                 "a closed descriptor is not evidence this daemon can see")
-        #expect(await fixture.registry.reader(for: fixture.terminalID) == nil)
+        let stillSuspended = try #require(await fixture.registry.reader(for: fixture.terminalID))
+        #expect(await !stillSuspended.isDraining,
+                "the daemon resumed a pty on nothing but a closed descriptor it cannot see")
         await #expect(throws: HolderRegistry.Error.attachedToViewer(terminalID: fixture.terminalID)) {
             try await fixture.registry.adopt(terminal: fixture.terminalRow)
         }

--- a/Tests/TBDDaemonLiveTests/Holder/HolderDetachHandbackTests.swift
+++ b/Tests/TBDDaemonLiveTests/Holder/HolderDetachHandbackTests.swift
@@ -92,6 +92,36 @@ struct HolderDetachHandbackTests {
         })
     }
 
+    /// The far side of `staleDaemon`: once the take-back lands, the same reader
+    /// is the live store again and says so.
+    ///
+    /// It is asserted here rather than in a unit test because `.daemon` is the
+    /// one source that cannot be constructed without a running drain thread —
+    /// it is read from the reader's own state, so a reader that is not actually
+    /// on a pty cannot answer it. `HolderScreenContractTests` says as much in
+    /// place of building a fake.
+    @Test func aHandbackMakesTheDaemonTheLiveStoreAgain() async throws {
+        let fixture = try await HandbackFixture.start(command: Self.echoJob)
+        defer { fixture.tearDown() }
+
+        let viewer = try await fixture.attachAViewer()
+        let suspended = try #require(await fixture.registry.reader(for: fixture.terminalID))
+        #expect(try await suspended.screen(maxLines: 50).source == .staleDaemon)
+
+        viewer.close()
+        try await fixture.registry.acceptHandback(
+            terminal: fixture.terminalRow, generation: viewer.generation,
+            preamble: viewer.terminal.snapshot())
+
+        let resumed = try #require(await fixture.registry.reader(for: fixture.terminalID))
+        #expect(await resumed.isDraining)
+        #expect(try await resumed.screen(maxLines: 50).source == .daemon, """
+            the daemon is draining this pty again but its screen still labels itself frozen, so \
+            every consumer keyed on `source` applies a stale policy to a live session
+            """)
+        #expect(await resumed.modeReading().source == .daemon)
+    }
+
     // MARK: - The unacknowledged attach, which kept its reader
 
     /// An attach that timed out unacknowledged keeps the claim *and* its

--- a/Tests/TBDDaemonLiveTests/Holder/HolderReaderTests.swift
+++ b/Tests/TBDDaemonLiveTests/Holder/HolderReaderTests.swift
@@ -89,7 +89,7 @@ struct HolderReaderTests {
             await reader.renderScreen().contains("line-5000")
         }
         #expect(sawTail)
-        let history = await reader.renderScreenWithScrollback(maxLines: 500)
+        let history = try await reader.screen(maxLines: 500).output
         #expect(history.contains("line-4900"), "the scrollback did not keep the recent history")
     }
 

--- a/Tests/TBDDaemonLiveTests/Holder/HolderReconcileGateTests.swift
+++ b/Tests/TBDDaemonLiveTests/Holder/HolderReconcileGateTests.swift
@@ -20,9 +20,12 @@ struct HolderReconcileGateTests {
 
     // MARK: - Gate 2: a viewer owning the pty ends it
 
-    /// After `confirmAttach` the app holds the descriptor and the daemon has no
-    /// reader at all, so every probe below this gate would be asking about a
-    /// session somebody is looking at right now.
+    /// After `confirmAttach` the app holds the descriptor and the daemon's own
+    /// reader is suspended, so every probe below this gate would be asking
+    /// about a session somebody is looking at right now. The gate keys on the
+    /// viewer's claim rather than on the reader, deliberately: the daemon
+    /// retains its reader across an attach, so its presence says nothing about
+    /// who owns the pty.
     @Test func aViewerHoldingTheDescriptorEndsTheQuestioning() async throws {
         let fixture = try await HolderProcessFixture.start(command: "sleep 120")
         defer { fixture.tearDown() }

--- a/Tests/TBDDaemonLiveTests/Holder/HolderResizeRoutingTests.swift
+++ b/Tests/TBDDaemonLiveTests/Holder/HolderResizeRoutingTests.swift
@@ -21,12 +21,12 @@ import Testing
 /// 123 columns into an 80-column grid — approached from the opposite direction,
 /// so it tracks the viewer whether or not the daemon touched the tty.
 ///
-/// The attached state used here is the one where the question is *observable*:
-/// an attach that was vended and never acknowledged. A confirmed attach
-/// releases the daemon's reader outright, so there is no emulator left to ask.
-/// This state is not contrived — it is the timed-out attach, where the viewer
-/// may already be live on its duplicate and the daemon is deliberately kept off
-/// the pty.
+/// The attached state used here is an attach that was vended and never
+/// acknowledged. The routing is the same on a confirmed attach — that reader is
+/// retained and suspended too — and this state is chosen because it is reached
+/// without a viewer standing in: the timed-out attach, where the viewer may
+/// already be live on its duplicate and the daemon is deliberately kept off the
+/// pty.
 ///
 /// **Tier 3.** A real `TBDHolder`, a real pty, and a real job.
 @Suite(.serialized)

--- a/Tests/TBDDaemonLiveTests/Holder/HolderSpawnGateTests.swift
+++ b/Tests/TBDDaemonLiveTests/Holder/HolderSpawnGateTests.swift
@@ -102,6 +102,47 @@ struct HolderSpawnGateTests {
             "the holder path started a tmux server: \(issued)")
     }
 
+    /// A spawned session's drain loop is counted exactly like an adopted
+    /// one's.
+    ///
+    /// `spawn` and `beginAdoption` are the registry's two publish sites, and
+    /// `peakLiveDrainLoops` is the one instrument for "two readers on one pty"
+    /// — the byte theft object identity cannot see. A publish that counted only
+    /// `drainLoopsStarted` left the live count at zero for every spawned
+    /// session, so the peak could not rise above zero however many loops ran
+    /// beside it, and the release's unconditional decrement then drove the
+    /// count negative and kept it there.
+    ///
+    /// The second half is what sees that drift: after the first session is
+    /// released the registry spawns another, and a live count that had gone to
+    /// -1 leaves the peak at 0 rather than 1. It pins the decrement too — a
+    /// release that stopped the reader without dropping the count would put the
+    /// peak at 2 here.
+    @Test func aSpawnedSessionCountsItsDrainLoopLikeAnAdoptedOne() async throws {
+        let fixture = try await GateFixture.make(flagEnabled: true)
+        defer { fixture.tearDown() }
+
+        let created = try await fixture.spawnPrimaryTerminals()
+        let terminalID = created[0].id
+        #expect(await fixture.registry.drainLoopsStarted == 1)
+        #expect(await fixture.registry.peakLiveDrainLoops == 1, """
+            a spawned session's drain loop was never counted live, so nothing can see a second \
+            reader started beside it
+            """)
+
+        await fixture.registry.release(terminalID: terminalID)
+        let second = try await fixture.spawnPrimaryTerminals()
+        let secondPrimary = try #require(try await fixture.db.terminals.get(id: second[0].id))
+        #expect(
+            secondPrimary.transport == .holder,
+            "the second session did not take the holder path")
+        #expect(await fixture.registry.drainLoopsStarted == 2)
+        #expect(await fixture.registry.peakLiveDrainLoops == 1, """
+            the live drain-loop count drifted across a release: one loop was live at a time \
+            throughout, and the peak says otherwise
+            """)
+    }
+
     /// Flag on, registry present, but nothing to spawn with: the create still
     /// succeeds, on tmux.
     ///

--- a/Tests/TBDDaemonTests/ActuationLogTests.swift
+++ b/Tests/TBDDaemonTests/ActuationLogTests.swift
@@ -373,6 +373,39 @@ struct ActuationLogTests {
         #expect(written.first?["message"] as? String == "second")
     }
 
+    // MARK: - Vocabulary
+
+    /// The record's `modeSource` and a screen's `source` name the same fact, and
+    /// a supervisor correlates them by string comparison — reading
+    /// `screen.source` out of `tbd terminal output --json` and matching it
+    /// against the row its send produced. Two spellings would break exactly the
+    /// case worth correlating, `staleDaemon`: the one that says the composition
+    /// was a guess.
+    ///
+    /// Driven off `TerminalScreen.Source.allCases`, so a case added there
+    /// reddens this until it is added here too — which is also the mapping's
+    /// totality check.
+    @Test("every screen source keeps its wire spelling in the actuation record")
+    func modeSourceSpellingsMatchTheScreens() {
+        for source in TerminalScreen.Source.allCases {
+            let recorded = ActuationModeSource(source).rawValue
+            #expect(
+                recorded == source.rawValue,
+                "the record spells \(source) as '\(recorded)', a screen as '\(source.rawValue)'")
+        }
+    }
+
+    /// `unavailable` is the record's own case — nothing answered at all — so it
+    /// has no screen spelling to agree with and the loop above cannot see it.
+    /// Pinned separately so the vocabulary is covered whole.
+    @Test("unavailable is the record's own case and keeps its spelling")
+    func unavailableIsTheRecordsOwn() {
+        #expect(ActuationModeSource.unavailable.rawValue == "unavailable")
+        #expect(
+            ActuationModeSource.allCases.count == TerminalScreen.Source.allCases.count + 1,
+            "the record's vocabulary is the screen's plus exactly `unavailable`")
+    }
+
     @Test("a file replaced by a different file between appends is followed, not written past")
     func replacedFileIsFollowed() async throws {
         let directory = try Self.makeDirectory()

--- a/Tests/TBDDaemonTests/Holder/HolderInjectionRoutingTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HolderInjectionRoutingTests.swift
@@ -300,18 +300,16 @@ struct HolderInjectionRoutingTests {
     /// is not under test here and this test stays green whatever that
     /// ownership becomes — it is not a tripwire for the gap.
     ///
-    /// The gap itself: once a viewer has acknowledged an attach the daemon has
-    /// released its reader and closed its descriptor, so the fail-open branch
-    /// has nothing to write to. Nothing is lost *silently* — the caller is
-    /// told and `performHolderSend` records a transport failure — but the
-    /// fallback is not yet a write.
+    /// The situation itself is now a genuine fault rather than an attached
+    /// session's ordinary state: the daemon keeps its reader across an attach,
+    /// suspended, so its descriptor is open and the fail-open branch really
+    /// writes. `writeDirectly` throws only when the registry holds no reader at
+    /// all — the session is gone, was never adopted, or is mid-release.
     ///
     /// **`Daemon.swift`'s `writeDirectly` closure is covered by no test.** The
-    /// registry-level fact it rests on — an acknowledged attach leaves the
-    /// daemon with no reader for that session — is pinned live, in
-    /// `HolderAttachHandoffTests` ("the daemon kept a reader for a session it
-    /// no longer reads"). That is the assertion a write-only dup across an
-    /// attach would have to be reconciled with; it is not this one.
+    /// registry-level fact underneath it — that an acknowledged attach leaves
+    /// the daemon a suspended reader with an open descriptor — is pinned live,
+    /// in `HolderAttachHandoffTests`. This test pins only the propagation.
     @Test("With no descriptor and no viewer answer, nothing is written and the caller is told")
     func fallbackWithNoDaemonDescriptorReportsFailure() async throws {
         let harness = Harness()

--- a/Tests/TBDDaemonTests/Holder/HolderSendCompositionTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HolderSendCompositionTests.swift
@@ -167,25 +167,28 @@ import Testing
         #expect(Self.occurrences(of: Self.end, in: composed) == 1)
     }
 
-    /// **Only the wrapped path touches the body.** With no paste open there is
-    /// nothing to break out of or restart, and the bytes are the caller's to
-    /// send — a caller writing paste markers to a child that reads them
-    /// literally is entitled to have them arrive. Silently editing an unwrapped
-    /// send would be a second, invisible rule about what `terminal.send`
-    /// delivers, so the body carries both markers here and both survive.
-    @Test("the same body unwrapped is delivered verbatim, both markers included")
-    func anUnwrappedBodyKeepsItsPasteMarkers() {
+    /// **The bare path strips too.** A paste marker is never content a child
+    /// can display: with bracketing off it prints the six bytes or misreads
+    /// them, so verbatim delivery serves no caller. And the mode this reads can
+    /// be stale — a `staleDaemon` "off" is a guess about a child that may have
+    /// turned bracketing on since the attach — in which case an unstripped
+    /// `ESC[200~` opens a paste nothing closes and swallows the `\r` below and
+    /// every later keystroke. So the same body composed bare loses both
+    /// markers, exactly as the wrapped one does.
+    @Test("the same body unwrapped loses its paste markers too")
+    func anUnwrappedBodyLosesItsPasteMarkersToo() {
         let body = "before\u{1b}[200~middle\u{1b}[201~after"
         let composed = HolderSendComposition.compose(
             body: body, submit: true, bracketedPaste: false)
 
-        #expect(composed == Self.expected(body: body, wrapped: false, submit: true))
         #expect(
-            Self.occurrences(of: Self.start, in: composed) == 1,
-            "the caller's own start marker did not survive an unwrapped send")
+            composed == Self.expected(body: "beforemiddleafter", wrapped: false, submit: true))
         #expect(
-            Self.occurrences(of: Self.end, in: composed) == 1,
-            "the caller's own end marker did not survive an unwrapped send")
+            Self.occurrences(of: Self.start, in: composed) == 0,
+            "a start marker survived a bare send and can open a paste nothing closes")
+        #expect(
+            Self.occurrences(of: Self.end, in: composed) == 0,
+            "an end marker survived a bare send")
     }
 
     /// A body that is *nothing but* an end marker has nothing left to paste,
@@ -213,6 +216,39 @@ import Testing
             body: "\u{1b}[201~", submit: false, bracketedPaste: true)
 
         #expect(composed.isEmpty)
+    }
+
+    /// The bare-mode variant of the pair above, and the case the stale-mode
+    /// hazard is sharpest in: a body that is nothing but a marker composes to a
+    /// bare Enter here too, because the strip runs before the emptiness test in
+    /// both modes. Delivering the marker instead would send a child that has
+    /// bracketing on — as a `staleDaemon` "off" cannot rule out — six bytes and
+    /// then a `\r` it would absorb.
+    @Test("a body of only a marker composes to a bare Enter in bare mode too")
+    func aBodyOfOnlyAMarkerIsABareEnterUnwrapped() {
+        for marker in ["\u{1b}[201~", "\u{1b}[200~"] {
+            let composed = HolderSendComposition.compose(
+                body: marker, submit: true, bracketedPaste: false)
+
+            #expect(
+                composed == Self.carriageReturn,
+                "a bare submitting send of only \(marker.debugDescription) was not a bare Enter")
+            #expect(Self.occurrences(of: Self.start, in: composed) == 0)
+            #expect(Self.occurrences(of: Self.end, in: composed) == 0)
+        }
+    }
+
+    /// And without `--submit` there is nothing left to write at all — the
+    /// second way a caller with something to say reaches an empty message,
+    /// reached in bare mode as well as wrapped.
+    @Test("a body of only a marker and no submit composes to nothing in bare mode too")
+    func aBodyOfOnlyAMarkerWithoutSubmitIsEmptyUnwrapped() {
+        for marker in ["\u{1b}[201~", "\u{1b}[200~"] {
+            #expect(
+                HolderSendComposition.compose(
+                    body: marker, submit: false, bracketedPaste: false).isEmpty,
+                "a bare non-submitting send of only \(marker.debugDescription) wrote bytes")
+        }
     }
 
     // MARK: - A body that tries to restart the paste itself

--- a/Tests/TBDDaemonTests/Holder/HolderSendCompositionTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HolderSendCompositionTests.swift
@@ -1,0 +1,131 @@
+import Foundation
+import Testing
+
+@testable import TBDDaemonLib
+
+/// The bytes a holder send is made of, asserted whole.
+///
+/// **Every case compares the entire `Data`.** A substring check would pass on a
+/// message with the submitting `\r` *inside* the paste — which is the exact
+/// defect this composition exists to fix, so an assertion that cannot see it is
+/// not an assertion about this at all. `--text --submit` was measured losing its
+/// Enter at ~230 bytes and again at 4 KB: an agent TUI's paste-burst heuristic
+/// keys on the shape of a chunk, so the envelope's own newline was enough to
+/// make a bare `\r` look like part of a paste. Putting the `\r` after an
+/// explicit `ESC[201~` is what makes it provably a keystroke.
+@Suite struct HolderSendCompositionTests {
+
+    private static let start = Data([0x1b, 0x5b, 0x32, 0x30, 0x30, 0x7e])  // ESC[200~
+    private static let end = Data([0x1b, 0x5b, 0x32, 0x30, 0x31, 0x7e])  // ESC[201~
+    private static let carriageReturn = Data([0x0d])
+
+    /// The expected bytes, assembled step by step.
+    ///
+    /// Spelled out rather than written as one `+` chain: `Data`'s concatenation
+    /// operators are generic over `Sequence`, and a four-term chain of them
+    /// takes the type checker past its budget.
+    private static func expected(
+        body: String, wrapped: Bool, submit: Bool
+    ) -> Data {
+        var data = Data()
+        if !body.isEmpty {
+            if wrapped { data.append(start) }
+            data.append(Data(body.utf8))
+            if wrapped { data.append(end) }
+        }
+        if submit { data.append(contentsOf: carriageReturn) }
+        return data
+    }
+
+    /// How many times `needle` occurs in `haystack`, spelled out rather than
+    /// taken from a stdlib search: these assertions are about exact byte
+    /// sequences, and the count is what distinguishes "the markers are there"
+    /// from "the markers are there once".
+    private static func occurrences(of needle: Data, in haystack: Data) -> Int {
+        let bytes = [UInt8](haystack)
+        let pattern = [UInt8](needle)
+        guard !pattern.isEmpty, bytes.count >= pattern.count else { return 0 }
+        var found = 0
+        for start in 0...(bytes.count - pattern.count)
+        where Array(bytes[start..<(start + pattern.count)]) == pattern {
+            found += 1
+        }
+        return found
+    }
+
+    /// The whole point, byte for byte: markers around the body, the Enter after
+    /// the closing marker, nothing else anywhere.
+    @Test("bracketed paste on, submitting: markers around the body, the Enter after them")
+    func wrapsAndSubmits() {
+        let composed = HolderSendComposition.compose(
+            body: "hello", submit: true, bracketedPaste: true)
+
+        #expect(composed == Self.expected(body: "hello", wrapped: true, submit: true))
+        // Stated separately because it is the property, not an artefact of the
+        // literal above: the Enter is the last byte and it follows the end
+        // marker rather than sitting inside the paste.
+        #expect(composed.last == 0x0d)
+        #expect(composed.dropLast().suffix(Self.end.count) == Self.end)
+    }
+
+    /// A child that never asked for bracketing must not receive markers. A
+    /// shell at its prompt would execute a line beginning with one.
+    @Test("bracketed paste off, submitting: bare body and the Enter, no markers")
+    func bareWhenTheChildDidNotAskForBracketing() {
+        let composed = HolderSendComposition.compose(
+            body: "hello", submit: true, bracketedPaste: false)
+
+        #expect(composed == Self.expected(body: "hello", wrapped: false, submit: true))
+        #expect(Self.occurrences(of: Self.start, in: composed) == 0)
+        #expect(Self.occurrences(of: Self.end, in: composed) == 0)
+    }
+
+    @Test("bracketed paste on, not submitting: markers and no Enter")
+    func wrapsWithoutSubmitting() {
+        let composed = HolderSendComposition.compose(
+            body: "hello", submit: false, bracketedPaste: true)
+
+        #expect(composed == Self.expected(body: "hello", wrapped: true, submit: false))
+        #expect(composed.last != 0x0d)
+    }
+
+    /// `tbd terminal send --text "" --submit` is a real way to press Enter and
+    /// has to stay one. Wrapping nothing would put a pair of markers in front
+    /// of it — bytes the child never asked for, in the one case where the
+    /// caller asked for a single keystroke and nothing else.
+    @Test("an empty body is never wrapped, in either mode")
+    func anEmptyBodyIsNeverWrapped() {
+        for bracketed in [true, false] {
+            #expect(
+                HolderSendComposition.compose(
+                    body: "", submit: true, bracketedPaste: bracketed) == Self.carriageReturn,
+                "an empty submitting send with bracketedPaste: \(bracketed) was not a bare Enter")
+        }
+    }
+
+    /// Nothing to say and no key to press composes to nothing, and the handler
+    /// above turns that into a dispatched row that wrote no bytes.
+    @Test("an empty body with no submit composes nothing at all")
+    func anEmptyBodyWithoutSubmitIsEmpty() {
+        for bracketed in [true, false] {
+            #expect(
+                HolderSendComposition.compose(
+                    body: "", submit: false, bracketedPaste: bracketed).isEmpty)
+        }
+    }
+
+    /// The multi-line shape the field defect was measured on: the body's own
+    /// newlines stay inside the paste, so the burst heuristic sees one paste
+    /// and one keystroke rather than one ambiguous chunk.
+    @Test("a multi-line body keeps its newlines inside the paste")
+    func multiLineBodyStaysInsideThePaste() {
+        let body = "<tbd-dispatch id=\"a\"/>\nfirst line\nsecond line"
+        let composed = HolderSendComposition.compose(
+            body: body, submit: true, bracketedPaste: true)
+
+        #expect(composed == Self.expected(body: body, wrapped: true, submit: true))
+        #expect(
+            Self.occurrences(of: Self.start, in: composed) == 1,
+            "the start marker appears more than once")
+    }
+}

--- a/Tests/TBDDaemonTests/Holder/HolderSendCompositionTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HolderSendCompositionTests.swift
@@ -128,4 +128,88 @@ import Testing
             Self.occurrences(of: Self.start, in: composed) == 1,
             "the start marker appears more than once")
     }
+
+    // MARK: - A body that tries to close the paste itself
+
+    /// The break-out. A body carrying `ESC[201~` — one `--text "$(cat file)"`
+    /// away — closes the paste where it sits, so the rest of the body and the
+    /// submitting `\r` arrive as keystrokes: the exact defect the wrapping
+    /// exists to prevent, reached through content instead of chunk shape.
+    ///
+    /// Asserted as the whole `Data` *and* as a marker count, because they fail
+    /// differently: the equality says the composition is right, the count says
+    /// there is no second marker anywhere for a child to act on.
+    @Test("an end marker inside the body is removed rather than allowed to close the paste")
+    func embeddedEndMarkerIsRemoved() {
+        let body = "before\u{1b}[201~after"
+        let composed = HolderSendComposition.compose(
+            body: body, submit: true, bracketedPaste: true)
+
+        #expect(composed == Self.expected(body: "beforeafter", wrapped: true, submit: true))
+        #expect(
+            Self.occurrences(of: Self.end, in: composed) == 1,
+            "the composed message carries more than one end marker")
+        #expect(composed.last == 0x0d)
+        #expect(composed.dropLast().suffix(Self.end.count) == Self.end)
+    }
+
+    /// One replacing pass is not enough, and this is the body that shows it:
+    /// take the marker out of `ESC[2` + marker + `01~` and the neighbours join
+    /// into a fresh one. The scan retracts a marker as the byte completing it
+    /// is appended, so the output provably holds none.
+    @Test("a marker that would re-form across the removal is removed too")
+    func aReformingEndMarkerIsAlsoRemoved() {
+        let body = "\u{1b}[2\u{1b}[201~01~tail"
+        let composed = HolderSendComposition.compose(
+            body: body, submit: false, bracketedPaste: true)
+
+        #expect(composed == Self.expected(body: "tail", wrapped: true, submit: false))
+        #expect(Self.occurrences(of: Self.end, in: composed) == 1)
+    }
+
+    /// **Only the wrapped path touches the body.** With no paste open there is
+    /// nothing to break out of, and the bytes are the caller's to send — a
+    /// caller writing an end marker to a child that reads them literally is
+    /// entitled to have it arrive. Silently editing an unwrapped send would be
+    /// a second, invisible rule about what `terminal.send` delivers.
+    @Test("the same body unwrapped is delivered verbatim, marker included")
+    func anUnwrappedBodyKeepsItsEndMarker() {
+        let body = "before\u{1b}[201~after"
+        let composed = HolderSendComposition.compose(
+            body: body, submit: true, bracketedPaste: false)
+
+        #expect(composed == Self.expected(body: body, wrapped: false, submit: true))
+        #expect(
+            Self.occurrences(of: Self.end, in: composed) == 1,
+            "the caller's own end marker did not survive an unwrapped send")
+        #expect(Self.occurrences(of: Self.start, in: composed) == 0)
+    }
+
+    /// A body that is *nothing but* an end marker has nothing left to paste,
+    /// and the empty-body rule then applies to it: a bare Enter, not a pair of
+    /// markers wrapped around nothing. The stripping runs before the emptiness
+    /// test precisely so the two rules compose.
+    @Test("a body of only an end marker composes to a bare Enter")
+    func aBodyOfOnlyAnEndMarker() {
+        let composed = HolderSendComposition.compose(
+            body: "\u{1b}[201~", submit: true, bracketedPaste: true)
+
+        #expect(composed == Self.carriageReturn)
+        #expect(Self.occurrences(of: Self.end, in: composed) == 0)
+        #expect(Self.occurrences(of: Self.start, in: composed) == 0)
+    }
+
+    /// The start marker is deliberately *not* stripped: it opens nothing a
+    /// child has not already been told is open, so it cannot break out, and
+    /// removing it would edit a body for no gain. This pins the asymmetry so it
+    /// reads as a decision rather than an oversight.
+    @Test("a start marker inside the body is left alone")
+    func anEmbeddedStartMarkerIsLeftAlone() {
+        let body = "before\u{1b}[200~after"
+        let composed = HolderSendComposition.compose(
+            body: body, submit: false, bracketedPaste: true)
+
+        #expect(composed == Self.expected(body: body, wrapped: true, submit: false))
+        #expect(Self.occurrences(of: Self.start, in: composed) == 2)
+    }
 }

--- a/Tests/TBDDaemonTests/Holder/HolderSendCompositionTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HolderSendCompositionTests.swift
@@ -199,6 +199,19 @@ import Testing
         #expect(Self.occurrences(of: Self.start, in: composed) == 0)
     }
 
+    /// The same body without `--submit`: the strip empties it, the empty-body
+    /// rule declines to wrap it, and no Return follows — so the composition is
+    /// nothing at all. It is the second way a caller with something to say
+    /// reaches an empty message, and the send arm above records the mode
+    /// provenance for it, because a composition did run.
+    @Test("a body of only an end marker and no submit composes to nothing")
+    func aBodyOfOnlyAnEndMarkerWithoutSubmit() {
+        let composed = HolderSendComposition.compose(
+            body: "\u{1b}[201~", submit: false, bracketedPaste: true)
+
+        #expect(composed.isEmpty)
+    }
+
     /// The start marker is deliberately *not* stripped: it opens nothing a
     /// child has not already been told is open, so it cannot break out, and
     /// removing it would edit a body for no gain. This pins the asymmetry so it

--- a/Tests/TBDDaemonTests/Holder/HolderSendCompositionTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HolderSendCompositionTests.swift
@@ -157,7 +157,7 @@ import Testing
     /// take the marker out of `ESC[2` + marker + `01~` and the neighbours join
     /// into a fresh one. The scan retracts a marker as the byte completing it
     /// is appended, so the output provably holds none.
-    @Test("a marker that would re-form across the removal is removed too")
+    @Test("an end marker that would re-form across the removal is removed too")
     func aReformingEndMarkerIsAlsoRemoved() {
         let body = "\u{1b}[2\u{1b}[201~01~tail"
         let composed = HolderSendComposition.compose(
@@ -168,21 +168,24 @@ import Testing
     }
 
     /// **Only the wrapped path touches the body.** With no paste open there is
-    /// nothing to break out of, and the bytes are the caller's to send — a
-    /// caller writing an end marker to a child that reads them literally is
-    /// entitled to have it arrive. Silently editing an unwrapped send would be
-    /// a second, invisible rule about what `terminal.send` delivers.
-    @Test("the same body unwrapped is delivered verbatim, marker included")
-    func anUnwrappedBodyKeepsItsEndMarker() {
-        let body = "before\u{1b}[201~after"
+    /// nothing to break out of or restart, and the bytes are the caller's to
+    /// send — a caller writing paste markers to a child that reads them
+    /// literally is entitled to have them arrive. Silently editing an unwrapped
+    /// send would be a second, invisible rule about what `terminal.send`
+    /// delivers, so the body carries both markers here and both survive.
+    @Test("the same body unwrapped is delivered verbatim, both markers included")
+    func anUnwrappedBodyKeepsItsPasteMarkers() {
+        let body = "before\u{1b}[200~middle\u{1b}[201~after"
         let composed = HolderSendComposition.compose(
             body: body, submit: true, bracketedPaste: false)
 
         #expect(composed == Self.expected(body: body, wrapped: false, submit: true))
         #expect(
+            Self.occurrences(of: Self.start, in: composed) == 1,
+            "the caller's own start marker did not survive an unwrapped send")
+        #expect(
             Self.occurrences(of: Self.end, in: composed) == 1,
             "the caller's own end marker did not survive an unwrapped send")
-        #expect(Self.occurrences(of: Self.start, in: composed) == 0)
     }
 
     /// A body that is *nothing but* an end marker has nothing left to paste,
@@ -212,17 +215,53 @@ import Testing
         #expect(composed.isEmpty)
     }
 
-    /// The start marker is deliberately *not* stripped: it opens nothing a
-    /// child has not already been told is open, so it cannot break out, and
-    /// removing it would edit a body for no gain. This pins the asymmetry so it
-    /// reads as a decision rather than an oversight.
-    @Test("a start marker inside the body is left alone")
-    func anEmbeddedStartMarkerIsLeftAlone() {
+    // MARK: - A body that tries to restart the paste itself
+
+    /// The other break-out, and the reason the start marker is stripped as
+    /// well: a child whose reader takes a nested `ESC[200~` as the beginning of
+    /// a new paste discards everything before it — the dispatch envelope
+    /// included — so what it acts on is not what the caller sent. A log or a
+    /// transcript that recorded raw terminal input carries one.
+    @Test("a start marker inside the body is removed rather than allowed to restart the paste")
+    func anEmbeddedStartMarkerIsRemoved() {
         let body = "before\u{1b}[200~after"
         let composed = HolderSendComposition.compose(
             body: body, submit: false, bracketedPaste: true)
 
-        #expect(composed == Self.expected(body: body, wrapped: true, submit: false))
-        #expect(Self.occurrences(of: Self.start, in: composed) == 2)
+        #expect(composed == Self.expected(body: "beforeafter", wrapped: true, submit: false))
+        #expect(
+            Self.occurrences(of: Self.start, in: composed) == 1,
+            "the composed message carries more than one start marker")
+    }
+
+    /// The re-formation property holds for the start marker too: take the
+    /// marker out of `ESC[2` + marker + `00~` and the neighbours join into a
+    /// fresh one, which the same append-and-retract scan catches as the byte
+    /// completing it is appended.
+    @Test("a start marker that would re-form across the removal is removed too")
+    func aReformingStartMarkerIsAlsoRemoved() {
+        let body = "\u{1b}[2\u{1b}[200~00~tail"
+        let composed = HolderSendComposition.compose(
+            body: body, submit: false, bracketedPaste: true)
+
+        #expect(composed == Self.expected(body: "tail", wrapped: true, submit: false))
+        #expect(Self.occurrences(of: Self.start, in: composed) == 1)
+    }
+
+    /// The two markers touching, which is what a body copied out of a recorded
+    /// paste looks like. They share their first four bytes, so removing one
+    /// must not leave a suffix that completes the other unnoticed — the scan
+    /// re-checks after every retraction, and both are gone.
+    @Test("a start and an end marker adjacent in the body are both removed")
+    func adjacentStartAndEndMarkersAreBothRemoved() {
+        let body = "head\u{1b}[200~\u{1b}[201~tail"
+        let composed = HolderSendComposition.compose(
+            body: body, submit: true, bracketedPaste: true)
+
+        #expect(composed == Self.expected(body: "headtail", wrapped: true, submit: true))
+        #expect(Self.occurrences(of: Self.start, in: composed) == 1)
+        #expect(Self.occurrences(of: Self.end, in: composed) == 1)
+        #expect(composed.last == 0x0d)
+        #expect(composed.dropLast().suffix(Self.end.count) == Self.end)
     }
 }

--- a/Tests/TBDDaemonTests/Holder/HolderTmuxAssumptionGateTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HolderTmuxAssumptionGateTests.swift
@@ -1032,6 +1032,48 @@ struct HolderTmuxAssumptionGateTests {
         #expect(outcome["modeAgeMilliseconds"] as? Int == 2_460_000)
     }
 
+    /// A caller with something to say whose message composes to nothing, and
+    /// the row still says what it was composed against.
+    ///
+    /// `--text $'\e[201~'` with no `--submit` against a bracketing child is the
+    /// second way to reach an empty message: the composition strips the end
+    /// marker — a caller's own marker would otherwise close the paste — and
+    /// what is left is empty, so nothing is written. The composition happened
+    /// all the same, and its provenance is a fact about the attempt, so the row
+    /// carries the source it asked. Only `--text ""` composes against nothing
+    /// and has nothing to disclose.
+    ///
+    /// A **shell** row, because the dispatch envelope goes only to agent
+    /// sessions: prepended, it would leave a non-empty body and this case could
+    /// not be reached at all.
+    @Test("a body that strips to nothing still records what it was composed against")
+    func strippedToNothingStillRecordsProvenance() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let recorded = RecordedTmuxArgs()
+        let (wt, dir) = try await seedWorktree(db)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "", tmuxPaneID: "",
+            label: TerminalLabel.shell, kind: .shell, transport: .holder,
+            holderPID: 9101, childPID: 9102)
+        let writes = HolderWrites()
+
+        let rpc = router(db, tmux: deadWindowTmux(recorded))
+        rpc.holderInjectionCourier = writes.courier()
+        rpc.holderModeOracle = oracle(bracketedPaste: true, source: .daemon, ageMilliseconds: 0)
+        let response = await rpc.handle(try RPCRequest(
+            method: RPCMethod.terminalSend,
+            params: TerminalSendParams(
+                terminalID: terminal.id, text: "\u{1b}[201~", submit: false)))
+
+        #expect(response.success, "error: \(response.error ?? "nil")")
+        #expect(writes.all.isEmpty, "a message that composed to nothing must write nothing")
+        let outcome = try #require(await Self.outcomeRow(of: rpc))
+        #expect(outcome["result"] as? String == "dispatched")
+        #expect(outcome["modeSource"] as? String == "daemon")
+        #expect(outcome["modeAgeMilliseconds"] as? Int == 0)
+    }
+
     @Test("terminal.send --verify refuses a holder row by naming verification")
     func sendVerifyRefusesHolderRow() async throws {
         let db = try TBDDatabase(inMemory: true)

--- a/Tests/TBDDaemonTests/Holder/HolderTmuxAssumptionGateTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HolderTmuxAssumptionGateTests.swift
@@ -1026,7 +1026,9 @@ struct HolderTmuxAssumptionGateTests {
 
         let outcome = try #require(await Self.outcomeRow(of: rpc))
         #expect(outcome["result"] as? String == "dispatched")
-        #expect(outcome["modeSource"] as? String == "stale-daemon")
+        // Spelled exactly as `TerminalScreen.Source.staleDaemon` encodes, so a
+        // supervisor can match the row against the screen it read.
+        #expect(outcome["modeSource"] as? String == "staleDaemon")
         #expect(outcome["modeAgeMilliseconds"] as? Int == 2_460_000)
     }
 

--- a/Tests/TBDDaemonTests/Holder/HolderTmuxAssumptionGateTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HolderTmuxAssumptionGateTests.swift
@@ -866,12 +866,168 @@ struct HolderTmuxAssumptionGateTests {
         #expect(writes.all.count == 1, "the whole send must be one write, not two")
         #expect(text.hasPrefix("<tbd-dispatch id="))
         #expect(text.hasSuffix("/>\nhello\r"))
+        // This router has neither an oracle seam nor a registry, so nothing
+        // could answer what modes the child is in — and the send proceeded
+        // anyway, bare, recording that it was a guess made blind. Refusing
+        // instead would make every rail's send fail closed whenever the daemon
+        // cannot see a store, which is precisely when rails need to send.
+        let outcome = try #require(await Self.outcomeRow(of: rpc))
+        #expect(outcome["modeSource"] as? String == "unavailable")
+        #expect(outcome["modeAgeMilliseconds"] == nil,
+                "an unavailable oracle has no store whose age could be recorded")
         let after = try #require(try await db.terminals.get(id: terminal.id))
         #expect(RowFingerprint(after) == before)
         // The strongest half: delivery sits ahead of the whole tmux mechanic,
         // so nothing about the send is addressed to a pane that never existed.
         #expect(recorded.snapshot().isEmpty,
                 "terminal.send reached tmux for a holder row: \(recorded.snapshot())")
+    }
+
+    // MARK: - Gate 10: the child's modes decide the bytes
+
+    /// The oracle seam, standing in for a registry-backed reader.
+    ///
+    /// Reaching the three answers through a real registry would mean a real
+    /// holder, a real pty and a real attach for what is a pure question about
+    /// which bytes get composed. The registry-backed resolution is exercised
+    /// live; this is how the composition's own branches are pinned.
+    private func oracle(
+        bracketedPaste: Bool,
+        source: TerminalScreen.Source = .daemon,
+        ageMilliseconds: Int = 0
+    ) -> @Sendable (UUID) async -> TerminalModeReading? {
+        { _ in
+            TerminalModeReading(
+                modes: TerminalScreen.ChildModes(
+                    bracketedPaste: bracketedPaste,
+                    applicationCursor: false,
+                    alternateScreen: false),
+                source: source,
+                ageMilliseconds: ageMilliseconds)
+        }
+    }
+
+    /// The outcome row this router last wrote, read back off its own actuation
+    /// log. The provenance is asserted **on the row** rather than on a log
+    /// line, because the row is what a person reading the record afterwards
+    /// actually has.
+    private static func outcomeRow(of rpc: RPCRouter) async -> [String: Any]? {
+        let path = await rpc.actuationLog.path
+        guard let contents = try? String(contentsOfFile: path, encoding: .utf8) else { return nil }
+        var rows: [[String: Any]] = []
+        for line in contents.split(separator: "\n") {
+            guard let object = try? JSONSerialization.jsonObject(with: Data(line.utf8)),
+                  let row = object as? [String: Any]
+            else { continue }
+            rows.append(row)
+        }
+        return rows.last { $0["kind"] as? String == "outcome" }
+    }
+
+    /// The defect this closes, at the router level: with the child in
+    /// bracketed-paste mode the whole message — envelope and body together —
+    /// goes inside one explicit paste, and the submitting `\r` follows the end
+    /// marker. Still one write, so the message is never split across a routing
+    /// decision.
+    @Test("a send to a bracketing child is one wrapped paste with the Enter outside it")
+    func sendWrapsForABracketingChild() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let recorded = RecordedTmuxArgs()
+        let (wt, dir) = try await seedWorktree(db)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let terminal = try await seedClaudeTerminal(db, worktreeID: wt.id, transport: .holder)
+        let writes = HolderWrites()
+
+        let rpc = router(db, tmux: deadWindowTmux(recorded))
+        rpc.holderInjectionCourier = writes.courier()
+        rpc.holderModeOracle = oracle(bracketedPaste: true, source: .daemon, ageMilliseconds: 0)
+        let response = await rpc.handle(try RPCRequest(
+            method: RPCMethod.terminalSend,
+            params: TerminalSendParams(
+                terminalID: terminal.id, text: "hello", submit: true)))
+
+        #expect(response.success, "error: \(response.error ?? "nil")")
+        #expect(writes.all.count == 1, "the whole send must be one write, not two")
+        let written = try #require(writes.all.first)
+        let text = try #require(String(data: written, encoding: .utf8))
+        #expect(text.hasPrefix("\u{1b}[200~<tbd-dispatch id="))
+        #expect(text.hasSuffix("/>\nhello\u{1b}[201~\r"))
+        #expect(
+            text.components(separatedBy: "\u{1b}[200~").count == 2,
+            "the start marker appears more than once: \(text.debugDescription)")
+
+        let outcome = try #require(await Self.outcomeRow(of: rpc))
+        #expect(outcome["result"] as? String == "dispatched")
+        #expect(outcome["modeSource"] as? String == "daemon")
+        #expect(outcome["modeAgeMilliseconds"] as? Int == 0)
+        #expect(recorded.snapshot().isEmpty)
+    }
+
+    /// The other direction, and it is not symmetry for its own sake: a shell at
+    /// its prompt, or any program that never asked for bracketing, prints
+    /// markers it does not understand and would execute a line starting with
+    /// one.
+    @Test("a send to a non-bracketing child is bare bytes and an Enter")
+    func sendStaysBareForANonBracketingChild() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let recorded = RecordedTmuxArgs()
+        let (wt, dir) = try await seedWorktree(db)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let terminal = try await seedClaudeTerminal(db, worktreeID: wt.id, transport: .holder)
+        let writes = HolderWrites()
+
+        let rpc = router(db, tmux: deadWindowTmux(recorded))
+        rpc.holderInjectionCourier = writes.courier()
+        rpc.holderModeOracle = oracle(bracketedPaste: false)
+        let response = await rpc.handle(try RPCRequest(
+            method: RPCMethod.terminalSend,
+            params: TerminalSendParams(
+                terminalID: terminal.id, text: "hello", submit: true)))
+
+        #expect(response.success, "error: \(response.error ?? "nil")")
+        let written = try #require(writes.all.first)
+        let text = try #require(String(data: written, encoding: .utf8))
+        #expect(text.hasSuffix("/>\nhello\r"))
+        #expect(!text.contains("\u{1b}[200~"))
+        #expect(!text.contains("\u{1b}[201~"))
+        #expect(recorded.snapshot().isEmpty)
+    }
+
+    /// The residue of the whole design, made examinable. When a viewer holds
+    /// the pty and does not answer, the daemon composes against the modes its
+    /// retained emulator held at the attach and **proceeds** — and records that
+    /// it guessed, and how old the guess was. A row reading `staleDaemon` at 41
+    /// minutes tells whoever reads the record afterwards exactly that.
+    @Test("a send composed against a stale emulator records its source and age")
+    func sendRecordsStaleProvenance() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let recorded = RecordedTmuxArgs()
+        let (wt, dir) = try await seedWorktree(db)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let terminal = try await seedClaudeTerminal(db, worktreeID: wt.id, transport: .holder)
+        let writes = HolderWrites()
+
+        let rpc = router(db, tmux: deadWindowTmux(recorded))
+        rpc.holderInjectionCourier = writes.courier()
+        rpc.holderModeOracle = oracle(
+            bracketedPaste: true, source: .staleDaemon, ageMilliseconds: 2_460_000)
+        let response = await rpc.handle(try RPCRequest(
+            method: RPCMethod.terminalSend,
+            params: TerminalSendParams(
+                terminalID: terminal.id, text: "hello", submit: true)))
+
+        #expect(response.success, "a stale oracle must not refuse the send")
+        // Composed per the stale modes, not bare: proceeding means acting on
+        // what the emulator says, not falling back to a safe-looking default.
+        let written = try #require(writes.all.first)
+        let text = try #require(String(data: written, encoding: .utf8))
+        #expect(text.hasPrefix("\u{1b}[200~"))
+        #expect(text.hasSuffix("\u{1b}[201~\r"))
+
+        let outcome = try #require(await Self.outcomeRow(of: rpc))
+        #expect(outcome["result"] as? String == "dispatched")
+        #expect(outcome["modeSource"] as? String == "stale-daemon")
+        #expect(outcome["modeAgeMilliseconds"] as? Int == 2_460_000)
     }
 
     @Test("terminal.send --verify refuses a holder row by naming verification")

--- a/Tests/TBDDaemonTests/HolderRenderProjectionTests.swift
+++ b/Tests/TBDDaemonTests/HolderRenderProjectionTests.swift
@@ -25,10 +25,10 @@ import Testing
 /// pins the daemon's renderer to the same projection.
 ///
 /// It exercises the production path rather than a copy of it: `ingest` feeds
-/// the reader's emulator synchronously, and `renderScreen` /
-/// `renderScreenWithScrollback` are the very functions `terminal.output`
-/// calls. No drain thread and no real pty are involved, so nothing here is
-/// timing-dependent.
+/// the reader's emulator synchronously, and `screen` is the very function
+/// `terminal.output` calls — `renderScreen` is the viewport-only twin the
+/// holder suites read a session's screen with. No drain thread and no real pty
+/// are involved, so nothing here is timing-dependent.
 @Suite struct HolderRenderProjectionTests {
 
     private static let nul = "\u{0}"
@@ -119,10 +119,10 @@ import Testing
 
     // MARK: - The scrollback render
 
-    /// `renderScreenWithScrollback` is a second, separate walk over the buffer
-    /// and needs the projection in its own right. The gap here is deliberately
-    /// placed on a line that has already scrolled off the viewport, so only the
-    /// scrollback path can produce it.
+    /// `screen` walks the whole buffer rather than the viewport, and needs the
+    /// projection in its own right. The gap here is deliberately placed on a
+    /// line that has already scrolled off the viewport, so only the scrollback
+    /// path can produce it.
     @Test("the scrollback render projects never-written cells as spaces too")
     func scrollbackRenderProjectsNeverWrittenCells() async throws {
         let harness = try Harness(columns: 40, rows: 5)
@@ -143,7 +143,7 @@ import Testing
             !viewport.contains("gap"),
             "the gap line is still on screen, so this asserts nothing about scrollback")
 
-        let history = await harness.reader.renderScreenWithScrollback(maxLines: 100)
+        let history = try await harness.reader.screen(maxLines: 100).output
         #expect(
             history.contains("          gap"),
             "rendered \(history.debugDescription)")

--- a/Tests/TBDDaemonTests/HolderScreenContractTests.swift
+++ b/Tests/TBDDaemonTests/HolderScreenContractTests.swift
@@ -249,6 +249,39 @@ import Testing
             """)
     }
 
+    /// The upper bound the field's documentation states, pinned: the index can
+    /// land **past** the end of `lines`, not merely at it.
+    ///
+    /// The trailing-blank trim walks off the end of the viewport and on into
+    /// scrollback whenever the viewport is blank, so a blank viewport sitting
+    /// over a blank scrollback row loses both. Here that is one written row,
+    /// one blank scrollback row and four blank viewport rows: six enumerated,
+    /// one surviving, and a viewport index of 2 — an index a consumer that
+    /// trusted `viewportStart <= lines.count` would use to slice and trap on.
+    @Test("viewportStart can exceed lines.count when the trim eats into scrollback")
+    func viewportStartCanExceedTheLineCount() async throws {
+        let harness = try Harness(columns: 40, rows: 4)
+        defer { harness.tearDown() }
+
+        // "a", then five newlines: three walk the cursor to the last row and
+        // two scroll, so the buffer holds "a" and one blank row of scrollback
+        // above a viewport of four blank rows.
+        await harness.reader.ingest(preamble: Self.data("a\r\n\r\n\r\n\r\n\r\n"))
+        let screen = try await harness.reader.screen(maxLines: 50)
+
+        #expect(screen.lines == ["a"])
+        #expect(screen.size.rows == 4)
+        #expect(
+            screen.viewportStart == 2,
+            """
+            the trim no longer reaches into scrollback, so this shape stopped proving the \
+            documented bound: lines \(screen.lines) start \(screen.viewportStart)
+            """)
+        #expect(
+            screen.viewportStart > screen.lines.count,
+            "viewportStart is documented as able to exceed lines.count and here it does not")
+    }
+
     // MARK: - Age
 
     /// One rule for every source: how long ago the answering store last

--- a/Tests/TBDDaemonTests/HolderScreenContractTests.swift
+++ b/Tests/TBDDaemonTests/HolderScreenContractTests.swift
@@ -43,6 +43,56 @@ import Testing
         #expect(!screen.output.contains(Self.nul))
     }
 
+    /// A child may legitimately print a `DEL`, and it lands in a cell verbatim:
+    /// the printable run inserter takes every byte from `0x20` through `0x7f`
+    /// without consulting a width, so `0x7f` is stored the way `A` is. The
+    /// whitelist refuses it, so a render that mapped only `U+0000` would make
+    /// one `printf '\x7f'` throw on **every** later read of the session, until
+    /// the line left the scrollback — a session-wide outage caused by the
+    /// session's own output. Two assertions in one again: a screen came back at
+    /// all, and the byte is visible as a replacement character rather than
+    /// silently gone.
+    ///
+    /// This is the only disallowed scalar a child can currently get into a
+    /// cell. C1 controls are dropped before insertion — measured: `U+0085`
+    /// through this same path renders as nothing at all, because SwiftTerm
+    /// consults a width table for non-ASCII and inserts nothing at width zero.
+    /// The render substitutes for every disallowed scalar regardless, against
+    /// `TerminalScreen.isDisallowed` rather than a list of the ones known to be
+    /// reachable, so a width table that changes its mind cannot reopen the
+    /// outage. `TerminalScreenTests` pins that predicate.
+    @Test("a DEL a child stored in a cell renders as U+FFFD instead of breaking the read")
+    func delInACellRendersAsReplacement() async throws {
+        let harness = try Harness(columns: 40, rows: 8)
+        defer { harness.tearDown() }
+
+        await harness.reader.ingest(preamble: Self.data("a\u{7f}b"))
+        let screen = try await harness.reader.screen(maxLines: 50)
+
+        #expect(
+            screen.lines.first == "a\u{fffd}b",
+            "rendered \(String(describing: screen.lines.first))")
+    }
+
+    /// The substitution must not swallow the case it was built beside: a
+    /// never-written cell is still a space, not a replacement character. A
+    /// render that mapped every disallowed scalar to `U+FFFD` without keeping
+    /// the NUL special would fill a differentially-painted line with visible
+    /// junk where `tmux capture-pane` returns blanks.
+    @Test("a never-written cell is still a space, not a replacement character")
+    func nulStillProjectsAsASpaceBesideTheSubstitution() async throws {
+        let harness = try Harness(columns: 40, rows: 8)
+        defer { harness.tearDown() }
+
+        await harness.reader.ingest(preamble: Self.data("a\(Self.esc)[4Gb\u{7f}c"))
+        let screen = try await harness.reader.screen(maxLines: 50)
+
+        #expect(
+            screen.lines.first == "a  b\u{fffd}c",
+            "rendered \(String(describing: screen.lines.first))")
+        #expect(!screen.output.contains(Self.nul))
+    }
+
     /// The trailing cell of a two-column glyph carries code 0 as well, and it
     /// is not an unwritten cell: padding it to a space would double the width
     /// of every CJK character and every emoji. The line is one grapheme per

--- a/Tests/TBDDaemonTests/HolderScreenContractTests.swift
+++ b/Tests/TBDDaemonTests/HolderScreenContractTests.swift
@@ -1,0 +1,319 @@
+import Darwin
+import Foundation
+import Testing
+
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// What the daemon's emulator answers when a machine asks it for a screen.
+///
+/// `HolderRenderProjectionTests` pins the *text*: no invisible holes, no
+/// doubled wide glyphs. This pins everything a string could not carry — where
+/// the viewport starts, where the cursor is and whether it is visible, what
+/// modes the child is in, which store answered, and how stale that store's
+/// view is. Each of those exists because a consumer's behaviour turns on it and
+/// there was previously no way to ask.
+///
+/// It exercises the production path rather than a copy of it: `ingest` feeds
+/// the reader's emulator synchronously, on the calling thread, and
+/// `HolderReader.screen` is the very function the `terminal.output` handler
+/// calls. No drain thread and no real pty are involved, so nothing here is
+/// timing-dependent — including the ages, which are read from an injected
+/// monotonic clock rather than measured.
+@Suite struct HolderScreenContractTests {
+
+    private static let esc = "\u{1b}"
+    private static let nul = "\u{0}"
+
+    // MARK: - The projection, seen through the type
+
+    /// The whitelist refuses a `U+0000`, so this is two assertions at once: the
+    /// render substitutes a space, *and* the screen was constructible at all.
+    /// A render that stopped substituting would not return a screen with holes
+    /// in it — it would throw.
+    @Test("a never-written cell reaches the screen as a space, never a NUL")
+    func neverWrittenCellsProjectAsSpaces() async throws {
+        let harness = try Harness(columns: 40, rows: 8)
+        defer { harness.tearDown() }
+
+        await harness.reader.ingest(preamble: Self.data("✻\(Self.esc)[3GCogitated"))
+        let screen = try await harness.reader.screen(maxLines: 50)
+
+        #expect(screen.lines.first == "✻ Cogitated")
+        #expect(!screen.output.contains(Self.nul))
+    }
+
+    /// The trailing cell of a two-column glyph carries code 0 as well, and it
+    /// is not an unwritten cell: padding it to a space would double the width
+    /// of every CJK character and every emoji. The line is one grapheme per
+    /// glyph.
+    @Test("a wide glyph's trailing half is omitted rather than padded")
+    func wideGlyphTrailingHalfIsOmitted() async throws {
+        let harness = try Harness(columns: 40, rows: 8)
+        defer { harness.tearDown() }
+
+        await harness.reader.ingest(preamble: Self.data("日本 x"))
+        let screen = try await harness.reader.screen(maxLines: 50)
+
+        #expect(screen.lines.first == "日本 x")
+        // One grapheme per glyph: 日, 本, the space, x. A trailing half padded
+        // to a space would make it six.
+        #expect(screen.lines.first?.count == 4, "the wide glyphs were padded out")
+    }
+
+    // MARK: - Modes
+
+    /// The three modes the input path composes against. Each is asserted in
+    /// both directions, because a reader wired to a constant would satisfy
+    /// either half alone.
+    @Test("bracketed paste follows the child's DECSET 2004")
+    func bracketedPasteFollowsTheChild() async throws {
+        let harness = try Harness(columns: 40, rows: 8)
+        defer { harness.tearDown() }
+
+        #expect(try await harness.reader.screen(maxLines: 8).modes.bracketedPaste == false)
+        await harness.reader.ingest(preamble: Self.data("\(Self.esc)[?2004h"))
+        #expect(try await harness.reader.screen(maxLines: 8).modes.bracketedPaste == true)
+        await harness.reader.ingest(preamble: Self.data("\(Self.esc)[?2004l"))
+        #expect(try await harness.reader.screen(maxLines: 8).modes.bracketedPaste == false)
+    }
+
+    @Test("application cursor follows the child's DECCKM")
+    func applicationCursorFollowsTheChild() async throws {
+        let harness = try Harness(columns: 40, rows: 8)
+        defer { harness.tearDown() }
+
+        #expect(try await harness.reader.screen(maxLines: 8).modes.applicationCursor == false)
+        await harness.reader.ingest(preamble: Self.data("\(Self.esc)[?1h"))
+        #expect(try await harness.reader.screen(maxLines: 8).modes.applicationCursor == true)
+        await harness.reader.ingest(preamble: Self.data("\(Self.esc)[?1l"))
+        #expect(try await harness.reader.screen(maxLines: 8).modes.applicationCursor == false)
+    }
+
+    @Test("the alternate screen flag follows 1049")
+    func alternateScreenFollowsTheChild() async throws {
+        let harness = try Harness(columns: 40, rows: 8)
+        defer { harness.tearDown() }
+
+        #expect(try await harness.reader.screen(maxLines: 8).modes.alternateScreen == false)
+        await harness.reader.ingest(preamble: Self.data("\(Self.esc)[?1049h"))
+        #expect(try await harness.reader.screen(maxLines: 8).modes.alternateScreen == true)
+        await harness.reader.ingest(preamble: Self.data("\(Self.esc)[?1049l"))
+        #expect(try await harness.reader.screen(maxLines: 8).modes.alternateScreen == false)
+    }
+
+    // MARK: - Cursor
+
+    @Test("the cursor reports its viewport row and column")
+    func cursorPosition() async throws {
+        let harness = try Harness(columns: 40, rows: 8)
+        defer { harness.tearDown() }
+
+        // `ESC[3;5H` is row 3, column 5, both 1-based; the screen reports them
+        // 0-based, so 2 and 4.
+        await harness.reader.ingest(preamble: Self.data("\(Self.esc)[3;5H"))
+        let screen = try await harness.reader.screen(maxLines: 8)
+        #expect(screen.cursor.row == 2)
+        #expect(screen.cursor.column == 4)
+    }
+
+    /// `cursorHidden` is not a public property, so visibility is a `DECRQM` 25
+    /// answer read through the collecting delegate. This is also what proves
+    /// that probe reaches the terminal at all: a reader that never asked would
+    /// report the default in both directions.
+    @Test("cursor visibility follows DECTCEM")
+    func cursorVisibility() async throws {
+        let harness = try Harness(columns: 40, rows: 8)
+        defer { harness.tearDown() }
+
+        #expect(try await harness.reader.screen(maxLines: 8).cursor.visible == true)
+        await harness.reader.ingest(preamble: Self.data("\(Self.esc)[?25l"))
+        #expect(try await harness.reader.screen(maxLines: 8).cursor.visible == false)
+        await harness.reader.ingest(preamble: Self.data("\(Self.esc)[?25h"))
+        #expect(try await harness.reader.screen(maxLines: 8).cursor.visible == true)
+    }
+
+    // MARK: - viewportStart
+
+    /// The field exists because it cannot be derived. Trailing blank rows are
+    /// dropped, so `lines.count - size.rows` is the wrong answer, and a
+    /// consumer that subtracted would land in the wrong row.
+    ///
+    /// Ten numbered lines on a four-row grid, asked for six: the tail is lines
+    /// 5 through 10, the viewport is the last four of them, and the cursor sits
+    /// on the last line of all.
+    @Test("viewportStart indexes the viewport's first row inside lines")
+    func viewportStartLocatesTheViewport() async throws {
+        let harness = try Harness(columns: 40, rows: 4)
+        defer { harness.tearDown() }
+
+        let numbered = (1...10).map { "line \($0)" }.joined(separator: "\r\n")
+        await harness.reader.ingest(preamble: Self.data(numbered))
+        let screen = try await harness.reader.screen(maxLines: 6)
+
+        #expect(screen.lines.count == 6)
+        #expect(screen.lines == (5...10).map { "line \($0)" })
+        #expect(screen.viewportStart == 2)
+        #expect(screen.size.rows == 4)
+        #expect(
+            screen.lines[screen.viewportStart + screen.cursor.row] == "line 10",
+            """
+            viewportStart + cursor.row does not land on the cursor's line: \
+            \(screen.lines) start \(screen.viewportStart) cursor \(screen.cursor.row)
+            """)
+    }
+
+    // MARK: - Age
+
+    /// One rule for every source: how long ago the answering store last
+    /// consumed a byte, and — before it ever has — how long ago the store
+    /// itself was adopted. So a fresh, silent session reads as exactly as old
+    /// as it is rather than as instantly current.
+    @Test("before any byte, the age is the age of the store itself")
+    func ageBeforeTheFirstByteIsTheStoresOwn() async throws {
+        let clock = SteppedMonotonicClock()
+        let harness = try Harness(columns: 40, rows: 8, monotonicNow: clock.read)
+        defer { harness.tearDown() }
+
+        clock.advance(by: .seconds(30))
+        #expect(try await harness.reader.screen(maxLines: 8).ageMilliseconds == 30_000)
+    }
+
+    /// After a byte the measurement moves to that byte, which is what makes the
+    /// number mean "how stale is this view" rather than "how old is this
+    /// session".
+    @Test("after a byte, the age is measured from that byte")
+    func ageAfterAByteIsMeasuredFromIt() async throws {
+        let clock = SteppedMonotonicClock()
+        let harness = try Harness(columns: 40, rows: 8, monotonicNow: clock.read)
+        defer { harness.tearDown() }
+
+        clock.advance(by: .seconds(30))
+        await harness.reader.ingest(preamble: Self.data("hello"))
+        #expect(try await harness.reader.screen(maxLines: 8).ageMilliseconds == 0)
+
+        // The spec's own example of a stale answer worth acting on.
+        clock.advance(by: .seconds(41 * 60))
+        #expect(try await harness.reader.screen(maxLines: 8).ageMilliseconds == 2_460_000)
+    }
+
+    /// The cursor-visibility probe feeds the terminal a `DECRQM` query, and a
+    /// query the daemon asked its own emulator is not a byte the child sent. If
+    /// it counted, every read would reset the age it was taken to measure and
+    /// no screen could ever be reported stale.
+    @Test("reading a screen does not make the screen look fresher")
+    func readingDoesNotResetTheAge() async throws {
+        let clock = SteppedMonotonicClock()
+        let harness = try Harness(columns: 40, rows: 8, monotonicNow: clock.read)
+        defer { harness.tearDown() }
+
+        await harness.reader.ingest(preamble: Self.data("hello"))
+        clock.advance(by: .seconds(41 * 60))
+        _ = try await harness.reader.screen(maxLines: 8)
+        _ = await harness.reader.modeReading()
+        #expect(try await harness.reader.screen(maxLines: 8).ageMilliseconds == 2_460_000)
+    }
+
+    // MARK: - Source
+
+    /// An idle reader is holding a screen it is not updating, so it must not
+    /// claim to be the live store — a consumer told `daemon` would apply a
+    /// live-screen policy to a frozen one.
+    ///
+    /// **`.daemon` is not reachable here**, and no fake is built to pretend it
+    /// is: it requires a reader whose drain thread is actually running, which
+    /// needs a real pty and a real job. It is asserted live, in
+    /// `HolderAttachHandoffTests` and `HolderDetachHandbackTests`, on both
+    /// sides of an attach.
+    @Test("a reader that is not draining answers staleDaemon")
+    func anIdleReaderIsStale() async throws {
+        let harness = try Harness(columns: 40, rows: 8)
+        defer { harness.tearDown() }
+
+        #expect(try await harness.reader.screen(maxLines: 8).source == .staleDaemon)
+        #expect(await harness.reader.modeReading().source == .staleDaemon)
+    }
+
+    /// The oracle's answer and the screen's are one observation of one store,
+    /// so they cannot be allowed to drift apart — pairing one store's modes
+    /// with another's screen is exactly what the `source` field exists to make
+    /// impossible.
+    @Test("modeReading agrees with the screen it is a narrower view of")
+    func modeReadingAgreesWithTheScreen() async throws {
+        let clock = SteppedMonotonicClock()
+        let harness = try Harness(columns: 40, rows: 8, monotonicNow: clock.read)
+        defer { harness.tearDown() }
+
+        await harness.reader.ingest(
+            preamble: Self.data("\(Self.esc)[?2004h\(Self.esc)[?1h"))
+        clock.advance(by: .seconds(7))
+
+        let screen = try await harness.reader.screen(maxLines: 8)
+        #expect(await harness.reader.modeReading() == screen.modeReading)
+        #expect(screen.modeReading.modes.bracketedPaste == true)
+        #expect(screen.modeReading.modes.applicationCursor == true)
+        #expect(screen.modeReading.ageMilliseconds == 7_000)
+    }
+
+    // MARK: - Harness
+
+    private static func data(_ text: String) -> Data { Data(text.utf8) }
+
+    /// A monotonic clock a test moves by hand.
+    ///
+    /// The reader's `monotonicNow` seam is separate from its `clock` because
+    /// `any Clock<Duration>` pins `Duration` and not `Instant`, so it cannot do
+    /// the instant arithmetic an age is. `ContinuousClock.Instant` can, which is
+    /// what lets these tests assert an exact number of milliseconds instead of
+    /// a tolerance window on a loaded box.
+    private final class SteppedMonotonicClock: @unchecked Sendable {
+        private let lock = NSLock()
+        private let base = ContinuousClock.now
+        private var offset: Duration = .zero
+
+        var read: @Sendable () -> ContinuousClock.Instant {
+            { [self] in lock.withLock { base + offset } }
+        }
+
+        func advance(by duration: Duration) {
+            lock.withLock { offset += duration }
+        }
+    }
+
+    /// A `HolderReader` over one end of a socketpair, never started — the same
+    /// shape `HolderRenderProjectionTests` uses, and for the same reason:
+    /// nothing on this path reads a tty's ioctls, and starting the drain would
+    /// only add a thread and a wait to a test whose whole subject is what the
+    /// emulator answers. `ingest` feeds the same emulator the drain loop feeds,
+    /// on the calling thread.
+    private struct Harness {
+        let reader: HolderReader
+        private let ours: Int32
+
+        init(
+            columns: Int, rows: Int,
+            monotonicNow: @escaping @Sendable () -> ContinuousClock.Instant = {
+                ContinuousClock.now
+            }
+        ) throws {
+            var pair: [Int32] = [-1, -1]
+            try #require(socketpair(AF_UNIX, SOCK_STREAM, 0, &pair) == 0)
+            ours = pair[1]
+            // The reader owns `pair[0]` and closes it in `tearDown`.
+            reader = HolderReader(
+                sessionID: UUID(),
+                ptyFD: pair[0],
+                columns: columns,
+                rows: rows,
+                scrollbackLines: 200,
+                monotonicNow: monotonicNow)
+        }
+
+        /// Closes this side only. The reader's own end is closed by its
+        /// `deinit`, which is safe precisely because the reader is `.idle`:
+        /// no thread was ever started, so none can be inside a read on it.
+        func tearDown() {
+            close(ours)
+        }
+    }
+}

--- a/Tests/TBDDaemonTests/HolderScreenContractTests.swift
+++ b/Tests/TBDDaemonTests/HolderScreenContractTests.swift
@@ -183,6 +183,33 @@ import Testing
         #expect(try await harness.reader.screen(maxLines: 8).cursor.visible == true)
     }
 
+    /// What a *reset* does to the tracked flag, pinned because the tracking is
+    /// by notification rather than by reading the emulator: a reset that
+    /// changed the cursor without saying so would leave this field disagreeing
+    /// with the terminal for as long as the session lived, and nothing else
+    /// here would notice.
+    ///
+    /// A soft reset (`DECSTR`, `CSI ! p`) shows the cursor and tells the
+    /// delegate, so the reading follows it out of hidden. A full reset (`RIS`,
+    /// `ESC c`) restores the visibility it found, so a hidden cursor stays
+    /// hidden across one. Both are asserted from hidden, which is the only
+    /// starting point at which either could diverge.
+    @Test("a soft reset shows the cursor and the tracking follows; a full reset preserves it")
+    func cursorVisibilityAcrossResets() async throws {
+        let harness = try Harness(columns: 40, rows: 8)
+        defer { harness.tearDown() }
+
+        await harness.reader.ingest(preamble: Self.data("\(Self.esc)[?25l"))
+        #expect(try await harness.reader.screen(maxLines: 8).cursor.visible == false)
+        await harness.reader.ingest(preamble: Self.data("\(Self.esc)[!p"))
+        #expect(try await harness.reader.screen(maxLines: 8).cursor.visible == true)
+
+        await harness.reader.ingest(preamble: Self.data("\(Self.esc)[?25l"))
+        #expect(try await harness.reader.screen(maxLines: 8).cursor.visible == false)
+        await harness.reader.ingest(preamble: Self.data("\(Self.esc)c"))
+        #expect(try await harness.reader.screen(maxLines: 8).cursor.visible == false)
+    }
+
     /// **A screen read must not feed the terminal.** This is the case that
     /// separates a tracked flag from a `DECRQM` probe.
     ///

--- a/Tests/TBDDaemonTests/HolderScreenContractTests.swift
+++ b/Tests/TBDDaemonTests/HolderScreenContractTests.swift
@@ -117,10 +117,10 @@ import Testing
         #expect(screen.cursor.column == 4)
     }
 
-    /// `cursorHidden` is not a public property, so visibility is a `DECRQM` 25
-    /// answer read through the collecting delegate. This is also what proves
-    /// that probe reaches the terminal at all: a reader that never asked would
-    /// report the default in both directions.
+    /// `cursorHidden` is not a public property, so visibility is tracked on the
+    /// delegate: SwiftTerm calls `showCursor`/`hideCursor` whenever the child
+    /// sets or resets mode 25. Asserted in both directions, because a reader
+    /// wired to the mode's default would satisfy either half alone.
     @Test("cursor visibility follows DECTCEM")
     func cursorVisibility() async throws {
         let harness = try Harness(columns: 40, rows: 8)
@@ -131,6 +131,42 @@ import Testing
         #expect(try await harness.reader.screen(maxLines: 8).cursor.visible == false)
         await harness.reader.ingest(preamble: Self.data("\(Self.esc)[?25h"))
         #expect(try await harness.reader.screen(maxLines: 8).cursor.visible == true)
+    }
+
+    /// **A screen read must not feed the terminal.** This is the case that
+    /// separates a tracked flag from a `DECRQM` probe.
+    ///
+    /// `screen` runs on every `terminal.output`, including against a reader
+    /// whose drain thread is mid-stream. SwiftTerm's parser carries its state
+    /// across `feed` calls and an `ESC` in any state aborts the pending
+    /// sequence, so a probe issued while the last read ended mid-sequence would
+    /// truncate the child's — routine, since a TUI repaint larger than the pty
+    /// buffer arrives split.
+    ///
+    /// Here the first ingest ends inside an SGR's parameters. Read the screen,
+    /// then deliver the rest: the halves must join and colour the `X`. A probe
+    /// would have aborted the `ESC[38;5;`, leaving `196m` to print as literal
+    /// text — so the whole line, not just its colour, is the assertion.
+    @Test("reading a screen does not abort a sequence split across two reads")
+    func readingDoesNotAbortASplitSequence() async throws {
+        let harness = try Harness(columns: 40, rows: 8)
+        defer { harness.tearDown() }
+
+        await harness.reader.ingest(preamble: Self.data("\(Self.esc)[?25l"))
+        await harness.reader.ingest(preamble: Self.data("\(Self.esc)[38;5;"))
+
+        // Reading mid-sequence answers with the visibility last set, and the
+        // half-parsed sequence has printed nothing.
+        let midParse = try await harness.reader.screen(maxLines: 8)
+        #expect(midParse.cursor.visible == false)
+        #expect(midParse.lines.isEmpty)
+
+        await harness.reader.ingest(preamble: Self.data("196mX"))
+        let screen = try await harness.reader.screen(maxLines: 8)
+        #expect(
+            screen.lines.first == "X",
+            "the split SGR did not complete — it printed as text: \(screen.lines)")
+        #expect(screen.cursor.visible == false)
     }
 
     // MARK: - viewportStart
@@ -197,10 +233,9 @@ import Testing
         #expect(try await harness.reader.screen(maxLines: 8).ageMilliseconds == 2_460_000)
     }
 
-    /// The cursor-visibility probe feeds the terminal a `DECRQM` query, and a
-    /// query the daemon asked its own emulator is not a byte the child sent. If
-    /// it counted, every read would reset the age it was taken to measure and
-    /// no screen could ever be reported stale.
+    /// A read is not a byte the child sent. If anything a read did counted,
+    /// every read would reset the age it was taken to measure and no screen
+    /// could ever be reported stale.
     @Test("reading a screen does not make the screen look fresher")
     func readingDoesNotResetTheAge() async throws {
         let clock = SteppedMonotonicClock()

--- a/Tests/TBDSharedTests/TerminalScreenTests.swift
+++ b/Tests/TBDSharedTests/TerminalScreenTests.swift
@@ -185,6 +185,24 @@ import Testing
         #expect(decoded.screen == screen, "the screen did not survive the round trip")
     }
 
+    /// The tmux arm's half of the same wire, and a contract a reader is told to
+    /// rely on: `TBDSkillContent` tells agents that a **missing** `screen` key
+    /// means a tmux-backed session. That reading is only sound while a nil
+    /// screen is omitted rather than encoded as `null` — an encoder configured
+    /// to write nulls would hand every tmux answer a `screen` key, and every
+    /// agent following the documented rule would read a tmux session as a
+    /// holder one whose screen it then cannot find.
+    @Test("the tmux arm's JSON omits the screen key rather than writing null")
+    func tmuxResultOmitsTheScreenKey() throws {
+        let data = try JSONEncoder().encode(TerminalOutputResult(output: "x"))
+        let object = try #require(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(object["output"] as? String == "x")
+        #expect(
+            object.keys.contains("screen") == false,
+            "a tmux answer carried a screen key, so a missing key no longer means tmux")
+    }
+
     /// The other half: whatever an `output` key on the wire says, the decoded
     /// value derives it from `lines`. A producer and a consumer can therefore
     /// never disagree, and a payload written before the key existed decodes the

--- a/Tests/TBDSharedTests/TerminalScreenTests.swift
+++ b/Tests/TBDSharedTests/TerminalScreenTests.swift
@@ -10,7 +10,9 @@ import Testing
 /// consumer that matches on text and would silently fail to find the characters
 /// on either side of it — the failure mode measured in the field as 1,595
 /// invisible `U+0000` cells nobody had noticed. And **`output` is derived**, so
-/// it can never disagree with `lines` however it arrived.
+/// it can never disagree with `lines` however it arrived — including on the
+/// wire, where the screen carries only `lines` and the joined string a script
+/// reads sits at the top level of `TerminalOutputResult`.
 ///
 /// The NUL-to-space projection itself is deliberately *not* here. It belongs to
 /// whichever store rendered the grid, and is pinned on the constructed value in
@@ -146,24 +148,41 @@ import Testing
         #expect(try Self.make(lines: ["ok"], ageMilliseconds: 0).ageMilliseconds == 0)
     }
 
-    // MARK: - `output` is derived, and it is on the wire
+    // MARK: - `output` is derived, and it is not on the screen's wire
 
     @Test("output is the lines joined with newlines")
     func outputIsDerived() throws {
         #expect(try Self.make(lines: ["one", "two", "three"]).output == "one\ntwo\nthree")
     }
 
-    /// Scripts read `tbd terminal output --json` and pull `.output` out of it.
-    /// A computed property would never reach the wire, so the encoder writes it
-    /// explicitly — and this is what would go red if that were dropped as
-    /// redundant.
-    @Test("output appears in the encoded JSON beside lines")
-    func outputIsEncoded() throws {
+    /// The screen ships its text once. `lines` is the text; the joined string a
+    /// script reads rides at the top level of `TerminalOutputResult`, and a copy
+    /// inside the screen object would put the same characters on the wire a
+    /// second time for no consumer at all.
+    @Test("the encoded screen carries lines and no output copy of them")
+    func outputIsNotEncodedInsideTheScreen() throws {
         let data = try JSONEncoder().encode(try Self.make(lines: ["alpha", "beta"]))
         let object = try #require(
             try JSONSerialization.jsonObject(with: data) as? [String: Any])
-        #expect(object["output"] as? String == "alpha\nbeta")
+        #expect(object["output"] == nil, "the screen encoded a redundant copy of its text")
         #expect(object["lines"] as? [String] == ["alpha", "beta"])
+    }
+
+    /// The compatibility half, and the reason the copy above can go: a script
+    /// that reads `.output` out of `tbd terminal output --json` still finds it,
+    /// at the top level, saying exactly what the screen's lines say.
+    @Test("the result's JSON carries a top-level output equal to the screen's")
+    func resultCarriesTopLevelOutput() throws {
+        let screen = try Self.make(lines: ["alpha", "beta"])
+        let data = try JSONEncoder().encode(TerminalOutputResult(screen: screen))
+        let object = try #require(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(object["output"] as? String == screen.output)
+        #expect(object["output"] as? String == "alpha\nbeta")
+
+        let decoded = try JSONDecoder().decode(TerminalOutputResult.self, from: data)
+        #expect(decoded.output == "alpha\nbeta")
+        #expect(decoded.screen == screen, "the screen did not survive the round trip")
     }
 
     /// The other half: whatever an `output` key on the wire says, the decoded

--- a/Tests/TBDSharedTests/TerminalScreenTests.swift
+++ b/Tests/TBDSharedTests/TerminalScreenTests.swift
@@ -84,6 +84,55 @@ import Testing
         #expect(screen.output == "name\tvalue")
     }
 
+    // MARK: - The predicate the render and the initializer share
+
+    /// **The whitelist is one predicate with two call sites**, and this pins the
+    /// half the initializer cannot: what a render is to substitute for.
+    ///
+    /// A render that owned its own copy of the rule would drift, and the shape
+    /// of the drift is a render letting through exactly what the initializer
+    /// throws on — a session whose every `terminal.output` fails until the
+    /// offending line leaves the scrollback. That is not hypothetical: the
+    /// holder render mapped `U+0000` alone, and a `DEL` is a byte a child can
+    /// put in a cell. So the predicate is public, the render reads it, and this
+    /// pins it over the whole excluded set rather than over the one scalar that
+    /// happens to be reachable through today's emulator.
+    @Test(
+        "isDisallowed names exactly the scalars a screen line may not hold",
+        arguments: [
+            (UInt32(0x00), true),  // NUL — a never-written cell the render must fill
+            (0x07, true),  // C0
+            (0x0a, true),  // a newline is a lost row boundary
+            (0x1f, true),  // the top of the C0 band
+            (0x7f, true),  // DEL — the one a child can currently store
+            (0x80, true),  // the bottom of the C1 band
+            (0x9b, true),  // C1
+            (0x9f, true),  // the top of the C1 band
+            (0x09, false),  // tab, the one control a line may hold
+            (0x20, false),  // space
+            (0x41, false),  // A
+            (0x7e, false),  // ~, the last printable ASCII
+            (0xa0, false),  // just past C1
+            (0x65e5, false),  // 日 — a wide glyph is not a control
+        ])
+    func isDisallowedNamesTheExcludedSet(scalar: UInt32, disallowed: Bool) throws {
+        let unicode = try #require(Unicode.Scalar(scalar))
+        #expect(
+            TerminalScreen.isDisallowed(unicode) == disallowed,
+            "U+\(String(format: "%04X", scalar)) was judged \(!disallowed ? "disallowed" : "allowed")")
+
+        // And the initializer agrees, which is what makes them one rule rather
+        // than two that happen to match today.
+        let line = "a\(Character(unicode))b"
+        if disallowed {
+            #expect(throws: TerminalScreen.ValidationError.self) {
+                _ = try Self.make(lines: [line])
+            }
+        } else {
+            #expect(try Self.make(lines: [line]).lines == [line])
+        }
+    }
+
     @Test("a negative age is refused")
     func negativeAgeIsRefused() throws {
         let error = #expect(throws: TerminalScreen.ValidationError.self) {

--- a/Tests/TBDSharedTests/TerminalScreenTests.swift
+++ b/Tests/TBDSharedTests/TerminalScreenTests.swift
@@ -1,0 +1,194 @@
+import Foundation
+import Testing
+
+@testable import TBDShared
+
+/// What `TerminalScreen` promises about any value that exists at all.
+///
+/// Two properties, both structural. **The whitelist is enforced at
+/// construction**, so a row carrying a control character cannot be shipped to a
+/// consumer that matches on text and would silently fail to find the characters
+/// on either side of it — the failure mode measured in the field as 1,595
+/// invisible `U+0000` cells nobody had noticed. And **`output` is derived**, so
+/// it can never disagree with `lines` however it arrived.
+///
+/// The NUL-to-space projection itself is deliberately *not* here. It belongs to
+/// whichever store rendered the grid, and is pinned on the constructed value in
+/// `HolderScreenContractTests`; here a NUL is simply refused like any other
+/// control character, which is what makes a projection that forgot it loud.
+@Suite struct TerminalScreenTests {
+
+    private static func make(
+        lines: [String],
+        viewportStart: Int = 0,
+        source: TerminalScreen.Source = .daemon,
+        ageMilliseconds: Int = 0
+    ) throws -> TerminalScreen {
+        try TerminalScreen(
+            lines: lines,
+            viewportStart: viewportStart,
+            cursor: TerminalScreen.Cursor(row: 0, column: 0, visible: true),
+            size: TerminalScreen.Size(columns: 80, rows: 24),
+            modes: TerminalScreen.ChildModes(
+                bracketedPaste: false, applicationCursor: false, alternateScreen: false),
+            source: source,
+            ageMilliseconds: ageMilliseconds)
+    }
+
+    // MARK: - The whitelist
+
+    /// The projection's job is to turn a never-written cell into a space. One
+    /// arriving here means it did not, so the boundary refuses rather than
+    /// passing on a hole nothing displays.
+    @Test("a NUL is refused, and the error names the line it was on")
+    func nulIsRefused() throws {
+        let error = #expect(throws: TerminalScreen.ValidationError.self) {
+            _ = try Self.make(lines: ["fine", "also fine", "bro\u{0}ken"])
+        }
+        #expect(error == .disallowedCharacter(lineIndex: 2, scalar: 0))
+        // The line index is in the text a reader sees, not only in the value —
+        // it is the whole of what makes the projection bug findable.
+        #expect(error?.description.contains("line 2") == true)
+        #expect(error?.description.contains("U+0000") == true)
+    }
+
+    @Test("any other control character is refused, named by line and scalar")
+    func controlCharactersAreRefused() throws {
+        // One from each excluded band: C0, DEL, and C1.
+        for (scalar, line) in [(UInt32(0x07), "bel\u{7}l"), (0x7f, "de\u{7f}l"), (0x9b, "c\u{9b}1")] {
+            let error = #expect(throws: TerminalScreen.ValidationError.self) {
+                _ = try Self.make(lines: ["clean", line])
+            }
+            #expect(error == .disallowedCharacter(lineIndex: 1, scalar: scalar))
+            #expect(error?.description.contains("line 1") == true)
+        }
+    }
+
+    /// A newline in a *line* is a projection that lost track of its rows, so it
+    /// is refused with everything else in the C0 band.
+    @Test("a newline inside a line is refused")
+    func newlineInsideALineIsRefused() throws {
+        let error = #expect(throws: TerminalScreen.ValidationError.self) {
+            _ = try Self.make(lines: ["two\nrows"])
+        }
+        #expect(error == .disallowedCharacter(lineIndex: 0, scalar: 0x0a))
+    }
+
+    /// Tab is the one control a line may hold: a program laying a screen out
+    /// with tabs is doing something a reader can see, and stripping them would
+    /// move every column after one.
+    @Test("a tab is allowed through")
+    func tabIsAllowed() throws {
+        let screen = try Self.make(lines: ["name\tvalue"])
+        #expect(screen.lines == ["name\tvalue"])
+        #expect(screen.output == "name\tvalue")
+    }
+
+    @Test("a negative age is refused")
+    func negativeAgeIsRefused() throws {
+        let error = #expect(throws: TerminalScreen.ValidationError.self) {
+            _ = try Self.make(lines: ["ok"], ageMilliseconds: -1)
+        }
+        #expect(error == .negativeAge(milliseconds: -1))
+    }
+
+    @Test("an age of zero is a well-formed answer, not a refusal")
+    func zeroAgeIsAllowed() throws {
+        #expect(try Self.make(lines: ["ok"], ageMilliseconds: 0).ageMilliseconds == 0)
+    }
+
+    // MARK: - `output` is derived, and it is on the wire
+
+    @Test("output is the lines joined with newlines")
+    func outputIsDerived() throws {
+        #expect(try Self.make(lines: ["one", "two", "three"]).output == "one\ntwo\nthree")
+    }
+
+    /// Scripts read `tbd terminal output --json` and pull `.output` out of it.
+    /// A computed property would never reach the wire, so the encoder writes it
+    /// explicitly — and this is what would go red if that were dropped as
+    /// redundant.
+    @Test("output appears in the encoded JSON beside lines")
+    func outputIsEncoded() throws {
+        let data = try JSONEncoder().encode(try Self.make(lines: ["alpha", "beta"]))
+        let object = try #require(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(object["output"] as? String == "alpha\nbeta")
+        #expect(object["lines"] as? [String] == ["alpha", "beta"])
+    }
+
+    /// The other half: whatever an `output` key on the wire says, the decoded
+    /// value derives it from `lines`. A producer and a consumer can therefore
+    /// never disagree, and a payload written before the key existed decodes the
+    /// same as one written after.
+    @Test("decoding ignores any output on the wire and re-derives it from lines")
+    func decodingIgnoresWireOutput() throws {
+        let cursor = #"{"row":1,"column":2,"visible":true}"#
+        let size = #"{"columns":80,"rows":24}"#
+        let modes =
+            #"{"bracketedPaste":true,"applicationCursor":false,"alternateScreen":false}"#
+
+        let lying = """
+            {"lines":["alpha","beta"],"viewportStart":0,"cursor":\(cursor),"size":\(size),\
+            "modes":\(modes),"source":"daemon","ageMilliseconds":5,"output":"NOT THE LINES"}
+            """
+        let fromLie = try JSONDecoder().decode(
+            TerminalScreen.self, from: Data(lying.utf8))
+        #expect(fromLie.output == "alpha\nbeta")
+
+        let withoutOutput = """
+            {"lines":["alpha","beta"],"viewportStart":0,"cursor":\(cursor),"size":\(size),\
+            "modes":\(modes),"source":"daemon","ageMilliseconds":5}
+            """
+        let fromAbsence = try JSONDecoder().decode(
+            TerminalScreen.self, from: Data(withoutOutput.utf8))
+        #expect(fromAbsence.output == "alpha\nbeta")
+        #expect(fromAbsence == fromLie, "the wire's output changed the decoded value")
+    }
+
+    // MARK: - The fields a string could not carry
+
+    /// A round trip through JSON is the shape every consumer actually meets,
+    /// and `source` is the field a consumer's whole policy is keyed on.
+    @Test("source and age survive a round trip")
+    func sourceAndAgeRoundTrip() throws {
+        let screen = try Self.make(
+            lines: ["idle"], source: .staleDaemon, ageMilliseconds: 2_460_000)
+        let decoded = try JSONDecoder().decode(
+            TerminalScreen.self, from: try JSONEncoder().encode(screen))
+        #expect(decoded.source == .staleDaemon)
+        #expect(decoded.ageMilliseconds == 2_460_000)
+        #expect(decoded == screen)
+    }
+
+    /// `viewportStart` is an index into `lines` and may fall outside it in both
+    /// directions — negative when the requested tail cut inside the viewport,
+    /// and equal to `lines.count` when the whole viewport was blank rows the
+    /// trim dropped. Both are well-formed, and a type that refused them would
+    /// refuse two ordinary reads.
+    @Test("viewportStart may sit outside the lines it indexes")
+    func viewportStartMayFallOutsideLines() throws {
+        #expect(try Self.make(lines: ["a", "b"], viewportStart: -3).viewportStart == -3)
+        #expect(try Self.make(lines: ["a", "b"], viewportStart: 2).viewportStart == 2)
+    }
+
+    /// The input path takes a narrower view of the same observation, and it
+    /// must be the *same* observation — modes paired with the provenance and
+    /// age of the store they came from, never with another's.
+    @Test("modeReading carries this screen's modes, source and age")
+    func modeReadingMirrorsTheScreen() throws {
+        let screen = try TerminalScreen(
+            lines: ["x"],
+            viewportStart: 0,
+            cursor: TerminalScreen.Cursor(row: 0, column: 0, visible: true),
+            size: TerminalScreen.Size(columns: 80, rows: 24),
+            modes: TerminalScreen.ChildModes(
+                bracketedPaste: true, applicationCursor: true, alternateScreen: false),
+            source: .staleDaemon,
+            ageMilliseconds: 41)
+        #expect(
+            screen.modeReading
+                == TerminalModeReading(
+                    modes: screen.modes, source: .staleDaemon, ageMilliseconds: 41))
+    }
+}

--- a/docs/specs/2026-08-30-pty-holder-session-transport-design.md
+++ b/docs/specs/2026-08-30-pty-holder-session-transport-design.md
@@ -415,14 +415,15 @@ already written directly is recorded and dropped, never used to retract or
 dedupe the write that happened; acking before writing would trade a visible
 duplicate for exactly the invisible loss this rejects.
 
-One attached state does not fail open. Once a viewer has *acknowledged* its
-attach, the daemon has released its reader and closed its descriptor, so a
-fallback has nothing to write to and the sender is told the send did not land.
-Nothing is lost silently — the caller is told and the actuation row records a
-transport failure — but there the fallback is a report rather than a write.
-Closing it means the daemon keeping a **write-only** dup across an attach; the
+The fallback has a descriptor to write to in every attached state, because
+the daemon's reader is retained across an attach rather than released at the
+acknowledgement: it is suspended, off the pty, and still holding its dup. The
 one-reader invariant is about readers, and multiple writers to a master are
-fine.
+fine. That retention is also what keeps the daemon's emulator available as
+the frozen-at-attach store described under "Two stores, reconciled on demand"
+below, and the emulator's modes are what
+[`2026-09-05-child-as-contract-party-design.md`](2026-09-05-child-as-contract-party-design.md)
+composes input against.
 
 The viewer's half of the arrangement is what keeps an injection out of a
 paste's markers. Its outgoing queue is the only place that sees both the

--- a/docs/specs/2026-09-05-child-as-contract-party-design.md
+++ b/docs/specs/2026-09-05-child-as-contract-party-design.md
@@ -212,12 +212,12 @@ design builds is the pull the model has always required.
 - **Viewer holds the pty and does not answer** – the pull is bounded on an
   injected clock. On expiry the daemon answers from the emulator it suspended
   at attach, `source: .staleDaemon`, `age` per the one rule above. The
-  emulator is retained across an attach for exactly this — it is not stopped
-  at the acknowledgement, only suspended, which is what the transport spec's
-  "frozen-at-attach" fallback assumed and the current release path does not
-  do (`HolderRegistry.swift:1416-1431` stops it). The memory cost is one
-  emulator per attached session, which is the cost the transport spec already
-  budgeted for every session.
+  emulator is retained across an attach for exactly this — the acknowledgement
+  suspends the daemon's reader and never stops it
+  (`HolderRegistry.confirmAttach`), which is what the transport spec's
+  "frozen-at-attach" fallback assumes. The memory cost is one emulator per
+  attached session, which is the cost the transport spec already budgeted for
+  every session.
 - **No reader at all** – the session is gone or never adopted. An error, as
   today, and the error says which.
 
@@ -598,7 +598,7 @@ two entries struck.
   only pushes deltas today; a request-reply pair on it is a new direction on
   a channel with no reply discipline, where the sidecar already has one
   (`injection` / `injectionAck`).
-- **Stop the daemon's emulator at attach, as today.** Makes `staleDaemon` an
+- **Stop the daemon's emulator at attach.** Makes `staleDaemon` an
   empty screen with an age — honest and useless. Suspending it costs one
   emulator per attached session, which the transport spec budgets for every
   session regardless.

--- a/docs/specs/2026-09-05-child-as-contract-party-design.md
+++ b/docs/specs/2026-09-05-child-as-contract-party-design.md
@@ -165,9 +165,15 @@ stale (`2026-08-30-pty-holder-session-transport-design.md:548-553`).
   For `viewer`, the app reports its own monotonic interval since its last
   byte and the daemon forwards it; the interval is a duration, so no clock
   has to be shared.
-- **`output: String`** – the lines joined with `\n`, kept for one reason:
-  scripts and skills read `tbd terminal output` today and the CLI prints it.
-  It is derived from `lines` and carries no information of its own.
+
+The screen is one field short of that list. **`output: String`** — the lines
+joined with `\n` — is kept for one reason, that scripts and skills read `tbd
+terminal output` today and the CLI prints it, and it lives at the top level of
+`TerminalOutputResult` rather than inside the screen: it is derived from
+`lines`, carries no information of its own, and a copy nested in the screen
+would put the same characters on the wire twice over for no consumer at all.
+The Swift-side screen exposes it as a computed property, so one derivation
+serves both.
 
 The typed screen is the answer of the existing `terminal.output` method, not
 a sibling method beside it. A second method would leave the first one


### PR DESCRIPTION
## Summary

A message sent to a holder-backed agent session lands in the agent's composer and never submits. The text is there, the trailing Enter is not, and nothing reports it: the transport's record reads `dispatched`, the agent sits idle looking healthy, and the sender believes it delivered. This hit live sessions six times in one day, each costing an orchestrator a full cycle to notice. One instance showed the message absorbed as a paste attachment (`[Pasted text #3 +2 lines]`), never submitted.

The cause is that the holder arm composes input blind. The daemon writes body and `\r` as one chunk, and an agent TUI's paste-burst heuristic keys on the shape of a chunk, so a multi-line message swallows its own Enter. tmux never had this problem because it tracked the pane's bracketed-paste mode and pasted inside explicit markers. This PR gives the daemon the same knowledge: `terminal.output` now answers a typed screen that carries the child's modes, and the send path composes against those modes, wrapping the body in `ESC[200~`…`ESC[201~` with the `\r` after the end marker whenever the child has bracketed paste on. A child that never asked for bracketing still gets bare bytes.

This is the first slice of the design, and the limit of the slice is worth stating plainly. A session nobody has open answers from the daemon's live emulator and is composed against current modes. A session a viewer holds answers from the daemon's emulator as it stood when the viewer attached, labelled `staleDaemon` with its age, and sends to it are composed against those at-attach modes. The live pull from the viewer (`screenRequest`/`screenReply`, which produces `source: viewer`), named keys, and delivery verification on the holder arm are the following slices.

## Why this shape

Spec: [`docs/specs/2026-09-05-child-as-contract-party-design.md`](docs/specs/2026-09-05-child-as-contract-party-design.md), ruled on by a human. The decisions this slice rests on:

- **Wrap inside one message rather than split the Enter into a second write.** A second write reintroduces a message straddling a routing decision, which "one message" exists to prevent, and leaves the composer blind to bracketing. Wrapping keeps atomicity and fixes the cause.
- **Proceed on stale modes and record the source, rather than refuse.** A viewer that holds the pty is an app that may be napping or busy, which is exactly when supervision needs to send. A refusal would make every rail fail closed at those moments. A stale-mode send can mis-paste visibly; it cannot vanish. The actuation outcome row records `modeSource` and the age of the answering emulator, so a later reader can tell a guess from a fact.
- **Retain the daemon's emulator across an attach instead of stopping it.** The transport spec's frozen-at-attach fallback assumed this and the code did not do it. Suspended, not stopped: one emulator per attached session, which the transport spec already budgeted for every session.
- **The typed screen is the existing method's answer, not a sibling method.** The result's top-level `output` stays on the wire, derived from the whitelisted lines, so every script reading `tbd terminal output` keeps working. The tmux arm carries no screen because capture-pane carries no modes or source; fabricating one would be worse than omitting it.
- **A send with no emulator to consult composes bare bytes and records `unavailable`.** With a registry present, no reader means the session is gone or never adopted, so the courier's write fails and says so. The composition step records what it composed against; the courier decides deliverability.

## What this PR does

- `HolderRegistry.confirmAttach` leaves the reader suspended in its slot instead of stopping it. Handback and dead-app seizure resume that reader rather than opening a fresh hand-over, so a handback no longer needs the holder's socket. The injection courier's fail-open fallback now has a descriptor in every attached state. Doc comments across the registry, courier, attach handler and panel were rewritten to state this.
- New `TerminalScreen` in `TBDShared`: whitelisted printable lines, `viewportStart`, cursor with visibility, size, child modes (`bracketedPaste`, `applicationCursor`, `alternateScreen`), `source` (`daemon` / `viewer` / `staleDaemon`), `ageMilliseconds` on the daemon's monotonic clock, and a derived `output` that stays a Swift-side convenience: on the wire the text travels once, in `lines`, and once more as the result's top-level `output` for the scripts that read it today. The constructor refuses control characters as a guard against projection bugs; the render is where a never-written cell becomes a space and a DEL byte a child stored becomes a replacement glyph, through the same predicate (C1 scalars were measured never to reach a cell in this SwiftTerm fork, but the substitution covers every disallowed scalar so a width-table change cannot reopen the read).
- `tbd terminal output` keeps printing the screen text on stdout and, when the answer is not the live emulator, writes one note to stderr naming the source and age, so a stale screen is never mistaken for a current one and scripts reading stdout are unaffected. The agent-facing skill text now tells an agent that a session someone has open answers from the at-attach store and that `--json` carries `screen.source` and `screen.ageMilliseconds` to check before acting on what it read.
- `HolderRegistry.spawn` now counts its drain loop the way an adoption does, through one shared publish helper. Before, a spawned session drove the live-loop counter negative on release, so the double-reader instrument could not see a second loop beside a spawned session. Pre-existing, surfaced because this branch's new tests assert on those counters.
- `TerminalOutputResult` gains `screen: TerminalScreen?`, filled on the holder arm. `HolderReader.screen(maxLines:)` and `modeReading()` project the emulator under its lock; `source` comes from the reader's own drain state. Cursor visibility is tracked from SwiftTerm's `showCursor`/`hideCursor` delegate calls rather than probed, because a DECRQM probe fed into a live parser can abort a sequence split across a read.
- `HolderSendComposition.compose` is the pure composition, and it strips any paste marker embedded in the body in both modes, since a marker is never content a child can display, inside a paste it can only break out or restart the paste, and under a stale mode reading a bare start marker could open a paste nothing closes; `performHolderSend` consults the mode oracle before composing and records `modeSource` and `modeAgeMilliseconds` on the outcome row. `ActuationRow` gains those two fields, spelled identically to the screen's `source`.
- The transport spec's paragraph claiming the acknowledged-attach state has no fallback descriptor is rewritten to the current design.

## Flag & rollout

No new flag. The change corrects the path that `pty_holder_enabled` already wraps, which has never shipped on; a second column would keep selectable a quadrant known to stall agents (the reasoning the single-typist spec gives for its own gate). No new durable resource is introduced: the retained emulator is daemon memory released with the session's reader.

## Assumptions

- Assumes an agent TUI sets bracketed paste once at startup and leaves it, so a `staleDaemon` answer is usually right. If a child toggles the mode while a viewer holds the pty, the send mis-pastes visibly and the row says the modes were stale.
- Assumes SwiftTerm's line list is always `yBase + rows` long, so the viewport is its tail. `viewportStart` is derived from that length because `yBase` is not public. If the fork changes that invariant, `viewportStart` drifts.
- Cursor visibility is a tracked fact, not a probed one: it follows SwiftTerm's `showCursor`/`hideCursor` delegate calls, so it is only as good as what the emulator announces. In the pinned fork both resets behave: a soft reset announces the cursor it re-shows, and a hard reset preserves the mode. A test pins both, so a fork update that dropped either announcement would redden rather than freeze reads on a hidden cursor.

## Evidence & verification

- **Composition on exact bytes.** `HolderSendCompositionTests` compares whole `Data` values: start marker, body, end marker, then `\r`; the negative case yields bare body and `\r` with no marker bytes; an empty body is never wrapped; an embedded start or end marker, including one that would re-form across a removal, is stripped and each marker occurs exactly once.
- **Wiring through the router.** `HolderTmuxAssumptionGateTests` drives `terminal.send` with the oracle answering bracketed paste on, off, `staleDaemon` at 41 minutes, and absent. Each asserts the courier receives exactly one write with the expected bytes and that the outcome row carries the matching `modeSource` and age.
- **The typed screen.** `TerminalScreenTests` covers the whitelist, the derived and encoded `output`, and decoding without it. `HolderScreenContractTests` drives a real emulator: NUL cells as spaces, a DEL as a replacement glyph, wide-glyph trailing halves omitted, all three modes in both directions, cursor position and visibility across both resets, `viewportStart` with scrollback and past the line count, age from adoption and from the last byte, and a split CSI that must survive a screen read. That last test was run against the probing implementation and failed as expected.
- **Retention.** Live suites assert the reader is retained and not draining after an acknowledgement, answers `staleDaemon` with the at-attach content, and answers `daemon` again after a handback; a handback succeeds with the holder's rendezvous socket unlinked; a dead-app seizure resumes the same reader with no second drain loop.
- Filtered runs of the unit and live suites passed, and `swiftlint --strict` reports no violations. Not built in this PR: the end-to-end paste-burst test against a raw-mode child, which needs a child that implements the burst heuristic and is left for the verification slice.

https://claude.ai/code/session_01N4itvGZ5F5C5YoGxGsAGo9

[20260905-elated-meadowlark](https://cheapsteak.github.io/tbd/open/?worktree=EAD1059F-189A-45B7-9B8E-EE25767EF478)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal output now includes structured screen data, including cursor, viewport, terminal modes, source, and screen age.
  * Terminal input honors bracketed-paste mode and records mode provenance.
  * Viewer-held sessions retain screen information and recover more reliably during handoff or application exit.

* **Bug Fixes**
  * Improved terminal rendering for unsupported control characters and empty cells.
  * More precise errors distinguish unavailable, transitioning, and previously unadopted sessions.
  * Improved recovery when viewer handoff or application connections end unexpectedly.

* **Documentation**
  * Updated terminal output guidance to explain stale data, metadata, and tmux-specific behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->