### PR TITLE
Feat: terminal.send delivers a composed message, and composer attachments get their reconcilers

### DIFF
--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -966,8 +966,9 @@ public final class Daemon: Sendable {
         if mockMode == nil {
             let gc = OrphanGC(db: database, git: git, broadcast: { [subs] delta in subs.broadcast(delta: delta) })
             self.orphanGC = gc
-            lifecycle.onWorktreeRemoved = { [gc] path, repoPath in
-                await gc.scratchpadCleanup(forRemovedWorktreePath: path, repoPath: repoPath)
+            lifecycle.onWorktreeRemoved = { [gc] worktreeID, path, repoPath in
+                await gc.removedWorktreeCleanup(
+                    worktreeID: worktreeID, worktreePath: path, repoPath: repoPath)
             }
         }
 

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -1057,6 +1057,12 @@ public final class Daemon: Sendable {
             pendingQuestions: pendingQuestions,
             remoteManager: remoteManager,
             claudeCloudLive: claudeCloudLive,
+            // Envelope suppression is authenticated against the sidecar's
+            // recorded client — the app — and against nothing the request says
+            // about itself. See `authenticatesEnvelopeSuppression`.
+            recordedAppIdentity: { [fdVendingServer] in
+                await fdVendingServer.currentClientIdentity()
+            },
             actuationLog: actuationLog
         )
         // Wire the shared input activity tracker to the coordinator

--- a/Sources/TBDDaemon/GC/AttachmentsCollector.swift
+++ b/Sources/TBDDaemon/GC/AttachmentsCollector.swift
@@ -32,10 +32,20 @@ struct AttachmentsCollector: Sendable {
         self.now = now
     }
 
-    /// Every entry directly under the attachments base.
+    /// Every directory directly under the attachments base.
+    ///
+    /// A non-directory entry is not a candidate at all, matching
+    /// `HolderRendezvousCollector.candidates()`: the wrong node type is filtered
+    /// out here rather than classified by `decide`, which never considered it.
+    /// Without this, a bare-UUID *file* at the top level would read as an
+    /// orphan directory whose `contentsOfDirectory` comes back empty — reaped
+    /// on the very first sweep past the floor.
     func candidates() -> [URL] {
-        (try? FileManager.default.contentsOfDirectory(
+        let entries = (try? FileManager.default.contentsOfDirectory(
             at: base, includingPropertiesForKeys: [.isDirectoryKey])) ?? []
+        return entries.filter {
+            (try? $0.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true
+        }
     }
 
     /// **Every branch fails toward keeping.**

--- a/Sources/TBDDaemon/GC/AttachmentsCollector.swift
+++ b/Sources/TBDDaemon/GC/AttachmentsCollector.swift
@@ -9,6 +9,16 @@ struct AttachmentsCollector: Sendable {
     enum Decision: Equatable, Sendable {
         case keep(reason: String)
         case reap
+        /// The directory names a worktree row that still exists. The directory
+        /// itself always stays — even once it holds nothing — and each staged
+        /// file the floor has passed goes on its own.
+        case reapFiles(stale: [URL], kept: [KeptFile])
+    }
+
+    /// One file inside a live worktree's directory that stays, and why.
+    struct KeptFile: Equatable, Sendable {
+        let file: URL
+        let reason: String
     }
 
     /// How long an orphan's files must have sat untouched before they go.
@@ -56,10 +66,10 @@ struct AttachmentsCollector: Sendable {
         guard let id = UUID(uuidString: directory.lastPathComponent) else {
             return .keep(reason: "not-a-worktree-id")
         }
-        guard !liveWorktreeIDs.contains(id) else {
-            return .keep(reason: "live-worktree")
-        }
         let floor = now().addingTimeInterval(-Double(floorDays) * 86_400)
+        if liveWorktreeIDs.contains(id) {
+            return decideLiveWorktree(directory, floor: floor)
+        }
         // **An unreadable directory is not an empty one.** Reading through `try?`
         // and falling back to `[]` made a directory the sweep cannot open — a
         // permissions problem, a volume that answered badly — look like a
@@ -92,10 +102,50 @@ struct AttachmentsCollector: Sendable {
         return .reap
     }
 
-    /// Unlink the directory and everything in it. Returns whether it went.
-    func reap(_ directory: URL) -> Bool {
+    /// A live worktree's directory outlives its files.
+    ///
+    /// The row is what makes the directory worth keeping, so the directory
+    /// stays for as long as the row does — but the images inside it do not age
+    /// with the worktree. A staged file is read at paste time, or at resume
+    /// time on the wake path, so it is needed for minutes; one the floor has
+    /// passed is spent, and the same fourteen days that govern an orphan govern
+    /// it. Every branch here still fails toward keeping.
+    private func decideLiveWorktree(_ directory: URL, floor: Date) -> Decision {
+        // An unreadable directory is not an empty one, exactly as in the orphan
+        // branch: it yields no files to classify, so nothing here may act.
+        guard let entries = try? FileManager.default.contentsOfDirectory(
+            at: directory, includingPropertiesForKeys: [.isRegularFileKey]) else {
+            return .keep(reason: "contents-unreadable")
+        }
+        var stale: [URL] = []
+        var kept: [KeptFile] = []
+        for entry in entries {
+            // Only a regular file is a staged image. A subdirectory, a symlink,
+            // or anything else a later feature puts here is left alone rather
+            // than classified by a rule that never considered it.
+            guard (try? entry.resourceValues(forKeys: [.isRegularFileKey]))?
+                .isRegularFile == true else { continue }
+            guard let attrs = try? FileManager.default.attributesOfItem(atPath: entry.path),
+                  let modified = attrs[.modificationDate] as? Date else {
+                // A file whose age cannot be read is a file whose age is
+                // unknown, and unknown is not old.
+                kept.append(KeptFile(file: entry, reason: "age-unreadable"))
+                continue
+            }
+            if modified > floor {
+                kept.append(KeptFile(file: entry, reason: "younger-than-floor"))
+            } else {
+                stale.append(entry)
+            }
+        }
+        return .reapFiles(stale: stale, kept: kept)
+    }
+
+    /// Unlink one node: a whole orphan directory with everything in it, or a
+    /// single staged file inside a live worktree's. Returns whether it went.
+    func reap(_ node: URL) -> Bool {
         do {
-            try FileManager.default.removeItem(at: directory)
+            try FileManager.default.removeItem(at: node)
             return true
         } catch {
             return false

--- a/Sources/TBDDaemon/GC/AttachmentsCollector.swift
+++ b/Sources/TBDDaemon/GC/AttachmentsCollector.swift
@@ -60,14 +60,31 @@ struct AttachmentsCollector: Sendable {
             return .keep(reason: "live-worktree")
         }
         let floor = now().addingTimeInterval(-Double(floorDays) * 86_400)
-        let files = (try? FileManager.default.contentsOfDirectory(
-            at: directory, includingPropertiesForKeys: [.contentModificationDateKey])) ?? []
-        // An empty orphan directory is reapable: there is nothing left to protect.
+        // **An unreadable directory is not an empty one.** Reading through `try?`
+        // and falling back to `[]` made a directory the sweep cannot open — a
+        // permissions problem, a volume that answered badly — look like a
+        // directory with nothing in it, and an empty orphan is reapable. The
+        // failure would have destroyed exactly the files it could not see.
+        guard let files = try? FileManager.default.contentsOfDirectory(
+            at: directory, includingPropertiesForKeys: [.contentModificationDateKey]) else {
+            return .keep(reason: "contents-unreadable")
+        }
         for file in files {
             guard let attrs = try? FileManager.default.attributesOfItem(atPath: file.path),
                   let modified = attrs[.modificationDate] as? Date else {
                 // A file whose age cannot be read is a file whose age is unknown,
                 // and unknown is not old.
+                return .keep(reason: "age-unreadable")
+            }
+            if modified > floor { return .keep(reason: "younger-than-floor") }
+        }
+        // An EMPTY orphan directory gets the floor too, measured on its own
+        // mtime: it has no file to age, and a directory minted moments ago is a
+        // composer somebody has open whose first image has not landed yet. Only
+        // past the floor is there nothing left to protect.
+        if files.isEmpty {
+            guard let attrs = try? FileManager.default.attributesOfItem(atPath: directory.path),
+                  let modified = attrs[.modificationDate] as? Date else {
                 return .keep(reason: "age-unreadable")
             }
             if modified > floor { return .keep(reason: "younger-than-floor") }

--- a/Sources/TBDDaemon/GC/AttachmentsCollector.swift
+++ b/Sources/TBDDaemon/GC/AttachmentsCollector.swift
@@ -1,0 +1,77 @@
+import Foundation
+import TBDShared
+
+/// Decides what to do with one directory under `~/tbd/attachments`.
+///
+/// Pure and injectable, so every case is stated in one line of a test without a
+/// filesystem walk or a database.
+struct AttachmentsCollector: Sendable {
+    enum Decision: Equatable, Sendable {
+        case keep(reason: String)
+        case reap
+    }
+
+    /// How long an orphan's files must have sat untouched before they go.
+    ///
+    /// A soak knob, not a load-bearing number. It exists because the failure it
+    /// guards against is asymmetric: a leaked image is a few hundred kilobytes a
+    /// later sweep still finds, while a wrong reap destroys something a person
+    /// staged for a message they have not sent yet — and a draft can sit unsent
+    /// across a weekend.
+    static let defaultFloorDays = 14
+
+    let base: URL
+    /// The date seam. Ages here are persisted file timestamps compared against a
+    /// time, which is data rather than behavior, so this is a `Date` provider
+    /// and not a `Clock` — and it is the sweep's single reading of now, handed
+    /// down so a test can state a fixture's age exactly.
+    let now: @Sendable () -> Date
+
+    init(base: URL, now: @escaping @Sendable () -> Date) {
+        self.base = base
+        self.now = now
+    }
+
+    /// Every entry directly under the attachments base.
+    func candidates() -> [URL] {
+        (try? FileManager.default.contentsOfDirectory(
+            at: base, includingPropertiesForKeys: [.isDirectoryKey])) ?? []
+    }
+
+    /// **Every branch fails toward keeping.**
+    func decide(_ directory: URL, liveWorktreeIDs: Set<UUID>, floorDays: Int) -> Decision {
+        // A whitelist: only a directory whose name IS a worktree UUID is a
+        // candidate at all. Anything else a human or a future feature put here is
+        // left alone rather than classified by a rule that never considered it.
+        guard let id = UUID(uuidString: directory.lastPathComponent) else {
+            return .keep(reason: "not-a-worktree-id")
+        }
+        guard !liveWorktreeIDs.contains(id) else {
+            return .keep(reason: "live-worktree")
+        }
+        let floor = now().addingTimeInterval(-Double(floorDays) * 86_400)
+        let files = (try? FileManager.default.contentsOfDirectory(
+            at: directory, includingPropertiesForKeys: [.contentModificationDateKey])) ?? []
+        // An empty orphan directory is reapable: there is nothing left to protect.
+        for file in files {
+            guard let attrs = try? FileManager.default.attributesOfItem(atPath: file.path),
+                  let modified = attrs[.modificationDate] as? Date else {
+                // A file whose age cannot be read is a file whose age is unknown,
+                // and unknown is not old.
+                return .keep(reason: "age-unreadable")
+            }
+            if modified > floor { return .keep(reason: "younger-than-floor") }
+        }
+        return .reap
+    }
+
+    /// Unlink the directory and everything in it. Returns whether it went.
+    func reap(_ directory: URL) -> Bool {
+        do {
+            try FileManager.default.removeItem(at: directory)
+            return true
+        } catch {
+            return false
+        }
+    }
+}

--- a/Sources/TBDDaemon/GC/OrphanGC.swift
+++ b/Sources/TBDDaemon/GC/OrphanGC.swift
@@ -961,10 +961,16 @@ public actor OrphanGC {
     /// `.active` here would let this leg reap out from under a worktree somebody
     /// can still revive.
     ///
+    /// A directory whose row still exists is never removed, but the files in it
+    /// age individually: a staged image is read at paste time, or at resume time
+    /// on the wake path, so one the floor has passed is spent and goes on its
+    /// own.
+    ///
     /// No `ReapRecord` is written. The record type is keyed by the worktree a
     /// reap removed and carries a restorability pointer; there is nothing a
     /// `tbd gc restore` could put back here, because the image was staged for a
-    /// message in a worktree that no longer exists.
+    /// message in a worktree that no longer exists — or, for a per-file reap,
+    /// for one nobody sent in two weeks.
     private func reclaimAttachments(
         config: Config, dryRun: Bool, planned: inout [String], reaped: inout Int
     ) async {
@@ -1008,6 +1014,30 @@ public actor OrphanGC {
                 logger.info("""
                 gc: reclaimed composer attachments \(candidate.path, privacy: .public)
                 """)
+            case .reapFiles(let stale, let kept):
+                // The directory belongs to a row that still exists, so it stays
+                // whatever happens to the files inside it — including when the
+                // last one goes and it is left empty.
+                planned.append("KEEP live-worktree \(candidate.path)")
+                for keptFile in kept {
+                    planned.append("KEEP \(keptFile.reason) \(keptFile.file.path)")
+                }
+                for file in stale {
+                    planned.append(
+                        "REAP attachments \(file.path) live-worktree-file-past-floor")
+                    guard !dryRun else { continue }
+                    guard attachmentsCollector.reap(file) else {
+                        planned.append("KEEP unlink-failed \(file.path)")
+                        logger.warning("""
+                        gc: could not unlink \(file.path, privacy: .public)
+                        """)
+                        continue
+                    }
+                    reaped += 1
+                    logger.info("""
+                    gc: reclaimed staged attachment \(file.path, privacy: .public)
+                    """)
+                }
             }
         }
     }

--- a/Sources/TBDDaemon/GC/OrphanGC.swift
+++ b/Sources/TBDDaemon/GC/OrphanGC.swift
@@ -1420,37 +1420,82 @@ public actor OrphanGC {
         broadcast(.reapRecordsChanged)
     }
 
-    // MARK: - Event-driven scratchpad cleanup
+    // MARK: - Event-driven removed-worktree cleanup
 
-    /// Entry point for the archive hook (Task 8): a TBD worktree at `path`
-    /// was just removed, so its Claude Code scratchpad (if any) is cleaned up
-    /// immediately rather than waiting for the next sweep's reconciliation.
-    /// `repoPath` is the owning repo's root (the archive caller has `repo` in
-    /// scope), stamped onto the resulting record; pass `""` when unknown.
+    /// Event-driven reclaim for a worktree that has just been removed: its
+    /// Claude Code scratchpad, and its composer attachments.
     ///
-    /// Verifies the worktree directory is actually gone before doing
-    /// anything else. `completeArchiveWorktree` already fires this callback
-    /// only once it has confirmed the path is gone — queued out of its pool
-    /// slot on the success leg, or a verified `git.worktreeRemove` on the
-    /// fallback leg — so this is defense in depth against a future caller
-    /// that doesn't uphold that contract, not a workaround for a swallowed
-    /// failure: a failed removal must never orphan-classify (and delete) a
-    /// scratchpad that's still in active use.
+    /// Renamed from `scratchpadCleanup` when attachments joined it: the callback
+    /// covers two resources now, and a name that promised one would send the next
+    /// reader looking for a second callback that does not exist.
+    ///
+    /// `repoPath` is the owning repo's root (the archive caller has `repo` in
+    /// scope), stamped onto the resulting scratchpad record; pass `""` when
+    /// unknown.
+    ///
+    /// Verifies the worktree directory is actually gone before doing anything
+    /// else. `completeArchiveWorktree` already fires this callback only once it
+    /// has confirmed the path is gone — queued out of its pool slot on the
+    /// success leg, or a verified `git.worktreeRemove` on the fallback leg — so
+    /// this is defense in depth against a future caller that doesn't uphold that
+    /// contract, not a workaround for a swallowed failure: a failed removal must
+    /// never orphan-classify (and delete) resources that are still in active use.
     ///
     /// The `gcEnabled` master switch governs ALL GC deletion, including this
-    /// event-driven path — one toggle covers both collectors. A config read
+    /// event-driven path — one toggle covers every collector. A config read
     /// failure also skips (fail toward keeping).
-    public func scratchpadCleanup(forRemovedWorktreePath path: String, repoPath: String) async {
-        guard !FileManager.default.fileExists(atPath: path) else {
-            logger.debug("gc: scratchpad cleanup skipped for \(path, privacy: .public) — worktree dir still exists")
+    ///
+    /// **Best effort, by design.** A revived worktree does not get its images
+    /// back, and every path this misses — a crash between the rename and this
+    /// call, a worktree removed outside TBD — is covered by the hourly
+    /// attachments sweep. That division is the doctrine: creation against the
+    /// filesystem cannot be transactional, so the sweep is the standing
+    /// guarantee and this is the prompt best effort.
+    public func removedWorktreeCleanup(
+        worktreeID: UUID, worktreePath: String, repoPath: String
+    ) async {
+        guard !FileManager.default.fileExists(atPath: worktreePath) else {
+            logger.debug("""
+            gc: removed-worktree cleanup skipped for \(worktreePath, privacy: .public) \
+            — worktree dir still exists
+            """)
             return
         }
         guard let config = try? await db.config.get(), config.gcEnabled else {
-            logger.debug("gc: scratchpad cleanup skipped for \(path, privacy: .public) — gc disabled")
+            logger.debug("""
+            gc: removed-worktree cleanup skipped for \(worktreePath, privacy: .public) \
+            — gc disabled
+            """)
             return
         }
+
+        // Attachments first: it is one `removeItem` and cannot fail the
+        // scratchpad reclaim below.
+        //
+        // NOT additionally gated on the composer flag. The directory exists only
+        // because the composer wrote into it, and a person who turned the
+        // composer off afterwards would otherwise leave images behind
+        // permanently — a flag that gates CREATION must not gate the reclaim of
+        // what was already created.
+        let attachments = TBDConstants.attachmentsDir(worktreeID: worktreeID)
+        if FileManager.default.fileExists(atPath: attachments.path) {
+            do {
+                try FileManager.default.removeItem(at: attachments)
+                logger.info("""
+                gc: removed attachments for worktree \
+                \(worktreeID.uuidString, privacy: .public)
+                """)
+            } catch {
+                logger.warning("""
+                gc: could not remove attachments for worktree \
+                \(worktreeID.uuidString, privacy: .public): \
+                \(error.localizedDescription, privacy: .public) — the hourly sweep will retry
+                """)
+            }
+        }
+
         guard let record = await scratchpadCollector.cleanUp(
-            forRemovedWorktreePath: path, repoPath: repoPath, now: now()
+            forRemovedWorktreePath: worktreePath, repoPath: repoPath, now: now()
         ) else {
             return
         }

--- a/Sources/TBDDaemon/GC/OrphanGC.swift
+++ b/Sources/TBDDaemon/GC/OrphanGC.swift
@@ -63,6 +63,7 @@ public actor OrphanGC {
     private let deletionQueueCollector: DeletionQueueCollector
     private let profileDirCollector: ProfileDirCollector
     private let holderRendezvousCollector: HolderRendezvousCollector
+    private let attachmentsCollector: AttachmentsCollector
     private let rowlessHolderCollector: RowlessHolderCollector
     /// Deletes the path-keyed Claude Code credentials item belonging to a
     /// quarantined profile dir. Injected so tests never reach the real login
@@ -148,6 +149,7 @@ public actor OrphanGC {
         orphanProcessPollInterval: Duration = .milliseconds(100),
         clock: any Clock<Duration> = ContinuousClock(),
         holdersBase: URL? = nil,
+        attachmentsBase: URL? = nil,
         holderListenerProbe: (@Sendable (String) async -> Bool)? = nil,
         rowlessHolderHandshake: (@Sendable (String) async -> RowlessHolderHandshake)? = nil,
         rowlessHolderReclaimer: (any RowlessHolderReclaiming)? = nil
@@ -186,6 +188,9 @@ public actor OrphanGC {
             now: resolvedNow,
             handshake: rowlessHolderHandshake,
             reclaimer: rowlessHolderReclaimer)
+        let resolvedAttachmentsBase = attachmentsBase ?? TBDConstants.attachmentsDir
+        self.attachmentsCollector = AttachmentsCollector(
+            base: resolvedAttachmentsBase, now: resolvedNow)
         self.processCWDsProvider = processCWDsProvider
         let resolvedSnapshotProvider: @Sendable () async -> [ProcessSnapshotEntry]? =
             processSnapshotProvider ?? { await OrphanProcessCollector.realProcessSnapshot() }
@@ -293,6 +298,10 @@ public actor OrphanGC {
         )
 
         await reclaimRetainedTranscripts(
+            config: config, dryRun: dryRun, planned: &planned, reaped: &reaped
+        )
+
+        await reclaimAttachments(
             config: config, dryRun: dryRun, planned: &planned, reaped: &reaped
         )
 
@@ -908,6 +917,88 @@ public actor OrphanGC {
                 logger.warning("""
                 gc: could not unlink \(file.path, privacy: .public): \
                 \(error.localizedDescription, privacy: .public)
+                """)
+            }
+        }
+    }
+
+    // MARK: - Composer attachments
+
+    /// Reclaims `~/tbd/attachments/<worktreeID>/` directories whose worktree is
+    /// gone — the named periodic reconciler for the composer's attachment files
+    /// (`docs/specs/2026-09-05-transcript-composer-design.md`, "Reclaim").
+    ///
+    /// Its event-driven sibling is `removedWorktreeCleanup`, which unlinks a
+    /// worktree's directory the moment the worktree is archived. That path is
+    /// best effort by construction — a crash between the archive's commit point
+    /// and the callback, or a worktree removed outside TBD, leaves a directory
+    /// nobody unlinked — and this is the standing guarantee behind it. That
+    /// division is the doctrine the whole codebase uses: creation against the
+    /// filesystem cannot be transactional, so the sweep is the mechanism and
+    /// create-time cleanup is the optimisation.
+    ///
+    /// Gated by `transcriptComposerEnabled` on top of `gcEnabled`, because the
+    /// feature that writes these files is itself behind that flag — a machine
+    /// that has never opened the composer has nothing here for this phase to be
+    /// right or wrong about. `dryRun` bypasses the flag exactly as `sweep` lets
+    /// it bypass `gcEnabled`: planning is read-only, and someone deciding whether
+    /// to enable a default-off flag needs to see what enabling it would reclaim.
+    /// A NON-dry run still requires the flag.
+    ///
+    /// **An unreadable worktree list skips the whole leg**, rather than reading
+    /// an empty list as "no worktree is live" and reaping every directory.
+    ///
+    /// The row read is unfiltered on purpose: an archived row is still a row, and
+    /// the archive path's own unlink is what handles its directory. Filtering to
+    /// `.active` here would let this leg reap out from under a worktree somebody
+    /// can still revive.
+    ///
+    /// No `ReapRecord` is written. The record type is keyed by the worktree a
+    /// reap removed and carries a restorability pointer; there is nothing a
+    /// `tbd gc restore` could put back here, because the image was staged for a
+    /// message in a worktree that no longer exists.
+    private func reclaimAttachments(
+        config: Config, dryRun: Bool, planned: inout [String], reaped: inout Int
+    ) async {
+        guard config.transcriptComposerEnabled || dryRun else { return }
+
+        let live: Set<UUID>
+        do {
+            live = Set(try await db.worktrees.list().map(\.id))
+        } catch {
+            logger.error("""
+            gc: worktree rows unreadable this sweep \
+            (\(error.localizedDescription, privacy: .public)) — skipping the attachments phase
+            """)
+            planned.append("KEEP rows-unreadable attachments")
+            return
+        }
+
+        for candidate in attachmentsCollector.candidates() {
+            switch attachmentsCollector.decide(
+                candidate, liveWorktreeIDs: live,
+                floorDays: AttachmentsCollector.defaultFloorDays
+            ) {
+            case .keep(let reason):
+                planned.append("KEEP \(reason) \(candidate.path)")
+                logger.debug("""
+                gc: keep \(reason, privacy: .public) \(candidate.path, privacy: .public)
+                """)
+            case .reap:
+                planned.append("REAP attachments \(candidate.path)")
+                // This leg's guard is `transcriptComposerEnabled || dryRun`, so
+                // every line below runs only with the flag actually on.
+                guard !dryRun else { continue }
+                guard attachmentsCollector.reap(candidate) else {
+                    planned.append("KEEP unlink-failed \(candidate.path)")
+                    logger.warning("""
+                    gc: could not unlink \(candidate.path, privacy: .public)
+                    """)
+                    continue
+                }
+                reaped += 1
+                logger.info("""
+                gc: reclaimed composer attachments \(candidate.path, privacy: .public)
                 """)
             }
         }

--- a/Sources/TBDDaemon/GC/OrphanGC.swift
+++ b/Sources/TBDDaemon/GC/OrphanGC.swift
@@ -64,6 +64,13 @@ public actor OrphanGC {
     private let profileDirCollector: ProfileDirCollector
     private let holderRendezvousCollector: HolderRendezvousCollector
     private let attachmentsCollector: AttachmentsCollector
+    /// The attachments root both halves of the reconciler pair read — the hourly
+    /// sweep through `attachmentsCollector`, and `removedWorktreeCleanup`
+    /// directly. Cached at init from the injected seam, so ONE seam governs
+    /// both: re-resolving `TBDConstants.attachmentsDir` per call would let an
+    /// injected base steer the sweep while the event-driven half kept walking
+    /// the process-global one.
+    private let attachmentsBase: URL
     private let rowlessHolderCollector: RowlessHolderCollector
     /// Deletes the path-keyed Claude Code credentials item belonging to a
     /// quarantined profile dir. Injected so tests never reach the real login
@@ -189,6 +196,7 @@ public actor OrphanGC {
             handshake: rowlessHolderHandshake,
             reclaimer: rowlessHolderReclaimer)
         let resolvedAttachmentsBase = attachmentsBase ?? TBDConstants.attachmentsDir
+        self.attachmentsBase = resolvedAttachmentsBase
         self.attachmentsCollector = AttachmentsCollector(
             base: resolvedAttachmentsBase, now: resolvedNow)
         self.processCWDsProvider = processCWDsProvider
@@ -1568,7 +1576,7 @@ public actor OrphanGC {
         // composer off afterwards would otherwise leave images behind
         // permanently — a flag that gates CREATION must not gate the reclaim of
         // what was already created.
-        let attachments = TBDConstants.attachmentsDir(worktreeID: worktreeID)
+        let attachments = attachmentsBase.appendingPathComponent(worktreeID.uuidString)
         if FileManager.default.fileExists(atPath: attachments.path) {
             do {
                 try FileManager.default.removeItem(at: attachments)

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator+Holder.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator+Holder.swift
@@ -977,7 +977,10 @@ extension HibernationCoordinator {
         // pane's screen, and this row has no pane. A holder session's resumed
         // id is recaptured the way every other fact about it is — from hooks.
         logger.info("woke holder-backed terminal \(terminal.id, privacy: .public) (resume \(sessionID, privacy: .public), holder \(handle.holderPID, privacy: .public), child \(handle.childPID, privacy: .public))")
-        return .ok
+        // The incarnation this wake minted for the replacement agent, the same
+        // fact the tmux arm reports: it is what scopes a caller's wait to the
+        // session THIS call started rather than to whatever starts next.
+        return .ok(sessionIncarnationID: incarnationID)
     }
 
     /// Un-park a parked row whose holder is already running, or answer nil so
@@ -1074,7 +1077,9 @@ extension HibernationCoordinator {
             terminal: terminal, hibernated: false, keepWarm: terminal.keepWarm,
             tmuxWindowID: "", tmuxPaneID: "")
         logger.info("wake: adopted the holder already running for \(terminal.id, privacy: .public) instead of spawning a second one — \(evidence, privacy: .public); the row was parked over it")
-        return .ok
+        // No incarnation: adopting a holder that was already running spawns
+        // nothing, so there is no new session for a caller's wait to scope to.
+        return .ok(sessionIncarnationID: nil)
     }
 
     /// Put the registry's own view of a session's processes back onto its row.

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
@@ -44,7 +44,10 @@ public enum UnparkedPaneDisagreement: Equatable, Sendable {
 }
 
 public enum WakeResult: Equatable, Sendable {
-    case ok
+    /// The wake respawned the agent. Carries the incarnation
+    /// `prepareHibernatedAgentRespawn` minted for that spawn, which is what
+    /// scopes a caller's wait to the session THIS call started.
+    case ok(sessionIncarnationID: UUID?)
     case notHibernated   // idempotent no-op: nothing to wake
     /// The row is NOT parked — TBD believes this terminal is awake — but its
     /// pane says otherwise, so there is no live session for an "already awake"
@@ -1319,7 +1322,7 @@ public actor HibernationCoordinator {
             server: liveServer,
             expectedIncarnationID: liveIncarnationID)
         logger.info("woke terminal \(terminal.id, privacy: .public) (resume \(sessionID, privacy: .public))")
-        return .ok
+        return .ok(sessionIncarnationID: liveIncarnationID)
     }
 
     /// Outcome of `wakeTmuxSection`: the live pane/window ids the rest of

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
@@ -215,10 +215,11 @@ extension WorktreeLifecycle {
             // callback's precondition — the path is gone — holds here, before
             // the bytes are actually reclaimed by the drain below. Firing now
             // rather than after drain matches the design's ordering and keeps
-            // the event-driven scratchpad cleanup this callback exists to
-            // trigger prompt even when the drain that follows is slow.
+            // the event-driven cleanup this callback exists to trigger — the
+            // scratchpad and the composer attachments — prompt even when the
+            // drain that follows is slow.
             if let onWorktreeRemoved {
-                await onWorktreeRemoved(worktree.localPath, repo.path)
+                await onWorktreeRemoved(worktree.id, worktree.localPath, repo.path)
             }
 
             // Reclaim the bytes inline, with no deadline attached. Every
@@ -251,7 +252,7 @@ extension WorktreeLifecycle {
                 // fired unconditionally after a swallowed failure.
                 let removed = !FileManager.default.fileExists(atPath: worktree.localPath)
                 if removed, let onWorktreeRemoved {
-                    await onWorktreeRemoved(worktree.localPath, repo.path)
+                    await onWorktreeRemoved(worktree.id, worktree.localPath, repo.path)
                 }
             } catch {
                 archiveLogger.error("""

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle.swift
@@ -113,16 +113,24 @@ public struct WorktreeLifecycle: Sendable {
     /// on the success path, right after `completeArchiveWorktree` renames it
     /// into `WorktreeDeletionQueue` (bytes may still be draining); on the
     /// fallback leg, only once `git.worktreeRemove` is verified to have
-    /// actually removed it from disk. Carries the removed worktree's path and
-    /// its owning repo's path (the archive caller has `repo` in scope). `nil`
-    /// by default (tests, older callers).
+    /// actually removed it from disk. `nil` by default (tests, older callers).
+    ///
+    /// Carries the removed worktree's **id**, its path, and its owning repo's
+    /// path (the archive caller has `worktree` and `repo` in scope). The id is
+    /// what the attachments reclaim needs: `~/tbd/attachments/<worktreeID>/` is
+    /// keyed by it, and the path is not derivable from a directory that no
+    /// longer exists.
+    ///
     /// `Daemon` wires this to
-    /// `OrphanGC.scratchpadCleanup(forRemovedWorktreePath:repoPath:)` so the
-    /// worktree's Claude Code scratchpad is reclaimed event-driven instead of
-    /// waiting for the next hourly sweep, stamped with the repo path so it
-    /// surfaces in that repo's History UI. Deliberately NOT fired by
-    /// `forgetWorktree` — forget leaves the directory in place.
-    public var onWorktreeRemoved: (@Sendable (_ worktreePath: String, _ repoPath: String) async -> Void)?
+    /// `OrphanGC.removedWorktreeCleanup(worktreeID:worktreePath:repoPath:)` so
+    /// the worktree's Claude Code scratchpad and its composer attachments are
+    /// reclaimed event-driven instead of waiting for the next hourly sweep, the
+    /// scratchpad stamped with the repo path so it surfaces in that repo's
+    /// History UI. Deliberately NOT fired by `forgetWorktree` — forget leaves
+    /// the directory in place.
+    public var onWorktreeRemoved:
+        (@Sendable (_ worktreeID: UUID, _ worktreePath: String, _ repoPath: String)
+            async -> Void)?
 
     /// Opt-in tmux control-mode wiring. `nil` when the daemon did not provide
     /// one (tests, older callers); when present, lifecycle paths open a gated

--- a/Sources/TBDDaemon/Process/ProcessIdentity.swift
+++ b/Sources/TBDDaemon/Process/ProcessIdentity.swift
@@ -8,7 +8,10 @@ import Foundation
 /// process from a stranger that inherited the number. The two facts beside it
 /// are what close that gap — the start time, which `execve` does not move, and
 /// the command line, which says what is running there now.
-struct ProcessIdentity: Sendable, Equatable {
+/// `public` only because it names a parameter of `RPCRouter`'s public
+/// initializer (the envelope-suppression seam). Its members stay internal:
+/// nothing outside this module constructs or reads one.
+public struct ProcessIdentity: Sendable, Equatable {
     let pid: Int32
     /// When the process holding `pid` started, as read from the kernel at the
     /// moment this identity was recorded.

--- a/Sources/TBDDaemon/Server/AwaitingInputSendGate.swift
+++ b/Sources/TBDDaemon/Server/AwaitingInputSendGate.swift
@@ -1,0 +1,55 @@
+import Foundation
+import TBDShared
+
+/// Whether an opted-in send may proceed against a session's standing
+/// awaiting-input reason.
+///
+/// A pasted body plus Enter into a permission dialog commits whichever option is
+/// highlighted, which is a destructive act nobody asked for. So the gate fails
+/// toward refusing, and an unrecognized reason is treated as a dialog — because
+/// that is exactly what a newer Claude Code's new dialog type looks like to this
+/// build, and a gate that allowed unknowns would silently stop working the day a
+/// dialog is added.
+///
+/// Informational reasons and the idle prompt are allowed: the first says nobody
+/// is being waited on, and the second is the agent waiting for its next
+/// instruction, which is the state the composer exists to answer.
+///
+/// **Pure.** The supersession question — has the session's own transcript shown
+/// it moved on since the prompt was recorded — is answered by
+/// `AwaitingInputSupersession`, the mechanism `terminal.list` already applies,
+/// and handed in as a Bool. Reimplementing it here would give TBD two answers to
+/// one question.
+enum AwaitingInputSendGate {
+    enum Decision: Equatable, Sendable {
+        case allow
+        case refuse(message: String)
+    }
+
+    static func decide(reason: AwaitingInputReason?, superseded: Bool) -> Decision {
+        guard let reason else { return .allow }
+        guard !superseded else { return .allow }
+        switch reason.classification {
+        case .promptOnScreen, .unrecognized:
+            return .refuse(message: refusalMessage(reason))
+        case .doneWaiting, .informational:
+            return .allow
+        }
+    }
+
+    /// The refusal a human reads. It carries the notification message verbatim,
+    /// because that message is the question being asked, and answering it in the
+    /// terminal is the correct resolution.
+    ///
+    /// TBD never *branches* on this text — that would be screen-scraping with an
+    /// extra hop — it only carries it.
+    static func refusalMessage(_ reason: AwaitingInputReason) -> String {
+        let kind = reason.classification == .unrecognized
+            ? "an awaiting-input state this build does not recognize"
+            : "a prompt on screen"
+        let quoted = reason.message.isEmpty ? "" : " — \"\(reason.message)\""
+        return "terminal.send was refused: the session has \(kind)\(quoted). Nothing was typed; "
+            + "a pasted message plus Enter would commit whichever option is highlighted. "
+            + "Answer it in the terminal."
+    }
+}

--- a/Sources/TBDDaemon/Server/FDVendingServer.swift
+++ b/Sources/TBDDaemon/Server/FDVendingServer.swift
@@ -191,6 +191,13 @@ actor FDVendingServer {
         onReceiveLoopExit = handler
     }
 
+    /// The identity recorded for the current client at adopt time, or nil when
+    /// no client is connected.
+    ///
+    /// Read-only on purpose: the sidecar is the only writer, and a second one
+    /// would be a way to install an identity the kernel never reported.
+    func currentClientIdentity() -> ProcessIdentity? { clientIdentity }
+
     /// Start listening on `path`. Any existing file at `path` is removed first.
     /// Only meaningful in the live daemon; tests should call `adoptConnection`
     /// directly.

--- a/Sources/TBDDaemon/Server/RPCConnectionContext.swift
+++ b/Sources/TBDDaemon/Server/RPCConnectionContext.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// What the daemon knows about the socket a request arrived on, as opposed to
+/// what the request says about itself.
+///
+/// One field, and it is the only fact on this path that cannot be forged:
+/// `LOCAL_PEERPID` is a property of the **socket**, not of the bytes on it, so
+/// the kernel names the process that actually connected. Contrast
+/// `ActuationActor`, which travels IN the request and is a self-declaration the
+/// daemon has never verified — it records which door an act came through and
+/// carries no authority.
+///
+/// Absent — a nil context, or a nil `peerPID` — means "not established". Every
+/// consumer must read that as no, never as probably fine: this is the input to
+/// an authorization decision and it has exactly two answers.
+///
+/// `public` only because it names a parameter of `RPCRouter.handleRaw` and
+/// `RPCRouter.handle`, which are public. Its member and initializer stay
+/// internal: the only thing entitled to mint one is the socket server that read
+/// the pid from the kernel.
+public struct RPCConnectionContext: Sendable, Equatable {
+    /// The pid the kernel reports for the peer of this connection, read once at
+    /// accept. Nil when the option could not be read, or when the request did
+    /// not arrive over a socket at all.
+    let peerPID: Int32?
+
+    init(peerPID: Int32?) { self.peerPID = peerPID }
+}

--- a/Sources/TBDDaemon/Server/RPCRouter+HibernationHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+HibernationHandlers.swift
@@ -69,6 +69,27 @@ extension RPCRouter {
         }
     }
 
+    /// The success payload for a wake outcome, or nil for an outcome that is an
+    /// RPC error rather than a result.
+    ///
+    /// Pure and static so the four rows that matter — woken with an id, woken
+    /// without one, and each idempotent no-op — are statable without a
+    /// coordinator, a database or a tmux server.
+    static func wakeResultPayload(for result: WakeResult) -> TerminalWakeResult? {
+        switch result {
+        case .ok(let incarnationID):
+            return TerminalWakeResult(woken: true, sessionIncarnationID: incarnationID)
+        case .notHibernated, .inFlight:
+            // Benign no-ops for an idempotent wake — `woken: false` so an
+            // autonomous caller knows its `prompt` was NOT delivered (the
+            // terminal is live; pasting into it now could hit a human session),
+            // and no incarnation, because no spawn happened to name.
+            return TerminalWakeResult(woken: false)
+        default:
+            return nil
+        }
+    }
+
     /// `terminal.wake` — respawn `claude --resume <id>` in the hibernated
     /// terminal's kept-alive window. Idempotent.
     func handleTerminalWake(
@@ -87,14 +108,10 @@ extension RPCRouter {
         await finishActuation(
             actuationID, ActuationOutcome.classify(result),
             error: ActuationOutcome.detail(result))
+        if let payload = Self.wakeResultPayload(for: result) {
+            return try RPCResponse(result: payload)
+        }
         switch result {
-        case .ok:
-            return try RPCResponse(result: TerminalWakeResult(woken: true))
-        case .notHibernated, .inFlight:
-            // Benign no-ops for an idempotent wake — but report woken: false so
-            // autonomous callers know their `prompt` was NOT delivered (the
-            // terminal is live; pasting into it now could hit a human session).
-            return try RPCResponse(result: TerminalWakeResult(woken: false))
         case .sessionGone(let paneID, let detail):
             // NOT a benign no-op: the row claims awake but its pane disagrees,
             // so there was nothing live to deliver `prompt` to. An error (not
@@ -121,6 +138,12 @@ extension RPCRouter {
             return RPCResponse(error: HibernationCoordinator.holderTransportRefusal)
         case .paneBusy(let pid):
             return RPCResponse(error: HibernationCoordinator.paneBusyRefusal(pid: pid))
+        case .ok, .notHibernated, .inFlight:
+            // Unreachable: `wakeResultPayload` returns non-nil for exactly
+            // these three cases and this function already returned above.
+            // Kept explicit (rather than `default:`) so a new WakeResult case
+            // added later must be classified deliberately in BOTH switches.
+            preconditionFailure("wakeResultPayload already handled \(result)")
         }
     }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+HibernationHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+HibernationHandlers.swift
@@ -148,7 +148,16 @@ extension RPCRouter {
             // these three cases and this function already returned above.
             // Kept explicit (rather than `default:`) so a new WakeResult case
             // added later must be classified deliberately in BOTH switches.
-            preconditionFailure("wakeResultPayload already handled \(result)")
+            //
+            // Fails SOFT rather than trapping. If the two switches ever drift
+            // apart, the caller gets an error naming the drift and the daemon —
+            // which is serving every other session on this machine — keeps
+            // running. A `preconditionFailure` here would take the whole fleet
+            // down over one wake.
+            return RPCResponse(
+                error: "terminal.wake produced an unclassified result (\(result)) — this is a "
+                    + "daemon bug: the wake may have happened. Re-read the terminal's state "
+                    + "before retrying.")
         }
     }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+HibernationHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+HibernationHandlers.swift
@@ -85,7 +85,12 @@ extension RPCRouter {
             // terminal is live; pasting into it now could hit a human session),
             // and no incarnation, because no spawn happened to name.
             return TerminalWakeResult(woken: false)
-        default:
+        case .sessionGone, .notFound, .noSessionID, .respawnFailed, .worktreeMissing,
+            .profileMissing, .holderTransport, .paneBusy:
+            // RPC errors, not results — the caller-facing switch in
+            // handleTerminalWake maps each to its own RPCResponse(error:).
+            // Named explicitly (not `default:`) so a new WakeResult case must
+            // be classified deliberately in BOTH switches.
             return nil
         }
     }

--- a/Sources/TBDDaemon/Server/RPCRouter+ScratchHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ScratchHandlers.swift
@@ -169,11 +169,13 @@ extension RPCRouter {
         // reconciliation has no path left to resolve it by. Scratch spaces
         // have no owning repo, so repoPath is "" — the same
         // unresolvable-repo convention `OrphanGC`'s own reconciliation uses.
-        // `scratchpadCleanup` re-verifies the directory is gone and is
+        // `removedWorktreeCleanup` re-verifies the directory is gone and is
         // gated by `gcEnabled` internally, so this is safe to call
-        // unconditionally.
+        // unconditionally. It also unlinks the row's composer attachments,
+        // which are keyed by the same worktree id the row is about to lose.
         if let orphanGC {
-            await orphanGC.scratchpadCleanup(forRemovedWorktreePath: wt.path, repoPath: "")
+            await orphanGC.removedWorktreeCleanup(
+                worktreeID: wt.id, worktreePath: wt.path, repoPath: "")
         }
 
         // Hard delete: closed-terminal history (rows + captured files) goes

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -2895,6 +2895,12 @@ extension RPCRouter {
     /// string sits unsent in Claude's composer. Splitting the message into
     /// several deliveries instead would reopen the at-least-once and routing
     /// questions that one delivery avoids, so this refuses rather than guessing.
+    /// It carries one more cause than "composite" suggests: an image-only
+    /// message whose write would also have to carry the dispatch envelope. The
+    /// tmux arm gives the envelope a separate leading paste; this transport has
+    /// no second delivery to give, and the envelope alone is 68 bytes, so the
+    /// combined write lands past the 64-byte cliff too.
+    ///
     /// PR #816 (child-as-contract-party) wraps in bracketed paste when the
     /// child's mode is on, in one write, and this refusal lifts with it.
     static func holderCompositeRefusal(terminalID: UUID, cause: String) -> String {
@@ -3065,7 +3071,7 @@ extension RPCRouter {
             submit: payload.recordedSubmit,
             verify: payload.recordedVerify)
 
-        // ─── The transport, ahead of every other declining rail ───
+        // ─── The transport's own declining rail ───
         //
         // A holder-backed session has no tmux pane: its `tmuxPaneID` is the
         // empty string by construction, so every tmux mechanic below — the
@@ -3074,13 +3080,19 @@ extension RPCRouter {
         // instead, which writes to the session's pty rather than to a pane
         // (see `performHolderSend`).
         //
-        // It sits ahead of the `--verify` rails because the holder path
-        // declines `--verify` for a *different* reason than they do — no
-        // delivery observation exists for this transport at all, rather than a
-        // flag being off — and a caller needs to be told which. It sits AFTER
-        // `beginActuation` for the reason the first refusal line above gives:
-        // a well-formed act the daemon declined gets a row and a refusal
-        // outcome, unlike a malformed payload that names no act.
+        // The transport decides WHICH rails apply, and dispatch happens below
+        // the awaiting-input gate rather than here, so both transports pass
+        // through that gate — the spec applies it before dispatching to
+        // either, and a holder row that skipped it would answer a permission
+        // dialog by committing whichever option is highlighted. Each rule
+        // therefore has exactly one code path: the tmux rails in the `else`
+        // arm, what the holder write cannot frame in this one, and one gate
+        // below covering both.
+        //
+        // This arm sits AFTER `beginActuation` for the reason the first
+        // refusal line above gives: a well-formed act the daemon declined gets
+        // a row and a refusal outcome, unlike a malformed payload that names
+        // no act.
         if terminal.transport == .holder {
             // ─── What the holder arm cannot carry yet ───
             //
@@ -3108,100 +3120,97 @@ extension RPCRouter {
                 await finishActuation(actuationID, .refused(.notEligible), error: message)
                 return RPCResponse(error: message)
             }
-            return await performHolderSend(
-                payload: payload, terminal: terminal, actuationID: actuationID,
-                actor: actor, envelope: envelope)
-        }
-
-        // ─── Is Claude actually running here? ───
-        //
-        // Text and parts, never keys. `--keys` exists to answer a dialog and to
-        // interrupt, and a key sequence into a shell is not the failure this
-        // rail exists to stop. A parts payload is subject to both rails exactly
-        // as a non-empty text payload is: it is pasted into the pane the same
-        // way, and a validated parts payload always has content — Task 2's
-        // shape validation refuses an empty one — so there is no emptiness
-        // guard to mirror for it the way there is for text.
-        //
-        // Two independent facts, because each fails on its own. The park stamp is
-        // written by the `SessionEnd` hook and is missed whenever the process
-        // crashes; the foreground-process inspector reads the process table and
-        // is available only for a tmux-backed row with a live pane. Both are
-        // machine facts — a column and `ps` — never the rendered screen, which
-        // this codebase forbids reading for state.
-        //
-        // The two rails split on the EMPTY payload — a bare Enter, which
-        // `--submit` with no text is — and they split deliberately:
-        //
-        //   - The park rail takes it. A parked row's pane holds a shell and
-        //     nothing else, so an Enter there has no message to lose and no
-        //     purpose to serve, and the refusal already names wake as the
-        //     remedy. Letting it through would be the one text payload that
-        //     reaches a session everyone agrees is gone.
-        //   - The foreground rail does not. A bare Enter is how a caller
-        //     answers a prompt the agent is already showing, and the inspector
-        //     is the fallible fact of the two — a pane it cannot read must not
-        //     cost a live row its Enter.
-        let subjectToParkRail: Bool
-        let subjectToForegroundRail: Bool
-        switch payload {
-        case .text(let body, _, _):
-            subjectToParkRail = true
-            subjectToForegroundRail = !body.isEmpty
-        case .keys:
-            subjectToParkRail = false
-            subjectToForegroundRail = false
-        case .parts:
-            subjectToParkRail = true
-            subjectToForegroundRail = true
-        }
-        if subjectToParkRail {
-            if terminal.hibernatedAt != nil {
-                let message = Self.parkedSendRefusal(
-                    terminalID: terminal.id, exited: terminal.isExitStamped)
-                await finishActuation(actuationID, .refused(.notEligible), error: message)
-                return RPCResponse(error: message)
+        } else {
+            // ─── Is Claude actually running here? ───
+            //
+            // Text and parts, never keys. `--keys` exists to answer a dialog and to
+            // interrupt, and a key sequence into a shell is not the failure this
+            // rail exists to stop. A parts payload is subject to both rails exactly
+            // as a non-empty text payload is: it is pasted into the pane the same
+            // way, and a validated parts payload always has content — Task 2's
+            // shape validation refuses an empty one — so there is no emptiness
+            // guard to mirror for it the way there is for text.
+            //
+            // Two independent facts, because each fails on its own. The park stamp is
+            // written by the `SessionEnd` hook and is missed whenever the process
+            // crashes; the foreground-process inspector reads the process table and
+            // is available only for a tmux-backed row with a live pane. Both are
+            // machine facts — a column and `ps` — never the rendered screen, which
+            // this codebase forbids reading for state.
+            //
+            // The two rails split on the EMPTY payload — a bare Enter, which
+            // `--submit` with no text is — and they split deliberately:
+            //
+            //   - The park rail takes it. A parked row's pane holds a shell and
+            //     nothing else, so an Enter there has no message to lose and no
+            //     purpose to serve, and the refusal already names wake as the
+            //     remedy. Letting it through would be the one text payload that
+            //     reaches a session everyone agrees is gone.
+            //   - The foreground rail does not. A bare Enter is how a caller
+            //     answers a prompt the agent is already showing, and the inspector
+            //     is the fallible fact of the two — a pane it cannot read must not
+            //     cost a live row its Enter.
+            let subjectToParkRail: Bool
+            let subjectToForegroundRail: Bool
+            switch payload {
+            case .text(let body, _, _):
+                subjectToParkRail = true
+                subjectToForegroundRail = !body.isEmpty
+            case .keys:
+                subjectToParkRail = false
+                subjectToForegroundRail = false
+            case .parts:
+                subjectToParkRail = true
+                subjectToForegroundRail = true
             }
-            // The foreground rail is kind-aware, not Claude-only. The
-            // inspector's question is "does a foreground process whose command
-            // line contains <name> own this pane", and the kind supplies the
-            // name: "claude" for a Claude row, "codex" for a Codex one, and for
-            // a row whose kind was never recorded, whichever of the two the
-            // Claude session id decides — the same reading `v22_terminal_kind`
-            // backfilled onto every such row and `Terminal.isClaudeResumable`
-            // already requires. A shell has no name to supply — its pane pid IS
-            // the shell, with no agent under it — so the rail never runs for
-            // one, and a shell send that would otherwise be refused every time
-            // goes through.
-            //
-            // Covering Codex here matters more than it does for Claude: a Codex
-            // row is never exit-stamped, because Codex ships no `SessionEnd`
-            // hook, and stamping one would be worse than not — the wake path
-            // refuses a non-Claude row, so the stamp would park it unwakeably.
-            // This rail is therefore the ONLY thing standing between a Codex
-            // pane whose agent left and a message pasted into its shell and run.
-            // The park rail above stays kind-agnostic: a parked row of any kind
-            // has no live session behind it.
-            //
-            // A pane id that resolves to a pid is the precondition for asking at
-            // all, and `panePID > 0` is not decoration: a tmux that cannot answer
-            // reports "0", and asking the process table about pid 0 is a question
-            // with no meaning. An unreadable pid therefore proceeds — a tmux that
-            // cannot answer is not evidence that Claude left, and the pane
-            // consultation below is the rail that judges a missing or dead pane,
-            // properly.
-            if subjectToForegroundRail,
-               let agentName = Self.foregroundAgentName(
-                    kind: terminal.kind, claudeSessionID: terminal.claudeSessionID),
-               let panePIDString = try? await tmux.panePID(
-                    server: worktree.tmuxServer, paneID: terminal.tmuxPaneID),
-               let panePID = Int32(panePIDString), panePID > 0,
-               paneProcessInspector.foregroundAgentPID(
-                    panePID: panePID, matching: agentName) == nil {
-                let message = Self.agentNotForegroundRefusal(
-                    terminalID: terminal.id, paneID: terminal.tmuxPaneID, agentName: agentName)
-                await finishActuation(actuationID, .refused(.notEligible), error: message)
-                return RPCResponse(error: message)
+            if subjectToParkRail {
+                if terminal.hibernatedAt != nil {
+                    let message = Self.parkedSendRefusal(
+                        terminalID: terminal.id, exited: terminal.isExitStamped)
+                    await finishActuation(actuationID, .refused(.notEligible), error: message)
+                    return RPCResponse(error: message)
+                }
+                // The foreground rail is kind-aware, not Claude-only. The
+                // inspector's question is "does a foreground process whose command
+                // line contains <name> own this pane", and the kind supplies the
+                // name: "claude" for a Claude row, "codex" for a Codex one, and for
+                // a row whose kind was never recorded, whichever of the two the
+                // Claude session id decides — the same reading `v22_terminal_kind`
+                // backfilled onto every such row and `Terminal.isClaudeResumable`
+                // already requires. A shell has no name to supply — its pane pid IS
+                // the shell, with no agent under it — so the rail never runs for
+                // one, and a shell send that would otherwise be refused every time
+                // goes through.
+                //
+                // Covering Codex here matters more than it does for Claude: a Codex
+                // row is never exit-stamped, because Codex ships no `SessionEnd`
+                // hook, and stamping one would be worse than not — the wake path
+                // refuses a non-Claude row, so the stamp would park it unwakeably.
+                // This rail is therefore the ONLY thing standing between a Codex
+                // pane whose agent left and a message pasted into its shell and run.
+                // The park rail above stays kind-agnostic: a parked row of any kind
+                // has no live session behind it.
+                //
+                // A pane id that resolves to a pid is the precondition for asking at
+                // all, and `panePID > 0` is not decoration: a tmux that cannot answer
+                // reports "0", and asking the process table about pid 0 is a question
+                // with no meaning. An unreadable pid therefore proceeds — a tmux that
+                // cannot answer is not evidence that Claude left, and the pane
+                // consultation below is the rail that judges a missing or dead pane,
+                // properly.
+                if subjectToForegroundRail,
+                   let agentName = Self.foregroundAgentName(
+                        kind: terminal.kind, claudeSessionID: terminal.claudeSessionID),
+                   let panePIDString = try? await tmux.panePID(
+                        server: worktree.tmuxServer, paneID: terminal.tmuxPaneID),
+                   let panePID = Int32(panePIDString), panePID > 0,
+                   paneProcessInspector.foregroundAgentPID(
+                        panePID: panePID, matching: agentName) == nil {
+                    let message = Self.agentNotForegroundRefusal(
+                        terminalID: terminal.id, paneID: terminal.tmuxPaneID, agentName: agentName)
+                    await finishActuation(actuationID, .refused(.notEligible), error: message)
+                    return RPCResponse(error: message)
+                }
             }
         }
 
@@ -3231,6 +3240,29 @@ extension RPCRouter {
                 await finishActuation(actuationID, .refused(.notEligible), error: message)
                 return RPCResponse(error: message)
             }
+        }
+
+        // Resolved ONCE, ahead of every delivery arm, so the holder write and
+        // the tmux pastes read the same answer. A rail's own `.suppressed`
+        // passes through; a request's is granted only on a connection the
+        // daemon authenticated.
+        let effectiveEnvelope = await effectiveEnvelope(
+            railDisposition: envelope,
+            requested: params.envelope,
+            connection: connection)
+
+        // ─── The holder dispatch ───
+        //
+        // Ahead of the `--verify` rails below because the holder path declines
+        // `--verify` for a *different* reason than they do — no delivery
+        // observation exists for this transport at all, rather than a flag being
+        // off — and a caller needs to be told which. It is handed the EFFECTIVE
+        // disposition, not the rail's: an authenticated suppression must reach
+        // this transport too.
+        if terminal.transport == .holder {
+            return await performHolderSend(
+                payload: payload, terminal: terminal, actuationID: actuationID,
+                actor: actor, envelope: effectiveEnvelope)
         }
 
         // ─── The second refusal line: a well-formed act the daemon declines ───
@@ -3316,14 +3348,6 @@ extension RPCRouter {
         // that pasted nothing (empty text, or keys). Handed to the arming seam
         // below so a retry can re-deliver byte-identically.
         var deliveredPayload: String?
-
-        // Resolved ONCE, ahead of the delivery block, so both arms below read
-        // the same answer. A rail's own `.suppressed` passes through; a
-        // request's is granted only on a connection the daemon authenticated.
-        let effectiveEnvelope = await effectiveEnvelope(
-            railDisposition: envelope,
-            requested: params.envelope,
-            connection: connection)
 
         do {
             switch payload {
@@ -3416,6 +3440,38 @@ extension RPCRouter {
                 // put a `<tbd-dispatch/>` line in the middle of a sentence.
                 var envelopePending = effectiveEnvelope == .attached
                     && Self.carriesDispatchEnvelope(terminal)
+
+                // ─── An image-only message is still attributed ───
+                //
+                // With no text part to ride on, the envelope takes a leading
+                // paste of ITS OWN rather than being dropped. Dropping it would
+                // let any local process submit an unattributed user turn
+                // carrying an image, on a request that needs no authentication
+                // — the one property the envelope exists to deny. It cannot
+                // ride ON the image part, because an image attaches only when
+                // the whole paste is the quoted path and nothing else.
+                //
+                // Every part is already its own bracketed paste, so this costs
+                // the image paste nothing: it stays bare and alone, which is the
+                // measured "text + image as separate pastes" shape the parts
+                // payload is built on.
+                let carriesText = parts.contains { part in
+                    switch part {
+                    case .text(let value): return !value.isEmpty
+                    case .imagePath: return false
+                    }
+                }
+                if envelopePending && !carriesText {
+                    try await tmux.pasteText(
+                        server: worktree.tmuxServer,
+                        paneID: terminal.tmuxPaneID,
+                        bytes: Data((Self.dispatchEnvelope(
+                            id: actuationID, from: (actor ?? .anonymous).dispatchLabel
+                        ) + "\n").utf8)
+                    )
+                    envelopePending = false
+                }
+
                 for part in parts {
                     let body: String
                     switch part {
@@ -3487,7 +3543,7 @@ extension RPCRouter {
     /// actuation row, the same dispatch envelope, the same per-terminal
     /// serializer lane (this runs inside it). What changes is the destination —
     /// `HolderInjectionCourier` routes by whether a viewer owns the pty — and
-    /// three things this transport cannot do yet, each refused by name rather
+    /// four things this transport cannot do yet, each refused by name rather
     /// than by "the holder transport", so a caller learns which capability is
     /// missing:
     ///
@@ -3499,12 +3555,18 @@ extension RPCRouter {
     ///   the holder arm cannot carry yet" there). The `.parts` case below
     ///   still turns away a multi-part payload defensively, but that gate
     ///   means it should never see one.
+    /// - An image-only message that would carry the dispatch envelope has
+    ///   nowhere to put it: the envelope cannot ride ahead of a path that
+    ///   attaches only when the paste is the path and nothing else, and there
+    ///   is no second write to give it. Refused in the `.parts` arm below,
+    ///   where the disposition is known.
     ///
     /// A daemon with no courier has no input path at all, and says so.
     ///
     /// **The whole send is one message.** The body, its envelope, its paste
-    /// markers and the carriage return that submits it are composed here and
-    /// handed to the courier in a single call, because a payload split across
+    /// markers and the carriage return that submits it are composed in
+    /// `deliverHolderText` below — which this function's arms converge on —
+    /// and handed to the courier in a single call, because a payload split across
     /// two writes can be split across a routing decision — and because
     /// `HolderReader.write` completes partial writes in a loop, so one call is
     /// one uninterrupted write.
@@ -3582,6 +3644,29 @@ extension RPCRouter {
                 text = value
                 envelopeEligible = true
             case .imagePath(let path):
+                // ─── One write cannot carry both ───
+                //
+                // An image attaches only when the WHOLE paste is the quoted path
+                // and nothing else (measured on 2.1.261), so the envelope that
+                // attributes this turn cannot ride ahead of it — and the tmux
+                // arm's answer, a separate leading paste, needs a second
+                // delivery this transport does not have. Dropping the envelope
+                // instead would let any local process submit an unattributed
+                // user turn carrying an image, which is the one property the
+                // envelope exists to deny.
+                //
+                // So this refuses while an envelope would be attached, and
+                // delivers the bare path when none would be — an authenticated
+                // suppression, or a row that carries no envelope at all.
+                // PR #816's bracketed-paste wrapping lifts it, exactly as it
+                // lifts the composite refusal.
+                guard envelope != .attached || !Self.carriesDispatchEnvelope(terminal) else {
+                    return await refuseHolderSend(
+                        actuationID, Self.holderCompositeRefusal(
+                            terminalID: terminal.id,
+                            cause: "an image on its own, which would have to share that one "
+                                + "write with the dispatch envelope attributing it,"))
+                }
                 text = Self.quotedImagePath(path)
                 envelopeEligible = false
             }

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -3552,10 +3552,19 @@ extension RPCRouter {
         }
         let text: String
         let submit: Bool
+        // Whether `text` is allowed to carry the dispatch envelope at all,
+        // independent of `envelope`'s disposition or `carriesDispatchEnvelope`.
+        // `false` only for a lone image part: Claude Code attaches an image
+        // exclusively when the WHOLE paste is one quoted path (measured on
+        // 2.1.261), so a prefix ahead of it turns the path into literal text
+        // and attaches nothing — matching the tmux arm's rule that an image
+        // part is never enveloped.
+        let envelopeEligible: Bool
         switch payload {
         case .text(let body, let submitting, _):
             text = body
             submit = submitting
+            envelopeEligible = true
         case .keys:
             return await refuseHolderSend(
                 actuationID, Self.holderKeysRefusal(terminalID: terminal.id))
@@ -3569,8 +3578,10 @@ extension RPCRouter {
             switch parts[0] {
             case .text(let value):
                 text = value
+                envelopeEligible = true
             case .imagePath(let path):
                 text = Self.quotedImagePath(path)
+                envelopeEligible = false
             }
             submit = submitting
         case .parts:
@@ -3585,17 +3596,22 @@ extension RPCRouter {
 
         return await deliverHolderText(
             text, submit: submit, terminal: terminal, actuationID: actuationID,
-            actor: actor, envelope: envelope, courier: courier)
+            actor: actor, envelope: envelope, envelopeEligible: envelopeEligible, courier: courier)
     }
 
     /// Deliver one body of text to a holder-backed session: the same envelope
     /// handling, submit handling and courier call the `.text` arm of
     /// `performHolderSend` uses, factored out so the single-part `.parts` arm
     /// can reuse it verbatim rather than duplicating it.
+    ///
+    /// `envelopeEligible` is a second, independent gate on the envelope,
+    /// ahead of `envelope`'s disposition and `carriesDispatchEnvelope`: a lone
+    /// image part passes `false` so the quoted path it built from is never
+    /// prefixed, no matter what those two would otherwise decide.
     private func deliverHolderText(
         _ text: String, submit: Bool, terminal: Terminal, actuationID: String,
         actor: ActuationActor?, envelope: DispatchEnvelopeDisposition,
-        courier: HolderInjectionCourier
+        envelopeEligible: Bool = true, courier: HolderInjectionCourier
     ) async -> RPCResponse {
         // Asked BEFORE anything is composed, because the answer decides the
         // bytes. Two sources, in order: the test seam if one is installed, then
@@ -3621,7 +3637,8 @@ extension RPCRouter {
         // is a real way to press Enter and must not start pasting a tag.
         let body = text.isEmpty
             ? ""
-            : (envelope == .attached && Self.carriesDispatchEnvelope(terminal)
+            : (envelopeEligible && envelope == .attached
+                && Self.carriesDispatchEnvelope(terminal)
                 ? Self.dispatchEnvelope(
                     id: actuationID, from: (actor ?? .anonymous).dispatchLabel) + "\n" + text
                 : text)

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -2881,15 +2881,13 @@ extension RPCRouter {
             + "input path wired for it. Nothing was typed and its session is unchanged."
     }
 
-    /// The refusal `terminal.send` returns for a validated `.parts` payload
-    /// today. `validateSendShape` accepts parts (Task 2 of the composer send
-    /// path), but neither delivery arm — this one or the holder arm — yet
-    /// composes the per-part pastes; that lands with the case that actually
-    /// walks the list (Task 3). Refused by name, on both transports, so a
-    /// caller learns the payload was well-formed and the daemon simply cannot
-    /// act on it yet, rather than either crashing on an unhandled case or
-    /// silently dropping to a `default:` that would also swallow a real future
-    /// bug.
+    /// The refusal a validated `.parts` payload gets on the **holder**
+    /// transport today. The tmux arm delivers parts; the holder arm, which
+    /// writes to a pty rather than pasting into a pane, does not compose the
+    /// per-part writes yet. Refused by name so a caller learns the payload was
+    /// well-formed and this transport simply cannot act on it yet, rather than
+    /// either crashing on an unhandled case or silently dropping to a
+    /// `default:` that would also swallow a real future bug.
     static func partsNotYetDeliverableRefusal(terminalID: UUID) -> String {
         "terminal.send parts was refused: terminal \(terminalID) validated a well-formed "
             + "parts payload, but delivery for parts is not implemented yet — nothing was "
@@ -3313,15 +3311,57 @@ extension RPCRouter {
                     )
                 }
 
-            case .parts:
-                // Shape-valid, not yet deliverable on this transport — see
-                // `partsNotYetDeliverableRefusal`. Refuse the same way every
-                // other well-formed-but-declined act in this function does:
-                // close the row that already exists rather than fall through
-                // to `.dispatched`.
-                let message = Self.partsNotYetDeliverableRefusal(terminalID: terminal.id)
-                await finishActuation(actuationID, .refused(.notEligible), error: message)
-                return RPCResponse(error: message)
+            case .parts(let parts, let submit):
+                // Each part is its own explicit bracketed paste, in order, and
+                // then ONE Enter. The split is what makes an image attach: Claude
+                // Code turns a paste into an image only when the whole paste is
+                // one quoted path, so an image concatenated with the words around
+                // it silently becomes literal text.
+                //
+                // The envelope, when it applies, rides on the FIRST text part —
+                // one envelope for one message. Prepending it to every part would
+                // put a `<tbd-dispatch/>` line in the middle of a sentence.
+                var envelopePending = envelope == .attached
+                    && Self.carriesDispatchEnvelope(terminal)
+                for part in parts {
+                    let body: String
+                    switch part {
+                    case .text(let value):
+                        // Skipped entirely, not pasted as an empty buffer — the
+                        // same reading the single-text arm gives an empty payload.
+                        guard !value.isEmpty else { continue }
+                        if envelopePending {
+                            body = Self.dispatchEnvelope(
+                                id: actuationID, from: (actor ?? .anonymous).dispatchLabel
+                            ) + "\n" + value
+                            envelopePending = false
+                        } else {
+                            body = value
+                        }
+                    case .imagePath(let path):
+                        // NEVER prefixed, whatever the envelope disposition: an
+                        // envelope line in front of the path is exactly the
+                        // "inside a sentence" case that measured as literal text.
+                        body = Self.quotedImagePath(path)
+                    }
+                    try await tmux.pasteText(
+                        server: worktree.tmuxServer,
+                        paneID: terminal.tmuxPaneID,
+                        bytes: Data(body.utf8)
+                    )
+                }
+
+                if submit {
+                    try await tmux.sendKey(
+                        server: worktree.tmuxServer,
+                        paneID: terminal.tmuxPaneID,
+                        key: "Enter"
+                    )
+                }
+
+                // `deliveredPayload` stays nil: it feeds the delivery verifier,
+                // which a parts payload cannot arm (`validateSendShape` refuses
+                // `--verify` with parts), so there is nothing to hand it.
             }
         } catch {
             await finishActuation(actuationID, .transportFailed, error: "\(error)")
@@ -3423,10 +3463,10 @@ extension RPCRouter {
             return await refuseHolderSend(
                 actuationID, Self.holderKeysRefusal(terminalID: terminal.id))
         case .parts:
-            // Same "shape-valid, not yet deliverable" refusal as the tmux arm
-            // — see `partsNotYetDeliverableRefusal`. Not a holder-specific
-            // capability gap like the two refusals above: no transport
-            // composes the per-part pastes yet.
+            // Shape-valid, not yet deliverable on THIS transport — see
+            // `partsNotYetDeliverableRefusal`. The tmux arm walks the list and
+            // pastes each part; this arm writes to a pty and has no equivalent
+            // yet, so the gap is holder-specific like the two refusals above.
             return await refuseHolderSend(
                 actuationID, Self.partsNotYetDeliverableRefusal(terminalID: terminal.id))
         }
@@ -3697,6 +3737,18 @@ extension RPCRouter {
         case .claude, .codex: return true
         case .shell: return false
         }
+    }
+
+    /// The bytes one image part is pasted as: the bare quoted absolute path and
+    /// nothing else.
+    ///
+    /// Single quotes, with an embedded quote escaped the POSIX way. Measured on
+    /// Claude Code 2.1.261: a paste whose ENTIRE content is one quoted path with
+    /// an image extension becomes a base64 image block in the user message, while
+    /// the same path inside a sentence stays literal text. So the quoting is not
+    /// decoration and the part must not be concatenated with its neighbours.
+    static func quotedImagePath(_ path: String) -> String {
+        "'" + path.replacingOccurrences(of: "'", with: #"'\''"#) + "'"
     }
 
     /// Whether an adapter exists that can actually observe a delivery to this

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -3169,6 +3169,34 @@ extension RPCRouter {
             }
         }
 
+        // ─── The opt-in awaiting-input gate ───
+        //
+        // Inside the per-terminal serializer, which this whole handler runs in,
+        // so the state this reads cannot change between the check and the paste
+        // it authorizes.
+        //
+        // Opt-in, never daemon-wide: agents use this verb to answer permission
+        // dialogs deliberately, and a blanket gate would refuse exactly those
+        // sends. The composer always opts in; existing CLI callers do not.
+        if params.gateOnAwaitingInput == true {
+            // The supersession check `terminal.list` already applies, through the
+            // same type and the same two injected seams — never a second
+            // implementation of "did the session move on".
+            let superseded = await AwaitingInputSupersession(
+                db: db,
+                fingerprint: transcriptFingerprinter,
+                delta: transcriptDeltaInspector
+            ).reconcile(terminal: terminal)
+
+            if case .refuse(let message) = AwaitingInputSendGate.decide(
+                reason: superseded ? nil : terminal.awaitingInputReason,
+                superseded: superseded
+            ) {
+                await finishActuation(actuationID, .refused(.notEligible), error: message)
+                return RPCResponse(error: message)
+            }
+        }
+
         // ─── The second refusal line: a well-formed act the daemon declines ───
         //
         // `--verify` while `delivery_verification_enabled` is off is a refusal,

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -3077,8 +3077,13 @@ extension RPCRouter {
 
         // ─── Is Claude actually running here? ───
         //
-        // Text only. `--keys` exists to answer a dialog and to interrupt, and a
-        // key sequence into a shell is not the failure this rail exists to stop.
+        // Text and parts, never keys. `--keys` exists to answer a dialog and to
+        // interrupt, and a key sequence into a shell is not the failure this
+        // rail exists to stop. A parts payload is subject to both rails exactly
+        // as a non-empty text payload is: it is pasted into the pane the same
+        // way, and a validated parts payload always has content — Task 2's
+        // shape validation refuses an empty one — so there is no emptiness
+        // guard to mirror for it the way there is for text.
         //
         // Two independent facts, because each fails on its own. The park stamp is
         // written by the `SessionEnd` hook and is missed whenever the process
@@ -3099,7 +3104,20 @@ extension RPCRouter {
         //     answers a prompt the agent is already showing, and the inspector
         //     is the fallible fact of the two — a pane it cannot read must not
         //     cost a live row its Enter.
-        if case .text(let body, _, _) = payload {
+        let subjectToParkRail: Bool
+        let subjectToForegroundRail: Bool
+        switch payload {
+        case .text(let body, _, _):
+            subjectToParkRail = true
+            subjectToForegroundRail = !body.isEmpty
+        case .keys:
+            subjectToParkRail = false
+            subjectToForegroundRail = false
+        case .parts:
+            subjectToParkRail = true
+            subjectToForegroundRail = true
+        }
+        if subjectToParkRail {
             if terminal.hibernatedAt != nil {
                 let message = Self.parkedSendRefusal(
                     terminalID: terminal.id, exited: terminal.isExitStamped)
@@ -3134,7 +3152,7 @@ extension RPCRouter {
             // cannot answer is not evidence that Claude left, and the pane
             // consultation below is the rail that judges a missing or dead pane,
             // properly.
-            if !body.isEmpty,
+            if subjectToForegroundRail,
                let agentName = Self.foregroundAgentName(
                     kind: terminal.kind, claudeSessionID: terminal.claudeSessionID),
                let panePIDString = try? await tmux.panePID(

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -3081,13 +3081,12 @@ extension RPCRouter {
         // `beginActuation` for the reason the first refusal line above gives:
         // a well-formed act the daemon declined gets a row and a refusal
         // outcome, unlike a malformed payload that names no act.
-
-        // ─── What the holder arm cannot carry yet ───
-        //
-        // Placed ahead of the holder branch so `performHolderSend` sees only
-        // payloads it can deliver, and so nothing inside that arm changes: PR
-        // #816 owns it.
         if terminal.transport == .holder {
+            // ─── What the holder arm cannot carry yet ───
+            //
+            // Computed ahead of the call to `performHolderSend` below so that
+            // function sees only payloads it can deliver, and so nothing
+            // inside that arm changes: PR #816 owns it.
             let compositeCause: String?
             switch payload {
             case .parts(let parts, _) where parts.count > 1:
@@ -3100,7 +3099,7 @@ extension RPCRouter {
                 compositeCause = "a message containing a newline"
             case .text(let body, _, _) where body.contains("\n"):
                 compositeCause = "a message containing a newline"
-            default:
+            case .parts, .text, .keys:
                 compositeCause = nil
             }
             if let compositeCause {
@@ -3109,9 +3108,6 @@ extension RPCRouter {
                 await finishActuation(actuationID, .refused(.notEligible), error: message)
                 return RPCResponse(error: message)
             }
-        }
-
-        if terminal.transport == .holder {
             return await performHolderSend(
                 payload: payload, terminal: terminal, actuationID: actuationID,
                 actor: actor, envelope: envelope)
@@ -3491,12 +3487,18 @@ extension RPCRouter {
     /// actuation row, the same dispatch envelope, the same per-terminal
     /// serializer lane (this runs inside it). What changes is the destination —
     /// `HolderInjectionCourier` routes by whether a viewer owns the pty — and
-    /// two things this transport cannot do yet, each refused by name rather
+    /// three things this transport cannot do yet, each refused by name rather
     /// than by "the holder transport", so a caller learns which capability is
     /// missing:
     ///
     /// - `--verify` has no delivery observation here.
     /// - `--keys` has no named-key → bytes mapping here (tmux owns that table).
+    /// - A composite send — more than one part, or a payload containing a
+    ///   newline — has no framing here at all; it is refused ahead of this
+    ///   function, by the composite gate in `performTerminalSend` (see "What
+    ///   the holder arm cannot carry yet" there). The `.parts` case below
+    ///   still turns away a multi-part payload defensively, but that gate
+    ///   means it should never see one.
     ///
     /// A daemon with no courier has no input path at all, and says so.
     ///
@@ -3600,9 +3602,10 @@ extension RPCRouter {
     }
 
     /// Deliver one body of text to a holder-backed session: the same envelope
-    /// handling, submit handling and courier call the `.text` arm of
-    /// `performHolderSend` uses, factored out so the single-part `.parts` arm
-    /// can reuse it verbatim rather than duplicating it.
+    /// handling, submit handling and courier call that `performHolderSend`
+    /// needs. Its `.text` arm and its single-part `.parts` arm converge on one
+    /// shared call to this function below their switch, rather than each
+    /// calling it separately — so there is exactly one call site, not two.
     ///
     /// `envelopeEligible` is a second, independent gate on the envelope,
     /// ahead of `envelope`'s disposition and `carriesDispatchEnvelope`: a lone
@@ -3611,7 +3614,7 @@ extension RPCRouter {
     private func deliverHolderText(
         _ text: String, submit: Bool, terminal: Terminal, actuationID: String,
         actor: ActuationActor?, envelope: DispatchEnvelopeDisposition,
-        envelopeEligible: Bool = true, courier: HolderInjectionCourier
+        envelopeEligible: Bool, courier: HolderInjectionCourier
     ) async -> RPCResponse {
         // Asked BEFORE anything is composed, because the answer decides the
         // bytes. Two sources, in order: the test seam if one is installed, then
@@ -4041,6 +4044,12 @@ extension RPCRouter {
                         "terminal.send image parts must name an absolute path; got \"\(path)\" "
                         + "— a relative path would resolve against whatever directory the "
                         + "receiving session happens to be in")
+                }
+                guard !path.contains("\n") else {
+                    return .malformed(
+                        "terminal.send image parts must not contain a newline; got \"\(path)\" "
+                        + "— an image attaches only when the whole paste is one quoted path, "
+                        + "and a newline inside it would split that one line into more than one")
                 }
             }
             if verify {

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -2881,6 +2881,21 @@ extension RPCRouter {
             + "input path wired for it. Nothing was typed and its session is unchanged."
     }
 
+    /// The refusal `terminal.send` returns for a validated `.parts` payload
+    /// today. `validateSendShape` accepts parts (Task 2 of the composer send
+    /// path), but neither delivery arm — this one or the holder arm — yet
+    /// composes the per-part pastes; that lands with the case that actually
+    /// walks the list (Task 3). Refused by name, on both transports, so a
+    /// caller learns the payload was well-formed and the daemon simply cannot
+    /// act on it yet, rather than either crashing on an unhandled case or
+    /// silently dropping to a `default:` that would also swallow a real future
+    /// bug.
+    static func partsNotYetDeliverableRefusal(terminalID: UUID) -> String {
+        "terminal.send parts was refused: terminal \(terminalID) validated a well-formed "
+            + "parts payload, but delivery for parts is not implemented yet — nothing was "
+            + "sent. Send the pieces as separate --text sends for now."
+    }
+
     /// The refusal a text `terminal.send` gets for a terminal whose Claude
     /// process is gone.
     ///
@@ -3297,6 +3312,16 @@ extension RPCRouter {
                         key: key
                     )
                 }
+
+            case .parts:
+                // Shape-valid, not yet deliverable on this transport — see
+                // `partsNotYetDeliverableRefusal`. Refuse the same way every
+                // other well-formed-but-declined act in this function does:
+                // close the row that already exists rather than fall through
+                // to `.dispatched`.
+                let message = Self.partsNotYetDeliverableRefusal(terminalID: terminal.id)
+                await finishActuation(actuationID, .refused(.notEligible), error: message)
+                return RPCResponse(error: message)
             }
         } catch {
             await finishActuation(actuationID, .transportFailed, error: "\(error)")
@@ -3397,6 +3422,13 @@ extension RPCRouter {
         case .keys:
             return await refuseHolderSend(
                 actuationID, Self.holderKeysRefusal(terminalID: terminal.id))
+        case .parts:
+            // Same "shape-valid, not yet deliverable" refusal as the tmux arm
+            // — see `partsNotYetDeliverableRefusal`. Not a holder-specific
+            // capability gap like the two refusals above: no transport
+            // composes the per-part pastes yet.
+            return await refuseHolderSend(
+                actuationID, Self.partsNotYetDeliverableRefusal(terminalID: terminal.id))
         }
 
         // Asked BEFORE anything is composed, because the answer decides the
@@ -3697,6 +3729,49 @@ extension RPCRouter {
     ) -> TerminalSendShape {
         let submit = params.submit == true
         let verify = params.verify == true
+
+        if let parts = params.parts {
+            // Exactly one payload kind, the rule the existing `(text, keys)`
+            // switch already enforces — extended rather than duplicated.
+            guard params.text == nil, params.keys == nil else {
+                return .malformed(
+                    "terminal.send takes exactly one payload: --text, --keys or parts, "
+                    + "not more than one")
+            }
+            guard !parts.isEmpty else {
+                return .malformed("terminal.send parts must name at least one part")
+            }
+            // A payload that is nothing but empty text names no act: every part
+            // is skipped at delivery, so this would press Enter on a composer
+            // nobody typed into.
+            let carriesSomething = parts.contains { part in
+                switch part {
+                case .text(let value): return !value.trimmingCharacters(
+                    in: .whitespacesAndNewlines).isEmpty
+                case .imagePath: return true
+                }
+            }
+            guard carriesSomething else {
+                return .malformed(
+                    "terminal.send parts must carry at least one non-empty text part or one "
+                    + "image path")
+            }
+            for case .imagePath(let path) in parts {
+                guard path.hasPrefix("/") else {
+                    return .malformed(
+                        "terminal.send image parts must name an absolute path; got \"\(path)\" "
+                        + "— a relative path would resolve against whatever directory the "
+                        + "receiving session happens to be in")
+                }
+            }
+            if verify {
+                return .malformed(
+                    "terminal.send --verify cannot be used with parts: the delivery observation "
+                    + "re-reads the pane for one delivered payload, and a multi-part send has no "
+                    + "single payload to look for")
+            }
+            return .valid(.parts(parts, submit: submit))
+        }
 
         switch (params.text, params.keys) {
         case (.some, .some):

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -2958,7 +2958,8 @@ extension RPCRouter {
     }
 
     func handleTerminalSend(
-        _ paramsData: Data, actor: ActuationActor? = nil
+        _ paramsData: Data, actor: ActuationActor? = nil,
+        connection: RPCConnectionContext? = nil
     ) async throws -> RPCResponse {
         let params = try decoder.decode(TerminalSendParams.self, from: paramsData)
         // Queue behind any send already mid-flight to this same terminal; sends
@@ -2966,7 +2967,7 @@ extension RPCRouter {
         // lane so the target check and the typing it authorizes cannot be
         // separated by another caller's paste.
         return try await terminalSendSerializer.run(terminalID: params.terminalID) {
-            try await self.performTerminalSend(params, actor: actor)
+            try await self.performTerminalSend(params, actor: actor, connection: connection)
         }
     }
 
@@ -3005,7 +3006,8 @@ extension RPCRouter {
 
     private func performTerminalSend(
         _ params: TerminalSendParams, actor: ActuationActor?,
-        envelope: DispatchEnvelopeDisposition = .attached
+        envelope: DispatchEnvelopeDisposition = .attached,
+        connection: RPCConnectionContext? = nil
     ) async throws -> RPCResponse {
         // ─── The first of two refusal lines, and the reason they differ ───
         //
@@ -3251,6 +3253,14 @@ extension RPCRouter {
         // below so a retry can re-deliver byte-identically.
         var deliveredPayload: String?
 
+        // Resolved ONCE, ahead of the delivery block, so both arms below read
+        // the same answer. A rail's own `.suppressed` passes through; a
+        // request's is granted only on a connection the daemon authenticated.
+        let effectiveEnvelope = await effectiveEnvelope(
+            railDisposition: envelope,
+            requested: params.envelope,
+            connection: connection)
+
         do {
             switch payload {
             case .text(let text, let submit, _):
@@ -3295,7 +3305,8 @@ extension RPCRouter {
                     // words must deliver them byte-identically. It is not
                     // reachable from `TerminalSendParams` — see
                     // `DispatchEnvelopeDisposition`.
-                    let composed = envelope == .attached && Self.carriesDispatchEnvelope(terminal)
+                    let composed = effectiveEnvelope == .attached
+                        && Self.carriesDispatchEnvelope(terminal)
                         ? Self.dispatchEnvelope(
                             id: actuationID, from: (actor ?? .anonymous).dispatchLabel
                         ) + "\n" + text
@@ -3339,7 +3350,7 @@ extension RPCRouter {
                 // The envelope, when it applies, rides on the FIRST text part —
                 // one envelope for one message. Prepending it to every part would
                 // put a `<tbd-dispatch/>` line in the middle of a sentence.
-                var envelopePending = envelope == .attached
+                var envelopePending = effectiveEnvelope == .attached
                     && Self.carriesDispatchEnvelope(terminal)
                 for part in parts {
                     let body: String
@@ -3754,6 +3765,90 @@ extension RPCRouter {
         switch terminal.kind ?? .shell {
         case .claude, .codex: return true
         case .shell: return false
+        }
+    }
+
+    /// The answer `authenticatesEnvelopeSuppression` gives, and there are only
+    /// two of them: an unauthenticated connection is never a shade of yes.
+    enum EnvelopeSuppressionVerdict: Equatable, Sendable {
+        case authenticated
+        /// Named, because a suppression that did not happen has to be
+        /// explainable from a log line without re-deriving the whole check.
+        case refused(reason: String)
+    }
+
+    /// Whether a request that asked for envelope suppression is entitled to it.
+    ///
+    /// **The connection is authenticated, not the request.** Suppression is
+    /// authority, not preference, so it rests on nothing the request says about
+    /// itself: `ActuationActor` is an ambient declaration any local process can
+    /// stamp, and the CLI, the app and every agent share one socket.
+    ///
+    /// Two halves. The kernel names the peer of an `AF_UNIX` socket, so the pid
+    /// cannot be claimed by somebody else — that gets us to "this connection is
+    /// provisionally the app's" for the cost of one `getsockopt` already paid at
+    /// accept. A pid is a number the kernel reissues, so the request that
+    /// actually asks pays for the rest: the sidecar's recorded identity is
+    /// re-verified through `ProcessIdentityCheck`, the one identity check in
+    /// this daemon, with a zero tolerance because the recorded start time IS the
+    /// fact rather than a proxy for it. Only `.same` authenticates. Two process
+    /// reads, on a composer send and nowhere else.
+    ///
+    /// **Fails closed in every direction**, and the reason names itself so a
+    /// suppression that did not happen can be explained afterwards.
+    ///
+    /// The daemon's own `.suppressed` disposition — the queued-prompt rail's,
+    /// set inside the send core and never arriving from a params struct — does
+    /// not pass through here at all.
+    func authenticatesEnvelopeSuppression(
+        connection: RPCConnectionContext?
+    ) async -> EnvelopeSuppressionVerdict {
+        guard let peerPID = connection?.peerPID else {
+            return .refused(reason: "peer-pid-unestablished")
+        }
+        guard let recorded = await recordedAppIdentity() else {
+            return .refused(reason: "no-recorded-sidecar-client")
+        }
+        guard recorded.pid == peerPID else {
+            return .refused(reason: "peer-pid-is-not-the-apps")
+        }
+        switch ProcessIdentityCheck.verify(
+            pid: recorded.pid,
+            startedWithin: 0,
+            of: recorded.startedAt,
+            executableIsAcceptable: { $0 == recorded.commandLine },
+            signaller: processSignaller
+        ) {
+        case .same: return .authenticated
+        case .notRunning: return .refused(reason: "recorded-app-not-running")
+        case .startTimeUnreadable: return .refused(reason: "start-time-unreadable")
+        case .startTimeMismatch: return .refused(reason: "pid-reused-start-time")
+        case .commandUnreadable: return .refused(reason: "command-unreadable")
+        case .foreignExecutable: return .refused(reason: "pid-reused-executable")
+        }
+    }
+
+    /// The disposition the daemon will actually apply to one send.
+    ///
+    /// A rail's internal `.suppressed` passes straight through — it was decided
+    /// inside the send core, not asked for on the wire. A request's asked-for
+    /// suppression is granted only on an authenticated connection.
+    private func effectiveEnvelope(
+        railDisposition: DispatchEnvelopeDisposition,
+        requested: EnvelopeDisposition?,
+        connection: RPCConnectionContext?
+    ) async -> DispatchEnvelopeDisposition {
+        if railDisposition == .suppressed { return .suppressed }
+        guard requested == .suppressed else { return .attached }
+        switch await authenticatesEnvelopeSuppression(connection: connection) {
+        case .authenticated:
+            return .suppressed
+        case .refused(let reason):
+            logger.debug("""
+                send: envelope suppression refused (\(reason, privacy: .public)) — \
+                attaching the dispatch line
+                """)
+            return .attached
         }
     }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -2881,17 +2881,43 @@ extension RPCRouter {
             + "input path wired for it. Nothing was typed and its session is unchanged."
     }
 
-    /// The refusal a validated `.parts` payload gets on the **holder**
-    /// transport today. The tmux arm delivers parts; the holder arm, which
-    /// writes to a pty rather than pasting into a pane, does not compose the
-    /// per-part writes yet. Refused by name so a caller learns the payload was
-    /// well-formed and this transport simply cannot act on it yet, rather than
-    /// either crashing on an unhandled case or silently dropping to a
-    /// `default:` that would also swallow a real future bug.
+    /// The refusal a multi-part or multi-line `terminal.send` gets for a
+    /// holder-backed row, until bracketed-paste wrapping lands there.
+    ///
+    /// It names the missing capability rather than "the holder transport",
+    /// because typing a single-line message into a holder session works and a
+    /// caller told otherwise would stop trying.
+    ///
+    /// The measurement: the holder arm writes body and carriage return in ONE
+    /// delivery with no bracketed-paste wrapping. Against 2.1.261 under a real
+    /// pty, a single unwrapped write of 63 bytes submits and 64 or more does not
+    /// — past that the carriage return is swallowed into the text and the whole
+    /// string sits unsent in Claude's composer. Splitting the message into
+    /// several deliveries instead would reopen the at-least-once and routing
+    /// questions that one delivery avoids, so this refuses rather than guessing.
+    /// PR #816 (child-as-contract-party) wraps in bracketed paste when the
+    /// child's mode is on, in one write, and this refusal lifts with it.
+    static func holderCompositeRefusal(terminalID: UUID, cause: String) -> String {
+        "terminal.send was refused: terminal \(terminalID) runs on the pty-holder transport, "
+            + "which delivers a message in one unwrapped write — and \(cause) cannot submit that "
+            + "way (past 64 bytes the carriage return is swallowed and the text sits unsent). "
+            + "Nothing was typed. Send a single-line message, or move the session to tmux."
+    }
+
+    /// The refusal a validated `.parts` payload still gets inside
+    /// `performHolderSend` after `holderCompositeRefusal` has already run
+    /// ahead of the holder branch in `performTerminalSend`. That gate only
+    /// catches a `.parts` payload that is multi-part or carries a newline —
+    /// the shapes this codebase's 64-byte measurement covers. A single-part,
+    /// single-line `.parts` payload (one image path, or one line of text named
+    /// through the parts wire shape instead of `--text`) is NOT composite and
+    /// passes that gate untouched, yet the holder arm still has no per-part
+    /// delivery of its own — Task 3 built that composition for the tmux arm
+    /// only. This is the defensive backstop for that remainder: kept so the
+    /// `switch` in `performHolderSend` stays exhaustive with no `default:`
+    /// that could also swallow a real future bug.
     static func partsNotYetDeliverableRefusal(terminalID: UUID) -> String {
-        "terminal.send parts was refused: terminal \(terminalID) validated a well-formed "
-            + "parts payload, but delivery for parts is not implemented yet — nothing was "
-            + "sent. Send the pieces as separate --text sends for now."
+        Self.holderCompositeRefusal(terminalID: terminalID, cause: "a message delivered as parts")
     }
 
     /// The refusal a text `terminal.send` gets for a terminal whose Claude
@@ -3071,6 +3097,36 @@ extension RPCRouter {
         // `beginActuation` for the reason the first refusal line above gives:
         // a well-formed act the daemon declined gets a row and a refusal
         // outcome, unlike a malformed payload that names no act.
+
+        // ─── What the holder arm cannot carry yet ───
+        //
+        // Placed ahead of the holder branch so `performHolderSend` sees only
+        // payloads it can deliver, and so nothing inside that arm changes: PR
+        // #816 owns it.
+        if terminal.transport == .holder {
+            let compositeCause: String?
+            switch payload {
+            case .parts(let parts, _) where parts.count > 1:
+                compositeCause = "a message in more than one part"
+            case .parts(let parts, _)
+                where parts.contains(where: { part in
+                    if case .text(let value) = part { return value.contains("\n") }
+                    return false
+                }):
+                compositeCause = "a message containing a newline"
+            case .text(let body, _, _) where body.contains("\n"):
+                compositeCause = "a message containing a newline"
+            default:
+                compositeCause = nil
+            }
+            if let compositeCause {
+                let message = Self.holderCompositeRefusal(
+                    terminalID: terminal.id, cause: compositeCause)
+                await finishActuation(actuationID, .refused(.notEligible), error: message)
+                return RPCResponse(error: message)
+            }
+        }
+
         if terminal.transport == .holder {
             return await performHolderSend(
                 payload: payload, terminal: terminal, actuationID: actuationID,
@@ -3520,10 +3576,12 @@ extension RPCRouter {
             return await refuseHolderSend(
                 actuationID, Self.holderKeysRefusal(terminalID: terminal.id))
         case .parts:
-            // Shape-valid, not yet deliverable on THIS transport — see
-            // `partsNotYetDeliverableRefusal`. The tmux arm walks the list and
-            // pastes each part; this arm writes to a pty and has no equivalent
-            // yet, so the gap is holder-specific like the two refusals above.
+            // Shape-valid and NOT composite — `performTerminalSend`'s
+            // `holderCompositeRefusal` gate already turned away a multi-part or
+            // multi-line send before this arm was reached. What lands here is
+            // the remainder: a single-part, single-line `.parts` payload the
+            // holder arm still has no per-part delivery for — see
+            // `partsNotYetDeliverableRefusal`.
             return await refuseHolderSend(
                 actuationID, Self.partsNotYetDeliverableRefusal(terminalID: terminal.id))
         }

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -3472,12 +3472,35 @@ extension RPCRouter {
                     envelopePending = false
                 }
 
+                // ─── The settle after an image paste ───
+                //
+                // Claude Code attaches an image and writes its `[Image#N]`
+                // token asynchronously, at the caret's position AT ATTACH TIME.
+                // So the wait belongs to the image paste rather than to any one
+                // successor: it is taken once per image part, before whatever
+                // comes next — the next paste, or the Enter if the image was
+                // last. That is why an image followed by text waits ONCE and
+                // not twice: by the time the trailing text has been pasted the
+                // token has already landed, and Enter after a plain text paste
+                // is the same thing the single-text arm has always done.
+                //
+                // `Self.imageAttachSettle` carries the measurement. Nothing
+                // here fires for a payload with no image part.
+                var settlePending = false
+                func settleIfNeeded() async throws {
+                    guard settlePending else { return }
+                    settlePending = false
+                    try await clock.sleep(for: Self.imageAttachSettle)
+                }
+
                 for part in parts {
                     let body: String
                     switch part {
                     case .text(let value):
                         // Skipped entirely, not pasted as an empty buffer — the
                         // same reading the single-text arm gives an empty payload.
+                        // Skipped BEFORE the settle too: a part that pastes
+                        // nothing moves no caret, so it needs nothing waited for.
                         guard !value.isEmpty else { continue }
                         if envelopePending {
                             body = Self.dispatchEnvelope(
@@ -3493,14 +3516,19 @@ extension RPCRouter {
                         // "inside a sentence" case that measured as literal text.
                         body = Self.quotedImagePath(path)
                     }
+                    try await settleIfNeeded()
                     try await tmux.pasteText(
                         server: worktree.tmuxServer,
                         paneID: terminal.tmuxPaneID,
                         bytes: Data(body.utf8)
                     )
+                    if case .imagePath = part { settlePending = true }
                 }
 
                 if submit {
+                    // An Enter that arrives mid-attach is swallowed, so the
+                    // same settle covers it when the image was the last part.
+                    try await settleIfNeeded()
                     try await tmux.sendKey(
                         server: worktree.tmuxServer,
                         paneID: terminal.tmuxPaneID,
@@ -4065,6 +4093,31 @@ extension RPCRouter {
     static func quotedImagePath(_ path: String) -> String {
         "'" + path.replacingOccurrences(of: "'", with: #"'\''"#) + "'"
     }
+
+    /// How long the parts arm waits after pasting an image path, before it
+    /// pastes anything else or presses Enter.
+    ///
+    /// **Why a wait exists at all.** Claude Code turns the paste into an
+    /// attachment *asynchronously* and then writes its `[Image#N]` token in at
+    /// wherever the caret is when the attach lands. Pasting the next part
+    /// before that happens moves the caret, so the token arrives at the END of
+    /// the message — the person's sentence reads
+    /// `look at  and tell me what it is[Image#1]` — and an Enter that arrives
+    /// mid-attach is swallowed, leaving the message standing unsent. Both were
+    /// observed live against Claude Code 2.1.261, on the first image a given
+    /// Claude process had ever been given.
+    ///
+    /// **Where the number comes from.** Measured against the real 2.1.261 TUI
+    /// driven under a pty against the fake model API, pasting one bare quoted
+    /// image path into a fresh session and timing until `[Image#1]` rendered:
+    /// 15 fresh sessions, min 0.18 s, max 0.68 s, median ≈0.24 s (the live
+    /// verification's own hand observation on a loaded fleet machine was ≈1 s).
+    /// 2 s is a clean number above twice both maxima.
+    ///
+    /// It is one constant in one place so a soak can move it, and it is spent
+    /// only by a payload that actually carries an image — a text-only parts
+    /// send waits for nothing.
+    static let imageAttachSettle: Duration = .seconds(2)
 
     /// Whether an adapter exists that can actually observe a delivery to this
     /// target — the narrower question `--verify` turns on.

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -2904,22 +2904,6 @@ extension RPCRouter {
             + "Nothing was typed. Send a single-line message, or move the session to tmux."
     }
 
-    /// The refusal a validated `.parts` payload still gets inside
-    /// `performHolderSend` after `holderCompositeRefusal` has already run
-    /// ahead of the holder branch in `performTerminalSend`. That gate only
-    /// catches a `.parts` payload that is multi-part or carries a newline —
-    /// the shapes this codebase's 64-byte measurement covers. A single-part,
-    /// single-line `.parts` payload (one image path, or one line of text named
-    /// through the parts wire shape instead of `--text`) is NOT composite and
-    /// passes that gate untouched, yet the holder arm still has no per-part
-    /// delivery of its own — Task 3 built that composition for the tmux arm
-    /// only. This is the defensive backstop for that remainder: kept so the
-    /// `switch` in `performHolderSend` stays exhaustive with no `default:`
-    /// that could also swallow a real future bug.
-    static func partsNotYetDeliverableRefusal(terminalID: UUID) -> String {
-        Self.holderCompositeRefusal(terminalID: terminalID, cause: "a message delivered as parts")
-    }
-
     /// The refusal a text `terminal.send` gets for a terminal whose Claude
     /// process is gone.
     ///
@@ -3575,17 +3559,44 @@ extension RPCRouter {
         case .keys:
             return await refuseHolderSend(
                 actuationID, Self.holderKeysRefusal(terminalID: terminal.id))
-        case .parts:
+        case .parts(let parts, let submitting) where parts.count == 1:
             // Shape-valid and NOT composite — `performTerminalSend`'s
             // `holderCompositeRefusal` gate already turned away a multi-part or
             // multi-line send before this arm was reached. What lands here is
-            // the remainder: a single-part, single-line `.parts` payload the
-            // holder arm still has no per-part delivery for — see
-            // `partsNotYetDeliverableRefusal`.
+            // exactly one part, and the holder arm carries it the same way the
+            // `.text` arm above carries its body: a text part's value verbatim,
+            // an image part as the same quoted path the tmux arm pastes.
+            switch parts[0] {
+            case .text(let value):
+                text = value
+            case .imagePath(let path):
+                text = Self.quotedImagePath(path)
+            }
+            submit = submitting
+        case .parts:
+            // Defensive backstop: the composite gate ahead of this arm already
+            // refuses any `.parts` payload with more than one part, so this
+            // should be unreachable. Kept so the switch stays exhaustive with
+            // no `default:` that could also swallow a real future bug.
             return await refuseHolderSend(
-                actuationID, Self.partsNotYetDeliverableRefusal(terminalID: terminal.id))
+                actuationID, Self.holderCompositeRefusal(
+                    terminalID: terminal.id, cause: "a message in more than one part"))
         }
 
+        return await deliverHolderText(
+            text, submit: submit, terminal: terminal, actuationID: actuationID,
+            actor: actor, envelope: envelope, courier: courier)
+    }
+
+    /// Deliver one body of text to a holder-backed session: the same envelope
+    /// handling, submit handling and courier call the `.text` arm of
+    /// `performHolderSend` uses, factored out so the single-part `.parts` arm
+    /// can reuse it verbatim rather than duplicating it.
+    private func deliverHolderText(
+        _ text: String, submit: Bool, terminal: Terminal, actuationID: String,
+        actor: ActuationActor?, envelope: DispatchEnvelopeDisposition,
+        courier: HolderInjectionCourier
+    ) async -> RPCResponse {
         // Asked BEFORE anything is composed, because the answer decides the
         // bytes. Two sources, in order: the test seam if one is installed, then
         // the registry's own reader for this session.

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -291,6 +291,24 @@ public final class RPCRouter: Sendable {
     /// needing a real `ps`. A process-table fact, never screen text.
     let paneProcessInspector: any PaneProcessInspecting
 
+    /// The identity the FD-vending sidecar recorded for its current client.
+    ///
+    /// That client is the app: it connects the sidecar eagerly and
+    /// unconditionally as soon as the RPC socket answers, and the sidecar has
+    /// exactly one. The daemon already treats this identity as load-bearing —
+    /// `AppLivenessArbiter` decides on it whether the daemon may read a pty
+    /// again — so nothing new is being trusted here, only read from one more
+    /// place.
+    ///
+    /// Injected, and defaulting to "no recorded client", so a router built in a
+    /// test authenticates nobody until a test says otherwise. That default is
+    /// the fail-closed one.
+    let recordedAppIdentity: @Sendable () async -> ProcessIdentity?
+    /// The one process-fact reader, injected for the same reason `AgentReaper`
+    /// and `AppLivenessArbiter` take one: the re-verification must be statable
+    /// in a test without a process to inspect.
+    let processSignaller: any ProcessSignaller
+
     public init(
         db: TBDDatabase,
         lifecycle: WorktreeLifecycle,
@@ -318,8 +336,12 @@ public final class RPCRouter: Sendable {
             = TranscriptDeltaInspection.live,
         paneProcessInspector: any PaneProcessInspecting = ProductionPaneProcessInspector(),
         completionInventory: CompletionInventoryService = CompletionInventoryService(),
+        recordedAppIdentity: @escaping @Sendable () async -> ProcessIdentity? = { nil },
+        processSignaller: any ProcessSignaller = ProductionProcessSignaller(),
         actuationLog: ActuationLog
     ) {
+        self.recordedAppIdentity = recordedAppIdentity
+        self.processSignaller = processSignaller
         self.now = now
         self.tmuxSocketPathResolver = tmuxSocketPathResolver
         self.transcriptFingerprinter = transcriptFingerprinter
@@ -415,17 +437,26 @@ public final class RPCRouter: Sendable {
 
     /// Handle a raw JSON Data blob representing an RPCRequest.
     /// Returns an RPCResponse.
-    public func handleRaw(_ data: Data) async -> RPCResponse {
+    ///
+    /// `connection` is what the daemon knows about the socket the bytes arrived
+    /// on, as opposed to what they say about themselves. Defaulted to nil —
+    /// "not established" — because most callers are not sockets at all, and
+    /// that is the fail-closed answer for every one of them.
+    public func handleRaw(
+        _ data: Data, connection: RPCConnectionContext? = nil
+    ) async -> RPCResponse {
         do {
             let request = try decoder.decode(RPCRequest.self, from: data)
-            return await handle(request)
+            return await handle(request, connection: connection)
         } catch {
             return RPCResponse(error: "Failed to decode request: \(error.localizedDescription)")
         }
     }
 
     /// Handle a decoded RPCRequest and return an RPCResponse.
-    public func handle(_ request: RPCRequest) async -> RPCResponse {
+    public func handle(
+        _ request: RPCRequest, connection: RPCConnectionContext? = nil
+    ) async -> RPCResponse {
         do {
             switch request.method {
             case RPCMethod.repoAdd:
@@ -489,7 +520,10 @@ public final class RPCRouter: Sendable {
             case RPCMethod.terminalAttachCommand:
                 return try await handleTerminalAttachCommand(request.paramsData)
             case RPCMethod.terminalSend:
-                return try await handleTerminalSend(request.paramsData, actor: request.actor)
+                // The ONE case that is handed the connection, because it is the
+                // one that makes an authorization decision on it.
+                return try await handleTerminalSend(
+                    request.paramsData, actor: request.actor, connection: connection)
             case RPCMethod.terminalCompletions:
                 return try await handleTerminalCompletions(request.paramsData)
             case RPCMethod.terminalDelete:

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -309,6 +309,15 @@ public final class RPCRouter: Sendable {
     /// in a test without a process to inspect.
     let processSignaller: any ProcessSignaller
 
+    /// Behavior seam for the one place the send path has to *wait*: the settle
+    /// after an image paste, before whatever the parts arm does next. A
+    /// `Duration` is behavior, so this is the `Clock` seam rather than the
+    /// `now` date seam beside it, and it is existential (`any Clock<Duration>`)
+    /// for the reason every other subsystem here holds one that way — a generic
+    /// parameter would infect the `Sendable` conformances the router already
+    /// carries.
+    let clock: any Clock<Duration>
+
     public init(
         db: TBDDatabase,
         lifecycle: WorktreeLifecycle,
@@ -338,10 +347,12 @@ public final class RPCRouter: Sendable {
         completionInventory: CompletionInventoryService = CompletionInventoryService(),
         recordedAppIdentity: @escaping @Sendable () async -> ProcessIdentity? = { nil },
         processSignaller: any ProcessSignaller = ProductionProcessSignaller(),
-        actuationLog: ActuationLog
+        actuationLog: ActuationLog,
+        clock: any Clock<Duration> = ContinuousClock()
     ) {
         self.recordedAppIdentity = recordedAppIdentity
         self.processSignaller = processSignaller
+        self.clock = clock
         self.now = now
         self.tmuxSocketPathResolver = tmuxSocketPathResolver
         self.transcriptFingerprinter = transcriptFingerprinter

--- a/Sources/TBDDaemon/Server/SocketServer.swift
+++ b/Sources/TBDDaemon/Server/SocketServer.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 import NIOCore
 import NIOPosix
@@ -433,6 +434,13 @@ private final class SocketRPCHandler: ChannelInboundHandler, @unchecked Sendable
     private let limiter: RPCConcurrencyLimiter
     private var buffer: String = ""
 
+    /// What the kernel says about this connection's peer, read once at accept.
+    ///
+    /// Mutated in `channelActive` and read in `channelRead`, both of which run
+    /// on the channel's event loop, so no lock is needed and none may be added
+    /// (`context.channel` access off the loop is a NIO precondition crash).
+    private var connection = RPCConnectionContext(peerPID: nil)
+
     init(router: RPCRouter, connectedClients: ManagedAtomic<Int>, limiter: RPCConcurrencyLimiter) {
         self.router = router
         self.connectedClients = connectedClients
@@ -441,6 +449,21 @@ private final class SocketRPCHandler: ChannelInboundHandler, @unchecked Sendable
 
     func channelActive(context: ChannelHandlerContext) {
         connectedClients.wrappingIncrementThenLoad()
+        // One `getsockopt`, through NIO's socket-option provider rather than a
+        // raw fd, because NIO owns the descriptor. `channelActive` runs ON the
+        // event loop, and the provider completes its promise inline in that
+        // case, so `whenComplete` fires before this method returns and therefore
+        // before any `channelRead` — the ordering the suppression check needs.
+        // If it ever did not, the failure direction is the safe one: an
+        // unestablished peer keeps the envelope.
+        guard let provider = context.channel as? SocketOptionProvider else { return }
+        provider.unsafeGetSocketOption(
+            level: NIOBSDSocket.OptionLevel(rawValue: SOL_LOCAL),
+            name: NIOBSDSocket.Option(rawValue: LOCAL_PEERPID)
+        ).whenComplete { [weak self] (result: Result<pid_t, any Error>) in
+            guard case .success(let pid) = result, pid > 0 else { return }
+            self?.connection = RPCConnectionContext(peerPID: pid)
+        }
     }
 
     func channelInactive(context: ChannelHandlerContext) {
@@ -464,8 +487,11 @@ private final class SocketRPCHandler: ChannelInboundHandler, @unchecked Sendable
             let wrappedCtx = SendableContext(context: context)
             let router = self.router
             let limiter = self.limiter
+            let connection = self.connection
             Task {
-                await Self.processLine(trimmed, router: router, limiter: limiter, wrappedCtx: wrappedCtx)
+                await Self.processLine(
+                    trimmed, router: router, limiter: limiter,
+                    wrappedCtx: wrappedCtx, connection: connection)
             }
         }
     }
@@ -474,7 +500,8 @@ private final class SocketRPCHandler: ChannelInboundHandler, @unchecked Sendable
         _ line: String,
         router: RPCRouter,
         limiter: RPCConcurrencyLimiter,
-        wrappedCtx: SendableContext
+        wrappedCtx: SendableContext,
+        connection: RPCConnectionContext
     ) async {
         guard let data = line.data(using: .utf8) else { return }
 
@@ -556,7 +583,7 @@ private final class SocketRPCHandler: ChannelInboundHandler, @unchecked Sendable
         let signposter = RPCSignposts.signposter
         let signpostID = signposter.makeSignpostID()
         let intervalState = signposter.beginInterval("rpc.handle", id: signpostID, "\(method, privacy: .public)")
-        let response = await router.handleRaw(data)
+        let response = await router.handleRaw(data, connection: connection)
         signposter.endInterval("rpc.handle", intervalState)
 
         await limiter.release()

--- a/Sources/TBDDaemon/Server/TerminalSendPayload.swift
+++ b/Sources/TBDDaemon/Server/TerminalSendPayload.swift
@@ -1,4 +1,5 @@
 import Foundation
+import TBDShared
 
 /// What one `terminal.send` request is asking for, once its shape has passed
 /// `RPCRouter.validateSendShape`.
@@ -26,6 +27,11 @@ enum TerminalSendPayload: Sendable, Equatable {
     /// `verbatim` is the caller's string as written, which is what the record
     /// stores — the tokens are an implementation detail of delivery.
     case keys(names: [String], verbatim: String)
+    /// An ordered list of pieces, each delivered as its own bracketed paste,
+    /// then one Enter. `verify` is deliberately absent rather than defaulted:
+    /// the delivery observation re-reads a pane for ONE delivered payload, and a
+    /// multi-part send has no single payload to look for.
+    case parts([SendPart], submit: Bool)
 
     /// The `message` field of the request row. The caller's payload as written,
     /// for both kinds.
@@ -33,6 +39,18 @@ enum TerminalSendPayload: Sendable, Equatable {
         switch self {
         case .text(let text, _, _): return text
         case .keys(_, let verbatim): return verbatim
+        // The row records what the caller asked to deliver, in order, with the
+        // image parts named by path — which is what a human reading the
+        // actuation log needs in order to tell what arrived where. It is not the
+        // bytes: those are three pastes and an Enter, and no single string is
+        // the message.
+        case .parts(let parts, _):
+            return parts.map { part in
+                switch part {
+                case .text(let value): return value
+                case .imagePath(let path): return "[image \(path)]"
+                }
+            }.joined()
         }
     }
 
@@ -43,6 +61,7 @@ enum TerminalSendPayload: Sendable, Equatable {
         switch self {
         case .text(_, let submit, _): return submit
         case .keys: return nil
+        case .parts(_, let submit): return submit
         }
     }
 
@@ -53,6 +72,7 @@ enum TerminalSendPayload: Sendable, Equatable {
         switch self {
         case .text(_, _, let verify): return verify ? true : nil
         case .keys: return nil
+        case .parts: return nil
         }
     }
 

--- a/Sources/TBDShared/Constants.swift
+++ b/Sources/TBDShared/Constants.swift
@@ -252,6 +252,59 @@ public enum TBDConstants {
         terminalHistoryPath(worktreeID: worktreeID, terminalID: terminalID, environment: ProcessInfo.processInfo.environment)
     }
 
+    /// Base directory for composer attachments: `~/tbd/attachments`. Honors
+    /// TBD_HOME.
+    ///
+    /// One subdirectory per worktree, holding the images a person pasted or
+    /// dropped into that worktree's transcript composer. File-backed rather than
+    /// a DB column for the same reason notes and terminal history are: the
+    /// content is a blob the app reads directly, and the row would carry only
+    /// bytes nobody queries.
+    public static func attachmentsDir(environment: [String: String]) -> URL {
+        configDir(environment: environment).appendingPathComponent("attachments")
+    }
+    public static var attachmentsDir: URL {
+        attachmentsDir(environment: ProcessInfo.processInfo.environment)
+    }
+
+    /// One worktree's attachment directory:
+    /// `~/tbd/attachments/<worktreeID>`. Honors TBD_HOME.
+    ///
+    /// Keyed by worktree rather than by terminal because a composer draft
+    /// survives a session rollover, and because reclaiming is a worktree-shaped
+    /// question — the archive path knows which worktree went away, and the GC
+    /// leg compares directory names against live worktree rows.
+    public static func attachmentsDir(
+        worktreeID: UUID, environment: [String: String]
+    ) -> URL {
+        attachmentsDir(environment: environment)
+            .appendingPathComponent(worktreeID.uuidString)
+    }
+    public static func attachmentsDir(worktreeID: UUID) -> URL {
+        attachmentsDir(worktreeID: worktreeID, environment: ProcessInfo.processInfo.environment)
+    }
+
+    /// Path to one staged attachment:
+    /// `~/tbd/attachments/<worktreeID>/<attachmentID>.png`. Honors TBD_HOME.
+    ///
+    /// Always `.png`: the app re-encodes every accepted image through ImageIO
+    /// before writing, so the extension is a fact about what TBD wrote rather
+    /// than a guess about what was pasted. Claude Code's paste handler keys its
+    /// image detection on the extension, which is why it is spelled here and not
+    /// carried from the source file.
+    public static func attachmentPath(
+        worktreeID: UUID, attachmentID: UUID, environment: [String: String]
+    ) -> String {
+        attachmentsDir(worktreeID: worktreeID, environment: environment)
+            .appendingPathComponent("\(attachmentID.uuidString).png")
+            .path
+    }
+    public static func attachmentPath(worktreeID: UUID, attachmentID: UUID) -> String {
+        attachmentPath(
+            worktreeID: worktreeID, attachmentID: attachmentID,
+            environment: ProcessInfo.processInfo.environment)
+    }
+
     /// Base directory for transcripts recalled from a provider's retained
     /// store: `~/tbd/transcripts`. Honors TBD_HOME.
     ///

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -2400,6 +2400,81 @@ public struct SessionStatesResult: Codable, Sendable {
     public init(reports: [SessionStateReport]) { self.reports = reports }
 }
 
+/// One piece of a composed message.
+///
+/// The composer splits its text at image tokens into an ordered list, and the
+/// daemon delivers each piece as its own bracketed paste. The split exists
+/// because of a measured property of Claude Code's paste handler: it turns a
+/// paste into an image attachment only when the WHOLE paste is one quoted path
+/// with an image extension. Measured on 2.1.261 — a bare quoted path pasted
+/// alone became a base64 image block in the user message, while the same path
+/// inside a sentence, and any path given as a command-line argument, stayed
+/// literal text. Pasting the parts in order reproduces what drag-and-drop
+/// produces: an `[Image #N]` placeholder at the caret between the words around
+/// it.
+///
+/// A tagged object rather than a bare string, deliberately. A reader has to be
+/// able to tell an image path from a sentence that happens to look like one, and
+/// a third kind later must not change the JSON type of a field that already
+/// exists.
+public enum SendPart: Codable, Sendable, Equatable {
+    /// Pasted as text.
+    case text(String)
+    /// Pasted as the bare quoted absolute path and nothing else.
+    case imagePath(String)
+
+    private enum CodingKeys: String, CodingKey { case kind, value }
+    private enum Kind: String, Codable { case text, imagePath }
+
+    public init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let value = try c.decode(String.self, forKey: .value)
+        switch try c.decode(Kind.self, forKey: .kind) {
+        case .text: self = .text(value)
+        case .imagePath: self = .imagePath(value)
+        }
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .text(let value):
+            try c.encode(Kind.text, forKey: .kind)
+            try c.encode(value, forKey: .value)
+        case .imagePath(let value):
+            try c.encode(Kind.imagePath, forKey: .kind)
+            try c.encode(value, forKey: .value)
+        }
+    }
+}
+
+/// Whether a send carries the `<tbd-dispatch/>` line ahead of its body.
+///
+/// **Asking for suppression is not the same as getting it, and this field is the
+/// asking.** The daemon honors `.suppressed` only on a connection it has already
+/// authenticated as the app's — the peer pid the kernel reports for the socket,
+/// matched against the pid the FD-vending sidecar recorded for its current
+/// client and then re-verified through the daemon's one start-time and
+/// command-line check. It does **not** read the request's declared actor, which
+/// is an ambient self-declaration any local process can stamp.
+///
+/// The envelope is how an agent-to-agent dispatch stays attributed inside the
+/// receiving session. A suppression switch any caller could throw would let any
+/// agent inject unattributed text, which is the one property the envelope exists
+/// to provide.
+public enum EnvelopeDisposition: String, Codable, Sendable {
+    case attached
+    case suppressed
+
+    /// An unknown disposition from a newer client is as unusable as an absent
+    /// one, and must not fail the whole payload's decode: it resolves to the
+    /// conservative reading, which is to attach.
+    public init(from decoder: any Decoder) throws {
+        let raw = try decoder.singleValueContainer().decode(String.self)
+        self = EnvelopeDisposition(rawValue: raw) ?? .attached
+    }
+}
+
 /// One `terminal.send` request. Exactly one payload kind per call — `text` or
 /// `keys`, never both and never neither (design §3, "Payloads, not verbs").
 ///
@@ -2429,15 +2504,39 @@ public struct TerminalSendParams: Codable, Sendable {
     /// transcript) and is incompatible with `keys`. Refused, never silently
     /// downgraded, while `delivery_verification_enabled` is off.
     public let verify: Bool?
+    /// An ordered list of pieces, delivered one bracketed paste each, then one
+    /// Enter. Mutually exclusive with both `text` and `keys`; empty text parts
+    /// are skipped. Absent on every request written before the composer existed,
+    /// which is what makes this additive.
+    public let parts: [SendPart]?
+    /// Whether the `<tbd-dispatch/>` envelope rides ahead of the body. Absent
+    /// means `.attached`, which is what every existing caller gets. Suppression
+    /// is a REQUEST, honored only on a connection the daemon has authenticated
+    /// as the app's — never on the strength of this field or of the declared
+    /// actor. See `EnvelopeDisposition`.
+    public let envelope: EnvelopeDisposition?
+    /// Opt in to the awaiting-input gate: refuse this send when the session has a
+    /// prompt on screen or an unrecognized awaiting-input reason.
+    ///
+    /// **Opt-in rather than daemon-wide, deliberately.** Agents use this verb to
+    /// answer permission dialogs on purpose, and a blanket gate would refuse
+    /// exactly those sends. The composer always opts in; existing CLI sends do
+    /// not, and absent means not gated.
+    public let gateOnAwaitingInput: Bool?
     public init(
         terminalID: UUID, text: String? = nil, keys: String? = nil,
-        submit: Bool? = nil, verify: Bool? = nil
+        submit: Bool? = nil, verify: Bool? = nil,
+        parts: [SendPart]? = nil, envelope: EnvelopeDisposition? = nil,
+        gateOnAwaitingInput: Bool? = nil
     ) {
         self.terminalID = terminalID
         self.text = text
         self.keys = keys
         self.submit = submit
         self.verify = verify
+        self.parts = parts
+        self.envelope = envelope
+        self.gateOnAwaitingInput = gateOnAwaitingInput
     }
 }
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -2785,7 +2785,22 @@ public struct TerminalWakeResult: Codable, Sendable {
     /// false — idempotent no-op (already awake, or another wake in flight).
     /// A `prompt` param is delivered only when true.
     public let woken: Bool
-    public init(woken: Bool) { self.woken = woken }
+    /// The session incarnation this respawn minted, planted in the spawned
+    /// process's environment as `TBD_TERMINAL_INCARNATION_ID` and echoed back on
+    /// that process's hooks.
+    ///
+    /// Populated **only** on the `woken: true` path, where a spawn actually
+    /// happened. Nil on every no-op, because there is no spawn to name — and a
+    /// caller that scoped a wait to this id would otherwise wait on somebody
+    /// else's session.
+    ///
+    /// Optional for wire compatibility in both directions: an older daemon sends
+    /// no field, and a caller that does not know about one ignores it.
+    public let sessionIncarnationID: UUID?
+    public init(woken: Bool, sessionIncarnationID: UUID? = nil) {
+        self.woken = woken
+        self.sessionIncarnationID = sessionIncarnationID
+    }
 }
 
 /// Params for `terminal.completions` — what slash commands, skills and subagents

--- a/Tests/TBDDaemonLiveTests/Holder/HolderHibernationLiveTests.swift
+++ b/Tests/TBDDaemonLiveTests/Holder/HolderHibernationLiveTests.swift
@@ -136,7 +136,7 @@ struct HolderHibernationLiveTests {
         #expect(await fixture.coordinator.manualHibernate(terminalID: terminal.id) == .ok)
 
         let result = await fixture.coordinator.wake(terminalID: terminal.id)
-        #expect(result == .ok, "wake refused: \(result)")
+        #expect(result.isOk, "wake refused: \(result)")
 
         let woken = try #require(try await fixture.db.terminals.get(id: terminal.id))
         #expect(!woken.isParked)
@@ -435,7 +435,7 @@ struct HolderHibernationLiveTests {
                 "the fixture lost its reader, so this test would exercise the wrong branch")
 
         let result = await fixture.coordinator.wake(terminalID: terminal.id)
-        #expect(result == .ok, "wake refused: \(result)")
+        #expect(result.isOk, "wake refused: \(result)")
 
         let woken = try #require(try await fixture.db.terminals.get(id: terminal.id))
         #expect(!woken.isParked)

--- a/Tests/TBDDaemonTests/ActuationLogTests.swift
+++ b/Tests/TBDDaemonTests/ActuationLogTests.swift
@@ -200,7 +200,7 @@ struct ActuationLogTests {
             == .refused(.notEligible))
         #expect(ActuationOutcome.classify(HibernateResult.notFound) == .refused(.notFound))
 
-        #expect(ActuationOutcome.classify(WakeResult.ok) == .dispatched)
+        #expect(ActuationOutcome.classify(WakeResult.ok(sessionIncarnationID: nil)) == .dispatched)
         #expect(ActuationOutcome.classify(WakeResult.respawnFailed(reason: "tmux")) == .transportFailed)
         #expect(ActuationOutcome.classify(WakeResult.notHibernated) == .refused(.noop))
         #expect(ActuationOutcome.classify(WakeResult.inFlight) == .refused(.inFlight))

--- a/Tests/TBDDaemonTests/ArchiveScratchpadCleanupTests.swift
+++ b/Tests/TBDDaemonTests/ArchiveScratchpadCleanupTests.swift
@@ -5,7 +5,7 @@ import Testing
 @testable import TBDShared
 
 /// Task 8: `WorktreeLifecycle.onWorktreeRemoved` fires whenever a worktree's
-/// directory is actually removed from disk, so `OrphanGC.scratchpadCleanup`
+/// directory is actually removed from disk, so `OrphanGC.removedWorktreeCleanup`
 /// can run event-driven instead of waiting for the next hourly sweep.
 @Suite struct ArchiveScratchpadCleanupTests {
     @Test func archiveWorktreeFiresOnWorktreeRemovedWithThePath() async throws {
@@ -20,7 +20,7 @@ import Testing
             hooks: HookResolver()
         )
         let box = RemovedPathBox()
-        lifecycle.onWorktreeRemoved = { path, repoPath in await box.record(path, repoPath) }
+        lifecycle.onWorktreeRemoved = { _, path, repoPath in await box.record(path, repoPath) }
 
         let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
         let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
@@ -70,7 +70,7 @@ import Testing
             hooks: HookResolver()
         )
         let box = RemovedPathBox()
-        lifecycle.onWorktreeRemoved = { path, repoPath in await box.record(path, repoPath) }
+        lifecycle.onWorktreeRemoved = { _, path, repoPath in await box.record(path, repoPath) }
 
         let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
         let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)

--- a/Tests/TBDDaemonTests/AttachmentArchiveCleanupTests.swift
+++ b/Tests/TBDDaemonTests/AttachmentArchiveCleanupTests.swift
@@ -16,9 +16,11 @@ extension TBDHomeSerialized {
 struct AttachmentArchiveCleanupTests {
     private let fm = FileManager.default
 
+    /// The fake home goes under the run's fenced scratch root, not
+    /// `fm.temporaryDirectory` — `scripts/test.sh` reclaims the former even when
+    /// the test process is killed, and does not fence the latter at all.
     private func isolateTBDHome() -> (URL, () -> Void) {
-        let home = fm.temporaryDirectory
-            .appendingPathComponent("tbd-att-\(UUID().uuidString.prefix(8))")
+        let home = URL(fileURLWithPath: fencedScratchRoot(prefix: "tbdatt"))
         try? fm.createDirectory(at: home, withIntermediateDirectories: true)
         let prior = setTBDHome(home.path)
         return (home, {

--- a/Tests/TBDDaemonTests/AttachmentArchiveCleanupTests.swift
+++ b/Tests/TBDDaemonTests/AttachmentArchiveCleanupTests.swift
@@ -1,0 +1,98 @@
+import Foundation
+import Testing
+import TestSupport
+@testable import TBDDaemonLib
+import TBDShared
+
+// Nested under TBDHomeSerialized: this walks `TBDConstants.attachmentsDir`,
+// which resolves from the process-global TBD_HOME. See TBDHomeSerializedSuites.swift.
+extension TBDHomeSerialized {
+
+/// The archive-time half of the attachments reconciler pair.
+///
+/// Best effort, and deliberately so: a revived worktree does not get its images
+/// back, and the hourly sweep is what covers every path this misses.
+@Suite("attachments are reclaimed when a worktree is removed")
+struct AttachmentArchiveCleanupTests {
+    private let fm = FileManager.default
+
+    private func isolateTBDHome() -> (URL, () -> Void) {
+        let home = fm.temporaryDirectory
+            .appendingPathComponent("tbd-att-\(UUID().uuidString.prefix(8))")
+        try? fm.createDirectory(at: home, withIntermediateDirectories: true)
+        let prior = setTBDHome(home.path)
+        return (home, {
+            restoreTBDHome(prior)
+            try? FileManager.default.removeItem(at: home)
+        })
+    }
+
+    private func stageAttachment(_ worktreeID: UUID) -> String {
+        let path = TBDConstants.attachmentPath(
+            worktreeID: worktreeID, attachmentID: UUID())
+        try? fm.createDirectory(
+            at: URL(fileURLWithPath: path).deletingLastPathComponent(),
+            withIntermediateDirectories: true)
+        fm.createFile(atPath: path, contents: Data([0x89, 0x50, 0x4E, 0x47]))
+        return path
+    }
+
+    @Test func removingAWorktreeUnlinksItsAttachments() async throws {
+        let (_, restore) = isolateTBDHome()
+        defer { restore() }
+        let db = try TBDDatabase(inMemory: true)
+        let worktreeID = UUID()
+        let path = stageAttachment(worktreeID)
+        #expect(fm.fileExists(atPath: path))
+
+        let gc = OrphanGC(db: db, git: GitManager(), broadcast: { _ in })
+        await gc.removedWorktreeCleanup(
+            worktreeID: worktreeID,
+            worktreePath: "/tmp/gone-\(UUID().uuidString)",
+            repoPath: "/tmp/repo")
+
+        #expect(!fm.fileExists(atPath: path))
+        #expect(!fm.fileExists(
+            atPath: TBDConstants.attachmentsDir(worktreeID: worktreeID).path))
+    }
+
+    /// The master switch governs ALL GC deletion, including this event-driven
+    /// path — one toggle covers every collector.
+    @Test func gcDisabledLeavesThemAlone() async throws {
+        let (_, restore) = isolateTBDHome()
+        defer { restore() }
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(false)
+        let worktreeID = UUID()
+        let path = stageAttachment(worktreeID)
+
+        let gc = OrphanGC(db: db, git: GitManager(), broadcast: { _ in })
+        await gc.removedWorktreeCleanup(
+            worktreeID: worktreeID,
+            worktreePath: "/tmp/gone-\(UUID().uuidString)",
+            repoPath: "/tmp/repo")
+
+        #expect(fm.fileExists(atPath: path))
+    }
+
+    /// Another worktree's images are not this worktree's business.
+    @Test func aSiblingWorktreesAttachmentsSurvive() async throws {
+        let (_, restore) = isolateTBDHome()
+        defer { restore() }
+        let db = try TBDDatabase(inMemory: true)
+        let removed = UUID()
+        let sibling = UUID()
+        _ = stageAttachment(removed)
+        let survivor = stageAttachment(sibling)
+
+        let gc = OrphanGC(db: db, git: GitManager(), broadcast: { _ in })
+        await gc.removedWorktreeCleanup(
+            worktreeID: removed,
+            worktreePath: "/tmp/gone-\(UUID().uuidString)",
+            repoPath: "/tmp/repo")
+
+        #expect(fm.fileExists(atPath: survivor))
+    }
+}
+
+}

--- a/Tests/TBDDaemonTests/AwaitingInputSendGateTests.swift
+++ b/Tests/TBDDaemonTests/AwaitingInputSendGateTests.swift
@@ -1,0 +1,145 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+import TBDShared
+
+/// The gate the composer opts into: refuse a send when the session has a dialog
+/// on screen, because a pasted body plus Enter into a permission dialog commits
+/// whichever option is highlighted.
+///
+/// Every branch fails toward REFUSING, and the unrecognized class is the reason
+/// why: a newer Claude Code's new dialog type looks exactly like an unknown
+/// notification to this build, and allowing it would mean the gate silently
+/// stops working the day a dialog is added.
+///
+/// Tier 1: pure decisions, one case per class.
+@Suite("AwaitingInputSendGate")
+struct AwaitingInputSendGateTests {
+
+    private func reason(_ type: String?, message: String = "Claude needs your permission")
+        -> AwaitingInputReason {
+        AwaitingInputReason(
+            message: message, hookEventName: "Notification", raw: nil, notificationType: type)
+    }
+
+    @Test func noStandingReasonAllows() {
+        #expect(AwaitingInputSendGate.decide(reason: nil, superseded: false) == .allow)
+    }
+
+    @Test func aPromptOnScreenRefusesAndCarriesItsMessage() {
+        let decision = AwaitingInputSendGate.decide(
+            reason: reason("permission_prompt", message: "Allow Bash(rm -rf)?"),
+            superseded: false)
+        guard case .refuse(let message) = decision else {
+            Issue.record("expected a refusal, got \(decision)")
+            return
+        }
+        #expect(message.contains("Allow Bash(rm -rf)?"))
+    }
+
+    @Test func everyPromptOnScreenTypeRefuses() {
+        for type in [
+            "permission_prompt", "elicitation_dialog", "agent_needs_input",
+            "worker_permission_prompt", "elicitation_url_dialog",
+        ] {
+            guard case .refuse = AwaitingInputSendGate.decide(
+                reason: reason(type), superseded: false) else {
+                Issue.record("\(type) must refuse")
+                continue
+            }
+        }
+    }
+
+    /// **The one that keeps the gate working as Claude Code changes.** A type
+    /// this build has never heard of is treated as a dialog.
+    @Test func anUnrecognizedTypeIsTreatedAsADialog() {
+        guard case .refuse = AwaitingInputSendGate.decide(
+            reason: reason("brand_new_dialog_kind"), superseded: false) else {
+            Issue.record("an unknown notification type must be treated as a dialog")
+            return
+        }
+        guard case .refuse = AwaitingInputSendGate.decide(
+            reason: reason(nil), superseded: false) else {
+            Issue.record("an absent notification type must be treated as a dialog")
+            return
+        }
+    }
+
+    /// The idle prompt is the agent waiting for its next instruction — the exact
+    /// state the composer exists to answer.
+    @Test func theIdlePromptIsAllowed() {
+        #expect(AwaitingInputSendGate.decide(
+            reason: reason("idle_prompt"), superseded: false) == .allow)
+    }
+
+    @Test func informationalReasonsAreAllowed() {
+        for type in ["agent_completed", "auth_success", "push_notification"] {
+            #expect(
+                AwaitingInputSendGate.decide(reason: reason(type), superseded: false) == .allow,
+                "\(type) must be allowed")
+        }
+    }
+
+    /// The supersession check is what stops a stale hand from blocking sends
+    /// forever: the session's own transcript showed it moved on.
+    @Test func aSupersededPromptIsAllowedThrough() {
+        #expect(AwaitingInputSendGate.decide(
+            reason: reason("permission_prompt"), superseded: true) == .allow)
+        #expect(AwaitingInputSendGate.decide(
+            reason: reason("brand_new_dialog_kind"), superseded: true) == .allow)
+    }
+}
+
+/// The gate is OPT-IN, and that is the whole reason it can exist: agents use
+/// `terminal.send` to answer permission dialogs deliberately, and a daemon-wide
+/// gate would refuse exactly those sends.
+@Suite("AwaitingInputSendGate opt-in")
+struct AwaitingInputSendGateOptInTests {
+
+    @Test func anOptedInSendIntoAPromptIsRefused() async throws {
+        let harness = try await SendHarness.make()
+        try await harness.db.terminals.recordAwaitingInputReason(
+            id: harness.terminal.id,
+            reason: AwaitingInputReason(
+                message: "Allow Bash(rm -rf)?", hookEventName: "Notification",
+                notificationType: "permission_prompt"),
+            observedAt: Date(timeIntervalSince1970: 1_800_000_000))
+
+        let response = try await harness.send(TerminalSendParams(
+            terminalID: harness.terminal.id, text: "yes", submit: true,
+            gateOnAwaitingInput: true),
+            actor: .app)
+
+        #expect(!response.success)
+        #expect(try #require(response.error).contains("Allow Bash(rm -rf)?"))
+        #expect(harness.tmux.pastedBodies.isEmpty, "nothing may be typed")
+    }
+
+    /// **The load-bearing negative.** The same row, the same prompt, no opt-in:
+    /// the send goes through, because that is how an agent answers a dialog.
+    @Test func anOptedOutSendIntoTheSamePromptIsNotGated() async throws {
+        let harness = try await SendHarness.make()
+        try await harness.db.terminals.recordAwaitingInputReason(
+            id: harness.terminal.id,
+            reason: AwaitingInputReason(
+                message: "Allow Bash(rm -rf)?", hookEventName: "Notification",
+                notificationType: "permission_prompt"),
+            observedAt: Date(timeIntervalSince1970: 1_800_000_000))
+
+        let response = try await harness.send(TerminalSendParams(
+            terminalID: harness.terminal.id, text: "yes", submit: true),
+            actor: ActuationActor.session(worktree: "W", terminal: "T"))
+
+        #expect(response.success, "error was: \(response.error ?? "none")")
+        #expect(!(harness.tmux.pastedBodies.isEmpty))
+    }
+
+    @Test func anOptedInSendToAnIdleSessionGoesThrough() async throws {
+        let harness = try await SendHarness.make()
+        let response = try await harness.send(TerminalSendParams(
+            terminalID: harness.terminal.id, text: "hi", submit: true,
+            gateOnAwaitingInput: true),
+            actor: .app)
+        #expect(response.success, "error was: \(response.error ?? "none")")
+    }
+}

--- a/Tests/TBDDaemonTests/AwaitingInputSendGateTests.swift
+++ b/Tests/TBDDaemonTests/AwaitingInputSendGateTests.swift
@@ -142,4 +142,70 @@ struct AwaitingInputSendGateOptInTests {
             actor: .app)
         #expect(response.success, "error was: \(response.error ?? "none")")
     }
+
+    /// **The gate applies to BOTH transports.** It used to sit after the
+    /// early return that dispatches a holder-backed row to its own delivery
+    /// arm, so a holder row was never gated at all: a composer send answered a
+    /// permission dialog by committing whichever option was highlighted. The
+    /// spec applies the gate before dispatching to either transport.
+    @Test func anOptedInSendToAHolderRowIsRefused() async throws {
+        let recorder = HolderWriteRecorder()
+        let harness = try await SendHarness.make(
+            transport: .holder, holderDeliveryRecorder: { recorder.record($0) })
+        try await harness.db.terminals.recordAwaitingInputReason(
+            id: harness.terminal.id,
+            reason: AwaitingInputReason(
+                message: "Allow Bash(rm -rf)?", hookEventName: "Notification",
+                notificationType: "permission_prompt"),
+            observedAt: Date(timeIntervalSince1970: 1_800_000_000))
+
+        let response = try await harness.send(TerminalSendParams(
+            terminalID: harness.terminal.id, text: "yes", submit: true,
+            gateOnAwaitingInput: true),
+            actor: .app)
+
+        #expect(!response.success)
+        #expect(try #require(response.error).contains("Allow Bash(rm -rf)?"))
+        #expect(recorder.writes.isEmpty, "nothing may be written to the pty")
+    }
+
+    /// The load-bearing negative for the transport above: no opt-in, same row,
+    /// same prompt — the send goes through, because that is how an agent answers
+    /// a dialog on a holder-backed session too.
+    @Test func anOptedOutSendToAHolderRowIsNotGated() async throws {
+        let recorder = HolderWriteRecorder()
+        let harness = try await SendHarness.make(
+            transport: .holder, holderDeliveryRecorder: { recorder.record($0) })
+        try await harness.db.terminals.recordAwaitingInputReason(
+            id: harness.terminal.id,
+            reason: AwaitingInputReason(
+                message: "Allow Bash(rm -rf)?", hookEventName: "Notification",
+                notificationType: "permission_prompt"),
+            observedAt: Date(timeIntervalSince1970: 1_800_000_000))
+
+        let response = try await harness.send(TerminalSendParams(
+            terminalID: harness.terminal.id, text: "yes", submit: true),
+            actor: ActuationActor.session(worktree: "W", terminal: "T"))
+
+        #expect(response.success, "error was: \(response.error ?? "none")")
+        #expect(recorder.writes.count == 1)
+    }
+}
+
+/// Collects the bytes the harness's stubbed `HolderInjectionCourier` was asked
+/// to write. Lock-guarded, because the courier's closure runs off the test's
+/// task.
+private final class HolderWriteRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _writes: [Data] = []
+    var writes: [Data] {
+        lock.lock()
+        defer { lock.unlock() }
+        return _writes
+    }
+    func record(_ bytes: Data) {
+        lock.lock()
+        defer { lock.unlock() }
+        _writes.append(bytes)
+    }
 }

--- a/Tests/TBDDaemonTests/EnvelopeSuppressionAuthTests.swift
+++ b/Tests/TBDDaemonTests/EnvelopeSuppressionAuthTests.swift
@@ -1,0 +1,208 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+import TBDShared
+
+/// Who may speak in a human's voice.
+///
+/// Every row here is about AUTHORITY, and the declared actor never changes an
+/// outcome in any of them — that is the whole point. The connection is what is
+/// authenticated; the request can only ask.
+@Suite("envelope suppression is authenticated on the connection")
+struct EnvelopeSuppressionAuthTests {
+
+    /// A `ProcessSignaller` whose answers the test chooses, so a `.same` verdict
+    /// and each way of failing one can be stated without a real process.
+    ///
+    /// The signalling requirements are inert: this suite never asks for a
+    /// signal, and a stub that could send one would be a stub that could kill
+    /// something on a mistake.
+    private struct StubSignaller: ProcessSignaller {
+        var alive = true
+        var startedAt: Date?
+        var command: String?
+        func isAlive(_ pid: Int32) -> Bool { alive }
+        func startTime(_ pid: Int32) -> Date? { startedAt }
+        func commandLine(_ pid: Int32) -> String? { command }
+        func stat(_ pid: Int32) -> String? { nil }
+        func children(ofServerPID serverPID: Int32) -> [Int32] { [] }
+        func terminate(_ pid: Int32) {}
+        func forceKill(_ pid: Int32) {}
+    }
+
+    private static let appStart = Date(timeIntervalSince1970: 1_800_000_000)
+    private static let appCommand = "/Applications/TBD.app/Contents/MacOS/TBDApp"
+    private static let appPID: Int32 = 909
+
+    private static func recordedApp() -> ProcessIdentity {
+        ProcessIdentity(pid: appPID, startedAt: appStart, commandLine: appCommand)
+    }
+
+    private static func liveSignaller() -> StubSignaller {
+        StubSignaller(alive: true, startedAt: appStart, command: appCommand)
+    }
+
+    private func harness(
+        recorded: ProcessIdentity? = recordedApp(),
+        signaller: any ProcessSignaller = liveSignaller()
+    ) async throws -> SendHarness {
+        try await SendHarness.make(
+            recordedAppIdentity: { recorded },
+            processSignaller: signaller)
+    }
+
+    // MARK: - The one row that authenticates
+
+    /// The app's own connection, verified: the person is speaking in their own
+    /// voice, exactly as at the keyboard, and Claude sees only the message.
+    @Test func theAppsOwnConnectionSuppressesTheEnvelope() async throws {
+        let harness = try await harness()
+        let response = try await harness.send(
+            TerminalSendParams(
+                terminalID: harness.terminal.id, text: "hi", submit: true,
+                envelope: .suppressed),
+            actor: .app,
+            connection: RPCConnectionContext(peerPID: Self.appPID))
+
+        #expect(response.success, "error was: \(response.error ?? "none")")
+        #expect(harness.tmux.pastedBodies == ["hi"])
+    }
+
+    // MARK: - The load-bearing negatives
+
+    /// **A CLI connection.** Same request, same `{"kind":"app"}` actor, a
+    /// different pid: the envelope stays. This is the row that stops any local
+    /// process from typing as a human.
+    @Test func aCLIConnectionAskingForSuppressionStillGetsTheEnvelope() async throws {
+        let harness = try await harness()
+        _ = try await harness.send(
+            TerminalSendParams(
+                terminalID: harness.terminal.id, text: "hi", submit: true,
+                envelope: .suppressed),
+            actor: .app,
+            connection: RPCConnectionContext(peerPID: 4321))
+
+        #expect(try #require(harness.tmux.pastedBodies.first).hasPrefix("<tbd-dispatch"))
+    }
+
+    /// An unreadable peer pid is not an app connection. It is "not established",
+    /// and this check has no third answer.
+    @Test func anUnreadablePeerPIDKeepsTheEnvelope() async throws {
+        let harness = try await harness()
+        _ = try await harness.send(
+            TerminalSendParams(
+                terminalID: harness.terminal.id, text: "hi", submit: true,
+                envelope: .suppressed),
+            actor: .app,
+            connection: RPCConnectionContext(peerPID: nil))
+        #expect(try #require(harness.tmux.pastedBodies.first).hasPrefix("<tbd-dispatch"))
+    }
+
+    /// No context at all — every non-socket caller of `handleRaw`, and the HTTP
+    /// server — is the same answer as an unreadable pid.
+    @Test func noConnectionContextKeepsTheEnvelope() async throws {
+        let harness = try await harness()
+        _ = try await harness.send(
+            TerminalSendParams(
+                terminalID: harness.terminal.id, text: "hi", submit: true,
+                envelope: .suppressed),
+            actor: .app,
+            connection: nil)
+        #expect(try #require(harness.tmux.pastedBodies.first).hasPrefix("<tbd-dispatch"))
+    }
+
+    /// The sidecar has no client: nothing was recorded, so there is nothing the
+    /// peer pid could match.
+    @Test func noRecordedSidecarClientKeepsTheEnvelope() async throws {
+        let harness = try await harness(recorded: nil)
+        _ = try await harness.send(
+            TerminalSendParams(
+                terminalID: harness.terminal.id, text: "hi", submit: true,
+                envelope: .suppressed),
+            actor: .app,
+            connection: RPCConnectionContext(peerPID: Self.appPID))
+        #expect(try #require(harness.tmux.pastedBodies.first).hasPrefix("<tbd-dispatch"))
+    }
+
+    /// **Pid reuse.** The pid matches what was recorded and the process at that
+    /// number is somebody else. Each way of failing `.same` is its own row,
+    /// because each is a different way the second half can save the first.
+    @Test func aReVerifyThatIsNotSameKeepsTheEnvelope() async throws {
+        let cases: [(String, StubSignaller)] = [
+            ("not-running", StubSignaller(alive: false, startedAt: nil, command: nil)),
+            ("start-time-unreadable",
+             StubSignaller(alive: true, startedAt: nil, command: Self.appCommand)),
+            ("start-time-mismatch",
+             StubSignaller(alive: true, startedAt: Self.appStart.addingTimeInterval(5),
+                           command: Self.appCommand)),
+            ("command-unreadable",
+             StubSignaller(alive: true, startedAt: Self.appStart, command: nil)),
+            ("foreign-executable",
+             StubSignaller(alive: true, startedAt: Self.appStart, command: "/bin/zsh")),
+        ]
+        for (name, signaller) in cases {
+            let harness = try await harness(signaller: signaller)
+            _ = try await harness.send(
+                TerminalSendParams(
+                    terminalID: harness.terminal.id, text: "hi", submit: true,
+                    envelope: .suppressed),
+                actor: .app,
+                connection: RPCConnectionContext(peerPID: Self.appPID))
+            #expect(
+                try #require(harness.tmux.pastedBodies.first).hasPrefix("<tbd-dispatch"),
+                "\(name) must keep the envelope")
+        }
+    }
+
+    // MARK: - The declared actor never decides anything
+
+    /// The authenticated connection suppresses however the request labels
+    /// itself, and an unauthenticated one does not however it labels itself.
+    /// Together these two say the actor field carries no authority at all.
+    @Test func theDeclaredActorChangesNothingInEitherDirection() async throws {
+        let authenticated = try await harness()
+        _ = try await authenticated.send(
+            TerminalSendParams(
+                terminalID: authenticated.terminal.id, text: "hi", submit: true,
+                envelope: .suppressed),
+            actor: ActuationActor.session(worktree: "W", terminal: "T"),
+            connection: RPCConnectionContext(peerPID: Self.appPID))
+        #expect(authenticated.tmux.pastedBodies == ["hi"])
+
+        let stranger = try await harness()
+        _ = try await stranger.send(
+            TerminalSendParams(
+                terminalID: stranger.terminal.id, text: "hi", submit: true,
+                envelope: .suppressed),
+            actor: .app,
+            connection: RPCConnectionContext(peerPID: 4321))
+        #expect(try #require(stranger.tmux.pastedBodies.first).hasPrefix("<tbd-dispatch"))
+    }
+
+    /// A send that does not ASK for suppression never pays for the identity
+    /// check, and gets the envelope on an authenticated connection like anyone
+    /// else. The check runs on a composer send and nowhere else.
+    @Test func anUnaskedSendKeepsTheEnvelopeOnTheAppsOwnConnection() async throws {
+        let harness = try await harness()
+        _ = try await harness.send(
+            TerminalSendParams(terminalID: harness.terminal.id, text: "hi", submit: true),
+            actor: .app,
+            connection: RPCConnectionContext(peerPID: Self.appPID))
+        #expect(try #require(harness.tmux.pastedBodies.first).hasPrefix("<tbd-dispatch"))
+    }
+}
+
+/// `ProcessIdentity.ofPeer` over a real connected socket, so the one thing this
+/// design rests on — that the kernel, not the caller, names the peer — is
+/// checked rather than assumed.
+@Suite("peer identity over a real socket")
+struct PeerIdentityOverSocketpairTests {
+    @Test func aSocketpairPeerIsThisProcess() throws {
+        var fds: [Int32] = [-1, -1]
+        #expect(socketpair(AF_UNIX, SOCK_STREAM, 0, &fds) == 0)
+        defer { close(fds[0]); close(fds[1]) }
+        let identity = try #require(
+            ProcessIdentity.ofPeer(onSocket: fds[0], signaller: ProductionProcessSignaller()))
+        #expect(identity.pid == ProcessInfo.processInfo.processIdentifier)
+    }
+}

--- a/Tests/TBDDaemonTests/EnvelopeSuppressionAuthTests.swift
+++ b/Tests/TBDDaemonTests/EnvelopeSuppressionAuthTests.swift
@@ -179,6 +179,46 @@ struct EnvelopeSuppressionAuthTests {
         #expect(try #require(stranger.tmux.pastedBodies.first).hasPrefix("<tbd-dispatch"))
     }
 
+    // MARK: - The shape the composer actually sends
+
+    /// **The production call is `parts` + `envelope: .suppressed`**, not `text`.
+    /// Every row above states the authority rule on a text payload; this states
+    /// it on the payload the composer actually builds, so the rule cannot hold
+    /// for one shape and quietly not the other.
+    @Test func theAppsOwnConnectionSuppressesTheEnvelopeOnAPartsSend() async throws {
+        let harness = try await harness()
+        let response = try await harness.send(
+            TerminalSendParams(
+                terminalID: harness.terminal.id, submit: true,
+                parts: [.text("look at "), .imagePath("/tmp/a.png"), .text(" and tell me")],
+                envelope: .suppressed),
+            actor: .app,
+            connection: RPCConnectionContext(peerPID: Self.appPID))
+
+        #expect(response.success, "error was: \(response.error ?? "none")")
+        #expect(harness.tmux.pastedBodies == ["look at ", "'/tmp/a.png'", " and tell me"])
+    }
+
+    /// The negative for the same shape: a stranger's connection asking for
+    /// suppression gets the envelope on the first TEXT part, exactly as an
+    /// unasked parts send does.
+    @Test func aStrangersPartsSendKeepsTheEnvelopeOnTheFirstTextPart() async throws {
+        let harness = try await harness()
+        _ = try await harness.send(
+            TerminalSendParams(
+                terminalID: harness.terminal.id, submit: true,
+                parts: [.text("look at "), .imagePath("/tmp/a.png")],
+                envelope: .suppressed),
+            actor: .app,
+            connection: RPCConnectionContext(peerPID: 4321))
+
+        let bodies = harness.tmux.pastedBodies
+        try #require(bodies.count == 2)
+        #expect(try #require(bodies.first).hasPrefix("<tbd-dispatch"))
+        #expect(try #require(bodies.first).hasSuffix("\nlook at "))
+        #expect(bodies[1] == "'/tmp/a.png'")
+    }
+
     /// A send that does not ASK for suppression never pays for the identity
     /// check, and gets the envelope on an authenticated connection like anyone
     /// else. The check runs on a composer send and nowhere else.

--- a/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
@@ -968,7 +968,7 @@ struct HibernationCoordinatorTests {
                 "the pendingResumeAt mirror must clear with the park write")
 
         let woke = await coord.wake(terminalID: terminalID)
-        #expect(woke == .ok)
+        #expect(isWakeOk(woke))
         #expect(try await db.scheduledResumes.pending(terminalID: terminalID) == nil,
                 "wake must not resurrect the cancelled resume")
         #expect(try await db.terminals.get(id: terminalID)?.pendingResumeAt == nil)
@@ -1000,7 +1000,7 @@ struct HibernationCoordinatorTests {
         #expect(try await db.terminals.get(id: terminalID)?.isHibernated == true)
 
         let wake = await coord.wake(terminalID: terminalID)
-        #expect(wake == .ok)
+        #expect(isWakeOk(wake))
         #expect(try await db.terminals.get(id: terminalID)?.hibernatedAt == nil)
 
         // A respawn-window with `claude --resume` must have been issued.
@@ -1019,7 +1019,7 @@ struct HibernationCoordinatorTests {
         #expect(await coord.manualHibernate(terminalID: terminalID) == .ok)
         let parked = try #require(try await db.terminals.get(id: terminalID))
 
-        #expect(await coord.wake(terminalID: terminalID) == .ok)
+        #expect(isWakeOk(await coord.wake(terminalID: terminalID)))
         let awake = try #require(try await db.terminals.get(id: terminalID))
         #expect(awake.sessionIncarnationID != parked.sessionIncarnationID)
         #expect(awake.tmuxWindowID == parked.tmuxWindowID)
@@ -1172,7 +1172,7 @@ struct HibernationCoordinatorTests {
         let coord = HibernationCoordinator(
             db: db, tmux: tmux, configDirManager: isolatedConfigDirManager(),
             actuationLog: makeTestActuationLog())
-        #expect(await coord.wake(terminalID: terminalID) == .ok)
+        #expect(isWakeOk(await coord.wake(terminalID: terminalID)))
         #expect(try await db.terminals.get(id: terminalID)?.isParked == false)
     }
 
@@ -1199,7 +1199,7 @@ struct HibernationCoordinatorTests {
         #expect(before?.suspendedAt != nil)
 
         let wake = await coordinator(db).wake(terminalID: terminalID)
-        #expect(wake == .ok)
+        #expect(isWakeOk(wake))
         let after = try await db.terminals.get(id: terminalID)
         #expect(after?.hibernatedAt == nil, "wake must clear hibernatedAt")
         #expect(after?.suspendedAt == nil, "wake must also clear legacy suspendedAt")
@@ -1223,7 +1223,7 @@ struct HibernationCoordinatorTests {
         #expect(before?.isParked == true)
 
         let wake = await coord.wake(terminalID: terminalID)
-        #expect(wake == .ok, "wake must un-park a suspendedAt-only row, not no-op it")
+        #expect(isWakeOk(wake), "wake must un-park a suspendedAt-only row, not no-op it")
         let after = try await db.terminals.get(id: terminalID)
         #expect(after?.isParked == false, "row fully un-parked (both columns nil)")
 
@@ -1286,7 +1286,7 @@ struct HibernationCoordinatorTests {
             paneProcessInspector: FakeInspector(claudePID: nil, foregroundPID: 4242),
             actuationLog: makeTestActuationLog())
 
-        #expect(await coord.wake(terminalID: terminalID) == .ok)
+        #expect(await coord.wake(terminalID: terminalID).isOk)
         #expect(try await db.terminals.get(id: terminalID)?.isParked == false)
         let joined = recorded.snapshot().map { $0.joined(separator: " ") }
         #expect(joined.contains { $0.contains("respawn-window") && $0.contains("claude --resume sess-1") },
@@ -1308,7 +1308,7 @@ struct HibernationCoordinatorTests {
             paneProcessInspector: FakeInspector(claudePID: nil, foregroundPID: 9999),
             actuationLog: makeTestActuationLog())
 
-        #expect(await coord.wake(terminalID: terminalID) == .ok)
+        #expect(await coord.wake(terminalID: terminalID).isOk)
         #expect(try await db.terminals.get(id: terminalID)?.isParked == false)
     }
 
@@ -1332,7 +1332,7 @@ struct HibernationCoordinatorTests {
         await coord.setOnServerCreated { server in serverHookCalls.append([server]) }
 
         let wake = await coord.wake(terminalID: terminalID)
-        #expect(wake == .ok)
+        #expect(isWakeOk(wake))
         let after = try await db.terminals.get(id: terminalID)
         #expect(after?.isParked == false, "row must be un-parked")
         #expect(after?.tmuxWindowID == "@0", "live-window wake must keep the window id")
@@ -1365,7 +1365,7 @@ struct HibernationCoordinatorTests {
         await coord.setOnServerCreated { server in serverHookCalls.append([server]) }
 
         let wake = await coord.wake(terminalID: terminalID)
-        #expect(wake == .ok)
+        #expect(isWakeOk(wake))
         let after = try await db.terminals.get(id: terminalID)
         #expect(after?.isParked == false, "row must be un-parked")
         #expect(after?.tmuxWindowID == "@mock-0", "recreate must persist the new window id")
@@ -1440,7 +1440,7 @@ struct HibernationCoordinatorTests {
         #expect((await router.handle(staleHook)).success)
         #expect(try await db.terminals.get(id: terminalID)?.claudeSessionID == "sess-1")
         recorder.release()
-        #expect(await wake.value == .ok)
+        #expect(isWakeOk(await wake.value))
 
         let replacementHook = try RPCRequest(
             method: RPCMethod.terminalSessionEvent,
@@ -1499,7 +1499,7 @@ struct HibernationCoordinatorTests {
         #expect(try await db.terminals.get(id: terminalID)?.claudeSessionID == "sess-1")
 
         recorder.release()
-        #expect(await wake.value == .ok)
+        #expect(isWakeOk(await wake.value))
         let finalized = try #require(try await db.terminals.get(id: terminalID))
         #expect(!finalized.isParked)
         #expect(finalized.claudeSessionID == "sess-1")
@@ -1544,7 +1544,7 @@ struct HibernationCoordinatorTests {
         try await db.terminals.delete(id: terminalID)
         recorder.release()
 
-        #expect(await wake.value != .ok)
+        #expect(!isWakeOk(await wake.value))
         #expect(deltas.snapshot().isEmpty,
                 "a wake whose final durable marker clear failed must not broadcast success")
         let joined = recorder.snapshot().map { $0.joined(separator: " ") }
@@ -1578,7 +1578,7 @@ struct HibernationCoordinatorTests {
         let coord = HibernationCoordinator(db: db, tmux: tmux, configDirManager: isolatedConfigDirManager(), actuationLog: makeTestActuationLog())
 
         let wake = await coord.wake(terminalID: terminalID)
-        #expect(wake == .ok)
+        #expect(isWakeOk(wake))
         let after = try await db.terminals.get(id: terminalID)
         #expect(after?.isParked == false)
         #expect(after?.tmuxWindowID == "@mock-0", "collision must force a recreate with fresh ids")
@@ -1609,7 +1609,7 @@ struct HibernationCoordinatorTests {
         let coord = HibernationCoordinator(db: db, tmux: tmux, configDirManager: isolatedConfigDirManager(), actuationLog: makeTestActuationLog())
 
         let wake = await coord.wake(terminalID: terminalID)
-        #expect(wake == .ok)
+        #expect(isWakeOk(wake))
         let after = try await db.terminals.get(id: terminalID)
         #expect(after?.tmuxWindowID == "@0", "no collision → in-place respawn keeps the ids")
         #expect(after?.tmuxPaneID == "%0")
@@ -1674,7 +1674,7 @@ struct HibernationCoordinatorTests {
 
         let results = await [first.value, second.value]
         #expect(duplicateWasRejectedBeforeDatabaseRelease)
-        #expect(results.filter { $0 == .ok }.count == 1)
+        #expect(results.filter { isWakeOk($0) }.count == 1)
         #expect(results.filter { $0 == .inFlight }.count == 1)
         let after = try #require(try await db.terminals.get(id: terminalID))
         #expect(after.sessionIncarnationID != parked.sessionIncarnationID)
@@ -1706,7 +1706,7 @@ struct HibernationCoordinatorTests {
             kind: .claude)
         try await db.terminals.setHibernated(
             id: terminalID, sessionID: "sess-retry")
-        #expect(await subject.wake(terminalID: terminalID) == .ok)
+        #expect(isWakeOk(await subject.wake(terminalID: terminalID)))
     }
 
     /// Two concurrent wakes, two parked terminals, SAME server, both windows
@@ -1731,8 +1731,8 @@ struct HibernationCoordinatorTests {
         async let wakeA = coord.wake(terminalID: terminalA)
         async let wakeB = coord.wake(terminalID: terminalB.id)
         let (resultA, resultB) = await (wakeA, wakeB)
-        #expect(resultA == .ok)
-        #expect(resultB == .ok)
+        #expect(isWakeOk(resultA))
+        #expect(isWakeOk(resultB))
 
         let afterA = try await db.terminals.get(id: terminalA)
         let afterB = try await db.terminals.get(id: terminalB.id)
@@ -1795,8 +1795,8 @@ struct HibernationCoordinatorTests {
         async let wakeA = coord.wake(terminalID: terminalA.id)
         async let wakeB = coord.wake(terminalID: terminalB.id)
         let (resultA, resultB) = await (wakeA, wakeB)
-        #expect(resultA == .ok, "different servers must not serialize/deadlock each other")
-        #expect(resultB == .ok, "different servers must not serialize/deadlock each other")
+        #expect(isWakeOk(resultA), "different servers must not serialize/deadlock each other")
+        #expect(isWakeOk(resultB), "different servers must not serialize/deadlock each other")
 
         let joined = recorded.snapshot().map { $0.joined(separator: " ") }
         #expect(joined.contains { $0.contains("new-window") && $0.contains("-L tbd-hib-a") },
@@ -1974,7 +1974,7 @@ struct HibernationCoordinatorTests {
         #expect(failed.claudeSessionID == "sess-1")
         #expect(failed.transcriptPath == "/tmp/live-wake-retry.jsonl")
 
-        #expect(await coord.wake(terminalID: terminalID) == .ok)
+        #expect(isWakeOk(await coord.wake(terminalID: terminalID)))
         let retried = try #require(try await db.terminals.get(id: terminalID))
         #expect(!retried.isParked)
         #expect(retried.claudeSessionID == "sess-1")
@@ -2014,7 +2014,7 @@ struct HibernationCoordinatorTests {
         #expect(failed.claudeSessionID == "sess-1")
         #expect(failed.transcriptPath == "/tmp/dead-wake-retry.jsonl")
 
-        #expect(await coord.wake(terminalID: terminalID) == .ok)
+        #expect(isWakeOk(await coord.wake(terminalID: terminalID)))
         let retried = try #require(try await db.terminals.get(id: terminalID))
         #expect(!retried.isParked)
         #expect(retried.claudeSessionID == "sess-1")
@@ -2052,7 +2052,7 @@ struct HibernationCoordinatorTests {
             actuationLog: makeTestActuationLog()
         )
         let wake = await coord.wake(terminalID: terminalID)
-        #expect(wake == .ok)
+        #expect(isWakeOk(wake))
 
         // `/tmp/hib-repo` munges to `-tmp-hib-repo` under the injected root.
         let derived = projects.appendingPathComponent("-tmp-hib-repo/sess-1.jsonl")
@@ -2107,7 +2107,7 @@ struct HibernationCoordinatorTests {
         let coord = coordinatorWithResolver(db)
         let wake = await coord.wake(terminalID: terminalID, allowDefaultProfileFallback: true)
 
-        #expect(wake == .ok)
+        #expect(isWakeOk(wake))
         let after = try await db.terminals.get(id: terminalID)
         #expect(after?.hibernatedAt == nil, "row must be un-parked")
     }
@@ -2125,7 +2125,7 @@ struct HibernationCoordinatorTests {
         let coord = coordinatorWithResolver(db)
         let wake = await coord.wake(terminalID: terminalID)
 
-        #expect(wake == .ok)
+        #expect(isWakeOk(wake))
         let after = try await db.terminals.get(id: terminalID)
         #expect(after?.hibernatedAt == nil, "row must be un-parked")
     }
@@ -2182,7 +2182,7 @@ struct HibernationCoordinatorTests {
         let commandCount = commands.snapshot().count
         keychainGate.release()
 
-        #expect(await wake.value != .ok)
+        #expect(!isWakeOk(await wake.value))
         let unchanged = try #require(try await db.terminals.get(id: terminalID))
         #expect(unchanged == swapped)
         #expect(commands.snapshot().count == commandCount,
@@ -2245,7 +2245,7 @@ struct HibernationCoordinatorTests {
             return
         }
 
-        #expect(await coordinator.wake(terminalID: terminalID) == .ok)
+        #expect(isWakeOk(await coordinator.wake(terminalID: terminalID)))
         let woken = try #require(try await db.terminals.get(id: terminalID))
         #expect(!woken.isParked)
         #expect(woken.profileID == oldProfile.id)
@@ -2275,7 +2275,7 @@ struct HibernationCoordinatorTests {
         let coord = coordinator(db)
         let wake = await coord.wake(terminalID: terminalID)
 
-        #expect(wake == .ok, "without a resolver, no profile check fires")
+        #expect(isWakeOk(wake), "without a resolver, no profile check fires")
         let after = try await db.terminals.get(id: terminalID)
         #expect(after?.hibernatedAt == nil)
     }
@@ -2456,7 +2456,7 @@ struct HibernationCoordinatorTests {
 
         _ = await coord.manualHibernate(terminalID: terminalID)
         let wake = await coord.wake(terminalID: terminalID)
-        #expect(wake == .ok)
+        #expect(isWakeOk(wake))
 
         let delta = recorder.snapshot().last
         #expect(delta?.hibernated == false)

--- a/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
@@ -968,7 +968,7 @@ struct HibernationCoordinatorTests {
                 "the pendingResumeAt mirror must clear with the park write")
 
         let woke = await coord.wake(terminalID: terminalID)
-        #expect(isWakeOk(woke))
+        #expect(woke.isOk)
         #expect(try await db.scheduledResumes.pending(terminalID: terminalID) == nil,
                 "wake must not resurrect the cancelled resume")
         #expect(try await db.terminals.get(id: terminalID)?.pendingResumeAt == nil)
@@ -1000,7 +1000,7 @@ struct HibernationCoordinatorTests {
         #expect(try await db.terminals.get(id: terminalID)?.isHibernated == true)
 
         let wake = await coord.wake(terminalID: terminalID)
-        #expect(isWakeOk(wake))
+        #expect(wake.isOk)
         #expect(try await db.terminals.get(id: terminalID)?.hibernatedAt == nil)
 
         // A respawn-window with `claude --resume` must have been issued.
@@ -1019,8 +1019,10 @@ struct HibernationCoordinatorTests {
         #expect(await coord.manualHibernate(terminalID: terminalID) == .ok)
         let parked = try #require(try await db.terminals.get(id: terminalID))
 
-        #expect(isWakeOk(await coord.wake(terminalID: terminalID)))
+        let wakeResult = await coord.wake(terminalID: terminalID)
+        #expect(wakeResult.isOk)
         let awake = try #require(try await db.terminals.get(id: terminalID))
+        #expect(wakeResult == .ok(sessionIncarnationID: awake.sessionIncarnationID))
         #expect(awake.sessionIncarnationID != parked.sessionIncarnationID)
         #expect(awake.tmuxWindowID == parked.tmuxWindowID)
         #expect(awake.tmuxPaneID == parked.tmuxPaneID)
@@ -1172,7 +1174,7 @@ struct HibernationCoordinatorTests {
         let coord = HibernationCoordinator(
             db: db, tmux: tmux, configDirManager: isolatedConfigDirManager(),
             actuationLog: makeTestActuationLog())
-        #expect(isWakeOk(await coord.wake(terminalID: terminalID)))
+        #expect((await coord.wake(terminalID: terminalID)).isOk)
         #expect(try await db.terminals.get(id: terminalID)?.isParked == false)
     }
 
@@ -1199,7 +1201,7 @@ struct HibernationCoordinatorTests {
         #expect(before?.suspendedAt != nil)
 
         let wake = await coordinator(db).wake(terminalID: terminalID)
-        #expect(isWakeOk(wake))
+        #expect(wake.isOk)
         let after = try await db.terminals.get(id: terminalID)
         #expect(after?.hibernatedAt == nil, "wake must clear hibernatedAt")
         #expect(after?.suspendedAt == nil, "wake must also clear legacy suspendedAt")
@@ -1223,7 +1225,7 @@ struct HibernationCoordinatorTests {
         #expect(before?.isParked == true)
 
         let wake = await coord.wake(terminalID: terminalID)
-        #expect(isWakeOk(wake), "wake must un-park a suspendedAt-only row, not no-op it")
+        #expect(wake.isOk, "wake must un-park a suspendedAt-only row, not no-op it")
         let after = try await db.terminals.get(id: terminalID)
         #expect(after?.isParked == false, "row fully un-parked (both columns nil)")
 
@@ -1332,7 +1334,7 @@ struct HibernationCoordinatorTests {
         await coord.setOnServerCreated { server in serverHookCalls.append([server]) }
 
         let wake = await coord.wake(terminalID: terminalID)
-        #expect(isWakeOk(wake))
+        #expect(wake.isOk)
         let after = try await db.terminals.get(id: terminalID)
         #expect(after?.isParked == false, "row must be un-parked")
         #expect(after?.tmuxWindowID == "@0", "live-window wake must keep the window id")
@@ -1365,7 +1367,7 @@ struct HibernationCoordinatorTests {
         await coord.setOnServerCreated { server in serverHookCalls.append([server]) }
 
         let wake = await coord.wake(terminalID: terminalID)
-        #expect(isWakeOk(wake))
+        #expect(wake.isOk)
         let after = try await db.terminals.get(id: terminalID)
         #expect(after?.isParked == false, "row must be un-parked")
         #expect(after?.tmuxWindowID == "@mock-0", "recreate must persist the new window id")
@@ -1440,7 +1442,7 @@ struct HibernationCoordinatorTests {
         #expect((await router.handle(staleHook)).success)
         #expect(try await db.terminals.get(id: terminalID)?.claudeSessionID == "sess-1")
         recorder.release()
-        #expect(isWakeOk(await wake.value))
+        #expect((await wake.value).isOk)
 
         let replacementHook = try RPCRequest(
             method: RPCMethod.terminalSessionEvent,
@@ -1499,7 +1501,7 @@ struct HibernationCoordinatorTests {
         #expect(try await db.terminals.get(id: terminalID)?.claudeSessionID == "sess-1")
 
         recorder.release()
-        #expect(isWakeOk(await wake.value))
+        #expect((await wake.value).isOk)
         let finalized = try #require(try await db.terminals.get(id: terminalID))
         #expect(!finalized.isParked)
         #expect(finalized.claudeSessionID == "sess-1")
@@ -1544,7 +1546,7 @@ struct HibernationCoordinatorTests {
         try await db.terminals.delete(id: terminalID)
         recorder.release()
 
-        #expect(!isWakeOk(await wake.value))
+        #expect(!(await wake.value).isOk)
         #expect(deltas.snapshot().isEmpty,
                 "a wake whose final durable marker clear failed must not broadcast success")
         let joined = recorder.snapshot().map { $0.joined(separator: " ") }
@@ -1578,7 +1580,7 @@ struct HibernationCoordinatorTests {
         let coord = HibernationCoordinator(db: db, tmux: tmux, configDirManager: isolatedConfigDirManager(), actuationLog: makeTestActuationLog())
 
         let wake = await coord.wake(terminalID: terminalID)
-        #expect(isWakeOk(wake))
+        #expect(wake.isOk)
         let after = try await db.terminals.get(id: terminalID)
         #expect(after?.isParked == false)
         #expect(after?.tmuxWindowID == "@mock-0", "collision must force a recreate with fresh ids")
@@ -1609,7 +1611,7 @@ struct HibernationCoordinatorTests {
         let coord = HibernationCoordinator(db: db, tmux: tmux, configDirManager: isolatedConfigDirManager(), actuationLog: makeTestActuationLog())
 
         let wake = await coord.wake(terminalID: terminalID)
-        #expect(isWakeOk(wake))
+        #expect(wake.isOk)
         let after = try await db.terminals.get(id: terminalID)
         #expect(after?.tmuxWindowID == "@0", "no collision → in-place respawn keeps the ids")
         #expect(after?.tmuxPaneID == "%0")
@@ -1674,7 +1676,7 @@ struct HibernationCoordinatorTests {
 
         let results = await [first.value, second.value]
         #expect(duplicateWasRejectedBeforeDatabaseRelease)
-        #expect(results.filter { isWakeOk($0) }.count == 1)
+        #expect(results.filter { $0.isOk }.count == 1)
         #expect(results.filter { $0 == .inFlight }.count == 1)
         let after = try #require(try await db.terminals.get(id: terminalID))
         #expect(after.sessionIncarnationID != parked.sessionIncarnationID)
@@ -1706,7 +1708,7 @@ struct HibernationCoordinatorTests {
             kind: .claude)
         try await db.terminals.setHibernated(
             id: terminalID, sessionID: "sess-retry")
-        #expect(isWakeOk(await subject.wake(terminalID: terminalID)))
+        #expect((await subject.wake(terminalID: terminalID)).isOk)
     }
 
     /// Two concurrent wakes, two parked terminals, SAME server, both windows
@@ -1731,8 +1733,8 @@ struct HibernationCoordinatorTests {
         async let wakeA = coord.wake(terminalID: terminalA)
         async let wakeB = coord.wake(terminalID: terminalB.id)
         let (resultA, resultB) = await (wakeA, wakeB)
-        #expect(isWakeOk(resultA))
-        #expect(isWakeOk(resultB))
+        #expect(resultA.isOk)
+        #expect(resultB.isOk)
 
         let afterA = try await db.terminals.get(id: terminalA)
         let afterB = try await db.terminals.get(id: terminalB.id)
@@ -1795,8 +1797,8 @@ struct HibernationCoordinatorTests {
         async let wakeA = coord.wake(terminalID: terminalA.id)
         async let wakeB = coord.wake(terminalID: terminalB.id)
         let (resultA, resultB) = await (wakeA, wakeB)
-        #expect(isWakeOk(resultA), "different servers must not serialize/deadlock each other")
-        #expect(isWakeOk(resultB), "different servers must not serialize/deadlock each other")
+        #expect(resultA.isOk, "different servers must not serialize/deadlock each other")
+        #expect(resultB.isOk, "different servers must not serialize/deadlock each other")
 
         let joined = recorded.snapshot().map { $0.joined(separator: " ") }
         #expect(joined.contains { $0.contains("new-window") && $0.contains("-L tbd-hib-a") },
@@ -1974,7 +1976,7 @@ struct HibernationCoordinatorTests {
         #expect(failed.claudeSessionID == "sess-1")
         #expect(failed.transcriptPath == "/tmp/live-wake-retry.jsonl")
 
-        #expect(isWakeOk(await coord.wake(terminalID: terminalID)))
+        #expect((await coord.wake(terminalID: terminalID)).isOk)
         let retried = try #require(try await db.terminals.get(id: terminalID))
         #expect(!retried.isParked)
         #expect(retried.claudeSessionID == "sess-1")
@@ -2014,7 +2016,7 @@ struct HibernationCoordinatorTests {
         #expect(failed.claudeSessionID == "sess-1")
         #expect(failed.transcriptPath == "/tmp/dead-wake-retry.jsonl")
 
-        #expect(isWakeOk(await coord.wake(terminalID: terminalID)))
+        #expect((await coord.wake(terminalID: terminalID)).isOk)
         let retried = try #require(try await db.terminals.get(id: terminalID))
         #expect(!retried.isParked)
         #expect(retried.claudeSessionID == "sess-1")
@@ -2052,7 +2054,7 @@ struct HibernationCoordinatorTests {
             actuationLog: makeTestActuationLog()
         )
         let wake = await coord.wake(terminalID: terminalID)
-        #expect(isWakeOk(wake))
+        #expect(wake.isOk)
 
         // `/tmp/hib-repo` munges to `-tmp-hib-repo` under the injected root.
         let derived = projects.appendingPathComponent("-tmp-hib-repo/sess-1.jsonl")
@@ -2107,7 +2109,7 @@ struct HibernationCoordinatorTests {
         let coord = coordinatorWithResolver(db)
         let wake = await coord.wake(terminalID: terminalID, allowDefaultProfileFallback: true)
 
-        #expect(isWakeOk(wake))
+        #expect(wake.isOk)
         let after = try await db.terminals.get(id: terminalID)
         #expect(after?.hibernatedAt == nil, "row must be un-parked")
     }
@@ -2125,7 +2127,7 @@ struct HibernationCoordinatorTests {
         let coord = coordinatorWithResolver(db)
         let wake = await coord.wake(terminalID: terminalID)
 
-        #expect(isWakeOk(wake))
+        #expect(wake.isOk)
         let after = try await db.terminals.get(id: terminalID)
         #expect(after?.hibernatedAt == nil, "row must be un-parked")
     }
@@ -2182,7 +2184,7 @@ struct HibernationCoordinatorTests {
         let commandCount = commands.snapshot().count
         keychainGate.release()
 
-        #expect(!isWakeOk(await wake.value))
+        #expect(!(await wake.value).isOk)
         let unchanged = try #require(try await db.terminals.get(id: terminalID))
         #expect(unchanged == swapped)
         #expect(commands.snapshot().count == commandCount,
@@ -2245,7 +2247,7 @@ struct HibernationCoordinatorTests {
             return
         }
 
-        #expect(isWakeOk(await coordinator.wake(terminalID: terminalID)))
+        #expect((await coordinator.wake(terminalID: terminalID)).isOk)
         let woken = try #require(try await db.terminals.get(id: terminalID))
         #expect(!woken.isParked)
         #expect(woken.profileID == oldProfile.id)
@@ -2275,7 +2277,7 @@ struct HibernationCoordinatorTests {
         let coord = coordinator(db)
         let wake = await coord.wake(terminalID: terminalID)
 
-        #expect(isWakeOk(wake), "without a resolver, no profile check fires")
+        #expect(wake.isOk, "without a resolver, no profile check fires")
         let after = try await db.terminals.get(id: terminalID)
         #expect(after?.hibernatedAt == nil)
     }
@@ -2456,7 +2458,7 @@ struct HibernationCoordinatorTests {
 
         _ = await coord.manualHibernate(terminalID: terminalID)
         let wake = await coord.wake(terminalID: terminalID)
-        #expect(isWakeOk(wake))
+        #expect(wake.isOk)
 
         let delta = recorder.snapshot().last
         #expect(delta?.hibernated == false)

--- a/Tests/TBDDaemonTests/Holder/HolderTmuxAssumptionGateTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HolderTmuxAssumptionGateTests.swift
@@ -826,7 +826,7 @@ struct HolderTmuxAssumptionGateTests {
             id: terminal.id, sessionID: "sess-holdergate", reason: .manual)
 
         let result = await coordinator(db, tmux: tmux).wake(terminalID: terminal.id)
-        #expect(result == .ok)
+        #expect(isWakeOk(result))
         #expect(try await db.terminals.get(id: terminal.id)?.isParked == false)
         #expect(!recorded.snapshot().isEmpty, "the tmux leg must still drive tmux")
     }
@@ -918,7 +918,7 @@ struct HolderTmuxAssumptionGateTests {
         let result = await coordinator(
             db, tmux: tmux, registry: registry, signaller: signaller)
             .wake(terminalID: terminal.id)
-        #expect(result == .ok,
+        #expect(result.isOk,
                 "a row parked over a live holder was not adopted")
 
         let after = try #require(try await db.terminals.get(id: terminal.id))
@@ -1005,7 +1005,7 @@ struct HolderTmuxAssumptionGateTests {
 
         let result = await coordinator(db, tmux: tmux, signaller: signaller)
             .wake(terminalID: terminal.id)
-        #expect(result == .ok)
+        #expect(result.isOk)
         #expect(try await db.terminals.get(id: terminal.id)?.isParked == false)
         #expect(!recorded.snapshot().isEmpty,
                 "the tmux leg must still drive tmux to wake a parked row")

--- a/Tests/TBDDaemonTests/Holder/HolderTmuxAssumptionGateTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HolderTmuxAssumptionGateTests.swift
@@ -826,7 +826,7 @@ struct HolderTmuxAssumptionGateTests {
             id: terminal.id, sessionID: "sess-holdergate", reason: .manual)
 
         let result = await coordinator(db, tmux: tmux).wake(terminalID: terminal.id)
-        #expect(isWakeOk(result))
+        #expect(result.isOk)
         #expect(try await db.terminals.get(id: terminal.id)?.isParked == false)
         #expect(!recorded.snapshot().isEmpty, "the tmux leg must still drive tmux")
     }

--- a/Tests/TBDDaemonTests/HolderCompositeSendRefusalTests.swift
+++ b/Tests/TBDDaemonTests/HolderCompositeSendRefusalTests.swift
@@ -96,16 +96,20 @@ struct HolderCompositeSendRefusalTests {
         #expect(body.hasSuffix("\nhello\r"))
     }
 
-    /// Same as above for a single image part, EXCEPT for the envelope: it
-    /// must carry none, regardless of disposition — Claude Code attaches an
-    /// image only when the paste is the bare quoted path and nothing else
-    /// (measured on 2.1.261), so a prefix ahead of it turns the path into
-    /// literal text and attaches nothing. `connection: nil` (unauthenticated,
-    /// requesting no suppression) is the harness's default, spelled out here
-    /// because this is exactly the disposition an envelope would otherwise
-    /// attach under — proving the exclusion is the image part's own rule, not
-    /// suppression having been granted.
-    @Test func aSingleImagePartSendToAHolderRowIsNotRefused() async throws {
+    /// **An image-only send that would carry an envelope is refused here.**
+    ///
+    /// The holder arm writes the whole message in ONE unwrapped write, and that
+    /// one write cannot carry both a dispatch envelope and a bare image path:
+    /// Claude Code attaches an image only when the whole paste is the quoted
+    /// path and nothing else (measured on 2.1.261), so prefixing it attaches
+    /// nothing — and dropping the envelope instead would let any local process
+    /// submit an unattributed user turn carrying an image. The tmux arm escapes
+    /// the dilemma by pasting the envelope separately; this transport has no
+    /// second write to give. PR #816's bracketed-paste wrapping lifts it.
+    ///
+    /// `connection: nil` (unauthenticated, asking for no suppression) is the
+    /// disposition an envelope attaches under.
+    @Test func anUnauthenticatedSingleImagePartSendToAHolderRowIsRefused() async throws {
         let recorder = HolderWriteRecorder()
         let harness = try await SendHarness.make(
             transport: .holder, holderDeliveryRecorder: { recorder.record($0) })
@@ -114,15 +118,72 @@ struct HolderCompositeSendRefusalTests {
                 terminalID: harness.terminal.id, submit: true, parts: [.imagePath("/tmp/a.png")]),
             actor: .app, connection: nil)
 
-        let error = response.error ?? ""
-        #expect(!error.contains("more than one part"))
-        #expect(!error.contains("newline"))
-        #expect(!error.contains("parts"))
-        #expect(response.success, "error was: \(error)")
+        #expect(!response.success)
+        let error = try #require(response.error)
+        #expect(error.contains("pty-holder"))
+        #expect(error.contains("image"))
+        #expect(recorder.writes.isEmpty, "nothing may be written")
+    }
+
+    /// The other branch: an authenticated connection that asked for suppression
+    /// carries no envelope, so the one write is the bare quoted path and the
+    /// image attaches exactly as it does on tmux.
+    @Test func anAuthenticatedSingleImagePartSendToAHolderRowIsDelivered() async throws {
+        let recorder = HolderWriteRecorder()
+        let harness = try await SendHarness.makeAuthenticated(
+            transport: .holder, holderDeliveryRecorder: { recorder.record($0) })
+        let response = try await harness.send(
+            TerminalSendParams(
+                terminalID: harness.terminal.id, submit: true,
+                parts: [.imagePath("/tmp/a.png")], envelope: .suppressed),
+            actor: .app, connection: SendHarness.AuthenticatedApp.connection)
+
+        #expect(response.success, "error was: \(response.error ?? "none")")
         #expect(recorder.writes.count == 1)
         let body = String(bytes: try #require(recorder.writes.first), encoding: .utf8) ?? ""
         #expect(!body.contains("<tbd-dispatch"))
         #expect(body == "'/tmp/a.png'\r")
+    }
+
+    /// A shell row carries no envelope whatever the disposition, so the same
+    /// image-only send goes through unauthenticated — the refusal above belongs
+    /// to the envelope that would otherwise have to share the write, not to
+    /// image parts as such.
+    @Test func anImageOnlySendToAHolderShellRowIsDelivered() async throws {
+        let recorder = HolderWriteRecorder()
+        let harness = try await SendHarness.make(
+            transport: .holder, kind: .shell,
+            holderDeliveryRecorder: { recorder.record($0) })
+        let response = try await harness.send(
+            TerminalSendParams(
+                terminalID: harness.terminal.id, submit: true, parts: [.imagePath("/tmp/a.png")]),
+            actor: .app, connection: nil)
+
+        #expect(response.success, "error was: \(response.error ?? "none")")
+        let body = String(bytes: try #require(recorder.writes.first), encoding: .utf8) ?? ""
+        #expect(body == "'/tmp/a.png'\r")
+    }
+
+    /// **The rail disposition is not the effective one.** An authenticated
+    /// suppression request must reach the holder arm too: before the fix
+    /// `performHolderSend` was handed the RAIL disposition, so a composer send
+    /// to a holder-backed row silently got the envelope the person asked to
+    /// speak without.
+    @Test func anAuthenticatedTextSendToAHolderRowCarriesNoEnvelope() async throws {
+        let recorder = HolderWriteRecorder()
+        let harness = try await SendHarness.makeAuthenticated(
+            transport: .holder, holderDeliveryRecorder: { recorder.record($0) })
+        let response = try await harness.send(
+            TerminalSendParams(
+                terminalID: harness.terminal.id, submit: true,
+                parts: [.text("hello")], envelope: .suppressed),
+            actor: .app, connection: SendHarness.AuthenticatedApp.connection)
+
+        #expect(response.success, "error was: \(response.error ?? "none")")
+        #expect(recorder.writes.count == 1)
+        let body = String(bytes: try #require(recorder.writes.first), encoding: .utf8) ?? ""
+        #expect(!body.contains("<tbd-dispatch"))
+        #expect(body == "hello\r")
     }
 
     /// A tmux row is untouched by any of it.

--- a/Tests/TBDDaemonTests/HolderCompositeSendRefusalTests.swift
+++ b/Tests/TBDDaemonTests/HolderCompositeSendRefusalTests.swift
@@ -42,18 +42,29 @@ struct HolderCompositeSendRefusalTests {
 
     /// A single-part, single-line message is exactly what the holder arm can
     /// carry today, and must still go through. Without this the suite could be
-    /// green on a refusal that rejects every holder send.
+    /// green on a refusal that rejects every holder send. Wired with the same
+    /// `holderDeliveryRecorder` seam the `.parts` tests below use, so this
+    /// asserts the exact bytes delivered rather than only "got past the gate".
     @Test func aSingleLineTextSendToAHolderRowIsNotRefused() async throws {
-        let harness = try await SendHarness.make(transport: .holder)
+        let recorder = HolderWriteRecorder()
+        let harness = try await SendHarness.make(
+            transport: .holder, holderDeliveryRecorder: { recorder.record($0) })
         let response = try await harness.send(TerminalSendParams(
             terminalID: harness.terminal.id, text: "hello", submit: true),
             actor: .app)
-        // A test daemon wires no injection courier, so this reaches the holder
-        // arm's own "no input path" refusal rather than succeeding — which is
-        // the point: it got PAST this rail.
+
         let error = response.error ?? ""
         #expect(!error.contains("more than one part"))
         #expect(!error.contains("newline"))
+        #expect(response.success, "error was: \(error)")
+        // `actor: .app` against a `.claude` row carries the dispatch envelope —
+        // mirroring the exact assertion `aSinglePartTextSendToAHolderRowIsNotRefused`
+        // makes for its single text part, since both paths converge on the same
+        // `deliverHolderText` call.
+        #expect(recorder.writes.count == 1)
+        let body = String(bytes: try #require(recorder.writes.first), encoding: .utf8) ?? ""
+        #expect(body.hasPrefix("<tbd-dispatch"))
+        #expect(body.hasSuffix("\nhello\r"))
     }
 
     /// A single-part `.parts` payload is exactly the remainder that reaches

--- a/Tests/TBDDaemonTests/HolderCompositeSendRefusalTests.swift
+++ b/Tests/TBDDaemonTests/HolderCompositeSendRefusalTests.swift
@@ -1,0 +1,73 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+import TBDShared
+
+/// Until bracketed-paste wrapping lands on the holder arm (PR #816), a
+/// multi-line or multi-part message to a holder-backed session is refused BY
+/// NAME rather than delivered and silently lost.
+///
+/// The measurement behind it, against 2.1.261 under a real pty: a single
+/// unwrapped write of 63 bytes submits, and a write of 64 bytes or more does not
+/// — the tokenizer splits control bytes into key events only while the pending
+/// chunk is under 64 bytes, so past that the carriage return is swallowed into
+/// the text and the whole string sits unsent in Claude's composer. Several
+/// deliveries instead of one would reopen the at-least-once and routing
+/// questions that one delivery avoids, so refusing is the honest answer.
+@Suite("holder composite send refusal")
+struct HolderCompositeSendRefusalTests {
+
+    @Test func aPartsSendToAHolderRowIsRefused() async throws {
+        let harness = try await SendHarness.make(transport: .holder)
+        let response = try await harness.send(TerminalSendParams(
+            terminalID: harness.terminal.id, submit: true,
+            parts: [.text("a"), .imagePath("/tmp/a.png")]),
+            actor: .app)
+
+        #expect(!response.success)
+        let error = try #require(response.error)
+        #expect(error.contains("pty-holder"))
+        #expect(error.contains("more than one part"))
+    }
+
+    @Test func aMultiLineTextSendToAHolderRowIsRefused() async throws {
+        let harness = try await SendHarness.make(transport: .holder)
+        let response = try await harness.send(TerminalSendParams(
+            terminalID: harness.terminal.id, text: "line one\nline two", submit: true),
+            actor: .app)
+
+        #expect(!response.success)
+        #expect(try #require(response.error).contains("newline"))
+    }
+
+    /// A single-part, single-line message is exactly what the holder arm can
+    /// carry today, and must still go through. Without this the suite could be
+    /// green on a refusal that rejects every holder send.
+    @Test func aSingleLineTextSendToAHolderRowIsNotRefused() async throws {
+        let harness = try await SendHarness.make(transport: .holder)
+        let response = try await harness.send(TerminalSendParams(
+            terminalID: harness.terminal.id, text: "hello", submit: true),
+            actor: .app)
+        // A test daemon wires no injection courier, so this reaches the holder
+        // arm's own "no input path" refusal rather than succeeding — which is
+        // the point: it got PAST this rail.
+        let error = response.error ?? ""
+        #expect(!error.contains("more than one part"))
+        #expect(!error.contains("newline"))
+    }
+
+    /// A tmux row is untouched by any of it.
+    @Test func aTmuxRowStillAcceptsMultiLineAndParts() async throws {
+        let harness = try await SendHarness.make(transport: .tmux)
+        let multiline = try await harness.send(TerminalSendParams(
+            terminalID: harness.terminal.id, text: "line one\nline two", submit: true),
+            actor: .app)
+        #expect(multiline.success, "error was: \(multiline.error ?? "none")")
+
+        let parts = try await harness.send(TerminalSendParams(
+            terminalID: harness.terminal.id, submit: true,
+            parts: [.text("a"), .imagePath("/tmp/a.png")]),
+            actor: .app)
+        #expect(parts.success, "error was: \(parts.error ?? "none")")
+    }
+}

--- a/Tests/TBDDaemonTests/HolderCompositeSendRefusalTests.swift
+++ b/Tests/TBDDaemonTests/HolderCompositeSendRefusalTests.swift
@@ -85,28 +85,33 @@ struct HolderCompositeSendRefusalTests {
         #expect(body.hasSuffix("\nhello\r"))
     }
 
-    /// Same as above for a single image part: delivered as the bare quoted
-    /// path — `RPCRouter.quotedImagePath` — the same bytes the tmux arm pastes.
+    /// Same as above for a single image part, EXCEPT for the envelope: it
+    /// must carry none, regardless of disposition — Claude Code attaches an
+    /// image only when the paste is the bare quoted path and nothing else
+    /// (measured on 2.1.261), so a prefix ahead of it turns the path into
+    /// literal text and attaches nothing. `connection: nil` (unauthenticated,
+    /// requesting no suppression) is the harness's default, spelled out here
+    /// because this is exactly the disposition an envelope would otherwise
+    /// attach under — proving the exclusion is the image part's own rule, not
+    /// suppression having been granted.
     @Test func aSingleImagePartSendToAHolderRowIsNotRefused() async throws {
         let recorder = HolderWriteRecorder()
         let harness = try await SendHarness.make(
             transport: .holder, holderDeliveryRecorder: { recorder.record($0) })
-        let response = try await harness.send(TerminalSendParams(
-            terminalID: harness.terminal.id, submit: true, parts: [.imagePath("/tmp/a.png")]),
-            actor: .app)
+        let response = try await harness.send(
+            TerminalSendParams(
+                terminalID: harness.terminal.id, submit: true, parts: [.imagePath("/tmp/a.png")]),
+            actor: .app, connection: nil)
 
         let error = response.error ?? ""
         #expect(!error.contains("more than one part"))
         #expect(!error.contains("newline"))
         #expect(!error.contains("parts"))
         #expect(response.success, "error was: \(error)")
-        // Same reasoning as the text case: a single-part `.parts` send is
-        // delivered exactly as the `.text` arm delivers a body, envelope
-        // included — unlike the tmux arm, which never envelopes an image part.
         #expect(recorder.writes.count == 1)
         let body = String(bytes: try #require(recorder.writes.first), encoding: .utf8) ?? ""
-        #expect(body.hasPrefix("<tbd-dispatch"))
-        #expect(body.hasSuffix("\n'/tmp/a.png'\r"))
+        #expect(!body.contains("<tbd-dispatch"))
+        #expect(body == "'/tmp/a.png'\r")
     }
 
     /// A tmux row is untouched by any of it.

--- a/Tests/TBDDaemonTests/HolderCompositeSendRefusalTests.swift
+++ b/Tests/TBDDaemonTests/HolderCompositeSendRefusalTests.swift
@@ -56,6 +56,59 @@ struct HolderCompositeSendRefusalTests {
         #expect(!error.contains("newline"))
     }
 
+    /// A single-part `.parts` payload is exactly the remainder that reaches
+    /// `performHolderSend`'s `.parts` arm once the composite gate above has
+    /// turned away anything bigger — and Fix round 1's ruling is that a single
+    /// text part is delivered the same way `--text` delivers a body. Modeled on
+    /// `aSingleLineTextSendToAHolderRowIsNotRefused`: SendHarness wires a real
+    /// (test-only) injection courier here, so this asserts the exact bytes
+    /// delivered rather than only "got past the gate".
+    @Test func aSinglePartTextSendToAHolderRowIsNotRefused() async throws {
+        let recorder = HolderWriteRecorder()
+        let harness = try await SendHarness.make(
+            transport: .holder, holderDeliveryRecorder: { recorder.record($0) })
+        let response = try await harness.send(TerminalSendParams(
+            terminalID: harness.terminal.id, submit: true, parts: [.text("hello")]),
+            actor: .app)
+
+        let error = response.error ?? ""
+        #expect(!error.contains("more than one part"))
+        #expect(!error.contains("newline"))
+        #expect(!error.contains("parts"))
+        #expect(response.success, "error was: \(error)")
+        // `actor: .app` against a `.claude` row carries the dispatch envelope,
+        // exactly as the `.text` arm's body would — this single-part `.parts`
+        // send is deliberately delivered the same way, envelope included.
+        #expect(recorder.writes.count == 1)
+        let body = String(bytes: try #require(recorder.writes.first), encoding: .utf8) ?? ""
+        #expect(body.hasPrefix("<tbd-dispatch"))
+        #expect(body.hasSuffix("\nhello\r"))
+    }
+
+    /// Same as above for a single image part: delivered as the bare quoted
+    /// path — `RPCRouter.quotedImagePath` — the same bytes the tmux arm pastes.
+    @Test func aSingleImagePartSendToAHolderRowIsNotRefused() async throws {
+        let recorder = HolderWriteRecorder()
+        let harness = try await SendHarness.make(
+            transport: .holder, holderDeliveryRecorder: { recorder.record($0) })
+        let response = try await harness.send(TerminalSendParams(
+            terminalID: harness.terminal.id, submit: true, parts: [.imagePath("/tmp/a.png")]),
+            actor: .app)
+
+        let error = response.error ?? ""
+        #expect(!error.contains("more than one part"))
+        #expect(!error.contains("newline"))
+        #expect(!error.contains("parts"))
+        #expect(response.success, "error was: \(error)")
+        // Same reasoning as the text case: a single-part `.parts` send is
+        // delivered exactly as the `.text` arm delivers a body, envelope
+        // included — unlike the tmux arm, which never envelopes an image part.
+        #expect(recorder.writes.count == 1)
+        let body = String(bytes: try #require(recorder.writes.first), encoding: .utf8) ?? ""
+        #expect(body.hasPrefix("<tbd-dispatch"))
+        #expect(body.hasSuffix("\n'/tmp/a.png'\r"))
+    }
+
     /// A tmux row is untouched by any of it.
     @Test func aTmuxRowStillAcceptsMultiLineAndParts() async throws {
         let harness = try await SendHarness.make(transport: .tmux)
@@ -69,5 +122,24 @@ struct HolderCompositeSendRefusalTests {
             parts: [.text("a"), .imagePath("/tmp/a.png")]),
             actor: .app)
         #expect(parts.success, "error was: \(parts.error ?? "none")")
+    }
+}
+
+/// Collects the bytes `SendHarness`'s stubbed `HolderInjectionCourier` was
+/// asked to write, when a test passes `holderDeliveryRecorder`. A lock-guarded
+/// class, matching `SendHarness.TmuxDouble`, because the courier's
+/// `writeDirectly` closure runs off the test's task.
+private final class HolderWriteRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _writes: [Data] = []
+    var writes: [Data] {
+        lock.lock()
+        defer { lock.unlock() }
+        return _writes
+    }
+    func record(_ bytes: Data) {
+        lock.lock()
+        defer { lock.unlock() }
+        _writes.append(bytes)
     }
 }

--- a/Tests/TBDDaemonTests/ModelProfileSpawnTests.swift
+++ b/Tests/TBDDaemonTests/ModelProfileSpawnTests.swift
@@ -1421,7 +1421,7 @@ struct ModelProfileSpawnTests {
         // Now wake via the unified coordinator (the router's own instance).
         let beforeWake = recorder.calls.count
         let wakeResult = await router.hibernationCoordinator.wake(terminalID: term.id)
-        #expect(wakeResult == .ok)
+        #expect(isWakeOk(wakeResult))
 
         let postWake = Array(recorder.calls.dropFirst(beforeWake))
         let joined = postWake.map { $0.joined(separator: " ") }.joined(separator: "\n")

--- a/Tests/TBDDaemonTests/ModelProfileSpawnTests.swift
+++ b/Tests/TBDDaemonTests/ModelProfileSpawnTests.swift
@@ -1421,7 +1421,7 @@ struct ModelProfileSpawnTests {
         // Now wake via the unified coordinator (the router's own instance).
         let beforeWake = recorder.calls.count
         let wakeResult = await router.hibernationCoordinator.wake(terminalID: term.id)
-        #expect(isWakeOk(wakeResult))
+        #expect(wakeResult.isOk)
 
         let postWake = Array(recorder.calls.dropFirst(beforeWake))
         let joined = postWake.map { $0.joined(separator: " ") }.joined(separator: "\n")

--- a/Tests/TBDDaemonTests/OrphanGCAttachmentsTests.swift
+++ b/Tests/TBDDaemonTests/OrphanGCAttachmentsTests.swift
@@ -192,6 +192,31 @@ struct OrphanGCAttachmentsTests {
         #expect(result.reaped >= 1)
     }
 
+    /// A bare-UUID top-level *file* (not a directory) must not be classified as
+    /// an orphan directory. Before this fix, `decide` read its
+    /// `contentsOfDirectory` as empty and reaped it as though it were an empty
+    /// orphan — `candidates()` must filter it out before `decide` ever sees it,
+    /// matching `HolderRendezvousCollector.candidates()`'s node-type rejection.
+    @Test func aBareUUIDFileIsNotAnAttachmentsCandidate() async throws {
+        let (home, restore) = isolateTBDHome()
+        defer { restore() }
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setTranscriptComposerEnabled(true)
+        let strayID = UUID()
+        let strayFile = TBDConstants.attachmentsDir.appendingPathComponent(strayID.uuidString)
+        try fm.createDirectory(
+            at: TBDConstants.attachmentsDir, withIntermediateDirectories: true)
+        fm.createFile(atPath: strayFile.path, contents: Data([0x89, 0x50, 0x4E, 0x47]))
+        let stamp = clock.addingTimeInterval(-30 * 86_400)
+        try? fm.setAttributes(
+            [.creationDate: stamp, .modificationDate: stamp], ofItemAtPath: strayFile.path)
+
+        let result = await makeGC(db: db, home: home).sweep()
+
+        #expect(fm.fileExists(atPath: strayFile.path), "a bare-UUID file must survive the sweep")
+        #expect(!result.planned.contains { $0.contains(strayFile.path) })
+    }
+
     // MARK: - The flag
 
     /// With the flag off the leg does nothing in a real sweep — the whole
@@ -224,6 +249,44 @@ struct OrphanGCAttachmentsTests {
         #expect(fm.fileExists(atPath: path), "a dry run must never touch disk")
         #expect(result.planned.contains { $0.hasPrefix("REAP attachments") })
         #expect(result.reaped == 0)
+    }
+
+    // MARK: - The injected base seam
+
+    /// Exercises `OrphanGC`'s `attachmentsBase:` seam directly: a base under the
+    /// fenced scratch root, distinct from (and outside) the isolated `TBD_HOME`
+    /// this suite otherwise sets — proof the collector honors the injected base
+    /// rather than falling back to `TBDConstants.attachmentsDir`.
+    @Test func attachmentsBaseSeamIsHonoredIndependentlyOfTBDHome() async throws {
+        let (home, restore) = isolateTBDHome()
+        defer { restore() }
+        let attachmentsBase = URL(fileURLWithPath: fencedScratchRoot(prefix: "tbdgcaatt"))
+        try fm.createDirectory(at: attachmentsBase, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: attachmentsBase) }
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setTranscriptComposerEnabled(true)
+        let orphan = UUID()
+        let orphanDir = attachmentsBase.appendingPathComponent(orphan.uuidString)
+        try fm.createDirectory(at: orphanDir, withIntermediateDirectories: true)
+        let file = orphanDir.appendingPathComponent("x.png")
+        fm.createFile(atPath: file.path, contents: Data([0x89, 0x50, 0x4E, 0x47]))
+        let stamp = clock.addingTimeInterval(-30 * 86_400)
+        try? fm.setAttributes(
+            [.creationDate: stamp, .modificationDate: stamp], ofItemAtPath: file.path)
+        let fixed = clock
+
+        let gc = OrphanGC(
+            db: db, git: GitManager(), broadcast: { _ in }, liveCWDsProvider: { [] },
+            scratchpadBase: home.appendingPathComponent("s", isDirectory: true),
+            now: { fixed },
+            profileDirBase: home.appendingPathComponent("p", isDirectory: true),
+            holdersBase: home.appendingPathComponent("h", isDirectory: true),
+            attachmentsBase: attachmentsBase)
+        let result = await gc.sweep()
+
+        #expect(!fm.fileExists(atPath: orphanDir.path))
+        #expect(result.planned.contains { $0.hasPrefix("REAP attachments") })
+        #expect(result.reaped >= 1)
     }
 }
 

--- a/Tests/TBDDaemonTests/OrphanGCAttachmentsTests.swift
+++ b/Tests/TBDDaemonTests/OrphanGCAttachmentsTests.swift
@@ -173,6 +173,74 @@ struct OrphanGCAttachmentsTests {
         #expect(result.planned.contains("KEEP rows-unreadable attachments"))
     }
 
+    /// **An unreadable directory is not an empty one.** Reading its contents
+    /// through `try?` made a directory the sweep cannot open look like a
+    /// directory with nothing in it — and an empty orphan is reapable, so a
+    /// permissions problem destroyed the images it was hiding.
+    @Test func anUnreadableOrphanDirectoryIsKept() async throws {
+        let (home, restore) = isolateTBDHome()
+        defer { restore() }
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setTranscriptComposerEnabled(true)
+        let orphan = UUID()
+        let path = stage(orphan)
+        let directory = TBDConstants.attachmentsDir(worktreeID: orphan)
+        try fm.setAttributes([.posixPermissions: 0o000], ofItemAtPath: directory.path)
+        // Restored before teardown removes the tree: a mode-000 directory cannot
+        // be emptied, so leaving it would leak the fixture.
+        defer {
+            try? fm.setAttributes([.posixPermissions: 0o755], ofItemAtPath: directory.path)
+        }
+
+        let result = await makeGC(db: db, home: home).sweep()
+
+        // Readable again before the assertions: `fileExists` on the staged file
+        // needs execute permission on its parent, which is what the fixture took
+        // away.
+        try fm.setAttributes([.posixPermissions: 0o755], ofItemAtPath: directory.path)
+        #expect(fm.fileExists(atPath: directory.path))
+        #expect(fm.fileExists(atPath: path))
+        #expect(result.planned.contains { $0.hasPrefix("KEEP contents-unreadable") })
+    }
+
+    /// An EMPTY orphan directory gets the floor too. It has nothing in it to age,
+    /// so its own mtime is the age — and a directory created moments ago is a
+    /// composer somebody has open, whose first image has not landed yet.
+    @Test func anEmptyOrphanYoungerThanTheFloorIsKept() async throws {
+        let (home, restore) = isolateTBDHome()
+        defer { restore() }
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setTranscriptComposerEnabled(true)
+        let orphan = UUID()
+        let directory = TBDConstants.attachmentsDir(worktreeID: orphan)
+        try fm.createDirectory(at: directory, withIntermediateDirectories: true)
+        let stamp = clock.addingTimeInterval(-3 * 86_400)
+        try fm.setAttributes([.modificationDate: stamp], ofItemAtPath: directory.path)
+
+        let result = await makeGC(db: db, home: home).sweep()
+
+        #expect(fm.fileExists(atPath: directory.path))
+        #expect(result.planned.contains { $0.hasPrefix("KEEP younger-than-floor") })
+    }
+
+    /// The discriminating other half: past the floor, an empty orphan goes.
+    @Test func anEmptyOrphanOlderThanTheFloorIsReaped() async throws {
+        let (home, restore) = isolateTBDHome()
+        defer { restore() }
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setTranscriptComposerEnabled(true)
+        let orphan = UUID()
+        let directory = TBDConstants.attachmentsDir(worktreeID: orphan)
+        try fm.createDirectory(at: directory, withIntermediateDirectories: true)
+        let stamp = clock.addingTimeInterval(-30 * 86_400)
+        try fm.setAttributes([.modificationDate: stamp], ofItemAtPath: directory.path)
+
+        let result = await makeGC(db: db, home: home).sweep()
+
+        #expect(!fm.fileExists(atPath: directory.path))
+        #expect(result.planned.contains { $0.hasPrefix("REAP attachments") })
+    }
+
     // MARK: - Reaps
 
     @Test func anOldOrphanIsReaped() async throws {
@@ -287,6 +355,41 @@ struct OrphanGCAttachmentsTests {
         #expect(!fm.fileExists(atPath: orphanDir.path))
         #expect(result.planned.contains { $0.hasPrefix("REAP attachments") })
         #expect(result.reaped >= 1)
+    }
+
+    /// The EVENT-DRIVEN half must read the same seam as the hourly one. It
+    /// re-resolved `TBDConstants.attachmentsDir` per call while the sweep cached
+    /// its base at init, so an injected base governed one of the pair and not
+    /// the other — and a test could green on a directory the archive path never
+    /// looked at.
+    @Test func removedWorktreeCleanupHonorsTheInjectedAttachmentsBase() async throws {
+        let (home, restore) = isolateTBDHome()
+        defer { restore() }
+        let attachmentsBase = URL(fileURLWithPath: fencedScratchRoot(prefix: "tbdgcaevt"))
+        try fm.createDirectory(at: attachmentsBase, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: attachmentsBase) }
+        let db = try TBDDatabase(inMemory: true)
+        let worktreeID = UUID()
+        let injected = attachmentsBase.appendingPathComponent(worktreeID.uuidString)
+        try fm.createDirectory(at: injected, withIntermediateDirectories: true)
+        fm.createFile(
+            atPath: injected.appendingPathComponent("x.png").path,
+            contents: Data([0x89, 0x50, 0x4E, 0x47]))
+        let fixed = clock
+
+        let gc = OrphanGC(
+            db: db, git: GitManager(), broadcast: { _ in }, liveCWDsProvider: { [] },
+            scratchpadBase: home.appendingPathComponent("s", isDirectory: true),
+            now: { fixed },
+            profileDirBase: home.appendingPathComponent("p", isDirectory: true),
+            holdersBase: home.appendingPathComponent("h", isDirectory: true),
+            attachmentsBase: attachmentsBase)
+        await gc.removedWorktreeCleanup(
+            worktreeID: worktreeID,
+            worktreePath: "/tmp/acme/tbd/worktrees/gone-\(worktreeID.uuidString)",
+            repoPath: "/tmp/acme/tbd")
+
+        #expect(!fm.fileExists(atPath: injected.path), "the injected base governs both halves")
     }
 }
 

--- a/Tests/TBDDaemonTests/OrphanGCAttachmentsTests.swift
+++ b/Tests/TBDDaemonTests/OrphanGCAttachmentsTests.swift
@@ -1,0 +1,230 @@
+import Foundation
+import GRDB
+import Testing
+import TestSupport
+@testable import TBDDaemonLib
+import TBDShared
+
+// Nested under TBDHomeSerialized for the same reason the archive suite is: the
+// leg walks `TBDConstants.attachmentsDir`, which resolves the process-global
+// TBD_HOME. See TBDHomeSerializedSuites.swift.
+extension TBDHomeSerialized {
+
+/// The hourly half of the attachments reconciler pair.
+///
+/// Every branch fails toward KEEPING, because the two mistakes are not
+/// symmetric: a leaked image is a few hundred kilobytes a later sweep still
+/// finds, while a wrong reap destroys something a person staged for a message
+/// they have not sent yet.
+///
+/// Tier 2: a real temp tree under an isolated TBD_HOME, an in-memory database,
+/// a fixed clock.
+@Suite("OrphanGC reclaims composer attachments")
+struct OrphanGCAttachmentsTests {
+    private let fm = FileManager.default
+    /// The sweep's fixed reading of now. Every fixture's age is expressed
+    /// against it, so nothing here depends on wall-clock time.
+    private let clock = Date(timeIntervalSince1970: 1_800_000_000)
+
+    /// The fake home goes under the run's fenced scratch root, not
+    /// `fm.temporaryDirectory` — `scripts/test.sh` reclaims the former even when
+    /// the test process is killed, and does not fence the latter at all.
+    private func isolateTBDHome() -> (URL, () -> Void) {
+        let home = URL(fileURLWithPath: fencedScratchRoot(prefix: "tbdgca"))
+        try? fm.createDirectory(at: home, withIntermediateDirectories: true)
+        let prior = setTBDHome(home.path)
+        return (home, {
+            restoreTBDHome(prior)
+            try? FileManager.default.removeItem(at: home)
+        })
+    }
+
+    private func makeGC(db: TBDDatabase, home: URL) -> OrphanGC {
+        let fixed = clock
+        return OrphanGC(
+            db: db, git: GitManager(),
+            broadcast: { _ in },
+            liveCWDsProvider: { [] },
+            scratchpadBase: home.appendingPathComponent("s", isDirectory: true),
+            now: { fixed },
+            profileDirBase: home.appendingPathComponent("p", isDirectory: true),
+            holdersBase: home.appendingPathComponent("h", isDirectory: true))
+    }
+
+    /// Writes one attachment and backdates it, so the 14-day floor has elapsed
+    /// against this suite's fixed clock unless the caller asks otherwise.
+    @discardableResult
+    private func stage(_ worktreeID: UUID, ageDays: Double = 30) -> String {
+        let path = TBDConstants.attachmentPath(
+            worktreeID: worktreeID, attachmentID: UUID())
+        try? fm.createDirectory(
+            at: URL(fileURLWithPath: path).deletingLastPathComponent(),
+            withIntermediateDirectories: true)
+        fm.createFile(atPath: path, contents: Data([0x89, 0x50, 0x4E, 0x47]))
+        let stamp = clock.addingTimeInterval(-ageDays * 86_400)
+        try? fm.setAttributes(
+            [.creationDate: stamp, .modificationDate: stamp], ofItemAtPath: path)
+        return path
+    }
+
+    /// A live worktree row whose id this suite chooses, so the attachments
+    /// directory it stages can be named after it.
+    private func insertWorktree(_ db: TBDDatabase, id: UUID) async throws {
+        try await db.writerForTests.write { conn in
+            try WorktreeRecord(from: Worktree(
+                id: id, repoID: nil, name: "wt", displayName: "wt", branch: "",
+                path: "/tmp/tbd-nonexistent-\(id.uuidString)",
+                status: .active, tmuxServer: "tbd-test", sortOrder: 1)).insert(conn)
+        }
+    }
+
+    // MARK: - Keeps
+
+    @Test func aLiveWorktreesAttachmentsAreKept() async throws {
+        let (home, restore) = isolateTBDHome()
+        defer { restore() }
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setTranscriptComposerEnabled(true)
+        let worktreeID = UUID()
+        try await insertWorktree(db, id: worktreeID)
+        let path = stage(worktreeID)
+
+        let result = await makeGC(db: db, home: home).sweep()
+
+        #expect(fm.fileExists(atPath: path))
+        #expect(result.planned.contains { $0.hasPrefix("KEEP live-worktree") })
+    }
+
+    /// An archived row is still a row: the archive path's own unlink is what
+    /// handles it, so this leg must read every status rather than only `.active`
+    /// and reap a directory out from under a worktree somebody can still revive.
+    @Test func anArchivedWorktreesAttachmentsAreKept() async throws {
+        let (home, restore) = isolateTBDHome()
+        defer { restore() }
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setTranscriptComposerEnabled(true)
+        let worktreeID = UUID()
+        try await db.writerForTests.write { conn in
+            try WorktreeRecord(from: Worktree(
+                id: worktreeID, repoID: nil, name: "wt", displayName: "wt", branch: "",
+                path: "/tmp/tbd-nonexistent-\(worktreeID.uuidString)",
+                status: .archived, tmuxServer: "tbd-test", sortOrder: 1)).insert(conn)
+        }
+        let path = stage(worktreeID)
+
+        let result = await makeGC(db: db, home: home).sweep()
+
+        #expect(fm.fileExists(atPath: path))
+        #expect(result.planned.contains { $0.hasPrefix("KEEP live-worktree") })
+    }
+
+    /// A directory whose name is not a UUID was put there by a human or by a
+    /// future feature. Classifying it under a rule that never considered it is
+    /// exactly the mistake this leg must not make.
+    @Test func aNonUUIDDirectoryIsKept() async throws {
+        let (home, restore) = isolateTBDHome()
+        defer { restore() }
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setTranscriptComposerEnabled(true)
+        let stray = TBDConstants.attachmentsDir.appendingPathComponent("notes-i-kept")
+        try fm.createDirectory(at: stray, withIntermediateDirectories: true)
+        fm.createFile(atPath: stray.appendingPathComponent("x.png").path, contents: Data())
+
+        let result = await makeGC(db: db, home: home).sweep()
+
+        #expect(fm.fileExists(atPath: stray.path))
+        #expect(result.planned.contains { $0.hasPrefix("KEEP not-a-worktree-id") })
+    }
+
+    /// The floor: an image staged for a message somebody has not sent yet.
+    @Test func anOrphanYoungerThanTheFloorIsKept() async throws {
+        let (home, restore) = isolateTBDHome()
+        defer { restore() }
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setTranscriptComposerEnabled(true)
+        let path = stage(UUID(), ageDays: 3)
+
+        let result = await makeGC(db: db, home: home).sweep()
+
+        #expect(fm.fileExists(atPath: path))
+        #expect(result.planned.contains { $0.hasPrefix("KEEP younger-than-floor") })
+    }
+
+    /// **Skip the whole leg on a failed database read**, never read an empty row
+    /// list as "no worktree is live" and reap everything.
+    ///
+    /// The worktree table is dropped rather than the whole database closed,
+    /// deliberately: closing would fail `sweep`'s own opening `config.get()` and
+    /// the test would pass without this leg ever running. Dropping one table
+    /// leaves every earlier read working and fails exactly the read under test.
+    @Test func anUnreadableWorktreeListSkipsTheLeg() async throws {
+        let (home, restore) = isolateTBDHome()
+        defer { restore() }
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setTranscriptComposerEnabled(true)
+        let path = stage(UUID())
+
+        try await db.writerForTests.write { conn in
+            try conn.execute(sql: "DROP TABLE worktree")
+        }
+        let result = await makeGC(db: db, home: home).sweep()
+
+        #expect(fm.fileExists(atPath: path), "a failed read must reap nothing")
+        #expect(result.planned.contains("KEEP rows-unreadable attachments"))
+    }
+
+    // MARK: - Reaps
+
+    @Test func anOldOrphanIsReaped() async throws {
+        let (home, restore) = isolateTBDHome()
+        defer { restore() }
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setTranscriptComposerEnabled(true)
+        let orphan = UUID()
+        let path = stage(orphan)
+
+        let result = await makeGC(db: db, home: home).sweep()
+
+        #expect(!fm.fileExists(atPath: path))
+        #expect(!fm.fileExists(
+            atPath: TBDConstants.attachmentsDir(worktreeID: orphan).path))
+        #expect(result.planned.contains { $0.hasPrefix("REAP attachments") })
+        #expect(result.reaped >= 1)
+    }
+
+    // MARK: - The flag
+
+    /// With the flag off the leg does nothing in a real sweep — the whole
+    /// feature is inert, and a sweep that reclaimed for it would be acting on a
+    /// feature nobody turned on.
+    @Test func theFlagOffLeavesEverythingAlone() async throws {
+        let (home, restore) = isolateTBDHome()
+        defer { restore() }
+        let db = try TBDDatabase(inMemory: true)
+        let path = stage(UUID())
+
+        let result = await makeGC(db: db, home: home).sweep()
+
+        #expect(fm.fileExists(atPath: path))
+        #expect(!result.planned.contains { $0.contains("attachments") })
+    }
+
+    /// `dryRun` bypasses the flag, exactly as it bypasses `gcEnabled`: someone
+    /// deciding whether to turn a default-off flag on needs to see what it would
+    /// reclaim first. It plans and touches nothing.
+    @Test func aDryRunPlansWithTheFlagOffAndUnlinksNothing() async throws {
+        let (home, restore) = isolateTBDHome()
+        defer { restore() }
+        let db = try TBDDatabase(inMemory: true)
+        let orphan = UUID()
+        let path = stage(orphan)
+
+        let result = await makeGC(db: db, home: home).sweep(dryRun: true)
+
+        #expect(fm.fileExists(atPath: path), "a dry run must never touch disk")
+        #expect(result.planned.contains { $0.hasPrefix("REAP attachments") })
+        #expect(result.reaped == 0)
+    }
+}
+
+}

--- a/Tests/TBDDaemonTests/OrphanGCAttachmentsTests.swift
+++ b/Tests/TBDDaemonTests/OrphanGCAttachmentsTests.swift
@@ -67,6 +67,24 @@ struct OrphanGCAttachmentsTests {
         return path
     }
 
+    /// The path as a plan line spells it. The sweep reaches every node through
+    /// `contentsOfDirectory`, which hands back the resolved `/private/tmp` form,
+    /// while `TBDConstants` composes the `/tmp` symlink — so a raw comparison
+    /// never matches and a negative one passes for the wrong reason.
+    ///
+    /// `realpath`, not `resolvingSymlinksInPath`: the Foundation call strips a
+    /// leading `/private` back off by design, which is the very difference this
+    /// has to erase. The parent is resolved and the last component appended, so
+    /// it answers for a file the sweep has already unlinked.
+    private func planPath(_ path: String) -> String {
+        let url = URL(fileURLWithPath: path)
+        guard let resolved = realpath(url.deletingLastPathComponent().path, nil) else {
+            return path
+        }
+        defer { free(resolved) }
+        return String(cString: resolved) + "/" + url.lastPathComponent
+    }
+
     /// A live worktree row whose id this suite chooses, so the attachments
     /// directory it stages can be named after it.
     private func insertWorktree(_ db: TBDDatabase, id: UUID) async throws {
@@ -80,6 +98,9 @@ struct OrphanGCAttachmentsTests {
 
     // MARK: - Keeps
 
+    /// The directory of a worktree row that still exists is never removed. The
+    /// files inside it age individually — see the per-file pair below — so this
+    /// stages one the floor has not reached.
     @Test func aLiveWorktreesAttachmentsAreKept() async throws {
         let (home, restore) = isolateTBDHome()
         defer { restore() }
@@ -87,7 +108,7 @@ struct OrphanGCAttachmentsTests {
         try await db.config.setTranscriptComposerEnabled(true)
         let worktreeID = UUID()
         try await insertWorktree(db, id: worktreeID)
-        let path = stage(worktreeID)
+        let path = stage(worktreeID, ageDays: 1)
 
         let result = await makeGC(db: db, home: home).sweep()
 
@@ -98,6 +119,7 @@ struct OrphanGCAttachmentsTests {
     /// An archived row is still a row: the archive path's own unlink is what
     /// handles it, so this leg must read every status rather than only `.active`
     /// and reap a directory out from under a worktree somebody can still revive.
+    /// Its file is younger than the floor, so the per-file rule leaves it too.
     @Test func anArchivedWorktreesAttachmentsAreKept() async throws {
         let (home, restore) = isolateTBDHome()
         defer { restore() }
@@ -110,7 +132,7 @@ struct OrphanGCAttachmentsTests {
                 path: "/tmp/tbd-nonexistent-\(worktreeID.uuidString)",
                 status: .archived, tmuxServer: "tbd-test", sortOrder: 1)).insert(conn)
         }
-        let path = stage(worktreeID)
+        let path = stage(worktreeID, ageDays: 1)
 
         let result = await makeGC(db: db, home: home).sweep()
 
@@ -283,6 +305,77 @@ struct OrphanGCAttachmentsTests {
 
         #expect(fm.fileExists(atPath: strayFile.path), "a bare-UUID file must survive the sweep")
         #expect(!result.planned.contains { $0.contains(strayFile.path) })
+    }
+
+    // MARK: - Files inside a live worktree
+
+    /// The per-file rule: inside a directory whose row still lives, a staged
+    /// file past the floor goes on its own while the directory and everything
+    /// younger stay. A staged image is read at paste time, or at resume time on
+    /// the wake path, so it is needed for minutes — a two-week-old one is spent.
+    @Test func aStaleFileInALiveWorktreeIsReapedWhileTheDirectoryStays() async throws {
+        let (home, restore) = isolateTBDHome()
+        defer { restore() }
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setTranscriptComposerEnabled(true)
+        let worktreeID = UUID()
+        try await insertWorktree(db, id: worktreeID)
+        let old = stage(worktreeID, ageDays: 30)
+        let young = stage(worktreeID, ageDays: 1)
+        let directory = TBDConstants.attachmentsDir(worktreeID: worktreeID)
+
+        let result = await makeGC(db: db, home: home).sweep()
+
+        #expect(!fm.fileExists(atPath: old), "a file past the floor goes")
+        #expect(fm.fileExists(atPath: young), "a file the floor has not reached stays")
+        #expect(fm.fileExists(atPath: directory.path), "the directory outlives its files")
+        #expect(result.planned.contains(
+            "REAP attachments \(planPath(old)) live-worktree-file-past-floor"))
+        #expect(result.planned.contains("KEEP younger-than-floor \(planPath(young))"))
+        #expect(result.planned.contains("KEEP live-worktree \(planPath(directory.path))"))
+        #expect(result.reaped == 1)
+    }
+
+    /// The dry run plans the per-file reap and touches nothing, the same way it
+    /// does for an orphan directory.
+    @Test func aDryRunPlansALiveWorktreesStaleFileWithoutUnlinkingIt() async throws {
+        let (home, restore) = isolateTBDHome()
+        defer { restore() }
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setTranscriptComposerEnabled(true)
+        let worktreeID = UUID()
+        try await insertWorktree(db, id: worktreeID)
+        let old = stage(worktreeID, ageDays: 30)
+
+        let result = await makeGC(db: db, home: home).sweep(dryRun: true)
+
+        #expect(fm.fileExists(atPath: old), "a dry run must never touch disk")
+        #expect(result.planned.contains(
+            "REAP attachments \(planPath(old)) live-worktree-file-past-floor"))
+        #expect(result.reaped == 0)
+    }
+
+    /// Only regular files age. A subdirectory somebody or some later feature
+    /// put inside a live worktree's directory is not a staged image, so no rule
+    /// here classifies it.
+    @Test func aNonRegularEntryInALiveWorktreeIsIgnored() async throws {
+        let (home, restore) = isolateTBDHome()
+        defer { restore() }
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setTranscriptComposerEnabled(true)
+        let worktreeID = UUID()
+        try await insertWorktree(db, id: worktreeID)
+        let nested = TBDConstants.attachmentsDir(worktreeID: worktreeID)
+            .appendingPathComponent("nested", isDirectory: true)
+        try fm.createDirectory(at: nested, withIntermediateDirectories: true)
+        let stamp = clock.addingTimeInterval(-30 * 86_400)
+        try fm.setAttributes([.modificationDate: stamp], ofItemAtPath: nested.path)
+
+        let result = await makeGC(db: db, home: home).sweep()
+
+        #expect(fm.fileExists(atPath: nested.path))
+        #expect(!result.planned.contains { $0.contains(planPath(nested.path)) })
+        #expect(result.reaped == 0)
     }
 
     // MARK: - The flag

--- a/Tests/TBDDaemonTests/OrphanGCTests.swift
+++ b/Tests/TBDDaemonTests/OrphanGCTests.swift
@@ -520,7 +520,8 @@ struct OrphanGCTests {
         let broadcaster = BroadcastDeltas()
         let gc = makeGC(db: db, git: GitManager(), broadcaster: broadcaster, scratchpadBase: base)
 
-        await gc.scratchpadCleanup(forRemovedWorktreePath: worktreePath, repoPath: "/Users/chang/tbd")
+        await gc.removedWorktreeCleanup(
+            worktreeID: UUID(), worktreePath: worktreePath, repoPath: "/Users/chang/tbd")
 
         #expect(!FileManager.default.fileExists(atPath: scratchDir.path))
         let records = try await db.reapRecords.list(repoPath: nil)
@@ -555,7 +556,8 @@ struct OrphanGCTests {
         let broadcaster = BroadcastDeltas()
         let gc = makeGC(db: db, git: GitManager(), broadcaster: broadcaster, scratchpadBase: base)
 
-        await gc.scratchpadCleanup(forRemovedWorktreePath: worktreeDir.path, repoPath: "/Users/chang/tbd")
+        await gc.removedWorktreeCleanup(
+            worktreeID: UUID(), worktreePath: worktreeDir.path, repoPath: "/Users/chang/tbd")
 
         #expect(FileManager.default.fileExists(atPath: scratchDir.path),
                 "worktree dir still on disk — the removal must have failed, so the scratchpad stays intact")
@@ -683,7 +685,8 @@ struct OrphanGCTests {
         let broadcaster = BroadcastDeltas()
         let gc = makeGC(db: db, git: GitManager(), broadcaster: broadcaster, scratchpadBase: base)
 
-        await gc.scratchpadCleanup(forRemovedWorktreePath: worktreePath, repoPath: "/Users/chang/tbd")
+        await gc.removedWorktreeCleanup(
+            worktreeID: UUID(), worktreePath: worktreePath, repoPath: "/Users/chang/tbd")
 
         #expect(FileManager.default.fileExists(atPath: scratchDir.path),
                 "the gcEnabled master switch must suppress event-driven deletion too")

--- a/Tests/TBDDaemonTests/OrphanGCTests.swift
+++ b/Tests/TBDDaemonTests/OrphanGCTests.swift
@@ -510,7 +510,7 @@ struct OrphanGCTests {
         try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: sandbox) }
 
-        let worktreePath = "/Users/chang/tbd/worktrees/removed-wt"
+        let worktreePath = "/tmp/acme/tbd/worktrees/removed-wt"
         let slug = ScratchpadCollector.slug(forWorktreePath: worktreePath)
         let scratchDir = base.appendingPathComponent(slug)
         try FileManager.default.createDirectory(at: scratchDir, withIntermediateDirectories: true)
@@ -521,13 +521,13 @@ struct OrphanGCTests {
         let gc = makeGC(db: db, git: GitManager(), broadcaster: broadcaster, scratchpadBase: base)
 
         await gc.removedWorktreeCleanup(
-            worktreeID: UUID(), worktreePath: worktreePath, repoPath: "/Users/chang/tbd")
+            worktreeID: UUID(), worktreePath: worktreePath, repoPath: "/tmp/acme/tbd")
 
         #expect(!FileManager.default.fileExists(atPath: scratchDir.path))
         let records = try await db.reapRecords.list(repoPath: nil)
         #expect(records.count == 1)
         #expect(records.first?.kind == .scratchpad)
-        #expect(records.first?.repoPath == "/Users/chang/tbd", "event path must stamp the caller's repoPath")
+        #expect(records.first?.repoPath == "/tmp/acme/tbd", "event path must stamp the caller's repoPath")
 
         let deltas = broadcaster.snapshot()
         #expect(deltas.contains { if case .reapRecordsChanged = $0 { return true }; return false })
@@ -557,7 +557,7 @@ struct OrphanGCTests {
         let gc = makeGC(db: db, git: GitManager(), broadcaster: broadcaster, scratchpadBase: base)
 
         await gc.removedWorktreeCleanup(
-            worktreeID: UUID(), worktreePath: worktreeDir.path, repoPath: "/Users/chang/tbd")
+            worktreeID: UUID(), worktreePath: worktreeDir.path, repoPath: "/tmp/acme/tbd")
 
         #expect(FileManager.default.fileExists(atPath: scratchDir.path),
                 "worktree dir still on disk — the removal must have failed, so the scratchpad stays intact")
@@ -674,7 +674,7 @@ struct OrphanGCTests {
         try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: sandbox) }
 
-        let worktreePath = "/Users/chang/tbd/worktrees/removed-wt"
+        let worktreePath = "/tmp/acme/tbd/worktrees/removed-wt"
         let slug = ScratchpadCollector.slug(forWorktreePath: worktreePath)
         let scratchDir = base.appendingPathComponent(slug)
         try FileManager.default.createDirectory(at: scratchDir, withIntermediateDirectories: true)
@@ -686,7 +686,7 @@ struct OrphanGCTests {
         let gc = makeGC(db: db, git: GitManager(), broadcaster: broadcaster, scratchpadBase: base)
 
         await gc.removedWorktreeCleanup(
-            worktreeID: UUID(), worktreePath: worktreePath, repoPath: "/Users/chang/tbd")
+            worktreeID: UUID(), worktreePath: worktreePath, repoPath: "/tmp/acme/tbd")
 
         #expect(FileManager.default.fileExists(atPath: scratchDir.path),
                 "the gcEnabled master switch must suppress event-driven deletion too")

--- a/Tests/TBDDaemonTests/RepoRemoveCascadeTests.swift
+++ b/Tests/TBDDaemonTests/RepoRemoveCascadeTests.swift
@@ -115,7 +115,7 @@ struct RepoRemoveCascadeTests {
         var lifecycle = WorktreeLifecycle(
             db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver())
         if let gate {
-            lifecycle.onWorktreeRemoved = { path, _ in await gate.wait(path) }
+            lifecycle.onWorktreeRemoved = { _, path, _ in await gate.wait(path) }
         }
         let router = RPCRouter(
             db: db, lifecycle: lifecycle, tmux: TmuxManager(dryRun: true),

--- a/Tests/TBDDaemonTests/ScratchPromoteMigrationTests.swift
+++ b/Tests/TBDDaemonTests/ScratchPromoteMigrationTests.swift
@@ -268,7 +268,7 @@ struct WakePathGuardTests {
 
         let result = await router.hibernationCoordinator.wake(terminalID: terminal.id)
 
-        #expect(isWakeOk(result))
+        #expect(result.isOk)
         #expect(try await db.terminals.get(id: terminal.id)?.hibernatedAt == nil)
         let derived = TranscriptProjectDirSync.derivedProjectDir(
             worktreePath: wtDir.path, projectsRoot: ambientRoot)

--- a/Tests/TBDDaemonTests/ScratchPromoteMigrationTests.swift
+++ b/Tests/TBDDaemonTests/ScratchPromoteMigrationTests.swift
@@ -268,7 +268,7 @@ struct WakePathGuardTests {
 
         let result = await router.hibernationCoordinator.wake(terminalID: terminal.id)
 
-        #expect(result == .ok)
+        #expect(isWakeOk(result))
         #expect(try await db.terminals.get(id: terminal.id)?.hibernatedAt == nil)
         let derived = TranscriptProjectDirSync.derivedProjectDir(
             worktreePath: wtDir.path, projectsRoot: ambientRoot)

--- a/Tests/TBDDaemonTests/SendHarness.swift
+++ b/Tests/TBDDaemonTests/SendHarness.swift
@@ -81,7 +81,12 @@ struct SendHarness {
 
     static func make(
         transport: TerminalTransport = .tmux,
-        kind: TerminalKind = .claude
+        kind: TerminalKind = .claude,
+        // Overrides the inspector's answer, per agent name, so a test can ask
+        // for "no foreground agent here" — the foreground rail's negative case
+        // — without touching anything else about the harness. Defaulted to the
+        // live-agent answer every other call site relies on.
+        foregroundByAgent: [String: Int32] = ["claude": 4242, "codex": 4242]
     ) async throws -> SendHarness {
         let double = TmuxDouble()
         let tmux = TmuxManager(
@@ -103,8 +108,7 @@ struct SendHarness {
             lifecycle: WorktreeLifecycle(
                 db: db, git: GitManager(), tmux: tmux, hooks: HookResolver()),
             tmux: tmux,
-            paneProcessInspector: StubInspector(
-                foregroundByAgent: ["claude": 4242, "codex": 4242]),
+            paneProcessInspector: StubInspector(foregroundByAgent: foregroundByAgent),
             actuationLog: ActuationLog(path: Self.scratchLogPath()))
 
         let repo = try await db.repos.create(

--- a/Tests/TBDDaemonTests/SendHarness.swift
+++ b/Tests/TBDDaemonTests/SendHarness.swift
@@ -54,7 +54,7 @@ struct SendHarness {
         func recordPaste(_ bytes: Data) {
             lock.lock()
             defer { lock.unlock() }
-            _pastes.append(String(decoding: bytes, as: UTF8.self))
+            _pastes.append(String(bytes: bytes, encoding: .utf8) ?? "")
         }
         /// Keys arrive as argv, because `sendKey` in dryRun hands the whole
         /// `send-keys` command to `dryRunRecorder` rather than to a key-shaped

--- a/Tests/TBDDaemonTests/SendHarness.swift
+++ b/Tests/TBDDaemonTests/SendHarness.swift
@@ -154,6 +154,54 @@ struct SendHarness {
         return SendHarness(router: router, db: db, terminal: terminal, tmux: double)
     }
 
+    /// The one identity the envelope-suppression check accepts, and a harness
+    /// wired to accept it.
+    ///
+    /// Shared here rather than restated per suite: the parts-delivery and holder
+    /// suites need an AUTHENTICATED connection only to reach a suppressed
+    /// disposition, while `EnvelopeSuppressionAuthTests` keeps its own stub
+    /// because its subject is the ways the check FAILS.
+    enum AuthenticatedApp {
+        static let pid: Int32 = 909
+        static let startedAt = Date(timeIntervalSince1970: 1_800_000_000)
+        static let commandLine = "/Applications/TBD.app/Contents/MacOS/TBDApp"
+
+        /// What a caller passes to `send` to arrive as the app.
+        static var connection: RPCConnectionContext { RPCConnectionContext(peerPID: pid) }
+
+        static var identity: ProcessIdentity {
+            ProcessIdentity(pid: pid, startedAt: startedAt, commandLine: commandLine)
+        }
+
+        /// Answers the re-verification with `.same` for that one pid. Inert on
+        /// the signalling half: a stub that could kill something is a stub that
+        /// will, on a mistake.
+        struct Signaller: ProcessSignaller {
+            func isAlive(_ pid: Int32) -> Bool { true }
+            func startTime(_ pid: Int32) -> Date? { AuthenticatedApp.startedAt }
+            func commandLine(_ pid: Int32) -> String? { AuthenticatedApp.commandLine }
+            func stat(_ pid: Int32) -> String? { nil }
+            func children(ofServerPID serverPID: Int32) -> [Int32] { [] }
+            func terminate(_ pid: Int32) {}
+            func forceKill(_ pid: Int32) {}
+        }
+    }
+
+    /// A harness on which `AuthenticatedApp.connection` authenticates, so a send
+    /// that asks for `envelope: .suppressed` actually gets it.
+    static func makeAuthenticated(
+        transport: TerminalTransport = .tmux,
+        kind: TerminalKind = .claude,
+        holderDeliveryRecorder: (@Sendable (Data) -> Void)? = nil
+    ) async throws -> SendHarness {
+        try await make(
+            transport: transport,
+            kind: kind,
+            recordedAppIdentity: { AuthenticatedApp.identity },
+            processSignaller: AuthenticatedApp.Signaller(),
+            holderDeliveryRecorder: holderDeliveryRecorder)
+    }
+
     /// `connection` is what the daemon would have learned from the socket the
     /// request arrived on. Defaulted to nil — "not established" — which is what
     /// every non-socket caller of the router gets, and the answer that keeps the

--- a/Tests/TBDDaemonTests/SendHarness.swift
+++ b/Tests/TBDDaemonTests/SendHarness.swift
@@ -86,7 +86,14 @@ struct SendHarness {
         // for "no foreground agent here" — the foreground rail's negative case
         // — without touching anything else about the harness. Defaulted to the
         // live-agent answer every other call site relies on.
-        foregroundByAgent: [String: Int32] = ["claude": 4242, "codex": 4242]
+        foregroundByAgent: [String: Int32] = ["claude": 4242, "codex": 4242],
+        // The two halves of the envelope-suppression check, defaulted to the
+        // fail-closed answers the production router defaults to: no recorded
+        // sidecar client, and the real process reader. A suite that does not
+        // pass them authenticates nobody, so every send it makes carries the
+        // envelope.
+        recordedAppIdentity: @escaping @Sendable () async -> ProcessIdentity? = { nil },
+        processSignaller: any ProcessSignaller = ProductionProcessSignaller()
     ) async throws -> SendHarness {
         let double = TmuxDouble()
         let tmux = TmuxManager(
@@ -109,6 +116,8 @@ struct SendHarness {
                 db: db, git: GitManager(), tmux: tmux, hooks: HookResolver()),
             tmux: tmux,
             paneProcessInspector: StubInspector(foregroundByAgent: foregroundByAgent),
+            recordedAppIdentity: recordedAppIdentity,
+            processSignaller: processSignaller,
             actuationLog: ActuationLog(path: Self.scratchLogPath()))
 
         let repo = try await db.repos.create(
@@ -131,10 +140,16 @@ struct SendHarness {
         return SendHarness(router: router, db: db, terminal: terminal, tmux: double)
     }
 
+    /// `connection` is what the daemon would have learned from the socket the
+    /// request arrived on. Defaulted to nil — "not established" — which is what
+    /// every non-socket caller of the router gets, and the answer that keeps the
+    /// envelope.
     func send(
         _ params: TerminalSendParams,
-        actor: ActuationActor?
+        actor: ActuationActor?,
+        connection: RPCConnectionContext? = nil
     ) async throws -> RPCResponse {
-        try await router.handleTerminalSend(try JSONEncoder().encode(params), actor: actor)
+        try await router.handleTerminalSend(
+            try JSONEncoder().encode(params), actor: actor, connection: connection)
     }
 }

--- a/Tests/TBDDaemonTests/SendHarness.swift
+++ b/Tests/TBDDaemonTests/SendHarness.swift
@@ -1,3 +1,4 @@
+import Clocks
 import Foundation
 import Testing
 @testable import TBDDaemonLib
@@ -101,7 +102,13 @@ struct SendHarness {
         // than only that some rail did or didn't refuse it. `nil` (the
         // default) leaves `holderInjectionCourier` unset, which is what every
         // other holder test relies on to reach `holderInputUnavailable`.
-        holderDeliveryRecorder: (@Sendable (Data) -> Void)? = nil
+        holderDeliveryRecorder: (@Sendable (Data) -> Void)? = nil,
+        // The send path's one wait: the settle the parts arm takes after an
+        // image paste. Defaulted to `ImmediateClock`, so every suite built on
+        // this harness runs the production arm without spending wall time on
+        // it; a suite that wants to PIN the wait passes an
+        // `EventDrivenTestClock` instead.
+        clock: any Clock<Duration> = ImmediateClock()
     ) async throws -> SendHarness {
         let double = TmuxDouble()
         let tmux = TmuxManager(
@@ -126,7 +133,8 @@ struct SendHarness {
             paneProcessInspector: StubInspector(foregroundByAgent: foregroundByAgent),
             recordedAppIdentity: recordedAppIdentity,
             processSignaller: processSignaller,
-            actuationLog: ActuationLog(path: Self.scratchLogPath()))
+            actuationLog: ActuationLog(path: Self.scratchLogPath()),
+            clock: clock)
         if let holderDeliveryRecorder {
             router.holderInjectionCourier = HolderInjectionCourier(
                 sendFrame: { _ in },
@@ -192,14 +200,16 @@ struct SendHarness {
     static func makeAuthenticated(
         transport: TerminalTransport = .tmux,
         kind: TerminalKind = .claude,
-        holderDeliveryRecorder: (@Sendable (Data) -> Void)? = nil
+        holderDeliveryRecorder: (@Sendable (Data) -> Void)? = nil,
+        clock: any Clock<Duration> = ImmediateClock()
     ) async throws -> SendHarness {
         try await make(
             transport: transport,
             kind: kind,
             recordedAppIdentity: { AuthenticatedApp.identity },
             processSignaller: AuthenticatedApp.Signaller(),
-            holderDeliveryRecorder: holderDeliveryRecorder)
+            holderDeliveryRecorder: holderDeliveryRecorder,
+            clock: clock)
     }
 
     /// `connection` is what the daemon would have learned from the socket the

--- a/Tests/TBDDaemonTests/SendHarness.swift
+++ b/Tests/TBDDaemonTests/SendHarness.swift
@@ -93,7 +93,15 @@ struct SendHarness {
         // pass them authenticates nobody, so every send it makes carries the
         // envelope.
         recordedAppIdentity: @escaping @Sendable () async -> ProcessIdentity? = { nil },
-        processSignaller: any ProcessSignaller = ProductionProcessSignaller()
+        processSignaller: any ProcessSignaller = ProductionProcessSignaller(),
+        // Wires a real `HolderInjectionCourier` whose viewer is always
+        // detached (so `deliver` takes the direct-write branch, never the
+        // sidecar) and whose write lands here instead of any pty, so a holder
+        // test can assert the exact bytes `performHolderSend` composed rather
+        // than only that some rail did or didn't refuse it. `nil` (the
+        // default) leaves `holderInjectionCourier` unset, which is what every
+        // other holder test relies on to reach `holderInputUnavailable`.
+        holderDeliveryRecorder: (@Sendable (Data) -> Void)? = nil
     ) async throws -> SendHarness {
         let double = TmuxDouble()
         let tmux = TmuxManager(
@@ -119,6 +127,12 @@ struct SendHarness {
             recordedAppIdentity: recordedAppIdentity,
             processSignaller: processSignaller,
             actuationLog: ActuationLog(path: Self.scratchLogPath()))
+        if let holderDeliveryRecorder {
+            router.holderInjectionCourier = HolderInjectionCourier(
+                sendFrame: { _ in },
+                viewerAttachment: { _ in nil },
+                writeDirectly: { _, bytes in holderDeliveryRecorder(bytes) })
+        }
 
         let repo = try await db.repos.create(
             path: "/tmp/acme-\(UUID().uuidString)", displayName: "acme",

--- a/Tests/TBDDaemonTests/SendHarness.swift
+++ b/Tests/TBDDaemonTests/SendHarness.swift
@@ -1,0 +1,136 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+import TBDShared
+import TestSupport
+
+/// One live Claude terminal, a dry-run tmux that records what it was asked to
+/// paste and press, and a router over an in-memory database.
+///
+/// The recording seams are `TmuxManager`'s own `dryRun*` hooks — the shape
+/// `TerminalSendDispatchTests` already uses — so nothing about the production
+/// path is stubbed out: the handler runs in full and the doubles only answer
+/// the questions tmux and the process table would have.
+///
+/// Shared deliberately, by the delivery suite that introduced it and by the
+/// authority, gate and holder suites that follow: one fixture over one handler
+/// means a rail added for any of them is a rail all of them run through.
+struct SendHarness {
+    let router: RPCRouter
+    let db: TBDDatabase
+    let terminal: Terminal
+    let tmux: TmuxDouble
+
+    /// The foreground rail asks the process table whether the session's agent
+    /// owns the pane. A live Claude row must answer yes, or every text send in
+    /// every suite built on this harness is refused before it reaches the pane.
+    struct StubInspector: PaneProcessInspecting {
+        let foregroundByAgent: [String: Int32]
+        func foregroundAgentPID(panePID: Int32, matching agentName: String) -> Int32? {
+            foregroundByAgent[agentName]
+        }
+        /// The wake rail's question, which no send this harness makes ever
+        /// asks. Answering the pane's own pid is "an idle shell".
+        func paneForegroundPID(panePID: Int32) -> Int32? { panePID }
+    }
+
+    /// Collects what reached the pane. A lock-guarded class rather than an
+    /// actor, because `TmuxManager`'s hooks are synchronous `@Sendable`
+    /// closures.
+    final class TmuxDouble: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _pastes: [String] = []
+        private var _keys: [String] = []
+        var pastedBodies: [String] {
+            lock.lock()
+            defer { lock.unlock() }
+            return _pastes
+        }
+        var sentKeys: [String] {
+            lock.lock()
+            defer { lock.unlock() }
+            return _keys
+        }
+        func recordPaste(_ bytes: Data) {
+            lock.lock()
+            defer { lock.unlock() }
+            _pastes.append(String(decoding: bytes, as: UTF8.self))
+        }
+        /// Keys arrive as argv, because `sendKey` in dryRun hands the whole
+        /// `send-keys` command to `dryRunRecorder` rather than to a key-shaped
+        /// hook. The key is the last argument.
+        func recordArgv(_ args: [String]) {
+            guard args.contains("send-keys"), let key = args.last else { return }
+            lock.lock()
+            defer { lock.unlock() }
+            _keys.append(key)
+        }
+    }
+
+    /// A throwaway actuation log per harness. `ActuationLog` takes a PATH, not a
+    /// database. It lands under the run's fenced scratch dir, which
+    /// `scripts/test.sh` removes even when the test process is killed; a
+    /// per-test `temporaryDirectory` would leak.
+    private static func scratchLogPath() -> String {
+        let directory = URL(
+            fileURLWithPath: fencedScratchRoot(prefix: "tbd-send-harness"), isDirectory: true)
+        try? FileManager.default.createDirectory(
+            at: directory, withIntermediateDirectories: true)
+        return directory.appendingPathComponent("actuations.jsonl").path
+    }
+
+    static func make(
+        transport: TerminalTransport = .tmux,
+        kind: TerminalKind = .claude
+    ) async throws -> SendHarness {
+        let double = TmuxDouble()
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunRecorder: { double.recordArgv($0) },
+            // Alive, carrying no identity: the branch that proceeds. The target
+            // check is `TerminalSendTargetCheckTests`' business, not this
+            // harness's.
+            dryRunPaneSendTarget: { _, _ in .live(terminalID: nil) },
+            // The foreground rail skips itself when the pane pid is "0", which
+            // is what `dryRun` answers by default. Supplying a real-looking pid
+            // means the rail RUNS and the harness proves it gets through it,
+            // rather than passing because the rail never fired.
+            dryRunPanePID: { _, _ in "4242" },
+            dryRunPasteBytes: { _, _, bytes in double.recordPaste(bytes) })
+        let db = try TBDDatabase(inMemory: true)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: tmux, hooks: HookResolver()),
+            tmux: tmux,
+            paneProcessInspector: StubInspector(
+                foregroundByAgent: ["claude": 4242, "codex": 4242]),
+            actuationLog: ActuationLog(path: Self.scratchLogPath()))
+
+        let repo = try await db.repos.create(
+            path: "/tmp/acme-\(UUID().uuidString)", displayName: "acme",
+            defaultBranch: "main")
+        let worktree = try await db.worktrees.create(
+            repoID: repo.id, name: "acme-wt", branch: "main",
+            path: FileManager.default.temporaryDirectory.path, tmuxServer: "tbd-acme")
+        // A holder row carries an empty pane id by construction; a tmux row
+        // carries a real one. Spelled out rather than defaulted, because the
+        // holder refusal tests turn on exactly this.
+        let terminal = try await db.terminals.create(
+            worktreeID: worktree.id,
+            tmuxWindowID: transport == .holder ? "" : "@3",
+            tmuxPaneID: transport == .holder ? "" : "%7",
+            claudeSessionID: "sess-1",
+            kind: kind,
+            transport: transport,
+            childPID: transport == .holder ? 4242 : nil)
+        return SendHarness(router: router, db: db, terminal: terminal, tmux: double)
+    }
+
+    func send(
+        _ params: TerminalSendParams,
+        actor: ActuationActor?
+    ) async throws -> RPCResponse {
+        try await router.handleTerminalSend(try JSONEncoder().encode(params), actor: actor)
+    }
+}

--- a/Tests/TBDDaemonTests/SocketServerPeerPIDTests.swift
+++ b/Tests/TBDDaemonTests/SocketServerPeerPIDTests.swift
@@ -1,0 +1,219 @@
+import Darwin
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+import TBDShared
+import TestSupport
+
+/// The kernel's answer about who connected has to reach the handler that
+/// decides on it, on the very first request, over a real socket.
+///
+/// Everything else about envelope suppression is stated over a hand-built
+/// `RPCConnectionContext`: `EnvelopeSuppressionAuthTests` pins every way the
+/// authority check answers no — an unestablished peer pid, a stranger's pid, a
+/// reused one — and `PeerIdentityOverSocketpairTests` pins that
+/// `ProcessIdentity.ofPeer` reads the pid from the socket rather than from the
+/// caller. Neither runs `SocketServer.channelActive`, which is the one link in
+/// the chain that has to populate the context from `LOCAL_PEERPID` *before* the
+/// first `channelRead` dispatches a line. That ordering is an assumption about
+/// NIO — the socket-option provider completing its promise inline when asked on
+/// the event loop — and an assumption is exactly what a real connection can
+/// check and a hand-built context cannot.
+///
+/// So these two rows drive the whole path from a `connect(2)` in this process:
+/// the kernel names this process, `channelActive` reads it, `channelRead`
+/// carries it, and the send handler compares it. The observable is the
+/// suppression itself, because that outcome happens if and only if the pid the
+/// router received equals the recorded one — and the negative row moves the
+/// recorded pid by one to show the comparison is against a specific number
+/// rather than against anything at all.
+@Suite("a connection's peer pid reaches the router over a real socket")
+struct SocketServerPeerPIDTests {
+
+    /// Answers the re-verification for whatever pid it is asked about, with the
+    /// values the recorded identity carries, so the only thing left deciding
+    /// the outcome is the pid comparison — which is this suite's subject.
+    ///
+    /// Inert on the signalling half: a stub that could kill something is a stub
+    /// that will, on a mistake. It is never asked anything in the negative row,
+    /// where the pid comparison refuses first.
+    private struct StubSignaller: ProcessSignaller {
+        func isAlive(_ pid: Int32) -> Bool { true }
+        func startTime(_ pid: Int32) -> Date? { SocketServerPeerPIDTests.recordedStart }
+        func commandLine(_ pid: Int32) -> String? { SocketServerPeerPIDTests.recordedCommand }
+        func stat(_ pid: Int32) -> String? { nil }
+        func children(ofServerPID serverPID: Int32) -> [Int32] { [] }
+        func terminate(_ pid: Int32) {}
+        func forceKill(_ pid: Int32) {}
+    }
+
+    private static let recordedStart = Date(timeIntervalSince1970: 1_800_000_000)
+    private static let recordedCommand = "/Applications/TBD.app/Contents/MacOS/TBDApp"
+
+    /// Short `/tmp` path, well under the ~104-byte `sun_path` limit. NOT
+    /// `~/tbd/sock`: this suite binds a socket of its own and never goes near
+    /// the live daemon's rendezvous path.
+    private func scratchSocketPath() -> String {
+        "/tmp/tbd-peerpid-\(UUID().uuidString.prefix(8)).sock"
+    }
+
+    /// One send over one fresh connection, with the recorded sidecar identity
+    /// claiming `recordedPID`. Returns what reached the pane.
+    ///
+    /// The request is the first and only line the connection ever carries, so a
+    /// context that arrived late — after `channelRead` had already dispatched —
+    /// is a context that never arrived at all.
+    private func pastedBodiesForSend(recordedPID: Int32) async throws -> [String] {
+        let identity = ProcessIdentity(
+            pid: recordedPID, startedAt: Self.recordedStart,
+            commandLine: Self.recordedCommand)
+        let harness = try await SendHarness.make(
+            recordedAppIdentity: { identity },
+            processSignaller: StubSignaller())
+
+        let socketPath = scratchSocketPath()
+        defer { unlink(socketPath) }
+        let server = SocketServer(router: harness.router, socketPath: socketPath)
+        try await server.start()
+        defer { Task { await server.stop() } }
+
+        let client = RawRPCClient()
+        defer { client.disconnect() }
+        try #require(
+            client.connect(to: socketPath, receiveTimeout: TestDeadlines.saturatedPassSeconds),
+            "the test process could not connect to the server it just started")
+
+        let request = try RPCRequest(
+            method: RPCMethod.terminalSend,
+            params: TerminalSendParams(
+                terminalID: harness.terminal.id, text: "hi", submit: true,
+                envelope: .suppressed),
+            actor: .app)
+        let line = try #require(String(data: try JSONEncoder().encode(request), encoding: .utf8))
+        try #require(client.send(line: line), "the request could not be written to the socket")
+
+        // Blocking reads run off the cooperative pool — a parked pool thread is
+        // one the daemon's own handling can no longer run on — and the socket
+        // carries a receive timeout, so a response that never comes reports
+        // itself rather than parking anything forever.
+        let responseLine = await gateHoldingTask { client.receiveLine() }.value
+        let raw = try #require(
+            responseLine, "no response line arrived within the receive timeout")
+        let response = try JSONDecoder().decode(RPCResponse.self, from: Data(raw.utf8))
+        #expect(response.success, "error was: \(response.error ?? "none")")
+
+        // The response is written after the handler has run, so the paste has
+        // already happened by here; the bounded wait covers the write itself
+        // racing the recorder rather than any part of the decision.
+        try await waitFor(
+            "the send to reach the pane",
+            observed: { "\(harness.tmux.pastedBodies.count) pastes" }
+        ) { !harness.tmux.pastedBodies.isEmpty }
+        return harness.tmux.pastedBodies
+    }
+
+    /// The positive row: the recorded sidecar identity is this process, and the
+    /// only way the daemon can know that is by reading the pid off the socket
+    /// this process connected on. Suppression is therefore the assertion that
+    /// `channelActive` populated the context, and did it before the first
+    /// request was dispatched.
+    @Test func theConnectingProcessesOwnPIDAuthenticatesTheFirstRequest() async throws {
+        let bodies = try await pastedBodiesForSend(recordedPID: getpid())
+        #expect(
+            bodies == ["hi"],
+            "the first request over a real socket did not carry this process's peer pid")
+    }
+
+    /// The negative row, and the reason the positive one is not vacuous: move
+    /// the recorded pid by one and the same connection, the same request and
+    /// the same `{"kind":"app"}` actor keep the envelope. The comparison is
+    /// against a specific number the kernel supplied, not against whatever
+    /// happened to be there.
+    ///
+    /// The stranger's pid is only ever compared, never signalled: the
+    /// comparison refuses before the identity check is reached.
+    @Test func aPIDOneOffFromTheConnectingProcessKeepsTheEnvelope() async throws {
+        let bodies = try await pastedBodiesForSend(recordedPID: getpid() &+ 1)
+        #expect(
+            try #require(bodies.first).hasPrefix("<tbd-dispatch"),
+            "suppression was granted to a connection whose peer pid was not the recorded one")
+    }
+}
+
+/// A newline-delimited-JSON client over a plain `AF_UNIX` socket — the daemon's
+/// wire protocol and nothing else, so nothing in TBD's own client code stands
+/// between the test and `connect(2)`.
+private final class RawRPCClient: @unchecked Sendable {
+    private var fd: Int32 = -1
+
+    func connect(to path: String, receiveTimeout: TimeInterval) -> Bool {
+        let newFD = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard newFD >= 0 else { return false }
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        let pathBytes = Array(path.utf8)
+        guard pathBytes.count < MemoryLayout.size(ofValue: addr.sun_path) else {
+            close(newFD)
+            return false
+        }
+        withUnsafeMutableBytes(of: &addr.sun_path) { raw in
+            raw.copyBytes(from: pathBytes)
+            raw[pathBytes.count] = 0
+        }
+        let connected = withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+                Darwin.connect(newFD, sockPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard connected == 0 else {
+            close(newFD)
+            return false
+        }
+        // Bounds the blocking read below, so a response that never comes fails
+        // the test instead of holding a thread for the rest of the run.
+        var timeout = timeval(
+            tv_sec: Int(receiveTimeout), tv_usec: 0)
+        _ = setsockopt(
+            newFD, SOL_SOCKET, SO_RCVTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))
+        fd = newFD
+        return true
+    }
+
+    func send(line: String) -> Bool {
+        guard fd >= 0 else { return false }
+        let bytes = Array((line + "\n").utf8)
+        var offset = 0
+        while offset < bytes.count {
+            let written = bytes[offset...].withUnsafeBufferPointer { buffer in
+                Darwin.write(fd, buffer.baseAddress, buffer.count)
+            }
+            guard written > 0 else { return false }
+            offset += written
+        }
+        return true
+    }
+
+    /// The first newline-terminated line, or nil if the peer closed or the
+    /// receive timeout expired first.
+    func receiveLine() -> String? {
+        guard fd >= 0 else { return nil }
+        var accumulated: [UInt8] = []
+        var scratch = [UInt8](repeating: 0, count: 4096)
+        while !accumulated.contains(UInt8(ascii: "\n")) {
+            let count = scratch.withUnsafeMutableBytes { buffer in
+                Darwin.read(fd, buffer.baseAddress, buffer.count)
+            }
+            guard count > 0 else { return nil }
+            accumulated.append(contentsOf: scratch[0..<count])
+        }
+        guard let newline = accumulated.firstIndex(of: UInt8(ascii: "\n")) else { return nil }
+        return String(bytes: accumulated[0..<newline], encoding: .utf8)
+    }
+
+    func disconnect() {
+        if fd >= 0 {
+            close(fd)
+            fd = -1
+        }
+    }
+}

--- a/Tests/TBDDaemonTests/TerminalSendPartsDeliveryTests.swift
+++ b/Tests/TBDDaemonTests/TerminalSendPartsDeliveryTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import Testing
 @testable import TBDDaemonLib
 import TBDShared
+import TestSupport
 
 /// What actually reaches the pane for a parts payload.
 ///
@@ -9,7 +10,7 @@ import TBDShared
 /// reason parts exist is that Claude Code turns a paste into an image attachment
 /// only when the WHOLE paste is one quoted path, so an image part pasted
 /// together with its surrounding words silently becomes literal text.
-@Suite("terminal.send parts delivery")
+@Suite("terminal.send parts delivery", .clockDriven)
 struct TerminalSendPartsDeliveryTests {
 
     // MARK: - The image paste
@@ -198,5 +199,111 @@ struct TerminalSendPartsDeliveryTests {
         #expect(error.contains("foreground process"))
         #expect(harness.tmux.pastedBodies.isEmpty)
         #expect(harness.tmux.sentKeys.isEmpty)
+    }
+
+    // MARK: - The settle after an image paste
+
+    /// **The image token lands where the caret is when the attach finishes.**
+    /// Claude Code turns a pasted quoted path into an attachment
+    /// asynchronously; pasting the next part before that lands moves the caret,
+    /// so the `[Image#N]` token arrives at the END of the message and an Enter
+    /// that arrives mid-attach is swallowed. Both were observed live against
+    /// 2.1.261, on the first image a Claude process had ever been given.
+    ///
+    /// **The wait is once per image part, not once per successor.** It belongs
+    /// to the image paste and is taken before whatever comes next, so an image
+    /// followed by text waits ONCE — between the two pastes — and not again
+    /// before Enter: the token has already landed by then, and Enter after a
+    /// plain text paste is what the single-text arm has always done. The image
+    /// being LAST is the case where that same one wait covers the Enter, which
+    /// `anImageAsTheLastPartSettlesBeforeEnter` pins.
+    ///
+    /// Pinned by advancing: the second paste has not happened before the
+    /// advance and has after.
+    @Test func anImagePartSettlesBeforeTheNextPaste() async throws {
+        let clock = EventDrivenTestClock()
+        let harness = try await SendHarness.make(clock: clock)
+        let send = Task {
+            try await harness.send(TerminalSendParams(
+                terminalID: harness.terminal.id, submit: true,
+                parts: [.imagePath("/tmp/a.png"), .text(" and tell me what it is")]),
+                actor: .app)
+        }
+
+        // Armed on the settle, with the image pasted and NOTHING after it.
+        await clock.sleeperArmed()
+        #expect(harness.tmux.pastedBodies == ["'/tmp/a.png'"])
+        #expect(harness.tmux.sentKeys.isEmpty)
+
+        await clock.advance(by: RPCRouter.imageAttachSettle)
+        // Bounded rather than `await send.value`, so a regression that arms a
+        // SECOND sleeper reports itself instead of wedging the suite.
+        _ = try await waitFor(
+            "the trailing text part and the Enter",
+            observed: { "pastes \(harness.tmux.pastedBodies), keys \(harness.tmux.sentKeys)" }
+        ) { harness.tmux.sentKeys == ["Enter"] }
+        send.cancel()
+        _ = await send.result
+
+        let bodies = harness.tmux.pastedBodies
+        try #require(bodies.count == 2)
+        #expect(bodies[0] == "'/tmp/a.png'")
+        #expect(bodies[1].hasSuffix(" and tell me what it is"))
+        // Once, not twice: nothing is still parked on the clock.
+        #expect(clock.sleeperCount == 0)
+    }
+
+    /// The image as the LAST part: the same one settle stands between its paste
+    /// and the Enter, which is the swallowed-Enter half of the defect.
+    @Test func anImageAsTheLastPartSettlesBeforeEnter() async throws {
+        let clock = EventDrivenTestClock()
+        let harness = try await SendHarness.make(clock: clock)
+        let send = Task {
+            try await harness.send(TerminalSendParams(
+                terminalID: harness.terminal.id, submit: true,
+                parts: [.text("look at "), .imagePath("/tmp/a.png")]),
+                actor: .app)
+        }
+
+        await clock.sleeperArmed()
+        #expect(harness.tmux.pastedBodies.count == 2)
+        #expect(harness.tmux.sentKeys.isEmpty, "Enter must not race the attach")
+
+        await clock.advance(by: RPCRouter.imageAttachSettle)
+        _ = try await waitFor(
+            "the Enter after the settle",
+            observed: { "keys \(harness.tmux.sentKeys)" }
+        ) { harness.tmux.sentKeys == ["Enter"] }
+        send.cancel()
+        _ = await send.result
+        #expect(clock.sleeperCount == 0)
+    }
+
+    /// **A payload with no image part waits for nothing.** The settle is the
+    /// image paste's, so a text-only parts send must cost exactly what it cost
+    /// before — it runs to completion with the clock never advanced, and
+    /// nothing is ever parked on it.
+    @Test func aTextOnlyPartsSendNeverTouchesTheClock() async throws {
+        let clock = EventDrivenTestClock()
+        let harness = try await SendHarness.make(clock: clock)
+        let send = Task {
+            try await harness.send(TerminalSendParams(
+                terminalID: harness.terminal.id, submit: true,
+                parts: [.text("look at "), .text("this")]),
+                actor: .app)
+        }
+
+        // Nothing advances the clock here. Completing at all is the assertion:
+        // a send that slept would still be parked.
+        _ = try await waitFor(
+            "the text-only send to finish with the clock never advanced",
+            observed: { "keys \(harness.tmux.sentKeys), sleepers \(clock.sleeperCount)" }
+        ) { harness.tmux.sentKeys == ["Enter"] }
+        send.cancel()
+        _ = await send.result
+
+        #expect(harness.tmux.pastedBodies.count == 2)
+        #expect(clock.sleeperCount == 0)
+        #expect(clock.now == EventDrivenTestClock.Instant(), "virtual time never moved")
     }
 }

--- a/Tests/TBDDaemonTests/TerminalSendPartsDeliveryTests.swift
+++ b/Tests/TBDDaemonTests/TerminalSendPartsDeliveryTests.swift
@@ -1,0 +1,83 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+import TBDShared
+
+/// What actually reaches the pane for a parts payload.
+///
+/// The ordering assertion is a documented contract, not an incident: the whole
+/// reason parts exist is that Claude Code turns a paste into an image attachment
+/// only when the WHOLE paste is one quoted path, so an image part pasted
+/// together with its surrounding words silently becomes literal text.
+@Suite("terminal.send parts delivery")
+struct TerminalSendPartsDeliveryTests {
+
+    // MARK: - The image paste
+
+    @Test func anImagePartIsPastedAsABareQuotedPath() {
+        #expect(RPCRouter.quotedImagePath("/tmp/a b.png") == "'/tmp/a b.png'")
+        #expect(RPCRouter.quotedImagePath("/tmp/it's.png") == #"'/tmp/it'\''s.png'"#)
+    }
+
+    // MARK: - Ordering
+
+    @Test func partsArePastedInOrderThenOneEnter() async throws {
+        let harness = try await SendHarness.make()
+        _ = try await harness.send(TerminalSendParams(
+            terminalID: harness.terminal.id, submit: true,
+            parts: [
+                .text("look at "),
+                .imagePath("/tmp/a.png"),
+                .text(" and tell me"),
+            ]),
+            actor: .app)
+
+        // One envelope, on the first text part; the rest verbatim and in order.
+        let bodies = harness.tmux.pastedBodies
+        #expect(bodies.count == 3)
+        #expect(try #require(bodies.first).hasSuffix("look at "))
+        #expect(bodies[1] == "'/tmp/a.png'")
+        #expect(bodies[2] == " and tell me")
+        #expect(harness.tmux.sentKeys == ["Enter"])
+    }
+
+    @Test func emptyTextPartsAreSkipped() async throws {
+        let harness = try await SendHarness.make()
+        _ = try await harness.send(TerminalSendParams(
+            terminalID: harness.terminal.id, submit: true,
+            parts: [.text(""), .imagePath("/tmp/a.png"), .text("")]),
+            actor: .app)
+
+        // Nothing empty was pasted. The envelope has no text part to ride on
+        // here, so it rides on nothing: an image part is NEVER prefixed.
+        #expect(harness.tmux.pastedBodies == ["'/tmp/a.png'"])
+        #expect(harness.tmux.sentKeys == ["Enter"])
+    }
+
+    /// One envelope for one message, on the FIRST text part — not one per paste,
+    /// which would put a `<tbd-dispatch/>` line in the middle of a sentence.
+    @Test func aPartsSendCarriesOneEnvelopeOnTheFirstPart() async throws {
+        let harness = try await SendHarness.make()
+        _ = try await harness.send(TerminalSendParams(
+            terminalID: harness.terminal.id, submit: true,
+            parts: [.text("first"), .text("second")]),
+            actor: ActuationActor.session(worktree: "W", terminal: "T"))
+
+        let bodies = harness.tmux.pastedBodies
+        #expect(bodies.count == 2)
+        #expect(bodies[0].hasPrefix("<tbd-dispatch"))
+        #expect(bodies[0].hasSuffix("\nfirst"))
+        #expect(bodies[1] == "second")
+    }
+
+    /// `submit: false` pastes and presses nothing — the same reading the single
+    /// text arm gives it.
+    @Test func anUnsubmittedPartsSendPressesNoEnter() async throws {
+        let harness = try await SendHarness.make()
+        _ = try await harness.send(TerminalSendParams(
+            terminalID: harness.terminal.id, submit: false,
+            parts: [.text("draft")]),
+            actor: .app)
+        #expect(harness.tmux.sentKeys.isEmpty)
+    }
+}

--- a/Tests/TBDDaemonTests/TerminalSendPartsDeliveryTests.swift
+++ b/Tests/TBDDaemonTests/TerminalSendPartsDeliveryTests.swift
@@ -41,6 +41,23 @@ struct TerminalSendPartsDeliveryTests {
         #expect(harness.tmux.sentKeys == ["Enter"])
     }
 
+    /// An image part before the first text part must carry no envelope; the
+    /// envelope belongs on the first TEXT part, not the first part outright.
+    @Test func anImagePartBeforeTextCarriesNoEnvelope() async throws {
+        let harness = try await SendHarness.make()
+        _ = try await harness.send(TerminalSendParams(
+            terminalID: harness.terminal.id, submit: true,
+            parts: [.imagePath("/tmp/a.png"), .text("hi")]),
+            actor: .app)
+
+        let bodies = harness.tmux.pastedBodies
+        #expect(bodies.count == 2)
+        #expect(bodies[0] == "'/tmp/a.png'")
+        #expect(bodies[1].hasPrefix("<tbd-dispatch"))
+        #expect(bodies[1].hasSuffix("\nhi"))
+        #expect(harness.tmux.sentKeys == ["Enter"])
+    }
+
     @Test func emptyTextPartsAreSkipped() async throws {
         let harness = try await SendHarness.make()
         _ = try await harness.send(TerminalSendParams(

--- a/Tests/TBDDaemonTests/TerminalSendPartsDeliveryTests.swift
+++ b/Tests/TBDDaemonTests/TerminalSendPartsDeliveryTests.swift
@@ -80,4 +80,47 @@ struct TerminalSendPartsDeliveryTests {
             actor: .app)
         #expect(harness.tmux.sentKeys.isEmpty)
     }
+
+    // MARK: - The not-running rails apply to parts too
+
+    /// A parts send into a parked row must be refused exactly as a text send
+    /// is — PR A's park rail was guarded on `.text` alone, which let a parts
+    /// payload paste into a pane whose Claude session had already exited.
+    @Test func aPartsSendIntoAParkedRowIsRefused() async throws {
+        let harness = try await SendHarness.make()
+        try await harness.db.terminals.setHibernated(
+            id: harness.terminal.id, sessionID: "sess-1", reason: .manual,
+            at: Date(timeIntervalSince1970: 1_800_000_000))
+
+        let response = try await harness.send(TerminalSendParams(
+            terminalID: harness.terminal.id, submit: true,
+            parts: [.text("look at "), .imagePath("/tmp/a.png")]),
+            actor: .app)
+
+        #expect(!response.success)
+        let error = try #require(response.error)
+        #expect(error.contains("is not running"))
+        #expect(harness.tmux.pastedBodies.isEmpty)
+        #expect(harness.tmux.sentKeys.isEmpty)
+    }
+
+    /// A parts send whose pane has no foreground agent must be refused exactly
+    /// as a text send is — PR A's foreground rail was guarded on `.text` alone,
+    /// which let a parts payload paste into a shell the agent had left behind.
+    /// No emptiness guard applies here: a validated parts payload always has
+    /// content.
+    @Test func aPartsSendWithNoForegroundAgentIsRefused() async throws {
+        let harness = try await SendHarness.make(foregroundByAgent: [:])
+
+        let response = try await harness.send(TerminalSendParams(
+            terminalID: harness.terminal.id, submit: true,
+            parts: [.text("look at "), .imagePath("/tmp/a.png")]),
+            actor: .app)
+
+        #expect(!response.success)
+        let error = try #require(response.error)
+        #expect(error.contains("foreground process"))
+        #expect(harness.tmux.pastedBodies.isEmpty)
+        #expect(harness.tmux.sentKeys.isEmpty)
+    }
 }

--- a/Tests/TBDDaemonTests/TerminalSendPartsDeliveryTests.swift
+++ b/Tests/TBDDaemonTests/TerminalSendPartsDeliveryTests.swift
@@ -65,10 +65,69 @@ struct TerminalSendPartsDeliveryTests {
             parts: [.text(""), .imagePath("/tmp/a.png"), .text("")]),
             actor: .app)
 
-        // Nothing empty was pasted. The envelope has no text part to ride on
-        // here, so it rides on nothing: an image part is NEVER prefixed.
+        // Nothing empty was pasted. Every text part being empty makes this an
+        // IMAGE-ONLY payload, so the envelope takes a leading paste of its own
+        // rather than being dropped — the image paste stays bare and alone.
+        let bodies = harness.tmux.pastedBodies
+        try #require(bodies.count == 2)
+        #expect(try #require(bodies.first).hasPrefix("<tbd-dispatch"))
+        #expect(bodies[1] == "'/tmp/a.png'")
+        #expect(harness.tmux.sentKeys == ["Enter"])
+    }
+
+    // MARK: - The image-only payload, and why it is not unattributed
+
+    /// **An image-only send is still a user turn, so it is still attributed.**
+    /// The envelope cannot ride ON the image part — Claude Code attaches an
+    /// image only when the whole paste is one quoted path — so it takes its own
+    /// leading paste instead. Each part is already its own bracketed paste, so
+    /// the image paste stays bare and alone and still attaches, and this is the
+    /// same "text + image as separate pastes" shape the design already relies on.
+    ///
+    /// Without it, any local process could submit an unattributed user turn
+    /// carrying an image, on a request that needs no authentication.
+    @Test func anUnauthenticatedImageOnlySendPastesTheEnvelopeFirst() async throws {
+        let harness = try await SendHarness.make()
+        _ = try await harness.send(TerminalSendParams(
+            terminalID: harness.terminal.id, submit: true,
+            parts: [.imagePath("/tmp/a.png")]),
+            actor: .app)
+
+        let bodies = harness.tmux.pastedBodies
+        try #require(bodies.count == 2)
+        #expect(try #require(bodies.first).hasPrefix("<tbd-dispatch"))
+        #expect(bodies[1] == "'/tmp/a.png'")
+        #expect(harness.tmux.sentKeys == ["Enter"])
+    }
+
+    /// The other branch: on an authenticated connection that asked for
+    /// suppression, the person is speaking in their own voice, so there is no
+    /// envelope to place anywhere and the image is the only paste.
+    @Test func anAuthenticatedImageOnlySendPastesOnlyThePath() async throws {
+        let harness = try await SendHarness.makeAuthenticated()
+        let response = try await harness.send(
+            TerminalSendParams(
+                terminalID: harness.terminal.id, submit: true,
+                parts: [.imagePath("/tmp/a.png")], envelope: .suppressed),
+            actor: .app,
+            connection: SendHarness.AuthenticatedApp.connection)
+
+        #expect(response.success, "error was: \(response.error ?? "none")")
         #expect(harness.tmux.pastedBodies == ["'/tmp/a.png'"])
         #expect(harness.tmux.sentKeys == ["Enter"])
+    }
+
+    /// A shell row carries no envelope at all, so an image-only send there has
+    /// nothing to place ahead of the path — the leading paste is the envelope's,
+    /// not the image-only shape's.
+    @Test func anImageOnlySendToAShellRowPastesOnlyThePath() async throws {
+        let harness = try await SendHarness.make(kind: .shell)
+        _ = try await harness.send(TerminalSendParams(
+            terminalID: harness.terminal.id, submit: true,
+            parts: [.imagePath("/tmp/a.png")]),
+            actor: .app)
+
+        #expect(harness.tmux.pastedBodies == ["'/tmp/a.png'"])
     }
 
     /// One envelope for one message, on the FIRST text part — not one per paste,

--- a/Tests/TBDDaemonTests/TerminalSendPartsShapeTests.swift
+++ b/Tests/TBDDaemonTests/TerminalSendPartsShapeTests.swift
@@ -76,6 +76,19 @@ struct TerminalSendPartsShapeTests {
         #expect(message.contains("absolute"))
     }
 
+    /// An image path with an embedded newline would split the single quoted
+    /// paste that makes an image attach into more than one line, so it is
+    /// rejected here rather than reaching actuation.
+    @Test func anImagePathContainingANewlineIsMalformed() {
+        let shape = RPCRouter.validateSendShape(TerminalSendParams(
+            terminalID: terminalID, submit: true, parts: [.imagePath("/tmp/a\n.png")]))
+        guard case .malformed(let message) = shape else {
+            Issue.record("expected malformed, got \(shape)")
+            return
+        }
+        #expect(message.contains("newline"))
+    }
+
     /// `--verify` re-reads a pane for one delivered payload; a multi-part send
     /// has no single payload to look for. Refused rather than silently
     /// downgraded, per the never-answer-a-request-for-evidence-with-silence rule.

--- a/Tests/TBDDaemonTests/TerminalSendPartsShapeTests.swift
+++ b/Tests/TBDDaemonTests/TerminalSendPartsShapeTests.swift
@@ -1,0 +1,116 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+import TBDShared
+
+/// Shape validation for the parts payload. Every malformed combination is
+/// rejected BEFORE a row exists, the line `RPCRouter+Actuation.swift` already
+/// draws: a row must not be written for a request that was never about to be
+/// dispatched.
+@Suite("terminal.send parts shape")
+struct TerminalSendPartsShapeTests {
+    private let terminalID = UUID()
+
+    @Test func aPartsPayloadValidates() throws {
+        let shape = RPCRouter.validateSendShape(TerminalSendParams(
+            terminalID: terminalID, submit: true,
+            parts: [.text("look at "), .imagePath("/tmp/a.png")]))
+        guard case .valid(.parts(let parts, let submit)) = shape else {
+            Issue.record("expected a valid parts payload, got \(shape)")
+            return
+        }
+        #expect(parts.count == 2)
+        #expect(submit)
+    }
+
+    @Test func partsAndTextTogetherAreMalformed() {
+        let shape = RPCRouter.validateSendShape(TerminalSendParams(
+            terminalID: terminalID, text: "hi", parts: [.text("hi")]))
+        guard case .malformed(let message) = shape else {
+            Issue.record("expected malformed, got \(shape)")
+            return
+        }
+        #expect(message.contains("exactly one payload"))
+    }
+
+    @Test func partsAndKeysTogetherAreMalformed() {
+        let shape = RPCRouter.validateSendShape(TerminalSendParams(
+            terminalID: terminalID, keys: "Escape", parts: [.text("hi")]))
+        guard case .malformed = shape else {
+            Issue.record("expected malformed, got \(shape)")
+            return
+        }
+    }
+
+    @Test func anEmptyPartsListIsMalformed() {
+        let shape = RPCRouter.validateSendShape(TerminalSendParams(
+            terminalID: terminalID, submit: true, parts: []))
+        guard case .malformed(let message) = shape else {
+            Issue.record("expected malformed, got \(shape)")
+            return
+        }
+        #expect(message.contains("at least one"))
+    }
+
+    /// A parts payload that is nothing but empty text names no act: every part
+    /// is skipped at delivery, so it would press Enter on a composer nobody
+    /// typed into.
+    @Test func partsThatAreAllEmptyTextAreMalformed() {
+        let shape = RPCRouter.validateSendShape(TerminalSendParams(
+            terminalID: terminalID, submit: true, parts: [.text(""), .text("  ")]))
+        guard case .malformed = shape else {
+            Issue.record("expected malformed, got \(shape)")
+            return
+        }
+    }
+
+    /// An image part must name an absolute path. A relative one would resolve
+    /// against whatever directory the receiving session happens to be in.
+    @Test func aRelativeImagePathIsMalformed() {
+        let shape = RPCRouter.validateSendShape(TerminalSendParams(
+            terminalID: terminalID, submit: true, parts: [.imagePath("a.png")]))
+        guard case .malformed(let message) = shape else {
+            Issue.record("expected malformed, got \(shape)")
+            return
+        }
+        #expect(message.contains("absolute"))
+    }
+
+    /// `--verify` re-reads a pane for one delivered payload; a multi-part send
+    /// has no single payload to look for. Refused rather than silently
+    /// downgraded, per the never-answer-a-request-for-evidence-with-silence rule.
+    @Test func verifyWithPartsIsMalformed() {
+        let shape = RPCRouter.validateSendShape(TerminalSendParams(
+            terminalID: terminalID, submit: true, verify: true, parts: [.text("hi")]))
+        guard case .malformed(let message) = shape else {
+            Issue.record("expected malformed, got \(shape)")
+            return
+        }
+        #expect(message.contains("--verify"))
+    }
+
+    /// The old shapes are untouched. Without this the suite could go green on a
+    /// validator that rejects everything.
+    @Test func theExistingShapesStillValidate() {
+        guard case .valid(.text) = RPCRouter.validateSendShape(
+            TerminalSendParams(terminalID: terminalID, text: "hi", submit: true)) else {
+            Issue.record("a plain text send must still validate")
+            return
+        }
+        guard case .valid(.keys) = RPCRouter.validateSendShape(
+            TerminalSendParams(terminalID: terminalID, keys: "Escape")) else {
+            Issue.record("a keys send must still validate")
+            return
+        }
+    }
+
+    @Test func theRecordedMessageNamesEveryPart() {
+        let payload = TerminalSendPayload.parts(
+            [.text("look at "), .imagePath("/tmp/a.png")], submit: true)
+        #expect(payload.recordedMessage.contains("look at "))
+        #expect(payload.recordedMessage.contains("/tmp/a.png"))
+        #expect(payload.recordedSubmit == true)
+        #expect(payload.recordedVerify == nil)
+        #expect(!payload.isVerifyArmed)
+    }
+}

--- a/Tests/TBDDaemonTests/TerminalWakeIncarnationTests.swift
+++ b/Tests/TBDDaemonTests/TerminalWakeIncarnationTests.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+import TBDShared
+
+/// `terminal.wake` reports the incarnation its respawn minted, and reports none
+/// when it did not respawn.
+///
+/// The negative rows are the load-bearing ones: an id on a no-op path would let
+/// the app's sending hold release on somebody else's `SessionStart`, which is
+/// the exact failure the id exists to prevent.
+@Suite("terminal.wake reports its incarnation")
+struct TerminalWakeIncarnationTests {
+
+    @Test func theWokenPathCarriesTheMintedID() throws {
+        let minted = UUID()
+        let result = try #require(
+            RPCRouter.wakeResultPayload(for: .ok(sessionIncarnationID: minted)))
+        #expect(result.woken)
+        #expect(result.sessionIncarnationID == minted)
+    }
+
+    /// `woken: false` means the prompt was never delivered anywhere, so there is
+    /// no spawn to name and nothing for a hold to wait on.
+    @Test func theNoOpPathsCarryNoID() throws {
+        for result in [WakeResult.notHibernated, WakeResult.inFlight] {
+            let payload = try #require(RPCRouter.wakeResultPayload(for: result))
+            #expect(!payload.woken)
+            #expect(payload.sessionIncarnationID == nil)
+        }
+    }
+
+    /// A daemon that respawned without being able to mint one — the shape a
+    /// legacy row produces — reports `woken: true` and no id, and the app must
+    /// then never enter the hold rather than hold forever.
+    @Test func aWokenPathWithNoIDIsStillWoken() throws {
+        let payload = try #require(
+            RPCRouter.wakeResultPayload(for: .ok(sessionIncarnationID: nil)))
+        #expect(payload.woken)
+        #expect(payload.sessionIncarnationID == nil)
+    }
+
+    /// Wire compatibility both ways: an older client's payload still decodes,
+    /// and an older daemon's response still decodes here.
+    @Test func theFieldIsAdditiveOnTheWire() throws {
+        let decoded = try JSONDecoder().decode(
+            TerminalWakeResult.self, from: Data(#"{"woken":true}"#.utf8))
+        #expect(decoded.woken)
+        #expect(decoded.sessionIncarnationID == nil)
+    }
+}

--- a/Tests/TBDDaemonTests/TerminalWakeIncarnationTests.swift
+++ b/Tests/TBDDaemonTests/TerminalWakeIncarnationTests.swift
@@ -30,9 +30,13 @@ struct TerminalWakeIncarnationTests {
         }
     }
 
-    /// A daemon that respawned without being able to mint one — the shape a
-    /// legacy row produces — reports `woken: true` and no id, and the app must
-    /// then never enter the hold rather than hold forever.
+    /// `sessionIncarnationID` is nil here for wire compatibility rather than
+    /// because the daemon can actually produce this shape — `liveIncarnationID`
+    /// is non-optional on the respawn path, so a nil id never comes from this
+    /// process today. The optional exists so an older daemon's `{"woken":true}`
+    /// (no field at all) still decodes; this test pins that the decoder
+    /// tolerates it and that the app must not hold forever waiting on an id
+    /// that will never arrive.
     @Test func aWokenPathWithNoIDIsStillWoken() throws {
         let payload = try #require(
             RPCRouter.wakeResultPayload(for: .ok(sessionIncarnationID: nil)))

--- a/Tests/TBDDaemonTests/WorktreeArchiveDeletionQueueTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeArchiveDeletionQueueTests.swift
@@ -45,7 +45,7 @@ struct WorktreeArchiveDeletionQueueTests {
         // `WorktreeLifecycle` is a struct, so the callback is supplied at
         // construction rather than assigned onto a stored instance.
         let observed = ObservedRemoval()
-        let harness = try await ArchiveHarness.make(onWorktreeRemoved: { path, _ in
+        let harness = try await ArchiveHarness.make(onWorktreeRemoved: { _, path, _ in
             await observed.record(
                 path: path,
                 existedAtCallTime: FileManager.default.fileExists(atPath: path)
@@ -139,7 +139,7 @@ struct WorktreeArchiveDeletionQueueTests {
         // here has one path succeed, so the callback firing looks correct
         // either way.
         let observed = ObservedRemoval()
-        let harness = try await ArchiveHarness.make(onWorktreeRemoved: { path, _ in
+        let harness = try await ArchiveHarness.make(onWorktreeRemoved: { _, path, _ in
             await observed.record(
                 path: path,
                 existedAtCallTime: FileManager.default.fileExists(atPath: path)
@@ -196,7 +196,9 @@ struct ArchiveHarness {
     let tempDir: URL
 
     static func make(
-        onWorktreeRemoved: (@Sendable (_ worktreePath: String, _ repoPath: String) async -> Void)? = nil
+        onWorktreeRemoved:
+            (@Sendable (_ worktreeID: UUID, _ worktreePath: String, _ repoPath: String)
+                async -> Void)? = nil
     ) async throws -> ArchiveHarness {
         let (tempDir, repoDir) = try await createTestRepo()
         let db = try TBDDatabase(inMemory: true)

--- a/Tests/TBDSharedTests/AttachmentPathTests.swift
+++ b/Tests/TBDSharedTests/AttachmentPathTests.swift
@@ -1,0 +1,41 @@
+import Foundation
+import Testing
+@testable import TBDShared
+
+/// Where a composer attachment lives. Every helper takes an explicit environment
+/// so this suite needs no `setenv` — the injection seam `Tests/CLAUDE.md`
+/// prefers, and the reason the test fence works at all.
+@Suite("attachment paths")
+struct AttachmentPathTests {
+    private let worktreeID = UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE")!
+    private let attachmentID = UUID(uuidString: "11111111-2222-3333-4444-555555555555")!
+
+    @Test func theBaseDirectorySitsUnderTheConfigDir() {
+        let env = ["TBD_HOME": "/scratch/home"]
+        #expect(TBDConstants.attachmentsDir(environment: env).path
+            == "/scratch/home/attachments")
+    }
+
+    /// The load-bearing property: `TBD_HOME` is honored, so a test run and the
+    /// live daemon never share a directory. A path composed from `$HOME` would
+    /// ignore this and defeat the fence.
+    @Test func itFollowsTBDHome() {
+        let a = TBDConstants.attachmentsDir(environment: ["TBD_HOME": "/one"])
+        let b = TBDConstants.attachmentsDir(environment: ["TBD_HOME": "/two"])
+        #expect(a != b)
+        #expect(a.path.hasPrefix("/one"))
+    }
+
+    @Test func aWorktreeGetsItsOwnDirectory() {
+        let env = ["TBD_HOME": "/scratch/home"]
+        #expect(TBDConstants.attachmentsDir(worktreeID: worktreeID, environment: env).path
+            == "/scratch/home/attachments/\(worktreeID.uuidString)")
+    }
+
+    @Test func aFilePathIsTheWorktreeDirectoryPlusAUUIDPNG() {
+        let env = ["TBD_HOME": "/scratch/home"]
+        #expect(TBDConstants.attachmentPath(
+            worktreeID: worktreeID, attachmentID: attachmentID, environment: env)
+            == "/scratch/home/attachments/\(worktreeID.uuidString)/\(attachmentID.uuidString).png")
+    }
+}

--- a/Tests/TBDSharedTests/TerminalSendPartsWireTests.swift
+++ b/Tests/TBDSharedTests/TerminalSendPartsWireTests.swift
@@ -1,0 +1,77 @@
+import Foundation
+import Testing
+@testable import TBDShared
+
+/// `terminal.send` grows three optional fields. The contract that matters is
+/// what an OLD caller's payload means: `{terminalID, text, submit}` must decode
+/// and behave byte-identically, because `~/.local/bin/tbd` is routinely stale
+/// relative to a running daemon and every agent in the fleet uses that verb.
+@Suite("terminal.send parts on the wire")
+struct TerminalSendPartsWireTests {
+    private let terminalID = UUID(uuidString: "11111111-2222-3333-4444-555555555555")!
+
+    @Test func anOldPayloadDecodesUnchanged() throws {
+        let json = """
+            {"terminalID":"\(terminalID.uuidString)","text":"hello","submit":true}
+            """
+        let params = try JSONDecoder().decode(
+            TerminalSendParams.self, from: Data(json.utf8))
+        #expect(params.text == "hello")
+        #expect(params.submit == true)
+        #expect(params.parts == nil)
+        #expect(params.envelope == nil)
+        #expect(params.gateOnAwaitingInput == nil)
+    }
+
+    @Test func partsDecodeInOrderAndKeepTheirKinds() throws {
+        let json = """
+            {"terminalID":"\(terminalID.uuidString)","submit":true,"parts":[
+              {"kind":"text","value":"look at "},
+              {"kind":"imagePath","value":"/tmp/a.png"},
+              {"kind":"text","value":" and tell me"}
+            ]}
+            """
+        let params = try JSONDecoder().decode(
+            TerminalSendParams.self, from: Data(json.utf8))
+        #expect(params.parts == [
+            .text("look at "),
+            .imagePath("/tmp/a.png"),
+            .text(" and tell me"),
+        ])
+    }
+
+    /// A tagged object, not a bare string: a reader must be able to tell an
+    /// image path from a sentence that happens to look like one, and a third
+    /// kind must be addable without changing an existing field's JSON type.
+    @Test func aPartEncodesAsATaggedObject() throws {
+        let json = try #require(String(
+            data: try JSONEncoder().encode(SendPart.imagePath("/tmp/a.png")),
+            encoding: .utf8))
+        #expect(json.contains(#""kind":"imagePath""#))
+        #expect(json.contains(#""value":"\/tmp\/a.png""#) || json.contains(#""value":"/tmp/a.png""#))
+    }
+
+    @Test func theEnvelopeAndGateFieldsRoundTrip() throws {
+        let explicit = TerminalSendParams(
+            terminalID: terminalID, submit: true,
+            parts: [.text("hi")], envelope: .suppressed, gateOnAwaitingInput: true)
+        let decoded = try JSONDecoder().decode(
+            TerminalSendParams.self, from: JSONEncoder().encode(explicit))
+        #expect(decoded.envelope == .suppressed)
+        #expect(decoded.gateOnAwaitingInput == true)
+        #expect(decoded.parts == [.text("hi")])
+    }
+
+    /// An envelope value this build does not know must not fail the whole
+    /// decode and lose the payload with it — the same reading `HibernateReason`
+    /// and `UpdateMode` already take.
+    @Test func anUnknownEnvelopeValueFallsBackToAttached() throws {
+        let json = """
+            {"terminalID":"\(terminalID.uuidString)","text":"hi","envelope":"redacted"}
+            """
+        let params = try JSONDecoder().decode(
+            TerminalSendParams.self, from: Data(json.utf8))
+        #expect(params.text == "hi")
+        #expect(params.envelope == .attached)
+    }
+}

--- a/Tests/TestSupport/WakeResultTestSupport.swift
+++ b/Tests/TestSupport/WakeResultTestSupport.swift
@@ -1,14 +1,16 @@
 import TBDDaemonLib
 
-/// Test-only helper for `WakeResult.ok`, whose `sessionIncarnationID` payload
-/// (added so `terminal.wake` can report the incarnation a respawn minted) most
-/// callers in this suite don't care about — they only care that the wake
-/// succeeded. Pattern-matches the case instead of comparing full equality so
-/// `== .ok` call sites don't need to hardcode which incarnation (or none) a
-/// given respawn actually minted.
-public func isWakeOk(_ result: WakeResult) -> Bool {
-    if case .ok = result {
-        return true
+/// `WakeResult.ok`'s `sessionIncarnationID` payload (added so `terminal.wake`
+/// can report the incarnation a respawn minted) is more detail than most
+/// callers in this suite care about — they only care that the wake succeeded.
+/// Pattern-matches the case instead of comparing full equality so `.isOk`
+/// call sites don't need to hardcode which incarnation (or none) a given
+/// respawn actually minted.
+extension WakeResult {
+    public var isOk: Bool {
+        if case .ok = self {
+            return true
+        }
+        return false
     }
-    return false
 }

--- a/Tests/TestSupport/WakeResultTestSupport.swift
+++ b/Tests/TestSupport/WakeResultTestSupport.swift
@@ -1,0 +1,14 @@
+import TBDDaemonLib
+
+/// Test-only helper for `WakeResult.ok`, whose `sessionIncarnationID` payload
+/// (added so `terminal.wake` can report the incarnation a respawn minted) most
+/// callers in this suite don't care about — they only care that the wake
+/// succeeded. Pattern-matches the case instead of comparing full equality so
+/// `== .ok` call sites don't need to hardcode which incarnation (or none) a
+/// given respawn actually minted.
+public func isWakeOk(_ result: WakeResult) -> Bool {
+    if case .ok = result {
+        return true
+    }
+    return false
+}

--- a/docs/specs/2026-09-05-transcript-composer-design.md
+++ b/docs/specs/2026-09-05-transcript-composer-design.md
@@ -522,9 +522,15 @@ This is a new kind of durable resource, so it names its reconcilers:
   worktree's attachments directory under the same GC-enabled guard. A revived
   worktree does not get its images back. This is best effort.
 - **Periodic sweep.** A new OrphanGC leg runs on the existing hourly cadence.
-  For each directory under attachments: keep it if its name is not a UUID or
-  names a live worktree row; otherwise delete files older than 14 days and
-  remove the directory when empty. It follows the existing leg shape: skip the
+  For each directory under attachments: keep it if its name is not a UUID;
+  otherwise, if no worktree row of that id remains, remove the whole directory
+  once nothing in it is younger than 14 days. Inside a directory whose row does
+  still exist, each file older than fourteen days is reclaimed on its own while
+  the directory stays — it is never removed while the row lives, even once it
+  holds nothing. That per-file reclaim is safe because a staged image is read at
+  paste time, or at resume time on the wake path: the file is needed for
+  minutes, never days, so one that has sat untouched for two weeks belongs to a
+  message nobody is going to send. It follows the existing leg shape: skip the
   whole leg on a failed database read, emit keep and reap lines into the plan,
   record each reclaim. Fourteen days is a soak knob, not a load-bearing number.
   A file whose token was deleted, or whose send failed, stays on disk for this


### PR DESCRIPTION
## Summary

TBD's transcript pane is getting a message composer: a place to type to the agent
running in a session — with images dropped in among the words — without leaving the
transcript for the terminal. This PR is the daemon half of that composer's send path,
plus the reclaim story for the files it will stage. Nothing in the app calls it yet;
the composer itself is the next PR in the stack.

What the daemon can do after this PR that it could not before:

- **Deliver a composed message, not a string.** `terminal.send` accepts an ordered
  list of parts — runs of text with image paths between them — and delivers them so
  the session shows *one* user turn reading `look at [Image #1] and tell me what it
  is`, image attached inline, rather than three separate messages.
- **Send in the person's own voice.** A send that TBD's own app makes on a human's
  behalf can ask for the `<tbd-dispatch/>` framing line to be left off, so what lands
  in the session is the message the person wrote and nothing else. That request is
  honoured only for the app's own connection, and cannot be obtained by asking.
- **Refuse rather than type into a dialog.** A caller can opt in to a gate that turns
  a send into a refusal — carrying the dialog's own message — when the session is
  sitting on a permission prompt, instead of having the keystrokes eaten by it.
- **Reclaim what the composer stages.** Images a composer prepares live under
  `~/tbd/attachments/<worktreeID>/`, and this PR gives that new durable resource its
  reconcilers before the code that creates it ships.

## Why this shape

Spec: [`docs/specs/2026-09-05-transcript-composer-design.md`](docs/specs/2026-09-05-transcript-composer-design.md)
— principally "Send pipeline" (Payload, Envelope, Refusals and the gate), "Transport
behavior and the holder dependency", "Attachments → Reclaim", and "Rejected
alternatives".

**Parts exist because of how the agent's paste handler works.** Claude Code turns a
paste into an attached image only when the *whole* paste is one quoted path with an
image extension (measured on 2.1.261). A single paste of `look at '/tmp/a.png' and
tell me` therefore arrives as literal text with a path in it. So the message is split
at its image tokens and each piece is pasted separately into the same composer line —
which reproduces byte for byte what a person dragging a file into the terminal
produces. Text pieces submit as one turn; image pieces attach.

**Envelope suppression is authenticated on the connection, never on the request.**
The kernel names the peer of an `AF_UNIX` socket, so a pid read with `getsockopt` at
accept time is a fact about who is on the other end and not a claim the caller can
make. A request that asks for suppression additionally re-verifies, through
`ProcessIdentityCheck`, the identity the FD-vending sidecar recorded for its current
client; only `.same` authenticates, and every other answer attaches the envelope. The
spec names the rejected alternatives: trusting the actor the request declares, letting
any caller suppress, matching the peer's executable *name* (spoofable by copying a
binary), and a startup nonce (a secret in every log and crash report). A dedicated
second socket for app traffic was rejected on cost alone, and stays the clean answer
if this ever needs to be more than a dev-tool boundary.

`ActuationActor` — the `{"actor":{"kind":"app"}}` field the RPC already carries —
gains no authority here. It is an ambient self-declaration that any local process can
stamp on a socket the CLI, the app, and every agent session share; it stays what it
was, a provenance label for the record.

**The awaiting-input gate is opt-in, for the mirror reason.** Agents answer permission
dialogs with this exact verb, on purpose. A daemon-wide gate would refuse precisely
those sends. So the gate is a field the caller sets, and the composer sets it because
a human typing prose into a transcript never means "press 1".

**The holder arm refuses what its single write cannot frame.** A holder-backed session
receives body and carriage return in one unwrapped write, and past a threshold in the
agent's own tokenizer the carriage return is swallowed rather than submitting — a
single unwrapped write of 63 bytes submits, 64 does not (same measurement,
2.1.261). Multi-line and multi-part payloads are therefore refused on that transport,
with a message that says why and names the fix. That fix is bracketed-paste wrapping,
which belongs to the holder work already in flight (#816); when it lands, the refusal
lifts. Note what the refusal is *not* keyed on: length. Length is #816's, and this PR
adds no byte-count leg.

## What this PR does

**`terminal.send` gains three optional params** (`Sources/TBDShared/RPCProtocol.swift`),
all of which decode absent as today's behaviour:

- `parts` — an ordered array of `{kind: "text" | "imagePath", value: …}`. Shape is
  validated before any session row is looked up, so a malformed payload fails the same
  way whatever the target.
- `envelope` — `"attached"` (default) or `"suppressed"`, a *request* that the
  connection must earn.
- `gateOnAwaitingInput` — the opt-in refusal above.

**Delivery.** On the tmux arm each part becomes its own bracketed paste in order, then
one Enter if submitting. When the envelope is attached and no part carries non-empty
text — an image-only message — the envelope goes out as its own leading paste so the
image paste stays bare and alone and still attaches, rather than being merged into a
line the agent would read as text.

**Authentication.** A new `RPCConnectionContext` carries the peer pid read once per
accepted connection (`Sources/TBDDaemon/Server/SocketServer.swift`), and the send
handler re-verifies the sidecar's recorded client identity before honouring a
suppression request.

**The gate.** `AwaitingInputSendGate` reuses the existing `AwaitingInputSupersession`
record, so it refuses on the same standing-dialog signal the rest of the daemon
already trusts, and carries that dialog's own message into the refusal. It sits in one
block that both transports fall into — not two call sites — because the bug that
motivated the restructure was exactly a rail added to one arm and forgotten in the
other.

**`terminal.wake` reports its incarnation.** `TerminalWakeResult` gains an optional
`sessionIncarnationID`, so a caller that wakes a hibernated session and then sends to
it can scope its wait to the session the wake actually minted. The no-op path (nothing
was hibernated) names no incarnation, which is what makes the field meaningful.

**Attachments paths and reclaim.** `TBDConstants.attachmentsDir` / `attachmentPath`
(TBD_HOME-honouring, like every other TBD-owned path), an unlink on the archive path,
and a new `reclaimAttachments` leg in `OrphanGC` — see Reconciler below.

**Builds on the two PRs below it.** PR A's two not-running rails, `paneProcessInspector`,
`HibernateReason.exited` and the app's wake prompt are already in `performTerminalSend`
and are neither re-added nor moved here — a reviewer reading that function top to
bottom is reading three PRs' rails at once. PR B's `transcript_composer_enabled` is the
column this PR's GC leg reads; it is not added here. One inherited behaviour worth
restating because the send path depends on it: a session row with a NULL `kind` reads
as Claude only when it carries a Claude session id, and as a shell otherwise — the same
rule the `v22` backfill used.

## Reconciler

**This PR introduces a new kind of durable resource — files under
`~/tbd/attachments/<worktreeID>/` — and names two reconcilers and three reclaim rules
for it.**

- **`OrphanGC.removedWorktreeCleanup`** (`Sources/TBDDaemon/GC/OrphanGC.swift`) unlinks
  a worktree's attachments directory on the existing worktree-removed callback that the
  archive path and `scratch.delete` already fire — the **archive-time unlink**. Best
  effort, under the `gcEnabled` master switch, and derived from the injected attachments
  base rather than a re-resolved global constant. `forgetWorktree` does not fire that
  callback; the hourly leg below covers what it leaves.
- **`OrphanGC.reclaimAttachments`** runs on the existing hourly cadence and is the
  standing guarantee. It carries the other two rules:
  - **An orphan directory past the floor** — no worktree row of that id remains, and
    nothing inside is younger than fourteen days — goes whole. Keep-biased and
    all-or-nothing: it keeps an entry that is not a directory, whose name is not a
    UUID, whose contents it cannot read, or that holds any file the floor has not
    reached; an empty one is measured on its own mtime against the same floor.
  - **A file past the floor inside a live worktree's directory** is reclaimed on its
    own, while the directory stays — never removed while the row lives, even once it
    holds nothing. This is safe because a staged image is read at paste time, or at
    resume time on the wake path: the file is needed for minutes, never days, so one
    that has sat untouched for two weeks belongs to a message nobody is going to send.
    Only regular files age; an unreadable file age keeps, as does an unreadable
    directory.

  It skips the whole leg on a failed database read, because "no worktrees" and "could
  not ask" must not look alike. Fourteen days is a soak knob, not a load-bearing number.

No `ReapRecord` is written for an attachments reap — matching the holder-rendezvous and
rowless-holder legs — because there is nothing a `tbd gc restore` could put back: the
image was staged for a message in a worktree that no longer exists. Consequently these
reaps do not appear in the History UI, and `.reapRecordsChanged` fires only via the
shared `reaped > 0` counter.

## Coordination

`performHolderSend`, `HolderInjectionCourier` and everything under
`Sources/TBDDaemon/Holder/` are untouched. The holder refusal is placed in
`performTerminalSend`, textually ahead of the holder branch, so that arm sees only
payloads it can already deliver. PR #816 owns the holder transport and lifts both
refusals this PR adds — the multi-line/multi-part one and the unauthenticated
image-only one.

## Flag & rollout

`transcript_composer_enabled` — a `config` column added in the PR below this one,
**default OFF**, no SQL default, so "nobody has chosen" stays a third state distinct
from an explicit opt-out. Enable it for a soak in Settings → General → Experimental.

What the flag gates here is exactly one thing: the `reclaimAttachments` GC leg, which
also requires `gcEnabled`. Both branches are tested, and a `--dry-run` sweep bypasses
the flag deliberately, so an operator can see what enabling it *would* reclaim before
enabling it.

Two things are deliberately **not** flag-gated, and the reasoning is the same for both:
a flag that gates *creation* must never gate *reclaim*, or turning the feature off
strands its files forever. So the archive-time unlink and the `scratch.delete` unlink
run under `gcEnabled` alone.

The send-path fields are ungated because they are inert: no shipped caller sets
`parts`, `envelope` or `gateOnAwaitingInput`, and each decodes absent as exactly
today's behaviour. Graduation is the composer PR's to make — the flag flips when the
composer itself is ready, and the change is the one `?? Config.transcriptComposerEnabledDefault`
constant.

## Assumptions

- **The agent's paste handler keys image detection on a whole-paste quoted path with
  an image extension.** If that changes, images arrive as literal paths and the agent
  reads them with its file-reading tool instead: degraded, not broken.
- **The holder byte threshold is a property of the agent's tokenizer**, not a number
  TBD controls or can negotiate. It was measured, not documented, and it can move.
- **The FD-vending sidecar has exactly one client, and that client is the app**, which
  connects eagerly and unconditionally as soon as the RPC socket answers — the same
  assumption the app-liveness arbiter already rests on. `FDVendingServer.adoptConnection`
  records whatever process connects, last writer wins, and a sidecar client can already
  inject raw bytes; suppression inherits that existing trust boundary rather than
  creating a new one. If the sidecar is not connected, suppression fails closed and a
  human's message carries a dispatch line — nothing is lost.
- **Wire compatibility.** An old caller's `{terminalID, text, submit}` decodes with the
  three new fields nil; an unrecognised `envelope` string decodes as `.attached`, the
  safe direction; `TerminalWakeResult.sessionIncarnationID` is additive.

## Evidence & verification

`scripts/swift-safe build --build-tests` clean; `swiftlint --strict` reports 0
violations across 992 files. The branch's own suites —
`TerminalSendPartsDeliveryTests`, `EnvelopeSuppressionAuthTests`,
`TerminalSendPartsShapeTests`, `TerminalSendDispatchTests`,
`TerminalSendNotRunningTests`, `AwaitingInputSendGateTests`,
`HolderCompositeSendRefusalTests`, `OrphanGCAttachmentsTests`, `OrphanGCTests`,
`AttachmentArchiveCleanupTests`, `TerminalWakeIncarnationTests`,
`AttachmentPathTests` — **145 tests in 15 suites, 0 failures** on the rebased head.

Full-suite CI was dispatched for this branch, since `test.yml` fires automatically only
for PRs based on `main`:
https://github.com/cheapsteak/tbd/actions/runs/34028298661 — **verdict pending at the
time of writing.**

**The discriminating tests**, i.e. the ones that fail if a rule is applied bluntly
rather than precisely:

- `anOptedOutSendIntoTheSamePromptIsNotGated` and `anOptedOutSendToAHolderRowIsNotGated`
  — fail if the awaiting-input gate is made unconditional on either transport.
- `anOptedInSendToAHolderRowIsRefused` — fails if the gate is skipped for one transport,
  the defect that motivated hoisting it above the transport fork. It asserts nothing
  reached the pty, through the harness's real injection courier.
- `aCLIConnectionAskingForSuppressionStillGetsTheEnvelope` and
  `theDeclaredActorChangesNothingInEitherDirection` — fail if `ActuationActor` is ever
  read for authority, in either direction.
- `aReVerifyThatIsNotSameKeepsTheEnvelope` — fails if only the peer pid is checked and
  the sidecar's recorded identity is not re-verified.
- `anUnauthenticatedImageOnlySendPastesTheEnvelopeFirst` /
  `anAuthenticatedImageOnlySendPastesOnlyThePath` — one asserts two pastes, the other
  one; a change that merges the envelope into the image paste fails the first, and a
  change that always emits it fails the second.
- `aTmuxRowStillAcceptsMultiLineAndParts` and PR A's
  `aLiveRowWithClaudeForegroundIsNotRefused` — the positive controls that fail if the
  rails start refusing everything.
- `theFlagOffLeavesEverythingAlone` and `aDryRunPlansWithTheFlagOffAndUnlinksNothing` —
  the flag's two branches, plus the dry-run bypass.
- `anUnreadableOrphanDirectoryIsKept`, `anEmptyOrphanYoungerThanTheFloorIsKept` vs
  `anEmptyOrphanOlderThanTheFloorIsReaped`, `aNonUUIDDirectoryIsKept`,
  `anArchivedWorktreesAttachmentsAreKept` — the keep-biased sweep's rules, each with a
  counterpart that reaps, so "keeps everything" cannot pass.
- `aStaleFileInALiveWorktreeIsReapedWhileTheDirectoryStays` — one 30-day file and one
  1-day file in the same live worktree's directory: fails if the per-file rule reaps
  the directory, spares the stale file, or takes the young one with it.
  `aDryRunPlansALiveWorktreesStaleFileWithoutUnlinkingIt` and
  `aNonRegularEntryInALiveWorktreeIsIgnored` fence the other two branches.

Every one of the above was observed RED before its fix and GREEN after, except the two
parts-payload additions to the auth suite, which are additive coverage of a rule that
already held and passed from the start.

**Live verification is deferred, and here is exactly what that means.** This machine is
running a live fleet of agent sessions, and the standing rule forbids restarting the
daemon or app, sending raw frames to the RPC socket, or running a real GC sweep against
the real home. So three checks the plan called for were **not** run:

- *Restart and confirm the process pair.* Nothing here changes the launch path.
- *Drive a parts send, an actor-spoofing send, and a gated send through the socket by
  hand.* Standing in for them: `TerminalSendPartsDeliveryTests` (order and paste
  shape end to end through the handler), `EnvelopeSuppressionAuthTests` (both the
  authenticated and the stranger connection, on `text` and on `parts`), and
  `AwaitingInputSendGateTests` (refusal message, opt-out, both transports).
- *A real `tbd gc sweep-now` and a staged, backdated orphan directory.*  Standing in
  for it: `OrphanGCAttachmentsTests`, which stages exactly that tree under a fenced
  `TBD_HOME` and an injected attachments base, backdates it through the injected `now`
  seam, and asserts both the dry-run plan and the real reap.

The one thing no test replaces is watching a real session render `look at [Image #1]`
as a single attributed turn. That needs the composer to exist to click, so it is the
first thing to check when the composer PR lands.

## Follow-ups

- The sidecar's trust anchor is last-writer-wins. First-client-wins, or a
  daemon-minted token handed to the app at launch, belongs to the sidecar rather than
  to this send path.
- `tbd terminal wake --json` does not yet print `sessionIncarnationID`.
- A `logger.debug` when the RPC channel is not a `SocketOptionProvider`, so
  suppression failing closed is visible rather than silent.
- The TOCTOU window between the not-running rails and the paste (noted in the PR
  below) applies to a parts send too — it is wider, since a parts send makes several
  pastes.
- #816 lifts both holder refusals.
- The `.reapRecordsChanged`-with-no-record edge is house style across several GC legs,
  not something this PR changes.


### Live run, 2026-09-06 — daemon and app built from `79d9e85d`, against a zero-token stub session

Run against the live fleet with `scripts/restart.sh` from `composer-d`; daemon
`daemon status` reported `Build: 79d9e85d (tbd/composer-d-app-composer)`. Every model
request went to `scripts/claude-stub.py` on loopback (both stub servers printed
`no model request left this machine`), so the session cost nothing. Full record:
`.superpowers/sdd/2026-09-05-composer-d-app-composer/live-verification-report.md`.

**The parts payload arrives as one turn with the image inline.** `terminal.send` with
`actor:{"kind":"app"}`, `envelope:"suppressed"`, `gateOnAwaitingInput:true` and three
parts, read back out of the session's transcript JSONL — not the screen:

```
[user] TEXT:'<tbd-dispatch id="965rlv98pe4y" from="app"/>\nlook at [Image #4] and tell me what it is' | IMAGE:image/png 240b
[user] TEXT:'[Image: source: /tmp/a.png]'
```

**The declared actor changes nothing.** The same payload re-sent as
`actor:{"kind":"session",…}` produced the identical shape — one turn, image inline,
envelope attached. Only the envelope's `from=` label follows the declaration.

**Suppression is refused on the connection, and the reason proves the whole chain.**
Each suppression-asking `nc` send logged exactly one line:

```
[com.tbd.daemon:terminalHandlers] send: envelope suppression refused (peer-pid-is-not-the-apps) — attaching the dispatch line
```

That reason is only reachable *after* `connection.peerPID` resolved and
`recordedAppIdentity()` returned a value, so the live run also demonstrates the
`getsockopt` at accept and a connected FD-vending sidecar with the app recorded as its
client — a sidecar-less daemon would have said `no-recorded-sidecar-client`, and an
unestablished peer `peer-pid-unestablished`.

**The awaiting-input gate refuses, and the opt-out passes.** TBD spawns Claude with
`--dangerously-skip-permissions`, so the state was produced through the hook's own RPC,
`terminal.notificationEvent` with `notification_type: "permission_prompt"` (the row took
it as `classification: "prompt_on_screen"`). Gated:

```
{"success":false,"error":"terminal.send was refused: the session has a prompt on screen — \"Claude needs your permission to run: echo hello-from-stub\". Nothing was typed; a pasted message plus Enter would commit whichever option is highlighted. Answer it in the terminal."}
```

Nothing was typed. The same payload with the field omitted, against the same standing
prompt, went through and the text appeared in the composer.

**The wake names its spawn, once.**

```
wake #1: {"woken":true,"sessionIncarnationID":"1FC3EB77-1DAD-4C1E-BF8A-8759A1E2BAE9"}
wake #2: {"woken":false}
```

and the woken pane's own `TBD_TERMINAL_INCARNATION_ID` read
`1FC3EB77-1DAD-4C1E-BF8A-8759A1E2BAE9`, matching the row.

**The holder refusals carry their reason.** Against a holder-backed terminal, a
multi-part payload and a payload whose text contains a newline are each refused with
"…delivers a message in one unwrapped write… Nothing was typed. Send a single-line
message, or move the session to tmux."

**The GC leg, all three branches, on staged fixtures under `~/tbd/attachments/`:**

```
flag ON,  --dry-run : KEEP not-a-worktree-id / KEEP live-worktree / REAP attachments
flag OFF, --dry-run : identical plan (the dry run bypasses the flag)
flag OFF, real sweep: all three directories still present
flag ON,  real sweep: only the backdated orphan gone
```

`tbd terminal completions --json` returned `{agents: 18, commands: 213, freshness:
"stale", source: "probe"}`.

**One defect found, and it is this PR's.** A parts message's `[Image #N]` token can land
at the **end** of the message instead of at its place among the words, and that send can
fail to submit. Observed twice, both times on the first image a Claude Code process had
ever been given:

```
expected: look at [Image #1] and tell me what it is
observed: look at  and tell me what it is[Image #1]      (and submit:true did not submit)
```

Repeats of the same payload in the same session landed correctly (runs 2–4), and a third
session's first parts send was also correct, so it is a race rather than a constant. The
shape points at the `.parts` arm pasting each part back-to-back with no pause while
Claude Code's paste handler inserts the token asynchronously: when the following text
paste wins, the token is appended at the caret's new position, and an Enter arriving
mid-attach is dropped. An image-only paste measured ~1 s to produce its token with
nothing competing. The splitting is right; the ordering needs a wait on the image part's
token before the next paste, and certainly before Enter.

[composer-c](https://cheapsteak.github.io/tbd/open/?worktree=98C2D440-D4F2-4EB3-966F-D67650C149DF)
https://claude.ai/code/session_01E9SPoxoVoApcVmduLiBWik



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Terminal messages support ordered text and image parts, image delivery controls, and submission options.
  - Sends can be gated while an active terminal prompt requires a response.
  - Dispatch-envelope suppression is authenticated for supported sends.
  - Successful terminal wake responses can identify the newly started session.

- **Bug Fixes**
  - Removed worktrees now clean up associated attachments and scratch data.
  - Attachment cleanup preserves active, recent, unknown, or unreadable data while reclaiming eligible stale files.
  - Unsupported multipart sends are prevented through holder terminals.
  - Wake handling now returns a safe error instead of terminating on unexpected results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
