### PR TITLE
Fix: A message sent to a terminal whose Claude has exited is refused, not run as a shell command

### DIFF
--- a/Sources/TBDApp/AppState+Hibernation.swift
+++ b/Sources/TBDApp/AppState+Hibernation.swift
@@ -311,9 +311,16 @@ extension AppState {
     /// the worktree. They wake only via the explicit affordances (parked-pane
     /// click, Wake menu). nil-reason (legacy), auto, and recovery parks still
     /// focus-wake.
+    ///
+    /// Exit-stamped sessions (`hibernateReason == .exited`) are excluded for a
+    /// different reason: `stampSessionExited` writes only two DB columns and
+    /// never replaces the pane with an inert placeholder the way every other
+    /// park path does, so a focus-wake would run `tmux respawn-window -k`
+    /// against the live shell Claude's exit left behind — killing it. They
+    /// wake only via the same explicit affordances as `.manual`.
     func terminalIDToWakeOnFocus(worktreeID: UUID) -> UUID? {
         let parked = (terminals[worktreeID] ?? []).filter {
-            $0.isParked && $0.isClaudeResumable && $0.hibernateReason != .manual
+            $0.isParked && $0.isClaudeResumable && $0.hibernateReason != .manual && $0.hibernateReason != .exited
         }
         guard !parked.isEmpty else { return nil }
         if let focusedID = terminalIDForAutofocus(worktreeID: worktreeID),
@@ -329,12 +336,21 @@ extension AppState {
     /// when the tab has no terminals, none are parked, or none are resumable.
     /// Called by `setActiveTab` to wake only what the user is about to see,
     /// never a parallel spawn storm.
+    ///
+    /// Excludes `.manual` (an explicit "Hibernate now" must not be undone by
+    /// tab activation) AND `.exited` (`stampSessionExited` never replaces the
+    /// pane with an inert placeholder, so waking it would `respawn-window -k`
+    /// the live shell Claude's exit left behind — killing it). Both wake only
+    /// via explicit affordances.
     func terminalIDsToWakeOnTabActivation(worktreeID: UUID, tabIndex: Int) -> [UUID] {
         guard let worktreeTabs = tabs[worktreeID], worktreeTabs.indices.contains(tabIndex) else { return [] }
         let tab = worktreeTabs[tabIndex]
         let terminalIDsInTab = terminalIDs(in: tab)
         return (terminals[worktreeID] ?? [])
-            .filter { terminalIDsInTab.contains($0.id) && $0.isParked && $0.isClaudeResumable && $0.hibernateReason != .manual }
+            .filter {
+                terminalIDsInTab.contains($0.id) && $0.isParked && $0.isClaudeResumable
+                    && $0.hibernateReason != .manual && $0.hibernateReason != .exited
+            }
             .map { $0.id }
     }
 }

--- a/Sources/TBDApp/AppState+Hibernation.swift
+++ b/Sources/TBDApp/AppState+Hibernation.swift
@@ -59,15 +59,15 @@ extension AppState {
     /// wraps this. `fallbackToDefaultProfile` opts into the ambient default login
     /// when the pinned profile is gone (used by the fallback retry).
     func wakeTerminalOutcome(terminalID: UUID, worktreeID: UUID, userInitiated: Bool,
-                             fallbackToDefaultProfile: Bool) async -> WakeAttemptOutcome {
+                             fallbackToDefaultProfile: Bool,
+                             prompt: String? = nil) async -> WakeAttemptOutcome {
         guard !wakeInFlight.contains(terminalID) else { return .ok }  // in-flight dedupe = benign no-op
         wakeInFlight.insert(terminalID)
         defer { wakeInFlight.remove(terminalID) }
         do {
             let size = mainAreaTerminalSize()
-            try await daemonClient.terminalWake(
-                terminalID: terminalID, cols: size.cols, rows: size.rows,
-                fallbackToDefaultProfile: fallbackToDefaultProfile)
+            try await terminalWakeSender(
+                terminalID, size.cols, size.rows, fallbackToDefaultProfile, prompt)
             await refreshTerminals(worktreeID: worktreeID)
             return .ok
         } catch {
@@ -103,9 +103,11 @@ extension AppState {
     /// windows) fired a modal per parked terminal. `userInitiated` drives the
     /// failure log level (explicit action → error; background → warning).
     @discardableResult
-    func wakeTerminal(terminalID: UUID, worktreeID: UUID, userInitiated: Bool) async -> String? {
+    func wakeTerminal(terminalID: UUID, worktreeID: UUID, userInitiated: Bool,
+                      prompt: String? = nil) async -> String? {
         switch await wakeTerminalOutcome(terminalID: terminalID, worktreeID: worktreeID,
-                                         userInitiated: userInitiated, fallbackToDefaultProfile: false) {
+                                         userInitiated: userInitiated,
+                                         fallbackToDefaultProfile: false, prompt: prompt) {
         case .ok: return nil
         case .failed(let m): return m
         case .profileMissing(_, _, let m): return m

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -1445,6 +1445,17 @@ final class AppState {
         { [daemonClient] enabled in
             try await daemonClient.setHolderHibernationEnabled(enabled: enabled)
         }
+    /// How `wakeTerminalOutcome` reaches the daemon — injectable for the same
+    /// reason as `controlModeSetter`, so the wake's prompt plumbing and its
+    /// failure branches are testable without a running daemon.
+    @ObservationIgnored
+    lazy var terminalWakeSender:
+        @MainActor (UUID, Int?, Int?, Bool, String?) async throws -> Void =
+        { [daemonClient] terminalID, cols, rows, fallback, prompt in
+            try await daemonClient.terminalWake(
+                terminalID: terminalID, cols: cols, rows: rows,
+                fallbackToDefaultProfile: fallback, prompt: prompt)
+        }
     /// How `setClaudeCloudEnabled` persists the Claude cloud gate — injectable
     /// for the same reason as `controlModeSetter`, so the Settings toggle's
     /// success and failure branches are testable without a real daemon.

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -1632,10 +1632,21 @@ actor DaemonClient {
 
     /// Wake a hibernated terminal: respawn `claude --resume` in its window.
     /// Idempotent — a double-call collapses to one respawn daemon-side.
-    func terminalWake(terminalID: UUID, cols: Int? = nil, rows: Int? = nil, fallbackToDefaultProfile: Bool = false) async throws {
+    ///
+    /// `prompt` is delivered as a trailing argv on `claude --resume`, atomic with
+    /// the respawn, so it reaches ONLY a session this call actually woke. On the
+    /// idempotent no-op paths (already awake, wake already in flight) the daemon
+    /// returns `woken: false` and delivers nothing — which is what makes the
+    /// parameter safe to pass from a UI that may be racing a background wake.
+    func terminalWake(
+        terminalID: UUID, cols: Int? = nil, rows: Int? = nil,
+        fallbackToDefaultProfile: Bool = false, prompt: String? = nil
+    ) async throws {
         try await callVoidAsync(
             method: RPCMethod.terminalWake,
-            params: TerminalWakeParams(terminalID: terminalID, cols: cols, rows: rows, fallbackToDefaultProfile: fallbackToDefaultProfile)
+            params: TerminalWakeParams(
+                terminalID: terminalID, cols: cols, rows: rows,
+                fallbackToDefaultProfile: fallbackToDefaultProfile, prompt: prompt)
         )
     }
 

--- a/Sources/TBDApp/Terminal/TerminalContainerView.swift
+++ b/Sources/TBDApp/Terminal/TerminalContainerView.swift
@@ -407,6 +407,8 @@ enum HibernatedBannerModel {
             return "Parked after a restart — click anywhere in the pane to resume"
         case .merged:
             return "Hibernated after the PR merged — click anywhere in the pane to resume"
+        case .exited:
+            return "Claude exited — click anywhere in the pane to resume"
         case .auto, nil:
             return "Hibernated while idle — click anywhere in the pane to resume"
         }

--- a/Sources/TBDCLI/Commands/SessionEndCommand.swift
+++ b/Sources/TBDCLI/Commands/SessionEndCommand.swift
@@ -42,16 +42,18 @@ struct SessionEndCommand: AsyncParsableCommand {
 
     mutating func run() async throws {
         let environment = ProcessInfo.processInfo.environment
+
+        // Read stdin BEFORE any early return, including the terminal-ID guard
+        // below: Claude Code pipes the payload and waits on the write, so a
+        // command that exits without draining it can leave the hook's writer
+        // blocked on a full pipe until its timeout.
+        let reason = Self.hookReason(from: FileHandle.standardInput.readDataToEndOfFile())
+
         guard let terminalIDString = environment["TBD_TERMINAL_ID"],
               let terminalID = UUID(uuidString: terminalIDString) else {
             sessionEndLogger.debug("suppressed reason=noTerminalID")
             return
         }
-
-        // Read stdin BEFORE the daemon check: Claude Code pipes the payload and
-        // waits on the write, so a command that exits without draining it can
-        // leave the hook's writer blocked on a full pipe until its timeout.
-        let reason = Self.hookReason(from: FileHandle.standardInput.readDataToEndOfFile())
 
         let client = SocketClient()
         guard client.isDaemonRunning else {

--- a/Sources/TBDCLI/Commands/SessionEndCommand.swift
+++ b/Sources/TBDCLI/Commands/SessionEndCommand.swift
@@ -6,7 +6,8 @@ import TBDShared
 private let sessionEndLogger = Logger(subsystem: "com.tbd.cli", category: "sessionEnd")
 
 /// Bridges Claude Code's `SessionEnd` hook into TBD so a session that exits
-/// while background agents are live cannot leave a standing delegation claim.
+/// while background agents are live cannot leave a standing delegation claim,
+/// and so the daemon knows the session's process is gone.
 ///
 /// Every failure is silent, like every other hook bridge: a hook must never
 /// wedge or redden the agent it observes.
@@ -17,8 +18,26 @@ struct SessionEndCommand: AsyncParsableCommand {
         shouldDisplay: false
     )
 
+    /// The fields this command reads out of Claude Code's `SessionEnd` payload.
+    /// Everything optional, everything else ignored — payload extensions are
+    /// additive and must not break the bridge.
+    private struct HookPayload: Decodable {
+        let reason: String?
+    }
+
     static func sessionIncarnationID(environment: [String: String]) -> UUID? {
         environment["TBD_TERMINAL_INCARNATION_ID"].flatMap(UUID.init(uuidString:))
+    }
+
+    /// Lift `reason` out of a hook payload. Static and pure so the parse is
+    /// testable without a pipe. The 1 MiB cap bounds *processing*, matching
+    /// `SessionEventCommand`; a payload that is empty, oversized, or not the
+    /// object this expects yields nil, which the daemon reads as "we do not know".
+    static func hookReason(from data: Data) -> String? {
+        guard !data.isEmpty, data.count <= 1 << 20,
+              let payload = try? JSONDecoder().decode(HookPayload.self, from: data)
+        else { return nil }
+        return payload.reason
     }
 
     mutating func run() async throws {
@@ -28,6 +47,11 @@ struct SessionEndCommand: AsyncParsableCommand {
             sessionEndLogger.debug("suppressed reason=noTerminalID")
             return
         }
+
+        // Read stdin BEFORE the daemon check: Claude Code pipes the payload and
+        // waits on the write, so a command that exits without draining it can
+        // leave the hook's writer blocked on a full pipe until its timeout.
+        let reason = Self.hookReason(from: FileHandle.standardInput.readDataToEndOfFile())
 
         let client = SocketClient()
         guard client.isDaemonRunning else {
@@ -40,7 +64,8 @@ struct SessionEndCommand: AsyncParsableCommand {
                 method: RPCMethod.terminalSessionEnded,
                 params: TerminalSessionEndedParams(
                     terminalID: terminalID,
-                    sessionIncarnationID: Self.sessionIncarnationID(environment: environment))
+                    sessionIncarnationID: Self.sessionIncarnationID(environment: environment),
+                    reason: reason)
             )
         } catch {
             sessionEndLogger.debug(

--- a/Sources/TBDDaemon/Actuation/ActuationOutcome+Park.swift
+++ b/Sources/TBDDaemon/Actuation/ActuationOutcome+Park.swift
@@ -57,6 +57,9 @@ extension ActuationOutcome {
         // The row's transport has a park/wake mechanic, but this install has
         // not armed it: `holder_hibernation_enabled` is off.
         case .holderTransport: return .refused(.notEligible)
+        // The row is exit-stamped and its pane is busy: a well-formed wake the
+        // daemon declines, and nothing was respawned.
+        case .paneBusy: return .refused(.notEligible)
         }
     }
 
@@ -79,6 +82,7 @@ extension ActuationOutcome {
         case .profileMissing(let profileID):
             return "Profile no longer exists: \(profileID.uuidString)"
         case .holderTransport: return HibernationCoordinator.holderTransportRefusal
+        case .paneBusy(let pid): return HibernationCoordinator.paneBusyRefusal(pid: pid)
         }
     }
 }

--- a/Sources/TBDDaemon/Claude/LimitResumeActuator.swift
+++ b/Sources/TBDDaemon/Claude/LimitResumeActuator.swift
@@ -20,14 +20,27 @@ public protocol ResumeSendingTmux: Sendable {
 
 extension TmuxManager: ResumeSendingTmux {}
 
-/// Finds the pane's foreground Claude process. `#{pane_current_command}`
+/// Finds the pane's foreground agent process. `#{pane_current_command}`
 /// reports `zsh` on macOS, so we walk the pane PID's process tree and check
 /// `ps -o stat=` for the `+` (foreground process group) flag instead
 /// (spec §Actuation 3).
 public protocol PaneProcessInspecting: Sendable {
-    /// PID of the Claude process that owns the pane's tty foreground group,
-    /// or nil when Claude is not foreground (bare shell, editor, …).
-    func foregroundClaudePID(panePID: Int32) -> Int32?
+    /// PID of the process that owns the pane's tty foreground group and whose
+    /// command line contains `agentName`, or nil when no such process is
+    /// foreground (bare shell, editor, an agent that exited, …).
+    ///
+    /// The name is a substring match on the lowercased command line, which is
+    /// how the Claude question has always been asked; passing "codex" asks the
+    /// same question about a Codex session.
+    func foregroundAgentPID(panePID: Int32, matching agentName: String) -> Int32?
+}
+
+extension PaneProcessInspecting {
+    /// The Claude-shaped question, unchanged for every caller that only ever
+    /// asks it: the limit-resume actuator.
+    public func foregroundClaudePID(panePID: Int32) -> Int32? {
+        foregroundAgentPID(panePID: panePID, matching: "claude")
+    }
 }
 
 public struct ProductionPaneProcessInspector: PaneProcessInspecting {
@@ -37,12 +50,14 @@ public struct ProductionPaneProcessInspector: PaneProcessInspecting {
         self.signaller = signaller
     }
 
-    public func foregroundClaudePID(panePID: Int32) -> Int32? {
+    public func foregroundAgentPID(panePID: Int32, matching agentName: String) -> Int32? {
         // Candidates, cheapest first: the pane PID itself (zsh may have exec'd
-        // into Claude) and its direct children, which one `ps` table scan
+        // into the agent) and its direct children, which one `ps` table scan
         // answers together.
         let children = signaller.children(ofServerPID: panePID)
-        if let match = firstForegroundClaude(in: [panePID] + children) { return match }
+        if let match = firstForegroundAgent(in: [panePID] + children, matching: agentName) {
+            return match
+        }
 
         // Grandchildren (wrapper-shell spawns) cost a FULL `ps -axo pid=,ppid=`
         // scan each, so they are walked only after the cheap candidates came up
@@ -51,7 +66,8 @@ public struct ProductionPaneProcessInspector: PaneProcessInspecting {
         // of its children. Scanning order is unchanged: a grandchild could only
         // ever have won after every child lost anyway.
         for child in children {
-            if let match = firstForegroundClaude(in: signaller.children(ofServerPID: child)) {
+            if let match = firstForegroundAgent(
+                in: signaller.children(ofServerPID: child), matching: agentName) {
                 return match
             }
         }
@@ -59,13 +75,13 @@ public struct ProductionPaneProcessInspector: PaneProcessInspecting {
     }
 
     /// The first pid in `pids` that owns its tty's foreground process group and
-    /// whose command line names Claude. Two `ps` invocations per candidate, so
-    /// callers pass the cheapest candidate set they have.
-    private func firstForegroundClaude(in pids: [Int32]) -> Int32? {
+    /// whose command line names the agent. Two `ps` invocations per candidate,
+    /// so callers pass the cheapest candidate set they have.
+    private func firstForegroundAgent(in pids: [Int32], matching agentName: String) -> Int32? {
         for pid in pids {
             guard let stat = signaller.stat(pid), stat.contains("+"),
                   let command = signaller.commandLine(pid)?.lowercased(),
-                  command.contains("claude")
+                  command.contains(agentName)
             else { continue }
             return pid
         }

--- a/Sources/TBDDaemon/Claude/LimitResumeActuator.swift
+++ b/Sources/TBDDaemon/Claude/LimitResumeActuator.swift
@@ -38,15 +38,31 @@ public struct ProductionPaneProcessInspector: PaneProcessInspecting {
     }
 
     public func foregroundClaudePID(panePID: Int32) -> Int32? {
-        // Candidates: pane PID itself (zsh may have exec'd into Claude),
-        // its children, and grandchildren (wrapper-shell spawns).
-        var candidates: [Int32] = [panePID]
+        // Candidates, cheapest first: the pane PID itself (zsh may have exec'd
+        // into Claude) and its direct children, which one `ps` table scan
+        // answers together.
         let children = signaller.children(ofServerPID: panePID)
-        candidates += children
+        if let match = firstForegroundClaude(in: [panePID] + children) { return match }
+
+        // Grandchildren (wrapper-shell spawns) cost a FULL `ps -axo pid=,ppid=`
+        // scan each, so they are walked only after the cheap candidates came up
+        // empty — which is exactly the case this rail is asked about on the
+        // interactive send path, where the ordinary answer is the pane pid or one
+        // of its children. Scanning order is unchanged: a grandchild could only
+        // ever have won after every child lost anyway.
         for child in children {
-            candidates += signaller.children(ofServerPID: child)
+            if let match = firstForegroundClaude(in: signaller.children(ofServerPID: child)) {
+                return match
+            }
         }
-        for pid in candidates {
+        return nil
+    }
+
+    /// The first pid in `pids` that owns its tty's foreground process group and
+    /// whose command line names Claude. Two `ps` invocations per candidate, so
+    /// callers pass the cheapest candidate set they have.
+    private func firstForegroundClaude(in pids: [Int32]) -> Int32? {
+        for pid in pids {
             guard let stat = signaller.stat(pid), stat.contains("+"),
                   let command = signaller.commandLine(pid)?.lowercased(),
                   command.contains("claude")

--- a/Sources/TBDDaemon/Claude/LimitResumeActuator.swift
+++ b/Sources/TBDDaemon/Claude/LimitResumeActuator.swift
@@ -33,6 +33,19 @@ public protocol PaneProcessInspecting: Sendable {
     /// how the Claude question has always been asked; passing "codex" asks the
     /// same question about a Codex session.
     func foregroundAgentPID(panePID: Int32, matching agentName: String) -> Int32?
+
+    /// PID of the process that owns the pane's tty foreground process group,
+    /// whatever it is — no name to match. An idle interactive shell answers
+    /// with the pane's OWN pid; anything the person started under it answers
+    /// with that child's. Nil when nothing in the pane's tree claims the
+    /// foreground group, which is the same "nothing answered" a caller must
+    /// treat as no evidence either way.
+    ///
+    /// Separate from `foregroundAgentPID` because the question is different:
+    /// that one asks "is THIS agent running here" and is answered by the send
+    /// rail, this one asks "is ANYTHING running here" and is answered by the
+    /// wake rail before it respawns a pane out from under a live process.
+    func paneForegroundPID(panePID: Int32) -> Int32?
 }
 
 extension PaneProcessInspecting {
@@ -70,6 +83,32 @@ public struct ProductionPaneProcessInspector: PaneProcessInspecting {
                 in: signaller.children(ofServerPID: child), matching: agentName) {
                 return match
             }
+        }
+        return nil
+    }
+
+    public func paneForegroundPID(panePID: Int32) -> Int32? {
+        // Same candidate ladder as `foregroundAgentPID`, cheapest first and for
+        // the same reason: the pane pid itself, then its children, then — only
+        // once those came up empty — the grandchildren a wrapper shell spawns.
+        // The pane pid comes first deliberately: an idle shell holds the
+        // foreground group itself, so the common case costs one `ps`.
+        let children = signaller.children(ofServerPID: panePID)
+        if let match = firstForeground(in: [panePID] + children) { return match }
+        for child in children {
+            if let match = firstForeground(in: signaller.children(ofServerPID: child)) {
+                return match
+            }
+        }
+        return nil
+    }
+
+    /// The first pid in `pids` whose `ps -o stat=` carries the `+` that means
+    /// "in the controlling terminal's foreground process group". No name is
+    /// matched — the caller wants whatever is there.
+    private func firstForeground(in pids: [Int32]) -> Int32? {
+        for pid in pids where signaller.stat(pid)?.contains("+") == true {
+            return pid
         }
         return nil
     }

--- a/Sources/TBDDaemon/Database/TerminalStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalStore.swift
@@ -1757,11 +1757,16 @@ public struct TerminalStore: Sendable {
     /// it, and a late `SessionEnd` from the process TBD itself killed would
     /// otherwise rewrite a deliberate `.manual` park into `.exited`.
     ///
-    /// `reportedIncarnationID` is the hook's own process-incarnation nonce. A
-    /// mismatch means the hook describes a process TBD has already replaced, so
-    /// stamping would park a live successor; nil means the hook predates the
-    /// nonce and cannot be checked, which is the same reading every other hook
-    /// handler gives it.
+    /// `reportedIncarnationID` is the hook's own process-incarnation nonce,
+    /// checked by exact equality against the record's — the same reading
+    /// `applySessionStart`, `applyActivityObservation` and
+    /// `updateSessionIDIfIncarnationMatches` each give it. A mismatch means the
+    /// hook describes a process TBD has already replaced, so stamping would
+    /// park a live successor. A `nil` report matches only a record that still
+    /// carries no incarnation of its own — once TBD mints one (a replacement
+    /// launch, via `updateTmuxIDs`), a delayed `SessionEnd` from the
+    /// pre-incarnation predecessor process reads as a mismatch too, not as an
+    /// unchecked report.
     ///
     /// The stamp is tmux-only. On a holder-backed row the Claude process IS the
     /// holder's whole job: there is no shell left in the pane for a send to
@@ -1782,10 +1787,8 @@ public struct TerminalStore: Sendable {
             }
             guard record.transport != TerminalTransport.holder.rawValue else { return false }
             guard record.hibernatedAt == nil else { return false }
-            if let reportedIncarnationID {
-                guard record.sessionIncarnationID == reportedIncarnationID.uuidString else {
-                    return false
-                }
+            guard record.sessionIncarnationID == reportedIncarnationID?.uuidString else {
+                return false
             }
             record.hibernatedAt = date
             record.hibernateReason = HibernateReason.exited.rawValue

--- a/Sources/TBDDaemon/Database/TerminalStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalStore.swift
@@ -1763,6 +1763,13 @@ public struct TerminalStore: Sendable {
     /// nonce and cannot be checked, which is the same reading every other hook
     /// handler gives it.
     ///
+    /// The stamp is tmux-only. On a holder-backed row the Claude process IS the
+    /// holder's whole job: there is no shell left in the pane for a send to
+    /// mis-execute, and the hibernation coordinator's wake respawns into a tmux
+    /// window, which cannot bring a holder session back. Parking such a row
+    /// would leave a park nothing can wake and no reconciler reclaims, so the
+    /// row stays unstamped and the holder path answers for its own liveness.
+    ///
     /// `date` follows the one-shot stamp seam (CLAUDE.md, "Duration is behavior,
     /// Date is data").
     @discardableResult
@@ -1773,6 +1780,7 @@ public struct TerminalStore: Sendable {
             guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
                 return false
             }
+            guard record.transport != TerminalTransport.holder.rawValue else { return false }
             guard record.hibernatedAt == nil else { return false }
             if let reportedIncarnationID {
                 guard record.sessionIncarnationID == reportedIncarnationID.uuidString else {

--- a/Sources/TBDDaemon/Database/TerminalStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalStore.swift
@@ -1741,6 +1741,73 @@ public struct TerminalStore: Sendable {
         }
     }
 
+    /// Park a row because Claude's own process left, reported by its `SessionEnd`
+    /// hook. Returns whether the row actually changed.
+    ///
+    /// **Deliberately narrower than `setHibernated`.** That writer mints a new
+    /// session incarnation, cancels pending scheduled resumes and rewrites the
+    /// activity triple, because it describes a park TBD performed and a process
+    /// TBD is about to replace. A hook only *reports* that the process is gone:
+    /// nothing was replaced, nothing was interrupted, and the resume this row
+    /// already points at is still the right one. So exactly two columns move.
+    ///
+    /// It refuses on an already-parked row for the same reason the awaiting-input
+    /// rail refuses an uninformative overwrite: `hibernateReason` is the record of
+    /// WHO parked a session, `HibernationCoordinator`'s wake-on-focus sweep reads
+    /// it, and a late `SessionEnd` from the process TBD itself killed would
+    /// otherwise rewrite a deliberate `.manual` park into `.exited`.
+    ///
+    /// `reportedIncarnationID` is the hook's own process-incarnation nonce. A
+    /// mismatch means the hook describes a process TBD has already replaced, so
+    /// stamping would park a live successor; nil means the hook predates the
+    /// nonce and cannot be checked, which is the same reading every other hook
+    /// handler gives it.
+    ///
+    /// `date` follows the one-shot stamp seam (CLAUDE.md, "Duration is behavior,
+    /// Date is data").
+    @discardableResult
+    public func stampSessionExited(
+        id: UUID, reportedIncarnationID: UUID?, at date: Date = Date()
+    ) async throws -> Bool {
+        try await writer.write { db in
+            guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
+                return false
+            }
+            guard record.hibernatedAt == nil else { return false }
+            if let reportedIncarnationID {
+                guard record.sessionIncarnationID == reportedIncarnationID.uuidString else {
+                    return false
+                }
+            }
+            record.hibernatedAt = date
+            record.hibernateReason = HibernateReason.exited.rawValue
+            try record.update(db)
+            return true
+        }
+    }
+
+    /// Retract an exit stamp because the session came back — the `SessionStart`
+    /// hook. Returns whether the row actually changed.
+    ///
+    /// Scoped to `.exited` on purpose. `SessionStart` also fires on `/clear` and
+    /// `/compact` inside a live process, and on a resume; a blanket un-park there
+    /// would undo an operator's deliberate `.manual` hibernate. `clearHibernated`
+    /// stays the wake path's writer — it also clears `suspendedAt` and the pending
+    /// incarnation, which belong to a respawn this never performs.
+    @discardableResult
+    public func clearSessionExitStamp(id: UUID) async throws -> Bool {
+        try await writer.write { db in
+            guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
+                return false
+            }
+            guard record.hibernateReason == HibernateReason.exited.rawValue else { return false }
+            record.hibernatedAt = nil
+            record.hibernateReason = nil
+            try record.update(db)
+            return true
+        }
+    }
+
     /// Prepare a parked shell for a fresh agent before launch. Preserve the
     /// captured session identity and transcript needed for a failed launch to
     /// retry, while clearing process-local ordering/activity and rotating the

--- a/Sources/TBDDaemon/Hooks/ClaudeHookOverlay.swift
+++ b/Sources/TBDDaemon/Hooks/ClaudeHookOverlay.swift
@@ -131,10 +131,20 @@ public enum ClaudeHookOverlay {
     static let waitingForUserCommand =
         #"tbd terminal-activity waiting_for_user 2>/dev/null || true"#
 
-    /// Clears any standing delegation claim when a session ends. A session
-    /// that exits while background agents are live leaves a final
-    /// `turn_duration` record still reporting them, and no later turn ever
-    /// corrects it — so without this the claim would stand forever.
+    /// Reports the end of a session, which lands two facts.
+    ///
+    /// It clears any standing delegation claim: a session that exits while
+    /// background agents are live leaves a final `turn_duration` record still
+    /// reporting them, and no later turn ever corrects it, so without this the
+    /// claim would stand forever.
+    ///
+    /// And, when the reason means the process itself is leaving, it stamps the
+    /// terminal as parked with `HibernateReason.exited` — the machine-readable
+    /// "Claude is not running here" a send refuses on, rather than pasting a
+    /// message into the shell sitting in the pane. The stamp is a fast path, not
+    /// the guarantee: the send path also reads the pane's foreground process
+    /// group, so a lost hook costs a slower answer and a stale claim, never a
+    /// message run as a shell command.
     static let sessionEndCommand =
         #"tbd session-end 2>/dev/null || true"#
 
@@ -145,8 +155,9 @@ public enum ClaudeHookOverlay {
     /// actually bounds the hook is Claude Code's ~1.5-second SessionEnd
     /// shutdown budget, which cuts the callback off first either way; this
     /// value stays above it so a healthy RPC has the whole budget to land the
-    /// clear. Losing the clear to either bound costs only a stale claim on a
-    /// terminal whose session is gone.
+    /// clear. Losing the hook to either bound costs a stale claim and an
+    /// unstamped row on a terminal whose session is gone; the send path's
+    /// foreground-process rail still refuses the send.
     static let sessionEndTimeoutSeconds = 2
 
     /// The extended regex the prefilter greps a Bash hook payload for.

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
@@ -78,6 +78,12 @@ public enum WakeResult: Equatable, Sendable {
     /// it may not run here yet, so wake refuses before touching anything and
     /// leaves the row exactly as it found it.
     case holderTransport
+    /// The row is exit-stamped (`.exited`) and a process other than the pane's
+    /// own shell owns the pane's foreground process group. Wake is
+    /// `respawn-window -k`, which would kill it. Nothing was respawned and the
+    /// row stays exit-stamped, so a retry once the process finishes still
+    /// wakes. Carries the foreground pid so the message can name it.
+    case paneBusy(pid: Int32)
 }
 
 /// Owns session PARKING — the single unified "park a Claude session" feature
@@ -236,6 +242,12 @@ public actor HibernationCoordinator {
     /// arranging a real one.
     let signaller: any ProcessSignaller
 
+    /// Reads a tmux pane's foreground process group from the process table.
+    /// Used by exactly one rail — the exit-stamped wake guard — and injected
+    /// so a test can state "the pane's shell is idle" or "something is running
+    /// in it" without arranging a real process.
+    private let paneProcessInspector: any PaneProcessInspecting
+
     /// The daemon's actuation record. The idle sweep and the merge-park rail
     /// are daemon-internal actuation sites — they bypass the router, so each
     /// logs its own row. Deliberately NOT logged inside `performHibernate`: the
@@ -260,6 +272,7 @@ public actor HibernationCoordinator {
         holderEscalationAttempts: Int = 5,
         clock: any Clock<Duration> = ContinuousClock(),
         signaller: any ProcessSignaller = ProductionProcessSignaller(),
+        paneProcessInspector: any PaneProcessInspecting = ProductionPaneProcessInspector(),
         actuationLog: ActuationLog
     ) {
         self.db = db
@@ -275,6 +288,7 @@ public actor HibernationCoordinator {
         self.holderEscalationAttempts = holderEscalationAttempts
         self.clock = clock
         self.signaller = signaller
+        self.paneProcessInspector = paneProcessInspector
         self.actuationLog = actuationLog
     }
 
@@ -471,6 +485,16 @@ public actor HibernationCoordinator {
         "Session runs on the pty-holder transport and holder hibernation is off "
         + "(Settings → Hibernate pty-holder sessions, or `tbd config "
         + "holder-hibernation on`)"
+
+    /// The one refusal text for an exit-stamped row whose pane is busy, so the
+    /// CLI, the app and the actuation record all name the same fact and the
+    /// same two ways out. Named here rather than at each call site for the same
+    /// reason `holderTransportRefusal` is.
+    static func paneBusyRefusal(pid: Int32) -> String {
+        "This session's agent process exited, but something is still running in its terminal "
+        + "(pid \(pid)), and waking would replace that shell and kill it. Finish or stop that "
+        + "process and retry, or wake the session from the terminal itself."
+    }
 
     private static func mergeBlockReason(_ decision: HibernationGate.Decision) -> String {
         switch decision {
@@ -1018,6 +1042,43 @@ public actor HibernationCoordinator {
         }
         let server = worktree.tmuxServer
         let paneID = terminal.tmuxPaneID
+
+        // ─── An exit-stamped row whose pane is busy is not ours to replace ───
+        //
+        // `.exited` parks the row while the pane's SHELL stays alive and usable
+        // — that is the whole point of the stamp — and wake is
+        // `respawn-window -k`, which kills whatever occupies the pane. For every
+        // other park reason that costs nothing: hibernate put an inert shell
+        // there itself. For an exit stamp the pane is the one the person was
+        // sitting in when the agent left, and they may have started something in
+        // it since.
+        //
+        // The app-side exclusion — `.exited` is not auto-woken on focus or tab
+        // activation — is the first line and stays the first line. It is not the
+        // only line, because it lives in the app: `docs/updating.md`'s
+        // `--no-app` makes "daemon newer than app" a supported skew, and an app
+        // binary older than this change reads `.exited` through the lenient
+        // `HibernateReason` decoder as `.auto` and auto-wakes it. So the daemon
+        // defends the respawn itself, and it does so for every caller — an old
+        // app, the CLI, the composer — rather than trusting who asked.
+        //
+        // Asked of the process table, never the rendered screen. The pane's own
+        // pid answering means an idle interactive shell and the wake proceeds
+        // exactly as before; a different pid means something is running under
+        // it. An unreadable pid proceeds too: a pane tmux cannot answer for is
+        // not evidence that a process is there, and refusing on it would strand
+        // an exit-stamped row behind a probe failure with no way back.
+        //
+        // tmux-only, for the same reason the cwd assertion below is: a holder
+        // row's pane id is the empty string and names no tmux coordinate.
+        if terminal.isExitStamped, terminal.transport != .holder,
+           let panePIDString = try? await tmux.panePID(server: server, paneID: paneID),
+           let panePID = Int32(panePIDString), panePID > 0,
+           let foregroundPID = paneProcessInspector.paneForegroundPID(panePID: panePID),
+           foregroundPID != panePID {
+            logger.info("wake: exit-stamped terminal \(terminal.id, privacy: .public) has foreground pid \(foregroundPID, privacy: .public) in pane \(paneID, privacy: .public) (pane pid \(panePID, privacy: .public)) — refusing the respawn rather than killing it")
+            return .paneBusy(pid: foregroundPID)
+        }
 
         // Assert that the process about to be resumed will run in THIS
         // worktree. Not a lookup concern: `claude --resume <id>` is not

--- a/Sources/TBDDaemon/Server/RPCRouter+HibernationHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+HibernationHandlers.swift
@@ -119,6 +119,8 @@ extension RPCRouter {
                 code: RPCErrorCode.profileMissing.rawValue)
         case .holderTransport:
             return RPCResponse(error: HibernationCoordinator.holderTransportRefusal)
+        case .paneBusy(let pid):
+            return RPCResponse(error: HibernationCoordinator.paneBusyRefusal(pid: pid))
         }
     }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+ManualSuspendHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ManualSuspendHandlers.swift
@@ -82,6 +82,8 @@ extension RPCRouter {
                 code: RPCErrorCode.profileMissing.rawValue)
         case .holderTransport:
             return RPCResponse(error: HibernationCoordinator.holderTransportRefusal)
+        case .paneBusy(let pid):
+            return RPCResponse(error: HibernationCoordinator.paneBusyRefusal(pid: pid))
         }
     }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -2881,6 +2881,36 @@ extension RPCRouter {
             + "input path wired for it. Nothing was typed and its session is unchanged."
     }
 
+    /// The refusal a text `terminal.send` gets for a terminal whose Claude
+    /// process is gone.
+    ///
+    /// Named separately from the transport refusals because the caller's remedy
+    /// is different and specific: wake the terminal, which delivers the message
+    /// atomically with the respawn. Without this rail the send finds a live pane
+    /// with a shell prompt in it, pastes the message, presses Enter, and runs the
+    /// message as a shell command while reporting success.
+    static func parkedSendRefusal(terminalID: UUID, exited: Bool) -> String {
+        let cause = exited
+            ? "its Claude session exited"
+            : "it is hibernated"
+        return "terminal.send was refused: terminal \(terminalID) is not running — \(cause), so "
+            + "nothing was typed. Wake it instead (`tbd terminal wake --terminal \(terminalID) "
+            + "--prompt \"…\"`), which delivers the message as the resumed session's first prompt."
+    }
+
+    /// The refusal a text `terminal.send` gets when the pane is alive but the
+    /// process table says Claude does not own its foreground process group.
+    ///
+    /// The second of two independent rails, and the one that covers a MISSED
+    /// hook: a crashed session emits no `SessionEnd`, so nothing stamped the row.
+    /// It asks the same inspector the limit-resume path has always asked, which
+    /// reads `ps` — a process-table fact, never the rendered screen.
+    static func claudeNotForegroundRefusal(terminalID: UUID, paneID: String) -> String {
+        "terminal.send was refused: Claude is not the foreground process of pane \(paneID) for "
+            + "terminal \(terminalID) — a shell is, so the message would have run as a command "
+            + "line. Nothing was typed."
+    }
+
     func handleTerminalSend(
         _ paramsData: Data, actor: ActuationActor? = nil
     ) async throws -> RPCResponse {
@@ -2997,6 +3027,42 @@ extension RPCRouter {
             return await performHolderSend(
                 payload: payload, terminal: terminal, actuationID: actuationID,
                 actor: actor, envelope: envelope)
+        }
+
+        // ─── Is Claude actually running here? ───
+        //
+        // Text only. `--keys` exists to answer a dialog and to interrupt, and a
+        // key sequence into a shell is not the failure this rail exists to stop.
+        //
+        // Two independent facts, because each fails on its own. The park stamp is
+        // written by the `SessionEnd` hook and is missed whenever the process
+        // crashes; the foreground-process inspector reads the process table and
+        // is available only for a tmux-backed row with a live pane. Both are
+        // machine facts — a column and `ps` — never the rendered screen, which
+        // this codebase forbids reading for state.
+        if case .text(let body, _, _) = payload, !body.isEmpty {
+            if terminal.hibernatedAt != nil {
+                let message = Self.parkedSendRefusal(
+                    terminalID: terminal.id, exited: terminal.isExitStamped)
+                await finishActuation(actuationID, .refused(.notEligible), error: message)
+                return RPCResponse(error: message)
+            }
+            // A pane id that resolves to a pid is the precondition for asking at
+            // all, and `panePID > 0` is not decoration: a tmux that cannot answer
+            // reports "0", and asking the process table about pid 0 is a question
+            // with no meaning. An unreadable pid therefore proceeds — a tmux that
+            // cannot answer is not evidence that Claude left, and the pane
+            // consultation below is the rail that judges a missing or dead pane,
+            // properly.
+            if let panePIDString = try? await tmux.panePID(
+                    server: worktree.tmuxServer, paneID: terminal.tmuxPaneID),
+               let panePID = Int32(panePIDString), panePID > 0,
+               paneProcessInspector.foregroundClaudePID(panePID: panePID) == nil {
+                let message = Self.claudeNotForegroundRefusal(
+                    terminalID: terminal.id, paneID: terminal.tmuxPaneID)
+                await finishActuation(actuationID, .refused(.notEligible), error: message)
+                return RPCResponse(error: message)
+            }
         }
 
         // ─── The second refusal line: a well-formed act the daemon declines ───

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -4358,7 +4358,8 @@ extension RPCRouter {
     /// runs the message as a shell command while reporting success. The park is
     /// deliberately the same state a hibernate produces — process gone, terminal
     /// alive, session id known — so one wake path and one UI cover both
-    /// (design 2026-09-05, "Not-running delivery").
+    /// (`docs/specs/2026-09-05-transcript-composer-design.md`, "Not-running
+    /// delivery").
     func handleTerminalSessionEnded(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(TerminalSessionEndedParams.self, from: paramsData)
         await claudeDelegationTracker.clear(

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -4121,11 +4121,22 @@ extension RPCRouter {
         // un-park there would silently undo an operator's deliberate hibernate.
         // Placed after the identity check above, so a hook this pass rejected
         // retracts nothing.
-        if (try? await db.terminals.clearSessionExitStamp(id: terminal.id)) == true {
-            await broadcastExitStampChange(terminalID: terminal.id, parked: false)
-            logger.debug("""
-                sessionEvent: cleared the exit stamp on terminal \
-                \(terminal.id.uuidString, privacy: .public)
+        // A thrown store error is NOT the same fact as a refused retraction, and
+        // collapsing the two would leave a terminal parked as `.exited` while its
+        // Claude is live — refused (`false`) stays a trace, a failure is an error.
+        do {
+            if try await db.terminals.clearSessionExitStamp(id: terminal.id) {
+                await broadcastExitStampChange(terminalID: terminal.id, parked: false)
+                logger.debug("""
+                    sessionEvent: cleared the exit stamp on terminal \
+                    \(terminal.id.uuidString, privacy: .public)
+                    """)
+            }
+        } catch {
+            logger.error("""
+                sessionEvent: clearing the exit stamp on terminal \
+                \(terminal.id.uuidString, privacy: .public) FAILED, the row stays \
+                parked as exited: \(String(describing: error), privacy: .public)
                 """)
         }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -3047,6 +3047,17 @@ extension RPCRouter {
                 await finishActuation(actuationID, .refused(.notEligible), error: message)
                 return RPCResponse(error: message)
             }
+            // The foreground rail is Claude-only, on the same predicate the
+            // `--verify` rails below use. The inspector's question is literally
+            // "does a foreground process whose command line contains `claude`
+            // own this pane" — which is `nil` for every healthy shell session
+            // (the pane pid IS the shell, with no children) and for every
+            // healthy Codex session (`codex …` contains no "claude"). Asking it
+            // about a non-Claude kind refuses a send that should have gone
+            // through, so the kind decides whether the question means anything.
+            // The park rail above stays kind-agnostic: a parked row of any kind
+            // has no live session behind it.
+            //
             // A pane id that resolves to a pid is the precondition for asking at
             // all, and `panePID > 0` is not decoration: a tmux that cannot answer
             // reports "0", and asking the process table about pid 0 is a question
@@ -3054,7 +3065,8 @@ extension RPCRouter {
             // cannot answer is not evidence that Claude left, and the pane
             // consultation below is the rail that judges a missing or dead pane,
             // properly.
-            if let panePIDString = try? await tmux.panePID(
+            if Self.supportsDeliveryObservation(terminal),
+               let panePIDString = try? await tmux.panePID(
                     server: worktree.tmuxServer, paneID: terminal.tmuxPaneID),
                let panePID = Int32(panePIDString), panePID > 0,
                paneProcessInspector.foregroundClaudePID(panePID: panePID) == nil {

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -4037,6 +4037,19 @@ extension RPCRouter {
             observedAt: observedAt
         ) else { return .ok() }
 
+        // The session is back, so an exit stamp describing its predecessor is
+        // stale. Scoped to `.exited` inside the store: SessionStart also fires on
+        // `/clear`, `/compact` and a resume inside a live process, and a blanket
+        // un-park there would silently undo an operator's deliberate hibernate.
+        // Placed after the identity check above, so a hook this pass rejected
+        // retracts nothing.
+        if (try? await db.terminals.clearSessionExitStamp(id: terminal.id)) == true {
+            logger.debug("""
+                sessionEvent: cleared the exit stamp on terminal \
+                \(terminal.id.uuidString, privacy: .public)
+                """)
+        }
+
         // The first accepted Codex session has no prior lifecycle to fence, and
         // its rollout can write task_started before this hook reaches TBD.
         // Later accepted starts capture the current EOF even when the path is
@@ -4241,15 +4254,43 @@ extension RPCRouter {
         return .ok()
     }
 
-    /// A Claude session ended. Drops any standing delegation claim: a session
-    /// that exits while background subagents are live leaves a final
-    /// `turn_duration` record still reporting them, and no later turn ever
-    /// arrives to retract it.
+    /// A Claude session ended. Two effects, both retractions of something the
+    /// session can no longer be reporting.
+    ///
+    /// Drops any standing delegation claim: a session that exits while background
+    /// subagents are live leaves a final `turn_duration` record still reporting
+    /// them, and no later turn ever arrives to retract it.
+    ///
+    /// And, when the reason means the PROCESS is leaving, parks the row with
+    /// `HibernateReason.exited`. That stamp is what makes "Claude is not running
+    /// here" a fact a caller can act on: without it a send to the terminal finds a
+    /// live pane with a shell prompt in it, pastes the message, presses Enter, and
+    /// runs the message as a shell command while reporting success. The park is
+    /// deliberately the same state a hibernate produces — process gone, terminal
+    /// alive, session id known — so one wake path and one UI cover both
+    /// (design 2026-09-05, "Not-running delivery").
     func handleTerminalSessionEnded(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(TerminalSessionEndedParams.self, from: paramsData)
         await claudeDelegationTracker.clear(
             terminalID: params.terminalID,
             sessionIncarnationID: params.sessionIncarnationID)
+
+        guard SessionEndReason.parksTheTerminal(params.reason) else {
+            logger.debug("""
+                sessionEnded: terminal=\(params.terminalID.uuidString, privacy: .public) \
+                reason=\(params.reason ?? "none", privacy: .public) — not a process exit, \
+                leaving the park state alone
+                """)
+            return .ok()
+        }
+        let stamped = (try? await db.terminals.stampSessionExited(
+            id: params.terminalID,
+            reportedIncarnationID: params.sessionIncarnationID,
+            at: now())) ?? false
+        logger.debug("""
+            sessionEnded: terminal=\(params.terminalID.uuidString, privacy: .public) \
+            reason=\(params.reason ?? "none", privacy: .public) stamped=\(stamped, privacy: .public)
+            """)
         return .ok()
     }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -2925,10 +2925,17 @@ extension RPCRouter {
     /// its command line, so the kind picks the name and the same `ps` question
     /// answers for both.
     ///
+    /// A row with NO recorded kind predates the column and is a Claude
+    /// terminal — the reading `Terminal.isClaudeResumable` and the
+    /// continue-in-Codex path already give it, and the one this follows.
+    /// Defaulting a kindless row to `.shell` instead would skip the rail for
+    /// exactly the oldest rows on the machine, which are the likeliest to have
+    /// outlived the agent that once ran in them.
+    ///
     /// Pure and static so the mapping is testable without a database, a pane, or
     /// a process table.
     static func foregroundAgentName(for kind: TerminalKind?) -> String? {
-        switch kind ?? .shell {
+        switch kind ?? .claude {
         case .shell: return nil
         case .claude: return "claude"
         case .codex: return "codex"
@@ -3064,7 +3071,20 @@ extension RPCRouter {
         // is available only for a tmux-backed row with a live pane. Both are
         // machine facts — a column and `ps` — never the rendered screen, which
         // this codebase forbids reading for state.
-        if case .text(let body, _, _) = payload, !body.isEmpty {
+        //
+        // The two rails split on the EMPTY payload — a bare Enter, which
+        // `--submit` with no text is — and they split deliberately:
+        //
+        //   - The park rail takes it. A parked row's pane holds a shell and
+        //     nothing else, so an Enter there has no message to lose and no
+        //     purpose to serve, and the refusal already names wake as the
+        //     remedy. Letting it through would be the one text payload that
+        //     reaches a session everyone agrees is gone.
+        //   - The foreground rail does not. A bare Enter is how a caller
+        //     answers a prompt the agent is already showing, and the inspector
+        //     is the fallible fact of the two — a pane it cannot read must not
+        //     cost a live row its Enter.
+        if case .text(let body, _, _) = payload {
             if terminal.hibernatedAt != nil {
                 let message = Self.parkedSendRefusal(
                     terminalID: terminal.id, exited: terminal.isExitStamped)
@@ -3074,10 +3094,12 @@ extension RPCRouter {
             // The foreground rail is kind-aware, not Claude-only. The
             // inspector's question is "does a foreground process whose command
             // line contains <name> own this pane", and the kind supplies the
-            // name: "claude" for a Claude row, "codex" for a Codex one. A shell
-            // has no name to supply — its pane pid IS the shell, with no agent
-            // under it — so the rail never runs for one, and a shell send that
-            // would otherwise be refused every time goes through.
+            // name: "claude" for a Claude row, "codex" for a Codex one, and
+            // "claude" again for a row whose kind was never recorded, which is
+            // what every other liveness reading in this codebase makes of one.
+            // A shell has no name to supply — its pane pid IS the shell, with no
+            // agent under it — so the rail never runs for one, and a shell send
+            // that would otherwise be refused every time goes through.
             //
             // Covering Codex here matters more than it does for Claude: a Codex
             // row is never exit-stamped, because Codex ships no `SessionEnd`
@@ -3095,7 +3117,8 @@ extension RPCRouter {
             // cannot answer is not evidence that Claude left, and the pane
             // consultation below is the rail that judges a missing or dead pane,
             // properly.
-            if let agentName = Self.foregroundAgentName(for: terminal.kind),
+            if !body.isEmpty,
+               let agentName = Self.foregroundAgentName(for: terminal.kind),
                let panePIDString = try? await tmux.panePID(
                     server: worktree.tmuxServer, paneID: terminal.tmuxPaneID),
                let panePID = Int32(panePIDString), panePID > 0,
@@ -4389,8 +4412,8 @@ extension RPCRouter {
     /// runs the message as a shell command while reporting success. The park is
     /// deliberately the same state a hibernate produces — process gone, terminal
     /// alive, session id known — so one wake path and one UI cover both
-    /// (`docs/specs/2026-09-05-transcript-composer-design.md`, "Not-running
-    /// delivery").
+    /// (`docs/specs/2026-09-05-transcript-composer-design.md`, landing in
+    /// PR #821, "Not-running delivery").
     func handleTerminalSessionEnded(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(TerminalSessionEndedParams.self, from: paramsData)
         await claudeDelegationTracker.clear(

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -2905,7 +2905,7 @@ extension RPCRouter {
     /// The second of two independent rails, and the one that covers a MISSED
     /// hook: a crashed session emits no `SessionEnd`, so nothing stamped the row.
     /// It is the only rail a Codex row has, because Codex ships no `SessionEnd`
-    /// hook to stamp with — see `foregroundAgentName(for:)`.
+    /// hook to stamp with — see `foregroundAgentName(kind:claudeSessionID:)`.
     /// It asks the same inspector the limit-resume path has always asked, which
     /// reads `ps` — a process-table fact, never the rendered screen.
     static func agentNotForegroundRefusal(
@@ -2925,17 +2925,19 @@ extension RPCRouter {
     /// its command line, so the kind picks the name and the same `ps` question
     /// answers for both.
     ///
-    /// A row with NO recorded kind predates the column and is a Claude
-    /// terminal — the reading `Terminal.isClaudeResumable` and the
-    /// continue-in-Codex path already give it, and the one this follows.
-    /// Defaulting a kindless row to `.shell` instead would skip the rail for
-    /// exactly the oldest rows on the machine, which are the likeliest to have
-    /// outlived the agent that once ran in them.
+    /// A row with NO recorded kind predates the column, and gets exactly the
+    /// reading migration `v22_terminal_kind`'s backfill gave every such row
+    /// when the column was introduced — Claude when it carries a Claude
+    /// session id, shell otherwise — which is also what `Terminal
+    /// .isClaudeResumable` already requires of a kindless row. Reading every
+    /// kindless row as Claude regardless of session id would run this rail,
+    /// expecting a "claude" process, against a plain shell pane that never
+    /// had one.
     ///
     /// Pure and static so the mapping is testable without a database, a pane, or
     /// a process table.
-    static func foregroundAgentName(for kind: TerminalKind?) -> String? {
-        switch kind ?? .claude {
+    static func foregroundAgentName(kind: TerminalKind?, claudeSessionID: String?) -> String? {
+        switch kind ?? (claudeSessionID == nil ? .shell : .claude) {
         case .shell: return nil
         case .claude: return "claude"
         case .codex: return "codex"
@@ -3094,12 +3096,14 @@ extension RPCRouter {
             // The foreground rail is kind-aware, not Claude-only. The
             // inspector's question is "does a foreground process whose command
             // line contains <name> own this pane", and the kind supplies the
-            // name: "claude" for a Claude row, "codex" for a Codex one, and
-            // "claude" again for a row whose kind was never recorded, which is
-            // what every other liveness reading in this codebase makes of one.
-            // A shell has no name to supply — its pane pid IS the shell, with no
-            // agent under it — so the rail never runs for one, and a shell send
-            // that would otherwise be refused every time goes through.
+            // name: "claude" for a Claude row, "codex" for a Codex one, and for
+            // a row whose kind was never recorded, whichever of the two the
+            // Claude session id decides — the same reading `v22_terminal_kind`
+            // backfilled onto every such row and `Terminal.isClaudeResumable`
+            // already requires. A shell has no name to supply — its pane pid IS
+            // the shell, with no agent under it — so the rail never runs for
+            // one, and a shell send that would otherwise be refused every time
+            // goes through.
             //
             // Covering Codex here matters more than it does for Claude: a Codex
             // row is never exit-stamped, because Codex ships no `SessionEnd`
@@ -3118,7 +3122,8 @@ extension RPCRouter {
             // consultation below is the rail that judges a missing or dead pane,
             // properly.
             if !body.isEmpty,
-               let agentName = Self.foregroundAgentName(for: terminal.kind),
+               let agentName = Self.foregroundAgentName(
+                    kind: terminal.kind, claudeSessionID: terminal.claudeSessionID),
                let panePIDString = try? await tmux.panePID(
                     server: worktree.tmuxServer, paneID: terminal.tmuxPaneID),
                let panePID = Int32(panePIDString), panePID > 0,

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -2899,16 +2899,40 @@ extension RPCRouter {
     }
 
     /// The refusal a text `terminal.send` gets when the pane is alive but the
-    /// process table says Claude does not own its foreground process group.
+    /// process table says the session's agent does not own its foreground
+    /// process group.
     ///
     /// The second of two independent rails, and the one that covers a MISSED
     /// hook: a crashed session emits no `SessionEnd`, so nothing stamped the row.
+    /// It is the only rail a Codex row has, because Codex ships no `SessionEnd`
+    /// hook to stamp with — see `foregroundAgentName(for:)`.
     /// It asks the same inspector the limit-resume path has always asked, which
     /// reads `ps` — a process-table fact, never the rendered screen.
-    static func claudeNotForegroundRefusal(terminalID: UUID, paneID: String) -> String {
-        "terminal.send was refused: Claude is not the foreground process of pane \(paneID) for "
-            + "terminal \(terminalID) — a shell is, so the message would have run as a command "
-            + "line. Nothing was typed."
+    static func agentNotForegroundRefusal(
+        terminalID: UUID, paneID: String, agentName: String
+    ) -> String {
+        "terminal.send was refused: the session's agent (\(agentName)) is not the foreground "
+            + "process of pane \(paneID) for terminal \(terminalID) — a shell is, so the message "
+            + "would have run as a command line. Nothing was typed."
+    }
+
+    /// The process name the foreground rail looks for in a pane, per terminal
+    /// kind — and `nil` for a kind the rail must not run for at all.
+    ///
+    /// A shell's pane pid IS the shell, with no agent under it, so asking the
+    /// inspector about one refuses every healthy shell send there is. Both
+    /// agent-bearing kinds do have a process to find, and each names itself on
+    /// its command line, so the kind picks the name and the same `ps` question
+    /// answers for both.
+    ///
+    /// Pure and static so the mapping is testable without a database, a pane, or
+    /// a process table.
+    static func foregroundAgentName(for kind: TerminalKind?) -> String? {
+        switch kind ?? .shell {
+        case .shell: return nil
+        case .claude: return "claude"
+        case .codex: return "codex"
+        }
     }
 
     func handleTerminalSend(
@@ -3047,14 +3071,20 @@ extension RPCRouter {
                 await finishActuation(actuationID, .refused(.notEligible), error: message)
                 return RPCResponse(error: message)
             }
-            // The foreground rail is Claude-only, on the same predicate the
-            // `--verify` rails below use. The inspector's question is literally
-            // "does a foreground process whose command line contains `claude`
-            // own this pane" — which is `nil` for every healthy shell session
-            // (the pane pid IS the shell, with no children) and for every
-            // healthy Codex session (`codex …` contains no "claude"). Asking it
-            // about a non-Claude kind refuses a send that should have gone
-            // through, so the kind decides whether the question means anything.
+            // The foreground rail is kind-aware, not Claude-only. The
+            // inspector's question is "does a foreground process whose command
+            // line contains <name> own this pane", and the kind supplies the
+            // name: "claude" for a Claude row, "codex" for a Codex one. A shell
+            // has no name to supply — its pane pid IS the shell, with no agent
+            // under it — so the rail never runs for one, and a shell send that
+            // would otherwise be refused every time goes through.
+            //
+            // Covering Codex here matters more than it does for Claude: a Codex
+            // row is never exit-stamped, because Codex ships no `SessionEnd`
+            // hook, and stamping one would be worse than not — the wake path
+            // refuses a non-Claude row, so the stamp would park it unwakeably.
+            // This rail is therefore the ONLY thing standing between a Codex
+            // pane whose agent left and a message pasted into its shell and run.
             // The park rail above stays kind-agnostic: a parked row of any kind
             // has no live session behind it.
             //
@@ -3065,13 +3095,14 @@ extension RPCRouter {
             // cannot answer is not evidence that Claude left, and the pane
             // consultation below is the rail that judges a missing or dead pane,
             // properly.
-            if Self.supportsDeliveryObservation(terminal),
+            if let agentName = Self.foregroundAgentName(for: terminal.kind),
                let panePIDString = try? await tmux.panePID(
                     server: worktree.tmuxServer, paneID: terminal.tmuxPaneID),
                let panePID = Int32(panePIDString), panePID > 0,
-               paneProcessInspector.foregroundClaudePID(panePID: panePID) == nil {
-                let message = Self.claudeNotForegroundRefusal(
-                    terminalID: terminal.id, paneID: terminal.tmuxPaneID)
+               paneProcessInspector.foregroundAgentPID(
+                    panePID: panePID, matching: agentName) == nil {
+                let message = Self.agentNotForegroundRefusal(
+                    terminalID: terminal.id, paneID: terminal.tmuxPaneID, agentName: agentName)
                 await finishActuation(actuationID, .refused(.notEligible), error: message)
                 return RPCResponse(error: message)
             }

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -4044,6 +4044,7 @@ extension RPCRouter {
         // Placed after the identity check above, so a hook this pass rejected
         // retracts nothing.
         if (try? await db.terminals.clearSessionExitStamp(id: terminal.id)) == true {
+            await broadcastExitStampChange(terminalID: terminal.id, parked: false)
             logger.debug("""
                 sessionEvent: cleared the exit stamp on terminal \
                 \(terminal.id.uuidString, privacy: .public)
@@ -4283,15 +4284,58 @@ extension RPCRouter {
                 """)
             return .ok()
         }
-        let stamped = (try? await db.terminals.stampSessionExited(
-            id: params.terminalID,
-            reportedIncarnationID: params.sessionIncarnationID,
-            at: now())) ?? false
+        // A thrown store error is NOT the same fact as a refused stamp, and
+        // collapsing the two into one `false` returns the feature to the bug it
+        // fixes — a terminal nobody parked, silently, at `.debug`. A refusal
+        // (`false`) stays a trace; a failure is an error.
+        let stamped: Bool
+        do {
+            stamped = try await db.terminals.stampSessionExited(
+                id: params.terminalID,
+                reportedIncarnationID: params.sessionIncarnationID,
+                at: now())
+        } catch {
+            logger.error("""
+                sessionEnded: stamping terminal \
+                \(params.terminalID.uuidString, privacy: .public) as exited FAILED, \
+                the row stays unparked: \(String(describing: error), privacy: .public)
+                """)
+            return .ok()
+        }
+        if stamped {
+            await broadcastExitStampChange(terminalID: params.terminalID, parked: true)
+        }
         logger.debug("""
             sessionEnded: terminal=\(params.terminalID.uuidString, privacy: .public) \
             reason=\(params.reason ?? "none", privacy: .public) stamped=\(stamped, privacy: .public)
             """)
         return .ok()
+    }
+
+    /// Publish an exit-stamp park or un-park on the same channel every other
+    /// writer of `hibernatedAt` uses (`HibernationCoordinator.broadcastHibernation`).
+    ///
+    /// The app applies `.terminalHibernationChanged` to its cached row IN PLACE,
+    /// and that is the only timely route: the parked view materializes on the
+    /// `isParked` flip and reads the row's snapshot once at creation, and
+    /// wake-on-focus filters on the cached `hibernateReason` — a value arriving
+    /// only in the next `terminal.list` refetch is too late for both. Without
+    /// this the moon appears whenever the app next happens to refetch.
+    ///
+    /// The row is re-read rather than reconstructed so the delta carries what
+    /// was actually committed, and `keepWarm`/`suspendedSnapshot` come from the
+    /// row for the same reason. A row that vanished between the write and the
+    /// read has nothing to publish about.
+    private func broadcastExitStampChange(terminalID: UUID, parked: Bool) async {
+        guard let row = try? await db.terminals.get(id: terminalID) else { return }
+        subscriptions.broadcast(delta: .terminalHibernationChanged(TerminalHibernationDelta(
+            terminalID: row.id,
+            worktreeID: row.worktreeID,
+            hibernated: parked,
+            keepWarm: row.keepWarm,
+            suspendedSnapshot: parked ? row.suspendedSnapshot : nil,
+            hibernateReason: parked ? row.hibernateReason : nil
+        )))
     }
 
     func handleTerminalActivityEvent(_ paramsData: Data) async throws -> RPCResponse {

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -281,6 +281,12 @@ public final class RPCRouter: Sendable {
     /// moved, this says whether the session itself did.
     let transcriptDeltaInspector: TranscriptDeltaInspector
 
+    /// How the daemon asks whether Claude owns a pane's foreground process
+    /// group. The same seam the limit-resume actuator uses, held here so the
+    /// send path can refuse a pane whose agent has left without any test
+    /// needing a real `ps`. A process-table fact, never screen text.
+    let paneProcessInspector: any PaneProcessInspecting
+
     public init(
         db: TBDDatabase,
         lifecycle: WorktreeLifecycle,
@@ -306,12 +312,14 @@ public final class RPCRouter: Sendable {
         transcriptFingerprinter: @escaping TranscriptFingerprinter = TranscriptFingerprinting.live,
         transcriptDeltaInspector: @escaping TranscriptDeltaInspector
             = TranscriptDeltaInspection.live,
+        paneProcessInspector: any PaneProcessInspecting = ProductionPaneProcessInspector(),
         actuationLog: ActuationLog
     ) {
         self.now = now
         self.tmuxSocketPathResolver = tmuxSocketPathResolver
         self.transcriptFingerprinter = transcriptFingerprinter
         self.transcriptDeltaInspector = transcriptDeltaInspector
+        self.paneProcessInspector = paneProcessInspector
         self.actuationLog = actuationLog
         self.db = db
         self.lifecycle = lifecycle

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -173,6 +173,11 @@ public struct TmuxManager: Sendable {
     /// transport failure rather than a refusal, and a non-throwing hook would
     /// leave that branch with no way to be exercised.
     public let dryRunPaneSendTarget: (@Sendable (String, String) throws -> PaneSendTarget)?
+    /// Optional test hook consulted by `panePID` in dryRun mode:
+    /// `(server, paneID)` to the pid string to report. Without it dryRun reports
+    /// "0", which makes the send path's foreground-process rail unreachable from
+    /// a test — the same gap `dryRunPaneCurrentCommand` closes for its own query.
+    public let dryRunPanePID: (@Sendable (String, String) -> String)?
     /// Optional test hook consulted by `killSessionIfClientless` in dryRun
     /// mode: `(server, session)` → true when tmux would have *spared* the
     /// session because a client attached between the listing and the kill.
@@ -239,7 +244,7 @@ public struct TmuxManager: Sendable {
         }
     }
 
-    public init(dryRun: Bool = false, dryRunRecorder: (@Sendable ([String]) -> Void)? = nil, dryRunWindowIsDead: (@Sendable (String) -> Bool)? = nil, dryRunListWindows: (@Sendable (String, String) -> [(windowID: String, paneID: String)])? = nil, dryRunListSessions: (@Sendable (String) -> [TmuxSessionInfo])? = nil, dryRunCapturePane: (@Sendable (String, String) -> String)? = nil, dryRunPaneCurrentCommand: (@Sendable (String, String) -> String)? = nil, dryRunCreateWindowError: (@Sendable (String) -> Error?)? = nil, dryRunRespawnWindowError: (@Sendable (String) -> Error?)? = nil, dryRunKillWindowError: (@Sendable (String, String) -> Error?)? = nil, dryRunPaneSendTarget: (@Sendable (String, String) throws -> PaneSendTarget)? = nil, dryRunSessionSpared: (@Sendable (String, String) -> Bool)? = nil, dryRunPaneWindowID: (@Sendable (String, String) -> String?)? = nil, dryRunPasteBytes: (@Sendable (String, String, Data) -> Void)? = nil, realModeWindowExistsOverride: (@Sendable (String, String) -> Bool?)? = nil, realModePaneCurrentCommandOverride: (@Sendable (String, String) -> String?)? = nil, dryRunServerPresence: (@Sendable (String) -> TmuxPresence)? = nil, dryRunWindowPresence: (@Sendable (String, String) -> TmuxPresence)? = nil, realModeServerPresenceOverride: (@Sendable (String) -> TmuxPresence?)? = nil, realModeWindowPresenceOverride: (@Sendable (String, String) -> TmuxPresence?)? = nil, subprocessTimeout: Duration = TmuxManager.commandTimeout) {
+    public init(dryRun: Bool = false, dryRunRecorder: (@Sendable ([String]) -> Void)? = nil, dryRunWindowIsDead: (@Sendable (String) -> Bool)? = nil, dryRunListWindows: (@Sendable (String, String) -> [(windowID: String, paneID: String)])? = nil, dryRunListSessions: (@Sendable (String) -> [TmuxSessionInfo])? = nil, dryRunCapturePane: (@Sendable (String, String) -> String)? = nil, dryRunPaneCurrentCommand: (@Sendable (String, String) -> String)? = nil, dryRunCreateWindowError: (@Sendable (String) -> Error?)? = nil, dryRunRespawnWindowError: (@Sendable (String) -> Error?)? = nil, dryRunKillWindowError: (@Sendable (String, String) -> Error?)? = nil, dryRunPaneSendTarget: (@Sendable (String, String) throws -> PaneSendTarget)? = nil, dryRunPanePID: (@Sendable (String, String) -> String)? = nil, dryRunSessionSpared: (@Sendable (String, String) -> Bool)? = nil, dryRunPaneWindowID: (@Sendable (String, String) -> String?)? = nil, dryRunPasteBytes: (@Sendable (String, String, Data) -> Void)? = nil, realModeWindowExistsOverride: (@Sendable (String, String) -> Bool?)? = nil, realModePaneCurrentCommandOverride: (@Sendable (String, String) -> String?)? = nil, dryRunServerPresence: (@Sendable (String) -> TmuxPresence)? = nil, dryRunWindowPresence: (@Sendable (String, String) -> TmuxPresence)? = nil, realModeServerPresenceOverride: (@Sendable (String) -> TmuxPresence?)? = nil, realModeWindowPresenceOverride: (@Sendable (String, String) -> TmuxPresence?)? = nil, subprocessTimeout: Duration = TmuxManager.commandTimeout) {
         self.dryRun = dryRun
         self.subprocessTimeout = subprocessTimeout
         self.counter = Counter()
@@ -254,6 +259,7 @@ public struct TmuxManager: Sendable {
         self.dryRunRespawnWindowError = dryRunRespawnWindowError
         self.dryRunKillWindowError = dryRunKillWindowError
         self.dryRunPaneSendTarget = dryRunPaneSendTarget
+        self.dryRunPanePID = dryRunPanePID
         self.dryRunSessionSpared = dryRunSessionSpared
         self.dryRunPaneWindowID = dryRunPaneWindowID
         self.dryRunPasteBytes = dryRunPasteBytes
@@ -1541,7 +1547,7 @@ public struct TmuxManager: Sendable {
     }
 
     public func panePID(server: String, paneID: String) async throws -> String {
-        if dryRun { return "0" }
+        if dryRun { return dryRunPanePID?(server, paneID) ?? "0" }
         let args = Self.panePIDQuery(server: server, paneID: paneID)
         return try await runTmux(args).trimmingCharacters(in: .whitespacesAndNewlines)
     }

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -177,7 +177,7 @@ public struct TmuxManager: Sendable {
     /// `(server, paneID)` to the pid string to report. Without it dryRun reports
     /// "0", which makes the send path's foreground-process rail unreachable from
     /// a test — the same gap `dryRunPaneCurrentCommand` closes for its own query.
-    public let dryRunPanePID: (@Sendable (String, String) -> String)?
+    public let dryRunPanePID: (@Sendable (String, String) throws -> String)?
     /// Optional test hook consulted by `killSessionIfClientless` in dryRun
     /// mode: `(server, session)` → true when tmux would have *spared* the
     /// session because a client attached between the listing and the kill.
@@ -244,7 +244,7 @@ public struct TmuxManager: Sendable {
         }
     }
 
-    public init(dryRun: Bool = false, dryRunRecorder: (@Sendable ([String]) -> Void)? = nil, dryRunWindowIsDead: (@Sendable (String) -> Bool)? = nil, dryRunListWindows: (@Sendable (String, String) -> [(windowID: String, paneID: String)])? = nil, dryRunListSessions: (@Sendable (String) -> [TmuxSessionInfo])? = nil, dryRunCapturePane: (@Sendable (String, String) -> String)? = nil, dryRunPaneCurrentCommand: (@Sendable (String, String) -> String)? = nil, dryRunCreateWindowError: (@Sendable (String) -> Error?)? = nil, dryRunRespawnWindowError: (@Sendable (String) -> Error?)? = nil, dryRunKillWindowError: (@Sendable (String, String) -> Error?)? = nil, dryRunPaneSendTarget: (@Sendable (String, String) throws -> PaneSendTarget)? = nil, dryRunPanePID: (@Sendable (String, String) -> String)? = nil, dryRunSessionSpared: (@Sendable (String, String) -> Bool)? = nil, dryRunPaneWindowID: (@Sendable (String, String) -> String?)? = nil, dryRunPasteBytes: (@Sendable (String, String, Data) -> Void)? = nil, realModeWindowExistsOverride: (@Sendable (String, String) -> Bool?)? = nil, realModePaneCurrentCommandOverride: (@Sendable (String, String) -> String?)? = nil, dryRunServerPresence: (@Sendable (String) -> TmuxPresence)? = nil, dryRunWindowPresence: (@Sendable (String, String) -> TmuxPresence)? = nil, realModeServerPresenceOverride: (@Sendable (String) -> TmuxPresence?)? = nil, realModeWindowPresenceOverride: (@Sendable (String, String) -> TmuxPresence?)? = nil, subprocessTimeout: Duration = TmuxManager.commandTimeout) {
+    public init(dryRun: Bool = false, dryRunRecorder: (@Sendable ([String]) -> Void)? = nil, dryRunWindowIsDead: (@Sendable (String) -> Bool)? = nil, dryRunListWindows: (@Sendable (String, String) -> [(windowID: String, paneID: String)])? = nil, dryRunListSessions: (@Sendable (String) -> [TmuxSessionInfo])? = nil, dryRunCapturePane: (@Sendable (String, String) -> String)? = nil, dryRunPaneCurrentCommand: (@Sendable (String, String) -> String)? = nil, dryRunCreateWindowError: (@Sendable (String) -> Error?)? = nil, dryRunRespawnWindowError: (@Sendable (String) -> Error?)? = nil, dryRunKillWindowError: (@Sendable (String, String) -> Error?)? = nil, dryRunPaneSendTarget: (@Sendable (String, String) throws -> PaneSendTarget)? = nil, dryRunPanePID: (@Sendable (String, String) throws -> String)? = nil, dryRunSessionSpared: (@Sendable (String, String) -> Bool)? = nil, dryRunPaneWindowID: (@Sendable (String, String) -> String?)? = nil, dryRunPasteBytes: (@Sendable (String, String, Data) -> Void)? = nil, realModeWindowExistsOverride: (@Sendable (String, String) -> Bool?)? = nil, realModePaneCurrentCommandOverride: (@Sendable (String, String) -> String?)? = nil, dryRunServerPresence: (@Sendable (String) -> TmuxPresence)? = nil, dryRunWindowPresence: (@Sendable (String, String) -> TmuxPresence)? = nil, realModeServerPresenceOverride: (@Sendable (String) -> TmuxPresence?)? = nil, realModeWindowPresenceOverride: (@Sendable (String, String) -> TmuxPresence?)? = nil, subprocessTimeout: Duration = TmuxManager.commandTimeout) {
         self.dryRun = dryRun
         self.subprocessTimeout = subprocessTimeout
         self.counter = Counter()
@@ -1547,7 +1547,7 @@ public struct TmuxManager: Sendable {
     }
 
     public func panePID(server: String, paneID: String) async throws -> String {
-        if dryRun { return dryRunPanePID?(server, paneID) ?? "0" }
+        if dryRun { return try dryRunPanePID?(server, paneID) ?? "0" }
         let args = Self.panePIDQuery(server: server, paneID: paneID)
         return try await runTmux(args).trimmingCharacters(in: .whitespacesAndNewlines)
     }

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -582,6 +582,16 @@ public enum HibernateReason: String, Codable, Sendable {
     /// Parked because the worktree's PR merged — system-initiated, so it
     /// auto-wakes on focus like `.auto`.
     case merged
+    /// Claude's own process left — reported by its `SessionEnd` hook, for the
+    /// reasons that mean the process is going away rather than starting a new
+    /// session inside the same process.
+    ///
+    /// Deliberately the SAME state as a deliberate park: process gone, terminal
+    /// alive, session id known. One state means one wake path and one UI (design
+    /// 2026-09-05, "A separate exited state beside hibernation" is a rejected
+    /// alternative). It behaves like `.auto` for wake-on-focus, which is what the
+    /// lenient decoder above already gives an older app binary reading this value.
+    case exited
 
     // Custom lenient decoder: the SYNTHESIZED `Decodable` throws
     // `DecodingError.dataCorrupted` on any raw value this build doesn't know.
@@ -769,6 +779,13 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
             value: awaitingInputReason,
             source: .hookEvent(hookEventName),
             observedAt: awaitingInputObservedAt)
+    }
+
+    /// Whether this row is parked because Claude's own process left, rather than
+    /// because TBD parked it. Both columns are required: `hibernatedAt` is what
+    /// makes it a park at all, and the reason is what says who ended it.
+    public var isExitStamped: Bool {
+        hibernatedAt != nil && hibernateReason == .exited
     }
 
     public init(id: UUID = UUID(), worktreeID: UUID, tmuxWindowID: String,

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -588,8 +588,9 @@ public enum HibernateReason: String, Codable, Sendable {
     ///
     /// Deliberately the SAME state as a deliberate park: process gone, terminal
     /// alive, session id known. One state means one wake path and one UI; see
-    /// `docs/specs/2026-09-05-transcript-composer-design.md`, where "A separate
-    /// exited state beside hibernation" is a rejected alternative.
+    /// `docs/specs/2026-09-05-transcript-composer-design.md`, landing in
+    /// PR #821, where "A separate exited state beside hibernation" is a
+    /// rejected alternative.
     /// It behaves like `.auto` for wake-on-focus, which is what the
     /// lenient decoder above already gives an older app binary reading this value.
     case exited

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -587,9 +587,10 @@ public enum HibernateReason: String, Codable, Sendable {
     /// session inside the same process.
     ///
     /// Deliberately the SAME state as a deliberate park: process gone, terminal
-    /// alive, session id known. One state means one wake path and one UI (design
-    /// 2026-09-05, "A separate exited state beside hibernation" is a rejected
-    /// alternative). It behaves like `.auto` for wake-on-focus, which is what the
+    /// alive, session id known. One state means one wake path and one UI; see
+    /// `docs/specs/2026-09-05-transcript-composer-design.md`, where "A separate
+    /// exited state beside hibernation" is a rejected alternative.
+    /// It behaves like `.auto` for wake-on-focus, which is what the
     /// lenient decoder above already gives an older app binary reading this value.
     case exited
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -4104,9 +4104,20 @@ public struct TerminalSessionEndedParams: Codable, Sendable, Equatable {
     /// Process incarnation planted by TBD before a managed replacement starts.
     /// Optional so older clients' payloads continue to decode unchanged.
     public let sessionIncarnationID: UUID?
-    public init(terminalID: UUID, sessionIncarnationID: UUID? = nil) {
+    /// Claude Code's `SessionEnd` hook `reason`, verbatim and unclassified —
+    /// `logout`, `clear`, `prompt_input_exit`, `other`, or a value this build has
+    /// never heard of. Carried, never parsed for meaning; the daemon files it
+    /// through `SessionEndReason.parksTheTerminal(_:)`, whose vocabulary is one
+    /// edit rather than a rule spread across three processes.
+    ///
+    /// Optional because `~/.local/bin/tbd` is routinely stale relative to a
+    /// running daemon: an older CLI sends no `reason`, which reads as "we do not
+    /// know" and parks nothing.
+    public let reason: String?
+    public init(terminalID: UUID, sessionIncarnationID: UUID? = nil, reason: String? = nil) {
         self.terminalID = terminalID
         self.sessionIncarnationID = sessionIncarnationID
+        self.reason = reason
     }
 }
 

--- a/Sources/TBDShared/SessionEndReason.swift
+++ b/Sources/TBDShared/SessionEndReason.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// Claude Code's `SessionEnd` hook `reason` field, read for one question: is the
+/// PROCESS going away?
+///
+/// A `/clear` fires `SessionEnd` and then `SessionStart` inside one live process
+/// — one conversation ends, another begins, and the pty is untouched. Parking on
+/// that would refuse every subsequent send to a healthy session, which is worse
+/// than the bug this exists to fix.
+///
+/// **A whitelist of leaving reasons, not a blacklist of staying ones.** An
+/// unrecognized reason from a newer Claude Code is an admission of ignorance, and
+/// ignorance must not park: the foreground-process rail in the send path still
+/// catches a genuinely departed process, so a missed stamp degrades to the
+/// pre-existing second check rather than to the pre-existing bug. TBD never
+/// branches on hook *message* text (that would be screen-scraping with an extra
+/// hop); `reason` is a closed machine vocabulary and is exactly what may be
+/// matched.
+public enum SessionEndReason {
+    /// The reasons that mean the process is leaving. Enumerated exhaustively so
+    /// adding one is a visible edit rather than a silent reclassification.
+    static let leavingReasons: Set<String> = ["logout", "exit", "prompt_input_exit", "other"]
+
+    /// Whether a `SessionEnd` with this `reason` should park the terminal.
+    public static func parksTheTerminal(_ raw: String?) -> Bool {
+        guard let raw else { return false }
+        let normalized = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return leavingReasons.contains(normalized)
+    }
+}

--- a/Tests/TBDAppTests/HibernatedBannerModelTests.swift
+++ b/Tests/TBDAppTests/HibernatedBannerModelTests.swift
@@ -71,6 +71,16 @@ struct HibernatedBannerModelTests {
         ))
     }
 
+    /// Session-exit park → names the process that left, not a TBD gesture.
+    @Test func exitedParkMessage() {
+        let banner = HibernatedBannerModel.banner(
+            for: terminal(hibernatedAt: Date(), hibernateReason: .exited)
+        )
+        #expect(banner == .hibernatedOverlay(
+            message: "Claude exited — click anywhere in the pane to resume"
+        ))
+    }
+
     /// Legacy pre-v46 park with no persisted reason → reads like `.auto`.
     @Test func nilReasonParkMessage() {
         let banner = HibernatedBannerModel.banner(

--- a/Tests/TBDAppTests/WakeOnFocusDecisionTests.swift
+++ b/Tests/TBDAppTests/WakeOnFocusDecisionTests.swift
@@ -125,6 +125,23 @@ struct WakeOnFocusDecisionTests {
         #expect(state.terminalIDToWakeOnFocus(worktreeID: wt) == merged)
     }
 
+    /// An exit-stamped session (`hibernateReason == .exited`) must NOT
+    /// focus-wake: `stampSessionExited` writes only two DB columns and never
+    /// replaces the pane with an inert placeholder the way every other park
+    /// does, so waking it runs `tmux respawn-window -k` against the live
+    /// shell Claude's exit left behind — killing it. Excluded exactly like
+    /// `.manual`, but for a different reason (no placeholder, not "user
+    /// explicitly parked this").
+    @Test func skipsExitedParkedTerminalEvenWhenFocused() {
+        let state = AppState()
+        let wt = UUID()
+        let exited = UUID()
+        state.terminals[wt] = [parkedTerminal(exited, reason: .exited)]
+        focus(state, worktreeID: wt, terminalID: exited)
+
+        #expect(state.terminalIDToWakeOnFocus(worktreeID: wt) == nil)
+    }
+
     /// A legacy parked row with NO reason (pre-v46) still wakes on focus —
     /// the old behavior is preserved for rows the migration can't attribute.
     @Test func wakesLegacyNilReasonParkedTerminalOnFocus() {

--- a/Tests/TBDAppTests/WakeOnTabActivationTests.swift
+++ b/Tests/TBDAppTests/WakeOnTabActivationTests.swift
@@ -137,6 +137,23 @@ struct WakeOnTabActivationTests {
         #expect(toWake.isEmpty)
     }
 
+    /// Parked resumable terminal with hibernateReason == .exited
+    /// → NOT returned. `stampSessionExited` never replaces the pane with a
+    /// placeholder (unlike every other park path), so waking it on tab
+    /// activation would `respawn-window -k` the live shell Claude's exit
+    /// left behind, killing it. Excluded like `.manual`, different reason.
+    @Test func skipsExitedParkedTerminal() {
+        let state = AppState()
+        let wt = UUID()
+        let exited = UUID()
+        let tabID = UUID()
+        state.terminals[wt] = [terminal(exited, parked: true, reason: .exited)]
+        state.tabs[wt] = [Tab(id: tabID, content: .terminal(terminalID: exited), label: nil)]
+
+        let toWake = state.terminalIDsToWakeOnTabActivation(worktreeID: wt, tabIndex: 0)
+        #expect(toWake.isEmpty)
+    }
+
     /// Parked resumable with .auto reason in activated tab → included.
     @Test func wakesAutoParkedInActivatedTab() {
         let state = AppState()

--- a/Tests/TBDAppTests/WakePromptTests.swift
+++ b/Tests/TBDAppTests/WakePromptTests.swift
@@ -1,0 +1,53 @@
+import Foundation
+import Testing
+@testable import TBDApp
+import TBDShared
+
+/// The app has never passed `terminal.wake`'s `prompt`, though the CLI, the RPC
+/// params, the handler, the coordinator and the spawn builder all carry it. This
+/// pins the parameter all the way to the encoded params.
+@MainActor
+@Suite("wake carries a prompt")
+struct WakePromptTests {
+
+    @Test func theParamsCarryThePromptToTheWire() throws {
+        let terminalID = UUID()
+        let params = TerminalWakeParams(
+            terminalID: terminalID, cols: 120, rows: 40,
+            fallbackToDefaultProfile: nil, prompt: "ship it")
+        let json = try #require(String(
+            data: try JSONEncoder().encode(params), encoding: .utf8))
+        #expect(json.contains("\"prompt\":\"ship it\""))
+    }
+
+    /// A wake with no prompt must encode no `prompt` key at all — an empty string
+    /// would become a trailing empty argv on `claude --resume`.
+    @Test func anAbsentPromptEncodesNoKey() throws {
+        let params = TerminalWakeParams(terminalID: UUID())
+        let json = try #require(String(
+            data: try JSONEncoder().encode(params), encoding: .utf8))
+        #expect(!json.contains("prompt"))
+    }
+
+    /// The app-level seam: `wakeTerminal` hands the prompt to the client.
+    @Test func appStateForwardsThePrompt() async throws {
+        let suiteName = "WakePromptTests-\(UUID().uuidString)"
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+        let state = AppState(userDefaults: UserDefaults(suiteName: suiteName)!)
+
+        let recorded = Recorder()
+        state.terminalWakeSender = { _, _, _, _, prompt in
+            await recorded.record(prompt)
+        }
+
+        _ = await state.wakeTerminal(
+            terminalID: UUID(), worktreeID: UUID(), userInitiated: true, prompt: "ship it")
+
+        #expect(await recorded.value == "ship it")
+    }
+
+    private actor Recorder {
+        private(set) var value: String?
+        func record(_ prompt: String?) { value = prompt }
+    }
+}

--- a/Tests/TBDCLITests/SessionEndHookReasonTests.swift
+++ b/Tests/TBDCLITests/SessionEndHookReasonTests.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Testing
+@testable import TBDCLI
+
+/// `SessionEndCommand.hookReason(from:)` is the whole parse standing between
+/// Claude Code's `SessionEnd` payload and the park stamp the daemon writes off
+/// it. Static and pure so it is testable without a pipe.
+///
+/// Every way it can fail must answer nil — "we do not know" — never throw: a
+/// hook bridge must not wedge or redden the agent it observes, and the daemon
+/// reads a missing reason as "not a process exit" and leaves the row alone.
+@Suite struct SessionEndHookReasonTests {
+    private func payload(_ json: String) -> Data { Data(json.utf8) }
+
+    @Test("a reason is lifted out of the payload, and unknown fields are ignored")
+    func reasonPresent() {
+        #expect(SessionEndCommand.hookReason(from: payload(#"{"reason":"clear"}"#)) == "clear")
+        #expect(SessionEndCommand.hookReason(
+            from: payload(#"{"session_id":"abc","reason":"other","cwd":"/tmp"}"#)) == "other")
+    }
+
+    @Test("a well-formed payload that names no reason knows nothing")
+    func reasonAbsent() {
+        #expect(SessionEndCommand.hookReason(from: payload("{}")) == nil)
+        #expect(SessionEndCommand.hookReason(from: payload(#"{"session_id":"abc"}"#)) == nil)
+        #expect(SessionEndCommand.hookReason(from: payload(#"{"reason":null}"#)) == nil)
+    }
+
+    @Test("an empty payload is a nil reason, not an error")
+    func emptyData() {
+        #expect(SessionEndCommand.hookReason(from: Data()) == nil)
+    }
+
+    /// The 1 MiB cap bounds PROCESSING, so it is judged on the byte count alone:
+    /// a payload one byte over the line is refused even though it parses
+    /// perfectly, and one exactly at the line is not.
+    @Test("an oversized payload is refused on its size alone")
+    func oversizedData() {
+        let cap = 1 << 20
+        func padded(to size: Int) -> Data {
+            let prefix = #"{"reason":"clear","pad":""#
+            let suffix = #""}"#
+            return payload(
+                prefix
+                    + String(repeating: "x", count: size - prefix.utf8.count - suffix.utf8.count)
+                    + suffix)
+        }
+
+        let atCap = padded(to: cap)
+        #expect(atCap.count == cap)
+        #expect(SessionEndCommand.hookReason(from: atCap) == "clear")
+
+        let overCap = padded(to: cap + 1)
+        #expect(overCap.count == cap + 1)
+        #expect(SessionEndCommand.hookReason(from: overCap) == nil)
+    }
+
+    @Test("malformed JSON, and JSON that is not the expected object, answer nil")
+    func malformedJSON() {
+        #expect(SessionEndCommand.hookReason(from: payload("{not json")) == nil)
+        #expect(SessionEndCommand.hookReason(from: payload("[]")) == nil)
+        #expect(SessionEndCommand.hookReason(from: payload(#"{"reason":42}"#)) == nil)
+    }
+}

--- a/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
@@ -1232,6 +1232,86 @@ struct HibernationCoordinatorTests {
                 "expected a respawn-window carrying claude --resume; got: \(joined)")
     }
 
+    // MARK: - Wake: the exit-stamped pane-busy guard
+    //
+    // An exit stamp parks the row while the pane's SHELL stays alive and
+    // usable — unlike every other park reason, whose pane holds an inert shell
+    // hibernate put there. Wake is `respawn-window -k`, so waking such a row
+    // kills whatever occupies that pane.
+    //
+    // The app excludes `.exited` from focus/tab auto-wake, and that stays the
+    // first line. It cannot be the only one: `docs/updating.md`'s `--no-app`
+    // makes "daemon newer than app" a supported skew, and an app binary older
+    // than the stamp decodes `.exited` through the lenient `HibernateReason`
+    // decoder as `.auto` and auto-wakes it. The three cases below pin the
+    // daemon-side guard, which answers the same way no matter who asked.
+
+    /// RED without the guard: an old app's focus-wake reaches a busy pane and
+    /// `respawn-window -k` kills the process running in it.
+    @Test func exitStampedWakeIsRefusedWhenThePaneIsBusy() async throws {
+        let (db, _, terminalID) = try await setup()
+        #expect(try await db.terminals.stampSessionExited(
+            id: terminalID, reportedIncarnationID: nil,
+            at: Date(timeIntervalSince1970: 1_800_000_000)))
+        let recorded = RecordedTmuxCommands()
+        let tmux = TmuxManager(
+            dryRun: true, dryRunRecorder: recorded.append,
+            dryRunPanePID: { _, _ in "4242" })
+        let coord = HibernationCoordinator(
+            db: db, tmux: tmux, configDirManager: isolatedConfigDirManager(),
+            paneProcessInspector: FakeInspector(claudePID: nil, foregroundPID: 9999),
+            actuationLog: makeTestActuationLog())
+
+        #expect(await coord.wake(terminalID: terminalID) == .paneBusy(pid: 9999))
+        #expect(recorded.snapshot().filter { $0.contains("respawn-window") }.isEmpty,
+                "the refusal must not touch the pane")
+        let after = try #require(try await db.terminals.get(id: terminalID))
+        #expect(after.isExitStamped, "the row stays exit-stamped so a later retry still wakes")
+    }
+
+    /// The positive control, and the ordinary case: nothing is running in the
+    /// pane, so the pane's own pid owns the foreground group and the wake
+    /// proceeds exactly as it did before the guard.
+    @Test func exitStampedWakeProceedsWhenThePaneIsAnIdleShell() async throws {
+        let (db, _, terminalID) = try await setup()
+        #expect(try await db.terminals.stampSessionExited(
+            id: terminalID, reportedIncarnationID: nil,
+            at: Date(timeIntervalSince1970: 1_800_000_000)))
+        let recorded = RecordedTmuxCommands()
+        let tmux = TmuxManager(
+            dryRun: true, dryRunRecorder: recorded.append,
+            dryRunPanePID: { _, _ in "4242" })
+        let coord = HibernationCoordinator(
+            db: db, tmux: tmux, configDirManager: isolatedConfigDirManager(),
+            paneProcessInspector: FakeInspector(claudePID: nil, foregroundPID: 4242),
+            actuationLog: makeTestActuationLog())
+
+        #expect(await coord.wake(terminalID: terminalID) == .ok)
+        #expect(try await db.terminals.get(id: terminalID)?.isParked == false)
+        let joined = recorded.snapshot().map { $0.joined(separator: " ") }
+        #expect(joined.contains { $0.contains("respawn-window") && $0.contains("claude --resume sess-1") },
+                "expected the ordinary respawn; got: \(joined)")
+    }
+
+    /// The guard is scoped to the exit stamp and to nothing else. A deliberate
+    /// park's pane holds the inert shell hibernate respawned into it, so a
+    /// foreground process there is that shell's own business and must not cost
+    /// the row its wake.
+    @Test func aDeliberatelyParkedRowIsUnaffectedByTheBusyPaneGuard() async throws {
+        let (db, _, terminalID) = try await setup()
+        try await db.terminals.setHibernated(
+            id: terminalID, sessionID: "sess-1", reason: .manual,
+            at: Date(timeIntervalSince1970: 1_800_000_000))
+        let tmux = TmuxManager(dryRun: true, dryRunPanePID: { _, _ in "4242" })
+        let coord = HibernationCoordinator(
+            db: db, tmux: tmux, configDirManager: isolatedConfigDirManager(),
+            paneProcessInspector: FakeInspector(claudePID: nil, foregroundPID: 9999),
+            actuationLog: makeTestActuationLog())
+
+        #expect(await coord.wake(terminalID: terminalID) == .ok)
+        #expect(try await db.terminals.get(id: terminalID)?.isParked == false)
+    }
+
     // MARK: - Wake: window-gone recreate branch
     //
     // A reboot destroys every tmux server, leaving parked rows pointing at

--- a/Tests/TBDDaemonTests/LimitResumeActuatorTests.swift
+++ b/Tests/TBDDaemonTests/LimitResumeActuatorTests.swift
@@ -60,7 +60,11 @@ final class FakeResumeTmux: ResumeSendingTmux, @unchecked Sendable {
 
 struct FakeInspector: PaneProcessInspecting {
     var claudePID: Int32?
+    /// Whatever owns the pane's foreground group. Defaults to the pane pid —
+    /// an idle shell — because no test in this file exercises that rail.
+    var foregroundPID: Int32?
     func foregroundAgentPID(panePID: Int32, matching agentName: String) -> Int32? { claudePID }
+    func paneForegroundPID(panePID: Int32) -> Int32? { foregroundPID ?? panePID }
 }
 
 @Suite struct LimitResumeActuatorTests {

--- a/Tests/TBDDaemonTests/LimitResumeActuatorTests.swift
+++ b/Tests/TBDDaemonTests/LimitResumeActuatorTests.swift
@@ -60,7 +60,7 @@ final class FakeResumeTmux: ResumeSendingTmux, @unchecked Sendable {
 
 struct FakeInspector: PaneProcessInspecting {
     var claudePID: Int32?
-    func foregroundClaudePID(panePID: Int32) -> Int32? { claudePID }
+    func foregroundAgentPID(panePID: Int32, matching agentName: String) -> Int32? { claudePID }
 }
 
 @Suite struct LimitResumeActuatorTests {

--- a/Tests/TBDDaemonTests/SessionExitStampHandlerTests.swift
+++ b/Tests/TBDDaemonTests/SessionExitStampHandlerTests.swift
@@ -2,6 +2,33 @@ import Foundation
 import Testing
 @testable import TBDDaemonLib
 import TBDShared
+import TestSupport
+
+/// Thread-safe collector for broadcast StateDeltas, mirroring the pattern in
+/// `SupervisionBrakeRPCTests` / `RPCRouterWorktreeCreateBroadcastTests`.
+private final class BroadcastDeltas: @unchecked Sendable {
+    private let lock = NSLock()
+    private var deltas: [StateDelta] = []
+
+    func append(_ delta: StateDelta) {
+        lock.lock(); defer { lock.unlock() }
+        deltas.append(delta)
+    }
+
+    func snapshot() -> [StateDelta] {
+        lock.lock(); defer { lock.unlock() }
+        return deltas
+    }
+
+    /// Only the hibernation deltas, unwrapped — the SessionStart handler
+    /// broadcasts session/activity deltas on the same channel.
+    func hibernationDeltas() -> [TerminalHibernationDelta] {
+        snapshot().compactMap {
+            if case .terminalHibernationChanged(let d) = $0 { return d }
+            return nil
+        }
+    }
+}
 
 /// The hook rail that makes "not running" a machine-readable fact.
 ///
@@ -14,13 +41,16 @@ struct SessionExitStampHandlerTests {
         let router: RPCRouter
         let db: TBDDatabase
         let terminal: Terminal
+        let deltas: BroadcastDeltas
     }
 
     /// A throwaway actuation log per fixture. `ActuationLog` takes a PATH, not a
-    /// database — the record is an append-only JSONL file.
+    /// database — the record is an append-only JSONL file. Rooted under the
+    /// run's fenced scratch dir, which `scripts/test.sh` removes even when the
+    /// test process is killed; a per-test `temporaryDirectory` would leak.
     private static func scratchLogPath() -> String {
-        let directory = FileManager.default.temporaryDirectory
-            .appendingPathComponent("tbd-plan-\(UUID().uuidString)", isDirectory: true)
+        let directory = URL(
+            fileURLWithPath: fencedScratchRoot(prefix: "tbd-exitstamp"), isDirectory: true)
         try? FileManager.default.createDirectory(
             at: directory, withIntermediateDirectories: true)
         return directory.appendingPathComponent("actuations.jsonl").path
@@ -37,13 +67,23 @@ struct SessionExitStampHandlerTests {
         let tmux = TmuxManager(dryRun: true, dryRunPaneSendTarget: { _, _ in
             .live(terminalID: nil)
         })
+        let deltas = BroadcastDeltas()
+        let subscriptions = StateSubscriptionManager()
+        subscriptions.addSubscriber { data in
+            if let delta = try? JSONDecoder().decode(StateDelta.self, from: data) {
+                deltas.append(delta)
+            }
+            return true
+        }
         let router = RPCRouter(
             db: db,
             lifecycle: WorktreeLifecycle(
-                db: db, git: GitManager(), tmux: tmux, hooks: HookResolver()),
+                db: db, git: GitManager(), tmux: tmux, hooks: HookResolver(),
+                subscriptions: subscriptions),
             tmux: tmux,
+            subscriptions: subscriptions,
             actuationLog: ActuationLog(path: Self.scratchLogPath()))
-        return Fixture(router: router, db: db, terminal: terminal)
+        return Fixture(router: router, db: db, terminal: terminal, deltas: deltas)
     }
 
     private func sessionEnded(_ f: Fixture, reason: String?) async throws {
@@ -99,6 +139,46 @@ struct SessionExitStampHandlerTests {
         let row = try #require(try await f.db.terminals.get(id: f.terminal.id))
         #expect(row.hibernatedAt == nil)
         #expect(row.hibernateReason == nil)
+    }
+
+    /// The park must reach the app as a `.terminalHibernationChanged` delta, not
+    /// only as a row the next `terminal.list` happens to refetch: the parked view
+    /// materializes on the `isParked` flip and reads its snapshot once, and
+    /// wake-on-focus filters on the CACHED `hibernateReason`. Every sibling
+    /// writer of `hibernatedAt` publishes this delta; the stamp must too.
+    @Test func theStampIsPublishedAsAHibernationDelta() async throws {
+        let f = try await makeFixture()
+        try await sessionEnded(f, reason: "logout")
+
+        let published = try #require(f.deltas.hibernationDeltas().last)
+        #expect(published.terminalID == f.terminal.id)
+        #expect(published.worktreeID == f.terminal.worktreeID)
+        #expect(published.hibernated)
+        #expect(published.hibernateReason == .exited)
+    }
+
+    /// And the retraction, symmetrically — otherwise the app keeps showing a moon
+    /// on a terminal whose session is demonstrably back.
+    @Test func theClearIsPublishedAsAWakeDelta() async throws {
+        let f = try await makeFixture()
+        try await sessionEnded(f, reason: "logout")
+        _ = try await f.router.handleTerminalSessionEvent(sessionStartPayload(f))
+
+        let published = try #require(f.deltas.hibernationDeltas().last)
+        #expect(published.terminalID == f.terminal.id)
+        #expect(published.worktreeID == f.terminal.worktreeID)
+        #expect(!published.hibernated)
+        #expect(published.hibernateReason == nil)
+    }
+
+    private func sessionStartPayload(_ f: Fixture) throws -> Data {
+        try JSONEncoder().encode(TerminalSessionEventParams(
+            terminalID: f.terminal.id,
+            sessionID: "sess-2",
+            transcriptPath: "/tmp/sess-2.jsonl",
+            source: "startup",
+            cwd: nil,
+            sessionIncarnationID: nil))
     }
 
     /// SessionStart must not un-park a session the OPERATOR parked. It fires on

--- a/Tests/TBDDaemonTests/SessionExitStampHandlerTests.swift
+++ b/Tests/TBDDaemonTests/SessionExitStampHandlerTests.swift
@@ -1,0 +1,126 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+import TBDShared
+
+/// The hook rail that makes "not running" a machine-readable fact.
+///
+/// Tier 2: an in-memory database and a dry-run tmux manager; no process is
+/// spawned and no pane is consulted.
+@Suite("SessionEnd exit stamp handlers")
+struct SessionExitStampHandlerTests {
+
+    private struct Fixture {
+        let router: RPCRouter
+        let db: TBDDatabase
+        let terminal: Terminal
+    }
+
+    /// A throwaway actuation log per fixture. `ActuationLog` takes a PATH, not a
+    /// database — the record is an append-only JSONL file.
+    private static func scratchLogPath() -> String {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-plan-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(
+            at: directory, withIntermediateDirectories: true)
+        return directory.appendingPathComponent("actuations.jsonl").path
+    }
+
+    private func makeFixture() async throws -> Fixture {
+        let db = try TBDDatabase(inMemory: true)
+        let worktree = try await db.worktrees.createScratch(
+            name: "wt", displayName: "wt",
+            path: "/tmp/tbd-nonexistent-\(UUID().uuidString)", tmuxServer: "tbd-test")
+        let terminal = try await db.terminals.create(
+            worktreeID: worktree.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "claude", claudeSessionID: "sess-1", kind: .claude)
+        let tmux = TmuxManager(dryRun: true, dryRunPaneSendTarget: { _, _ in
+            .live(terminalID: nil)
+        })
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: tmux, hooks: HookResolver()),
+            tmux: tmux,
+            actuationLog: ActuationLog(path: Self.scratchLogPath()))
+        return Fixture(router: router, db: db, terminal: terminal)
+    }
+
+    private func sessionEnded(_ f: Fixture, reason: String?) async throws {
+        let data = try JSONEncoder().encode(TerminalSessionEndedParams(
+            terminalID: f.terminal.id, reason: reason))
+        _ = try await f.router.handleTerminalSessionEnded(data)
+    }
+
+    @Test func aLogoutStampsTheTerminalAsExited() async throws {
+        let f = try await makeFixture()
+        try await sessionEnded(f, reason: "logout")
+
+        let row = try #require(try await f.db.terminals.get(id: f.terminal.id))
+        #expect(row.isExitStamped)
+        #expect(row.hibernateReason == .exited)
+    }
+
+    /// The discriminating negative. `/clear` ends one session inside a LIVE
+    /// process; stamping there would refuse every later send to a healthy pane.
+    @Test func aClearDoesNotStamp() async throws {
+        let f = try await makeFixture()
+        try await sessionEnded(f, reason: "clear")
+
+        let row = try #require(try await f.db.terminals.get(id: f.terminal.id))
+        #expect(row.hibernatedAt == nil)
+        #expect(!row.isExitStamped)
+    }
+
+    /// An older `~/.local/bin/tbd` sends no reason at all. Not knowing must not
+    /// park — the foreground-process rail still catches a real exit.
+    @Test func anAbsentReasonDoesNotStamp() async throws {
+        let f = try await makeFixture()
+        try await sessionEnded(f, reason: nil)
+
+        let row = try #require(try await f.db.terminals.get(id: f.terminal.id))
+        #expect(row.hibernatedAt == nil)
+    }
+
+    @Test func sessionStartClearsTheExitStamp() async throws {
+        let f = try await makeFixture()
+        try await sessionEnded(f, reason: "logout")
+        #expect(try #require(try await f.db.terminals.get(id: f.terminal.id)).isExitStamped)
+
+        let data = try JSONEncoder().encode(TerminalSessionEventParams(
+            terminalID: f.terminal.id,
+            sessionID: "sess-2",
+            transcriptPath: "/tmp/sess-2.jsonl",
+            source: "startup",
+            cwd: nil,
+            sessionIncarnationID: nil))
+        _ = try await f.router.handleTerminalSessionEvent(data)
+
+        let row = try #require(try await f.db.terminals.get(id: f.terminal.id))
+        #expect(row.hibernatedAt == nil)
+        #expect(row.hibernateReason == nil)
+    }
+
+    /// SessionStart must not un-park a session the OPERATOR parked. It fires on
+    /// `/clear` inside a live process too, so a blanket clear would silently
+    /// undo a deliberate hibernate.
+    @Test func sessionStartLeavesADeliberateParkAlone() async throws {
+        let f = try await makeFixture()
+        try await f.db.terminals.setHibernated(
+            id: f.terminal.id, sessionID: "sess-1", reason: .manual,
+            at: Date(timeIntervalSince1970: 1_800_000_000))
+
+        let data = try JSONEncoder().encode(TerminalSessionEventParams(
+            terminalID: f.terminal.id,
+            sessionID: "sess-2",
+            transcriptPath: "/tmp/sess-2.jsonl",
+            source: "startup",
+            cwd: nil,
+            sessionIncarnationID: nil))
+        _ = try await f.router.handleTerminalSessionEvent(data)
+
+        let row = try #require(try await f.db.terminals.get(id: f.terminal.id))
+        #expect(row.hibernateReason == .manual)
+        #expect(row.hibernatedAt != nil)
+    }
+}

--- a/Tests/TBDDaemonTests/TerminalExitStampStoreTests.swift
+++ b/Tests/TBDDaemonTests/TerminalExitStampStoreTests.swift
@@ -70,6 +70,31 @@ struct TerminalExitStampStoreTests {
         #expect(row.hibernatedAt == nil)
     }
 
+    /// A holder-backed row is never stamped. The holder's whole job is the
+    /// Claude process, so there is no shell for a send to mis-execute, and the
+    /// coordinator's wake respawns into a tmux window it cannot use — a park
+    /// here is one nothing could reclaim.
+    @Test func stampLeavesAHolderBackedRowAlone() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let worktree = try await db.worktrees.createScratch(
+            name: "wt", displayName: "wt",
+            path: "/tmp/tbd-nonexistent-\(UUID().uuidString)", tmuxServer: "tbd-test")
+        // `childPID: 0` deliberately: it is the one pid no disposal signals, so
+        // the fixture cannot name a process this shared box is really running.
+        let terminal = try await db.terminals.create(
+            worktreeID: worktree.id, tmuxWindowID: "", tmuxPaneID: "",
+            label: "claude", claudeSessionID: "sess-1", kind: .claude,
+            transport: .holder, holderPID: 9101, childPID: 0)
+
+        let changed = try await db.terminals.stampSessionExited(
+            id: terminal.id, reportedIncarnationID: nil, at: stamp)
+
+        #expect(!changed)
+        let row = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(row.hibernatedAt == nil)
+        #expect(row.hibernateReason == nil)
+    }
+
     @Test func clearRetractsOnlyAnExitStamp() async throws {
         let db = try TBDDatabase(inMemory: true)
         let terminal = try await makeTerminal(db)

--- a/Tests/TBDDaemonTests/TerminalExitStampStoreTests.swift
+++ b/Tests/TBDDaemonTests/TerminalExitStampStoreTests.swift
@@ -70,6 +70,26 @@ struct TerminalExitStampStoreTests {
         #expect(row.hibernatedAt == nil)
     }
 
+    /// The mirror of the mismatch above, from the other side: a hook that
+    /// PREDATES the nonce (`reportedIncarnationID: nil`) must not stamp a row
+    /// TBD has since minted a durable incarnation for. `updateTmuxIDs` is the
+    /// production path that mints one on a replacement launch; the guard has
+    /// to read it as exact equality (nil matches only nil), not as "skip the
+    /// check whenever the report is nil" — a delayed `SessionEnd` from the
+    /// pre-incarnation predecessor process must not park a live successor.
+    @Test func stampDeclinesANilReportAgainstANamedIncarnation() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let terminal = try await makeTerminal(db)
+        try await db.terminals.updateTmuxIDs(id: terminal.id, windowID: "@2", paneID: "%2")
+
+        let changed = try await db.terminals.stampSessionExited(
+            id: terminal.id, reportedIncarnationID: nil, at: stamp)
+
+        #expect(!changed)
+        let row = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(row.hibernatedAt == nil)
+    }
+
     /// A holder-backed row is never stamped. The holder's whole job is the
     /// Claude process, so there is no shell for a send to mis-execute, and the
     /// coordinator's wake respawns into a tmux window it cannot use — a park

--- a/Tests/TBDDaemonTests/TerminalExitStampStoreTests.swift
+++ b/Tests/TBDDaemonTests/TerminalExitStampStoreTests.swift
@@ -1,0 +1,99 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+import TBDShared
+
+/// The two narrow writers behind the exit stamp. They are deliberately NOT
+/// `setHibernated` / `clearHibernated`: those mint a session incarnation, cancel
+/// scheduled resumes and clear `suspendedAt`, all of which belong to a park TBD
+/// performed. A hook reporting that Claude left performed no park and must move
+/// exactly two columns.
+@Suite("TerminalStore exit stamp")
+struct TerminalExitStampStoreTests {
+    private let stamp = Date(timeIntervalSince1970: 1_800_000_000)
+
+    private func makeTerminal(_ db: TBDDatabase) async throws -> Terminal {
+        let worktree = try await db.worktrees.createScratch(
+            name: "wt", displayName: "wt",
+            path: "/tmp/tbd-nonexistent-\(UUID().uuidString)", tmuxServer: "tbd-test")
+        return try await db.terminals.create(
+            worktreeID: worktree.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "claude", claudeSessionID: "sess-1", kind: .claude)
+    }
+
+    @Test func stampParksTheRowWithTheExitedReason() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let terminal = try await makeTerminal(db)
+
+        let changed = try await db.terminals.stampSessionExited(
+            id: terminal.id, reportedIncarnationID: nil, at: stamp)
+
+        #expect(changed)
+        let row = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(row.hibernatedAt == stamp)
+        #expect(row.hibernateReason == .exited)
+        #expect(row.isExitStamped)
+        // Untouched: the session is still the one to resume.
+        #expect(row.claudeSessionID == "sess-1")
+    }
+
+    /// The load-bearing negative. A row TBD deliberately parked already carries
+    /// its own reason, and a late `SessionEnd` from the process TBD killed must
+    /// not rewrite it — the record of who parked a session is what
+    /// wake-on-focus reads.
+    @Test func stampLeavesAnAlreadyParkedRowAlone() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let terminal = try await makeTerminal(db)
+        try await db.terminals.setHibernated(
+            id: terminal.id, sessionID: "sess-1", reason: .manual,
+            at: Date(timeIntervalSince1970: 1_700_000_000))
+
+        let changed = try await db.terminals.stampSessionExited(
+            id: terminal.id, reportedIncarnationID: nil, at: stamp)
+
+        #expect(!changed)
+        let row = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(row.hibernateReason == .manual)
+        #expect(row.hibernatedAt == Date(timeIntervalSince1970: 1_700_000_000))
+    }
+
+    /// A hook from a process TBD has already replaced names the OLD incarnation.
+    /// Stamping on it would park a live successor.
+    @Test func stampDeclinesAMismatchedIncarnation() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let terminal = try await makeTerminal(db)
+        let changed = try await db.terminals.stampSessionExited(
+            id: terminal.id, reportedIncarnationID: UUID(), at: stamp)
+
+        #expect(!changed)
+        let row = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(row.hibernatedAt == nil)
+    }
+
+    @Test func clearRetractsOnlyAnExitStamp() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let terminal = try await makeTerminal(db)
+        try await db.terminals.stampSessionExited(
+            id: terminal.id, reportedIncarnationID: nil, at: stamp)
+
+        #expect(try await db.terminals.clearSessionExitStamp(id: terminal.id))
+        let row = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(row.hibernatedAt == nil)
+        #expect(row.hibernateReason == nil)
+    }
+
+    /// The mirror negative: a deliberate park survives a SessionStart. Claude
+    /// Code fires SessionStart on `/clear` inside a live process too, and a
+    /// blanket un-park there would silently undo the operator's own gesture.
+    @Test func clearLeavesADeliberateParkAlone() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let terminal = try await makeTerminal(db)
+        try await db.terminals.setHibernated(
+            id: terminal.id, sessionID: "sess-1", reason: .manual, at: stamp)
+
+        #expect(try await db.terminals.clearSessionExitStamp(id: terminal.id) == false)
+        let row = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(row.hibernatedAt == stamp)
+        #expect(row.hibernateReason == .manual)
+    }
+}

--- a/Tests/TBDDaemonTests/TerminalSendNotRunningTests.swift
+++ b/Tests/TBDDaemonTests/TerminalSendNotRunningTests.swift
@@ -53,7 +53,7 @@ struct TerminalSendNotRunningTests {
     /// supplies one through the `dryRunPanePID` hook this task adds — the shape
     /// every other dry-run answer in that file already uses.
     private func makeFixture(
-        foregroundByAgent: [String: Int32], kind: TerminalKind = .claude
+        foregroundByAgent: [String: Int32], kind: TerminalKind? = .claude
     ) async throws -> Fixture {
         let db = try TBDDatabase(inMemory: true)
         let worktree = try await db.worktrees.createScratch(
@@ -164,11 +164,59 @@ struct TerminalSendNotRunningTests {
 
     /// The kind picks the name, and nothing else does. Mapping it wrong in
     /// either direction is the whole bug this rail had.
+    ///
+    /// A row with NO recorded kind is a legacy Claude terminal, which is the
+    /// reading `Terminal.isClaudeResumable` and the continue-in-Codex path
+    /// already give it. Reading it as a shell instead would skip the rail
+    /// entirely for the oldest rows on the machine.
     @Test func theForegroundAgentNameFollowsTheKind() {
         #expect(RPCRouter.foregroundAgentName(for: .claude) == "claude")
         #expect(RPCRouter.foregroundAgentName(for: .codex) == "codex")
         #expect(RPCRouter.foregroundAgentName(for: .shell) == nil)
-        #expect(RPCRouter.foregroundAgentName(for: nil) == nil)
+        #expect(RPCRouter.foregroundAgentName(for: nil) == "claude")
+    }
+
+    /// The handler-level half of the same fact: a row whose `kind` column is
+    /// NULL still gets the foreground rail, and it gets the Claude one.
+    @Test func aKindlessTerminalWithNoForegroundClaudeIsRefused() async throws {
+        let f = try await makeFixture(foregroundByAgent: [:], kind: nil)
+
+        let response = try await send(f)
+        #expect(!response.success)
+        let error = try #require(response.error)
+        #expect(error.contains("foreground process"))
+        #expect(error.contains("(claude)"), "a kindless row is read as a Claude row")
+    }
+
+    /// The two rails split on the empty payload, and the park rail takes it.
+    /// A bare Enter into a parked row carries no message, but it has no purpose
+    /// either — the pane holds a shell — and the refusal already names wake as
+    /// the remedy.
+    @Test func anEmptyTextSubmitToAHibernatedRowIsRefused() async throws {
+        let f = try await makeFixture(foregroundByAgent: ["claude": 4242])
+        try await f.db.terminals.setHibernated(
+            id: f.terminal.id, sessionID: "sess-1", reason: .manual,
+            at: Date(timeIntervalSince1970: 1_800_000_000))
+
+        let data = try JSONEncoder().encode(TerminalSendParams(
+            terminalID: f.terminal.id, text: "", submit: true))
+        let response = try await f.router.handleTerminalSend(data, actor: .app)
+        #expect(!response.success)
+        let error = try #require(response.error)
+        #expect(error.contains("is not running"))
+    }
+
+    /// The other side of that split, so the rule is asserted in both
+    /// directions: the FOREGROUND rail stays text-with-a-body, because a bare
+    /// Enter is how a caller answers a prompt, and an inspector that cannot see
+    /// the agent must not take that away from a live row.
+    @Test func anEmptyTextSubmitToALiveRowSkipsTheForegroundRail() async throws {
+        let f = try await makeFixture(foregroundByAgent: [:])
+
+        let data = try JSONEncoder().encode(TerminalSendParams(
+            terminalID: f.terminal.id, text: "", submit: true))
+        let response = try await f.router.handleTerminalSend(data, actor: .app)
+        #expect(response.success, "error was: \(response.error ?? "none")")
     }
 
     /// The refusal is a text-send rail, not a terminal-wide one. `--keys` exists

--- a/Tests/TBDDaemonTests/TerminalSendNotRunningTests.swift
+++ b/Tests/TBDDaemonTests/TerminalSendNotRunningTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import Testing
 @testable import TBDDaemonLib
 import TBDShared
+import TestSupport
 
 /// The refusal the composer and the CLI both need: a text send to a terminal
 /// whose Claude process is gone must not be pasted into the shell that is
@@ -28,10 +29,12 @@ struct TerminalSendNotRunningTests {
     }
 
     /// A throwaway actuation log per fixture. `ActuationLog` takes a PATH, not a
-    /// database — the record is an append-only JSONL file.
+    /// database — the record is an append-only JSONL file. It lands under the
+    /// run's fenced scratch dir, which `scripts/test.sh` removes even when the
+    /// test process is killed; a per-test `temporaryDirectory` would leak.
     private static func scratchLogPath() -> String {
-        let directory = FileManager.default.temporaryDirectory
-            .appendingPathComponent("tbd-plan-\(UUID().uuidString)", isDirectory: true)
+        let directory = URL(
+            fileURLWithPath: fencedScratchRoot(prefix: "tbd-sendnotrunning"), isDirectory: true)
         try? FileManager.default.createDirectory(
             at: directory, withIntermediateDirectories: true)
         return directory.appendingPathComponent("actuations.jsonl").path

--- a/Tests/TBDDaemonTests/TerminalSendNotRunningTests.swift
+++ b/Tests/TBDDaemonTests/TerminalSendNotRunningTests.swift
@@ -53,7 +53,8 @@ struct TerminalSendNotRunningTests {
     /// supplies one through the `dryRunPanePID` hook this task adds — the shape
     /// every other dry-run answer in that file already uses.
     private func makeFixture(
-        foregroundByAgent: [String: Int32], kind: TerminalKind? = .claude
+        foregroundByAgent: [String: Int32], kind: TerminalKind? = .claude,
+        claudeSessionID: String? = "sess-1"
     ) async throws -> Fixture {
         let db = try TBDDatabase(inMemory: true)
         let worktree = try await db.worktrees.createScratch(
@@ -61,7 +62,7 @@ struct TerminalSendNotRunningTests {
             path: "/tmp/tbd-nonexistent-\(UUID().uuidString)", tmuxServer: "tbd-test")
         let terminal = try await db.terminals.create(
             worktreeID: worktree.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
-            label: "claude", claudeSessionID: "sess-1", kind: kind)
+            label: "claude", claudeSessionID: claudeSessionID, kind: kind)
         let tmux = TmuxManager(
             dryRun: true,
             dryRunPaneSendTarget: { _, _ in .live(terminalID: nil) },
@@ -165,15 +166,19 @@ struct TerminalSendNotRunningTests {
     /// The kind picks the name, and nothing else does. Mapping it wrong in
     /// either direction is the whole bug this rail had.
     ///
-    /// A row with NO recorded kind is a legacy Claude terminal, which is the
-    /// reading `Terminal.isClaudeResumable` and the continue-in-Codex path
-    /// already give it. Reading it as a shell instead would skip the rail
-    /// entirely for the oldest rows on the machine.
+    /// A row with NO recorded kind gets exactly the reading migration
+    /// `v22_terminal_kind`'s backfill gave it — Claude when it carries a
+    /// Claude session id, shell otherwise — which is also what `Terminal
+    /// .isClaudeResumable` already requires. Reading every kindless row as
+    /// Claude regardless of session id, as an earlier version of this helper
+    /// did, ran the rail against a plain shell pane that never had a "claude"
+    /// process to find.
     @Test func theForegroundAgentNameFollowsTheKind() {
-        #expect(RPCRouter.foregroundAgentName(for: .claude) == "claude")
-        #expect(RPCRouter.foregroundAgentName(for: .codex) == "codex")
-        #expect(RPCRouter.foregroundAgentName(for: .shell) == nil)
-        #expect(RPCRouter.foregroundAgentName(for: nil) == "claude")
+        #expect(RPCRouter.foregroundAgentName(kind: .claude, claudeSessionID: "sess-1") == "claude")
+        #expect(RPCRouter.foregroundAgentName(kind: .codex, claudeSessionID: nil) == "codex")
+        #expect(RPCRouter.foregroundAgentName(kind: .shell, claudeSessionID: nil) == nil)
+        #expect(RPCRouter.foregroundAgentName(kind: nil, claudeSessionID: "sess-1") == "claude")
+        #expect(RPCRouter.foregroundAgentName(kind: nil, claudeSessionID: nil) == nil)
     }
 
     /// The handler-level half of the same fact: a row whose `kind` column is
@@ -185,7 +190,20 @@ struct TerminalSendNotRunningTests {
         #expect(!response.success)
         let error = try #require(response.error)
         #expect(error.contains("foreground process"))
-        #expect(error.contains("(claude)"), "a kindless row is read as a Claude row")
+        #expect(error.contains("(claude)"), "a kindless row with a Claude session id is read as claude")
+    }
+
+    /// The other half of the same fact: a kindless row with NO Claude session
+    /// id either is the plain-shell shape the live suite's fixtures create
+    /// (`db.terminals.create` with neither `kind` nor `claudeSessionID`
+    /// supplied) — the regression this case guards is the rail reading such a
+    /// row as Claude and refusing a healthy shell send that never had a
+    /// "claude" process to find.
+    @Test func aKindlessTerminalWithNoSessionIsNotSubjectToTheForegroundRail() async throws {
+        let f = try await makeFixture(foregroundByAgent: [:], kind: nil, claudeSessionID: nil)
+
+        let response = try await send(f)
+        #expect(response.success, "error was: \(response.error ?? "none")")
     }
 
     /// The two rails split on the empty payload, and the park rail takes it.

--- a/Tests/TBDDaemonTests/TerminalSendNotRunningTests.swift
+++ b/Tests/TBDDaemonTests/TerminalSendNotRunningTests.swift
@@ -40,14 +40,16 @@ struct TerminalSendNotRunningTests {
     /// `TmuxManager(dryRun:)` reports every pane pid as "0", so the fixture
     /// supplies one through the `dryRunPanePID` hook this task adds — the shape
     /// every other dry-run answer in that file already uses.
-    private func makeFixture(foreground: Int32?) async throws -> Fixture {
+    private func makeFixture(
+        foreground: Int32?, kind: TerminalKind = .claude
+    ) async throws -> Fixture {
         let db = try TBDDatabase(inMemory: true)
         let worktree = try await db.worktrees.createScratch(
             name: "wt", displayName: "wt",
             path: "/tmp/tbd-nonexistent-\(UUID().uuidString)", tmuxServer: "tbd-test")
         let terminal = try await db.terminals.create(
             worktreeID: worktree.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
-            label: "claude", claudeSessionID: "sess-1", kind: .claude)
+            label: "claude", claudeSessionID: "sess-1", kind: kind)
         let tmux = TmuxManager(
             dryRun: true,
             dryRunPaneSendTarget: { _, _ in .live(terminalID: nil) },
@@ -107,6 +109,27 @@ struct TerminalSendNotRunningTests {
     /// passing because every send is refused.
     @Test func aLiveRowWithClaudeForegroundIsNotRefused() async throws {
         let f = try await makeFixture(foreground: 4242)
+
+        let response = try await send(f)
+        #expect(response.success, "error was: \(response.error ?? "none")")
+    }
+
+    /// A shell terminal has no Claude to be foreground, so the foreground rail
+    /// must never run for one. Without the kind gate this send is refused in
+    /// production: the pane pid is `-zsh`, it has no `claude` descendant, and the
+    /// inspector answers nil for every shell session there is.
+    @Test func aShellTerminalIsNotSubjectToTheForegroundRail() async throws {
+        let f = try await makeFixture(foreground: nil, kind: .shell)
+
+        let response = try await send(f)
+        #expect(response.success, "error was: \(response.error ?? "none")")
+    }
+
+    /// Codex is agent-bearing and supported, and its command line contains no
+    /// "claude", so the inspector answers nil for a perfectly healthy Codex
+    /// session. The gate is on the terminal's KIND, not on what `ps` says.
+    @Test func aCodexTerminalIsNotSubjectToTheForegroundRail() async throws {
+        let f = try await makeFixture(foreground: nil, kind: .codex)
 
         let response = try await send(f)
         #expect(response.success, "error was: \(response.error ?? "none")")

--- a/Tests/TBDDaemonTests/TerminalSendNotRunningTests.swift
+++ b/Tests/TBDDaemonTests/TerminalSendNotRunningTests.swift
@@ -5,21 +5,30 @@ import TBDShared
 import TestSupport
 
 /// The refusal the composer and the CLI both need: a text send to a terminal
-/// whose Claude process is gone must not be pasted into the shell that is
+/// whose agent process is gone must not be pasted into the shell that is
 /// sitting in the pane and executed as a command line.
 ///
-/// Two independent facts answer "is Claude running here", and each gets its own
-/// case because each fails on its own: the hook stamp (missed on a crash) and
-/// the pane's foreground process group (unavailable on a holder row).
+/// Two independent facts answer "is the agent running here", and each gets its
+/// own case because each fails on its own: the hook stamp (missed on a crash,
+/// and never written at all for Codex, which has no `SessionEnd` hook) and the
+/// pane's foreground process group (unavailable on a holder row). The
+/// foreground fact is kind-aware — it looks for the name the kind implies — so
+/// both agent-bearing kinds get discriminating cases and a shell gets none.
 ///
 /// Tier 2: an in-memory database, a dry-run tmux manager and a stub inspector.
 @Suite("terminal.send refuses a not-running terminal")
 struct TerminalSendNotRunningTests {
 
-    /// A `PaneProcessInspecting` whose answer the test chooses.
+    /// A `PaneProcessInspecting` whose answer the test chooses, PER agent name
+    /// the rail asks about — so a fixture can say "codex is foreground here,
+    /// claude is not", which is exactly the discrimination the kind-aware rail
+    /// makes. A name absent from the dictionary answers nil, as the production
+    /// inspector does when no matching process owns the pane.
     private struct StubInspector: PaneProcessInspecting {
-        let foreground: Int32?
-        func foregroundClaudePID(panePID: Int32) -> Int32? { foreground }
+        let foregroundByAgent: [String: Int32]
+        func foregroundAgentPID(panePID: Int32, matching agentName: String) -> Int32? {
+            foregroundByAgent[agentName]
+        }
     }
 
     private struct Fixture {
@@ -44,7 +53,7 @@ struct TerminalSendNotRunningTests {
     /// supplies one through the `dryRunPanePID` hook this task adds — the shape
     /// every other dry-run answer in that file already uses.
     private func makeFixture(
-        foreground: Int32?, kind: TerminalKind = .claude
+        foregroundByAgent: [String: Int32], kind: TerminalKind = .claude
     ) async throws -> Fixture {
         let db = try TBDDatabase(inMemory: true)
         let worktree = try await db.worktrees.createScratch(
@@ -62,7 +71,7 @@ struct TerminalSendNotRunningTests {
             lifecycle: WorktreeLifecycle(
                 db: db, git: GitManager(), tmux: tmux, hooks: HookResolver()),
             tmux: tmux,
-            paneProcessInspector: StubInspector(foreground: foreground),
+            paneProcessInspector: StubInspector(foregroundByAgent: foregroundByAgent),
             actuationLog: ActuationLog(path: Self.scratchLogPath()))
         return Fixture(router: router, db: db, terminal: terminal)
     }
@@ -74,7 +83,7 @@ struct TerminalSendNotRunningTests {
     }
 
     @Test func aHibernatedRowIsRefused() async throws {
-        let f = try await makeFixture(foreground: 4242)
+        let f = try await makeFixture(foregroundByAgent: ["claude": 4242])
         try await f.db.terminals.setHibernated(
             id: f.terminal.id, sessionID: "sess-1", reason: .manual,
             at: Date(timeIntervalSince1970: 1_800_000_000))
@@ -86,7 +95,7 @@ struct TerminalSendNotRunningTests {
     }
 
     @Test func anExitStampedRowIsRefused() async throws {
-        let f = try await makeFixture(foreground: 4242)
+        let f = try await makeFixture(foregroundByAgent: ["claude": 4242])
         _ = try await f.db.terminals.stampSessionExited(
             id: f.terminal.id, reportedIncarnationID: nil,
             at: Date(timeIntervalSince1970: 1_800_000_000))
@@ -100,7 +109,7 @@ struct TerminalSendNotRunningTests {
     /// The rail that covers a MISSED hook: nothing is stamped, the pane is alive,
     /// and the process table says Claude is not the foreground process.
     @Test func aLiveRowWithNoForegroundClaudeIsRefused() async throws {
-        let f = try await makeFixture(foreground: nil)
+        let f = try await makeFixture(foregroundByAgent: [:])
 
         let response = try await send(f)
         #expect(!response.success)
@@ -111,7 +120,7 @@ struct TerminalSendNotRunningTests {
     /// The positive control. Without it the three refusals above could all be
     /// passing because every send is refused.
     @Test func aLiveRowWithClaudeForegroundIsNotRefused() async throws {
-        let f = try await makeFixture(foreground: 4242)
+        let f = try await makeFixture(foregroundByAgent: ["claude": 4242])
 
         let response = try await send(f)
         #expect(response.success, "error was: \(response.error ?? "none")")
@@ -122,27 +131,51 @@ struct TerminalSendNotRunningTests {
     /// production: the pane pid is `-zsh`, it has no `claude` descendant, and the
     /// inspector answers nil for every shell session there is.
     @Test func aShellTerminalIsNotSubjectToTheForegroundRail() async throws {
-        let f = try await makeFixture(foreground: nil, kind: .shell)
+        let f = try await makeFixture(foregroundByAgent: [:], kind: .shell)
 
         let response = try await send(f)
         #expect(response.success, "error was: \(response.error ?? "none")")
     }
 
-    /// Codex is agent-bearing and supported, and its command line contains no
-    /// "claude", so the inspector answers nil for a perfectly healthy Codex
-    /// session. The gate is on the terminal's KIND, not on what `ps` says.
-    @Test func aCodexTerminalIsNotSubjectToTheForegroundRail() async throws {
-        let f = try await makeFixture(foreground: nil, kind: .codex)
+    /// A Codex pane whose agent has left is the case NEITHER other rail catches:
+    /// Codex ships no `SessionEnd` hook, so the row is never exit-stamped, and a
+    /// stamp would be wrong anyway (the wake path refuses a non-Claude row, so
+    /// the stamp would park it unwakeably). The foreground rail is the only
+    /// thing between this send and a message run as a shell command.
+    @Test func aCodexTerminalWithNoForegroundCodexIsRefused() async throws {
+        let f = try await makeFixture(foregroundByAgent: [:], kind: .codex)
+
+        let response = try await send(f)
+        #expect(!response.success)
+        let error = try #require(response.error)
+        #expect(error.contains("foreground process"))
+        #expect(error.contains("(codex)"), "the refusal must name the agent it looked for")
+    }
+
+    /// The positive control for the Codex leg: the rail asks about "codex", not
+    /// about "claude", so a healthy Codex session — whose command line contains
+    /// no "claude" at all — proceeds.
+    @Test func aCodexTerminalWithCodexForegroundIsNotRefused() async throws {
+        let f = try await makeFixture(foregroundByAgent: ["codex": 4242], kind: .codex)
 
         let response = try await send(f)
         #expect(response.success, "error was: \(response.error ?? "none")")
+    }
+
+    /// The kind picks the name, and nothing else does. Mapping it wrong in
+    /// either direction is the whole bug this rail had.
+    @Test func theForegroundAgentNameFollowsTheKind() {
+        #expect(RPCRouter.foregroundAgentName(for: .claude) == "claude")
+        #expect(RPCRouter.foregroundAgentName(for: .codex) == "codex")
+        #expect(RPCRouter.foregroundAgentName(for: .shell) == nil)
+        #expect(RPCRouter.foregroundAgentName(for: nil) == nil)
     }
 
     /// The refusal is a text-send rail, not a terminal-wide one. `--keys` exists
     /// to answer a dialog and to interrupt; refusing it on a parked row would
     /// take away the one payload that has nothing to do with typing a message.
     @Test func aKeysPayloadIsNotRefusedByTheseRails() async throws {
-        let f = try await makeFixture(foreground: nil)
+        let f = try await makeFixture(foregroundByAgent: [:])
         let data = try JSONEncoder().encode(TerminalSendParams(
             terminalID: f.terminal.id, keys: "Escape"))
 

--- a/Tests/TBDDaemonTests/TerminalSendNotRunningTests.swift
+++ b/Tests/TBDDaemonTests/TerminalSendNotRunningTests.swift
@@ -1,0 +1,126 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+import TBDShared
+
+/// The refusal the composer and the CLI both need: a text send to a terminal
+/// whose Claude process is gone must not be pasted into the shell that is
+/// sitting in the pane and executed as a command line.
+///
+/// Two independent facts answer "is Claude running here", and each gets its own
+/// case because each fails on its own: the hook stamp (missed on a crash) and
+/// the pane's foreground process group (unavailable on a holder row).
+///
+/// Tier 2: an in-memory database, a dry-run tmux manager and a stub inspector.
+@Suite("terminal.send refuses a not-running terminal")
+struct TerminalSendNotRunningTests {
+
+    /// A `PaneProcessInspecting` whose answer the test chooses.
+    private struct StubInspector: PaneProcessInspecting {
+        let foreground: Int32?
+        func foregroundClaudePID(panePID: Int32) -> Int32? { foreground }
+    }
+
+    private struct Fixture {
+        let router: RPCRouter
+        let db: TBDDatabase
+        let terminal: Terminal
+    }
+
+    /// A throwaway actuation log per fixture. `ActuationLog` takes a PATH, not a
+    /// database — the record is an append-only JSONL file.
+    private static func scratchLogPath() -> String {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-plan-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(
+            at: directory, withIntermediateDirectories: true)
+        return directory.appendingPathComponent("actuations.jsonl").path
+    }
+
+    /// `TmuxManager(dryRun:)` reports every pane pid as "0", so the fixture
+    /// supplies one through the `dryRunPanePID` hook this task adds — the shape
+    /// every other dry-run answer in that file already uses.
+    private func makeFixture(foreground: Int32?) async throws -> Fixture {
+        let db = try TBDDatabase(inMemory: true)
+        let worktree = try await db.worktrees.createScratch(
+            name: "wt", displayName: "wt",
+            path: "/tmp/tbd-nonexistent-\(UUID().uuidString)", tmuxServer: "tbd-test")
+        let terminal = try await db.terminals.create(
+            worktreeID: worktree.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "claude", claudeSessionID: "sess-1", kind: .claude)
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunPaneSendTarget: { _, _ in .live(terminalID: nil) },
+            dryRunPanePID: { _, _ in "4242" })
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: tmux, hooks: HookResolver()),
+            tmux: tmux,
+            paneProcessInspector: StubInspector(foreground: foreground),
+            actuationLog: ActuationLog(path: Self.scratchLogPath()))
+        return Fixture(router: router, db: db, terminal: terminal)
+    }
+
+    private func send(_ f: Fixture) async throws -> RPCResponse {
+        let data = try JSONEncoder().encode(TerminalSendParams(
+            terminalID: f.terminal.id, text: "hello", submit: true))
+        return try await f.router.handleTerminalSend(data, actor: .app)
+    }
+
+    @Test func aHibernatedRowIsRefused() async throws {
+        let f = try await makeFixture(foreground: 4242)
+        try await f.db.terminals.setHibernated(
+            id: f.terminal.id, sessionID: "sess-1", reason: .manual,
+            at: Date(timeIntervalSince1970: 1_800_000_000))
+
+        let response = try await send(f)
+        #expect(!response.success)
+        let error = try #require(response.error)
+        #expect(error.contains("is not running"))
+    }
+
+    @Test func anExitStampedRowIsRefused() async throws {
+        let f = try await makeFixture(foreground: 4242)
+        _ = try await f.db.terminals.stampSessionExited(
+            id: f.terminal.id, reportedIncarnationID: nil,
+            at: Date(timeIntervalSince1970: 1_800_000_000))
+
+        let response = try await send(f)
+        #expect(!response.success)
+        let error = try #require(response.error)
+        #expect(error.contains("its Claude session exited"))
+    }
+
+    /// The rail that covers a MISSED hook: nothing is stamped, the pane is alive,
+    /// and the process table says Claude is not the foreground process.
+    @Test func aLiveRowWithNoForegroundClaudeIsRefused() async throws {
+        let f = try await makeFixture(foreground: nil)
+
+        let response = try await send(f)
+        #expect(!response.success)
+        let error = try #require(response.error)
+        #expect(error.contains("foreground process"))
+    }
+
+    /// The positive control. Without it the three refusals above could all be
+    /// passing because every send is refused.
+    @Test func aLiveRowWithClaudeForegroundIsNotRefused() async throws {
+        let f = try await makeFixture(foreground: 4242)
+
+        let response = try await send(f)
+        #expect(response.success, "error was: \(response.error ?? "none")")
+    }
+
+    /// The refusal is a text-send rail, not a terminal-wide one. `--keys` exists
+    /// to answer a dialog and to interrupt; refusing it on a parked row would
+    /// take away the one payload that has nothing to do with typing a message.
+    @Test func aKeysPayloadIsNotRefusedByTheseRails() async throws {
+        let f = try await makeFixture(foreground: nil)
+        let data = try JSONEncoder().encode(TerminalSendParams(
+            terminalID: f.terminal.id, keys: "Escape"))
+
+        let response = try await f.router.handleTerminalSend(data, actor: .app)
+        #expect(response.success, "error was: \(response.error ?? "none")")
+    }
+}

--- a/Tests/TBDDaemonTests/TerminalSendNotRunningTests.swift
+++ b/Tests/TBDDaemonTests/TerminalSendNotRunningTests.swift
@@ -29,13 +29,44 @@ struct TerminalSendNotRunningTests {
         func foregroundAgentPID(panePID: Int32, matching agentName: String) -> Int32? {
             foregroundByAgent[agentName]
         }
+        /// The send rail never asks this one — it is the wake rail's question —
+        /// so answer the pane pid, which is "an idle shell", and let a failure
+        /// here mean the rail asked something it should not have.
+        func paneForegroundPID(panePID: Int32) -> Int32? { panePID }
     }
 
     private struct Fixture {
         let router: RPCRouter
         let db: TBDDatabase
         let terminal: Terminal
+        /// Bodies the dry-run tmux was asked to paste into the pane. The
+        /// fail-open cases assert the send did not merely return success but
+        /// actually reached the pane.
+        let pastes: PastedBodies
     }
+
+    /// Collects `dryRunPasteBytes` payloads. `@unchecked Sendable` behind a
+    /// lock because the hook is `@Sendable` and the send runs on the router's
+    /// executor.
+    private final class PastedBodies: @unchecked Sendable {
+        private let lock = NSLock()
+        private var bodies: [String] = []
+        func append(_ data: Data) {
+            lock.lock()
+            defer { lock.unlock() }
+            bodies.append(String(bytes: data, encoding: .utf8) ?? "")
+        }
+        func snapshot() -> [String] {
+            lock.lock()
+            defer { lock.unlock() }
+            return bodies
+        }
+    }
+
+    /// An error the `dryRunPanePID` hook can throw, standing in for the tmux
+    /// invocation that fails — a server that went away between the row's read
+    /// and the query, most commonly.
+    private struct PanePIDUnavailable: Error {}
 
     /// A throwaway actuation log per fixture. `ActuationLog` takes a PATH, not a
     /// database — the record is an append-only JSONL file. It lands under the
@@ -54,7 +85,8 @@ struct TerminalSendNotRunningTests {
     /// every other dry-run answer in that file already uses.
     private func makeFixture(
         foregroundByAgent: [String: Int32], kind: TerminalKind? = .claude,
-        claudeSessionID: String? = "sess-1"
+        claudeSessionID: String? = "sess-1",
+        panePID: @escaping @Sendable (String, String) throws -> String = { _, _ in "4242" }
     ) async throws -> Fixture {
         let db = try TBDDatabase(inMemory: true)
         let worktree = try await db.worktrees.createScratch(
@@ -63,10 +95,12 @@ struct TerminalSendNotRunningTests {
         let terminal = try await db.terminals.create(
             worktreeID: worktree.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
             label: "claude", claudeSessionID: claudeSessionID, kind: kind)
+        let pastes = PastedBodies()
         let tmux = TmuxManager(
             dryRun: true,
             dryRunPaneSendTarget: { _, _ in .live(terminalID: nil) },
-            dryRunPanePID: { _, _ in "4242" })
+            dryRunPanePID: panePID,
+            dryRunPasteBytes: { _, _, bytes in pastes.append(bytes) })
         let router = RPCRouter(
             db: db,
             lifecycle: WorktreeLifecycle(
@@ -74,7 +108,7 @@ struct TerminalSendNotRunningTests {
             tmux: tmux,
             paneProcessInspector: StubInspector(foregroundByAgent: foregroundByAgent),
             actuationLog: ActuationLog(path: Self.scratchLogPath()))
-        return Fixture(router: router, db: db, terminal: terminal)
+        return Fixture(router: router, db: db, terminal: terminal, pastes: pastes)
     }
 
     private func send(_ f: Fixture) async throws -> RPCResponse {
@@ -235,6 +269,51 @@ struct TerminalSendNotRunningTests {
             terminalID: f.terminal.id, text: "", submit: true))
         let response = try await f.router.handleTerminalSend(data, actor: .app)
         #expect(response.success, "error was: \(response.error ?? "none")")
+    }
+
+    // MARK: - The rail fails OPEN on an unreadable pane pid
+
+    // All three cases below pass `foregroundByAgent: [:]` — the inspector would
+    // say "no claude here" if it were ever asked. That is what makes them
+    // discriminating: with a readable pid these fixtures are refused
+    // (`aLiveRowWithNoForegroundClaudeIsRefused` is the same fixture and the
+    // same stub), so a send that goes through went through because the pid
+    // could not be read, and for no other reason. Each asserts the paste
+    // actually reached the pane, not merely that the response said success.
+
+    /// tmux could not answer the pid query at all — the `try?` in the rail
+    /// swallows it. A tmux that cannot answer is not evidence that the agent
+    /// left, so the send proceeds.
+    @Test func anUnaskablePanePIDLetsTheSendThrough() async throws {
+        let f = try await makeFixture(
+            foregroundByAgent: [:], panePID: { _, _ in throw PanePIDUnavailable() })
+
+        let response = try await send(f)
+        #expect(response.success, "error was: \(response.error ?? "none")")
+        #expect(f.pastes.snapshot().contains { $0.hasSuffix("hello") })
+    }
+
+    /// tmux answered, but with something that is not a pid. Same fail-open, and
+    /// for the same reason: an answer the daemon cannot parse is not an answer
+    /// about the agent.
+    @Test func aNonNumericPanePIDLetsTheSendThrough() async throws {
+        let f = try await makeFixture(foregroundByAgent: [:], panePID: { _, _ in "abc" })
+
+        let response = try await send(f)
+        #expect(response.success, "error was: \(response.error ?? "none")")
+        #expect(f.pastes.snapshot().contains { $0.hasSuffix("hello") })
+    }
+
+    /// tmux's own "I don't know" is the literal `0`, which is also what a
+    /// dry-run manager reports when no hook is supplied. Asking the process
+    /// table about pid 0 is a question with no meaning, so the rail declines to
+    /// ask and the send proceeds.
+    @Test func aZeroPanePIDLetsTheSendThrough() async throws {
+        let f = try await makeFixture(foregroundByAgent: [:], panePID: { _, _ in "0" })
+
+        let response = try await send(f)
+        #expect(response.success, "error was: \(response.error ?? "none")")
+        #expect(f.pastes.snapshot().contains { $0.hasSuffix("hello") })
     }
 
     /// The refusal is a text-send rail, not a terminal-wide one. `--keys` exists

--- a/Tests/TBDSharedTests/HibernateReasonExitedTests.swift
+++ b/Tests/TBDSharedTests/HibernateReasonExitedTests.swift
@@ -12,6 +12,9 @@ struct HibernateReasonExitedTests {
     @Test func theRawValueIsStableOnTheWire() throws {
         #expect(HibernateReason.exited.rawValue == "exited")
         let encoded = try JSONEncoder().encode(HibernateReason.exited)
+        // `String(bytes:encoding:)` on purpose: SwiftLint's
+        // `optional_data_string_conversion` rejects `String(decoding:as:)`, whose
+        // lossy replacement of invalid bytes would let a broken encoding pass.
         #expect(String(bytes: encoded, encoding: .utf8) == "\"exited\"")
     }
 

--- a/Tests/TBDSharedTests/HibernateReasonExitedTests.swift
+++ b/Tests/TBDSharedTests/HibernateReasonExitedTests.swift
@@ -12,7 +12,7 @@ struct HibernateReasonExitedTests {
     @Test func theRawValueIsStableOnTheWire() throws {
         #expect(HibernateReason.exited.rawValue == "exited")
         let encoded = try JSONEncoder().encode(HibernateReason.exited)
-        #expect(String(decoding: encoded, as: UTF8.self) == "\"exited\"")
+        #expect(String(bytes: encoded, encoding: .utf8) == "\"exited\"")
     }
 
     @Test func itRoundTripsThroughATerminal() throws {

--- a/Tests/TBDSharedTests/HibernateReasonExitedTests.swift
+++ b/Tests/TBDSharedTests/HibernateReasonExitedTests.swift
@@ -1,0 +1,53 @@
+import Foundation
+import Testing
+@testable import TBDShared
+
+/// `HibernateReason.exited` is the machine-readable "the Claude process left on
+/// its own" fact the send path refuses on. It rides the same TEXT column and the
+/// same wire field as the other reasons, so the only new risks are the raw value
+/// and the lenient decoder that protects older app binaries.
+@Suite("HibernateReason.exited")
+struct HibernateReasonExitedTests {
+
+    @Test func theRawValueIsStableOnTheWire() throws {
+        #expect(HibernateReason.exited.rawValue == "exited")
+        let encoded = try JSONEncoder().encode(HibernateReason.exited)
+        #expect(String(decoding: encoded, as: UTF8.self) == "\"exited\"")
+    }
+
+    @Test func itRoundTripsThroughATerminal() throws {
+        var terminal = Terminal(
+            worktreeID: UUID(), tmuxWindowID: "@1", tmuxPaneID: "%1", kind: .claude)
+        terminal.hibernatedAt = Date(timeIntervalSince1970: 1_800_000_000)
+        terminal.hibernateReason = .exited
+        let decoded = try JSONDecoder().decode(
+            Terminal.self, from: JSONEncoder().encode(terminal))
+        #expect(decoded.hibernateReason == .exited)
+        #expect(decoded.isExitStamped)
+    }
+
+    /// The lenient decoder stays lenient: a reason a FUTURE daemon invents must
+    /// still not fail the whole `Terminal` decode on this build.
+    @Test func anUnknownReasonStillFallsBackToAuto() throws {
+        let json = Data(#""quiesced""#.utf8)
+        #expect(try JSONDecoder().decode(HibernateReason.self, from: json) == .auto)
+    }
+
+    /// `isExitStamped` is about BOTH columns: a row parked by the idle sweep is
+    /// hibernated but not exit-stamped, and a reason with no stamp is not a park.
+    @Test func isExitStampedNeedsBothColumns() {
+        var terminal = Terminal(
+            worktreeID: UUID(), tmuxWindowID: "@1", tmuxPaneID: "%1", kind: .claude)
+        #expect(!terminal.isExitStamped)
+
+        terminal.hibernatedAt = Date(timeIntervalSince1970: 1)
+        terminal.hibernateReason = .auto
+        #expect(!terminal.isExitStamped)
+
+        terminal.hibernateReason = .exited
+        #expect(terminal.isExitStamped)
+
+        terminal.hibernatedAt = nil
+        #expect(!terminal.isExitStamped)
+    }
+}

--- a/Tests/TBDSharedTests/SessionEndReasonTests.swift
+++ b/Tests/TBDSharedTests/SessionEndReasonTests.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Testing
+@testable import TBDShared
+
+/// Which `SessionEnd` reasons mean the Claude PROCESS is going away.
+///
+/// A `/clear` ends one session and starts another inside the same live process,
+/// so parking on it would refuse every send to a perfectly healthy session.
+/// The unknown case fails toward NOT parking for the same asymmetry the whole
+/// design uses: a missed stamp costs one bad paste that the foreground-process
+/// rail still catches, while a wrong stamp refuses a live session's sends.
+@Suite("SessionEndReason")
+struct SessionEndReasonTests {
+
+    @Test func reasonsThatMeanTheProcessIsLeaving() {
+        #expect(SessionEndReason.parksTheTerminal("logout"))
+        #expect(SessionEndReason.parksTheTerminal("exit"))
+        #expect(SessionEndReason.parksTheTerminal("prompt_input_exit"))
+        #expect(SessionEndReason.parksTheTerminal("other"))
+    }
+
+    @Test func clearAndCompactStayInTheSameProcess() {
+        #expect(!SessionEndReason.parksTheTerminal("clear"))
+        #expect(!SessionEndReason.parksTheTerminal("compact"))
+        #expect(!SessionEndReason.parksTheTerminal("resume"))
+    }
+
+    /// No reason at all is an older Claude Code, or a hook payload this build
+    /// could not read. Both are "we do not know", and not-knowing must not park.
+    @Test func anAbsentOrUnknownReasonDoesNotPark() {
+        #expect(!SessionEndReason.parksTheTerminal(nil))
+        #expect(!SessionEndReason.parksTheTerminal(""))
+        #expect(!SessionEndReason.parksTheTerminal("teleported"))
+    }
+
+    @Test func matchingIsCaseInsensitiveAndTrimmed() {
+        #expect(SessionEndReason.parksTheTerminal("  Logout \n"))
+        #expect(!SessionEndReason.parksTheTerminal("  CLEAR "))
+    }
+}

--- a/Tests/TBDSharedTests/TerminalSessionEndedParamsTests.swift
+++ b/Tests/TBDSharedTests/TerminalSessionEndedParamsTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Testing
+@testable import TBDShared
+
+/// `terminal.sessionEnded` gains the hook payload's `reason`. The wire contract
+/// is that an OLDER `~/.local/bin/tbd` — which is routinely stale relative to a
+/// running daemon — keeps decoding, and a newer one adds a field the daemon may
+/// or may not read.
+@Suite("TerminalSessionEndedParams")
+struct TerminalSessionEndedParamsTests {
+    private let terminalID = UUID(uuidString: "11111111-2222-3333-4444-555555555555")!
+
+    @Test func aPayloadWithoutTheReasonStillDecodes() throws {
+        let json = """
+            {"terminalID":"\(terminalID.uuidString)"}
+            """
+        let params = try JSONDecoder().decode(
+            TerminalSessionEndedParams.self, from: Data(json.utf8))
+        #expect(params.terminalID == terminalID)
+        #expect(params.reason == nil)
+    }
+
+    @Test func aPayloadWithTheReasonCarriesItVerbatim() throws {
+        let json = """
+            {"terminalID":"\(terminalID.uuidString)","reason":"logout"}
+            """
+        let params = try JSONDecoder().decode(
+            TerminalSessionEndedParams.self, from: Data(json.utf8))
+        #expect(params.reason == "logout")
+    }
+
+    @Test func itRoundTrips() throws {
+        let params = TerminalSessionEndedParams(
+            terminalID: terminalID, sessionIncarnationID: UUID(), reason: "clear")
+        let decoded = try JSONDecoder().decode(
+            TerminalSessionEndedParams.self, from: JSONEncoder().encode(params))
+        #expect(decoded == params)
+    }
+}

--- a/docs/specs/2026-09-05-transcript-composer-design.md
+++ b/docs/specs/2026-09-05-transcript-composer-design.md
@@ -560,6 +560,21 @@ composer exists: every parameter it adds defaults to nil, nothing in the app
 passes a prompt yet, and a nil prompt encodes no field. The envelope option,
 the parts list, and the opt-in gate land with the composer.
 
+The exit stamp earns the same unflagged treatment on its own terms, not by
+riding along with the wake prompt's. It records a fact the agent's own
+`SessionEnd` hook reported — that the process has already ended — and neither
+kills anything nor sends anything, which is exactly what distinguishes it from
+the two auto-park causes that do sit behind flags: the idle sweep's
+`auto_hibernate_enabled` decides to end a session nobody asked to end, and the
+merge park's gate in `HibernationGate` decides to interrupt one. The stamp
+decides nothing; it transcribes. It is scoped by session incarnation and
+excludes holder transport, so it can only ever describe the tmux process it
+was told about, and it is retracted the moment `SessionStart` or the wake path
+reports the session back — so a wrong stamp costs one stray banner and one
+refused send, never lost input. The refusal it enables is the bug fix: without
+it, a send to a parked pane finds a live shell prompt, pastes the message,
+presses Enter, and runs the text as a shell command while reporting success.
+
 Graduation: after a soak with the toggle on, flip the default constant.
 
 ## Testing


### PR DESCRIPTION
## What's broken

Send a message to a TBD terminal whose Claude has gone away, and the message is
executed as a shell command.

The pathway is ordinary. A terminal tab is running Claude; the agent exits —
because someone typed `/exit` or `Ctrl-D`, because the session was deliberately
hibernated, or because the process ended on its own — and the tmux window stays
alive with a shell prompt sitting in it. Any later `tbd terminal send` (or the
same call from the app, or from another agent coordinating across worktrees)
finds a live pane whose id matches the row, pastes the text into it, presses
Enter, and reports success. What the user sees is their prose typed at a shell:
`what did we just do?` becomes `zsh: command not found: what`. What they
expected is a refusal, or a resumed session.

The blast radius is every caller of `terminal.send` — the CLI, the app, and
agent-to-agent sends — and the failure is silent at the API boundary, because
the daemon returns success.

## Why it happens

Two gaps, one on each side of the send.

**TBD had no machine-readable "Claude is not running here" fact for the exit
case.** Claude Code fires a `SessionEnd` hook when a session ends, and TBD's
`tbd session-end` bridge forwarded the terminal identity — but it never read the
hook payload from stdin at all, so the `reason` that says *why* the session
ended never reached the daemon. Nothing was recorded, and the row went on
looking exactly like a row with a live agent in it.

**The send path's only pre-typing check asked the wrong question.** Before
typing, it asked tmux whether the pane was alive and whether it belonged to this
terminal. A shell prompt answers both affirmatively. Liveness of the *pane* is
not liveness of the *agent*, and nothing in the path distinguished them.

## What this PR does

Three changes, two rails and a small app fix.

**The exit stamp.** `tbd session-end` now reads the hook payload and forwards
its `reason`. The daemon parks the row with a new `HibernateReason.exited` for
the reasons that mean the process is leaving, and `SessionStart` retracts that
stamp — scoped to `.exited`, so a deliberate `.manual` park is not cleared by a
`/clear` in some other session. Both the stamp and its retraction broadcast the
same hibernation delta the hibernation coordinator already sends, so the app
reflects the change immediately rather than on its next poll. An exit-stamped
row is excluded from `AppState`'s focus- and tab-activation auto-wake, the same
way a `.manual` park already is, because `stampSessionExited` never replaces
the pane with an inert placeholder the way every other park does — an
automatic wake there would `respawn-window -k` the live shell Claude's exit
left behind. It wakes only via the explicit affordances (parked-pane banner
click, Wake menu, CLI/composer send, `terminal.wake`).

The stamp is a hibernation rather than a new state because the situation has a
hibernation's exact shape: process gone, terminal alive, session id known. One
state gives one wake path and one UI. `HibernateReason`'s decoder already
resolves an unknown reason to `.auto`, so an older app binary reading `"exited"`
behaves as it does for an idle-sweep park. `Sources/TBDApp/Terminal/TerminalContainerView.swift`
gained an `.exited` banner arm because the new enum case made an existing
exhaustive switch non-exhaustive — compile-forced, and covered by a test.

**The foreground rail.** A text send is refused when the row carries the stamp,
and — for a tmux row with a readable pane pid — when the process table says
Claude does not own the pane's foreground process group. It uses the same
`PaneProcessInspecting` seam the limit-resume path has always used. `--keys`
sends are deliberately unaffected: a key sequence is how you interact with a
shell, and refusing those would break the escape hatch.

The rail is gated on the terminal's KIND, which supplies the process name to
look for: `claude` for a Claude row, `codex` for a Codex one, and nothing for a
shell — a shell's pane pid *is* the shell, with no agent under it, so asking the
inspector about one would refuse every healthy shell send there is. A row whose
`kind` column is NULL is read exactly as migration `v22_terminal_kind`'s
backfill and `Terminal.isClaudeResumable` already read one: Claude when it
carries a Claude session id, shell otherwise. Reading every kindless row as
Claude regardless of session id ran this rail against a plain shell pane that
never had a "claude" process to find — the CI regression fixed below — so the
session id is now load-bearing in the mapping, not just the kind.
The mapping is one pure function, `RPCRouter.foregroundAgentName(kind:claudeSessionID:)`,
with its own test.
`PaneProcessInspecting` gained the kind-aware `foregroundAgentPID(panePID:matching:)`
— the same lowercased-substring match on the command line the Claude question
has always used, and the same lazy grandchild walk — and `foregroundClaudePID`
survives as a thin wrapper over it, so the limit-resume actuator's behavior and
its 57 tests are unchanged.

**The two rails split on a bare Enter.** An empty-text `--submit` carries no
message, and the rails treat it differently on purpose. The **park** rail takes
it: a parked row's pane holds a shell and nothing else, so an Enter there has no
message to lose and no purpose to serve, and the refusal already names wake as
the remedy. The **foreground** rail does not: a bare Enter is how a caller
answers a prompt the agent is already showing, and the inspector is the fallible
fact of the two — a pane it cannot read must not cost a live row its Enter. Both
directions are asserted.

**Codex panes are covered by the foreground rail, and by that rail only.** The
exit stamp does not reach a Codex row and deliberately never will here: the
Codex hook overlay wires `SessionStart`, `Stop`, `UserPromptSubmit` and
`PermissionRequest` and no `SessionEnd`, so `tbd session-end` is never invoked
for one — and stamping one anyway would be worse than not, because
`isClaudeResumable` is unconditionally false for a Codex row, so the wake path
would refuse it and the stamp would be a park nothing can wake. The process
table is therefore the only fact available about a Codex session's liveness, and
it is the fact this rail reads. The bug described at the top of this PR —
message typed at a shell, run, success reported — is closed for a Codex terminal
whose agent exits, in the same shape as for Claude: refused, nothing typed, with
the refusal naming the agent it looked for. Giving Codex a hook-driven stamp (and
a wake path that would make one meaningful) remains separate work.

**The wake prompt.** The app now passes `terminal.wake`'s `prompt`, which the
CLI, the RPC params, the handler, the hibernation coordinator and the spawn
builder all already carried. It is dormant on this branch — no production call
site passes a non-nil prompt until the composer lands — but the plumbing is now
complete end to end.

## Assumptions

- **The `SessionEnd` reason vocabulary is Claude Code's.** `logout`, `exit`,
  `prompt_input_exit` and `other` park the terminal; `clear`, `compact`,
  `resume`, an absent reason, and any unrecognized value do not. It is a
  whitelist, so an unknown value fails toward *not* parking and the foreground
  rail is what catches that exit. `other` is in the parking set because Claude
  Code documents it as "other exit reasons" — a same-process transition reports
  `clear`.
- **A holder-backed row is deliberately not stamped.** The hibernation
  coordinator's wake cannot respawn a pty holder, so a stamped holder row would
  be a park that nothing can wake and no reconciler can reclaim. That guard is a
  limitation, not a design preference; it lifts when holder park/wake lands
  (PR #818's area). Until then an exited holder session is not marked
  not-running, and a send falls through to the holder arm's own liveness
  handling.
- **Foreground-process inspection can be fooled.** Inherited unchanged from the
  limit-resume inspector: a `tcsetpgrp`-style foreground handoff, or a wrapper
  layer deeper than grandchildren, can produce a false refusal. The rail forks
  `ps` — one full-table `ps -axo pid=,ppid=` plus two `ps` per candidate, per
  text send to a Claude tmux terminal — and walks grandchildren only after the
  pane pid and its direct children lose. Collapsing that to a single snapshot is
  a named follow-up, not this PR.
- **The stamp records no suspended-screen snapshot**, so the parked overlay
  shows a blank pane. The `.recovery` park it displaces behaved the same way.
- **Both hook bridges read stdin without an interactive-terminal guard.** That
  is the pre-existing pattern across the hook commands, so running one by hand
  in a terminal hangs waiting for input. Follow-up, not this PR.

## Evidence & verification

**The repro.** Start Claude in a terminal tab, confirm `tbd terminal send
--terminal <id> --text "hello" --submit` lands in the session, exit the agent,
and re-run the same send: before this change the text is typed at the shell
prompt and run, and the call returns success.

**Discriminating tests.** The evidence for the send rails is
`TerminalSendNotRunningTests` — 12 cases, including `aLiveRowWithClaudeForegroundIsNotRefused`
and `aCodexTerminalWithCodexForegroundIsNotRefused` as the positive controls that
fail if the rails refuse everything, `aCodexTerminalWithNoForegroundCodexIsRefused`
which fails if the rail skips Codex panes, and the `--keys` and shell cases that
fail if the rail is applied too broadly. `aKindlessTerminalWithNoForegroundClaudeIsRefused` fails if a NULL-kind row
carrying a Claude session id skips the rail, and its sibling
`aKindlessTerminalWithNoSessionIsNotSubjectToTheForegroundRail` fails if a
NULL-kind row with no session id is wrongly read as Claude — the CI regression
below. The pair `anEmptyTextSubmitToAHibernatedRowIsRefused` /
`anEmptyTextSubmitToALiveRowSkipsTheForegroundRail` pins the bare-Enter split in
both directions. `theForegroundAgentNameFollowsTheKind`
pins the `(kind, claudeSessionID) → agent-name` mapping in every combination,
both NULL together included.
The evidence for the stamp is `SessionExitStampHandlerTests`, whose two
positives were written red first, and which asserts the delta broadcasts;
`aClearDoesNotStamp` and `sessionStartLeavesADeliberateParkAlone` are the
negatives that fail if the stamp is applied bluntly. `SessionEndReasonTests`
pins the reason whitelist, and `HibernateReasonExitedTests` pins the lenient
decode. `SessionEndHookReasonTests` covers the payload parse the stamp is built
on — reason present, reason absent, empty stdin, a payload refused on its byte
count alone at the 1 MiB cap, and malformed JSON — since every one of those must
answer nil rather than throw inside a hook.

`TerminalSendDispatchTests` passes on this branch but is **not** evidence for
the rails: its dry-run pane pid is `"0"`, so it bypasses the foreground rail
entirely and evidences send ordering only.

**CI regression fix, sha `b1249269`.** The quiet pass failed three
`TerminalSendTargetCheckLiveTests` cases ("a dead remain-on-exit pane errors…",
"a live pane belonging to another terminal is refused, naming both ids", "a
live pane carrying no identity still sends") because their fixtures call
`db.terminals.create(worktreeID:tmuxWindowID:tmuxPaneID:)` with neither `kind`
nor `claudeSessionID`, against a real tmux pane running a plain shell. The old
`foregroundAgentName(for:)` read that as `kind ?? .claude`, so the foreground
rail asked the process table for a "claude" process before the target check
under test ever ran, and refused every one of them. `foregroundAgentName` now
takes `claudeSessionID` alongside `kind` and reads a NULL kind exactly as
migration `v22_terminal_kind`'s backfill and `Terminal.isClaudeResumable`
already do — Claude when the row carries a Claude session id, shell otherwise
— so a plain-shell fixture is no longer subject to the rail.
`Tests/TBDDaemonTests/TerminalSendNotRunningTests.swift` gained the
NULL-kind/no-session case and its unit-level mapping assertion; the live suite
itself is unchanged. Dispatched CI run:
https://github.com/cheapsteak/tbd/actions/runs/34022464777.

**Live verification is deferred to the human.** This machine runs a live agent
fleet, so restarting the app and daemon to drive the refusal by hand is not
something this branch's work could do. The discriminating unit tests above and
the CI run are the evidence here; the by-hand run — send, exit, refused send,
`tbd terminal wake --prompt`, send succeeds again — is worth doing before merge.

## No flag

These ship unflagged, as bug fixes. The transcript composer design's Flag
section (`docs/specs/2026-09-05-transcript-composer-design.md`) now carries
both rationales by name, each in its own paragraph: the wake-prompt paragraph
this carve-out was originally named after, and a paragraph for the exit stamp
— it records a fact the agent's own `SessionEnd` hook already reported rather
than deciding anything, unlike the two flagged auto-park causes in this
codebase (`auto_hibernate_enabled`, the merge park's gate in
`HibernationGate`); it is scoped by session incarnation and excludes holder
transport; and it is retracted by `SessionStart` or the wake path, so a wrong
stamp costs one banner and one refused send rather than lost input. The
refusal it enables is the fix for a real defect: text typed at a dead Claude
executes in its shell.

This PR is now stacked on #821 (base branch `tbd/20260905-abundant-earwig`), so
the spec these comments cite is reachable from this PR's own HEAD rather than
only from a branch this PR cannot see. GitHub retargets the base back to `main`
automatically once #821 merges.

An exit-stamped row is excluded from focus- and tab-activation auto-wake for
the same no-flag reason as the stamp itself: it is a targeted refusal against a
real defect (an unguarded auto-wake would kill the live shell an exit leaves
behind), not a new autonomous behavior, so it needs no soak.

**That app-side exclusion is the first line, not the only one.** It lives in
the app, and [`docs/updating.md`](docs/updating.md)'s `--no-app` makes daemon-newer-than-app a
supported skew: an app binary older than this PR decodes `.exited` through the
lenient `HibernateReason` decoder as `.auto`, and its focus-wake and
tab-activation still fire `terminal.wake` — which is `respawn-window -k` over
the live shell the stamp exists to preserve. So the daemon defends the wake
itself, for every caller (an old app, the CLI, the composer) rather than
trusting who asked: an exit-stamped tmux row whose pane's foreground process is
not the pane's own shell is refused with `WakeResult.paneBusy`, naming the pid
and the two ways out (finish the process, or wake from the terminal). An idle
shell — the pane's own pid owning the foreground group — wakes exactly as
before, and an unreadable pane pid proceeds for the same reason the send rail's
does. That guard is also unflagged and for the same reason: it is a refusal
against a defect, it mutates nothing, and it leaves the row exit-stamped so a
retry after the process finishes still wakes.

## Reconciler

No new durable external resource. This writes two columns on an existing row and
refuses an existing act; the stamp is retracted by `SessionStart` or by the wake
path. Nothing new can orphan.

## Coordination

Touches `performTerminalSend` only. `performHolderSend`, `HolderInjectionCourier`
and everything under `Sources/TBDDaemon/Holder/` are untouched — PR #816 owns
them.

## Follow-ups

**A narrower TOCTOU remains between the park/foreground check and the paste**
in `performTerminalSend`: the rails read a snapshot of the row and the
foreground process, and the actual paste lands several awaits later. A
`SessionEnd` stamp that arrives in that window is not caught. It is narrower
than the accepted race already named in this same file — the assumption above
that foreground-process inspection can be fooled — and is left for a
follow-up rather than fixed here.

[composer-a](https://cheapsteak.github.io/tbd/open/?worktree=B6F8AB9D-8BD6-4902-98EF-16F8DCA04FE5)
https://claude.ai/code/session_01E9SPoxoVoApcVmduLiBWik


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Claude sessions that end are marked as exited with clearer hibernation banners.
  - Wake requests can include an optional prompt when sessions resume.
  - Session-end reasons help determine whether terminals should be parked.
  - Wake-on-focus and tab activation avoid automatically reopening exited sessions.
  - Wake operations refuse to replace another process occupying an exited terminal.

- **Bug Fixes**
  - Text messages are blocked for inactive or no-longer-running Claude and Codex sessions, while key input remains available.
  - Session state refreshes correctly when sessions start or end, preserving intentional manual parks.

- **Tests**
  - Added coverage for wake prompts, exit handling, banners, guarded message delivery, and busy terminals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->







