### PR TITLE
Feat: A message composer in the live transcript pane

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -277,6 +277,13 @@ custom_rules:
       - "Sources/TBDApp/Panes/Transcript/TranscriptOverlayView\\.swift"
       # OverlayFileView is the body of a file frame in the overlay — outside the transcript list, real ScrollView is safe.
       - "Sources/TBDApp/Panes/Transcript/OverlayFileView\\.swift"
+      # CompletionOverlayView is the composer's completion menu, a fixed-height
+      # floating overlay above the composer — never hosted or measured as a
+      # transcript row card.
+      - "Sources/TBDApp/Panes/Transcript/Composer/CompletionOverlayView\\.swift"
+      # AttachmentStrip is the composer's thumbnail strip above the text field —
+      # also outside the transcript list's row-measurement path.
+      - "Sources/TBDApp/Panes/Transcript/Composer/AttachmentStrip\\.swift"
     regex: '\bScrollView\b'
     match_kinds:
       - identifier

--- a/Sources/TBDApp/AppState+Composer.swift
+++ b/Sources/TBDApp/AppState+Composer.swift
@@ -26,6 +26,32 @@ extension AppState {
         composerDrafts[terminalID] = nil
     }
 
+    /// Forget everything the composer keys on this terminal, because the
+    /// terminal itself is gone.
+    ///
+    /// Called from both deaths a terminal has: the tab close that deletes it,
+    /// and `removeDeletedTerminalFromState`, which every other route — a pane
+    /// close, an archive, a daemon-reported removal — funnels through. The tab
+    /// close alone was not enough: it is the rarer of the two, and a draft left
+    /// behind by the common path sits in the map for the app's lifetime, joined
+    /// by a fresh empty one whenever a send finishing after the row is gone asks
+    /// `composerDraft(for:)` again.
+    ///
+    /// Memory only, and safe by construction: the terminal row no longer exists,
+    /// so nothing can send this draft, mount this composer, or spawn into this
+    /// incarnation. The two focus registries hold their views weakly and leak
+    /// nothing, but they do accumulate empty boxes, so they are pruned here too.
+    ///
+    /// Waiters are RESUMED rather than dropped — see
+    /// `releaseSessionStartWaiters`.
+    func forgetComposerState(for terminalID: UUID) {
+        discardComposerDraft(for: terminalID)
+        composerFocusTargets.removeValue(forKey: terminalID)
+        transcriptFocusTargets.removeValue(forKey: terminalID)
+        lastStartedIncarnation.removeValue(forKey: terminalID)
+        releaseSessionStartWaiters(terminalID: terminalID)
+    }
+
     /// Whether the daemon reports the composer as enabled. False until
     /// capabilities have been fetched, which is the conservative reading: a
     /// composer that flashed in and then disappeared would be worse than one that

--- a/Sources/TBDApp/AppState+Composer.swift
+++ b/Sources/TBDApp/AppState+Composer.swift
@@ -1,0 +1,51 @@
+import Foundation
+import os
+import TBDShared
+
+private let logger = Logger(subsystem: "com.tbd.app", category: "composer")
+
+extension AppState {
+
+    /// This terminal's draft, created on first ask and kept for the app's
+    /// lifetime — or until `discardComposerDraft` forgets it.
+    ///
+    /// Kept in an `@ObservationIgnored` dictionary because the DICTIONARY is not
+    /// what anything observes: each `ComposerDraft` is itself `@Observable`, and
+    /// a view that holds one re-renders on its changes. Making the registry
+    /// observable would republish every composer in the app whenever any of them
+    /// gained a draft.
+    func composerDraft(for terminalID: UUID) -> ComposerDraft {
+        if let existing = composerDrafts[terminalID] { return existing }
+        let draft = ComposerDraft()
+        composerDrafts[terminalID] = draft
+        return draft
+    }
+
+    /// Forget a terminal's draft — on a successful send, and when its tab closes.
+    func discardComposerDraft(for terminalID: UUID) {
+        composerDrafts[terminalID] = nil
+    }
+
+    /// Whether the daemon reports the composer as enabled. False until
+    /// capabilities have been fetched, which is the conservative reading: a
+    /// composer that flashed in and then disappeared would be worse than one that
+    /// appeared a moment late.
+    var transcriptComposerEnabled: Bool {
+        daemonCapabilities?.transcriptComposerEnabled ?? false
+    }
+
+    /// Fetch this terminal's completion inventory. nil on any failure — the menu
+    /// shows its loading row and then simply has nothing to offer, which is a
+    /// smaller loss than an error banner over a text field.
+    func fetchCompletions(terminalID: UUID) async -> TerminalCompletionsResult? {
+        do {
+            return try await daemonClient.terminalCompletions(terminalID: terminalID)
+        } catch {
+            logger.debug("""
+            completions unavailable for terminal \
+            \(terminalID.uuidString, privacy: .public): \(error, privacy: .public)
+            """)
+            return nil
+        }
+    }
+}

--- a/Sources/TBDApp/AppState+ComposerFocus.swift
+++ b/Sources/TBDApp/AppState+ComposerFocus.swift
@@ -1,0 +1,102 @@
+import AppKit
+import Foundation
+
+/// A weak handle on one composer's text view, so focus can be moved to it from
+/// a menu command without the registry keeping a torn-down pane alive.
+///
+/// The `TerminalFocusTarget` shape (`AppState+TerminalFocus.swift`), for the
+/// same reason: focus is a fact about a view that exists right now.
+@MainActor
+final class ComposerFocusTarget {
+    weak var view: NSView?
+
+    init(_ view: NSView) { self.view = view }
+}
+
+/// What a composer's wake answered.
+///
+/// Three cases rather than a `Bool` and an error string, because the middle one
+/// is the interesting one: a wake the daemon answered `woken: false` delivered
+/// the prompt nowhere, which is neither a success nor a failure and must not be
+/// reported as either.
+///
+/// Named at file scope rather than nested in `ComposerSendCoordinator` so this
+/// plumbing compiles before the coordinator exists; the coordinator adopts it
+/// as its `WakeReply`.
+enum ComposerWakeReply: Equatable, Sendable {
+    /// A spawn happened. The incarnation is the id that spawn will echo on its
+    /// `SessionStart`, or nil from a daemon that predates the field — in which
+    /// case there is nothing to scope a wait to.
+    case woken(incarnationID: UUID?)
+    /// Idempotent no-op: already awake, or another wake was in flight. The
+    /// prompt reached nobody.
+    case noOp
+    case failed(message: String)
+}
+
+extension AppState {
+    func registerComposerView(_ view: NSView, for terminalID: UUID) {
+        composerFocusTargets[terminalID] = ComposerFocusTarget(view)
+    }
+
+    /// Only the CURRENT view may unregister. A pane rebuilt while the old view is
+    /// still deallocating would otherwise evict its own replacement.
+    func unregisterComposerView(_ view: NSView, for terminalID: UUID) {
+        guard composerFocusTargets[terminalID]?.view === view else { return }
+        composerFocusTargets.removeValue(forKey: terminalID)
+    }
+
+    /// Cmd+/ — put the caret in this terminal's composer. A no-op when no
+    /// composer is mounted, which is the honest answer for a pane that is closed.
+    func focusComposer(terminalID: UUID) {
+        guard let view = composerFocusTargets[terminalID]?.view else { return }
+        view.window?.makeFirstResponder(view)
+    }
+
+    /// Escape from the composer — hand focus back to the transcript, which is
+    /// where the person was reading.
+    func focusTranscript(terminalID: UUID) {
+        guard let view = transcriptFocusTargets[terminalID]?.view else {
+            // No transcript table registered: give up first responder rather
+            // than holding it, so the pane's own key handling resumes.
+            composerFocusTargets[terminalID]?.view?.window?.makeFirstResponder(nil)
+            return
+        }
+        view.window?.makeFirstResponder(view)
+    }
+
+    /// The Reveal Terminal action on the blocked banner. Answering a dialog in
+    /// the terminal is the correct resolution, so the composer's job is to get
+    /// the person there rather than to offer a second way to answer.
+    func revealTerminal(terminalID: UUID) {
+        guard let view = terminalFocusTargets[terminalID]?.view else { return }
+        view.window?.makeFirstResponder(view)
+        view.window?.makeKeyAndOrderFront(nil)
+    }
+
+    /// The Reveal Terminal action's sibling for the wake path: wake this
+    /// terminal and report what the daemon answered, incarnation included.
+    ///
+    /// A sibling of `wakeTerminal` rather than a change to it. That one returns
+    /// an error string, which is all its five call sites want, and threading a
+    /// result through PR A's shared `terminalWakeSender` seam would change every
+    /// one of them to serve one screen. The app's own `wakeInFlight` dedupe is
+    /// deliberately not consulted here either: the daemon has its own
+    /// `wakesInFlight`, and it answers a racing wake with `woken: false`, which
+    /// is exactly the honest reply for a composer — the prompt went nowhere.
+    func wakeTerminalForComposer(
+        terminalID: UUID, worktreeID: UUID, prompt: String
+    ) async -> ComposerWakeReply {
+        do {
+            let size = mainAreaTerminalSize()
+            let result = try await composerWakeSender(
+                terminalID, size.cols, size.rows, prompt)
+            await refreshTerminals(worktreeID: worktreeID)
+            return result.woken
+                ? .woken(incarnationID: result.sessionIncarnationID)
+                : .noOp
+        } catch {
+            return .failed(message: error.localizedDescription)
+        }
+    }
+}

--- a/Sources/TBDApp/AppState+ComposerFocus.swift
+++ b/Sources/TBDApp/AppState+ComposerFocus.swift
@@ -134,27 +134,50 @@ extension AppState {
 }
 
 extension AppState {
-    /// The terminal the composer menu commands act on.
+    /// The terminal the composer menu commands act on: the first one, among the
+    /// tabs that could plausibly be on screen, that actually has a composer
+    /// mounted.
     ///
-    /// `resolvedFocusedTabCloseContext()` is the accessor the Terminal menu's
-    /// other items already use to name what has focus. It answers nil while
-    /// focus sits in something that is not a terminal view — the transcript
-    /// table and the composer itself both qualify, and both are exactly where
-    /// somebody pressing these shortcuts is — so the last-focused tab is the
-    /// fallback, which is the same value that method falls back to when nothing
-    /// has registered at all.
+    /// **The registration is the answer, not a tie-breaker.** ⌘/ is only ever
+    /// meaningful for a terminal whose composer exists; `focusComposer` on any
+    /// other terminal is a no-op. Naming the registered one — and nil when there
+    /// is none — is what makes the menu items' `.disabled(…)` honest instead of
+    /// offering an action that quietly does nothing.
+    ///
+    /// **Two candidate tabs, in order.** The focused-terminal context first, so
+    /// a split holding both a terminal and a transcript still answers for the
+    /// half the person is in. Then the selected worktree's active tab, which is
+    /// the only candidate that exists at all while focus sits in the transcript
+    /// table or the composer itself: `resolvedFocusedTabCloseContext()` answers
+    /// nil for anything that is not a `TBDTerminalView`, and nothing writes
+    /// `focusedTabCloseContext` for a `.liveTranscript` tab — so relying on it
+    /// alone made ⌘/ in a transcript pane name the last-focused *terminal* tab,
+    /// which is either a no-op or, worse, a caret moved in a background tab.
+    ///
+    /// The unconditional `resolvedFocusedTabCloseContext()` call also keeps the
+    /// observable dependency it documents: it reads `focusedTabCloseContext`,
+    /// the one observable property that moves when focus does, so `.disabled(…)`
+    /// re-evaluates. `composerFocusTargets` is `@ObservationIgnored`, so a
+    /// composer mounting or going away still does not re-evaluate the menu on
+    /// its own — the same staleness `canCloseFocusedTab` documents, and the
+    /// consequence is a stale menu state rather than a wrong action.
     ///
     /// `terminalIDs(in:)` rather than the layout's own enumeration, because a
     /// `.liveTranscript` tab — the composer's own home — is precisely the shape
     /// `allTerminalIDs()` does not report. A tab rendering several terminals
-    /// prefers whichever one has a composer registered, and names the tab's
-    /// first otherwise, so the command still points somewhere during the one
-    /// main-actor turn before the composer's deferred registration lands.
+    /// with composers picks among them by `Set` order, which is deterministic
+    /// and exact for the single-terminal tabs the composer actually lives in.
     var composerCommandTerminalID: UUID? {
-        guard let context = resolvedFocusedTabCloseContext() ?? focusedTabCloseContext,
-              let tab = tabs[context.worktreeID]?.first(where: { $0.id == context.tabID })
-        else { return nil }
-        let ids = terminalIDs(in: tab)
-        return ids.first(where: { composerFocusTargets[$0]?.view != nil }) ?? ids.first
+        let focusedTab = resolvedFocusedTabCloseContext().flatMap { context in
+            tabs[context.worktreeID]?.first(where: { $0.id == context.tabID })
+        }
+        let activeTab = selectedWorktreeIDs.first.flatMap { resolvedActiveTab(worktreeID: $0) }
+        for tab in [focusedTab, activeTab].compactMap({ $0 }) {
+            if let id = terminalIDs(in: tab).first(
+                where: { composerFocusTargets[$0]?.view != nil }) {
+                return id
+            }
+        }
+        return nil
     }
 }

--- a/Sources/TBDApp/AppState+ComposerFocus.swift
+++ b/Sources/TBDApp/AppState+ComposerFocus.swift
@@ -84,6 +84,18 @@ extension AppState {
     /// deliberately not consulted here either: the daemon has its own
     /// `wakesInFlight`, and it answers a racing wake with `woken: false`, which
     /// is exactly the honest reply for a composer — the prompt went nowhere.
+    ///
+    /// **Returns before the terminal refresh, on purpose.** The refresh is a
+    /// second daemon round trip that buys this method nothing the reply
+    /// itself needs — the caller's next move is `awaitSessionStart`, scoped to
+    /// the incarnation this method already has in hand. Awaiting the refresh
+    /// first would open a window between minting that incarnation and the
+    /// caller registering its waiter: a `SessionStart` landing in that window
+    /// would reach `noteSessionStart` before any waiter existed to release,
+    /// stalling the send to its timeout. (`noteSessionStart`'s latch closes
+    /// that gap too, independently — this is the other half of the fix.)
+    /// Firing the refresh as its own unstructured task keeps it happening
+    /// without making the caller wait for it.
     func wakeTerminalForComposer(
         terminalID: UUID, worktreeID: UUID, prompt: String
     ) async -> ComposerWakeReply {
@@ -91,7 +103,9 @@ extension AppState {
             let size = mainAreaTerminalSize()
             let result = try await composerWakeSender(
                 terminalID, size.cols, size.rows, prompt)
-            await refreshTerminals(worktreeID: worktreeID)
+            Task { @MainActor [weak self] in
+                await self?.refreshTerminals(worktreeID: worktreeID)
+            }
             return result.woken
                 ? .woken(incarnationID: result.sessionIncarnationID)
                 : .noOp

--- a/Sources/TBDApp/AppState+ComposerFocus.swift
+++ b/Sources/TBDApp/AppState+ComposerFocus.swift
@@ -53,6 +53,24 @@ extension AppState {
         view.window?.makeFirstResponder(view)
     }
 
+    /// The transcript table this terminal is reading, so Escape in the composer
+    /// has somewhere to send focus back to.
+    ///
+    /// Written from `TableTranscriptView.makeNSView` rather than from a deferred
+    /// task: both registries are `@ObservationIgnored`, so the write publishes
+    /// nothing and cannot re-enter the view update that is making the view.
+    func registerTranscriptView(_ view: NSView, for terminalID: UUID) {
+        transcriptFocusTargets[terminalID] = ComposerFocusTarget(view)
+    }
+
+    /// Newer-wins, exactly as `unregisterComposerView` is: a session rollover
+    /// rebuilds the table under its `.id`, and the outgoing view must not evict
+    /// the replacement that has already registered.
+    func unregisterTranscriptView(_ view: NSView, for terminalID: UUID) {
+        guard transcriptFocusTargets[terminalID]?.view === view else { return }
+        transcriptFocusTargets.removeValue(forKey: terminalID)
+    }
+
     /// Escape from the composer — hand focus back to the transcript, which is
     /// where the person was reading.
     func focusTranscript(terminalID: UUID) {
@@ -112,5 +130,31 @@ extension AppState {
         } catch {
             return .failed(message: error.localizedDescription)
         }
+    }
+}
+
+extension AppState {
+    /// The terminal the composer menu commands act on.
+    ///
+    /// `resolvedFocusedTabCloseContext()` is the accessor the Terminal menu's
+    /// other items already use to name what has focus. It answers nil while
+    /// focus sits in something that is not a terminal view — the transcript
+    /// table and the composer itself both qualify, and both are exactly where
+    /// somebody pressing these shortcuts is — so the last-focused tab is the
+    /// fallback, which is the same value that method falls back to when nothing
+    /// has registered at all.
+    ///
+    /// `terminalIDs(in:)` rather than the layout's own enumeration, because a
+    /// `.liveTranscript` tab — the composer's own home — is precisely the shape
+    /// `allTerminalIDs()` does not report. A tab rendering several terminals
+    /// prefers whichever one has a composer registered, and names the tab's
+    /// first otherwise, so the command still points somewhere during the one
+    /// main-actor turn before the composer's deferred registration lands.
+    var composerCommandTerminalID: UUID? {
+        guard let context = resolvedFocusedTabCloseContext() ?? focusedTabCloseContext,
+              let tab = tabs[context.worktreeID]?.first(where: { $0.id == context.tabID })
+        else { return nil }
+        let ids = terminalIDs(in: tab)
+        return ids.first(where: { composerFocusTargets[$0]?.view != nil }) ?? ids.first
     }
 }

--- a/Sources/TBDApp/AppState+SessionStartWaiters.swift
+++ b/Sources/TBDApp/AppState+SessionStartWaiters.swift
@@ -85,6 +85,17 @@ extension AppState {
         for waiter in matched { waiter.resume(true) }
     }
 
+    /// Fail every waiter on this terminal, because the terminal has stopped
+    /// existing and the spawn they are holding for can no longer report in.
+    ///
+    /// Resumed `false` rather than dropped: the entry is a suspended
+    /// continuation, and a continuation nobody resumes hangs its send for the
+    /// life of the app rather than timing out.
+    func releaseSessionStartWaiters(terminalID: UUID) {
+        guard let waiters = sessionStartWaiters.removeValue(forKey: terminalID) else { return }
+        for waiter in waiters { waiter.resume(false) }
+    }
+
     private func withdrawSessionStartWaiter(terminalID: UUID, token: UUID) {
         guard let waiters = sessionStartWaiters[terminalID],
               let waiter = waiters.first(where: { $0.token == token })

--- a/Sources/TBDApp/AppState+SessionStartWaiters.swift
+++ b/Sources/TBDApp/AppState+SessionStartWaiters.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+/// One suspended caller waiting for one spawn to report in.
+///
+/// Scoped by the incarnation rather than by the terminal alone, because the
+/// terminal is not the question: a competing wake, a post-`--fork-session`
+/// recapture, and a person typing `claude --resume` in the pane all raise a
+/// `SessionStart` on the same terminal, and none of them is the message's own
+/// session.
+@MainActor
+struct SessionStartWaiter {
+    /// Identifies this registration so cancellation can withdraw exactly it.
+    let token: UUID
+    let incarnationID: UUID
+    let resume: (Bool) -> Void
+}
+
+extension AppState {
+    /// Resolves true when this terminal reports a `SessionStart` carrying
+    /// exactly `incarnationID`, and false on cancellation.
+    ///
+    /// **No deadline of its own, on purpose.** `ComposerSendCoordinator` races
+    /// this against its injected clock and cancels the loser, which is where the
+    /// timeout belongs and the only place a test can advance it.
+    ///
+    /// The cancellation handling is not defensive bookkeeping: the coordinator's
+    /// task group awaits all of its children on exit, so a continuation nobody
+    /// resumes would hang the send forever rather than time out.
+    func awaitSessionStart(terminalID: UUID, incarnationID: UUID) async -> Bool {
+        let token = UUID()
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
+                // Cancelled before we could register: resume here, or nothing
+                // ever will.
+                guard !Task.isCancelled else {
+                    continuation.resume(returning: false)
+                    return
+                }
+                sessionStartWaiters[terminalID, default: []].append(
+                    SessionStartWaiter(
+                        token: token, incarnationID: incarnationID,
+                        resume: { continuation.resume(returning: $0) }))
+            }
+        } onCancel: {
+            Task { @MainActor [weak self] in
+                self?.withdrawSessionStartWaiter(terminalID: terminalID, token: token)
+            }
+        }
+    }
+
+    /// A `SessionStart` was accepted for this terminal. Release the waiters that
+    /// were waiting for THIS spawn.
+    ///
+    /// **A delta carrying no incarnation releases nobody.** A worktree's first
+    /// spawn and an archive restore plant no id, so "no id" is a real state
+    /// rather than a gap — and a hold that released on it would release on a
+    /// session the composer never started.
+    func noteSessionStart(terminalID: UUID, incarnationID: UUID?) {
+        guard let incarnationID, let waiters = sessionStartWaiters[terminalID] else { return }
+        let matched = waiters.filter { $0.incarnationID == incarnationID }
+        guard !matched.isEmpty else { return }
+        let remaining = waiters.filter { $0.incarnationID != incarnationID }
+        sessionStartWaiters[terminalID] = remaining.isEmpty ? nil : remaining
+        for waiter in matched { waiter.resume(true) }
+    }
+
+    private func withdrawSessionStartWaiter(terminalID: UUID, token: UUID) {
+        guard let waiters = sessionStartWaiters[terminalID],
+              let waiter = waiters.first(where: { $0.token == token })
+        else { return }
+        let remaining = waiters.filter { $0.token != token }
+        sessionStartWaiters[terminalID] = remaining.isEmpty ? nil : remaining
+        waiter.resume(false)
+    }
+}

--- a/Sources/TBDApp/AppState+SessionStartWaiters.swift
+++ b/Sources/TBDApp/AppState+SessionStartWaiters.swift
@@ -19,6 +19,14 @@ extension AppState {
     /// Resolves true when this terminal reports a `SessionStart` carrying
     /// exactly `incarnationID`, and false on cancellation.
     ///
+    /// **Checks the latch before registering.** `wakeTerminalForComposer`
+    /// mints the incarnation and returns before the daemon's refresh round
+    /// trip completes, so the caller registering a waiter here can race a
+    /// `SessionStart` that already landed. `noteSessionStart` latches every
+    /// incarnation it sees regardless of whether a waiter existed at the time,
+    /// so a latch already holding this incarnation answers `true` immediately
+    /// — no continuation, no registration, no wait.
+    ///
     /// **No deadline of its own, on purpose.** `ComposerSendCoordinator` races
     /// this against its injected clock and cancels the loser, which is where the
     /// timeout belongs and the only place a test can advance it.
@@ -27,6 +35,9 @@ extension AppState {
     /// task group awaits all of its children on exit, so a continuation nobody
     /// resumes would hang the send forever rather than time out.
     func awaitSessionStart(terminalID: UUID, incarnationID: UUID) async -> Bool {
+        if lastStartedIncarnation[terminalID] == incarnationID {
+            return true
+        }
         let token = UUID()
         return await withTaskCancellationHandler {
             await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
@@ -48,15 +59,25 @@ extension AppState {
         }
     }
 
-    /// A `SessionStart` was accepted for this terminal. Release the waiters that
-    /// were waiting for THIS spawn.
+    /// A `SessionStart` was accepted for this terminal. Latch the incarnation
+    /// and release the waiters that were waiting for THIS spawn.
     ///
-    /// **A delta carrying no incarnation releases nobody.** A worktree's first
-    /// spawn and an archive restore plant no id, so "no id" is a real state
-    /// rather than a gap — and a hold that released on it would release on a
-    /// session the composer never started.
+    /// **A delta carrying no incarnation releases nobody, and latches nothing.**
+    /// A worktree's first spawn and an archive restore plant no id, so "no id"
+    /// is a real state rather than a gap — and a hold that released on it
+    /// would release on a session the composer never started.
+    ///
+    /// **The latch is written even when nobody is waiting yet.** That is the
+    /// whole point of it: a `SessionStart` can land before
+    /// `wakeTerminalForComposer`'s caller has registered its
+    /// `awaitSessionStart` waiter, and without a latch that start is simply
+    /// lost — nothing was there to release. Recording it here lets the waiter,
+    /// once it does register (or checks in `awaitSessionStart` before
+    /// registering), find it retroactively.
     func noteSessionStart(terminalID: UUID, incarnationID: UUID?) {
-        guard let incarnationID, let waiters = sessionStartWaiters[terminalID] else { return }
+        guard let incarnationID else { return }
+        lastStartedIncarnation[terminalID] = incarnationID
+        guard let waiters = sessionStartWaiters[terminalID] else { return }
         let matched = waiters.filter { $0.incarnationID == incarnationID }
         guard !matched.isEmpty else { return }
         let remaining = waiters.filter { $0.incarnationID != incarnationID }

--- a/Sources/TBDApp/AppState+Tabs.swift
+++ b/Sources/TBDApp/AppState+Tabs.swift
@@ -381,6 +381,20 @@ extension AppState {
         // doesn't leak stale UUIDs into `unreadTerminals`.
         unreadTerminals.subtract(terminalIDsInTab)
 
+        // A closed tab takes its composers' unsent messages with it: the
+        // terminals below are being deleted, so a kept draft could never be
+        // sent and would only sit in the map for the app's lifetime. Safe from
+        // eating a send in flight — the send path clears the draft itself on
+        // success, and a tab cannot close while its own send is mid-flight
+        // without the person closing it deliberately.
+        //
+        // `terminalIDs(in:)` rather than `terminalIDsInTab`, because a
+        // `.liveTranscript` tab — the composer's own home — is exactly the
+        // shape `allTerminalIDs()` does not enumerate.
+        for terminalID in terminalIDs(in: tab) {
+            discardComposerDraft(for: terminalID)
+        }
+
         layouts.removeValue(forKey: tab.id)
         arr.remove(at: index)
         tabs[worktreeID] = arr

--- a/Sources/TBDApp/AppState+Tabs.swift
+++ b/Sources/TBDApp/AppState+Tabs.swift
@@ -381,18 +381,19 @@ extension AppState {
         // doesn't leak stale UUIDs into `unreadTerminals`.
         unreadTerminals.subtract(terminalIDsInTab)
 
-        // A closed tab takes its composers' unsent messages with it: the
-        // terminals below are being deleted, so a kept draft could never be
-        // sent and would only sit in the map for the app's lifetime. Safe from
-        // eating a send in flight — the send path clears the draft itself on
-        // success, and a tab cannot close while its own send is mid-flight
-        // without the person closing it deliberately.
+        // A closed tab takes its composers' unsent messages — and their focus
+        // registrations and spawn bookkeeping — with it: the terminals below are
+        // being deleted, so a kept draft could never be sent and would only sit
+        // in the map for the app's lifetime. Safe from eating a send in flight —
+        // the send path clears the draft itself on success, and a tab cannot
+        // close while its own send is mid-flight without the person closing it
+        // deliberately.
         //
         // `terminalIDs(in:)` rather than `terminalIDsInTab`, because a
         // `.liveTranscript` tab — the composer's own home — is exactly the
         // shape `allTerminalIDs()` does not enumerate.
         for terminalID in terminalIDs(in: tab) {
-            discardComposerDraft(for: terminalID)
+            forgetComposerState(for: terminalID)
         }
 
         layouts.removeValue(forKey: tab.id)

--- a/Sources/TBDApp/AppState+Terminals.swift
+++ b/Sources/TBDApp/AppState+Terminals.swift
@@ -578,6 +578,10 @@ extension AppState {
         date: Date = Date()
     ) {
         terminals[worktreeID]?.removeAll { $0.id == terminalID }
+        // This is the death every route shares — a pane close, an archive, a
+        // daemon-reported removal — so it is where the composer's per-terminal
+        // memory is reclaimed. Memory only, and safe: the row is gone above.
+        forgetComposerState(for: terminalID)
         // An already-dispatched recreation RPC cannot be unsent. Keep its
         // in-flight claim intact so no second request can race it, and defer
         // budget cleanup until its `finishTerminalRecreation` runs.

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -806,6 +806,10 @@ final class AppState {
     /// Tab-close ownership keyed by terminal UUID for views that belong to a
     /// visible tab, used to resolve the currently focused closable tab.
     @ObservationIgnored var terminalTabCloseContexts: [UUID: TabCloseContext] = [:]
+    /// Per-terminal composer drafts. `@ObservationIgnored` because each
+    /// `ComposerDraft` is itself `@Observable` — an observable registry would
+    /// republish every composer in the app whenever any one of them appeared.
+    @ObservationIgnored var composerDrafts: [UUID: ComposerDraft] = [:]
     /// Visual screenshots taken at suspend-click time, shown while daemon works.
     /// Keyed by terminal UUID. Cleared when suspend completes.
     var suspendingSnapshots: [UUID: NSImage] = [:]

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -821,6 +821,16 @@ final class AppState {
     /// terminal. `@ObservationIgnored` for the same reason as the two above:
     /// nothing renders from it.
     @ObservationIgnored var sessionStartWaiters: [UUID: [SessionStartWaiter]] = [:]
+    /// The most recent incarnation each terminal's `SessionStart` reported,
+    /// latched by `noteSessionStart` independent of whether anyone was waiting
+    /// at the time. Closes the gap between `wakeTerminalForComposer` minting an
+    /// incarnation and the caller registering an `awaitSessionStart` waiter for
+    /// it: a `SessionStart` that lands in that window would otherwise reach
+    /// `noteSessionStart` with no waiter to release and be dropped on the
+    /// floor, stalling the send to its timeout. `awaitSessionStart` checks this
+    /// latch before registering, so a already-arrived start is a same-frame
+    /// `true` rather than a wait.
+    @ObservationIgnored var lastStartedIncarnation: [UUID: UUID] = [:]
     /// Visual screenshots taken at suspend-click time, shown while daemon works.
     /// Keyed by terminal UUID. Cleared when suspend completes.
     var suspendingSnapshots: [UUID: NSImage] = [:]

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -810,6 +810,17 @@ final class AppState {
     /// `ComposerDraft` is itself `@Observable` — an observable registry would
     /// republish every composer in the app whenever any one of them appeared.
     @ObservationIgnored var composerDrafts: [UUID: ComposerDraft] = [:]
+    /// Weak composer text views keyed by terminal, so Cmd+/ can move focus into
+    /// one. `@ObservationIgnored` for the same reason `terminalFocusTargets` is:
+    /// focus is not state anything renders from.
+    @ObservationIgnored var composerFocusTargets: [UUID: ComposerFocusTarget] = [:]
+    /// Weak transcript tables keyed by terminal, so Escape in the composer can
+    /// hand focus back to what the person was reading.
+    @ObservationIgnored var transcriptFocusTargets: [UUID: ComposerFocusTarget] = [:]
+    /// Suspended callers waiting for one spawn's `SessionStart`, keyed by
+    /// terminal. `@ObservationIgnored` for the same reason as the two above:
+    /// nothing renders from it.
+    @ObservationIgnored var sessionStartWaiters: [UUID: [SessionStartWaiter]] = [:]
     /// Visual screenshots taken at suspend-click time, shown while daemon works.
     /// Keyed by terminal UUID. Cleared when suspend completes.
     var suspendingSnapshots: [UUID: NSImage] = [:]
@@ -1459,6 +1470,16 @@ final class AppState {
             try await daemonClient.terminalWake(
                 terminalID: terminalID, cols: cols, rows: rows,
                 fallbackToDefaultProfile: fallback, prompt: prompt)
+        }
+    /// How the composer's wake reaches the daemon — the result-returning sibling
+    /// of `terminalWakeSender`, injectable for the same reason, so the wake's
+    /// three replies are statable in a test without a running daemon.
+    @ObservationIgnored
+    lazy var composerWakeSender:
+        @MainActor (UUID, Int?, Int?, String) async throws -> TerminalWakeResult =
+        { [daemonClient] terminalID, cols, rows, prompt in
+            try await daemonClient.terminalWakeReporting(
+                terminalID: terminalID, cols: cols, rows: rows, prompt: prompt)
         }
     /// How `setTranscriptComposerEnabled` persists the composer gate —
     /// injectable for the same reason as `controlModeSetter`.
@@ -2297,6 +2318,10 @@ final class AppState {
                 await self?.refreshDaemonCapabilities()
             }
         case .terminalSessionUpdated(let d):
+            // Ahead of the row update, and outside it: `applyTerminalSessionDelta`
+            // returns early for a terminal this app has not cached, and a wake's
+            // hold must release whether or not the row happens to be in the map.
+            noteSessionStart(terminalID: d.terminalID, incarnationID: d.sessionIncarnationID)
             applyTerminalSessionDelta(d)
         case .terminalCreated(let d):
             applyTerminalCreatedDelta(d)

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -2207,6 +2207,16 @@ actor DaemonClient {
         )
     }
 
+    /// What slash commands, skills and subagents this terminal's session knows.
+    /// Refused by the daemon when the composer flag is off.
+    func terminalCompletions(terminalID: UUID) async throws -> TerminalCompletionsResult {
+        try await callAsync(
+            method: RPCMethod.terminalCompletions,
+            params: TerminalCompletionsParams(terminalID: terminalID),
+            resultType: TerminalCompletionsResult.self
+        )
+    }
+
     /// Notify the daemon whether the app is in the foreground (drives usage poller).
     func setAppForegroundState(isForeground: Bool) async throws {
         try await callVoidAsync(

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -825,6 +825,20 @@ actor DaemonClient {
         )
     }
 
+    /// Send a composed message: an ordered parts list, the dispatch envelope
+    /// suppressed, and the awaiting-input gate opted in. Distinct from
+    /// `sendToTerminal` so the composer's contract is one call site rather than
+    /// five defaulted arguments spread across every caller of a shared verb.
+    ///
+    /// Note what asking for suppression does and does not do. The daemon honors
+    /// it only on a connection it has authenticated as this app's — the peer pid
+    /// the kernel reports for the socket, matched against the pid the FD-vending
+    /// sidecar recorded and then re-verified. Nothing about this call asserts
+    /// anything; it asks, on a socket that already belongs to us.
+    func sendComposerMessage(_ params: TerminalSendParams) async throws {
+        try await callVoidAsync(method: RPCMethod.terminalSend, params: params)
+    }
+
     /// Publish an explicit terminal activity state transition.
     func setTerminalActivity(
         terminalID: UUID,
@@ -1657,6 +1671,23 @@ actor DaemonClient {
             params: TerminalWakeParams(
                 terminalID: terminalID, cols: cols, rows: rows,
                 fallbackToDefaultProfile: fallbackToDefaultProfile, prompt: prompt)
+        )
+    }
+
+    /// Wake a terminal and read back what the daemon answered.
+    ///
+    /// The same RPC `terminalWake` calls. A separate method only because that
+    /// one is `callVoidAsync` and its existing callers all want it to stay that
+    /// way — the composer is the only caller that needs the result, because it
+    /// is the only one that scopes a wait to the spawn this call made.
+    func terminalWakeReporting(
+        terminalID: UUID, cols: Int? = nil, rows: Int? = nil, prompt: String
+    ) async throws -> TerminalWakeResult {
+        try await callAsync(
+            method: RPCMethod.terminalWake,
+            params: TerminalWakeParams(
+                terminalID: terminalID, cols: cols, rows: rows, prompt: prompt),
+            resultType: TerminalWakeResult.self
         )
     }
 

--- a/Sources/TBDApp/Helpers/KeyboardShortcuts.swift
+++ b/Sources/TBDApp/Helpers/KeyboardShortcuts.swift
@@ -177,5 +177,32 @@ private struct TerminalCommandsContent: View {
         }
         .keyboardShortcut("w", modifiers: .command)
         .disabled(!appState.canCloseFocusedTab)
+
+        Divider()
+
+        // ⌘/ is unbound in this app, unclaimed by the terminal view, inert in
+        // SwiftTerm, and not a system default. A terminal with no composer
+        // mounted answers the call with a no-op, which is the honest result for
+        // a pane that is closed or a session the composer's scope excludes.
+        Button("Focus Message Composer") {
+            Task { @MainActor in
+                guard let terminalID = appState.composerCommandTerminalID else { return }
+                appState.focusComposer(terminalID: terminalID)
+            }
+        }
+        .keyboardShortcut("/", modifiers: .command)
+        .disabled(appState.composerCommandTerminalID == nil)
+
+        // The way back, for people who reach for a menu rather than Escape —
+        // which the composer's own key handling already answers with this same
+        // call. ⌥ rather than ⇧, because ⌘⇧/ is macOS's Help search field.
+        Button("Focus Transcript") {
+            Task { @MainActor in
+                guard let terminalID = appState.composerCommandTerminalID else { return }
+                appState.focusTranscript(terminalID: terminalID)
+            }
+        }
+        .keyboardShortcut("/", modifiers: [.command, .option])
+        .disabled(appState.composerCommandTerminalID == nil)
     }
 }

--- a/Sources/TBDApp/Helpers/VisualEffectView.swift
+++ b/Sources/TBDApp/Helpers/VisualEffectView.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+/// AppKit visual-effect bridge so a SwiftUI overlay can pick up a system
+/// material (menu, sidebar, etc). Shared by the jump menu panel and the
+/// composer's completion overlay — both want the same system-chrome look, one
+/// `.behindWindow` (a floating panel), the other `.withinWindow` (an overlay
+/// stacked above the transcript's own content, inside the same window).
+struct VisualEffectView: NSViewRepresentable {
+    let material: NSVisualEffectView.Material
+    let blendingMode: NSVisualEffectView.BlendingMode
+
+    func makeNSView(context: Context) -> NSVisualEffectView {
+        let v = NSVisualEffectView()
+        v.material = material
+        v.blendingMode = blendingMode
+        v.state = .active
+        return v
+    }
+
+    func updateNSView(_ nsView: NSVisualEffectView, context: Context) {}
+}

--- a/Sources/TBDApp/JumpMenu/JumpMenuView.swift
+++ b/Sources/TBDApp/JumpMenu/JumpMenuView.swift
@@ -131,19 +131,3 @@ struct JumpMenuView: View {
             .padding(.vertical, 24)
     }
 }
-
-/// AppKit visual-effect bridge so the panel picks up the system menu material.
-private struct VisualEffectView: NSViewRepresentable {
-    let material: NSVisualEffectView.Material
-    let blendingMode: NSVisualEffectView.BlendingMode
-
-    func makeNSView(context: Context) -> NSVisualEffectView {
-        let v = NSVisualEffectView()
-        v.material = material
-        v.blendingMode = blendingMode
-        v.state = .active
-        return v
-    }
-
-    func updateNSView(_ nsView: NSVisualEffectView, context: Context) {}
-}

--- a/Sources/TBDApp/Panes/Transcript/Composer/AttachmentStrip.swift
+++ b/Sources/TBDApp/Panes/Transcript/Composer/AttachmentStrip.swift
@@ -26,10 +26,15 @@ struct AttachmentStrip: View {
 
     var body: some View {
         if !ordered.isEmpty {
+            // Scanned ONCE per render and handed down. `detachedNumbers` runs a
+            // regex over the whole message, and reading it inside the row builder
+            // ran that scan once per thumbnail — on every keystroke, because the
+            // text it scans is what changed.
+            let detached = Set(draft.detachedNumbers)
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 8) {
                     ForEach(ordered) { attachment in
-                        thumbnail(attachment)
+                        thumbnail(attachment, detached: detached.contains(attachment.number))
                     }
                 }
                 .padding(.horizontal, 8)
@@ -39,8 +44,9 @@ struct AttachmentStrip: View {
     }
 
     @ViewBuilder
-    private func thumbnail(_ attachment: ComposerDraft.Attachment) -> some View {
-        let detached = draft.detachedNumbers.contains(attachment.number)
+    private func thumbnail(
+        _ attachment: ComposerDraft.Attachment, detached: Bool
+    ) -> some View {
         VStack(spacing: 2) {
             ZStack(alignment: .topTrailing) {
                 AttachmentThumbnailImage(path: attachment.path)

--- a/Sources/TBDApp/Panes/Transcript/Composer/AttachmentStrip.swift
+++ b/Sources/TBDApp/Panes/Transcript/Composer/AttachmentStrip.swift
@@ -106,7 +106,7 @@ private struct AttachmentThumbnailImage: View {
     var body: some View {
         Group {
             if let image {
-                Image(nsImage: image).resizable().aspectRatio(contentMode: .fill)
+                Image(nsImage: image).resizable().scaledToFill()
             } else {
                 RoundedRectangle(cornerRadius: 6).fill(Color.secondary.opacity(0.15))
             }

--- a/Sources/TBDApp/Panes/Transcript/Composer/AttachmentStrip.swift
+++ b/Sources/TBDApp/Panes/Transcript/Composer/AttachmentStrip.swift
@@ -1,0 +1,106 @@
+import AppKit
+import SwiftUI
+
+/// Thumbnails of every staged image, above the text field, hidden when there are
+/// none.
+///
+/// **A view of the map; the text decides what is sent.** An image whose token is
+/// gone from the text shows as detached — greyed and marked "not in message" —
+/// so nothing is dropped silently. Clicking a detached thumbnail re-inserts its
+/// token at the caret; clicking an attached one moves the caret to its token. The
+/// x removes both the token and the image from the send.
+struct AttachmentStrip: View {
+    let draft: ComposerDraft
+    let onReinsert: (Int) -> Void
+    let onReveal: (Int) -> Void
+    let onRemove: (Int) -> Void
+    let hoveredNumber: Int?
+    let onHover: (Int?) -> Void
+
+    private var ordered: [ComposerDraft.Attachment] {
+        draft.attachments.values.sorted { $0.number < $1.number }
+    }
+
+    var body: some View {
+        if !ordered.isEmpty {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 8) {
+                    ForEach(ordered) { attachment in
+                        thumbnail(attachment)
+                    }
+                }
+                .padding(.horizontal, 8)
+                .padding(.vertical, 6)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func thumbnail(_ attachment: ComposerDraft.Attachment) -> some View {
+        let detached = draft.detachedNumbers.contains(attachment.number)
+        VStack(spacing: 2) {
+            ZStack(alignment: .topTrailing) {
+                AttachmentThumbnailImage(path: attachment.path)
+                    .frame(width: 56, height: 56)
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
+                    .opacity(detached ? 0.45 : 1)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 6)
+                            .stroke(
+                                hoveredNumber == attachment.number
+                                    ? Color.accentColor : Color.secondary.opacity(0.25),
+                                lineWidth: hoveredNumber == attachment.number ? 2 : 1))
+                Button {
+                    onRemove(attachment.number)
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .padding(2)
+                .accessibilityLabel("Remove image \(attachment.number)")
+            }
+            Text(detached ? "not in message" : "#\(attachment.number)")
+                .font(.system(size: 9))
+                .foregroundStyle(detached ? Color.orange : Color.secondary)
+        }
+        .contentShape(Rectangle())
+        .onHover { inside in onHover(inside ? attachment.number : nil) }
+        .onTapGesture {
+            if detached { onReinsert(attachment.number) } else { onReveal(attachment.number) }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(
+            detached
+                ? "Image \(attachment.number), not in message. Click to re-insert."
+                : "Image \(attachment.number), in message.")
+    }
+}
+
+/// One thumbnail, decoded off the main thread through the same ImageIO service
+/// the transcript uses — never `NSImage(contentsOfFile:)`, which decodes the
+/// whole file on whatever thread asks.
+private struct AttachmentThumbnailImage: View {
+    let path: String
+    @State private var image: NSImage?
+
+    var body: some View {
+        Group {
+            if let image {
+                Image(nsImage: image).resizable().aspectRatio(contentMode: .fill)
+            } else {
+                RoundedRectangle(cornerRadius: 6).fill(Color.secondary.opacity(0.15))
+            }
+        }
+        .task(id: path) {
+            await withCheckedContinuation { continuation in
+                TranscriptImageService.shared.thumbnail(
+                    forPath: path, maxPixelSize: 112
+                ) { loaded in
+                    image = loaded
+                    continuation.resume()
+                }
+            }
+        }
+    }
+}

--- a/Sources/TBDApp/Panes/Transcript/Composer/AttachmentStrip.swift
+++ b/Sources/TBDApp/Panes/Transcript/Composer/AttachmentStrip.swift
@@ -65,7 +65,13 @@ struct AttachmentStrip: View {
                 .foregroundStyle(detached ? Color.orange : Color.secondary)
         }
         .contentShape(Rectangle())
-        .onHover { inside in onHover(inside ? attachment.number : nil) }
+        .onHover { inside in
+            if inside {
+                onHover(attachment.number)
+            } else if hoveredNumber == attachment.number {
+                onHover(nil)
+            }
+        }
         .onTapGesture {
             if detached { onReinsert(attachment.number) } else { onReveal(attachment.number) }
         }

--- a/Sources/TBDApp/Panes/Transcript/Composer/AttachmentStrip.swift
+++ b/Sources/TBDApp/Panes/Transcript/Composer/AttachmentStrip.swift
@@ -12,7 +12,10 @@ import SwiftUI
 struct AttachmentStrip: View {
     let draft: ComposerDraft
     let onReinsert: (Int) -> Void
-    let onReveal: (Int) -> Void
+    /// An attached thumbnail was clicked: move the caret to its token. There is
+    /// deliberately no second gesture — no Finder reveal — because there is no
+    /// second affordance on a thumbnail to carry one.
+    let onFocusToken: (Int) -> Void
     let onRemove: (Int) -> Void
     let hoveredNumber: Int?
     let onHover: (Int?) -> Void
@@ -73,13 +76,17 @@ struct AttachmentStrip: View {
             }
         }
         .onTapGesture {
-            if detached { onReinsert(attachment.number) } else { onReveal(attachment.number) }
+            if detached {
+                onReinsert(attachment.number)
+            } else {
+                onFocusToken(attachment.number)
+            }
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel(
             detached
                 ? "Image \(attachment.number), not in message. Click to re-insert."
-                : "Image \(attachment.number), in message.")
+                : "Image \(attachment.number), in message. Click to go to it.")
     }
 }
 

--- a/Sources/TBDApp/Panes/Transcript/Composer/CommandRanker.swift
+++ b/Sources/TBDApp/Panes/Transcript/Composer/CommandRanker.swift
@@ -1,0 +1,266 @@
+import Foundation
+import TBDShared
+
+/// Orders the completion menu.
+///
+/// **Match quality first, frecency only as a tiebreak.** The order is: exact
+/// name, exact alias, name prefix with the shortest first, alias prefix, fuzzy
+/// score, then frecency. A command used heavily yesterday must never outrank the
+/// one whose name the person just typed in full — that is the single property
+/// that makes the menu feel obedient rather than opinionated.
+///
+/// Matching is case-insensitive against the name, its segments split on colon,
+/// dash, underscore, dot and slash, its aliases, and its description at low
+/// weight — so `brain` finds the brainstorming skill inside its plugin
+/// namespace, and `sup:br` matches segment by segment.
+///
+/// Pure, and in the app target with its tests, following both existing palette
+/// precedents (`JumpMenuViewModel`, `PaneHistoryPaletteFilter`).
+enum CommandRanker {
+
+    // MARK: - Tier
+
+    /// Match quality, highest first. The tier is compared before any score, which
+    /// is what makes "prefix beats fuzzy" a structural property rather than an
+    /// artifact of the numbers.
+    private enum Tier: Int, Comparable {
+        case exactName = 0
+        case exactAlias = 1
+        case namePrefix = 2
+        case aliasPrefix = 3
+        case fuzzy = 4
+        static func < (lhs: Tier, rhs: Tier) -> Bool { lhs.rawValue < rhs.rawValue }
+    }
+
+    struct Row: Equatable, Identifiable {
+        let command: CompletionCommand
+        /// UTF-16 offsets into `command.name` that matched, for highlighting.
+        let matchedRanges: [NSRange]
+        /// The alias that matched, shown in parentheses. nil when the name did.
+        let matchedAlias: String?
+
+        /// The command name IS the identity — derived, never passed, so a row can
+        /// never disagree with the command it carries.
+        var id: String { command.name }
+    }
+
+    // MARK: - Scoring constants
+    //
+    // Copied from the design and not tuned here. Changing one is a deliberate
+    // edit with a reviewer, because the ORDERING tests pin relationships these
+    // numbers produce, not the numbers themselves.
+
+    private static let perCharacter = 16
+    private static let adjacentPair = 4
+    private static let gapPenaltyBase = 3
+    private static let boundaryBonus = 8
+    private static let camelBonus = 6
+    /// Awarded when every colon-separated query segment prefixes a distinct
+    /// candidate segment, in order.
+    private static let segmentRunBonus = 200
+
+    private static let separators = CharacterSet(charactersIn: ":_-./")
+
+    static func segments(_ name: String) -> [String] {
+        name.components(separatedBy: separators).filter { !$0.isEmpty }
+    }
+
+    /// A greedy leftmost subsequence match. nil when `query` is not a subsequence
+    /// of `candidate` at all.
+    static func fuzzyScore(query: String, candidate: String) -> Int? {
+        let needle = Array(query.lowercased())
+        let hay = Array(candidate)
+        let hayLower = Array(candidate.lowercased())
+        guard !needle.isEmpty else { return 0 }
+
+        var score = 0
+        var hayIndex = 0
+        var lastMatch = -2
+        for character in needle {
+            var found = false
+            while hayIndex < hay.count {
+                defer { hayIndex += 1 }
+                guard hayLower[hayIndex] == character else { continue }
+                score += perCharacter
+                if hayIndex == lastMatch + 1 { score += adjacentPair }
+                if hayIndex == 0 {
+                    score += boundaryBonus
+                } else {
+                    let previous = hay[hayIndex - 1]
+                    if String(previous).rangeOfCharacter(from: separators) != nil {
+                        score += boundaryBonus
+                    } else if previous.isLowercase && hay[hayIndex].isUppercase {
+                        score += camelBonus
+                    }
+                }
+                if lastMatch >= 0, hayIndex > lastMatch + 1 {
+                    let gap = hayIndex - lastMatch - 1
+                    score -= gapPenaltyBase + gap
+                }
+                lastMatch = hayIndex
+                found = true
+                break
+            }
+            guard found else { return nil }
+        }
+        // A shortness bonus, so `cat` prefers `cat` over `catalogue`.
+        score += max(0, 32 - hay.count)
+        return score
+    }
+
+    static func rank(
+        commands: [CompletionCommand], query: String, frecency: (String) -> Double
+    ) -> [Row] {
+        let trimmed = query.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return defaultRows(commands: commands, frecency: frecency) }
+        let needle = trimmed.lowercased()
+
+        struct Scored {
+            let row: Row
+            let tier: Tier
+            let score: Int
+            let nameLength: Int
+            let frecency: Double
+        }
+
+        var scored: [Scored] = []
+        for command in commands {
+            let name = command.name
+            let lowerName = name.lowercased()
+            let matchedAlias = command.aliases.first { $0.lowercased() == needle }
+                ?? command.aliases.first { $0.lowercased().hasPrefix(needle) }
+
+            let tier: Tier
+            let score: Int
+            if lowerName == needle {
+                tier = .exactName
+                score = Int.max / 2
+            } else if command.aliases.contains(where: { $0.lowercased() == needle }) {
+                tier = .exactAlias
+                score = Int.max / 4
+            } else if lowerName.hasPrefix(needle) {
+                tier = .namePrefix
+                score = 0
+            } else if command.aliases.contains(where: { $0.lowercased().hasPrefix(needle) }) {
+                tier = .aliasPrefix
+                score = 0
+            } else {
+                // Fuzzy, across every field at its own weight. Doubled integers
+                // rather than Doubles so the ordering is exact: name 3, display
+                // and segments and aliases 2, description ½ — expressed as 6, 4,
+                // 4, 4, 1 over a common denominator of 2.
+                var best = 0
+                var matched = false
+                if let nameScore = fuzzyScore(query: trimmed, candidate: name) {
+                    best = max(best, nameScore * 6)
+                    matched = true
+                }
+                for segment in segments(name) {
+                    if let segmentScore = fuzzyScore(query: trimmed, candidate: segment) {
+                        best = max(best, segmentScore * 4)
+                        matched = true
+                    }
+                }
+                for alias in command.aliases {
+                    if let aliasScore = fuzzyScore(query: trimmed, candidate: alias) {
+                        best = max(best, aliasScore * 4)
+                        matched = true
+                    }
+                }
+                if let descriptionScore = fuzzyScore(query: trimmed, candidate: command.description) {
+                    best = max(best, descriptionScore * 1)
+                    matched = true
+                }
+                // A colon in the query means the person is spelling out a
+                // namespace. Every query segment must prefix a distinct candidate
+                // segment, in order, and that earns a large bonus — it is a much
+                // stronger statement of intent than a subsequence.
+                if trimmed.contains(":") {
+                    let querySegments = segments(trimmed)
+                    let candidateSegments = segments(name).map { $0.lowercased() }
+                    var cursor = 0
+                    var allMatched = !querySegments.isEmpty
+                    for piece in querySegments.map({ $0.lowercased() }) {
+                        guard cursor <= candidateSegments.count,
+                              let hit = candidateSegments[cursor...].firstIndex(where: {
+                                  $0.hasPrefix(piece)
+                              })
+                        else {
+                            allMatched = false
+                            break
+                        }
+                        cursor = hit + 1
+                    }
+                    if allMatched {
+                        best += segmentRunBonus
+                        matched = true
+                    }
+                }
+                guard matched else { continue }
+                tier = .fuzzy
+                score = best
+            }
+            scored.append(Scored(
+                row: Row(
+                    command: command,
+                    matchedRanges: highlightRanges(query: trimmed, in: name),
+                    matchedAlias: lowerName.hasPrefix(needle) ? nil : matchedAlias),
+                tier: tier,
+                score: score,
+                nameLength: name.count,
+                frecency: frecency(name)))
+        }
+
+        return scored.sorted { lhs, rhs in
+            if lhs.tier != rhs.tier { return lhs.tier < rhs.tier }
+            // Within the prefix tiers the shortest name wins; elsewhere the
+            // higher score does.
+            if lhs.tier == .namePrefix || lhs.tier == .aliasPrefix {
+                if lhs.nameLength != rhs.nameLength { return lhs.nameLength < rhs.nameLength }
+            } else if lhs.score != rhs.score {
+                return lhs.score > rhs.score
+            }
+            if lhs.frecency != rhs.frecency { return lhs.frecency > rhs.frecency }
+            return lhs.row.id < rhs.row.id
+        }.map(\.row)
+    }
+
+    /// A bare sigil: the top five by frecency, then everything else
+    /// alphabetically. Every command stays reachable by scrolling — the five is
+    /// a lead, not a cap.
+    static func defaultRows(
+        commands: [CompletionCommand], frecency: (String) -> Double
+    ) -> [Row] {
+        let byFrecency = commands
+            .filter { frecency($0.name) > 0 }
+            .sorted { frecency($0.name) > frecency($1.name) }
+            .prefix(5)
+        let leadNames = Set(byFrecency.map(\.name))
+        let rest = commands
+            .filter { !leadNames.contains($0.name) }
+            .sorted { $0.name < $1.name }
+        return (Array(byFrecency) + rest).map {
+            Row(command: $0, matchedRanges: [], matchedAlias: nil)
+        }
+    }
+
+    /// UTF-16 ranges of the greedy leftmost subsequence, for highlighting. Empty
+    /// when the query does not appear as a subsequence — a matched alias row
+    /// highlights nothing on the name, which is honest.
+    private static func highlightRanges(query: String, in name: String) -> [NSRange] {
+        let nsName = name as NSString
+        let needle = Array(query.lowercased())
+        var ranges: [NSRange] = []
+        var needleIndex = 0
+        var offset = 0
+        while offset < nsName.length, needleIndex < needle.count {
+            let range = nsName.rangeOfComposedCharacterSequence(at: offset)
+            if nsName.substring(with: range).lowercased() == String(needle[needleIndex]) {
+                ranges.append(range)
+                needleIndex += 1
+            }
+            offset = range.location + range.length
+        }
+        return needleIndex == needle.count ? ranges : []
+    }
+}

--- a/Sources/TBDApp/Panes/Transcript/Composer/CommandRanker.swift
+++ b/Sources/TBDApp/Panes/Transcript/Composer/CommandRanker.swift
@@ -70,7 +70,10 @@ enum CommandRanker {
     static func fuzzyScore(query: String, candidate: String) -> Int? {
         let needle = Array(query.lowercased())
         let hay = Array(candidate)
-        let hayLower = Array(candidate.lowercased())
+        // Lowercased element-wise, not `Array(candidate.lowercased())` — a
+        // lowercasing that changes grapheme count (e.g. İ) would desync the two
+        // arrays and index `hayLower` out of step with `hay`.
+        let hayLower = hay.map { Character(String($0).lowercased()) }
         guard !needle.isEmpty else { return 0 }
 
         var score = 0
@@ -245,8 +248,9 @@ enum CommandRanker {
     }
 
     /// UTF-16 ranges of the greedy leftmost subsequence, for highlighting. Empty
-    /// when the query does not appear as a subsequence — a matched alias row
-    /// highlights nothing on the name, which is honest.
+    /// when the query does not appear as a subsequence of `name` — highlights
+    /// apply only when the query is a subsequence of the name, whether or not
+    /// the row's match actually came from an alias.
     private static func highlightRanges(query: String, in name: String) -> [NSRange] {
         let nsName = name as NSString
         let needle = Array(query.lowercased())

--- a/Sources/TBDApp/Panes/Transcript/Composer/CompletionController.swift
+++ b/Sources/TBDApp/Panes/Transcript/Composer/CompletionController.swift
@@ -45,6 +45,10 @@ final class CompletionController {
     /// Memoized rows, keyed by the kind and query that produced them.
     private var memoKey: String?
     private var memoRows: [CommandRanker.Row] = []
+    /// How many times ranking actually ran (as opposed to reusing `memoRows`).
+    /// Not part of the public surface — exists so a test can pin the
+    /// memoization the doc comment above promises.
+    private(set) var rankCount = 0
 
     init(frecency: FrecencyStore) {
         self.frecency = frecency
@@ -64,8 +68,10 @@ final class CompletionController {
         hasInventory = true
         memoKey = nil
         // Re-evaluate against the text that is already there, so a menu showing
-        // its loading row swaps in real rows the moment the cache lands.
-        if let match {
+        // its loading row swaps in real rows the moment the cache lands. Skipped
+        // when the current token is suppressed: otherwise an inventory that
+        // lands after Escape reopens the menu with no keystroke asking for it.
+        if let match, suppressedToken != token(for: match) {
             apply(match: match)
         }
     }
@@ -81,11 +87,20 @@ final class CompletionController {
         let currentToken = token(for: found)
         if let suppressedToken, suppressedToken == currentToken {
             match = found
-            presentation = .closed
+            setClosed()
             return
         }
         suppressedToken = nil
         apply(match: found)
+    }
+
+    /// Closes the menu and clears its rows and selection together, so a view
+    /// that binds `rows` independently of `isOpen` never shows stale content
+    /// from before the close.
+    private func setClosed() {
+        presentation = .closed
+        rows = []
+        selectedIndex = nil
     }
 
     /// The identity of a query: its sigil kind and the text after it. Used both
@@ -106,6 +121,7 @@ final class CompletionController {
         let key = token(for: found)
         if memoKey != key {
             memoKey = key
+            rankCount += 1
             memoRows = CommandRanker.rank(
                 commands: found.kind == .command
                     ? commands
@@ -118,10 +134,15 @@ final class CompletionController {
         rows = memoRows
 
         if rows.isEmpty {
-            // One character that matches nothing is almost always mid-typing;
-            // saying "no commands match" there is noise.
-            presentation = found.query.count > 1 ? .noMatch : .rows
-            selectedIndex = nil
+            // One character that matches nothing is almost always mid-typing,
+            // so it stays closed rather than presenting "no commands match" —
+            // that copy is reserved for a query past one character.
+            if found.query.count > 1 {
+                presentation = .noMatch
+                selectedIndex = nil
+            } else {
+                setClosed()
+            }
             return
         }
         presentation = .rows
@@ -180,8 +201,7 @@ final class CompletionController {
         if suppressingCurrentToken, let match {
             suppressedToken = token(for: match)
         }
-        presentation = .closed
-        selectedIndex = nil
+        setClosed()
     }
 
     func recordAcceptance(_ row: CommandRanker.Row) {
@@ -191,8 +211,6 @@ final class CompletionController {
 
     private func dismiss() {
         match = nil
-        rows = []
-        selectedIndex = nil
-        presentation = .closed
+        setClosed()
     }
 }

--- a/Sources/TBDApp/Panes/Transcript/Composer/CompletionController.swift
+++ b/Sources/TBDApp/Panes/Transcript/Composer/CompletionController.swift
@@ -61,6 +61,10 @@ final class CompletionController {
         }
     }
 
+    /// The commands this controller is ranking over. Read by the argument-hint
+    /// placeholder, which needs the inventory but not the menu.
+    var inventoryCommands: [CompletionCommand] { commands }
+
     func adopt(inventory: TerminalCompletionsResult?) {
         guard let inventory else { return }
         commands = inventory.commands

--- a/Sources/TBDApp/Panes/Transcript/Composer/CompletionController.swift
+++ b/Sources/TBDApp/Panes/Transcript/Composer/CompletionController.swift
@@ -1,0 +1,198 @@
+import Foundation
+import Observation
+import TBDShared
+
+/// The completion menu's state: what is showing, what is highlighted, and what
+/// an accept would take.
+///
+/// Shaped like `JumpMenuViewModel` — query in, rows out, a selection that moves —
+/// and pure in the same sense: it owns no view, touches no daemon, and every test
+/// drives it by calling `update`.
+///
+/// **Filtering is synchronous on every keystroke, with no debounce.** The list is
+/// at most a few hundred items and the rows are memoized by query, so the work is
+/// a sort; a debounce would only make the menu lag behind the typing it is
+/// describing.
+@Observable
+@MainActor
+final class CompletionController {
+
+    enum Presentation: Equatable {
+        case closed
+        /// The inventory has not arrived. One dim row, nothing preselected.
+        case loading
+        case rows
+        case noMatch
+    }
+
+    /// Eight rows visible, in a list with a fixed maximum height and a scroller,
+    /// so a change in row count never shifts the layout under the caret.
+    static let visibleRowCount = 8
+
+    private(set) var match: CompletionTrigger.Match?
+    private(set) var rows: [CommandRanker.Row] = []
+    private(set) var selectedIndex: Int?
+    private(set) var presentation: Presentation = .closed
+
+    private let frecency: FrecencyStore
+    private var commands: [CompletionCommand] = []
+    private var agents: [CompletionAgent] = []
+    private var hasInventory = false
+    /// The token Escape closed the menu for. Cleared as soon as the token
+    /// changes, which is what makes Escape mean something without making it a
+    /// mode.
+    private var suppressedToken: String?
+    /// Memoized rows, keyed by the kind and query that produced them.
+    private var memoKey: String?
+    private var memoRows: [CommandRanker.Row] = []
+
+    init(frecency: FrecencyStore) {
+        self.frecency = frecency
+    }
+
+    var isOpen: Bool {
+        switch presentation {
+        case .closed: return false
+        case .loading, .rows, .noMatch: return true
+        }
+    }
+
+    func adopt(inventory: TerminalCompletionsResult?) {
+        guard let inventory else { return }
+        commands = inventory.commands
+        agents = inventory.agents
+        hasInventory = true
+        memoKey = nil
+        // Re-evaluate against the text that is already there, so a menu showing
+        // its loading row swaps in real rows the moment the cache lands.
+        if let match {
+            apply(match: match)
+        }
+    }
+
+    /// The one entry point the text view calls after every edit and every
+    /// selection change.
+    func update(text: String, selectionLocation: Int, hasMarkedText: Bool) {
+        // No menu opens or updates during composition: the candidate window owns
+        // those keystrokes, and a list appearing under it would fight for them.
+        guard !hasMarkedText else { return dismiss() }
+        guard let found = CompletionTrigger.detect(
+            text: text, selectionLocation: selectionLocation) else { return dismiss() }
+        let currentToken = token(for: found)
+        if let suppressedToken, suppressedToken == currentToken {
+            match = found
+            presentation = .closed
+            return
+        }
+        suppressedToken = nil
+        apply(match: found)
+    }
+
+    /// The identity of a query: its sigil kind and the text after it. Used both
+    /// as the memoization key and as the token Escape suppresses, so the two can
+    /// never drift apart.
+    private func token(for found: CompletionTrigger.Match) -> String {
+        "\(found.kind)\u{1}\(found.query)"
+    }
+
+    private func apply(match found: CompletionTrigger.Match) {
+        match = found
+        guard hasInventory else {
+            rows = []
+            selectedIndex = nil
+            presentation = .loading
+            return
+        }
+        let key = token(for: found)
+        if memoKey != key {
+            memoKey = key
+            memoRows = CommandRanker.rank(
+                commands: found.kind == .command
+                    ? commands
+                    : agents.map {
+                        CompletionCommand(name: $0.name, description: $0.description)
+                    },
+                query: found.query,
+                frecency: { [frecency] name in frecency.score(name) })
+        }
+        rows = memoRows
+
+        if rows.isEmpty {
+            // One character that matches nothing is almost always mid-typing;
+            // saying "no commands match" there is noise.
+            presentation = found.query.count > 1 ? .noMatch : .rows
+            selectedIndex = nil
+            return
+        }
+        presentation = .rows
+        selectedIndex = preselectedIndex(for: found)
+    }
+
+    /// At the start of the input, preselect the first row on a GENUINE prefix
+    /// match of the name, an alias, or a segment — so `/comp` + Enter runs
+    /// compact as it does in the terminal, and `/xyz` + Enter sends a message.
+    ///
+    /// Mid-sentence nothing is preselected: a slash token there is text to Claude
+    /// Code, which expands a command only at the start of a message, so Enter
+    /// must send and the menu engages only on Down, Tab or a click.
+    private func preselectedIndex(for found: CompletionTrigger.Match) -> Int? {
+        guard found.sigilLocation == 0, !found.query.isEmpty, let first = rows.first
+        else { return nil }
+        let needle = found.query.lowercased()
+        let name = first.command.name.lowercased()
+        let prefixes = name.hasPrefix(needle)
+            || first.command.aliases.contains { $0.lowercased().hasPrefix(needle) }
+            || CommandRanker.segments(name).contains { $0.hasPrefix(needle) }
+        return prefixes ? 0 : nil
+    }
+
+    func moveDown() {
+        guard !rows.isEmpty else { return }
+        selectedIndex = ((selectedIndex ?? -1) + 1) % rows.count
+    }
+
+    func moveUp() {
+        guard !rows.isEmpty else { return }
+        selectedIndex = ((selectedIndex ?? 0) - 1 + rows.count) % rows.count
+    }
+
+    /// A click, or a hover the view chose to promote. Bounds-checked rather than
+    /// clamped: a stale index from a list that has already re-ranked would
+    /// otherwise highlight whatever now sits at that position.
+    func moveTo(index: Int) {
+        guard rows.indices.contains(index) else { return }
+        selectedIndex = index
+    }
+
+    /// What Tab or Return would take: the highlighted row, or the first when none
+    /// is highlighted. Tab is the accept gesture the composer surfaces in any
+    /// hint it shows.
+    var acceptTarget: CommandRanker.Row? {
+        guard case .rows = presentation else { return nil }
+        if let selectedIndex, rows.indices.contains(selectedIndex) { return rows[selectedIndex] }
+        return rows.first
+    }
+
+    /// Escape, or the caret leaving the token. `suppressingCurrentToken` is what
+    /// makes Escape stick: without it the menu reopens on the next keystroke and
+    /// Escape means nothing.
+    func close(suppressingCurrentToken: Bool) {
+        if suppressingCurrentToken, let match {
+            suppressedToken = token(for: match)
+        }
+        presentation = .closed
+        selectedIndex = nil
+    }
+
+    func recordAcceptance(_ row: CommandRanker.Row) {
+        frecency.record(row.command.name)
+        dismiss()
+    }
+
+    private func dismiss() {
+        match = nil
+        rows = []
+        selectedIndex = nil
+        presentation = .closed
+    }
+}

--- a/Sources/TBDApp/Panes/Transcript/Composer/CompletionOverlayView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Composer/CompletionOverlayView.swift
@@ -1,0 +1,185 @@
+import SwiftUI
+
+/// The completion list: a SwiftUI overlay **inside the pane**, never a separate
+/// window.
+///
+/// The text view keeps first responder, so the caret keeps blinking and the IME
+/// candidate panel keeps working while the list has logical focus. The transcript
+/// pane already renders a SwiftUI overlay above its AppKit table, so this is a
+/// shape it is known to support. A non-key child window is the fallback if
+/// clipping ever bites — and it is the fallback rather than the default because
+/// the floating-panel code documents that adding a child window to the split-view
+/// window raises an exception.
+///
+/// It opens **upward** from the composer, and its height is fixed at eight rows
+/// with a scroller, so a change in row count never shifts the text field under
+/// the caret.
+struct CompletionOverlayView: View {
+    let controller: CompletionController
+    let onAccept: (CommandRanker.Row) -> Void
+    let onHighlight: (Int) -> Void
+
+    /// The row the pointer is over. Deliberately SEPARATE from the controller's
+    /// `selectedIndex`: hover previews a row without moving the keyboard cursor,
+    /// so a pointer resting over the list cannot change what Return would take.
+    @State private var hoveredIndex: Int?
+
+    static let rowHeight: CGFloat = 44
+    static let maxHeight: CGFloat = rowHeight * CGFloat(CompletionController.visibleRowCount)
+
+    var body: some View {
+        Group {
+            switch controller.presentation {
+            case .closed:
+                EmptyView()
+            case .loading:
+                message("Loading commands")
+            case .noMatch:
+                message("No commands match")
+            case .rows:
+                // A one-character query that matches nothing also stays
+                // `.rows` (the controller reserves "no commands match" for
+                // longer queries, so a fresh keystroke isn't noisy) — render
+                // it the same way rather than an empty scroll view.
+                if controller.rows.isEmpty {
+                    message("No commands match")
+                } else {
+                    list
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(VisualEffectView(material: .menu, blendingMode: .withinWindow))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(Color.secondary.opacity(0.2), lineWidth: 1))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .shadow(radius: 8, y: 2)
+    }
+
+    /// A single dim row while the inventory is in flight, with nothing
+    /// preselected — so Enter cannot accept a row that appeared under the finger.
+    @ViewBuilder
+    private func message(_ text: String) -> some View {
+        Text(text)
+            .font(.callout)
+            .foregroundStyle(.tertiary)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .accessibilityLabel(text)
+    }
+
+    private var list: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(spacing: 0) {
+                    ForEach(Array(controller.rows.enumerated()), id: \.element.id) { index, row in
+                        CompletionRowView(
+                            row: row,
+                            isSelected: index == controller.selectedIndex,
+                            isHovered: index == hoveredIndex)
+                        .id(row.id)
+                        .contentShape(Rectangle())
+                        // Hover PREVIEWS: it emphasizes the row and moves
+                        // nothing, so what Return would take does not change
+                        // under a resting pointer.
+                        .onHover { inside in hoveredIndex = inside ? index : nil }
+                        // A click HIGHLIGHTS rather than runs. Mouse mis-clicks
+                        // on a list are common and these rows are much larger
+                        // targets than a terminal's, so a click that ran a
+                        // command would be a command nobody chose.
+                        .onTapGesture { onHighlight(index) }
+                    }
+                }
+            }
+            .frame(maxHeight: Self.maxHeight)
+            .onChange(of: controller.selectedIndex) { _, index in
+                guard let index, controller.rows.indices.contains(index) else { return }
+                proxy.scrollTo(controller.rows[index].id, anchor: .center)
+            }
+        }
+    }
+}
+
+/// One row: the name with a matched alias in parentheses, a source badge, the
+/// one-line description, and the argument hint. Matched characters highlighted.
+private struct CompletionRowView: View {
+    let row: CommandRanker.Row
+    let isSelected: Bool
+    /// The pointer is over this row. A weaker emphasis than selection, and it
+    /// carries no accessibility trait — nothing has moved.
+    let isHovered: Bool
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 6) {
+                    highlightedName
+                    if let alias = row.matchedAlias {
+                        Text("(\(alias))")
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                    }
+                    if let hint = row.command.argumentHint, !hint.isEmpty {
+                        Text(hint)
+                            .font(.caption)
+                            .foregroundStyle(.tertiary)
+                    }
+                }
+                if !row.command.description.isEmpty {
+                    Text(row.command.description)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+        .frame(height: CompletionOverlayView.rowHeight)
+        .background(
+            isSelected
+                ? Color.accentColor.opacity(0.18)
+                : (isHovered ? Color.primary.opacity(0.06) : Color.clear))
+        // Every row carries a label, and the highlighted one is announced as the
+        // selection moves — the list has logical focus while the text view holds
+        // first responder, so VoiceOver has no other way to follow it.
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+    }
+
+    private var accessibilityLabel: String {
+        var parts = [row.command.name]
+        if let alias = row.matchedAlias { parts.append("alias \(alias)") }
+        if !row.command.description.isEmpty { parts.append(row.command.description) }
+        if let hint = row.command.argumentHint, !hint.isEmpty { parts.append("takes \(hint)") }
+        return parts.joined(separator: ", ")
+    }
+
+    /// Matched characters bolded. Built from the ranker's UTF-16 ranges, so the
+    /// highlight and the match cannot disagree.
+    private var highlightedName: some View {
+        let name = row.command.name as NSString
+        var result = Text("")
+        var cursor = 0
+        for range in row.matchedRanges {
+            if range.location > cursor {
+                // swiftlint:disable:next shorthand_operator - Text has `+` but no `+=`; `result += …` fails to typecheck.
+                result = result + Text(
+                    name.substring(with: NSRange(
+                        location: cursor, length: range.location - cursor)))
+            }
+            // swiftlint:disable:next shorthand_operator - Text has `+` but no `+=`; `result += …` fails to typecheck.
+            result = result + Text(name.substring(with: range)).bold()
+            cursor = range.location + range.length
+        }
+        if cursor < name.length {
+            // swiftlint:disable:next shorthand_operator - Text has `+` but no `+=`; `result += …` fails to typecheck.
+            result = result + Text(name.substring(from: cursor))
+        }
+        return result.font(.callout)
+    }
+}

--- a/Sources/TBDApp/Panes/Transcript/Composer/CompletionOverlayView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Composer/CompletionOverlayView.swift
@@ -28,33 +28,44 @@ struct CompletionOverlayView: View {
     static let maxHeight: CGFloat = rowHeight * CGFloat(CompletionController.visibleRowCount)
 
     var body: some View {
-        Group {
-            switch controller.presentation {
-            case .closed:
-                EmptyView()
-            case .loading:
-                message("Loading commands")
-            case .noMatch:
+        // `.closed` renders nothing at all — no chrome, no zero-height frame —
+        // rather than falling through to the background/stroke/shadow modifiers
+        // below, which would otherwise paint a hairline and shadow around an
+        // empty layout.
+        if case .closed = controller.presentation {
+            EmptyView()
+        } else {
+            content
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(VisualEffectView(material: .menu, blendingMode: .withinWindow))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(Color.secondary.opacity(0.2), lineWidth: 1))
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+                .shadow(radius: 8, y: 2)
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch controller.presentation {
+        case .closed:
+            EmptyView()
+        case .loading:
+            message("Loading commands")
+        case .noMatch:
+            message("No commands match")
+        case .rows:
+            // A one-character query that matches nothing also stays
+            // `.rows` (the controller reserves "no commands match" for
+            // longer queries, so a fresh keystroke isn't noisy) — render
+            // it the same way rather than an empty scroll view.
+            if controller.rows.isEmpty {
                 message("No commands match")
-            case .rows:
-                // A one-character query that matches nothing also stays
-                // `.rows` (the controller reserves "no commands match" for
-                // longer queries, so a fresh keystroke isn't noisy) — render
-                // it the same way rather than an empty scroll view.
-                if controller.rows.isEmpty {
-                    message("No commands match")
-                } else {
-                    list
-                }
+            } else {
+                list
             }
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(VisualEffectView(material: .menu, blendingMode: .withinWindow))
-        .overlay(
-            RoundedRectangle(cornerRadius: 8)
-                .stroke(Color.secondary.opacity(0.2), lineWidth: 1))
-        .clipShape(RoundedRectangle(cornerRadius: 8))
-        .shadow(radius: 8, y: 2)
     }
 
     /// A single dim row while the inventory is in flight, with nothing
@@ -84,7 +95,13 @@ struct CompletionOverlayView: View {
                         // Hover PREVIEWS: it emphasizes the row and moves
                         // nothing, so what Return would take does not change
                         // under a resting pointer.
-                        .onHover { inside in hoveredIndex = inside ? index : nil }
+                        .onHover { inside in
+                            if inside {
+                                hoveredIndex = index
+                            } else if hoveredIndex == index {
+                                hoveredIndex = nil
+                            }
+                        }
                         // A click HIGHLIGHTS rather than runs. Mouse mis-clicks
                         // on a list are common and these rows are much larger
                         // targets than a terminal's, so a click that ran a
@@ -102,8 +119,8 @@ struct CompletionOverlayView: View {
     }
 }
 
-/// One row: the name with a matched alias in parentheses, a source badge, the
-/// one-line description, and the argument hint. Matched characters highlighted.
+/// One row: the name with a matched alias in parentheses, the one-line
+/// description, and the argument hint. Matched characters highlighted.
 private struct CompletionRowView: View {
     let row: CommandRanker.Row
     let isSelected: Bool
@@ -163,23 +180,20 @@ private struct CompletionRowView: View {
     /// highlight and the match cannot disagree.
     private var highlightedName: some View {
         let name = row.command.name as NSString
-        var result = Text("")
+        var runs: [Text] = []
         var cursor = 0
         for range in row.matchedRanges {
             if range.location > cursor {
-                // swiftlint:disable:next shorthand_operator - Text has `+` but no `+=`; `result += …` fails to typecheck.
-                result = result + Text(
+                runs.append(Text(
                     name.substring(with: NSRange(
-                        location: cursor, length: range.location - cursor)))
+                        location: cursor, length: range.location - cursor))))
             }
-            // swiftlint:disable:next shorthand_operator - Text has `+` but no `+=`; `result += …` fails to typecheck.
-            result = result + Text(name.substring(with: range)).bold()
+            runs.append(Text(name.substring(with: range)).bold())
             cursor = range.location + range.length
         }
         if cursor < name.length {
-            // swiftlint:disable:next shorthand_operator - Text has `+` but no `+=`; `result += …` fails to typecheck.
-            result = result + Text(name.substring(from: cursor))
+            runs.append(Text(name.substring(from: cursor)))
         }
-        return result.font(.callout)
+        return runs.reduce(Text(""), +).font(.callout)
     }
 }

--- a/Sources/TBDApp/Panes/Transcript/Composer/CompletionOverlayView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Composer/CompletionOverlayView.swift
@@ -56,10 +56,14 @@ struct CompletionOverlayView: View {
         case .noMatch:
             message("No commands match")
         case .rows:
-            // A one-character query that matches nothing also stays
-            // `.rows` (the controller reserves "no commands match" for
-            // longer queries, so a fresh keystroke isn't noisy) — render
-            // it the same way rather than an empty scroll view.
+            // Defensive. The controller reaches `.rows` only with rows to show:
+            // a query that matches nothing goes to `.noMatch`, or closes
+            // outright at one character, where "no commands match" would be
+            // noise on a keystroke somebody is still typing. `rows` is published
+            // separately from `presentation`, though, so the empty case is
+            // rendered as that same sentence rather than as an empty scroll
+            // view — a branch that should never run, and says something if it
+            // does.
             if controller.rows.isEmpty {
                 message("No commands match")
             } else {

--- a/Sources/TBDApp/Panes/Transcript/Composer/CompletionTrigger.swift
+++ b/Sources/TBDApp/Panes/Transcript/Composer/CompletionTrigger.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+/// Whether the caret is inside a completion token, and which one.
+///
+/// **A suggestion, never a mode.** The menu opens on a sigil typed at the start
+/// of the input, at the start of a line, or after whitespace — anywhere in the
+/// text — and it never opens inside a word, which is what keeps `https://` and
+/// `foo/bar` from stealing Return from somebody typing a URL. A space, or the
+/// caret leaving the token, closes it.
+///
+/// Pure, and a function of the text alone. The stateful halves of the rule live
+/// in the controller, because they are not properties of the string: Escape
+/// closes the menu and keeps it closed for that token until the token changes,
+/// and no menu opens or updates while an input method has marked text.
+///
+/// **Every offset is UTF-16.** `NSTextView` selection ranges are, and a range
+/// computed in `Character` offsets replaces the wrong bytes the first time
+/// somebody types an emoji.
+enum CompletionTrigger {
+    enum Kind: Equatable {
+        /// `/` — commands, skills, plugin items.
+        case command
+        /// `@` — subagents, in the first version.
+        case mention
+    }
+
+    struct Match: Equatable {
+        let kind: Kind
+        /// The sigil's index in the string's UTF-16 view.
+        let sigilLocation: Int
+        /// The whole token including the sigil, from the sigil to the caret.
+        let tokenRange: NSRange
+        /// What the person has typed after the sigil, up to the caret. Filtering
+        /// follows the caret rather than the token's end, so backspacing into a
+        /// token widens the match instead of keeping the old query.
+        let query: String
+    }
+
+    /// Characters a completion token may not contain. A token ends at the first
+    /// of these, which is what makes "a space closes it" true without a second
+    /// rule.
+    private static let terminators = CharacterSet.whitespacesAndNewlines
+
+    static func detect(text: String, selectionLocation: Int) -> Match? {
+        let ns = text as NSString
+        guard selectionLocation >= 0, selectionLocation <= ns.length else { return nil }
+
+        // Walk back from the caret to the token's start. Stop at whitespace (the
+        // token ended) or at a sigil (found it).
+        var index = selectionLocation
+        while index > 0 {
+            let scalarRange = ns.rangeOfComposedCharacterSequence(at: index - 1)
+            let piece = ns.substring(with: scalarRange)
+            if piece == "/" || piece == "@" {
+                let sigilLocation = scalarRange.location
+                // The sigil must start the input, start a line, or follow
+                // whitespace. Anything else means it sits inside a word —
+                // `https://`, `foo/bar`, `me@example.com` — and opening there is
+                // the trap this rule exists to avoid.
+                if sigilLocation > 0 {
+                    let beforeRange = ns.rangeOfComposedCharacterSequence(at: sigilLocation - 1)
+                    let before = ns.substring(with: beforeRange)
+                    guard before.rangeOfCharacter(from: terminators) != nil else { return nil }
+                }
+                let queryRange = NSRange(
+                    location: scalarRange.location + scalarRange.length,
+                    length: selectionLocation - (scalarRange.location + scalarRange.length))
+                return Match(
+                    kind: piece == "/" ? .command : .mention,
+                    sigilLocation: sigilLocation,
+                    tokenRange: NSRange(
+                        location: sigilLocation,
+                        length: selectionLocation - sigilLocation),
+                    query: ns.substring(with: queryRange))
+            }
+            if piece.rangeOfCharacter(from: terminators) != nil {
+                // Whitespace before any sigil: the caret is not in a token.
+                return nil
+            }
+            index = scalarRange.location
+        }
+        return nil
+    }
+}

--- a/Sources/TBDApp/Panes/Transcript/Composer/ComposerArgumentHint.swift
+++ b/Sources/TBDApp/Panes/Transcript/Composer/ComposerArgumentHint.swift
@@ -1,0 +1,41 @@
+import Foundation
+import TBDShared
+
+/// The dim placeholder shown after an accepted command token, naming what the
+/// command takes.
+///
+/// It appears only once a space follows the token: before that the completion
+/// menu is up and already showing the hint on the row, and rendering the same
+/// string twice at once is one rendering too many. It retires as soon as an
+/// argument is typed, because the placeholder has then been answered.
+///
+/// Start of the input only. Claude Code expands a command only at the start of a
+/// message, so a mid-sentence token takes no arguments and a placeholder there
+/// would promise behaviour that does not exist.
+///
+/// Pure, and a function of the text and the caret alone — so the drawing has no
+/// state of its own to get out of step.
+enum ComposerArgumentHint {
+    static func hint(
+        text: String, selectionLocation: Int, commands: [CompletionCommand]
+    ) -> String? {
+        let ns = text as NSString
+        guard ns.length > 0, text.hasPrefix("/") else { return nil }
+        guard let spaceRange = ns.range(of: " ").toOptionalRange() else { return nil }
+        // Exactly one space, and the caret sitting right after it: the argument
+        // position, and nothing typed into it yet.
+        let argumentStart = spaceRange.location + spaceRange.length
+        guard argumentStart == ns.length, selectionLocation == ns.length else { return nil }
+
+        let name = ns.substring(with: NSRange(location: 1, length: spaceRange.location - 1))
+        guard let command = commands.first(where: { $0.name == name }),
+              let hint = command.argumentHint, !hint.isEmpty
+        else { return nil }
+        return hint
+    }
+}
+
+private extension NSRange {
+    /// `NSString.range(of:)` reports `NSNotFound` rather than nil.
+    func toOptionalRange() -> NSRange? { location == NSNotFound ? nil : self }
+}

--- a/Sources/TBDApp/Panes/Transcript/Composer/ComposerDraft.swift
+++ b/Sources/TBDApp/Panes/Transcript/Composer/ComposerDraft.swift
@@ -1,0 +1,69 @@
+import Foundation
+import Observation
+
+/// One terminal's unsent message: the text, and a side map of staged images.
+///
+/// **The text decides what is sent; this map only says where the files are.** A
+/// token the person deleted or edited drops its image at send time, and the strip
+/// shows the orphan as detached rather than dropping it silently.
+///
+/// Held by `AppState`, deliberately **outside** the transcript's session-identity
+/// reset: the table rebuilds under `.id(PaneIdentity(terminalID:sessionID:))`, so
+/// a `/clear` tears the view down, and a draft that lived in the view would go
+/// with it.
+@Observable
+@MainActor
+final class ComposerDraft {
+    struct Attachment: Equatable, Identifiable {
+        /// The staged file's own id — also its filename under
+        /// `~/tbd/attachments/<worktreeID>/`.
+        let id: UUID
+        /// The `[Image #N]` number this file answers to.
+        let number: Int
+        let path: String
+    }
+
+    var text: String = ""
+    private(set) var attachments: [Int: Attachment] = [:]
+
+    /// Monotonic within one message. A freed number is never reused, because
+    /// reusing it would silently re-point a token the person had already typed
+    /// somewhere else in the same sentence.
+    private var nextNumber = 1
+
+    /// Stage a prepared file and return the token number to insert at the caret.
+    @discardableResult
+    func stage(path: String, id: UUID) -> Int {
+        let number = nextNumber
+        nextNumber += 1
+        attachments[number] = Attachment(id: id, number: number, path: path)
+        return number
+    }
+
+    /// The x on a thumbnail: the image leaves the send, and its token leaves the
+    /// text. (Removing the token from the text is the view's job — this forgets
+    /// the file.)
+    func removeAttachment(number: Int) {
+        attachments[number] = nil
+    }
+
+    /// Staged images the text no longer anchors, in stable order. Shown greyed
+    /// and marked "not in message".
+    var detachedNumbers: [Int] {
+        let attached = ComposerTokens.attachedNumbers(in: text)
+        return attachments.keys.filter { !attached.contains($0) }.sorted()
+    }
+
+    /// Paths keyed by token number, the shape `ComposerTokens` wants.
+    var pathsByNumber: [Int: String] {
+        attachments.mapValues(\.path)
+    }
+
+    /// A successful send, or an explicit discard. Numbering restarts because a
+    /// fresh message has no tokens to collide with.
+    func clear() {
+        text = ""
+        attachments = [:]
+        nextNumber = 1
+    }
+}

--- a/Sources/TBDApp/Panes/Transcript/Composer/ComposerImagePreparer.swift
+++ b/Sources/TBDApp/Panes/Transcript/Composer/ComposerImagePreparer.swift
@@ -1,0 +1,131 @@
+import AppKit
+import Foundation
+import ImageIO
+import UniformTypeIdentifiers
+
+/// Turns whatever arrived — clipboard TIFF, clipboard PNG, a dropped file — into
+/// one PNG the composer can write and Claude Code can read.
+///
+/// **The original bytes are never passed through unexamined.** Everything is
+/// decoded and re-encoded, which is what lets the composer promise that the file
+/// it wrote is an image and that its `.png` extension tells the truth — and
+/// Claude Code's paste handler keys its image detection on that extension.
+///
+/// Downscaling uses ImageIO's thumbnail path with
+/// `kCGImageSourceCreateThumbnailFromImageAlways`. The **if-absent** variant can
+/// return a stale embedded EXIF thumbnail, which is a different picture from the
+/// one the person pasted; always-from-image costs a decode and cannot.
+enum ComposerImagePreparer {
+    enum PrepareError: Error, Equatable, LocalizedError {
+        /// ImageIO could not read it. Refused with a message rather than written
+        /// as an unopenable file.
+        case undecodable
+        /// Still over Claude Code's cap after the smallest re-encode this will
+        /// attempt. The payload is the BASE64 size, the number the cap is
+        /// measured against.
+        case tooLargeAfterReencoding(bytes: Int)
+
+        /// The message a person sees. It names the numbers, because "too large"
+        /// on its own tells them nothing about what to do next.
+        var errorDescription: String? {
+            switch self {
+            case .undecodable:
+                return "That is not an image TBD can read."
+            case .tooLargeAfterReencoding(let bytes):
+                return """
+                    Still \(bytes) bytes once base64-encoded at \
+                    \(ComposerImagePreparer.smallestEdge) px on its long edge, \
+                    over the \(ComposerImagePreparer.maxBase64Bytes)-byte limit.
+                    """
+            }
+        }
+    }
+
+    /// The longest edge any prepared image may have. A screenshot is legible far
+    /// below its native resolution, and the cap is what keeps a Retina capture
+    /// from spending the whole message budget on pixels nobody reads.
+    static let maxLongEdge = 2000
+
+    /// Claude Code's 5 MiB cap, measured against the BASE64 form — the encoding
+    /// the image travels in, which is four bytes out for every three in.
+    static let maxBase64Bytes = 5 * 1024 * 1024
+
+    /// The floor the re-encode loop will not go below: past this an image is too
+    /// small to read anything off, so failing with a number beats silently
+    /// handing over a thumbnail.
+    private static let smallestEdge = 640
+
+    /// Successively smaller long edges to try when the first result is too big.
+    /// Descending, so the loop keeps the largest size that fits.
+    private static let fallbackEdges = [1600, 1200, 900, smallestEdge]
+
+    static func preparePNG(from data: Data) throws -> Data {
+        guard !data.isEmpty,
+              let source = CGImageSourceCreateWithData(data as CFData, nil),
+              CGImageSourceGetCount(source) > 0
+        else { throw PrepareError.undecodable }
+
+        for edge in [maxLongEdge] + fallbackEdges {
+            guard let png = encodePNG(source: source, maxPixelSize: edge) else { continue }
+            if base64Size(of: png) <= maxBase64Bytes { return png }
+        }
+        // One last attempt at the smallest size, so the error can name a real
+        // number rather than a guess.
+        guard let smallest = encodePNG(source: source, maxPixelSize: smallestEdge)
+        else { throw PrepareError.undecodable }
+        throw PrepareError.tooLargeAfterReencoding(bytes: base64Size(of: smallest))
+    }
+
+    /// Base64 is four output bytes for every three input bytes, rounded up to a
+    /// whole quantum. The cap is measured against this, not against the raw
+    /// count, because the expansion is what the message actually carries.
+    private static func base64Size(of data: Data) -> Int { (data.count + 2) / 3 * 4 }
+
+    /// One decode-and-encode at a given cap. `kCGImageSourceCreateThumbnailFromImageAlways`
+    /// forces a real decode; `kCGImageSourceCreateThumbnailWithTransform` applies
+    /// the EXIF orientation to the pixels, so nothing downstream has to re-read a
+    /// tag that the PNG will not carry anyway.
+    private static func encodePNG(source: CGImageSource, maxPixelSize: Int) -> Data? {
+        let options: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceShouldCacheImmediately: true,
+            kCGImageSourceThumbnailMaxPixelSize: maxPixelSize,
+        ]
+        guard let image = CGImageSourceCreateThumbnailAtIndex(
+            source, 0, options as CFDictionary) else { return nil }
+        let output = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(
+            output, UTType.png.identifier as CFString, 1, nil) else { return nil }
+        CGImageDestinationAddImage(destination, image, nil)
+        guard CGImageDestinationFinalize(destination) else { return nil }
+        return output as Data
+    }
+
+    /// Read image bytes off the pasteboard **without** adding image types to the
+    /// text view's readable types.
+    ///
+    /// That distinction is the whole reason this exists: letting `NSTextView`'s
+    /// default pipeline see an image would make it insert an inline attachment
+    /// into the storage, which reopens every rich-text hazard the plain-text
+    /// composer closes. It is the same shape the terminal view's paste override
+    /// already uses (`TBDTerminalView.paste(_:)`).
+    @MainActor
+    static func imageData(from pasteboard: NSPasteboard) -> Data? {
+        for type in [NSPasteboard.PasteboardType.png, .tiff] {
+            if let data = pasteboard.data(forType: type) { return data }
+        }
+        // A copied file, e.g. from Finder.
+        if let urls = pasteboard.readObjects(
+            forClasses: [NSURL.self],
+            options: [.urlReadingFileURLsOnly: true]) as? [URL],
+           let first = urls.first {
+            return imageData(fromFileAt: first)
+        }
+        return nil
+    }
+
+    static func imageData(fromFileAt url: URL) -> Data? {
+        try? Data(contentsOf: url)
+    }
+}

--- a/Sources/TBDApp/Panes/Transcript/Composer/ComposerImagePreparer.swift
+++ b/Sources/TBDApp/Panes/Transcript/Composer/ComposerImagePreparer.swift
@@ -136,16 +136,45 @@ enum ComposerImagePreparer {
     /// one the filesystem already knows. It is not the last word: a screenshot
     /// saved with the wrong extension is still an image, so bytes ImageIO can
     /// open as an image are accepted regardless of what the file is called.
+    ///
+    /// **Nothing is read whole before it is identified.** A drop hands over
+    /// whatever URL the pasteboard carried — a disk image, a core dump, a video
+    /// — so the type comes first, and the fallback for a file whose type says
+    /// nothing sniffs only `sniffPrefixBytes` rather than pulling gigabytes into
+    /// memory to learn that they are not a picture. The read that does happen is
+    /// mapped, so the pages the preparer never touches are never faulted in.
     static func imageData(fromFileAt url: URL) -> Data? {
-        guard let data = try? Data(contentsOf: url), !data.isEmpty else { return nil }
-        if let declared = try? url.resourceValues(forKeys: [.contentTypeKey]).contentType,
-           declared.conforms(to: .image) {
-            return data
-        }
-        guard let source = CGImageSourceCreateWithData(data as CFData, nil),
-              CGImageSourceGetType(source) != nil,
-              CGImageSourceGetCount(source) > 0
+        let declared = try? url.resourceValues(forKeys: [.contentTypeKey]).contentType
+        if declared?.conforms(to: .image) == true { return mappedContents(of: url) }
+        guard sniffedTypeIsImage(at: url) else { return nil }
+        return mappedContents(of: url)
+    }
+
+    /// How much of an unidentified file is read to decide whether it is an image.
+    /// Every container this can accept declares itself in its first bytes; 8 KB
+    /// clears the largest of those headers with room to spare.
+    private static let sniffPrefixBytes = 8 * 1024
+
+    private static func mappedContents(of url: URL) -> Data? {
+        guard let data = try? Data(contentsOf: url, options: [.mappedIfSafe]),
+              !data.isEmpty
         else { return nil }
         return data
+    }
+
+    /// Does the head of this file look like an image container?
+    ///
+    /// Only the TYPE is asked of the prefix — never the frame count, which a
+    /// truncated buffer cannot answer for every format. The full bytes are
+    /// decoded later by `preparePNG`, which refuses anything ImageIO cannot open.
+    private static func sniffedTypeIsImage(at url: URL) -> Bool {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return false }
+        defer { try? handle.close() }
+        guard let prefix = try? handle.read(upToCount: sniffPrefixBytes), !prefix.isEmpty,
+              let source = CGImageSourceCreateWithData(prefix as CFData, nil),
+              let type = CGImageSourceGetType(source),
+              UTType(type as String)?.conforms(to: .image) == true
+        else { return false }
+        return true
     }
 }

--- a/Sources/TBDApp/Panes/Transcript/Composer/ComposerImagePreparer.swift
+++ b/Sources/TBDApp/Panes/Transcript/Composer/ComposerImagePreparer.swift
@@ -125,7 +125,27 @@ enum ComposerImagePreparer {
         return nil
     }
 
+    /// Read a dropped or copied file, **only if it really holds an image**.
+    ///
+    /// The drop path hands over whatever URL the pasteboard carried, so without
+    /// this a dragged source file, log or PDF would reach `onImageData` and be
+    /// written into the composer as an attachment, failing later — inside the
+    /// preparer, as an opaque "not an image" — rather than at the drop.
+    ///
+    /// The declared type is asked first because it is the cheap answer and the
+    /// one the filesystem already knows. It is not the last word: a screenshot
+    /// saved with the wrong extension is still an image, so bytes ImageIO can
+    /// open as an image are accepted regardless of what the file is called.
     static func imageData(fromFileAt url: URL) -> Data? {
-        try? Data(contentsOf: url)
+        guard let data = try? Data(contentsOf: url), !data.isEmpty else { return nil }
+        if let declared = try? url.resourceValues(forKeys: [.contentTypeKey]).contentType,
+           declared.conforms(to: .image) {
+            return data
+        }
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil),
+              CGImageSourceGetType(source) != nil,
+              CGImageSourceGetCount(source) > 0
+        else { return nil }
+        return data
     }
 }

--- a/Sources/TBDApp/Panes/Transcript/Composer/ComposerKeyRouter.swift
+++ b/Sources/TBDApp/Panes/Transcript/Composer/ComposerKeyRouter.swift
@@ -1,0 +1,98 @@
+import AppKit
+
+/// What the composer does with one resolved key command.
+///
+/// Pure, and the **only** decision site. The existing `ComposerReturnKey`
+/// answers the same question for the two first-message sheets and stays exactly
+/// as it is; this extends the shape with the one input those sheets do not have —
+/// whether a completion menu is open — because a second decision site is how a
+/// composer ends up with a key that means one thing in one branch and another
+/// somewhere else.
+///
+/// The four inputs are exactly what `doCommandBy` can know: the command AppKit
+/// resolved the keystroke to, the modifiers on the current event, and whether an
+/// input method is mid-composition.
+///
+/// `menuOpen` is a **parameter**, never state held here. The caller reads its
+/// controller at decision time, so a stale flag — a menu that closed between the
+/// keystroke and the decision — is impossible by construction rather than by
+/// discipline.
+enum ComposerKeyRouter {
+    enum Action: Equatable {
+        /// Send the message.
+        case submit
+        /// Insert a line break and keep composing.
+        case newline
+        /// Move the completion selection.
+        case menuUp
+        case menuDown
+        /// Accept the highlighted row, or the first when none is highlighted.
+        case menuAccept
+        /// Close the menu, leaving the text untouched.
+        case menuClose
+        /// Give up first responder — Escape with no menu open, which returns
+        /// focus to the transcript.
+        case blur
+        /// Not ours. Let AppKit do whatever it would have done.
+        case passThrough
+    }
+
+    static func action(
+        selector: Selector,
+        shiftHeld: Bool,
+        commandHeld: Bool,
+        controlHeld: Bool,
+        hasMarkedText: Bool,
+        menuOpen: Bool
+    ) -> Action {
+        // Unconditional, before anything else. While an input method has marked
+        // text, every key belongs to the composition — including Return, which
+        // commits it, and the arrows, which move through candidates.
+        guard !hasMarkedText else { return .passThrough }
+
+        // Cmd+Return always sends, menu open or closed: the escape hatch for a
+        // person who highlighted a row and then decided they meant their own
+        // words.
+        if commandHeld, selector == #selector(NSResponder.insertNewline(_:)) {
+            return .submit
+        }
+
+        if selector == #selector(NSResponder.insertNewlineIgnoringFieldEditor(_:)) {
+            // Option+Return: a line break, whatever else is on screen.
+            return .newline
+        }
+
+        if selector == #selector(NSResponder.insertNewline(_:)) {
+            // Shift+Return keeps meaning "not now, I am still writing" even with
+            // the menu up. `StandardKeyBinding.dict` has no Shift+Return entry,
+            // so the modifier is the only thing separating it from a plain
+            // Return.
+            if shiftHeld { return .newline }
+            return menuOpen ? .menuAccept : .submit
+        }
+
+        guard menuOpen else {
+            // With no menu, Escape gives up first responder and everything else
+            // is AppKit's business. Tab must insert a tab, and the arrows must
+            // move the caret — a composer that stole them would break multi-line
+            // editing for a person who is only typing.
+            if selector == #selector(NSResponder.cancelOperation(_:)) { return .blur }
+            return .passThrough
+        }
+
+        // `controlHeld` is not read to DISTINGUISH anything here: AppKit resolves
+        // Ctrl+N and Ctrl+P to the same `moveDown:` / `moveUp:` commands as the
+        // arrows, so both gestures arrive already unified. It stays in the
+        // signature because the router's contract is "everything doCommandBy can
+        // know", and a future binding that needs it must not change every call
+        // site.
+        _ = controlHeld
+        switch selector {
+        case #selector(NSResponder.moveUp(_:)): return .menuUp
+        case #selector(NSResponder.moveDown(_:)): return .menuDown
+        case #selector(NSResponder.insertTab(_:)): return .menuAccept
+        case #selector(NSResponder.cancelOperation(_:)): return .menuClose
+        default: return .passThrough
+        }
+    }
+}

--- a/Sources/TBDApp/Panes/Transcript/Composer/ComposerKeyRouter.swift
+++ b/Sources/TBDApp/Panes/Transcript/Composer/ComposerKeyRouter.swift
@@ -27,7 +27,18 @@ enum ComposerKeyRouter {
         case menuUp
         case menuDown
         /// Accept the highlighted row, or the first when none is highlighted.
+        /// **Tab, and only Tab** — the gesture whose entire meaning is "take the
+        /// obvious completion", which is why it may fall back to the first row.
         case menuAccept
+        /// Return with the menu open. Accept the highlighted row if there is
+        /// one; otherwise **send the message as typed**.
+        ///
+        /// A separate case rather than `.menuAccept` because the two keys mean
+        /// different things and only the caller knows which row, if any, is
+        /// highlighted. Collapsing them would make Return take `rows.first`,
+        /// rewriting a person's own words into a command they never chose — the
+        /// one failure the Enter/Tab split exists to prevent.
+        case menuAcceptOrSubmit
         /// Close the menu, leaving the text untouched.
         case menuClose
         /// Give up first responder — Escape with no menu open, which returns
@@ -68,7 +79,10 @@ enum ComposerKeyRouter {
             // so the modifier is the only thing separating it from a plain
             // Return.
             if shiftHeld { return .newline }
-            return menuOpen ? .menuAccept : .submit
+            // With the menu up this is Return, not Tab, and the difference is
+            // load-bearing: the caller accepts only a row the person actually
+            // highlighted and otherwise sends what they typed.
+            return menuOpen ? .menuAcceptOrSubmit : .submit
         }
 
         guard menuOpen else {

--- a/Sources/TBDApp/Panes/Transcript/Composer/ComposerSendCoordinator.swift
+++ b/Sources/TBDApp/Panes/Transcript/Composer/ComposerSendCoordinator.swift
@@ -1,0 +1,227 @@
+import Foundation
+import os
+import TBDShared
+
+private let logger = Logger(subsystem: "com.tbd.app", category: "composer.send")
+
+/// How a composed message leaves the app.
+///
+/// Two paths, and the branch between them is a machine fact rather than a guess:
+/// a running session takes a paste, a parked one takes an argv on its respawn.
+///
+/// **Running.** `terminal.send` with the ordered parts list, the envelope
+/// suppressed, and the awaiting-input gate opted in. The composer never uses the
+/// keys path and never asks for verification.
+///
+/// **Not running.** `terminal.wake` with the message in its `prompt`, which the
+/// daemon passes to the spawn builder as a trailing argument on
+/// `claude --resume <id>` — atomic with the respawn, so no paste-readiness
+/// question arises. An argument prompt cannot carry image attachments, so each
+/// token is replaced inline with its quoted path; Claude reads the files with its
+/// Read tool.
+///
+/// **And then it holds — on its own spawn.** A wake whose session id no longer
+/// resolves makes Claude print one line and exit 1 with the prompt lost, while
+/// tmux reports the respawn as a success, so the text stays held as *sending*
+/// until the session reports in and is restored editable on timeout. But a
+/// `SessionStart` on the same terminal is not that evidence: a competing wake, a
+/// post-`--fork-session` recapture, and a person typing `claude --resume` in the
+/// pane all produce one. The wake result names the incarnation the respawn
+/// minted — the id the daemon planted in the child's environment as
+/// `TBD_TERMINAL_INCARNATION_ID` and gets back on that process's hooks — and the
+/// hold releases on the `SessionStart` carrying that id and on no other. A
+/// `SessionStart` with a different id, or with none at all (a worktree's first
+/// spawn, an archive restore), leaves it held.
+@MainActor
+final class ComposerSendCoordinator {
+    enum Outcome: Equatable {
+        case sent
+        /// The wake landed and the session THIS wake started reported in.
+        case woke
+        /// Nothing was delivered, or delivery could not be confirmed. The caller
+        /// restores the text and shows this message.
+        case failed(message: String)
+    }
+
+    /// What a wake answered: the incarnation it minted, or why nothing happened.
+    ///
+    /// Three cases rather than an optional message, because the two failure
+    /// shapes mean different things to a person: `.noOp` says the terminal was
+    /// already live and the prompt went nowhere, while `.failed` says the
+    /// session is gone. Collapsing them would make one of the two unreportable.
+    ///
+    /// The enum itself lives at file scope in `AppState+ComposerFocus.swift`,
+    /// where the wake that produces it does; this is the name the send path
+    /// reads it under.
+    typealias WakeReply = ComposerWakeReply
+
+    typealias Sender = @Sendable @MainActor (TerminalSendParams) async throws -> Void
+    /// terminalID, worktreeID, prompt → what the wake answered.
+    typealias Waker = @Sendable @MainActor (UUID, UUID, String) async -> WakeReply
+    /// terminalID, incarnationID → true when THAT spawn's `SessionStart` arrives.
+    /// Never on another id, never on none.
+    typealias SessionStartWaiter = @Sendable @MainActor (UUID, UUID) async -> Bool
+
+    /// How long the text is held as sending before it comes back editable.
+    ///
+    /// Sized against a cold `claude --resume` on a large session, not against
+    /// impatience: the failure it bounds is a lost message, and restoring too
+    /// early would show an error for a wake that was about to land.
+    static let wakeHoldTimeout: Duration = .seconds(45)
+
+    private let sendParams: Sender
+    private let wake: Waker
+    private let awaitSessionStart: SessionStartWaiter
+    private let clock: any Clock<Duration>
+
+    init(
+        send: @escaping Sender,
+        wake: @escaping Waker,
+        awaitSessionStart: @escaping SessionStartWaiter,
+        clock: any Clock<Duration> = ContinuousClock()
+    ) {
+        self.sendParams = send
+        self.wake = wake
+        self.awaitSessionStart = awaitSessionStart
+        self.clock = clock
+    }
+
+    func send(
+        text: String, paths: [Int: String], state: ComposerState,
+        terminalID: UUID, worktreeID: UUID
+    ) async -> Outcome {
+        let parts = ComposerTokens.parts(text: text, paths: paths)
+        // A message that is nothing but whitespace names nothing — but one that
+        // is nothing but an image token is a real message.
+        let carriesSomething = parts.contains { part in
+            switch part {
+            case .text(let value):
+                return !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            case .imagePath:
+                return true
+            }
+        }
+        guard carriesSomething else {
+            return .failed(message: "Nothing to send.")
+        }
+
+        switch state {
+        case .hidden:
+            return .failed(message: "This terminal has no composer.")
+        case .blocked(let message):
+            return .failed(message: message)
+        case .running:
+            return await sendToRunningSession(parts: parts, terminalID: terminalID)
+        case .notRunning:
+            return await wakeWith(
+                text: text, paths: paths, terminalID: terminalID, worktreeID: worktreeID)
+        }
+    }
+
+    // MARK: - Running
+
+    private func sendToRunningSession(
+        parts: [SendPart], terminalID: UUID
+    ) async -> Outcome {
+        do {
+            try await sendParams(TerminalSendParams(
+                terminalID: terminalID,
+                submit: true,
+                parts: parts,
+                // The person is speaking in their own voice, exactly as at the
+                // keyboard; Claude should see only the message. Suppression is a
+                // request — the daemon authenticates the connection and decides.
+                envelope: .suppressed,
+                // The composer always opts in. A pasted body plus Enter into a
+                // permission dialog commits whichever option is highlighted.
+                gateOnAwaitingInput: true))
+            return .sent
+        } catch {
+            logger.warning("""
+            composer send failed for terminal \(terminalID.uuidString, privacy: .public): \
+            \(error, privacy: .public)
+            """)
+            return .failed(message: error.localizedDescription)
+        }
+    }
+
+    // MARK: - Not running
+
+    private func wakeWith(
+        text: String, paths: [Int: String], terminalID: UUID, worktreeID: UUID
+    ) async -> Outcome {
+        let prompt = ComposerTokens.flattened(text: text, paths: paths)
+        let incarnationID: UUID
+        switch await wake(terminalID, worktreeID, prompt) {
+        case .failed(let message):
+            // Session gone, worktree missing, profile missing. Nothing was
+            // delivered and there is nothing to wait for.
+            return .failed(message: message)
+        case .noOp:
+            // `woken: false`. The terminal was already live, or another wake was
+            // in flight, and the daemon delivered the prompt NOWHERE — which is
+            // exactly what makes the parameter safe to pass while racing a
+            // background wake. Surfaced, never held on.
+            return .failed(message:
+                "This terminal was already running, so the message was not "
+                + "delivered. It is back in the box — try sending it again.")
+        case .woken(let minted):
+            guard let minted else {
+                // The wake respawned and delivered the prompt, but named no
+                // spawn — an older daemon, or a row that carried no incarnation.
+                // There is nothing to scope a wait to, and waiting on "any
+                // SessionStart" is exactly what this design rejects, so report
+                // the delivery rather than hold until the timeout and show an
+                // error for a message that landed.
+                logger.debug("""
+                wake for terminal \(terminalID.uuidString, privacy: .public) named no \
+                incarnation; not entering the hold
+                """)
+                return .woke
+            }
+            incarnationID = minted
+        }
+
+        guard await holdUntilSessionStart(
+            terminalID: terminalID, incarnationID: incarnationID)
+        else {
+            return .failed(message:
+                "The session this send started did not report in within "
+                + "\(Self.wakeHoldTimeout). Your message was not delivered — "
+                + "it is back in the box.")
+        }
+        return .woke
+    }
+
+    /// Held as sending until THIS spawn says it started.
+    ///
+    /// Written duration-relative as a task-group race, which is the shape the
+    /// existential clock supports and the shape a test can advance: the loser is
+    /// cancelled, and the waiter answers `false` on cancellation rather than
+    /// leaving a continuation nobody resumes.
+    private func holdUntilSessionStart(
+        terminalID: UUID, incarnationID: UUID
+    ) async -> Bool {
+        // Lifted into locals rather than captured off `self`: both are `Sendable`
+        // on their own, and a capture list on a child closure is a shape the
+        // region-based isolation checker cannot reason about.
+        let waiter = awaitSessionStart
+        let holdClock = clock
+        return await withTaskGroup(of: Bool.self) { group in
+            // No isolation annotation on the child: `waiter` is an async
+            // `@MainActor` closure, so the call hops to the main actor by
+            // itself. Spelling `@MainActor` on the closure instead is a shape
+            // the region-based isolation checker rejects outright.
+            group.addTask {
+                await waiter(terminalID, incarnationID)
+            }
+            group.addTask {
+                try? await holdClock.sleep(for: Self.wakeHoldTimeout)
+                return false
+            }
+            let first = await group.next() ?? false
+            group.cancelAll()
+            return first
+        }
+    }
+}

--- a/Sources/TBDApp/Panes/Transcript/Composer/ComposerSendCoordinator.swift
+++ b/Sources/TBDApp/Panes/Transcript/Composer/ComposerSendCoordinator.swift
@@ -141,8 +141,24 @@ final class ComposerSendCoordinator {
             composer send failed for terminal \(terminalID.uuidString, privacy: .public): \
             \(error, privacy: .public)
             """)
-            return .failed(message: error.localizedDescription)
+            return .failed(message: Self.bannerMessage(for: error))
         }
+    }
+
+    /// What the banner says about a send that did not land.
+    ///
+    /// A refusal comes back as `DaemonClientError.rpcError` carrying the
+    /// **daemon's own sentence** about why it refused — the only part of it a
+    /// person can act on. Its `localizedDescription` prefixes that with
+    /// "RPC error: ", which names a transport nobody using the composer has
+    /// heard of. Everything else keeps its description, because for those the
+    /// framing is the whole message.
+    static func bannerMessage(for error: any Error) -> String {
+        if let daemonError = error as? DaemonClientError,
+           case .rpcError(let message, _) = daemonError {
+            return message
+        }
+        return error.localizedDescription
     }
 
     // MARK: - Not running

--- a/Sources/TBDApp/Panes/Transcript/Composer/ComposerSendCoordinator.swift
+++ b/Sources/TBDApp/Panes/Transcript/Composer/ComposerSendCoordinator.swift
@@ -69,6 +69,11 @@ final class ComposerSendCoordinator {
     /// early would show an error for a wake that was about to land.
     static let wakeHoldTimeout: Duration = .seconds(45)
 
+    /// The same bound as a whole number, for the sentence a person reads.
+    /// Interpolating the `Duration` itself spells it "45.0 seconds", which reads
+    /// like a measurement rather than a deadline.
+    static var wakeHoldTimeoutSeconds: Int { Int(wakeHoldTimeout.components.seconds) }
+
     private let sendParams: Sender
     private let wake: Waker
     private let awaitSessionStart: SessionStartWaiter
@@ -201,10 +206,15 @@ final class ComposerSendCoordinator {
         guard await holdUntilSessionStart(
             terminalID: terminalID, incarnationID: incarnationID)
         else {
+            // Deliberately NOT "your message was not delivered": the prompt went
+            // out on the respawn's own argv, and a session that never reported
+            // in is a session TBD heard nothing from — which is not the same as
+            // one that got nothing. What the app knows is that it could not
+            // confirm.
             return .failed(message:
                 "The session this send started did not report in within "
-                + "\(Self.wakeHoldTimeout). Your message was not delivered — "
-                + "it is back in the box.")
+                + "\(Self.wakeHoldTimeoutSeconds) seconds, so delivery could not be "
+                + "confirmed. Your message is back in the box.")
         }
         return .woke
     }

--- a/Sources/TBDApp/Panes/Transcript/Composer/ComposerState.swift
+++ b/Sources/TBDApp/Panes/Transcript/Composer/ComposerState.swift
@@ -1,0 +1,63 @@
+import Foundation
+import TBDShared
+
+/// What the composer offers for one terminal.
+///
+/// **Every input is a machine fact.** `kind`, `hibernatedAt`, `hibernateReason`
+/// and `awaitingInputReason` are columns the daemon wrote from Claude Code's
+/// hooks and the process table; the worktree's location is TBD's own record.
+/// Nothing here reads rendered text, which this codebase forbids for state.
+///
+/// The order of the branches is the design: scope first (is there a composer at
+/// all), then whether the process is running, then whether it is blocked. Not-
+/// running outranks a standing prompt deliberately — a parked session cannot be
+/// sitting on a dialog, and telling somebody to answer it in the terminal would
+/// send them to a pane with a shell in it.
+enum ComposerState: Equatable {
+    /// No composer at all: the flag is off, the worktree is remote, or this is
+    /// not a Claude session. Scope is Claude sessions on local worktrees; Codex,
+    /// shell and remote are out, and the archived transcript view never gets one.
+    case hidden
+    /// Claude is working, idle, or in an informational state. A message sent
+    /// mid-turn queues inside Claude Code, as it does when typed.
+    case running
+    /// The process is gone. Enabled, with a note that sending will resume the
+    /// session and a send button that says so. `exited` distinguishes only the
+    /// wording — a session that left on its own from one TBD parked.
+    case notRunning(exited: Bool)
+    /// A dialog is on screen, or an awaiting-input reason this build does not
+    /// recognize. Disabled, showing the message the daemon carried and a Reveal
+    /// Terminal action: answering in the terminal is the correct resolution,
+    /// because a pasted body plus Enter would commit whichever option is
+    /// highlighted.
+    case blocked(message: String)
+
+    var isEnabled: Bool {
+        switch self {
+        case .running, .notRunning: return true
+        case .blocked, .hidden: return false
+        }
+    }
+
+    static func resolve(
+        terminal: Terminal?, isRemoteWorktree: Bool, composerEnabled: Bool
+    ) -> ComposerState {
+        guard composerEnabled, !isRemoteWorktree,
+              let terminal, terminal.kind == .claude
+        else { return .hidden }
+
+        if terminal.hibernatedAt != nil {
+            return .notRunning(exited: terminal.hibernateReason == .exited)
+        }
+
+        if let reason = terminal.awaitingInputReason {
+            switch reason.classification {
+            case .promptOnScreen, .unrecognized:
+                return .blocked(message: reason.message)
+            case .doneWaiting, .informational:
+                return .running
+            }
+        }
+        return .running
+    }
+}

--- a/Sources/TBDApp/Panes/Transcript/Composer/ComposerTokens.swift
+++ b/Sources/TBDApp/Panes/Transcript/Composer/ComposerTokens.swift
@@ -1,0 +1,97 @@
+import Foundation
+import TBDShared
+
+/// The inline `[Image #N]` placeholder, and what it means at send time.
+///
+/// **The token is the anchor.** It decides whether an image is sent and where it
+/// sits among the words; the draft's side map only says which file each number
+/// points at. So a token the person deleted drops its image, and a token they
+/// edited so it no longer matches is literal text that drops its image too —
+/// the rule Claude Code's own composer applies to the same placeholders. The
+/// alternative, a chip strip with no inline anchors, was rejected because it
+/// gives no way to refer to an image at a point in the sentence.
+///
+/// Every range is UTF-16, matching `NSTextView` selection coordinates.
+enum ComposerTokens {
+    struct Token: Equatable {
+        let number: Int
+        let range: NSRange
+    }
+
+    static func text(for number: Int) -> String { "[Image #\(number)]" }
+
+    /// Deliberately anchored and exact: `[Image #` then digits then `]`. A looser
+    /// pattern would swallow `[Image #1x]`, which is a token the person edited
+    /// and therefore must NOT resolve.
+    private static let pattern = try? NSRegularExpression(
+        pattern: #"\[Image #(\d+)\]"#, options: [])
+
+    static func scan(_ text: String) -> [Token] {
+        guard let pattern else { return [] }
+        let ns = text as NSString
+        return pattern.matches(in: text, range: NSRange(location: 0, length: ns.length))
+            .compactMap { match in
+                guard match.numberOfRanges == 2,
+                      let number = Int(ns.substring(with: match.range(at: 1)))
+                else { return nil }
+                return Token(number: number, range: match.range)
+            }
+    }
+
+    /// Split at the tokens that resolve, in order. Text between them is a text
+    /// part; an empty one is skipped rather than sent as an empty paste.
+    ///
+    /// A token with no staged file is left in place as literal text: a part
+    /// pointing at nothing would arrive as a broken path in the message.
+    static func parts(text: String, paths: [Int: String]) -> [SendPart] {
+        let ns = text as NSString
+        var result: [SendPart] = []
+        var cursor = 0
+        for token in scan(text) {
+            guard let path = paths[token.number] else { continue }
+            if token.range.location > cursor {
+                let slice = ns.substring(
+                    with: NSRange(
+                        location: cursor, length: token.range.location - cursor))
+                if !slice.isEmpty { result.append(.text(slice)) }
+            }
+            result.append(.imagePath(path))
+            cursor = token.range.location + token.range.length
+        }
+        if cursor < ns.length {
+            let tail = ns.substring(from: cursor)
+            if !tail.isEmpty { result.append(.text(tail)) }
+        }
+        return result
+    }
+
+    /// The not-running form: every resolving token replaced inline with its
+    /// quoted absolute path.
+    ///
+    /// An argument prompt cannot carry image attachments at all, so this is what
+    /// a woken session receives. The sentence reads the same, and Claude reads
+    /// the files with its Read tool — whose image reads are capped near 500 KB,
+    /// which is why the composer says so on the send button.
+    static func flattened(text: String, paths: [Int: String]) -> String {
+        let ns = text as NSString
+        var result = ""
+        var cursor = 0
+        for token in scan(text) {
+            guard let path = paths[token.number] else { continue }
+            if token.range.location > cursor {
+                result += ns.substring(
+                    with: NSRange(location: cursor, length: token.range.location - cursor))
+            }
+            result += "'" + path.replacingOccurrences(of: "'", with: #"'\''"#) + "'"
+            cursor = token.range.location + token.range.length
+        }
+        if cursor < ns.length { result += ns.substring(from: cursor) }
+        return result
+    }
+
+    /// Which staged numbers the text still anchors. The strip greys out the rest
+    /// as "not in message", so nothing is dropped silently.
+    static func attachedNumbers(in text: String) -> Set<Int> {
+        Set(scan(text).map(\.number))
+    }
+}

--- a/Sources/TBDApp/Panes/Transcript/Composer/FrecencyStore.swift
+++ b/Sources/TBDApp/Panes/Transcript/Composer/FrecencyStore.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+/// How often a command was used, decayed by how long ago.
+///
+/// A **tiebreak**, never a rank. It settles the order of two rows an exact,
+/// prefix or fuzzy match already put level with each other; it must never let a
+/// command you used yesterday outrank the one whose name you just typed in full.
+///
+/// One global store keyed by command name, in app defaults, not one per
+/// worktree: a person's habits are theirs, and a per-worktree store would forget
+/// them every time they started fresh work.
+///
+/// Seven-day half-life, floored at ten percent of the raw count. The floor is
+/// what keeps an old favourite from decaying to indistinguishable-from-never —
+/// without it the tiebreak carries no memory at all after a couple of months.
+///
+/// `Date` here is **data**: a persisted timestamp compared against a time. So the
+/// seam is `now: () -> Date`, not a `Clock`.
+///
+/// `UserDefaults`-holding types in this tree are main-actor isolated rather than
+/// bare `Sendable` structs (precedent: `CLIInstallerCoordinator`,
+/// `LegacyHooksCoordinator`); its only consumer, `CompletionController`, is
+/// main-actor too.
+@MainActor
+final class FrecencyStore {
+    nonisolated static let defaultsKey = "composerCommandFrecency"
+    nonisolated static let halfLife: TimeInterval = 7 * 86_400
+    /// The fraction of the raw count a score can never fall below.
+    nonisolated static let floor = 0.1
+
+    private let defaults: UserDefaults
+    private let now: () -> Date
+
+    init(defaults: UserDefaults, now: @escaping () -> Date = { Date() }) {
+        self.defaults = defaults
+        self.now = now
+    }
+
+    /// The decay curve, pure so it is testable without a store.
+    ///
+    /// A `lastUsedAt` in the future — a clock that went backwards, a synced
+    /// defaults file from another machine — is clamped to now rather than
+    /// amplifying the score.
+    nonisolated static func decayed(usageCount: Int, lastUsedAt: Date, now: Date) -> Double {
+        let raw = Double(usageCount)
+        guard raw > 0 else { return 0 }
+        let elapsed = max(0, now.timeIntervalSince(lastUsedAt))
+        let decayed = raw * pow(0.5, elapsed / halfLife)
+        return max(decayed, raw * floor)
+    }
+
+    func score(_ name: String) -> Double {
+        guard let entry = entries()[name],
+              let count = entry["count"] as? Int,
+              let stamp = entry["lastUsedAt"] as? Double else { return 0 }
+        return Self.decayed(
+            usageCount: count, lastUsedAt: Date(timeIntervalSince1970: stamp), now: now())
+    }
+
+    /// Accept a completion: one more use, clock reset.
+    func record(_ name: String) {
+        var all = entries()
+        let previous = (all[name]?["count"] as? Int) ?? 0
+        all[name] = ["count": previous + 1, "lastUsedAt": now().timeIntervalSince1970]
+        defaults.set(all, forKey: Self.defaultsKey)
+    }
+
+    private func entries() -> [String: [String: Any]] {
+        defaults.dictionary(forKey: Self.defaultsKey) as? [String: [String: Any]] ?? [:]
+    }
+}

--- a/Sources/TBDApp/Panes/Transcript/Composer/MessageComposerTextView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Composer/MessageComposerTextView.swift
@@ -93,8 +93,13 @@ struct MessageComposerTextView: NSViewRepresentable {
             // Refused rather than clamped: a range the text no longer holds means
             // the person edited while this was in flight, and inserting at a
             // clamped position would put the token somewhere nobody asked for.
+            // Two comparisons rather than `location + length <= ns.length`:
+            // the range this is most likely to refuse is
+            // `NSRange(location: NSNotFound, …)`, whose location is `Int.max`,
+            // and that addition traps before the comparison can refuse it.
             guard range.location >= 0, range.length >= 0,
-                  range.location + range.length <= ns.length else { return }
+                  range.location <= ns.length,
+                  range.length <= ns.length - range.location else { return }
             textView.insertText(replacement, replacementRange: range)
             textView.setSelectedRange(
                 NSRange(location: range.location + (replacement as NSString).length, length: 0))
@@ -109,15 +114,40 @@ struct MessageComposerTextView: NSViewRepresentable {
     // MARK: - NSViewRepresentable
 
     func makeNSView(context: Context) -> NSScrollView {
-        let scrollView = NSScrollView()
+        makeScrollView(coordinator: context.coordinator)
+    }
+
+    /// Build the scroll view and the text view inside it.
+    ///
+    /// Split out of `makeNSView(context:)` because an
+    /// `NSViewRepresentableContext` cannot be constructed outside SwiftUI, and
+    /// the geometry set up here is exactly what a test has to be able to reach.
+    func makeScrollView(coordinator: Coordinator) -> NSScrollView {
+        let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 100, height: 100))
         scrollView.drawsBackground = false
+        scrollView.borderType = .noBorder
         // A fixed maximum height with a scroller past it, so a growing message
         // never shifts the transcript above it.
         scrollView.hasVerticalScroller = true
         scrollView.autohidesScrollers = true
 
-        let textView = ComposerTextView(frame: .zero)
-        textView.delegate = context.coordinator
+        let contentSize = scrollView.contentSize
+        let textView = ComposerTextView(frame: NSRect(origin: .zero, size: contentSize))
+        // The geometry `NSTextView.scrollableTextView()` would have set up,
+        // spelled out because a subclass rules that factory out. It is stated
+        // rather than inherited: `NSScrollView`'s `documentView` setter happens
+        // to re-seed `minSize`, `maxSize` and the container from the clip view,
+        // and `widthTracksTextView` happens to default to `true`, so a text view
+        // built at `.zero` does grow today — but none of that is documented, and
+        // a composer that silently stops growing is a box a paragraph cannot be
+        // typed into.
+        textView.minSize = NSSize(width: 0, height: 0)
+        textView.maxSize = NSSize(
+            width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+        textView.textContainer?.containerSize = NSSize(
+            width: contentSize.width, height: CGFloat.greatestFiniteMagnitude)
+        textView.textContainer?.widthTracksTextView = true
+        textView.delegate = coordinator
         textView.isRichText = false
         textView.allowsUndo = true
         textView.drawsBackground = false
@@ -137,7 +167,7 @@ struct MessageComposerTextView: NSViewRepresentable {
         textView.registerForDraggedTypes([.fileURL])
 
         scrollView.documentView = textView
-        context.coordinator.textView = textView
+        coordinator.textView = textView
         onViewReady?(textView)
         return scrollView
     }
@@ -177,6 +207,21 @@ struct MessageComposerTextView: NSViewRepresentable {
             guard lastAppliedToken != command.token else { return false }
             lastAppliedToken = command.token
             MessageComposerTextView.apply(command, to: textView)
+            switch command.kind {
+            case .restore, .clear:
+                // These two assign `.string`, which posts no text-change
+                // notification at all. A selection change does fire, and it
+                // happens to report through the same helper — but that is an
+                // undocumented side effect, and the write it would be carrying
+                // is the one that must never be missed: a send clears the box,
+                // and a composer whose state is not resynchronised still
+                // believes it holds the message that just went out.
+                report(textView)
+            case .replaceRange, .insertAtCaret:
+                // `insertText(_:replacementRange:)` goes through
+                // `didChangeText`, which reports already.
+                break
+            }
             return true
         }
 

--- a/Sources/TBDApp/Panes/Transcript/Composer/MessageComposerTextView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Composer/MessageComposerTextView.swift
@@ -270,10 +270,13 @@ struct MessageComposerTextView: NSViewRepresentable {
             case .blur:
                 parent.onEscape()
                 return true
-            case .menuUp, .menuDown, .menuAccept, .menuClose:
+            case .menuUp, .menuDown, .menuAccept, .menuAcceptOrSubmit, .menuClose:
                 // Only reachable with the menu open — the router returns these
-                // four solely under `menuOpen`, so Tab still moves focus and the
+                // five solely under `menuOpen`, so Tab still moves focus and the
                 // arrows still move the caret when nothing is showing.
+                // `.menuAcceptOrSubmit` is Return, and the caller decides
+                // between accepting and sending: only it knows whether a row is
+                // highlighted.
                 parent.onMenuAction(action)
                 return true
             case .passThrough:
@@ -286,6 +289,16 @@ struct MessageComposerTextView: NSViewRepresentable {
 /// The text view, with the paste and drop overrides.
 final class ComposerTextView: NSTextView {
     var onImageData: ((Data) -> Void)?
+
+    /// The placeholder drawn after the caret, naming what an accepted command
+    /// takes. Set by the composer view whenever the text changes; nil hides it.
+    ///
+    /// **Drawn, never inserted.** Putting the hint in the storage would make it
+    /// part of the message — the composer's whole plain-text contract is that
+    /// what is in the view is what is sent.
+    var argumentHint: String? {
+        didSet { if argumentHint != oldValue { needsDisplay = true } }
+    }
 
     /// Text wins when the pasteboard advertises both, preserving ordinary Cmd-V.
     /// An image-only paste is lifted here and never handed to `super`, so

--- a/Sources/TBDApp/Panes/Transcript/Composer/MessageComposerTextView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Composer/MessageComposerTextView.swift
@@ -1,0 +1,282 @@
+import AppKit
+import SwiftUI
+
+/// A one-shot imperative instruction for the composer's text view.
+///
+/// The composer needs three writes `SubmittingTextEditor`'s one-way contract
+/// forbids — restore a draft, replace a token on accept, clear on send — and its
+/// doc comment already names the shape to add them in: "an explicit command
+/// rather than as state SwiftUI can resend at a moment of its own choosing".
+/// That is what the token is for: the coordinator remembers the last one it ran,
+/// so a republish carrying the same command does nothing.
+struct ComposerCommand: Equatable {
+    enum Kind: Equatable {
+        /// Replace everything — restoring a draft when the pane reappears.
+        case restore(String)
+        /// Replace one range, caret after the insertion — accepting a completion.
+        case replaceRange(NSRange, with: String)
+        /// Insert at the caret — an image token.
+        case insertAtCaret(String)
+        /// Empty it — a successful send.
+        case clear
+    }
+    /// Monotonic. A command whose token the coordinator has already run is
+    /// ignored.
+    let token: Int
+    let kind: Kind
+}
+
+/// The composer's text view: plain text, chat-box Return semantics, an image
+/// paste that never becomes an inline attachment, and three one-shot commands.
+///
+/// **Plain text, deliberately.** Image tokens are ordinary characters styled
+/// through the layout manager's temporary attributes, which never touch the
+/// storage. Enabling rich text to make them real attachments would reopen the
+/// substitution and paste-formatting hazards the submitting editor closed, and a
+/// styled plain-text token gives the same anchor.
+///
+/// **The paste override reads the pasteboard itself** and does not add image
+/// types to the view's readable types, so `NSTextView`'s default pipeline never
+/// inserts an inline attachment — the same shape `TBDTerminalView.paste(_:)`
+/// already uses.
+///
+/// SwiftUI's `TextEditor` is rejected because Apple documents neither whether its
+/// key handler runs before insertion nor its behavior during composition, and it
+/// has no fit-to-content sizing on macOS. `NSTextView`'s built-in completion is
+/// rejected because Apple documents it as a plain string list.
+struct MessageComposerTextView: NSViewRepresentable {
+    /// Roughly six lines, then it scrolls. A first message is often a paragraph;
+    /// a box that stretched to fit one would push the transcript off screen.
+    static let maxVisibleLines = 6
+
+    var command: ComposerCommand?
+    var isEnabled: Bool = true
+    /// Every edit and every selection change: the text, the caret's UTF-16
+    /// location, and whether an input method is mid-composition. The caller's own
+    /// state follows the view rather than driving it.
+    ///
+    /// The third value is not a convenience: the completion controller dismisses
+    /// the menu outright while text is marked, and it can only know that from the
+    /// text view — so the view reports it rather than letting a caller guess.
+    var onTextChange: (String, Int, Bool) -> Void
+    /// Return, carrying the TEXT VIEW's current string — never anything held on
+    /// this struct, which a SwiftUI update pass can leave one behind.
+    var onSubmit: (String) -> Void
+    /// Escape with no menu open.
+    var onEscape: () -> Void
+    /// Pasted or dropped image bytes, already lifted off the pasteboard.
+    var onImageData: (Data) -> Void
+    /// Read at decision time, so a stale menu-open flag is impossible.
+    var menuIsOpen: () -> Bool
+    var onMenuAction: (ComposerKeyRouter.Action) -> Void
+    /// The text view, handed out once when it is made.
+    ///
+    /// Deliberately not a lifecycle pair driven from `dismantleNSView`: the
+    /// SwiftUI view that owns this one registers and unregisters itself in
+    /// `onAppear`/`onDisappear`, which are ordered against its own state, and a
+    /// second teardown signal arriving from AppKit would be a second source of
+    /// truth for the same fact. This hand-out exists only so that view has an
+    /// `NSView` to focus and to draw an argument hint on.
+    var onViewReady: ((NSView) -> Void)?
+
+    // MARK: - Command application
+
+    /// Apply one command. Static and free of the coordinator so every case is
+    /// testable against a bare `NSTextView`.
+    static func apply(_ command: ComposerCommand, to textView: NSTextView) {
+        let ns = textView.string as NSString
+        switch command.kind {
+        case .restore(let text):
+            textView.string = text
+            textView.setSelectedRange(NSRange(location: (text as NSString).length, length: 0))
+        case .replaceRange(let range, let replacement):
+            // Refused rather than clamped: a range the text no longer holds means
+            // the person edited while this was in flight, and inserting at a
+            // clamped position would put the token somewhere nobody asked for.
+            guard range.location >= 0, range.length >= 0,
+                  range.location + range.length <= ns.length else { return }
+            textView.insertText(replacement, replacementRange: range)
+            textView.setSelectedRange(
+                NSRange(location: range.location + (replacement as NSString).length, length: 0))
+        case .insertAtCaret(let text):
+            textView.insertText(text, replacementRange: textView.selectedRange())
+        case .clear:
+            textView.string = ""
+            textView.setSelectedRange(NSRange(location: 0, length: 0))
+        }
+    }
+
+    // MARK: - NSViewRepresentable
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let scrollView = NSScrollView()
+        scrollView.drawsBackground = false
+        // A fixed maximum height with a scroller past it, so a growing message
+        // never shifts the transcript above it.
+        scrollView.hasVerticalScroller = true
+        scrollView.autohidesScrollers = true
+
+        let textView = ComposerTextView(frame: .zero)
+        textView.delegate = context.coordinator
+        textView.isRichText = false
+        textView.allowsUndo = true
+        textView.drawsBackground = false
+        // The TRANSCRIPT text theme, not the terminal's: the composer sits under
+        // the transcript and belongs to it.
+        textView.font = TranscriptTextTheme.chatBubble.bodyFont
+        textView.textContainerInset = NSSize(width: 6, height: 8)
+        // Handed to an agent verbatim; silently turning a straight quote into a
+        // curly one corrupts a prompt that quotes code.
+        textView.isAutomaticQuoteSubstitutionEnabled = false
+        textView.isAutomaticDashSubstitutionEnabled = false
+        textView.isAutomaticTextReplacementEnabled = false
+        textView.isVerticallyResizable = true
+        textView.isHorizontallyResizable = false
+        textView.autoresizingMask = [.width]
+        textView.onImageData = onImageData
+        textView.registerForDraggedTypes([.fileURL])
+
+        scrollView.documentView = textView
+        context.coordinator.textView = textView
+        onViewReady?(textView)
+        return scrollView
+    }
+
+    func updateNSView(_ scrollView: NSScrollView, context: Context) {
+        // Refreshing the parent is load-bearing: `self` is a fresh struct each
+        // pass, and this is what keeps the closures pointing at the current
+        // body's. Deliberately nothing else touches the text or the selection —
+        // that is the whole contract — except a command that has not run yet.
+        context.coordinator.parent = self
+        guard let textView = context.coordinator.textView else { return }
+        textView.isEditable = isEnabled
+        textView.isSelectable = true
+        textView.onImageData = onImageData
+        if let command {
+            context.coordinator.applyIfNew(command, to: textView)
+        }
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator(self) }
+
+    final class Coordinator: NSObject, NSTextViewDelegate {
+        var parent: MessageComposerTextView?
+        weak var textView: ComposerTextView?
+        private var lastAppliedToken: Int?
+
+        override init() { super.init() }
+
+        init(_ parent: MessageComposerTextView) {
+            self.parent = parent
+            super.init()
+        }
+
+        /// Run a command once. Returns whether it ran.
+        @discardableResult
+        func applyIfNew(_ command: ComposerCommand, to textView: NSTextView) -> Bool {
+            guard lastAppliedToken != command.token else { return false }
+            lastAppliedToken = command.token
+            MessageComposerTextView.apply(command, to: textView)
+            return true
+        }
+
+        func textDidChange(_ notification: Notification) {
+            guard let textView = notification.object as? NSTextView else { return }
+            report(textView)
+        }
+
+        func textViewDidChangeSelection(_ notification: Notification) {
+            guard let textView = notification.object as? NSTextView else { return }
+            // The caret leaving a token closes the menu, which is a selection
+            // change and not an edit — so it needs its own hook.
+            report(textView)
+        }
+
+        private func report(_ textView: NSTextView) {
+            parent?.onTextChange(
+                textView.string, textView.selectedRange().location, textView.hasMarkedText())
+        }
+
+        func textView(
+            _ textView: NSTextView, doCommandBy commandSelector: Selector
+        ) -> Bool {
+            guard let parent else { return false }
+            let event = NSApp.currentEvent
+            let flags = event?.modifierFlags ?? []
+            let action = ComposerKeyRouter.action(
+                selector: commandSelector,
+                shiftHeld: flags.contains(.shift),
+                commandHeld: flags.contains(.command),
+                controlHeld: flags.contains(.control),
+                hasMarkedText: textView.hasMarkedText(),
+                // Read at decision time, from the controller — never a flag
+                // captured earlier, which could describe a menu that has closed.
+                menuOpen: parent.menuIsOpen())
+
+            switch action {
+            case .submit:
+                // The text view, never the parent: a SwiftUI update pass can
+                // leave `parent` one keystroke behind, and the view cannot be.
+                parent.onSubmit(textView.string)
+                return true
+            case .newline:
+                textView.insertNewlineIgnoringFieldEditor(nil)
+                return true
+            case .blur:
+                parent.onEscape()
+                return true
+            case .menuUp, .menuDown, .menuAccept, .menuClose:
+                // Only reachable with the menu open — the router returns these
+                // four solely under `menuOpen`, so Tab still moves focus and the
+                // arrows still move the caret when nothing is showing.
+                parent.onMenuAction(action)
+                return true
+            case .passThrough:
+                return false
+            }
+        }
+    }
+}
+
+/// The text view, with the paste and drop overrides.
+final class ComposerTextView: NSTextView {
+    var onImageData: ((Data) -> Void)?
+
+    /// Text wins when the pasteboard advertises both, preserving ordinary Cmd-V.
+    /// An image-only paste is lifted here and never handed to `super`, so
+    /// AppKit's default pipeline cannot insert an inline attachment.
+    override func paste(_ sender: Any?) {
+        let pasteboard = NSPasteboard.general
+        if pasteboard.string(forType: .string) == nil,
+           let data = ComposerImagePreparer.imageData(from: pasteboard) {
+            onImageData?(data)
+            return
+        }
+        super.pasteAsPlainText(sender)
+    }
+
+    override func draggingEntered(_ sender: any NSDraggingInfo) -> NSDragOperation {
+        if sender.draggingPasteboard.canReadObject(
+            forClasses: [NSURL.self], options: [.urlReadingFileURLsOnly: true]) {
+            return .copy
+        }
+        // Anything else — dragged text, most of all — stays AppKit's business.
+        return super.draggingEntered(sender)
+    }
+
+    override func performDragOperation(_ sender: any NSDraggingInfo) -> Bool {
+        guard let urls = sender.draggingPasteboard.readObjects(
+            forClasses: [NSURL.self],
+            options: [.urlReadingFileURLsOnly: true]) as? [URL], !urls.isEmpty
+        else { return super.performDragOperation(sender) }
+        var handled = false
+        for url in urls {
+            guard let data = ComposerImagePreparer.imageData(fromFileAt: url) else { continue }
+            onImageData?(data)
+            handled = true
+        }
+        // A dropped file that holds no image is not ours; let the text view do
+        // what it would have done with it.
+        return handled ? true : super.performDragOperation(sender)
+    }
+}

--- a/Sources/TBDApp/Panes/Transcript/Composer/MessageComposerTextView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Composer/MessageComposerTextView.swift
@@ -300,6 +300,24 @@ final class ComposerTextView: NSTextView {
         didSet { if argumentHint != oldValue { needsDisplay = true } }
     }
 
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+        guard let argumentHint, !argumentHint.isEmpty,
+              let layoutManager, let textContainer else { return }
+        let caret = selectedRange().location
+        let glyph = layoutManager.glyphIndexForCharacter(at: caret)
+        var origin = layoutManager.boundingRect(
+            forGlyphRange: NSRange(location: glyph, length: 0), in: textContainer).origin
+        origin.x += textContainerOrigin.x
+        origin.y += textContainerOrigin.y
+        (argumentHint as NSString).draw(
+            at: origin,
+            withAttributes: [
+                .font: font ?? NSFont.systemFont(ofSize: NSFont.systemFontSize),
+                .foregroundColor: NSColor.tertiaryLabelColor,
+            ])
+    }
+
     /// Text wins when the pasteboard advertises both, preserving ordinary Cmd-V.
     /// An image-only paste is lifted here and never handed to `super`, so
     /// AppKit's default pipeline cannot insert an inline attachment.

--- a/Sources/TBDApp/Panes/Transcript/Composer/MessageComposerTextView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Composer/MessageComposerTextView.swift
@@ -189,10 +189,16 @@ struct MessageComposerTextView: NSViewRepresentable {
 
     func makeCoordinator() -> Coordinator { Coordinator(self) }
 
+    @MainActor
     final class Coordinator: NSObject, NSTextViewDelegate {
         var parent: MessageComposerTextView?
         weak var textView: ComposerTextView?
         private var lastAppliedToken: Int?
+        /// True for the duration of one command's application. AppKit posts its
+        /// text and selection notifications synchronously from `insertText`, and
+        /// a command is applied from inside `updateNSView` — so those reports are
+        /// swallowed here and re-issued one turn later.
+        private var isApplyingCommand = false
 
         override init() { super.init() }
 
@@ -202,27 +208,38 @@ struct MessageComposerTextView: NSViewRepresentable {
         }
 
         /// Run a command once. Returns whether it ran.
+        ///
+        /// **Every kind reports, and every kind reports LATE.** `.restore` and
+        /// `.clear` assign `.string`, which posts no text-change notification at
+        /// all, so the report has to be made here rather than hoped for; a send
+        /// clears the box, and a composer whose state is not resynchronised
+        /// still believes it holds the message that just went out.
+        /// `.replaceRange` and `.insertAtCaret` do go through `didChangeText` —
+        /// but synchronously, from inside `updateNSView`.
+        ///
+        /// Either way the report writes `@Observable` state that sibling views
+        /// render, and SwiftUI treats a write during a view update as undefined
+        /// behavior. So the notifications this application raises are swallowed
+        /// and ONE report is made a main-actor turn later, the same deferral
+        /// `MessageComposerView.adopt` makes for its registration.
         @discardableResult
         func applyIfNew(_ command: ComposerCommand, to textView: NSTextView) -> Bool {
             guard lastAppliedToken != command.token else { return false }
             lastAppliedToken = command.token
+            isApplyingCommand = true
             MessageComposerTextView.apply(command, to: textView)
-            switch command.kind {
-            case .restore, .clear:
-                // These two assign `.string`, which posts no text-change
-                // notification at all. A selection change does fire, and it
-                // happens to report through the same helper — but that is an
-                // undocumented side effect, and the write it would be carrying
-                // is the one that must never be missed: a send clears the box,
-                // and a composer whose state is not resynchronised still
-                // believes it holds the message that just went out.
-                report(textView)
-            case .replaceRange, .insertAtCaret:
-                // `insertText(_:replacementRange:)` goes through
-                // `didChangeText`, which reports already.
-                break
-            }
+            isApplyingCommand = false
+            scheduleReport(textView)
             return true
+        }
+
+        /// The one deferred report. Weak on both sides: a pane torn down inside
+        /// the one-turn gap leaves nothing to report to.
+        private func scheduleReport(_ textView: NSTextView) {
+            Task { @MainActor [weak self, weak textView] in
+                guard let self, let textView else { return }
+                self.report(textView)
+            }
         }
 
         func textDidChange(_ notification: Notification) {
@@ -238,6 +255,9 @@ struct MessageComposerTextView: NSViewRepresentable {
         }
 
         private func report(_ textView: NSTextView) {
+            // A command's own notifications are swallowed; `scheduleReport`
+            // makes the one report that covers them.
+            guard !isApplyingCommand else { return }
             parent?.onTextChange(
                 textView.string, textView.selectedRange().location, textView.hasMarkedText())
         }

--- a/Sources/TBDApp/Panes/Transcript/Composer/MessageComposerView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Composer/MessageComposerView.swift
@@ -31,7 +31,7 @@ struct MessageComposerView: View {
     @State private var isSending = false
     @State private var errorMessage: String?
     @State private var hoveredAttachment: Int?
-    @State private var textViewHandle: NSView?
+    @State private var handle = ComposerViewHandle()
 
     private var draft: ComposerDraft { appState.composerDraft(for: terminal.id) }
 
@@ -57,7 +57,7 @@ struct MessageComposerView: View {
             AttachmentStrip(
                 draft: draft,
                 onReinsert: { insertToken($0) },
-                onReveal: { reveal($0) },
+                onFocusToken: { focusToken($0) },
                 onRemove: { removeAttachment($0) },
                 hoveredNumber: hoveredAttachment,
                 onHover: { hoveredAttachment = $0 })
@@ -98,8 +98,13 @@ struct MessageComposerView: View {
             }
         }
         .onDisappear {
-            guard let textViewHandle else { return }
-            appState.unregisterComposerView(textViewHandle, for: terminal.id)
+            // The flag first, and unconditionally: it is what stops a
+            // registration still sitting in the deferred queue from installing a
+            // dead view as this terminal's focus target.
+            handle.isGone = true
+            guard let view = handle.view else { return }
+            appState.unregisterComposerView(view, for: terminal.id)
+            handle.view = nil
         }
         .task(id: terminal.id) { await setUp() }
     }
@@ -107,16 +112,31 @@ struct MessageComposerView: View {
     // MARK: - Set-up
 
     /// The text view hands itself out once, from `makeNSView`. Registration is
-    /// deferred off that call because it writes `@State`, and SwiftUI treats a
-    /// state write during a view update as undefined behavior.
+    /// deferred off that call because it mutates observable state, and SwiftUI
+    /// treats a state write during a view update as undefined behavior.
+    ///
+    /// **The handle itself is not deferred.** It lives in a reference box written
+    /// synchronously here, so a teardown landing inside the one-turn gap still
+    /// has a view to unregister — and still gets to veto the registration that
+    /// has not run yet. `registerComposerView` has no newer-wins guard (only
+    /// `unregisterComposerView` does), so a late registration would silently
+    /// install a view whose pane is gone as this terminal's focus target, and
+    /// Cmd+/ would put the caret nowhere.
     private func adopt(_ view: NSView) {
+        handle.view = view
+        // A freshly made view is a new life for this box, whatever the last one
+        // ended in.
+        handle.isGone = false
         Task { @MainActor in
-            textViewHandle = view
+            guard !handle.isGone, view.window != nil else { return }
             appState.registerComposerView(view, for: terminal.id)
         }
     }
 
     private func setUp() async {
+        // A banner belongs to the terminal it was raised for; carrying it across
+        // a switch would blame the new session for the old one's refusal.
+        errorMessage = nil
         if controller == nil {
             controller = CompletionController(
                 frecency: FrecencyStore(defaults: appState.userDefaults))
@@ -139,11 +159,9 @@ struct MessageComposerView: View {
                         terminalID: terminalID, incarnationID: incarnationID)
                 })
         }
-        // Restore the draft into a view that has just been made — the one write
-        // the one-way contract admits, as an explicit one-shot command.
-        if !draft.text.isEmpty {
-            issue(.restore(draft.text))
-        }
+        // Restore the draft into the view — the one write the one-way contract
+        // admits, as an explicit one-shot command.
+        issue(Self.restoreCommand(draftText: draft.text))
         // The inventory is warmed when the composer first appears, never on a
         // keystroke: the probe is a process spawn, and paying it on `/` would put
         // half a second between the sigil and the list.
@@ -157,6 +175,16 @@ struct MessageComposerView: View {
     private func issue(_ kind: ComposerCommand.Kind) {
         commandToken += 1
         command = ComposerCommand(token: commandToken, kind: kind)
+    }
+
+    /// What a composer handed a terminal does to the text view it is **reusing**.
+    ///
+    /// An empty draft is a command too. The `NSTextView` survives a switch from
+    /// one terminal to the next, so restoring only non-empty drafts leaves the
+    /// previous terminal's half-written message sitting in the box — addressed,
+    /// after the switch, to somebody else.
+    static func restoreCommand(draftText: String) -> ComposerCommand.Kind {
+        draftText.isEmpty ? .clear : .restore(draftText)
     }
 
     // MARK: - Completion
@@ -272,18 +300,65 @@ struct MessageComposerView: View {
         issue(.insertAtCaret(ComposerTokens.text(for: number)))
     }
 
-    private func reveal(_ number: Int) {
-        guard let path = draft.pathsByNumber[number] else { return }
-        NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: path)])
+    /// Where the caret goes when an **attached** thumbnail is clicked: onto that
+    /// image's own token.
+    ///
+    /// The token is replaced with itself, which is how the one-shot command
+    /// vocabulary spells "put the caret here" — `.replaceRange` leaves the
+    /// insertion point after what it inserted, so the text is unchanged
+    /// character for character and the caret lands at the end of the token that
+    /// was clicked. A person clicking a thumbnail that is in the message is
+    /// asking where in the sentence it sits, which is a question only the caret
+    /// can answer; the strip carries no second gesture that could mean anything
+    /// else.
+    static func caretCommand(text: String, number: Int) -> ComposerCommand.Kind? {
+        guard let token = ComposerTokens.scan(text).first(where: { $0.number == number })
+        else { return nil }
+        return .replaceRange(token.range, with: ComposerTokens.text(for: number))
+    }
+
+    /// The one command that strips **every** occurrence of one image token.
+    ///
+    /// One command rather than one per occurrence: the view holds a single
+    /// pending instruction, so two issued in the same turn collapse and only the
+    /// last would ever reach the text view. The span from the first occurrence to
+    /// the last is rewritten in one go instead, with the tokens inside it removed
+    /// back to front so the earlier offsets stay valid, and nothing outside the
+    /// span is touched. A duplicated token is ordinary — re-inserting an image
+    /// twice is how a person refers to it twice — and leaving the second copy
+    /// behind would send a path for an image the strip no longer lists.
+    static func removalCommand(text: String, number: Int) -> ComposerCommand.Kind? {
+        let ranges = ComposerTokens.scan(text)
+            .filter { $0.number == number }
+            .map(\.range)
+        guard let first = ranges.first, let last = ranges.last else { return nil }
+        let span = NSRange(
+            location: first.location,
+            length: last.location + last.length - first.location)
+        var replacement = (text as NSString).substring(with: span) as NSString
+        for range in ranges.reversed() {
+            replacement = replacement.replacingCharacters(
+                in: NSRange(location: range.location - span.location, length: range.length),
+                with: "") as NSString
+        }
+        return .replaceRange(span, with: replacement as String)
+    }
+
+    private func focusToken(_ number: Int) {
+        guard let kind = Self.caretCommand(text: currentText(), number: number)
+        else { return }
+        issue(kind)
+        appState.focusComposer(terminalID: terminal.id)
     }
 
     private func removeAttachment(_ number: Int) {
+        // The text first: the strip's own map is what `currentText()` is read
+        // against, and removing the image before the token would leave the
+        // command scanning for a number that is already gone.
+        let kind = Self.removalCommand(text: currentText(), number: number)
         draft.removeAttachment(number: number)
-        // Remove its token from the text too, so the strip and the message agree.
-        let token = ComposerTokens.text(for: number)
-        if let range = (draft.text as NSString).range(of: token).toOptional() {
-            issue(.replaceRange(range, with: ""))
-        }
+        // Remove its tokens from the text too, so the strip and the message agree.
+        if let kind { issue(kind) }
     }
 
     // MARK: - Sending
@@ -291,7 +366,7 @@ struct MessageComposerView: View {
     /// The text view's own string, never a struct SwiftUI can leave a keystroke
     /// behind. The draft is the fallback for the moment before the view exists.
     private func currentText() -> String {
-        (textViewHandle as? NSTextView)?.string ?? draft.text
+        (handle.view as? NSTextView)?.string ?? draft.text
     }
 
     private func submit(_ text: String) {
@@ -378,7 +453,17 @@ struct MessageComposerView: View {
     }
 }
 
-private extension NSRange {
-    /// `NSString.range(of:)` reports `NSNotFound` rather than nil.
-    func toOptional() -> NSRange? { location == NSNotFound ? nil : self }
+/// The composer's text view, and whether its pane has gone.
+///
+/// A reference box rather than `@State` for one reason: both facts are written
+/// from places a view update forbids state writes in — `makeNSView`, and the
+/// deferred turn after it — and both must be readable by `onDisappear`, which can
+/// land between the two. Nothing here drives rendering, so nothing needs to
+/// invalidate the view.
+@MainActor
+final class ComposerViewHandle {
+    var view: NSView?
+    /// Set by `onDisappear`. A registration still queued when this flips must not
+    /// run: the pane it belongs to is already gone.
+    var isGone = false
 }

--- a/Sources/TBDApp/Panes/Transcript/Composer/MessageComposerView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Composer/MessageComposerView.swift
@@ -204,6 +204,10 @@ struct MessageComposerView: View {
         case close
         /// Take `acceptTarget` — the highlighted row, or the first.
         case accept
+        /// Take `acceptTarget` and send in the same keystroke, because the
+        /// completed token is the whole message and there is nothing left to
+        /// write.
+        case acceptAndSubmit
         /// Send the text as typed.
         case submit
         /// Not a menu key at all.
@@ -211,7 +215,8 @@ struct MessageComposerView: View {
     }
 
     static func menuOutcome(
-        for action: ComposerKeyRouter.Action, selectedIndex: Int?
+        for action: ComposerKeyRouter.Action, selectedIndex: Int?,
+        acceptFillsTheMessage: Bool = false
     ) -> MenuOutcome {
         switch action {
         case .menuUp: return .moveUp
@@ -219,7 +224,9 @@ struct MessageComposerView: View {
         case .menuClose: return .close
         case .menuAccept:
             // Tab. Its whole meaning is "take the obvious one", so it accepts
-            // `acceptTarget` whether or not anything is highlighted.
+            // `acceptTarget` whether or not anything is highlighted — and it
+            // NEVER sends, whatever else is in the box. Tab is how a person puts
+            // the name in the message and keeps writing.
             return .accept
         case .menuAcceptOrSubmit:
             // Return. It accepts only a row the person actually arrowed to;
@@ -227,20 +234,85 @@ struct MessageComposerView: View {
             // mid-sentence, on a non-prefix query, and while the inventory is
             // still loading — every case where a fallback to `rows.first` would
             // be a guess at what somebody meant.
-            return selectedIndex == nil ? .submit : .accept
+            //
+            // A row that IS highlighted is accepted, and sent in the same
+            // keystroke when the completed token is the whole message: `/comp`
+            // plus Enter runs compact as it does in the terminal. With anything
+            // else in the box the accept stands alone, and a second Return
+            // sends.
+            guard selectedIndex != nil else { return .submit }
+            return acceptFillsTheMessage ? .acceptAndSubmit : .accept
         case .submit, .newline, .blur, .passThrough:
             return .ignore
         }
     }
 
+    /// What accepting a completion writes into the text: the sigil, the name, and
+    /// a trailing space, so the argument hint renders as an inline placeholder
+    /// and the menu closes because the token ended.
+    static func completionReplacement(
+        kind: CompletionTrigger.Kind, name: String
+    ) -> String {
+        sigil(kind) + name + " "
+    }
+
+    /// The message an accept would leave behind **when the completed token is the
+    /// whole message** — nil in every other case.
+    ///
+    /// Trimmed on both sides rather than compared span by span: what makes a
+    /// message "just the command" is that nothing else survives the trim — no
+    /// other words, and no `[Image #N]` token, which is ordinary text here and
+    /// so fails the comparison by itself.
+    ///
+    /// It returns the TEXT rather than a Bool because an accept reaches the text
+    /// view as a one-shot command, which lands a SwiftUI pass later. A send in
+    /// the same keystroke therefore has to carry the completed string; reading
+    /// `currentText()` would send the prefix the person typed.
+    static func acceptedWholeMessage(
+        text: String, tokenRange: NSRange, replacement: String
+    ) -> String? {
+        let ns = text as NSString
+        // The same refusal `apply` makes, for the same reason: a range the text
+        // no longer holds means the person edited while this was in flight.
+        // `NSNotFound` as a location is `Int.max`, so the addition is spelled as
+        // a subtraction to keep it from trapping.
+        guard tokenRange.location >= 0, tokenRange.length >= 0,
+              tokenRange.location <= ns.length,
+              tokenRange.length <= ns.length - tokenRange.location else { return nil }
+        let completed = ns.replacingCharacters(in: tokenRange, with: replacement)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let token = replacement.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !token.isEmpty, completed == token else { return nil }
+        return completed
+    }
+
+    private static func acceptedWholeMessage(
+        text: String, match: CompletionTrigger.Match?, row: CommandRanker.Row?
+    ) -> String? {
+        guard let match, let row else { return nil }
+        return acceptedWholeMessage(
+            text: text, tokenRange: match.tokenRange,
+            replacement: completionReplacement(kind: match.kind, name: row.command.name))
+    }
+
     private func handleMenu(_ action: ComposerKeyRouter.Action) {
         guard let controller else { return }
-        switch Self.menuOutcome(for: action, selectedIndex: controller.selectedIndex) {
+        let completed = Self.acceptedWholeMessage(
+            text: currentText(), match: controller.match, row: controller.acceptTarget)
+        switch Self.menuOutcome(
+            for: action, selectedIndex: controller.selectedIndex,
+            acceptFillsTheMessage: completed != nil) {
         case .moveUp: controller.moveUp()
         case .moveDown: controller.moveDown()
         case .close: controller.close(suppressingCurrentToken: true)
         case .accept:
             if let row = controller.acceptTarget { accept(row) }
+        case .acceptAndSubmit:
+            guard let row = controller.acceptTarget, let completed else { return }
+            accept(row)
+            // The completed text, never `currentText()`: the accept above is a
+            // command the text view has not run yet.
+            submit(completed)
         case .submit: submit(currentText())
         case .ignore: break
         }
@@ -248,10 +320,9 @@ struct MessageComposerView: View {
 
     private func accept(_ row: CommandRanker.Row) {
         guard let controller, let match = controller.match else { return }
-        // A trailing space, so the argument hint renders as an inline placeholder
-        // and the menu closes because the token ended.
         issue(.replaceRange(
-            match.tokenRange, with: Self.sigil(match.kind) + row.command.name + " "))
+            match.tokenRange,
+            with: Self.completionReplacement(kind: match.kind, name: row.command.name)))
         controller.recordAcceptance(row)
     }
 
@@ -408,7 +479,12 @@ struct MessageComposerView: View {
                 Text(Self.sendButtonLabel(state: state, terminalLabel: terminal.label))
             }
         }
-        .keyboardShortcut(.return, modifiers: .command)
+        // **No key equivalent.** `ComposerKeyRouter` already maps Cmd+Return to
+        // `.submit`, and a SwiftUI key equivalent is live for the whole WINDOW
+        // while the composer is mounted — so a button shortcut here would fire
+        // this send from a sibling terminal pane of a split, where the person
+        // pressing Cmd+Return means the terminal they are typing into. The
+        // router owns the key; the button stays clickable.
         .disabled(!state.isEnabled || isSending)
         .help(Self.sendButtonHelp(state: state))
     }

--- a/Sources/TBDApp/Panes/Transcript/Composer/MessageComposerView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Composer/MessageComposerView.swift
@@ -1,0 +1,384 @@
+import AppKit
+import SwiftUI
+import TBDShared
+
+/// The composer: a text field pinned below the transcript, inside the session
+/// workbench beside the index rail.
+///
+/// A send button that **names the target terminal**, so the injection is never
+/// anonymous.
+///
+/// Text sitting unsent in the terminal's own input box is invisible here, and a
+/// message sent from the composer appends to it. No signal exists for that
+/// outside the rendered screen — Claude Code keeps its composer in process
+/// memory, writes no draft file for a pty-hosted session, and exposes nothing
+/// about it on its peer socket. The design accepts the limitation rather than
+/// warning from a keystroke timestamp that would be wrong in both directions.
+///
+/// This type owns the **wiring** only. Every decision it makes — which key means
+/// what, what the button says, where a staged image lands — is a static function
+/// below, tested without mounting SwiftUI.
+struct MessageComposerView: View {
+    let terminal: Terminal
+    let worktree: LocalWorktree
+    let state: ComposerState
+
+    @Environment(AppState.self) private var appState
+    @State private var controller: CompletionController?
+    @State private var coordinator: ComposerSendCoordinator?
+    @State private var command: ComposerCommand?
+    @State private var commandToken = 0
+    @State private var isSending = false
+    @State private var errorMessage: String?
+    @State private var hoveredAttachment: Int?
+    @State private var textViewHandle: NSView?
+
+    private var draft: ComposerDraft { appState.composerDraft(for: terminal.id) }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .padding(.horizontal, 10)
+                    .padding(.top, 6)
+            }
+            if case .blocked(let message) = state {
+                blockedBanner(message)
+            }
+            if case .notRunning(let exited) = state {
+                Text(Self.notRunningNoteText(exited: exited))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 10)
+                    .padding(.top, 6)
+            }
+            AttachmentStrip(
+                draft: draft,
+                onReinsert: { insertToken($0) },
+                onReveal: { reveal($0) },
+                onRemove: { removeAttachment($0) },
+                hoveredNumber: hoveredAttachment,
+                onHover: { hoveredAttachment = $0 })
+            HStack(alignment: .bottom, spacing: 8) {
+                MessageComposerTextView(
+                    command: command,
+                    isEnabled: state.isEnabled && !isSending,
+                    onTextChange: { text, caret, hasMarkedText in
+                        draft.text = text
+                        controller?.update(
+                            text: text, selectionLocation: caret,
+                            hasMarkedText: hasMarkedText)
+                    },
+                    onSubmit: { text in submit(text) },
+                    onEscape: { appState.focusTranscript(terminalID: terminal.id) },
+                    onImageData: { stage($0) },
+                    menuIsOpen: { controller?.isOpen ?? false },
+                    onMenuAction: { handleMenu($0) },
+                    onViewReady: { view in adopt(view) })
+                .frame(minHeight: 32, maxHeight: 132)
+                sendButton
+            }
+            .padding(8)
+        }
+        .background(.background.secondary)
+        .overlay(alignment: .bottomLeading) {
+            // Opens UPWARD from the composer, offset by the composer's own
+            // height so it never covers the text being typed.
+            if let controller, controller.isOpen {
+                CompletionOverlayView(
+                    controller: controller,
+                    onAccept: { accept($0) },
+                    // Reached only from an explicit click; hover is handled
+                    // inside the overlay and moves nothing.
+                    onHighlight: { controller.moveTo(index: $0) })
+                .frame(width: 460)
+                .alignmentGuide(.bottom) { $0[.top] }
+            }
+        }
+        .onDisappear {
+            guard let textViewHandle else { return }
+            appState.unregisterComposerView(textViewHandle, for: terminal.id)
+        }
+        .task(id: terminal.id) { await setUp() }
+    }
+
+    // MARK: - Set-up
+
+    /// The text view hands itself out once, from `makeNSView`. Registration is
+    /// deferred off that call because it writes `@State`, and SwiftUI treats a
+    /// state write during a view update as undefined behavior.
+    private func adopt(_ view: NSView) {
+        Task { @MainActor in
+            textViewHandle = view
+            appState.registerComposerView(view, for: terminal.id)
+        }
+    }
+
+    private func setUp() async {
+        if controller == nil {
+            controller = CompletionController(
+                frecency: FrecencyStore(defaults: appState.userDefaults))
+        }
+        if coordinator == nil {
+            coordinator = ComposerSendCoordinator(
+                send: { [appState] params in
+                    try await appState.daemonClient.sendComposerMessage(params)
+                },
+                // NOT `wakeTerminal`: that returns only an error string, and the
+                // composer needs the incarnation the wake minted, which is the
+                // only thing that scopes the hold to this send's own spawn.
+                wake: { [appState] terminalID, worktreeID, prompt in
+                    await appState.wakeTerminalForComposer(
+                        terminalID: terminalID, worktreeID: worktreeID,
+                        prompt: prompt)
+                },
+                awaitSessionStart: { [appState] terminalID, incarnationID in
+                    await appState.awaitSessionStart(
+                        terminalID: terminalID, incarnationID: incarnationID)
+                })
+        }
+        // Restore the draft into a view that has just been made — the one write
+        // the one-way contract admits, as an explicit one-shot command.
+        if !draft.text.isEmpty {
+            issue(.restore(draft.text))
+        }
+        // The inventory is warmed when the composer first appears, never on a
+        // keystroke: the probe is a process spawn, and paying it on `/` would put
+        // half a second between the sigil and the list.
+        controller?.adopt(inventory: await appState.fetchCompletions(terminalID: terminal.id))
+    }
+
+    // MARK: - Commands
+
+    /// Every command gets a fresh token, including two consecutive `.clear`s:
+    /// two commands sharing one is the single way to lose a write.
+    private func issue(_ kind: ComposerCommand.Kind) {
+        commandToken += 1
+        command = ComposerCommand(token: commandToken, kind: kind)
+    }
+
+    // MARK: - Completion
+
+    /// What one menu key does, given whether a row is highlighted.
+    ///
+    /// Pure and named so the Enter/Tab split is assertable: it is the difference
+    /// between a composer that sends what a person typed and one that quietly
+    /// replaces it with a command they never chose.
+    enum MenuOutcome: Equatable {
+        case moveUp
+        case moveDown
+        case close
+        /// Take `acceptTarget` — the highlighted row, or the first.
+        case accept
+        /// Send the text as typed.
+        case submit
+        /// Not a menu key at all.
+        case ignore
+    }
+
+    static func menuOutcome(
+        for action: ComposerKeyRouter.Action, selectedIndex: Int?
+    ) -> MenuOutcome {
+        switch action {
+        case .menuUp: return .moveUp
+        case .menuDown: return .moveDown
+        case .menuClose: return .close
+        case .menuAccept:
+            // Tab. Its whole meaning is "take the obvious one", so it accepts
+            // `acceptTarget` whether or not anything is highlighted.
+            return .accept
+        case .menuAcceptOrSubmit:
+            // Return. It accepts only a row the person actually arrowed to;
+            // otherwise the message goes as typed. `selectedIndex` is nil
+            // mid-sentence, on a non-prefix query, and while the inventory is
+            // still loading — every case where a fallback to `rows.first` would
+            // be a guess at what somebody meant.
+            return selectedIndex == nil ? .submit : .accept
+        case .submit, .newline, .blur, .passThrough:
+            return .ignore
+        }
+    }
+
+    private func handleMenu(_ action: ComposerKeyRouter.Action) {
+        guard let controller else { return }
+        switch Self.menuOutcome(for: action, selectedIndex: controller.selectedIndex) {
+        case .moveUp: controller.moveUp()
+        case .moveDown: controller.moveDown()
+        case .close: controller.close(suppressingCurrentToken: true)
+        case .accept:
+            if let row = controller.acceptTarget { accept(row) }
+        case .submit: submit(currentText())
+        case .ignore: break
+        }
+    }
+
+    private func accept(_ row: CommandRanker.Row) {
+        guard let controller, let match = controller.match else { return }
+        // A trailing space, so the argument hint renders as an inline placeholder
+        // and the menu closes because the token ended.
+        issue(.replaceRange(
+            match.tokenRange, with: Self.sigil(match.kind) + row.command.name + " "))
+        controller.recordAcceptance(row)
+    }
+
+    private static func sigil(_ kind: CompletionTrigger.Kind) -> String {
+        switch kind {
+        case .command: return "/"
+        case .mention: return "@"
+        }
+    }
+
+    // MARK: - Attachments
+
+    /// Write one prepared PNG into this worktree's attachment directory.
+    ///
+    /// **Atomic, and the directory first.** The token that names this file is
+    /// inserted into the message the moment this returns, so a half-written file
+    /// behind it would be sent as a broken path. The path is derived from
+    /// `TBDConstants`, which is what makes `TBD_HOME` and the test fence apply;
+    /// the id is minted per write, so a second image can never overwrite a first.
+    static func writeAttachment(
+        _ png: Data,
+        worktreeID: UUID,
+        attachmentID: UUID = UUID(),
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) throws -> (id: UUID, path: String) {
+        let directory = TBDConstants.attachmentsDir(
+            worktreeID: worktreeID, environment: environment)
+        try FileManager.default.createDirectory(
+            at: directory, withIntermediateDirectories: true)
+        let path = TBDConstants.attachmentPath(
+            worktreeID: worktreeID, attachmentID: attachmentID, environment: environment)
+        try png.write(to: URL(fileURLWithPath: path), options: [.atomic])
+        return (attachmentID, path)
+    }
+
+    private func stage(_ data: Data) {
+        do {
+            let prepared = try ComposerImagePreparer.preparePNG(from: data)
+            // A write that fails prevents the send — the token would otherwise
+            // point at a file that is not there.
+            let staged = try Self.writeAttachment(prepared, worktreeID: worktree.id)
+            insertToken(draft.stage(path: staged.path, id: staged.id))
+            errorMessage = nil
+        } catch {
+            errorMessage = "That image could not be attached: \(error.localizedDescription)"
+        }
+    }
+
+    private func insertToken(_ number: Int) {
+        issue(.insertAtCaret(ComposerTokens.text(for: number)))
+    }
+
+    private func reveal(_ number: Int) {
+        guard let path = draft.pathsByNumber[number] else { return }
+        NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: path)])
+    }
+
+    private func removeAttachment(_ number: Int) {
+        draft.removeAttachment(number: number)
+        // Remove its token from the text too, so the strip and the message agree.
+        let token = ComposerTokens.text(for: number)
+        if let range = (draft.text as NSString).range(of: token).toOptional() {
+            issue(.replaceRange(range, with: ""))
+        }
+    }
+
+    // MARK: - Sending
+
+    /// The text view's own string, never a struct SwiftUI can leave a keystroke
+    /// behind. The draft is the fallback for the moment before the view exists.
+    private func currentText() -> String {
+        (textViewHandle as? NSTextView)?.string ?? draft.text
+    }
+
+    private func submit(_ text: String) {
+        // A Return must not do what a disabled button cannot.
+        guard state.isEnabled, !isSending, let coordinator else { return }
+        draft.text = text
+        errorMessage = nil
+        isSending = true
+        Task { @MainActor in
+            defer { isSending = false }
+            let outcome = await coordinator.send(
+                text: text, paths: draft.pathsByNumber, state: state,
+                terminalID: terminal.id, worktreeID: worktree.id)
+            switch outcome {
+            case .sent, .woke:
+                draft.clear()
+                issue(.clear)
+            case .failed(let message):
+                // The text stays exactly where it is; only the banner changes.
+                errorMessage = message
+            }
+        }
+    }
+
+    // MARK: - Chrome
+
+    @ViewBuilder
+    private var sendButton: some View {
+        Button {
+            submit(currentText())
+        } label: {
+            if isSending {
+                ProgressView().controlSize(.small)
+            } else {
+                Text(Self.sendButtonLabel(state: state, terminalLabel: terminal.label))
+            }
+        }
+        .keyboardShortcut(.return, modifiers: .command)
+        .disabled(!state.isEnabled || isSending)
+        .help(Self.sendButtonHelp(state: state))
+    }
+
+    /// The button names the target, so an injection is never anonymous.
+    static func sendButtonLabel(state: ComposerState, terminalLabel: String?) -> String {
+        let name = terminalLabel ?? "Claude"
+        switch state {
+        case .notRunning: return "Resume \(name)"
+        case .running, .blocked, .hidden: return "Send to \(name)"
+        }
+    }
+
+    static func sendButtonHelp(state: ComposerState) -> String {
+        switch state {
+        case .notRunning:
+            return "Claude is not running here. Sending resumes the session with this "
+                + "message as its first prompt. Images are sent as file paths for Claude to "
+                + "read, not as attachments."
+        case .running, .blocked, .hidden:
+            return "Return sends, Shift+Return breaks the line."
+        }
+    }
+
+    /// One wake path, two sentences: a session that left on its own reads
+    /// differently from one TBD parked, and that is the only difference.
+    static func notRunningNoteText(exited: Bool) -> String {
+        exited
+            ? "Claude exited in this terminal. Sending will resume the session."
+            : "This session is hibernated. Sending will resume it."
+    }
+
+    @ViewBuilder
+    private func blockedBanner(_ message: String) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: "hand.raised.fill").foregroundStyle(.orange)
+            Text(message).font(.caption).lineLimit(2)
+            Spacer(minLength: 0)
+            Button("Reveal Terminal") {
+                appState.revealTerminal(terminalID: terminal.id)
+            }
+            .controlSize(.small)
+        }
+        .padding(.horizontal, 10)
+        .padding(.top, 6)
+    }
+}
+
+private extension NSRange {
+    /// `NSString.range(of:)` reports `NSNotFound` rather than nil.
+    func toOptional() -> NSRange? { location == NSNotFound ? nil : self }
+}

--- a/Sources/TBDApp/Panes/Transcript/Composer/MessageComposerView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Composer/MessageComposerView.swift
@@ -70,6 +70,10 @@ struct MessageComposerView: View {
                         controller?.update(
                             text: text, selectionLocation: caret,
                             hasMarkedText: hasMarkedText)
+                        (handle.view as? ComposerTextView)?.argumentHint =
+                            ComposerArgumentHint.hint(
+                                text: text, selectionLocation: caret,
+                                commands: controller?.inventoryCommands ?? [])
                     },
                     onSubmit: { text in submit(text) },
                     onEscape: { appState.focusTranscript(terminalID: terminal.id) },

--- a/Sources/TBDApp/Panes/Transcript/Table/TableTranscriptPaneView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Table/TableTranscriptPaneView.swift
@@ -294,9 +294,10 @@ struct TableTranscriptPaneView: View {
     /// What the composer mount resolves to, or nil for no composer at all.
     ///
     /// A value rather than a `ComposerState`, because the view's initializer
-    /// needs the `LocalWorktree` too, and `LocalWorktree` is the second half of
-    /// the same question: a row that cannot produce one is remote, which is one
-    /// of the states `ComposerState.resolve` already answers `.hidden` for.
+    /// needs the `LocalWorktree` too, and a row that cannot produce one has no
+    /// files on this machine to send a message about — a remote row, or a local
+    /// `.creating` placeholder whose path is still empty. Either way: no local
+    /// worktree, no composer.
     struct ComposerMount {
         let terminal: Terminal
         let worktree: LocalWorktree

--- a/Sources/TBDApp/Panes/Transcript/Table/TableTranscriptPaneView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Table/TableTranscriptPaneView.swift
@@ -234,24 +234,83 @@ struct TableTranscriptPaneView: View {
             sections: presentation.indexSections,
             onOpen: { itemID in openTranscriptOverlay?(itemID) }
         ) {
-            TableTranscriptView(
-                context: cardContext,
-                atBottom: $atBottom,
-                scrollToBottomToken: scrollToBottomToken,
-                activityToggleToken: activityToggleToken,
-                linkRoot: linkRoot,
-                nodesProvider: { timedRenderNodes(presentation.nodes) }
-            )
-            // Compose the terminal with its current Claude session so a session
-            // rollover within one terminal tears down and rebuilds the stateful
-            // Coordinator, re-resolving from a clean baseline rather than persisting
-            // the prior session's drilled-in subagent thread. (#129)
-            .id(PaneIdentity(terminalID: terminalID, sessionID: currentSessionID))
-            .overlay(alignment: .bottomLeading) {
-                jumpToBottomButton
-                    .animation(.easeInOut(duration: 0.2), value: atBottom)
+            VStack(spacing: 0) {
+                TableTranscriptView(
+                    context: cardContext,
+                    atBottom: $atBottom,
+                    scrollToBottomToken: scrollToBottomToken,
+                    activityToggleToken: activityToggleToken,
+                    linkRoot: linkRoot,
+                    nodesProvider: { timedRenderNodes(presentation.nodes) },
+                    onTableReady: { [appState, terminalID] table in
+                        appState.registerTranscriptView(table, for: terminalID)
+                    }
+                )
+                // Compose the terminal with its current Claude session so a session
+                // rollover within one terminal tears down and rebuilds the stateful
+                // Coordinator, re-resolving from a clean baseline rather than persisting
+                // the prior session's drilled-in subagent thread. (#129)
+                .id(PaneIdentity(terminalID: terminalID, sessionID: currentSessionID))
+                .overlay(alignment: .bottomLeading) {
+                    jumpToBottomButton
+                        .animation(.easeInOut(duration: 0.2), value: atBottom)
+                }
+
+                // OUTSIDE the `.id` above, deliberately: a `/clear` rebuilds the
+                // table, and it must not take a half-written message with it.
+                if let decision = Self.composerMount(
+                    terminal: terminal,
+                    worktree: appState.findWorktree(id: worktreeID),
+                    composerEnabled: appState.transcriptComposerEnabled) {
+                    Divider()
+                    MessageComposerView(
+                        terminal: decision.terminal,
+                        worktree: decision.worktree,
+                        state: decision.state)
+                        // A terminal switch reuses this pane, and the composer's
+                        // registration is keyed on the terminal it was made for.
+                        // A fresh view per terminal is what keeps the two agreeing.
+                        .id(decision.terminal.id)
+                }
             }
         }
+    }
+
+    // MARK: - The mount decision
+
+    /// What the composer mount resolves to, or nil for no composer at all.
+    ///
+    /// A value rather than a `ComposerState`, because the view's initializer
+    /// needs the `LocalWorktree` too, and `LocalWorktree` is the second half of
+    /// the same question: a row that cannot produce one is remote, which is one
+    /// of the states `ComposerState.resolve` already answers `.hidden` for.
+    struct ComposerMount {
+        let terminal: Terminal
+        let worktree: LocalWorktree
+        let state: ComposerState
+    }
+
+    /// Whether this pane mounts a composer, and with what.
+    ///
+    /// Static and taking its three inputs explicitly so the gate is assertable
+    /// without a view hierarchy — including both branches of the daemon
+    /// capability, which is the flag this whole feature ships behind.
+    ///
+    /// `!= .hidden` rather than `isEnabled`: a parked session's composer is
+    /// mounted and disabled-looking but very much present, because sending to it
+    /// is what resumes it.
+    static func composerMount(
+        terminal: Terminal?, worktree: Worktree?, composerEnabled: Bool
+    ) -> ComposerMount? {
+        guard let worktree else { return nil }
+        let state = ComposerState.resolve(
+            terminal: terminal,
+            isRemoteWorktree: !worktree.location.isLocal,
+            composerEnabled: composerEnabled)
+        guard state != .hidden, let terminal, let local = LocalWorktree(worktree) else {
+            return nil
+        }
+        return ComposerMount(terminal: terminal, worktree: local, state: state)
     }
 
     private func setActivityGroup(_ id: String, expanded: Bool) {

--- a/Sources/TBDApp/Panes/Transcript/Table/TableTranscriptPaneView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Table/TableTranscriptPaneView.swift
@@ -62,6 +62,13 @@ struct TableTranscriptPaneView: View {
     /// `@State` reference-holder shape as `presentationMemo` above.
     @State private var linkCache = TranscriptLinkResolverCache()
 
+    /// The transcript table this pane registered as its focus target, so
+    /// `onDisappear` can withdraw exactly the one it installed. A reference box
+    /// for the same reason `ComposerViewHandle` is one: it is written from
+    /// inside `makeNSView`, where a `@State` write is undefined behaviour, and
+    /// nothing renders from it.
+    @State private var registeredTable = RegisteredTranscriptTable()
+
     /// Absolute worktree root for resolving relative paths in transcript text.
     /// Empty when the worktree row has not loaded — or when it is remote, which
     /// `LocalWorktree` rejects — which makes relative paths simply not resolve.
@@ -138,7 +145,12 @@ struct TableTranscriptPaneView: View {
         .onChange(of: currentSessionID) { _, _ in
             activityGroupExpansion.removeAll()
         }
-        .onDisappear { clearWatchdogContext() }
+        .onDisappear {
+            clearWatchdogContext()
+            if let table = registeredTable.view {
+                appState.unregisterTranscriptView(table, for: terminalID)
+            }
+        }
     }
 
     // MARK: - Hang watchdog context
@@ -242,7 +254,8 @@ struct TableTranscriptPaneView: View {
                     activityToggleToken: activityToggleToken,
                     linkRoot: linkRoot,
                     nodesProvider: { timedRenderNodes(presentation.nodes) },
-                    onTableReady: { [appState, terminalID] table in
+                    onTableReady: { [appState, terminalID, registeredTable] table in
+                        registeredTable.view = table
                         appState.registerTranscriptView(table, for: terminalID)
                     }
                 )
@@ -624,4 +637,15 @@ private struct TaskKey: Equatable {
 private struct PaneIdentity: Hashable {
     let terminalID: UUID
     let sessionID: String?
+}
+
+/// A weak handle on the transcript table one pane registered.
+///
+/// Weak because the registry's own reference is weak and this box must not be
+/// the thing that keeps a torn-down table alive; it exists only so
+/// `onDisappear` can name the view it should withdraw rather than clearing the
+/// key and evicting a replacement that has already registered under it.
+@MainActor
+final class RegisteredTranscriptTable {
+    weak var view: NSTableView?
 }

--- a/Sources/TBDApp/Panes/Transcript/Table/TableTranscriptView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Table/TableTranscriptView.swift
@@ -38,6 +38,10 @@ struct TableTranscriptView: NSViewRepresentable {
     /// tells the Coordinator its composed rows were built against a stale one.
     let linkRoot: String
     let nodesProvider: @MainActor () -> [TranscriptRenderNode]
+    /// Handed the table view once it exists, so the pane can register it as the
+    /// place Escape in the composer returns focus to. Nil where nothing needs
+    /// that handle — Session History mounts no composer.
+    var onTableReady: (@MainActor (NSTableView) -> Void)?
 
     private static let log = Logger(subsystem: "com.tbd.app", category: "table-transcript")
 
@@ -159,6 +163,7 @@ struct TableTranscriptView: NSViewRepresentable {
         let makeNSViewMs = Double(DispatchTime.now().uptimeNanoseconds &- makeStart) / 1_000_000
         Self.log.debug(
             "table.open.makeNSViewDone ms=\(makeNSViewMs, format: .fixed(precision: 1), privacy: .public) rows=\(nodes.count, privacy: .public)")
+        onTableReady?(tableView)
         return scrollView
     }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -4747,7 +4747,12 @@ extension RPCRouter {
             worktreeID: terminal.worktreeID,
             sessionID: sessionApplication.sessionID,
             transcriptPath: sessionApplication.transcriptPath,
-            sessionOrderObservedAt: sessionApplication.orderObservedAt
+            sessionOrderObservedAt: sessionApplication.orderObservedAt,
+            // The ACCEPTED hook's own incarnation. `applySessionStart` accepts
+            // only when the reported id equals the row's, so on this line the
+            // two are the same value and this is the id of the spawn that just
+            // reported in.
+            sessionIncarnationID: params.sessionIncarnationID
         )))
         if let application = sessionApplication.activityObservation {
             subscriptions.broadcast(delta: .terminalActivityUpdated(TerminalActivityDelta(

--- a/Sources/TBDShared/StateDelta.swift
+++ b/Sources/TBDShared/StateDelta.swift
@@ -216,18 +216,28 @@ public struct TerminalSessionDelta: Codable, Sendable {
     /// Ordering generation of the accepted SessionStart. Optional for wire
     /// compatibility with older daemons and for non-hook session updates.
     public let sessionOrderObservedAt: Date?
+    /// The session incarnation the accepted `SessionStart` reported — the id TBD
+    /// planted in that process's environment as `TBD_TERMINAL_INCARNATION_ID`.
+    ///
+    /// Nil for a spawn that carried none (a worktree's first, an archive
+    /// restore), for session updates that are not a hook, and for daemons that
+    /// predate this field. A consumer scoping a wait to one spawn must read nil
+    /// as "not this one", never as "close enough".
+    public let sessionIncarnationID: UUID?
     public init(
         terminalID: UUID,
         worktreeID: UUID,
         sessionID: String,
         transcriptPath: String?,
-        sessionOrderObservedAt: Date? = nil
+        sessionOrderObservedAt: Date? = nil,
+        sessionIncarnationID: UUID? = nil
     ) {
         self.terminalID = terminalID
         self.worktreeID = worktreeID
         self.sessionID = sessionID
         self.transcriptPath = transcriptPath
         self.sessionOrderObservedAt = sessionOrderObservedAt
+        self.sessionIncarnationID = sessionIncarnationID
     }
 }
 

--- a/Tests/TBDAppTests/CommandRankerTests.swift
+++ b/Tests/TBDAppTests/CommandRankerTests.swift
@@ -1,0 +1,174 @@
+import Foundation
+import Testing
+@testable import TBDApp
+import TBDShared
+
+/// Ranking, stated as the orderings a person would notice.
+///
+/// The absolute scores are not the contract — the ORDER is. Asserting exact
+/// numbers would pin an incident; asserting that a prefix beats a fuzzy match
+/// pins the property.
+@Suite("CommandRanker")
+struct CommandRankerTests {
+
+    private func command(
+        _ name: String, description: String = "", aliases: [String] = []
+    ) -> CompletionCommand {
+        CompletionCommand(name: name, description: description, aliases: aliases)
+    }
+
+    /// `checkout` earns its place: `co` fuzzy-matches it and does NOT prefix it,
+    /// which is what makes `prefixBeatsFuzzy`'s "find a non-prefix row"
+    /// satisfiable rather than vacuous.
+    private let inventory = [
+        CompletionCommand(name: "compact", description: "Compact the conversation"),
+        CompletionCommand(name: "code-review", description: "Review the diff",
+                          aliases: ["review"]),
+        CompletionCommand(name: "config", description: "Open settings"),
+        CompletionCommand(name: "superpowers:brainstorming",
+                          description: "Explore intent before implementing"),
+        CompletionCommand(name: "clear", description: "Clear the conversation"),
+        CompletionCommand(name: "checkout", description: "Switch branches"),
+    ]
+
+    private func names(_ query: String, frecency: @escaping (String) -> Double = { _ in 0 })
+        -> [String] {
+        CommandRanker.rank(commands: inventory, query: query, frecency: frecency)
+            .map(\.id)
+    }
+
+    // MARK: - Segments
+
+    @Test func namesSplitOnEverySeparator() {
+        #expect(CommandRanker.segments("superpowers:brainstorming")
+            == ["superpowers", "brainstorming"])
+        #expect(CommandRanker.segments("code-review") == ["code", "review"])
+        #expect(CommandRanker.segments("a_b.c/d") == ["a", "b", "c", "d"])
+    }
+
+    // MARK: - Order
+
+    @Test func anExactNameWins() {
+        #expect(names("compact").first == "compact")
+    }
+
+    @Test func anExactAliasBeatsAPrefix() throws {
+        let ranked = names("review")
+        #expect(ranked.first == "code-review",
+                "the exact alias must win over anything that merely contains it")
+    }
+
+    /// **Prefix beats fuzzy.** `co` prefixes three commands; a command it only
+    /// fuzzy-matches must sort below all of them.
+    @Test func prefixBeatsFuzzy() throws {
+        let ranked = names("co")
+        let prefixes = Set(["compact", "code-review", "config"])
+        let firstNonPrefix = try #require(ranked.firstIndex { !prefixes.contains($0) })
+        #expect(firstNonPrefix >= 3, "every prefix match must sort above every fuzzy one: \(ranked)")
+    }
+
+    /// Among prefix matches, the shortest name first — it is the one the person
+    /// most likely meant with the fewest characters typed.
+    @Test func amongPrefixesTheShortestFirst() {
+        let ranked = names("c")
+        let clear = try? #require(ranked.firstIndex(of: "clear"))
+        let codeReview = try? #require(ranked.firstIndex(of: "code-review"))
+        #expect((clear ?? 0) < (codeReview ?? 0))
+    }
+
+    /// `brain` finds the brainstorming skill inside its plugin namespace — the
+    /// case the segment matching exists for.
+    @Test func aSegmentMatchFindsANamespacedSkill() {
+        #expect(names("brain").contains("superpowers:brainstorming"))
+    }
+
+    /// `sup:br` matches segment by segment, in order.
+    @Test func aColonQueryMatchesSegmentBySegment() {
+        let ranked = names("sup:br")
+        #expect(ranked.first == "superpowers:brainstorming", "got \(ranked)")
+    }
+
+    /// **Frecency breaks ties ONLY.** A heavily-used command must not outrank an
+    /// exact name match. Run with a frecency that strongly favours the wrong row.
+    @Test func frecencyNeverOutranksAMatchQuality() {
+        let ranked = names("compact", frecency: { $0 == "clear" ? 1000 : 0 })
+        #expect(ranked.first == "compact",
+                "frecency must be a tiebreak, not a rank: \(ranked)")
+    }
+
+    /// Two names of EQUAL length, so the "shortest name first" rule inside the
+    /// prefix tier cannot settle the tie before frecency gets to.
+    @Test func frecencyDoesBreakARealTie() {
+        let pair = [command("alpha"), command("alphb")]
+        let favouringB = CommandRanker.rank(
+            commands: pair, query: "alp", frecency: { $0 == "alphb" ? 100 : 0 })
+        #expect(favouringB.first?.id == "alphb")
+        let favouringA = CommandRanker.rank(
+            commands: pair, query: "alp", frecency: { $0 == "alpha" ? 100 : 0 })
+        #expect(favouringA.first?.id == "alpha")
+    }
+
+    // MARK: - Tier boundaries, each stated so removing the tier reddens it
+    //
+    // The orderings above are the ones a person notices; these are the ones that
+    // keep the LADDER honest. Each pairs two commands that the tier rule alone
+    // separates, and each hands the loser a large frecency so a pass cannot be an
+    // accident of the tiebreak.
+
+    @Test func anExactNameBeatsAnExactAlias() {
+        let ranked = CommandRanker.rank(
+            commands: [command("deploy"), command("ship", aliases: ["deploy"])],
+            query: "deploy", frecency: { $0 == "ship" ? 100 : 0 })
+        #expect(ranked.map(\.id) == ["deploy", "ship"])
+    }
+
+    @Test func anExactAliasBeatsANamePrefixOutright() {
+        let ranked = CommandRanker.rank(
+            commands: [command("review-all"), command("code-review", aliases: ["review"])],
+            query: "review", frecency: { $0 == "review-all" ? 100 : 0 })
+        #expect(ranked.map(\.id) == ["code-review", "review-all"])
+    }
+
+    /// The name is what the person is typing; an alias is a courtesy. `zebra` is
+    /// the SHORTER name, so without the tier the prefix rule would hand it first
+    /// place.
+    @Test func aNamePrefixBeatsAnAliasPrefix() {
+        let ranked = CommandRanker.rank(
+            commands: [command("confetti"), command("zebra", aliases: ["configure"])],
+            query: "conf", frecency: { $0 == "zebra" ? 100 : 0 })
+        #expect(ranked.map(\.id) == ["confetti", "zebra"])
+    }
+
+    // MARK: - No match
+
+    @Test func aQueryThatMatchesNothingRanksNothing() {
+        #expect(names("zzzzqqq").isEmpty)
+    }
+
+    // MARK: - The bare sigil
+
+    @Test func anEmptyQueryLeadsWithTheTopFiveByFrecency() {
+        let rows = CommandRanker.defaultRows(
+            commands: inventory, frecency: { $0 == "clear" ? 100 : 0 })
+        #expect(rows.first?.id == "clear")
+        #expect(rows.count == inventory.count, "every command is still reachable by scrolling")
+    }
+
+    // MARK: - Highlighting
+
+    @Test func matchedRangesPointAtTheMatchedCharacters() throws {
+        let row = try #require(CommandRanker.rank(
+            commands: [command("compact")], query: "cmp", frecency: { _ in 0 }).first)
+        #expect(!row.matchedRanges.isEmpty)
+        let name = "compact" as NSString
+        let matched = row.matchedRanges.map { name.substring(with: $0) }.joined()
+        #expect(matched == "cmp")
+    }
+
+    @Test func aMatchedAliasIsNamed() throws {
+        let row = try #require(CommandRanker.rank(
+            commands: [command("code-review", aliases: ["review"])],
+            query: "review", frecency: { _ in 0 }).first)
+        #expect(row.matchedAlias == "review")
+    }
+}

--- a/Tests/TBDAppTests/CommandRankerTests.swift
+++ b/Tests/TBDAppTests/CommandRankerTests.swift
@@ -115,6 +115,13 @@ struct CommandRankerTests {
     // separates, and each hands the loser a large frecency so a pass cannot be an
     // accident of the tiebreak.
 
+    /// Not tier-discriminating: the source's own sentinel scores (`Int.max/2`
+    /// for an exact name, `Int.max/4` for an exact alias) already sort in the
+    /// same order as the tiers do, so a sort that dropped the tier comparison
+    /// and fell back to score alone would still pass this. No pair of commands
+    /// can equalize those two constants from the outside. What this pins is the
+    /// observable order — `deploy` before `ship` — and that a heavy frecency on
+    /// the loser cannot override it.
     @Test func anExactNameBeatsAnExactAlias() {
         let ranked = CommandRanker.rank(
             commands: [command("deploy"), command("ship", aliases: ["deploy"])],

--- a/Tests/TBDAppTests/CompletionControllerTests.swift
+++ b/Tests/TBDAppTests/CompletionControllerTests.swift
@@ -114,6 +114,30 @@ struct CompletionControllerTests {
         }
     }
 
+    /// Escape while the inventory is still loading must stay closed even once
+    /// the inventory arrives — otherwise the menu reopens with no keystroke,
+    /// the trap the spec forbids.
+    @Test func escapeWhileLoadingStaysClosedWhenInventoryArrives() {
+        let suiteName = "CompletionControllerTests-\(UUID().uuidString)"
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+        let c = CompletionController(
+            frecency: FrecencyStore(defaults: UserDefaults(suiteName: suiteName)!))
+        c.update(text: "/comp", selectionLocation: 5, hasMarkedText: false)
+        #expect(c.presentation == .loading)
+        c.close(suppressingCurrentToken: true)
+        #expect(!c.isOpen)
+
+        c.adopt(inventory: TerminalCompletionsResult(
+            commands: [
+                CompletionCommand(name: "compact", description: "Compact"),
+                CompletionCommand(name: "config", description: "Settings"),
+                CompletionCommand(name: "clear", description: "Clear"),
+            ],
+            agents: [CompletionAgent(name: "Explore", description: "Search")],
+            freshness: .fresh, source: .probe))
+        #expect(!c.isOpen)
+    }
+
     /// No menu opens or updates while an input method has marked text.
     @Test func compositionKeepsItClosed() {
         run { c in
@@ -141,8 +165,25 @@ struct CompletionControllerTests {
         run { c in
             c.update(text: "/z", selectionLocation: 2, hasMarkedText: false)
             #expect(c.presentation != .noMatch)
+            #expect(!c.isOpen)
             c.update(text: "/zqq", selectionLocation: 4, hasMarkedText: false)
             #expect(c.presentation == .noMatch)
+        }
+    }
+
+    /// Rows are memoized by query so a repeated `update` call with an
+    /// unchanged token does not re-rank; a changed query ranks again.
+    @Test func repeatedUpdatesMemoizeByQuery() {
+        run { c in
+            c.update(text: "/comp", selectionLocation: 5, hasMarkedText: false)
+            let afterFirst = c.rankCount
+            #expect(afterFirst > 0)
+
+            c.update(text: "/comp", selectionLocation: 5, hasMarkedText: false)
+            #expect(c.rankCount == afterFirst, "an unchanged token must not re-rank")
+
+            c.update(text: "/config", selectionLocation: 7, hasMarkedText: false)
+            #expect(c.rankCount == afterFirst + 1, "a changed query must rank again")
         }
     }
 

--- a/Tests/TBDAppTests/CompletionControllerTests.swift
+++ b/Tests/TBDAppTests/CompletionControllerTests.swift
@@ -1,0 +1,156 @@
+import Foundation
+import Testing
+@testable import TBDApp
+import TBDShared
+
+/// The menu as a state machine: what is showing, what is highlighted, and what
+/// Enter would do.
+///
+/// The preselection rule is the delicate one. At the start of the input a genuine
+/// prefix match is preselected, so `/comp` + Enter runs compact exactly as it
+/// does in the terminal. Mid-sentence nothing is preselected, so Enter sends the
+/// message and the menu engages only on Down, Tab or a click.
+@MainActor
+@Suite("CompletionController")
+struct CompletionControllerTests {
+
+    private func makeController(suiteName: String) -> CompletionController {
+        let controller = CompletionController(
+            frecency: FrecencyStore(defaults: UserDefaults(suiteName: suiteName)!))
+        controller.adopt(inventory: TerminalCompletionsResult(
+            commands: [
+                CompletionCommand(name: "compact", description: "Compact"),
+                CompletionCommand(name: "config", description: "Settings"),
+                CompletionCommand(name: "clear", description: "Clear"),
+            ],
+            agents: [CompletionAgent(name: "Explore", description: "Search")],
+            freshness: .fresh, source: .probe))
+        return controller
+    }
+
+    private func run(_ body: (CompletionController) -> Void) {
+        let suiteName = "CompletionControllerTests-\(UUID().uuidString)"
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+        body(makeController(suiteName: suiteName))
+    }
+
+    @Test func typingASlashOpensIt() {
+        run { c in
+            c.update(text: "/", selectionLocation: 1, hasMarkedText: false)
+            #expect(c.isOpen)
+            #expect(c.presentation == .rows)
+            #expect(!c.rows.isEmpty)
+        }
+    }
+
+    @Test func typingFiltersSynchronously() {
+        run { c in
+            c.update(text: "/comp", selectionLocation: 5, hasMarkedText: false)
+            #expect(c.rows.map(\.id) == ["compact"])
+        }
+    }
+
+    /// At the start of the input, a genuine prefix match is preselected, so
+    /// `/comp` + Enter runs compact as it does in the terminal.
+    @Test func aPrefixMatchAtTheStartIsPreselected() {
+        run { c in
+            c.update(text: "/comp", selectionLocation: 5, hasMarkedText: false)
+            #expect(c.selectedIndex == 0)
+            #expect(c.acceptTarget?.id == "compact")
+        }
+    }
+
+    /// `/xyz` + Enter must SEND, not accept a row that merely fuzzy-matched.
+    @Test func aNonPrefixQueryPreselectsNothing() {
+        run { c in
+            c.update(text: "/xyz", selectionLocation: 4, hasMarkedText: false)
+            #expect(c.selectedIndex == nil)
+        }
+    }
+
+    /// **Mid-sentence nothing is preselected**, so Enter sends the message.
+    @Test func aMidSentenceTokenPreselectsNothing() {
+        run { c in
+            c.update(text: "please /comp", selectionLocation: 12, hasMarkedText: false)
+            #expect(c.isOpen)
+            #expect(c.selectedIndex == nil)
+            // Tab still accepts the first row — that is the accept gesture.
+            #expect(c.acceptTarget?.id == "compact")
+        }
+    }
+
+    @Test func arrowsMoveAndWrap() {
+        run { c in
+            c.update(text: "/c", selectionLocation: 2, hasMarkedText: false)
+            let count = c.rows.count
+            #expect(count >= 3)
+            c.moveDown()
+            #expect(c.selectedIndex == 1)
+            for _ in 0..<count { c.moveDown() }
+            #expect(c.selectedIndex == 1, "moving down \(count) times must wrap back around")
+            c.moveUp()
+            #expect(c.selectedIndex == 0)
+            c.moveUp()
+            #expect(c.selectedIndex == count - 1, "up from the top wraps to the bottom")
+        }
+    }
+
+    /// **Escape closes it and keeps it closed for that token until the token
+    /// changes.** Without the second half, the menu reopens on the next keystroke
+    /// and Escape means nothing.
+    @Test func escapeSuppressesUntilTheTokenChanges() {
+        run { c in
+            c.update(text: "/comp", selectionLocation: 5, hasMarkedText: false)
+            c.close(suppressingCurrentToken: true)
+            #expect(!c.isOpen)
+
+            // Same token, re-evaluated: still closed.
+            c.update(text: "/comp", selectionLocation: 5, hasMarkedText: false)
+            #expect(!c.isOpen)
+
+            // The token changed: it reopens.
+            c.update(text: "/compa", selectionLocation: 6, hasMarkedText: false)
+            #expect(c.isOpen)
+        }
+    }
+
+    /// No menu opens or updates while an input method has marked text.
+    @Test func compositionKeepsItClosed() {
+        run { c in
+            c.update(text: "/comp", selectionLocation: 5, hasMarkedText: true)
+            #expect(!c.isOpen)
+        }
+    }
+
+    /// Before the inventory lands, a single dim row — and NOTHING preselected, so
+    /// Enter cannot accept a row that appeared under the finger.
+    @Test func withNoInventoryItShowsLoadingAndPreselectsNothing() {
+        let suiteName = "CompletionControllerTests-\(UUID().uuidString)"
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+        let c = CompletionController(
+            frecency: FrecencyStore(defaults: UserDefaults(suiteName: suiteName)!))
+        c.update(text: "/comp", selectionLocation: 5, hasMarkedText: false)
+        #expect(c.presentation == .loading)
+        #expect(c.selectedIndex == nil)
+        #expect(c.acceptTarget == nil)
+    }
+
+    /// "No commands match" only once the query is longer than one character —
+    /// a single letter that matches nothing is almost always mid-typing.
+    @Test func noMatchAppearsOnlyPastOneCharacter() {
+        run { c in
+            c.update(text: "/z", selectionLocation: 2, hasMarkedText: false)
+            #expect(c.presentation != .noMatch)
+            c.update(text: "/zqq", selectionLocation: 4, hasMarkedText: false)
+            #expect(c.presentation == .noMatch)
+        }
+    }
+
+    /// The at-sign offers subagents, and only subagents in this version.
+    @Test func theAtSignOffersAgents() {
+        run { c in
+            c.update(text: "@Exp", selectionLocation: 4, hasMarkedText: false)
+            #expect(c.rows.map(\.id) == ["Explore"])
+        }
+    }
+}

--- a/Tests/TBDAppTests/CompletionTriggerTests.swift
+++ b/Tests/TBDAppTests/CompletionTriggerTests.swift
@@ -1,0 +1,96 @@
+import Foundation
+import Testing
+@testable import TBDApp
+
+/// When a completion menu opens, expressed as a function of the text and the
+/// caret. Everything stateful — Escape suppression, IME composition — belongs to
+/// the controller; this is the part that can be stated as a table.
+///
+/// The negatives are the point. A menu that opens inside `https://` or `foo/bar`
+/// is a trap: it steals Return from a person typing a URL.
+@Suite("CompletionTrigger")
+struct CompletionTriggerTests {
+
+    private func detect(_ text: String, caret: Int? = nil) -> CompletionTrigger.Match? {
+        CompletionTrigger.detect(
+            text: text, selectionLocation: caret ?? (text as NSString).length)
+    }
+
+    // MARK: - Opens
+
+    @Test func atTheStartOfTheInput() throws {
+        let match = try #require(detect("/comp"))
+        #expect(match.kind == .command)
+        #expect(match.query == "comp")
+        #expect(match.sigilLocation == 0)
+        #expect(match.tokenRange == NSRange(location: 0, length: 5))
+    }
+
+    @Test func afterWhitespaceMidSentence() throws {
+        let match = try #require(detect("please run /comp"))
+        #expect(match.query == "comp")
+        #expect(match.sigilLocation == 11)
+    }
+
+    @Test func atTheStartOfALine() throws {
+        let match = try #require(detect("first line\n/comp"))
+        #expect(match.query == "comp")
+    }
+
+    @Test func theAtSignOpensTheMentionMenu() throws {
+        let match = try #require(detect("ask @Expl"))
+        #expect(match.kind == .mention)
+        #expect(match.query == "Expl")
+    }
+
+    /// A bare sigil is a real trigger: it shows the top rows by frecency.
+    @Test func aBareSigilOpensWithAnEmptyQuery() throws {
+        let match = try #require(detect("/"))
+        #expect(match.query.isEmpty)
+    }
+
+    // MARK: - Never a trap
+
+    @Test func neverInsideAWord() {
+        #expect(detect("https://example.com") == nil)
+        #expect(detect("foo/bar") == nil)
+        #expect(detect("me@example.com") == nil)
+        #expect(detect("a/b/c") == nil)
+    }
+
+    /// A space closes it: the token ended, and what follows is arguments.
+    @Test func aSpaceAfterTheTokenClosesIt() {
+        #expect(detect("/compact ") == nil)
+        #expect(detect("/compact now") == nil)
+    }
+
+    /// The caret leaving the token closes it, even though the token is still in
+    /// the text. The menu is a suggestion about what is being typed, not a mode.
+    @Test func aCaretOutsideTheTokenClosesIt() {
+        #expect(detect("/comp and more", caret: 14) == nil)
+        // Caret moved back to the very start, before the sigil.
+        #expect(detect("/comp", caret: 0) == nil)
+    }
+
+    /// Backspacing into the token reopens it — the caret is inside again.
+    @Test func aCaretInsideTheTokenReopensIt() throws {
+        let match = try #require(detect("/compact", caret: 5))
+        #expect(match.query == "comp",
+                "the query is what precedes the caret, so filtering follows the edit")
+    }
+
+    @Test func emptyTextTriggersNothing() {
+        #expect(detect("") == nil)
+    }
+
+    /// Multi-scalar characters must not shift the range: `NSTextView` selection
+    /// is UTF-16, and a range computed in Character offsets would replace the
+    /// wrong bytes on accept.
+    @Test func rangesAreInUTF16Units() throws {
+        let text = "🎉 /comp"
+        let match = try #require(detect(text))
+        #expect(match.sigilLocation == 3, "the emoji is two UTF-16 units plus a space")
+        #expect(match.tokenRange == NSRange(location: 3, length: 5))
+        #expect((text as NSString).substring(with: match.tokenRange) == "/comp")
+    }
+}

--- a/Tests/TBDAppTests/ComposerArgumentHintTests.swift
+++ b/Tests/TBDAppTests/ComposerArgumentHintTests.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Testing
+@testable import TBDApp
+import TBDShared
+
+/// The dim placeholder after an accepted command token.
+///
+/// It is a function of the text and the caret, exactly like the trigger
+/// detector, so the drawing has no state to get wrong: the hint either applies
+/// right now or it does not.
+@Suite("ComposerArgumentHint")
+struct ComposerArgumentHintTests {
+
+    private let commands = [
+        CompletionCommand(
+            name: "compact", description: "d", argumentHint: "[instructions]"),
+        CompletionCommand(name: "clear", description: "d"),
+    ]
+
+    private func hint(_ text: String, caret: Int? = nil) -> String? {
+        ComposerArgumentHint.hint(
+            text: text, selectionLocation: caret ?? (text as NSString).length,
+            commands: commands)
+    }
+
+    @Test func aSpaceAfterTheTokenShowsTheHint() {
+        #expect(hint("/compact ") == "[instructions]")
+    }
+
+    /// Before the space, the completion MENU is showing and owns the hint. Two
+    /// renderings of the same string at once would be one too many.
+    @Test func noSpaceMeansNoHint() {
+        #expect(hint("/compact") == nil)
+    }
+
+    /// Once an argument is typed the placeholder has been answered.
+    @Test func anArgumentTypedRetiresTheHint() {
+        #expect(hint("/compact be brief") == nil)
+    }
+
+    @Test func aCommandWithNoHintShowsNothing() {
+        #expect(hint("/clear ") == nil)
+    }
+
+    /// Claude Code expands a command only at the START of a message, so a
+    /// mid-sentence token takes no arguments and gets no placeholder.
+    @Test func aMidSentenceTokenGetsNoHint() {
+        #expect(hint("please /compact ") == nil)
+    }
+
+    @Test func anUnknownCommandGetsNoHint() {
+        #expect(hint("/nonesuch ") == nil)
+    }
+
+    /// The caret has to be where the argument would go. Parked back inside the
+    /// token, the person is editing the name, not filling in an argument.
+    @Test func theCaretMustBeAtTheArgumentPosition() {
+        #expect(hint("/compact ", caret: 4) == nil)
+    }
+
+    @Test func emptyTextShowsNothing() {
+        #expect(hint("") == nil)
+    }
+}

--- a/Tests/TBDAppTests/ComposerDraftTests.swift
+++ b/Tests/TBDAppTests/ComposerDraftTests.swift
@@ -1,0 +1,92 @@
+import Foundation
+import Testing
+@testable import TBDApp
+import TBDShared
+
+/// Drafts are per terminal and survive a session rollover.
+///
+/// That survival is the whole reason they live on `AppState` rather than in the
+/// pane: the transcript table rebuilds under `.id(PaneIdentity(terminalID:
+/// sessionID:))`, so a `/clear` tears the view down — and it must not take a
+/// half-written message with it.
+@MainActor
+@Suite("ComposerDraft")
+struct ComposerDraftTests {
+
+    private func makeState() -> (AppState, String) {
+        let suiteName = "ComposerDraftTests-\(UUID().uuidString)"
+        return (AppState(userDefaults: UserDefaults(suiteName: suiteName)!), suiteName)
+    }
+
+    @Test func stagingNumbersTokensFromOne() {
+        let draft = ComposerDraft()
+        #expect(draft.stage(path: "/tmp/a.png", id: UUID()) == 1)
+        #expect(draft.stage(path: "/tmp/b.png", id: UUID()) == 2)
+    }
+
+    /// **Numbers are never reused within one message.** Reusing a freed number
+    /// would silently re-point a token the person had already typed elsewhere.
+    @Test func aRemovedNumberIsNotReused() {
+        let draft = ComposerDraft()
+        _ = draft.stage(path: "/tmp/a.png", id: UUID())
+        _ = draft.stage(path: "/tmp/b.png", id: UUID())
+        draft.removeAttachment(number: 1)
+        #expect(draft.stage(path: "/tmp/c.png", id: UUID()) == 3)
+    }
+
+    /// A staged image whose token is gone from the text is DETACHED — greyed and
+    /// marked "not in message", never dropped silently.
+    @Test func detachedAttachmentsAreTheOnesTheTextNoLongerAnchors() {
+        let draft = ComposerDraft()
+        let one = draft.stage(path: "/tmp/a.png", id: UUID())
+        let two = draft.stage(path: "/tmp/b.png", id: UUID())
+        draft.text = "look at \(ComposerTokens.text(for: one))"
+        #expect(draft.detachedNumbers == [two])
+
+        draft.text += " and \(ComposerTokens.text(for: two))"
+        #expect(draft.detachedNumbers.isEmpty)
+    }
+
+    @Test func clearingEmptiesBothHalves() {
+        let draft = ComposerDraft()
+        _ = draft.stage(path: "/tmp/a.png", id: UUID())
+        draft.text = "words"
+        draft.clear()
+        #expect(draft.text.isEmpty)
+        #expect(draft.attachments.isEmpty)
+        #expect(draft.stage(path: "/tmp/b.png", id: UUID()) == 1,
+                "a cleared draft starts a fresh message, so numbering restarts")
+    }
+
+    // MARK: - The registry
+
+    @Test func oneDraftPerTerminal() {
+        let (state, suiteName) = makeState()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+        let a = UUID(), b = UUID()
+
+        state.composerDraft(for: a).text = "for a"
+        state.composerDraft(for: b).text = "for b"
+
+        #expect(state.composerDraft(for: a).text == "for a")
+        #expect(state.composerDraft(for: b).text == "for b")
+    }
+
+    /// The same instance comes back, which is what makes the draft survive a
+    /// view teardown.
+    @Test func theSameTerminalGetsTheSameInstance() {
+        let (state, suiteName) = makeState()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+        let id = UUID()
+        #expect(state.composerDraft(for: id) === state.composerDraft(for: id))
+    }
+
+    @Test func discardingForgetsIt() {
+        let (state, suiteName) = makeState()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+        let id = UUID()
+        state.composerDraft(for: id).text = "gone soon"
+        state.discardComposerDraft(for: id)
+        #expect(state.composerDraft(for: id).text.isEmpty)
+    }
+}

--- a/Tests/TBDAppTests/ComposerImagePreparerTests.swift
+++ b/Tests/TBDAppTests/ComposerImagePreparerTests.swift
@@ -1,0 +1,203 @@
+import AppKit
+import Foundation
+import ImageIO
+import TestSupport
+import Testing
+import UniformTypeIdentifiers
+@testable import TBDApp
+
+/// Image preparation. Every accepted image is decoded, downscaled, and
+/// re-encoded as PNG — the original bytes are never passed through unexamined,
+/// which is what lets the composer promise the file it writes is an image and
+/// what its extension says it is.
+///
+/// **Every fixture is built at an exact pixel size** with
+/// `NSBitmapImageRep(bitmapDataPlanes:…)`, never with `NSImage.lockFocus()`.
+/// `lockFocus` renders at the deepest attached screen's backing scale, so on a
+/// Retina developer machine a "64×48" fixture is really 128×96 pixels and
+/// `aSmallImageKeepsItsSize` fails there while passing on a CI runner with no
+/// screen. The pixel dimensions are the subject of these tests, so they are
+/// stated rather than inherited from the hardware.
+@MainActor
+@Suite("ComposerImagePreparer")
+struct ComposerImagePreparerTests {
+
+    /// A bitmap at an exact pixel size. `noisy` fills it with deterministic
+    /// pseudo-random bytes, which is the only way to make a PNG big enough to
+    /// exercise the size cap — a solid colour compresses to nothing at any
+    /// resolution and would let the cap test pass without the cap existing.
+    private func makeBitmap(width: Int, height: Int, noisy: Bool = false) throws
+        -> NSBitmapImageRep
+    {
+        let rep = try #require(NSBitmapImageRep(
+            bitmapDataPlanes: nil,
+            pixelsWide: width,
+            pixelsHigh: height,
+            bitsPerSample: 8,
+            samplesPerPixel: 3,
+            hasAlpha: false,
+            isPlanar: false,
+            colorSpaceName: .deviceRGB,
+            bytesPerRow: width * 3,
+            bitsPerPixel: 24))
+        let bytes = try #require(rep.bitmapData)
+        let count = rep.bytesPerRow * height
+        if noisy {
+            // A tiny xorshift, so the fixture is incompressible and identical
+            // on every run.
+            var state: UInt32 = 0x1234_5678
+            for index in 0..<count {
+                state ^= state << 13
+                state ^= state >> 17
+                state ^= state << 5
+                bytes[index] = UInt8(truncatingIfNeeded: state)
+            }
+        } else {
+            memset(bytes, 0x40, count)
+        }
+        return rep
+    }
+
+    /// A solid-colour image at a chosen size, in a chosen format.
+    private func makeImage(width: Int, height: Int, type: UTType, noisy: Bool = false)
+        throws -> Data
+    {
+        let rep = try makeBitmap(width: width, height: height, noisy: noisy)
+        // `UTType` is a struct, not an enum, so this is a lookup rather than a
+        // switch that could be exhaustive.
+        let format: NSBitmapImageRep.FileType = type == .tiff ? .tiff
+            : (type == .png ? .png : .jpeg)
+        return try #require(rep.representation(using: format, properties: [:]))
+    }
+
+    /// A JPEG that really carries an EXIF orientation tag, written through
+    /// ImageIO because `NSBitmapImageRep` has no way to attach one.
+    private func makeOrientedImage(width: Int, height: Int, orientation: Int) throws -> Data {
+        let cgImage = try #require(try makeBitmap(width: width, height: height).cgImage)
+        let output = NSMutableData()
+        let destination = try #require(CGImageDestinationCreateWithData(
+            output, UTType.jpeg.identifier as CFString, 1, nil))
+        CGImageDestinationAddImage(destination, cgImage, [
+            kCGImagePropertyOrientation: orientation,
+        ] as CFDictionary)
+        #expect(CGImageDestinationFinalize(destination))
+        return output as Data
+    }
+
+    private func properties(of data: Data) throws -> [CFString: Any] {
+        let source = try #require(CGImageSourceCreateWithData(data as CFData, nil))
+        return try #require(CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any])
+    }
+
+    private func dimensions(of data: Data) throws -> (width: Int, height: Int) {
+        let props = try properties(of: data)
+        return (
+            try #require(props[kCGImagePropertyPixelWidth] as? Int),
+            try #require(props[kCGImagePropertyPixelHeight] as? Int))
+    }
+
+    private func orientation(of data: Data) throws -> Int? {
+        try properties(of: data)[kCGImagePropertyOrientation] as? Int
+    }
+
+    private func isPNG(_ data: Data) -> Bool {
+        data.starts(with: [0x89, 0x50, 0x4E, 0x47])
+    }
+
+    @Test func tiffInPngOut() throws {
+        let out = try ComposerImagePreparer.preparePNG(
+            from: try makeImage(width: 64, height: 48, type: .tiff))
+        #expect(isPNG(out))
+    }
+
+    @Test func pngInPngOut() throws {
+        let out = try ComposerImagePreparer.preparePNG(
+            from: try makeImage(width: 64, height: 48, type: .png))
+        #expect(isPNG(out))
+    }
+
+    /// A small image is not upscaled. Downscaling is a cap, not a target.
+    @Test func aSmallImageKeepsItsSize() throws {
+        let source = try makeImage(width: 64, height: 48, type: .png)
+        // The fixture itself must be the size it claims, or this test would be
+        // measuring the developer machine's backing scale.
+        #expect(try dimensions(of: source) == (width: 64, height: 48))
+        let out = try ComposerImagePreparer.preparePNG(from: source)
+        let size = try dimensions(of: out)
+        #expect(size.width == 64 && size.height == 48)
+    }
+
+    @Test func aLargeImageIsCappedOnItsLongEdge() throws {
+        let out = try ComposerImagePreparer.preparePNG(
+            from: try makeImage(width: 4000, height: 1000, type: .png))
+        let size = try dimensions(of: out)
+        #expect(size.width == ComposerImagePreparer.maxLongEdge)
+        #expect(size.height == 500, "the aspect ratio must survive: got \(size)")
+    }
+
+    @Test func aTallImageIsCappedOnItsLongEdgeToo() throws {
+        let out = try ComposerImagePreparer.preparePNG(
+            from: try makeImage(width: 1000, height: 4000, type: .png))
+        let size = try dimensions(of: out)
+        #expect(size.height == ComposerImagePreparer.maxLongEdge)
+    }
+
+    /// **The result must fit Claude Code's cap after base64 expansion**, which is
+    /// four bytes out for every three in. The fixture is noise, so the long-edge
+    /// cap alone is not enough to get under it and the re-encode loop has to run.
+    @Test func theResultFitsTheBase64Cap() throws {
+        let out = try ComposerImagePreparer.preparePNG(
+            from: try makeImage(width: 4000, height: 3000, type: .png, noisy: true))
+        let base64Bytes = (out.count + 2) / 3 * 4
+        #expect(base64Bytes <= ComposerImagePreparer.maxBase64Bytes,
+                "\(out.count) raw bytes expand to \(base64Bytes) base64 bytes")
+        // …and it really did have to shrink further than the long-edge cap,
+        // which is what makes the assertion above discriminating.
+        #expect(try dimensions(of: out).width < ComposerImagePreparer.maxLongEdge)
+    }
+
+    /// Undecodable input is refused with a message, never written and never sent.
+    @Test func undecodableInputIsRefused() {
+        #expect(throws: ComposerImagePreparer.PrepareError.undecodable) {
+            try ComposerImagePreparer.preparePNG(from: Data("not an image".utf8))
+        }
+        #expect(throws: ComposerImagePreparer.PrepareError.undecodable) {
+            try ComposerImagePreparer.preparePNG(from: Data())
+        }
+    }
+
+    /// A file drop shares the same path — the bytes are read and then prepared,
+    /// never linked to in place.
+    @Test func aFileDropIsReadAndPrepared() throws {
+        let root = URL(fileURLWithPath: fencedScratchRoot(prefix: "tbdimg"), isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let url = root.appendingPathComponent("drop.png")
+        try makeImage(width: 32, height: 32, type: .png).write(to: url)
+
+        let read = try #require(ComposerImagePreparer.imageData(fromFileAt: url))
+        #expect(isPNG(try ComposerImagePreparer.preparePNG(from: read)))
+    }
+
+    /// Orientation is applied rather than carried: a rotated source must come out
+    /// with its pixels already in reading order, because the token that follows
+    /// it is a path and nothing downstream re-reads EXIF.
+    ///
+    /// The fixture carries a real EXIF orientation of 6 (rotate 90° clockwise for
+    /// display), so its 200×100 stored pixels are a 100×200 picture. A preparer
+    /// that ignored the tag would emit 200×100 and fail here — which an
+    /// orientation-tag assertion on an untagged fixture could not do, since PNG
+    /// carries no orientation and the check would read its own default back.
+    @Test func orientationIsBakedIntoThePixels() throws {
+        let data = try makeOrientedImage(width: 200, height: 100, orientation: 6)
+        #expect(try orientation(of: data) == 6,
+                "the fixture must really carry the tag, or this test proves nothing")
+
+        let out = try ComposerImagePreparer.preparePNG(from: data)
+        let size = try dimensions(of: out)
+        #expect(size.width == 100 && size.height == 200,
+                "the rotation must be in the pixels: got \(size)")
+        #expect((try orientation(of: out) ?? 1) == 1,
+                "the output must carry no residual orientation tag")
+    }
+}

--- a/Tests/TBDAppTests/ComposerImagePreparerTests.swift
+++ b/Tests/TBDAppTests/ComposerImagePreparerTests.swift
@@ -227,6 +227,25 @@ struct ComposerImagePreparerTests {
         #expect(ComposerImagePreparer.imageData(fromFileAt: url) == written)
     }
 
+    /// **The sniff reads a prefix; what comes back is the whole file.** An
+    /// unidentified file is decided on its first few KB rather than by pulling
+    /// all of it into memory — a drop hands over whatever URL the pasteboard
+    /// carried, which may be a disk image or a video. The fixture here is
+    /// comfortably larger than that prefix, so an implementation that returned
+    /// what it sniffed would hand back a truncated PNG and fail.
+    @Test func aMisnamedImageLargerThanTheSniffPrefixComesBackWhole() throws {
+        let root = URL(fileURLWithPath: fencedScratchRoot(prefix: "tbdimg"), isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let url = root.appendingPathComponent("capture")
+        // Noise, so the PNG cannot compress down under the sniff prefix.
+        let written = try makeImage(width: 400, height: 400, type: .png, noisy: true)
+        #expect(written.count > 8 * 1024, "the fixture must exceed the sniff prefix")
+        try written.write(to: url)
+
+        #expect(ComposerImagePreparer.imageData(fromFileAt: url) == written)
+    }
+
     /// A misnamed image is still an image: the type check falls back to
     /// sniffing the bytes, so a screenshot saved without an extension works.
     @Test func aPNGWithAMisleadingExtensionIsStillRead() throws {

--- a/Tests/TBDAppTests/ComposerImagePreparerTests.swift
+++ b/Tests/TBDAppTests/ComposerImagePreparerTests.swift
@@ -200,4 +200,42 @@ struct ComposerImagePreparerTests {
         #expect((try orientation(of: out) ?? 1) == 1,
                 "the output must carry no residual orientation tag")
     }
+
+    /// **A dropped file is validated before its bytes become an image.** The
+    /// drop path reads whatever URL the pasteboard carried, so without a check
+    /// a dragged source file or log would be handed to `onImageData` and only
+    /// fail later, deep inside the preparer, as an opaque "not an image".
+    @Test func aDroppedTextFileIsRefused() throws {
+        let root = URL(fileURLWithPath: fencedScratchRoot(prefix: "tbdimg"), isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let url = root.appendingPathComponent("notes.txt")
+        try Data("not a picture, just prose".utf8).write(to: url)
+
+        #expect(ComposerImagePreparer.imageData(fromFileAt: url) == nil)
+    }
+
+    /// The same check must not refuse the thing it exists to let through.
+    @Test func aDroppedPNGFileIsRead() throws {
+        let root = URL(fileURLWithPath: fencedScratchRoot(prefix: "tbdimg"), isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let url = root.appendingPathComponent("shot.png")
+        let written = try makeImage(width: 24, height: 24, type: .png)
+        try written.write(to: url)
+
+        #expect(ComposerImagePreparer.imageData(fromFileAt: url) == written)
+    }
+
+    /// A misnamed image is still an image: the type check falls back to
+    /// sniffing the bytes, so a screenshot saved without an extension works.
+    @Test func aPNGWithAMisleadingExtensionIsStillRead() throws {
+        let root = URL(fileURLWithPath: fencedScratchRoot(prefix: "tbdimg"), isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let url = root.appendingPathComponent("screenshot.txt")
+        try makeImage(width: 24, height: 24, type: .png).write(to: url)
+
+        #expect(ComposerImagePreparer.imageData(fromFileAt: url) != nil)
+    }
 }

--- a/Tests/TBDAppTests/ComposerKeyRouterTests.swift
+++ b/Tests/TBDAppTests/ComposerKeyRouterTests.swift
@@ -40,7 +40,8 @@ struct ComposerKeyRouterTests {
             for shift in [false, true] {
                 let action = act(selector, shift: shift, menuOpen: false)
                 #expect(
-                    ![.menuUp, .menuDown, .menuAccept, .menuClose].contains(action),
+                    ![.menuUp, .menuDown, .menuAccept, .menuAcceptOrSubmit, .menuClose]
+                        .contains(action),
                     "\(selector) shift=\(shift) resolved to \(action) with no menu open")
             }
         }
@@ -77,7 +78,19 @@ struct ComposerKeyRouterTests {
         #expect(act(up, menuOpen: true) == .menuUp)
         #expect(act(down, menuOpen: true) == .menuDown)
         #expect(act(cancel, menuOpen: true) == .menuClose)
-        #expect(act(newline, menuOpen: true) == .menuAccept)
+        #expect(act(newline, menuOpen: true) == .menuAcceptOrSubmit)
+    }
+
+    /// **Return and Tab are not the same key.** Tab's whole meaning is "take the
+    /// obvious completion", so it may fall back to the first row; Return must
+    /// accept only a row the person actually highlighted and otherwise send what
+    /// they typed. The router cannot know which row is highlighted, so it names
+    /// the two gestures apart and lets the composer decide — collapsing them here
+    /// would silently rewrite somebody's words into a command they never chose.
+    @Test func returnAndTabAreDistinguishableWithTheMenuOpen() {
+        #expect(act(tab, menuOpen: true) != act(newline, menuOpen: true))
+        #expect(act(tab, menuOpen: true) == .menuAccept)
+        #expect(act(newline, menuOpen: true) == .menuAcceptOrSubmit)
     }
 
     /// Shift+Return keeps breaking the line even with the menu up: it is the one

--- a/Tests/TBDAppTests/ComposerKeyRouterTests.swift
+++ b/Tests/TBDAppTests/ComposerKeyRouterTests.swift
@@ -1,0 +1,112 @@
+import AppKit
+import Foundation
+import Testing
+@testable import TBDApp
+
+/// Every key the composer sees, decided in one pure function.
+///
+/// The property that matters most is the **closed-menu** one: with no menu up,
+/// Tab, Up, Down and Escape must mean exactly what they mean in any text box.
+/// A router that returned a menu action there would steal keys from a person who
+/// is only typing, and it would do it invisibly.
+///
+/// `menuOpen` is a parameter rather than state because the caller reads the
+/// controller at decision time — a stale flag is then impossible by construction.
+@MainActor
+@Suite("ComposerKeyRouter")
+struct ComposerKeyRouterTests {
+    private let newline = #selector(NSResponder.insertNewline(_:))
+    private let optionNewline = #selector(NSResponder.insertNewlineIgnoringFieldEditor(_:))
+    private let tab = #selector(NSResponder.insertTab(_:))
+    private let up = #selector(NSResponder.moveUp(_:))
+    private let down = #selector(NSResponder.moveDown(_:))
+    private let cancel = #selector(NSResponder.cancelOperation(_:))
+
+    private func act(
+        _ selector: Selector, shift: Bool = false, command: Bool = false,
+        control: Bool = false, marked: Bool = false, menuOpen: Bool = false
+    ) -> ComposerKeyRouter.Action {
+        ComposerKeyRouter.action(
+            selector: selector, shiftHeld: shift, commandHeld: command,
+            controlHeld: control, hasMarkedText: marked, menuOpen: menuOpen)
+    }
+
+    // MARK: - Menu closed
+
+    /// **The load-bearing negative.** With the menu closed, no key may resolve to
+    /// a menu action.
+    @Test func withTheMenuClosedNothingIsAMenuAction() {
+        for selector in [newline, optionNewline, tab, up, down, cancel] {
+            for shift in [false, true] {
+                let action = act(selector, shift: shift, menuOpen: false)
+                #expect(
+                    ![.menuUp, .menuDown, .menuAccept, .menuClose].contains(action),
+                    "\(selector) shift=\(shift) resolved to \(action) with no menu open")
+            }
+        }
+    }
+
+    @Test func returnSendsAndShiftBreaksTheLine() {
+        #expect(act(newline) == .submit)
+        #expect(act(newline, shift: true) == .newline)
+        #expect(act(optionNewline) == .newline)
+    }
+
+    /// Cmd+Return always sends, menu open or closed — the escape hatch when a
+    /// row is highlighted and the person meant the text they typed.
+    @Test func commandReturnAlwaysSends() {
+        #expect(act(newline, command: true) == .submit)
+        #expect(act(newline, command: true, menuOpen: true) == .submit)
+        #expect(act(newline, shift: true, command: true, menuOpen: true) == .submit)
+    }
+
+    @Test func escapeBlursWhenNoMenuIsOpen() {
+        #expect(act(cancel) == .blur)
+    }
+
+    @Test func tabAndArrowsPassThroughWhenNoMenuIsOpen() {
+        #expect(act(tab) == .passThrough)
+        #expect(act(up) == .passThrough)
+        #expect(act(down) == .passThrough)
+    }
+
+    // MARK: - Menu open
+
+    @Test func theMenuOwnsItsKeys() {
+        #expect(act(tab, menuOpen: true) == .menuAccept)
+        #expect(act(up, menuOpen: true) == .menuUp)
+        #expect(act(down, menuOpen: true) == .menuDown)
+        #expect(act(cancel, menuOpen: true) == .menuClose)
+        #expect(act(newline, menuOpen: true) == .menuAccept)
+    }
+
+    /// Shift+Return keeps breaking the line even with the menu up: it is the one
+    /// gesture whose whole meaning is "not now, I am still writing".
+    @Test func shiftReturnStillBreaksTheLineWithTheMenuOpen() {
+        #expect(act(newline, shift: true, menuOpen: true) == .newline)
+        #expect(act(optionNewline, menuOpen: true) == .newline)
+    }
+
+    /// Ctrl+N and Ctrl+P move the selection, the emacs bindings AppKit resolves
+    /// to the same move commands.
+    @Test func controlNAndPMoveTheSelection() {
+        #expect(act(down, control: true, menuOpen: true) == .menuDown)
+        #expect(act(up, control: true, menuOpen: true) == .menuUp)
+    }
+
+    // MARK: - IME
+
+    /// **Marked text passes through unconditionally**, menu open or closed. While
+    /// a Japanese or Chinese candidate window is up, Return commits the
+    /// composition; sending there would submit a half-typed sentence AND swallow
+    /// the commit.
+    @Test func markedTextPassesThroughEverything() {
+        for selector in [newline, optionNewline, tab, up, down, cancel] {
+            for menuOpen in [false, true] {
+                #expect(
+                    act(selector, marked: true, menuOpen: menuOpen) == .passThrough,
+                    "\(selector) menuOpen=\(menuOpen) must pass through during composition")
+            }
+        }
+    }
+}

--- a/Tests/TBDAppTests/ComposerMountingTests.swift
+++ b/Tests/TBDAppTests/ComposerMountingTests.swift
@@ -455,22 +455,70 @@ struct ComposerMountingTests {
             label: "Transcript")
     }
 
-    /// Cmd+/ needs a terminal, and the focused tab names it — including for a
-    /// `.liveTranscript` tab, whose terminal the layout enumeration alone does
-    /// not report.
-    @Test func theComposerCommandNamesTheFocusedTabsTerminal() {
+    private func terminalTab(terminalID: UUID) -> TBDShared.Tab {
+        TBDShared.Tab(
+            id: UUID(), content: .terminal(terminalID: terminalID), label: "Agent")
+    }
+
+    /// **⌘/ from where somebody actually presses it.** Driven through the
+    /// production state only: a selected worktree, a `.liveTranscript` tab that
+    /// `resolvedActiveTab` resolves to, and a composer registered the way the
+    /// pane's mount registers one.
+    ///
+    /// Nothing writes `focusedTabCloseContext` for a transcript tab — only
+    /// terminal views do — and `resolvedFocusedTabCloseContext()` answers nil
+    /// for any first responder that is not a `TBDTerminalView`, which is every
+    /// responder in this pane. Resolving through those two alone therefore named
+    /// no terminal at all here.
+    @Test func theComposerCommandNamesTheSelectedWorktreesActiveTranscriptTerminal() {
         let (state, suiteName) = makeState()
         defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
         let worktreeID = UUID(), terminalID = UUID()
-        let tab = liveTranscriptTab(terminalID: terminalID)
-        state.tabs[worktreeID] = [tab]
-        state.focusedTabCloseContext = TabCloseContext(worktreeID: worktreeID, tabID: tab.id)
+        state.tabs[worktreeID] = [liveTranscriptTab(terminalID: terminalID)]
+        state.selectedWorktreeIDs = [worktreeID]
+        let composerView = NSView()
+        state.registerComposerView(composerView, for: terminalID)
 
         #expect(state.composerCommandTerminalID == terminalID)
     }
 
-    /// Nothing focused, nothing to act on — the menu items disable rather than
-    /// guessing at a terminal.
+    /// **The worse half of the same bug.** A stale last-focused context naming a
+    /// BACKGROUND terminal tab must not win over the transcript the person is
+    /// looking at — ⌘/ there moved the caret in a tab that is not on screen.
+    /// The registration is what decides: the terminal tab has no composer.
+    @Test func aStaleTerminalTabContextDoesNotStealTheComposerCommand() {
+        let (state, suiteName) = makeState()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+        let worktreeID = UUID(), background = UUID(), transcript = UUID()
+        let backgroundTab = terminalTab(terminalID: background)
+        state.tabs[worktreeID] = [
+            liveTranscriptTab(terminalID: transcript), backgroundTab
+        ]
+        state.selectedWorktreeIDs = [worktreeID]
+        state.focusedTabCloseContext = TabCloseContext(
+            worktreeID: worktreeID, tabID: backgroundTab.id)
+        let composerView = NSView()
+        state.registerComposerView(composerView, for: transcript)
+
+        #expect(state.composerCommandTerminalID == transcript)
+    }
+
+    /// **The negative.** No composer registered anywhere — the flag is off, or
+    /// the pane has not mounted one — and the accessor answers nil, which is
+    /// what the two menu items' `.disabled(…)` reads. `focusComposer` on a
+    /// terminal with no registered composer is a no-op, so an enabled item there
+    /// would be an offer of nothing.
+    @Test func withNoComposerRegisteredTheComposerCommandNamesNothing() {
+        let (state, suiteName) = makeState()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+        let worktreeID = UUID(), terminalID = UUID()
+        state.tabs[worktreeID] = [liveTranscriptTab(terminalID: terminalID)]
+        state.selectedWorktreeIDs = [worktreeID]
+
+        #expect(state.composerCommandTerminalID == nil)
+    }
+
+    /// Nothing selected and nothing focused — nothing to act on either.
     @Test func withNoFocusedTabTheComposerCommandNamesNothing() {
         let (state, suiteName) = makeState()
         defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
@@ -478,7 +526,7 @@ struct ComposerMountingTests {
         #expect(state.composerCommandTerminalID == nil)
     }
 
-    // MARK: - A closed tab takes its draft with it
+    // MARK: - A dead terminal takes its composer state with it
 
     @Test func closingATabDiscardsItsComposerDraft() {
         let (state, suiteName) = makeState()
@@ -491,6 +539,92 @@ struct ComposerMountingTests {
         state.closeTab(worktreeID: worktreeID, index: 0)
 
         #expect(state.composerDrafts[terminalID] == nil)
+    }
+
+    /// The focus registries hold their views weakly, so nothing leaks — but an
+    /// empty box per dead terminal accumulates for the app's lifetime. A closed
+    /// tab leaves neither entry behind, nor the incarnation latch.
+    @Test func closingATabLeavesNoComposerRegistryEntry() {
+        let (state, suiteName) = makeState()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+        let worktreeID = UUID(), terminalID = UUID()
+        let tab = liveTranscriptTab(terminalID: terminalID)
+        state.tabs[worktreeID] = [tab]
+        let composerView = NSView(), transcriptView = NSView()
+        state.registerComposerView(composerView, for: terminalID)
+        state.registerTranscriptView(transcriptView, for: terminalID)
+        state.lastStartedIncarnation[terminalID] = UUID()
+
+        state.closeTab(worktreeID: worktreeID, index: 0)
+
+        #expect(state.composerFocusTargets[terminalID] == nil)
+        #expect(state.transcriptFocusTargets[terminalID] == nil)
+        #expect(state.lastStartedIncarnation[terminalID] == nil)
+    }
+
+    /// **The common death.** A tab close is the rarer one; every pane close,
+    /// archive and daemon-reported removal funnels through
+    /// `removeDeletedTerminalFromState`, which left the draft — and a send
+    /// finishing after the row was gone then minted a fresh empty one through
+    /// `composerDraft(for:)`.
+    @Test func removingADeletedTerminalForgetsItsComposerState() {
+        let (state, suiteName) = makeState()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+        let worktreeID = UUID(), terminalID = UUID()
+        state.composerDraft(for: terminalID).text = "half a sentence"
+        let composerView = NSView(), transcriptView = NSView()
+        state.registerComposerView(composerView, for: terminalID)
+        state.registerTranscriptView(transcriptView, for: terminalID)
+        state.lastStartedIncarnation[terminalID] = UUID()
+
+        state.removeDeletedTerminalFromState(
+            terminalID: terminalID, worktreeID: worktreeID)
+
+        #expect(state.composerDrafts[terminalID] == nil)
+        #expect(state.composerFocusTargets[terminalID] == nil)
+        #expect(state.transcriptFocusTargets[terminalID] == nil)
+        #expect(state.lastStartedIncarnation[terminalID] == nil)
+    }
+
+    /// A waiter on a terminal that stops existing is RESUMED false, never
+    /// dropped: it is a suspended continuation, and one nobody resumes hangs its
+    /// send for the life of the app instead of timing out.
+    @Test func removingADeletedTerminalFailsItsPendingSessionStartWait() async throws {
+        let (state, suiteName) = makeState()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+        let worktreeID = UUID(), terminalID = UUID()
+
+        let task = Task { @MainActor in
+            await state.awaitSessionStart(terminalID: terminalID, incarnationID: UUID())
+        }
+        try #require(await waiterRegistered(state, terminalID: terminalID))
+
+        state.removeDeletedTerminalFromState(
+            terminalID: terminalID, worktreeID: worktreeID)
+
+        #expect(await task.value == false)
+        #expect(state.sessionStartWaiters[terminalID] == nil)
+    }
+
+    /// The prune is scoped to the dead terminal. A live sibling's registrations
+    /// and latch survive.
+    @Test func forgettingOneTerminalLeavesAnothersRegistrationsAlone() {
+        let (state, suiteName) = makeState()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+        let dying = UUID(), surviving = UUID()
+        let dyingView = NSView(), survivingView = NSView()
+        state.registerComposerView(dyingView, for: dying)
+        state.registerComposerView(survivingView, for: surviving)
+        state.registerTranscriptView(survivingView, for: surviving)
+        let incarnation = UUID()
+        state.lastStartedIncarnation[surviving] = incarnation
+
+        state.forgetComposerState(for: dying)
+
+        #expect(state.composerFocusTargets[dying] == nil)
+        #expect(state.composerFocusTargets[surviving]?.view === survivingView)
+        #expect(state.transcriptFocusTargets[surviving]?.view === survivingView)
+        #expect(state.lastStartedIncarnation[surviving] == incarnation)
     }
 
     /// The discard is scoped to the closed tab's own terminals. A sibling tab's

--- a/Tests/TBDAppTests/ComposerMountingTests.swift
+++ b/Tests/TBDAppTests/ComposerMountingTests.swift
@@ -305,4 +305,210 @@ struct ComposerMountingTests {
         }
         #expect(message.contains("session gone"))
     }
+
+    // MARK: - The mount decision
+
+    private func terminal(
+        worktreeID: UUID,
+        id: UUID = UUID(),
+        kind: TerminalKind? = .claude,
+        hibernatedAt: Date? = nil
+    ) -> Terminal {
+        Terminal(
+            id: id, worktreeID: worktreeID, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            kind: kind, hibernatedAt: hibernatedAt,
+            hibernateReason: hibernatedAt == nil ? nil : .manual)
+    }
+
+    private func worktree(id: UUID = UUID(), remote: Bool = false) -> Worktree {
+        let location: WorktreeLocation =
+            remote ? .remote(provider: "test", sessionID: "s1") : .local
+        return Worktree(
+            id: id, repoID: UUID(), name: "wt", displayName: "WT", branch: "main",
+            path: location.storagePath ?? "/tmp/wt", status: .active,
+            tmuxServer: "test-server", location: location)
+    }
+
+    private func mount(
+        terminal: Terminal?, worktree: Worktree?, enabled: Bool = true
+    ) -> TableTranscriptPaneView.ComposerMount? {
+        TableTranscriptPaneView.composerMount(
+            terminal: terminal, worktree: worktree, composerEnabled: enabled)
+    }
+
+    /// **The flag-off branch.** With the daemon capability off the pane renders
+    /// exactly as it did before: no composer is built at all, so
+    /// `MessageComposerView` — which reads `AppState` non-optionally from the
+    /// environment — is never evaluated.
+    @Test func theFlagOffMountsNoComposer() {
+        let wt = worktree()
+        #expect(mount(terminal: terminal(worktreeID: wt.id), worktree: wt, enabled: false) == nil)
+    }
+
+    /// **The flag-on branch.** A live Claude terminal on a local worktree gets a
+    /// running composer, and the mount carries the `LocalWorktree` the view's
+    /// initializer takes.
+    @Test func aLiveClaudeTerminalOnALocalWorktreeMounts() throws {
+        let wt = worktree()
+        let decision = try #require(mount(terminal: terminal(worktreeID: wt.id), worktree: wt))
+        #expect(decision.state == .running)
+        #expect(decision.worktree.id == wt.id)
+    }
+
+    /// A remote worktree has no composer, and it cannot even produce the
+    /// `LocalWorktree` the view requires — the two facts agree.
+    @Test func aRemoteWorktreeMountsNoComposer() {
+        let wt = worktree(remote: true)
+        #expect(mount(terminal: terminal(worktreeID: wt.id), worktree: wt) == nil)
+    }
+
+    @Test func aNonClaudeTerminalMountsNoComposer() {
+        let wt = worktree()
+        #expect(mount(terminal: terminal(worktreeID: wt.id, kind: .codex), worktree: wt) == nil)
+        #expect(mount(terminal: terminal(worktreeID: wt.id, kind: .shell), worktree: wt) == nil)
+        #expect(mount(terminal: terminal(worktreeID: wt.id, kind: nil), worktree: wt) == nil)
+    }
+
+    /// The pane can render before either row is cached — the transcript comes
+    /// from the daemon, the rows from their own RPCs — so both absences are
+    /// real states rather than impossible ones.
+    @Test func aMissingRowMountsNoComposer() {
+        let wt = worktree()
+        #expect(mount(terminal: nil, worktree: wt) == nil)
+        #expect(mount(terminal: terminal(worktreeID: wt.id), worktree: nil) == nil)
+    }
+
+    /// A parked session still gets a composer: sending resumes it. This is the
+    /// case a `state != .hidden` gate must keep and an `isEnabled` gate would
+    /// have dropped.
+    @Test func aHibernatedClaudeTerminalStillMounts() throws {
+        let wt = worktree()
+        let decision = try #require(mount(
+            terminal: terminal(worktreeID: wt.id, hibernatedAt: Date()), worktree: wt))
+        #expect(decision.state == .notRunning(exited: false))
+    }
+
+    // MARK: - The transcript as a focus target
+
+    @Test func transcriptRegistrationIsKeyedByTerminal() {
+        let (state, suiteName) = makeState()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+        let id = UUID()
+        let table = NSTableView()
+
+        state.registerTranscriptView(table, for: id)
+        #expect(state.transcriptFocusTargets[id]?.view === table)
+
+        state.unregisterTranscriptView(table, for: id)
+        #expect(state.transcriptFocusTargets[id] == nil)
+    }
+
+    /// Same newer-wins rule as the composer registry, and for the same reason:
+    /// a session rollover rebuilds the table while the old one is still
+    /// deallocating.
+    @Test func aStaleTranscriptUnregisterDoesNotEvictTheLiveView() {
+        let (state, suiteName) = makeState()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+        let id = UUID()
+        let old = NSTableView(), new = NSTableView()
+
+        state.registerTranscriptView(old, for: id)
+        state.registerTranscriptView(new, for: id)
+        state.unregisterTranscriptView(old, for: id)
+
+        #expect(state.transcriptFocusTargets[id]?.view === new)
+    }
+
+    /// **Escape's destination.** With a transcript table registered,
+    /// `focusTranscript` moves AppKit's first responder onto it rather than
+    /// taking the resign-first-responder fallback the earlier test pins.
+    @Test func focusTranscriptMakesTheRegisteredTableFirstResponder() {
+        let (state, suiteName) = makeState()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+        _ = NSApplication.shared
+        let id = UUID()
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 240),
+            styleMask: [.titled], backing: .buffered, defer: true)
+        // A column-less NSTableView refuses first responder outright, so the
+        // fixture has to be shaped like the real one — `TableTranscriptView`
+        // adds exactly one column before the table is ever shown.
+        let table = NSTableView(frame: window.contentLayoutRect)
+        table.addTableColumn(NSTableColumn(identifier: NSUserInterfaceItemIdentifier("c")))
+        window.contentView?.addSubview(table)
+        state.registerTranscriptView(table, for: id)
+
+        state.focusTranscript(terminalID: id)
+
+        #expect(
+            window.firstResponder === table,
+            "focus went to \(String(describing: window.firstResponder)) instead")
+    }
+
+    // MARK: - Which terminal the menu commands act on
+
+    private func liveTranscriptTab(terminalID: UUID) -> TBDShared.Tab {
+        let tabID = UUID()
+        return TBDShared.Tab(
+            id: tabID,
+            content: .liveTranscript(id: tabID, terminalID: terminalID),
+            label: "Transcript")
+    }
+
+    /// Cmd+/ needs a terminal, and the focused tab names it — including for a
+    /// `.liveTranscript` tab, whose terminal the layout enumeration alone does
+    /// not report.
+    @Test func theComposerCommandNamesTheFocusedTabsTerminal() {
+        let (state, suiteName) = makeState()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+        let worktreeID = UUID(), terminalID = UUID()
+        let tab = liveTranscriptTab(terminalID: terminalID)
+        state.tabs[worktreeID] = [tab]
+        state.focusedTabCloseContext = TabCloseContext(worktreeID: worktreeID, tabID: tab.id)
+
+        #expect(state.composerCommandTerminalID == terminalID)
+    }
+
+    /// Nothing focused, nothing to act on — the menu items disable rather than
+    /// guessing at a terminal.
+    @Test func withNoFocusedTabTheComposerCommandNamesNothing() {
+        let (state, suiteName) = makeState()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+
+        #expect(state.composerCommandTerminalID == nil)
+    }
+
+    // MARK: - A closed tab takes its draft with it
+
+    @Test func closingATabDiscardsItsComposerDraft() {
+        let (state, suiteName) = makeState()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+        let worktreeID = UUID(), terminalID = UUID()
+        let tab = liveTranscriptTab(terminalID: terminalID)
+        state.tabs[worktreeID] = [tab]
+        state.composerDraft(for: terminalID).text = "half a sentence"
+
+        state.closeTab(worktreeID: worktreeID, index: 0)
+
+        #expect(state.composerDrafts[terminalID] == nil)
+    }
+
+    /// The discard is scoped to the closed tab's own terminals. A sibling tab's
+    /// half-written message survives.
+    @Test func closingATabLeavesAnotherTabsDraftAlone() {
+        let (state, suiteName) = makeState()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+        let worktreeID = UUID(), closing = UUID(), surviving = UUID()
+        state.tabs[worktreeID] = [
+            liveTranscriptTab(terminalID: closing),
+            liveTranscriptTab(terminalID: surviving)
+        ]
+        state.composerDraft(for: closing).text = "going away"
+        state.composerDraft(for: surviving).text = "staying"
+
+        state.closeTab(worktreeID: worktreeID, index: 0)
+
+        #expect(state.composerDrafts[closing] == nil)
+        #expect(state.composerDrafts[surviving]?.text == "staying")
+    }
 }

--- a/Tests/TBDAppTests/ComposerMountingTests.swift
+++ b/Tests/TBDAppTests/ComposerMountingTests.swift
@@ -1,0 +1,202 @@
+import AppKit
+import Foundation
+import Testing
+@testable import TBDApp
+import TBDShared
+
+/// The composer's registration and focus plumbing — the parts of mounting that
+/// are not layout.
+///
+/// The registry is the `TerminalFocusTarget` shape: a weak reference keyed by
+/// terminal, so a torn-down pane cannot keep a view alive and a stale entry
+/// cannot steal focus from a live one.
+@MainActor
+@Suite("composer mounting")
+struct ComposerMountingTests {
+
+    private func makeState() -> (AppState, String) {
+        let suiteName = "ComposerMountingTests-\(UUID().uuidString)"
+        return (AppState(userDefaults: UserDefaults(suiteName: suiteName)!), suiteName)
+    }
+
+    @Test func registrationIsKeyedByTerminal() {
+        let (state, suiteName) = makeState()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+        let id = UUID()
+        let view = NSView()
+
+        state.registerComposerView(view, for: id)
+        #expect(state.composerFocusTargets[id]?.view === view)
+
+        state.unregisterComposerView(view, for: id)
+        #expect(state.composerFocusTargets[id] == nil)
+    }
+
+    /// A LATER registration wins, and an earlier view's teardown must not
+    /// unregister it — the pane can be rebuilt while the old view is still
+    /// deallocating.
+    @Test func aStaleUnregisterDoesNotEvictTheLiveView() {
+        let (state, suiteName) = makeState()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+        let id = UUID()
+        let old = NSView(), new = NSView()
+
+        state.registerComposerView(old, for: id)
+        state.registerComposerView(new, for: id)
+        state.unregisterComposerView(old, for: id)
+
+        #expect(state.composerFocusTargets[id]?.view === new)
+    }
+
+    /// Unregistering a terminal that never registered is a no-op, not a crash:
+    /// the composer's `onDisappear` runs for a view whose registration a later
+    /// pane may already have replaced, or that never happened at all.
+    @Test func unregisteringSomethingNeverRegisteredIsANoOp() {
+        let (state, suiteName) = makeState()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+
+        state.unregisterComposerView(NSView(), for: UUID())
+        #expect(state.composerFocusTargets.isEmpty)
+    }
+
+    /// The reference is weak: a pane that went away leaves no view behind.
+    @Test func theRegistryHoldsTheViewWeakly() {
+        let (state, suiteName) = makeState()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+        let id = UUID()
+        do {
+            let view = NSView()
+            state.registerComposerView(view, for: id)
+            #expect(state.composerFocusTargets[id]?.view != nil)
+        }
+        #expect(state.composerFocusTargets[id]?.view == nil)
+    }
+
+    /// Focusing a terminal with no registered composer is a no-op, not a crash —
+    /// Cmd+/ can be pressed with the transcript pane closed.
+    @Test func focusingAnUnregisteredComposerIsANoOp() {
+        let (state, suiteName) = makeState()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+
+        state.focusComposer(terminalID: UUID())
+        #expect(state.composerFocusTargets.isEmpty)
+    }
+
+    // MARK: - The sending hold's release condition
+
+    /// The composer's own spawn reports in, and the hold releases.
+    @Test func aMatchingIncarnationReleasesTheHold() async throws {
+        let (state, suiteName) = makeState()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+        let terminalID = UUID()
+        let incarnation = UUID()
+
+        async let started = state.awaitSessionStart(
+            terminalID: terminalID, incarnationID: incarnation)
+        await Task.yield()  // let the waiter register
+        state.noteSessionStart(terminalID: terminalID, incarnationID: incarnation)
+        #expect(await started)
+        #expect(state.sessionStartWaiters[terminalID] == nil, "a released waiter is removed")
+    }
+
+    /// **The load-bearing negative.** Another spawn's SessionStart on the same
+    /// terminal — a competing wake, a recapture, a person typing
+    /// `claude --resume` in the pane — leaves the hold held.
+    @Test func anotherIncarnationDoesNotRelease() async throws {
+        let (state, suiteName) = makeState()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+        let terminalID = UUID()
+        let mine = UUID()
+
+        let task = Task { @MainActor in
+            await state.awaitSessionStart(terminalID: terminalID, incarnationID: mine)
+        }
+        await Task.yield()
+        state.noteSessionStart(terminalID: terminalID, incarnationID: UUID())
+        #expect(state.sessionStartWaiters[terminalID]?.count == 1, "still waiting")
+
+        // Cancellation is the only other way out, and it must answer false
+        // rather than hang — the coordinator's task group awaits this child.
+        task.cancel()
+        #expect(await task.value == false)
+    }
+
+    /// A SessionStart carrying NO incarnation releases nobody. A worktree's
+    /// first spawn and an archive restore both produce one.
+    @Test func anIncarnationlessSessionStartReleasesNobody() async throws {
+        let (state, suiteName) = makeState()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+        let terminalID = UUID()
+        let mine = UUID()
+
+        let task = Task { @MainActor in
+            await state.awaitSessionStart(terminalID: terminalID, incarnationID: mine)
+        }
+        await Task.yield()
+        state.noteSessionStart(terminalID: terminalID, incarnationID: nil)
+        #expect(state.sessionStartWaiters[terminalID]?.count == 1)
+        task.cancel()
+        #expect(await task.value == false)
+    }
+
+    /// Another terminal's SessionStart is not this terminal's business.
+    @Test func anotherTerminalsSessionStartReleasesNobody() async throws {
+        let (state, suiteName) = makeState()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+        let mine = UUID(), incarnation = UUID()
+
+        let task = Task { @MainActor in
+            await state.awaitSessionStart(terminalID: mine, incarnationID: incarnation)
+        }
+        await Task.yield()
+        state.noteSessionStart(terminalID: UUID(), incarnationID: incarnation)
+        #expect(state.sessionStartWaiters[mine]?.count == 1)
+        task.cancel()
+        #expect(await task.value == false)
+    }
+
+    // MARK: - What the wake reports
+
+    private func stateWakingWith(
+        _ result: Result<TerminalWakeResult, any Error>
+    ) -> (AppState, String) {
+        let (state, suiteName) = makeState()
+        state.composerWakeSender = { _, _, _, _ in try result.get() }
+        return (state, suiteName)
+    }
+
+    @Test func aWokenWakeReportsItsIncarnation() async throws {
+        let incarnation = UUID()
+        let (state, suiteName) = stateWakingWith(
+            .success(TerminalWakeResult(woken: true, sessionIncarnationID: incarnation)))
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+
+        let reply = await state.wakeTerminalForComposer(
+            terminalID: UUID(), worktreeID: UUID(), prompt: "hi")
+        #expect(reply == .woken(incarnationID: incarnation))
+    }
+
+    /// `woken: false` is a no-op, never a success: the prompt went nowhere.
+    @Test func aNoOpWakeIsReportedAsSuch() async throws {
+        let (state, suiteName) = stateWakingWith(.success(TerminalWakeResult(woken: false)))
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+
+        let reply = await state.wakeTerminalForComposer(
+            terminalID: UUID(), worktreeID: UUID(), prompt: "hi")
+        #expect(reply == .noOp)
+    }
+
+    @Test func aFailedWakeCarriesItsMessage() async throws {
+        let (state, suiteName) = stateWakingWith(
+            .failure(DaemonClientError.rpcError("session gone", code: nil)))
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+
+        let reply = await state.wakeTerminalForComposer(
+            terminalID: UUID(), worktreeID: UUID(), prompt: "hi")
+        guard case .failed(let message) = reply else {
+            Issue.record("expected a failure, got \(reply)")
+            return
+        }
+        #expect(message.contains("session gone"))
+    }
+}

--- a/Tests/TBDAppTests/ComposerMountingTests.swift
+++ b/Tests/TBDAppTests/ComposerMountingTests.swift
@@ -19,6 +19,26 @@ struct ComposerMountingTests {
         return (AppState(userDefaults: UserDefaults(suiteName: suiteName)!), suiteName)
     }
 
+    /// Polls for a registered waiter instead of trusting a single
+    /// `Task.yield()` to have been enough hops for the child task below to
+    /// reach its registration point. A single yield that happens not to be
+    /// enough doesn't redden these tests — it silently produces the same
+    /// `false` outcome a *real* regression would (the `noteSessionStart` call
+    /// below finds nothing to release, cancellation resolves the waiter
+    /// `false`), so a registration bug and a passing test look identical.
+    /// Bounding the poll and `#require`-ing it caught means a registration
+    /// failure fails fast and says so, rather than either hanging or passing
+    /// for the wrong reason.
+    private func waiterRegistered(
+        _ state: AppState, terminalID: UUID, maxYields: Int = 1000
+    ) async -> Bool {
+        for _ in 0..<maxYields {
+            if state.sessionStartWaiters[terminalID] != nil { return true }
+            await Task.yield()
+        }
+        return false
+    }
+
     @Test func registrationIsKeyedByTerminal() {
         let (state, suiteName) = makeState()
         defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
@@ -82,6 +102,48 @@ struct ComposerMountingTests {
         #expect(state.composerFocusTargets.isEmpty)
     }
 
+    /// `focusTranscript`'s fallback branch: no transcript table has registered
+    /// for this terminal (Task 13 hasn't wired one in yet), so it resigns first
+    /// responder instead of crashing on a nil lookup. A composer view with no
+    /// window makes `view.window?.makeFirstResponder(nil)` a no-op through the
+    /// optional chain, so the discriminating check is that the composer's own
+    /// registration survives the call untouched.
+    @Test func focusTranscriptFallsBackToResigningFirstResponderWhenNoneIsRegistered() {
+        let (state, suiteName) = makeState()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+        let id = UUID()
+        let composerView = NSView()
+        state.registerComposerView(composerView, for: id)
+
+        state.focusTranscript(terminalID: id)
+
+        #expect(state.composerFocusTargets[id]?.view === composerView)
+    }
+
+    /// The Reveal Terminal action moves AppKit's first responder to the
+    /// registered terminal view — the observable effect `revealTerminal`
+    /// actually mutates (it touches no `AppState` property; the registry read
+    /// is the only state involved).
+    @Test func revealTerminalMakesTheTerminalViewFirstResponder() {
+        let (state, suiteName) = makeState()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+        _ = NSApplication.shared
+        let id = UUID()
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 240),
+            styleMask: [.titled], backing: .buffered, defer: true)
+        let view = TBDTerminalView(
+            frame: window.contentLayoutRect,
+            font: TBDTerminalView.defaultMonospaceFont,
+            appearance: AppearanceSettings(defaults: UserDefaults(suiteName: suiteName)!))
+        window.contentView?.addSubview(view)
+        state.registerTerminalView(view, for: id)
+
+        state.revealTerminal(terminalID: id)
+
+        #expect(window.firstResponder === view)
+    }
+
     // MARK: - The sending hold's release condition
 
     /// The composer's own spawn reports in, and the hold releases.
@@ -93,10 +155,54 @@ struct ComposerMountingTests {
 
         async let started = state.awaitSessionStart(
             terminalID: terminalID, incarnationID: incarnation)
-        await Task.yield()  // let the waiter register
+        try #require(await waiterRegistered(state, terminalID: terminalID))
         state.noteSessionStart(terminalID: terminalID, incarnationID: incarnation)
         #expect(await started)
         #expect(state.sessionStartWaiters[terminalID] == nil, "a released waiter is removed")
+    }
+
+    /// **The other half of the fix.** `wakeTerminalForComposer` mints its
+    /// incarnation and returns before the daemon's refresh round trip
+    /// completes, so a `SessionStart` can be accepted before the caller ever
+    /// calls `awaitSessionStart`. Without a latch, that start reaches
+    /// `noteSessionStart` with no waiter registered and is dropped — the
+    /// later `awaitSessionStart` call then waits to its timeout for a start
+    /// that already happened. `noteSessionStart` latches the incarnation
+    /// regardless of whether anyone is waiting, and `awaitSessionStart`
+    /// checks that latch before registering.
+    @Test func aSessionStartBeforeTheWaiterStillReleases() async throws {
+        let (state, suiteName) = makeState()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+        let terminalID = UUID()
+        let incarnation = UUID()
+
+        state.noteSessionStart(terminalID: terminalID, incarnationID: incarnation)
+        let started = await state.awaitSessionStart(
+            terminalID: terminalID, incarnationID: incarnation)
+
+        #expect(started)
+        #expect(state.sessionStartWaiters[terminalID] == nil, "no waiter was ever registered")
+    }
+
+    /// **The negative pair.** A latch holding a DIFFERENT incarnation must not
+    /// short-circuit a later waiter for this one — the latch is scoped by
+    /// exact incarnation, not "something started recently".
+    @Test func aLatchedDifferentIncarnationDoesNotReleaseALaterWaiter() async throws {
+        let (state, suiteName) = makeState()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+        let terminalID = UUID()
+        let mine = UUID()
+
+        state.noteSessionStart(terminalID: terminalID, incarnationID: UUID())
+
+        let task = Task { @MainActor in
+            await state.awaitSessionStart(terminalID: terminalID, incarnationID: mine)
+        }
+        try #require(await waiterRegistered(state, terminalID: terminalID))
+        #expect(state.sessionStartWaiters[terminalID]?.count == 1, "still waiting")
+
+        task.cancel()
+        #expect(await task.value == false)
     }
 
     /// **The load-bearing negative.** Another spawn's SessionStart on the same
@@ -111,7 +217,7 @@ struct ComposerMountingTests {
         let task = Task { @MainActor in
             await state.awaitSessionStart(terminalID: terminalID, incarnationID: mine)
         }
-        await Task.yield()
+        try #require(await waiterRegistered(state, terminalID: terminalID))
         state.noteSessionStart(terminalID: terminalID, incarnationID: UUID())
         #expect(state.sessionStartWaiters[terminalID]?.count == 1, "still waiting")
 
@@ -132,7 +238,7 @@ struct ComposerMountingTests {
         let task = Task { @MainActor in
             await state.awaitSessionStart(terminalID: terminalID, incarnationID: mine)
         }
-        await Task.yield()
+        try #require(await waiterRegistered(state, terminalID: terminalID))
         state.noteSessionStart(terminalID: terminalID, incarnationID: nil)
         #expect(state.sessionStartWaiters[terminalID]?.count == 1)
         task.cancel()
@@ -148,7 +254,7 @@ struct ComposerMountingTests {
         let task = Task { @MainActor in
             await state.awaitSessionStart(terminalID: mine, incarnationID: incarnation)
         }
-        await Task.yield()
+        try #require(await waiterRegistered(state, terminalID: mine))
         state.noteSessionStart(terminalID: UUID(), incarnationID: incarnation)
         #expect(state.sessionStartWaiters[mine]?.count == 1)
         task.cancel()

--- a/Tests/TBDAppTests/ComposerSendCoordinatorTests.swift
+++ b/Tests/TBDAppTests/ComposerSendCoordinatorTests.swift
@@ -1,0 +1,279 @@
+import Foundation
+import TestSupport
+import Testing
+@testable import TBDApp
+import TBDShared
+
+/// How a composed message leaves the app.
+///
+/// The two paths are genuinely different mechanisms — a paste into a live
+/// session, and an argv on a respawn — and the branch between them is a machine
+/// fact, not a guess. The hold-until-SessionStart is what makes the wake path
+/// honest: a wake whose session id no longer resolves makes Claude print one line
+/// and exit 1 with the prompt lost, while tmux reports the respawn as a success.
+@MainActor
+@Suite("ComposerSendCoordinator")
+struct ComposerSendCoordinatorTests {
+
+    private static let mintedIncarnation = UUID()
+
+    /// Main-actor isolated, and so `Sendable`: the coordinator's closure
+    /// typealiases are `@Sendable`, which is what keeps a child of its task
+    /// group from capturing state nobody has serialized.
+    @MainActor
+    private final class Recorder {
+        var params: [TerminalSendParams] = []
+        var wakePrompts: [String] = []
+        /// The (terminal, incarnation) pairs the hold actually waited on.
+        var waitedOn: [(UUID, UUID)] = []
+    }
+
+    private func makeCoordinator(
+        recorder: Recorder,
+        sendFails: Bool = false,
+        wakeReply: ComposerSendCoordinator.WakeReply
+            = .woken(incarnationID: ComposerSendCoordinatorTests.mintedIncarnation),
+        /// Which incarnation the terminal's own SessionStart eventually carries.
+        /// nil means none ever arrives.
+        sessionStartCarries: UUID? = ComposerSendCoordinatorTests.mintedIncarnation,
+        clock: any Clock<Duration> = ContinuousClock()
+    ) -> ComposerSendCoordinator {
+        ComposerSendCoordinator(
+            send: { params in
+                recorder.params.append(params)
+                if sendFails { throw DaemonClientError.rpcError("nope", code: nil) }
+            },
+            wake: { _, _, prompt in
+                recorder.wakePrompts.append(prompt)
+                return wakeReply
+            },
+            awaitSessionStart: { terminalID, incarnationID in
+                recorder.waitedOn.append((terminalID, incarnationID))
+                // The production waiter resolves only on a matching id; the
+                // double models exactly that rather than answering a bare Bool.
+                return sessionStartCarries == incarnationID
+            },
+            clock: clock)
+    }
+
+    // MARK: - Running
+
+    @Test func aRunningSendCarriesPartsSuppressionAndTheGate() async throws {
+        let recorder = Recorder()
+        let outcome = await makeCoordinator(recorder: recorder).send(
+            text: "look at \(ComposerTokens.text(for: 1)) please",
+            paths: [1: "/tmp/a.png"],
+            state: .running, terminalID: UUID(), worktreeID: UUID())
+
+        #expect(outcome == .sent)
+        let params = try #require(recorder.params.first)
+        #expect(params.parts == [
+            .text("look at "), .imagePath("/tmp/a.png"), .text(" please"),
+        ])
+        #expect(params.envelope == .suppressed)
+        #expect(params.gateOnAwaitingInput == true)
+        #expect(params.submit == true)
+        // The composer never uses the keys path and never asks for verification.
+        #expect(params.keys == nil)
+        #expect(params.verify == nil)
+        #expect(params.text == nil)
+    }
+
+    @Test func aFailedSendReportsItAndDoesNotClaimDelivery() async throws {
+        let recorder = Recorder()
+        let outcome = await makeCoordinator(recorder: recorder, sendFails: true).send(
+            text: "hi", paths: [:], state: .running,
+            terminalID: UUID(), worktreeID: UUID())
+        guard case .failed = outcome else {
+            Issue.record("expected a failure, got \(outcome)")
+            return
+        }
+    }
+
+    // MARK: - Not running
+
+    /// An argument prompt cannot carry attachments, so each token is replaced
+    /// inline with its quoted path and Claude reads the files with its Read tool.
+    @Test func aNotRunningSendWakesWithTheFlattenedText() async throws {
+        let recorder = Recorder()
+        let terminalID = UUID()
+        let outcome = await makeCoordinator(recorder: recorder).send(
+            text: "look at \(ComposerTokens.text(for: 1)) please",
+            paths: [1: "/tmp/a.png"],
+            state: .notRunning(exited: true), terminalID: terminalID, worktreeID: UUID())
+
+        #expect(outcome == .woke)
+        #expect(recorder.wakePrompts == ["look at '/tmp/a.png' please"])
+        #expect(recorder.params.isEmpty, "a not-running send must never call terminal.send")
+        // The hold waited on THIS wake's own spawn, not on the terminal at large.
+        #expect(recorder.waitedOn.count == 1)
+        #expect(recorder.waitedOn.first?.0 == terminalID)
+        #expect(recorder.waitedOn.first?.1 == Self.mintedIncarnation)
+    }
+
+    /// **The hold.** The composer's own session never reports in, so the text
+    /// comes back editable with an error line rather than vanishing into a
+    /// session that exited 1 while tmux called the respawn a success.
+    @Test func aWakeWhoseSessionNeverStartsFails() async throws {
+        let recorder = Recorder()
+        let outcome = await makeCoordinator(
+            recorder: recorder, sessionStartCarries: nil).send(
+            text: "hi", paths: [:], state: .notRunning(exited: true),
+            terminalID: UUID(), worktreeID: UUID())
+
+        guard case .failed(let message) = outcome else {
+            Issue.record("expected a failure, got \(outcome)")
+            return
+        }
+        #expect(message.contains("did not report"))
+    }
+
+    /// **The load-bearing negative for the whole incarnation scoping.** A
+    /// SessionStart arrives on this terminal, and it belongs to somebody else's
+    /// spawn — a competing wake, a post-`--fork-session` recapture, a person
+    /// typing `claude --resume` in the pane. It must NOT release the hold.
+    @Test func aSessionStartFromAnotherIncarnationDoesNotRelease() async throws {
+        let recorder = Recorder()
+        let outcome = await makeCoordinator(
+            recorder: recorder, sessionStartCarries: UUID()).send(
+            text: "hi", paths: [:], state: .notRunning(exited: true),
+            terminalID: UUID(), worktreeID: UUID())
+
+        guard case .failed = outcome else {
+            Issue.record("another spawn's SessionStart must not release the hold")
+            return
+        }
+    }
+
+    /// `woken: false` is an idempotent no-op: the prompt was never delivered
+    /// anywhere, there is no spawn to wait on, and the hold is never entered.
+    @Test func aNoOpWakeSurfacesWithoutEnteringTheHold() async throws {
+        let recorder = Recorder()
+        let outcome = await makeCoordinator(recorder: recorder, wakeReply: .noOp).send(
+            text: "hi", paths: [:], state: .notRunning(exited: false),
+            terminalID: UUID(), worktreeID: UUID())
+
+        guard case .failed = outcome else {
+            Issue.record("expected a failure, got \(outcome)")
+            return
+        }
+        #expect(recorder.waitedOn.isEmpty, "a no-op names no spawn to wait on")
+    }
+
+    /// The session-gone error surfaces too, and also without entering the hold.
+    /// The wake RPC distinguishes the two and the app must swallow neither.
+    @Test func aRefusedWakeSurfacesItsMessage() async throws {
+        let recorder = Recorder()
+        let outcome = await makeCoordinator(
+            recorder: recorder, wakeReply: .failed(message: "session gone")).send(
+            text: "hi", paths: [:], state: .notRunning(exited: false),
+            terminalID: UUID(), worktreeID: UUID())
+
+        guard case .failed(let message) = outcome else {
+            Issue.record("expected a failure, got \(outcome)")
+            return
+        }
+        #expect(message.contains("session gone"))
+        #expect(recorder.waitedOn.isEmpty)
+    }
+
+    /// A daemon too old to report an incarnation woke the session and delivered
+    /// the prompt — it just cannot name the spawn. Holding until the timeout
+    /// would show an error for a message that landed, so this reports success
+    /// and does not wait.
+    @Test func aWokenWakeWithNoIncarnationDoesNotHold() async throws {
+        let recorder = Recorder()
+        let outcome = await makeCoordinator(
+            recorder: recorder, wakeReply: .woken(incarnationID: nil),
+            sessionStartCarries: nil).send(
+            text: "hi", paths: [:], state: .notRunning(exited: true),
+            terminalID: UUID(), worktreeID: UUID())
+
+        #expect(outcome == .woke)
+        #expect(recorder.waitedOn.isEmpty)
+    }
+
+    /// The hold's deadline is the **injected** clock's, never wall time. A
+    /// waiter that simply never answers is released by advancing virtual time
+    /// past the timeout — which is the only way a 45-second bound is testable
+    /// at all, and the reason the coordinator takes a clock.
+    @Test func theHoldTimesOutOnTheInjectedClock() async throws {
+        let recorder = Recorder()
+        let clock = EventDrivenTestClock()
+        let coordinator = ComposerSendCoordinator(
+            send: { recorder.params.append($0) },
+            wake: { _, _, prompt in
+                recorder.wakePrompts.append(prompt)
+                return .woken(incarnationID: Self.mintedIncarnation)
+            },
+            awaitSessionStart: { terminalID, incarnationID in
+                recorder.waitedOn.append((terminalID, incarnationID))
+                // Never answers on its own. Only the clock can end this send.
+                while !Task.isCancelled { await Task.yield() }
+                return false
+            },
+            clock: clock)
+
+        async let outcome = coordinator.send(
+            text: "hi", paths: [:], state: .notRunning(exited: true),
+            terminalID: UUID(), worktreeID: UUID())
+
+        try await clock.requireAdvanceWhenArmed(by: ComposerSendCoordinator.wakeHoldTimeout)
+
+        guard case .failed(let message) = await outcome else {
+            Issue.record("the hold must expire on the injected clock")
+            return
+        }
+        #expect(message.contains("did not report"))
+        #expect(recorder.waitedOn.count == 1)
+    }
+
+    // MARK: - Refusals
+
+    @Test func aBlockedComposerSendsNothing() async throws {
+        let recorder = Recorder()
+        let outcome = await makeCoordinator(recorder: recorder).send(
+            text: "hi", paths: [:], state: .blocked(message: "Allow?"),
+            terminalID: UUID(), worktreeID: UUID())
+
+        guard case .failed = outcome else {
+            Issue.record("expected a failure, got \(outcome)")
+            return
+        }
+        #expect(recorder.params.isEmpty)
+        #expect(recorder.wakePrompts.isEmpty)
+    }
+
+    /// A composer that is not on screen at all cannot have been asked to send —
+    /// but the coordinator answers for the state anyway rather than assuming.
+    @Test func aHiddenComposerSendsNothing() async throws {
+        let recorder = Recorder()
+        let outcome = await makeCoordinator(recorder: recorder).send(
+            text: "hi", paths: [:], state: .hidden,
+            terminalID: UUID(), worktreeID: UUID())
+
+        guard case .failed = outcome else {
+            Issue.record("expected a failure, got \(outcome)")
+            return
+        }
+        #expect(recorder.params.isEmpty)
+        #expect(recorder.wakePrompts.isEmpty)
+    }
+
+    @Test func blankTextSendsNothing() async throws {
+        let recorder = Recorder()
+        _ = await makeCoordinator(recorder: recorder).send(
+            text: "   \n ", paths: [:], state: .running,
+            terminalID: UUID(), worktreeID: UUID())
+        #expect(recorder.params.isEmpty)
+    }
+
+    /// A message that is nothing but an image token is still a message.
+    @Test func aTokenOnlyMessageIsNotBlank() async throws {
+        let recorder = Recorder()
+        _ = await makeCoordinator(recorder: recorder).send(
+            text: ComposerTokens.text(for: 1), paths: [1: "/tmp/a.png"],
+            state: .running, terminalID: UUID(), worktreeID: UUID())
+        #expect(recorder.params.first?.parts == [.imagePath("/tmp/a.png")])
+    }
+}

--- a/Tests/TBDAppTests/ComposerSendCoordinatorTests.swift
+++ b/Tests/TBDAppTests/ComposerSendCoordinatorTests.swift
@@ -197,7 +197,7 @@ struct ComposerSendCoordinatorTests {
     /// waiter that simply never answers is released by advancing virtual time
     /// past the timeout — which is the only way a 45-second bound is testable
     /// at all, and the reason the coordinator takes a clock.
-    @Test func theHoldTimesOutOnTheInjectedClock() async throws {
+    @Test(.clockDriven) func theHoldTimesOutOnTheInjectedClock() async throws {
         let recorder = Recorder()
         let clock = EventDrivenTestClock()
         let coordinator = ComposerSendCoordinator(
@@ -229,7 +229,22 @@ struct ComposerSendCoordinatorTests {
             text: "hi", paths: [:], state: .notRunning(exited: true),
             terminalID: UUID(), worktreeID: UUID())
 
-        try await clock.requireAdvanceWhenArmed(by: ComposerSendCoordinator.wakeHoldTimeout)
+        // **Wait for the sleeper, then advance — on the fast pass's budget, not
+        // on the handshake's.** Three things have to happen before the timeout
+        // child registers anything: the `async let` child has to get a thread,
+        // `send` has to run its `wake` double and reach the task group *on the
+        // main actor* — a process-wide serialization point every other
+        // `@MainActor` test in the pass queues on — and the group's timeout child
+        // has to get a thread of its own. None of that is the coordinator being
+        // slow, so the bound belongs to `TestDeadlines.saturatedPass` (90 s): the
+        // clock's 45 s default sits *below* fast pass 2's measured p90 per-test
+        // latency (51.4 s, max 55.3 s), which is how this test came back red on
+        // CI while passing on an idle machine. Nothing in the doubles can hold
+        // the group back — the waiter double releases the main actor at its first
+        // suspension and the timeout child never touches it — so the wait only
+        // ever pays for scheduling.
+        try await clock.requireSleeperArmed(timeout: TestDeadlines.saturatedPass)
+        await clock.advance(by: ComposerSendCoordinator.wakeHoldTimeout)
 
         guard case .failed(let message) = await outcome else {
             Issue.record("the hold must expire on the injected clock")

--- a/Tests/TBDAppTests/ComposerSendCoordinatorTests.swift
+++ b/Tests/TBDAppTests/ComposerSendCoordinatorTests.swift
@@ -208,8 +208,19 @@ struct ComposerSendCoordinatorTests {
             },
             awaitSessionStart: { terminalID, incarnationID in
                 recorder.waitedOn.append((terminalID, incarnationID))
-                // Never answers on its own. Only the clock can end this send.
-                while !Task.isCancelled { await Task.yield() }
+                // Never answers on its own. Only the clock can end this send —
+                // and this parks until it does rather than spinning: a
+                // `Task.yield()` loop burns a core for the whole hold and, on a
+                // cooperative pool of one, can starve the very timer it is
+                // waiting for.
+                let (parked, release) = AsyncStream<Void>.makeStream()
+                await withTaskCancellationHandler {
+                    // Nothing is ever yielded into it; the loop ends when the
+                    // race cancels the loser and `finish()` closes the stream.
+                    for await _ in parked {}
+                } onCancel: {
+                    release.finish()
+                }
                 return false
             },
             clock: clock)
@@ -226,6 +237,39 @@ struct ComposerSendCoordinatorTests {
         }
         #expect(message.contains("did not report"))
         #expect(recorder.waitedOn.count == 1)
+    }
+
+    // MARK: - What the banner says
+
+    /// A refusal reaches the person in the daemon's own words. The error's
+    /// `localizedDescription` would prefix them with "RPC error: ", which names
+    /// a transport nobody typing into the composer has heard of.
+    @Test func aRefusalsMessageReachesTheBannerVerbatim() async throws {
+        let recorder = Recorder()
+        let outcome = await makeCoordinator(recorder: recorder, sendFails: true).send(
+            text: "hi", paths: [:], state: .running,
+            terminalID: UUID(), worktreeID: UUID())
+
+        #expect(outcome == .failed(message: "nope"))
+    }
+
+    private struct BoomError: LocalizedError {
+        var errorDescription: String? { "boom" }
+    }
+
+    /// The other branch: anything that is not an RPC refusal keeps its own
+    /// description. The unwrapping drops the daemon's framing, not the error.
+    @Test func aNonRPCFailureKeepsItsOwnDescription() async throws {
+        let coordinator = ComposerSendCoordinator(
+            send: { _ in throw BoomError() },
+            wake: { _, _, _ in .noOp },
+            awaitSessionStart: { _, _ in false })
+
+        let outcome = await coordinator.send(
+            text: "hi", paths: [:], state: .running,
+            terminalID: UUID(), worktreeID: UUID())
+
+        #expect(outcome == .failed(message: "boom"))
     }
 
     // MARK: - Refusals

--- a/Tests/TBDAppTests/ComposerSendCoordinatorTests.swift
+++ b/Tests/TBDAppTests/ComposerSendCoordinatorTests.swift
@@ -236,6 +236,16 @@ struct ComposerSendCoordinatorTests {
             return
         }
         #expect(message.contains("did not report"))
+        // **The sentence a person reads.** The bound is spelled in whole
+        // seconds — interpolating the `Duration` renders "45.0 seconds", which
+        // reads as a measurement — and the copy claims only what the app can
+        // know. The prompt left on the respawn's own argv, so a session that
+        // never reported in is one TBD heard nothing FROM, which is not the same
+        // as one that received nothing.
+        #expect(message.contains("45 seconds"))
+        #expect(!message.contains("45.0"))
+        #expect(message.contains("could not be confirmed"))
+        #expect(!message.lowercased().contains("was not delivered"))
         #expect(recorder.waitedOn.count == 1)
     }
 

--- a/Tests/TBDAppTests/ComposerStateTests.swift
+++ b/Tests/TBDAppTests/ComposerStateTests.swift
@@ -1,0 +1,124 @@
+import Foundation
+import Testing
+@testable import TBDApp
+import TBDShared
+
+/// The composer's four states, derived from `Terminal` columns and the
+/// worktree's location — never from anything rendered.
+///
+/// The `hidden` cases are the scope statement: Claude sessions on local
+/// worktrees, and nothing else.
+@Suite("ComposerState")
+struct ComposerStateTests {
+
+    private func terminal(
+        kind: TerminalKind? = .claude,
+        hibernatedAt: Date? = nil,
+        hibernateReason: HibernateReason? = nil,
+        awaitingInput: AwaitingInputReason? = nil
+    ) -> Terminal {
+        Terminal(
+            worktreeID: UUID(), tmuxWindowID: "@1", tmuxPaneID: "%1",
+            kind: kind, hibernatedAt: hibernatedAt, hibernateReason: hibernateReason,
+            awaitingInputReason: awaitingInput,
+            awaitingInputObservedAt: awaitingInput == nil ? nil : Date())
+    }
+
+    private func reason(_ type: String?, message: String = "Allow Bash(rm)?")
+        -> AwaitingInputReason {
+        AwaitingInputReason(
+            message: message, hookEventName: "Notification", notificationType: type)
+    }
+
+    private func resolve(
+        _ terminal: Terminal?, remote: Bool = false, enabled: Bool = true
+    ) -> ComposerState {
+        ComposerState.resolve(
+            terminal: terminal, isRemoteWorktree: remote, composerEnabled: enabled)
+    }
+
+    // MARK: - Hidden
+
+    /// The flag is the outermost gate: with it off the pane renders exactly as it
+    /// did before.
+    @Test func theFlagOffHidesIt() {
+        #expect(resolve(terminal(), enabled: false) == .hidden)
+    }
+
+    @Test func codexAndShellTerminalsHaveNone() {
+        #expect(resolve(terminal(kind: .codex)) == .hidden)
+        #expect(resolve(terminal(kind: .shell)) == .hidden)
+        #expect(resolve(terminal(kind: nil)) == .hidden)
+    }
+
+    @Test func aRemoteWorktreeHasNone() {
+        #expect(resolve(terminal(), remote: true) == .hidden)
+    }
+
+    @Test func noTerminalAtAllHasNone() {
+        #expect(resolve(nil) == .hidden)
+    }
+
+    // MARK: - Running
+
+    @Test func aLiveClaudeSessionIsRunning() {
+        #expect(resolve(terminal()) == .running)
+    }
+
+    /// Informational notifications and the idle prompt do not block: a subagent
+    /// finishing is not a question, and the idle prompt is the agent waiting for
+    /// exactly what the composer is about to send.
+    @Test func informationalStatesStayRunning() {
+        #expect(resolve(terminal(awaitingInput: reason("agent_completed"))) == .running)
+        #expect(resolve(terminal(awaitingInput: reason("idle_prompt"))) == .running)
+    }
+
+    // MARK: - Not running
+
+    @Test func aHibernatedSessionIsNotRunning() {
+        #expect(resolve(terminal(
+            hibernatedAt: Date(), hibernateReason: .manual)) == .notRunning(exited: false))
+    }
+
+    /// The exit stamp and a deliberate park are the same state with different
+    /// wording on the button — one wake path, one UI.
+    @Test func anExitedSessionIsNotRunningAndSaysSo() {
+        #expect(resolve(terminal(
+            hibernatedAt: Date(), hibernateReason: .exited)) == .notRunning(exited: true))
+    }
+
+    /// Not-running wins over a stale prompt: a parked session cannot be sitting
+    /// on a dialog, and offering "answer it in the terminal" would send the
+    /// person to a pane with a shell in it.
+    @Test func notRunningOutranksAStandingPrompt() {
+        #expect(resolve(terminal(
+            hibernatedAt: Date(), hibernateReason: .exited,
+            awaitingInput: reason("permission_prompt"))) == .notRunning(exited: true))
+    }
+
+    // MARK: - Blocked
+
+    @Test func aPromptOnScreenBlocksAndCarriesItsMessage() {
+        #expect(resolve(terminal(awaitingInput: reason("permission_prompt")))
+            == .blocked(message: "Allow Bash(rm)?"))
+    }
+
+    /// An unrecognized reason blocks too, for the same reason the daemon's gate
+    /// refuses on it: a newer Claude Code's new dialog type looks exactly like
+    /// this to this build.
+    @Test func anUnrecognizedReasonBlocks() {
+        #expect(resolve(terminal(awaitingInput: reason("brand_new_dialog")))
+            == .blocked(message: "Allow Bash(rm)?"))
+        #expect(resolve(terminal(awaitingInput: reason(nil)))
+            == .blocked(message: "Allow Bash(rm)?"))
+    }
+
+    // MARK: - Enablement
+
+    @Test func onlyBlockedAndHiddenAreDisabled() {
+        #expect(ComposerState.running.isEnabled)
+        #expect(ComposerState.notRunning(exited: true).isEnabled)
+        #expect(!ComposerState.blocked(message: "x").isEnabled)
+        #expect(!ComposerState.hidden.isEnabled)
+    }
+}

--- a/Tests/TBDAppTests/ComposerTokensTests.swift
+++ b/Tests/TBDAppTests/ComposerTokensTests.swift
@@ -1,0 +1,101 @@
+import Foundation
+import Testing
+@testable import TBDApp
+import TBDShared
+
+/// The inline `[Image #N]` token is the anchor: it decides WHETHER an image is
+/// sent and WHERE it sits among the words. A side map holds token → staged file;
+/// the text is what decides.
+///
+/// The deletion and edit cases are the ones that matter. A token the person
+/// removed must drop its image silently-but-visibly (the strip shows it
+/// detached), and a token they typed over must not still smuggle a file into the
+/// message.
+@Suite("ComposerTokens")
+struct ComposerTokensTests {
+
+    @Test func theTokenTextIsStable() {
+        #expect(ComposerTokens.text(for: 1) == "[Image #1]")
+        #expect(ComposerTokens.text(for: 12) == "[Image #12]")
+    }
+
+    @Test func scanFindsTokensInOrderWithTheirRanges() {
+        let text = "look at [Image #1] and [Image #2] please"
+        let tokens = ComposerTokens.scan(text)
+        #expect(tokens.map(\.number) == [1, 2])
+        let ns = text as NSString
+        #expect(ns.substring(with: tokens[0].range) == "[Image #1]")
+        #expect(ns.substring(with: tokens[1].range) == "[Image #2]")
+    }
+
+    @Test func splittingProducesTextAndImagePartsInOrder() {
+        let parts = ComposerTokens.parts(
+            text: "look at [Image #1] and tell me",
+            paths: [1: "/tmp/a.png"])
+        #expect(parts == [
+            .text("look at "),
+            .imagePath("/tmp/a.png"),
+            .text(" and tell me"),
+        ])
+    }
+
+    @Test func emptyTextPartsAreSkipped() {
+        let parts = ComposerTokens.parts(
+            text: "[Image #1][Image #2]",
+            paths: [1: "/tmp/a.png", 2: "/tmp/b.png"])
+        #expect(parts == [.imagePath("/tmp/a.png"), .imagePath("/tmp/b.png")])
+    }
+
+    /// **A deleted token drops its image.** The map still holds the file; the
+    /// text is what decides.
+    @Test func aDeletedTokenDropsItsImage() {
+        let parts = ComposerTokens.parts(
+            text: "just words now",
+            paths: [1: "/tmp/a.png"])
+        #expect(parts == [.text("just words now")])
+    }
+
+    /// An edited token no longer matches, so it is literal text and its image is
+    /// dropped — exactly what Claude Code's own composer does to the same
+    /// placeholders.
+    @Test func anEditedTokenIsLiteralTextAndDropsItsImage() {
+        let parts = ComposerTokens.parts(
+            text: "look at [Image #1x]",
+            paths: [1: "/tmp/a.png"])
+        #expect(parts == [.text("look at [Image #1x]")])
+    }
+
+    /// A token whose file was never staged is literal text too — never a part
+    /// pointing at nothing.
+    @Test func aTokenWithNoStagedFileStaysText() {
+        let parts = ComposerTokens.parts(text: "look at [Image #9]", paths: [:])
+        #expect(parts == [.text("look at [Image #9]")])
+    }
+
+    /// The not-running form: an argv prompt cannot carry attachments, so each
+    /// token becomes the quoted path inline. The sentence reads the same and
+    /// Claude reads the files with its Read tool.
+    @Test func flatteningReplacesTokensWithQuotedPaths() {
+        #expect(ComposerTokens.flattened(
+            text: "look at [Image #1] and tell me",
+            paths: [1: "/tmp/a.png"])
+            == "look at '/tmp/a.png' and tell me")
+    }
+
+    @Test func flatteningLeavesAnUnstagedTokenAlone() {
+        #expect(ComposerTokens.flattened(text: "see [Image #9]", paths: [:])
+            == "see [Image #9]")
+    }
+
+    @Test func attachedNumbersAreWhatTheTextHolds() {
+        #expect(ComposerTokens.attachedNumbers(in: "a [Image #1] b [Image #3]") == [1, 3])
+        #expect(ComposerTokens.attachedNumbers(in: "nothing here").isEmpty)
+    }
+
+    /// Ranges are UTF-16, so an emoji ahead of a token does not shift the split.
+    @Test func splittingSurvivesMultiScalarText() {
+        let parts = ComposerTokens.parts(
+            text: "🎉 [Image #1] 🎉", paths: [1: "/tmp/a.png"])
+        #expect(parts == [.text("🎉 "), .imagePath("/tmp/a.png"), .text(" 🎉")])
+    }
+}

--- a/Tests/TBDAppTests/FrecencyStoreTests.swift
+++ b/Tests/TBDAppTests/FrecencyStoreTests.swift
@@ -1,0 +1,90 @@
+import Foundation
+import Testing
+@testable import TBDApp
+
+/// Frecency: usage count decayed with a seven-day half-life, floored at ten
+/// percent. It is a TIEBREAK, never a rank — a command you used yesterday must
+/// not outrank an exact-name match you just typed.
+///
+/// `Date` is data here, not behavior, so the seam is `now: () -> Date` rather
+/// than a `Clock` (CLAUDE.md, "Duration is behavior, Date is data").
+///
+/// `FrecencyStore` is `@MainActor`-isolated (every `UserDefaults` holder in
+/// this tree is), so the whole suite runs on the main actor.
+@MainActor
+@Suite("FrecencyStore")
+struct FrecencyStoreTests {
+    private let epoch = Date(timeIntervalSince1970: 1_800_000_000)
+
+    private func store(_ suiteName: String, now: Date) -> FrecencyStore {
+        FrecencyStore(defaults: UserDefaults(suiteName: suiteName)!, now: { now })
+    }
+
+    // MARK: - The curve
+
+    @Test func aFreshUseScoresItsFullCount() {
+        #expect(FrecencyStore.decayed(usageCount: 4, lastUsedAt: epoch, now: epoch) == 4)
+    }
+
+    @Test func sevenDaysHalvesIt() {
+        let score = FrecencyStore.decayed(
+            usageCount: 4, lastUsedAt: epoch, now: epoch.addingTimeInterval(7 * 86_400))
+        #expect(abs(score - 2) < 0.0001)
+    }
+
+    @Test func fourteenDaysQuartersIt() {
+        let score = FrecencyStore.decayed(
+            usageCount: 4, lastUsedAt: epoch, now: epoch.addingTimeInterval(14 * 86_400))
+        #expect(abs(score - 1) < 0.0001)
+    }
+
+    /// **The floor is what keeps an old favourite from vanishing.** Without it a
+    /// command used heavily a year ago decays to indistinguishable-from-never,
+    /// and the tiebreak stops carrying any memory at all.
+    @Test func itNeverDecaysBelowTenPercent() {
+        let score = FrecencyStore.decayed(
+            usageCount: 10, lastUsedAt: epoch, now: epoch.addingTimeInterval(365 * 86_400))
+        #expect(score >= 1.0, "10 uses floored at 10% is 1.0, however long ago: \(score)")
+    }
+
+    /// A clock that went backwards must not inflate a score.
+    @Test func aFutureTimestampDoesNotAmplify() {
+        let score = FrecencyStore.decayed(
+            usageCount: 3, lastUsedAt: epoch.addingTimeInterval(86_400), now: epoch)
+        #expect(score <= 3)
+    }
+
+    // MARK: - The store
+
+    @Test func anUnknownCommandScoresZero() {
+        let suiteName = "FrecencyStoreTests-\(UUID().uuidString)"
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+        #expect(store(suiteName, now: epoch).score("never-used") == 0)
+    }
+
+    @Test func recordingAccumulatesAndPersists() {
+        let suiteName = "FrecencyStoreTests-\(UUID().uuidString)"
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+
+        let first = store(suiteName, now: epoch)
+        first.record("compact")
+        first.record("compact")
+        #expect(first.score("compact") == 2)
+
+        // A separate instance over the same suite reads the same numbers.
+        let later = store(suiteName, now: epoch.addingTimeInterval(7 * 86_400))
+        #expect(abs(later.score("compact") - 1) < 0.0001)
+    }
+
+    /// Recording refreshes the timestamp, so a re-used command climbs back.
+    @Test func aNewUseResetsTheDecayClock() {
+        let suiteName = "FrecencyStoreTests-\(UUID().uuidString)"
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+
+        store(suiteName, now: epoch).record("compact")
+        let weekLater = store(suiteName, now: epoch.addingTimeInterval(7 * 86_400))
+        weekLater.record("compact")
+        #expect(weekLater.score("compact") > 1.5,
+                "a fresh use must beat the decayed one it replaced")
+    }
+}

--- a/Tests/TBDAppTests/MessageComposerTextViewTests.swift
+++ b/Tests/TBDAppTests/MessageComposerTextViewTests.swift
@@ -12,6 +12,14 @@ import Testing
 /// composer genuinely needs, as ONE-SHOT COMMANDS carrying a token — the idiom
 /// the transcript pane already uses for scroll-to-bottom — so a re-sent value
 /// can never re-apply.
+/// Records `onTextChange` calls. A reference type because the representable's
+/// callbacks are escaping closures, and a captured local `var` cannot be
+/// mutated from one under Swift 6 concurrency checking.
+@MainActor
+private final class TextChangeRecorder {
+    var reports: [(text: String, caret: Int, marked: Bool)] = []
+}
+
 @MainActor
 @Suite("MessageComposerTextView commands")
 struct MessageComposerTextViewTests {
@@ -20,6 +28,19 @@ struct MessageComposerTextViewTests {
         let view = NSTextView(frame: NSRect(x: 0, y: 0, width: 300, height: 80))
         view.string = initial
         return view
+    }
+
+    /// A representable with inert callbacks, apart from any the caller replaces.
+    private func makeComposer(
+        onTextChange: @escaping (String, Int, Bool) -> Void = { _, _, _ in }
+    ) -> MessageComposerTextView {
+        MessageComposerTextView(
+            onTextChange: onTextChange,
+            onSubmit: { _ in },
+            onEscape: {},
+            onImageData: { _ in },
+            menuIsOpen: { false },
+            onMenuAction: { _ in })
     }
 
     @Test func restoreReplacesTheWholeText() {
@@ -81,6 +102,108 @@ struct MessageComposerTextViewTests {
             ComposerCommand(
                 token: 1,
                 kind: .replaceRange(NSRange(location: 40, length: 5), with: "x")),
+            to: view)
+        #expect(view.string == "short")
+    }
+
+    /// **The text view actually grows, and overflows into a scroll.** A
+    /// regression guard rather than a bug fix: the composer builds its own
+    /// `NSTextView` instead of taking one from
+    /// `NSTextView.scrollableTextView()`, so the sizing that factory performs —
+    /// `minSize`, `maxSize`, the container size, `widthTracksTextView` — is
+    /// stated by hand, and nothing else in this process would notice if a later
+    /// edit dropped one of them and left the box a sliver.
+    ///
+    /// Layout has to be forced: nothing here is in a window, and `sizeToFit()`
+    /// reports the last laid-out size rather than laying out first.
+    @Test func theTextViewGrowsWithItsContentAndScrollsPastTheCap() throws {
+        let scrollView = makeComposer().makeScrollView(
+            coordinator: MessageComposerTextView.Coordinator())
+        scrollView.setFrameSize(NSSize(width: 300, height: 40))
+        scrollView.layoutSubtreeIfNeeded()
+        let textView = try #require(scrollView.documentView as? NSTextView)
+
+        func layOut() {
+            if let manager = textView.layoutManager, let container = textView.textContainer {
+                manager.ensureLayout(for: container)
+            }
+            textView.sizeToFit()
+        }
+
+        textView.string = "one line"
+        layOut()
+        let oneLine = textView.frame.height
+        #expect(oneLine > 0, "a view clamped by a zero maxSize can never show anything")
+
+        textView.string = Array(repeating: "line", count: 5).joined(separator: "\n")
+        layOut()
+        let fiveLines = textView.frame.height
+        #expect(fiveLines > oneLine, "five lines must be taller than one")
+
+        // Past the visible cap the document keeps growing and the scroll view
+        // scrolls it, rather than the box swallowing the overflow.
+        textView.string = Array(repeating: "line", count: 40).joined(separator: "\n")
+        layOut()
+        #expect(textView.frame.height > scrollView.contentSize.height,
+                "overflowing text must make the document taller than the clip view")
+    }
+
+    /// **A wholesale write reports itself, rather than hoping AppKit will.**
+    /// `.restore` and `.clear` assign `NSTextView.string`, which — measured on
+    /// this AppKit — posts no text-change notification at all; what fires is a
+    /// selection change, and only because the caret is reset afterwards.
+    /// Leaning on that leaves `onTextChange` depending on an undocumented side
+    /// effect for the one write that must never be missed: a send clears the
+    /// box, and a composer whose state is not resynchronised still believes it
+    /// holds the message that was just sent.
+    ///
+    /// The text view here is deliberately NOT wired to the coordinator as its
+    /// delegate, so what is measured is the command path's own reporting rather
+    /// than whatever notifications AppKit chose to post.
+    @Test func clearOnAlreadyEmptyTextReportsWithoutAnyNotification() {
+        let recorder = TextChangeRecorder()
+        let coordinator = MessageComposerTextView.Coordinator(
+            makeComposer { text, caret, marked in
+                recorder.reports.append((text, caret, marked))
+            })
+        let view = makeTextView("")
+
+        coordinator.applyIfNew(ComposerCommand(token: 1, kind: .clear), to: view)
+
+        #expect(recorder.reports.count == 1, "an empty clear still has to report")
+        #expect(recorder.reports.first?.text == "")
+        #expect(recorder.reports.first?.caret == 0)
+        #expect(recorder.reports.first?.marked == false,
+                "the marked flag is read off the text view, never assumed")
+    }
+
+    /// A `.restore` reports too, carrying the text and the caret it just placed.
+    @Test func restoreReportsWithoutAnyNotification() {
+        let recorder = TextChangeRecorder()
+        let coordinator = MessageComposerTextView.Coordinator(
+            makeComposer { text, caret, marked in
+                recorder.reports.append((text, caret, marked))
+            })
+        let view = makeTextView("")
+
+        coordinator.applyIfNew(ComposerCommand(token: 1, kind: .restore("draft")), to: view)
+
+        #expect(recorder.reports.count == 1)
+        #expect(recorder.reports.first?.text == "draft")
+        #expect(recorder.reports.first?.caret == 5)
+    }
+
+    /// **A "not found" range is refused, not trapped.** A completion whose token
+    /// the text no longer holds produces `NSRange(location: NSNotFound, …)`,
+    /// whose location is `Int.max`; a bounds check written as
+    /// `location + length <= length` overflows and crashes the app before it can
+    /// refuse anything.
+    @Test func aNotFoundRangeIsRefusedRatherThanOverflowing() {
+        let view = makeTextView("short")
+        MessageComposerTextView.apply(
+            ComposerCommand(
+                token: 1,
+                kind: .replaceRange(NSRange(location: NSNotFound, length: 3), with: "x")),
             to: view)
         #expect(view.string == "short")
     }

--- a/Tests/TBDAppTests/MessageComposerTextViewTests.swift
+++ b/Tests/TBDAppTests/MessageComposerTextViewTests.swift
@@ -1,0 +1,87 @@
+import AppKit
+import Foundation
+import Testing
+@testable import TBDApp
+
+/// The imperative half of the composer's text view.
+///
+/// `SubmittingTextEditor`'s one-way contract is what makes its caret safe: a
+/// SwiftUI update pass is not ordered against typing, so writing text back from
+/// a republish can delete a character the person just typed and strand the caret
+/// at the end. This view keeps that contract and adds the three writes the
+/// composer genuinely needs, as ONE-SHOT COMMANDS carrying a token — the idiom
+/// the transcript pane already uses for scroll-to-bottom — so a re-sent value
+/// can never re-apply.
+@MainActor
+@Suite("MessageComposerTextView commands")
+struct MessageComposerTextViewTests {
+
+    private func makeTextView(_ initial: String = "") -> NSTextView {
+        let view = NSTextView(frame: NSRect(x: 0, y: 0, width: 300, height: 80))
+        view.string = initial
+        return view
+    }
+
+    @Test func restoreReplacesTheWholeText() {
+        let view = makeTextView("stale")
+        MessageComposerTextView.apply(
+            ComposerCommand(token: 1, kind: .restore("a draft")), to: view)
+        #expect(view.string == "a draft")
+        #expect(view.selectedRange().location == 7, "the caret lands at the end of a restore")
+    }
+
+    @Test func replaceRangePutsTheCaretAfterTheInsertion() {
+        let view = makeTextView("please /comp and more")
+        MessageComposerTextView.apply(
+            ComposerCommand(
+                token: 1,
+                kind: .replaceRange(NSRange(location: 7, length: 5), with: "/compact ")),
+            to: view)
+        #expect(view.string == "please /compact  and more")
+        #expect(view.selectedRange().location == 16)
+    }
+
+    @Test func insertAtCaretGoesWhereTheCaretIs() {
+        let view = makeTextView("look at  please")
+        view.setSelectedRange(NSRange(location: 8, length: 0))
+        MessageComposerTextView.apply(
+            ComposerCommand(token: 1, kind: .insertAtCaret("[Image #1]")), to: view)
+        #expect(view.string == "look at [Image #1] please")
+    }
+
+    @Test func clearEmptiesIt() {
+        let view = makeTextView("something")
+        MessageComposerTextView.apply(ComposerCommand(token: 1, kind: .clear), to: view)
+        #expect(view.string.isEmpty)
+    }
+
+    /// **A command applies once.** The coordinator remembers the last token it
+    /// ran, so a SwiftUI republish carrying the same command is a no-op — which
+    /// is exactly the staleness the one-way contract exists to prevent.
+    @Test func aCommandWithTheSameTokenDoesNotReapply() {
+        let coordinator = MessageComposerTextView.Coordinator()
+        let view = makeTextView("start")
+        let command = ComposerCommand(token: 7, kind: .clear)
+
+        #expect(coordinator.applyIfNew(command, to: view))
+        view.string = "typed again"
+        #expect(!coordinator.applyIfNew(command, to: view))
+        #expect(view.string == "typed again", "a re-sent command must not clobber typing")
+
+        #expect(coordinator.applyIfNew(ComposerCommand(token: 8, kind: .clear), to: view))
+        #expect(view.string.isEmpty)
+    }
+
+    /// A range the text no longer holds — the person edited while a completion
+    /// was being accepted — is refused rather than applied at a clamped
+    /// position, which would insert the token in the wrong place.
+    @Test func anOutOfBoundsRangeIsRefused() {
+        let view = makeTextView("short")
+        MessageComposerTextView.apply(
+            ComposerCommand(
+                token: 1,
+                kind: .replaceRange(NSRange(location: 40, length: 5), with: "x")),
+            to: view)
+        #expect(view.string == "short")
+    }
+}

--- a/Tests/TBDAppTests/MessageComposerTextViewTests.swift
+++ b/Tests/TBDAppTests/MessageComposerTextViewTests.swift
@@ -160,7 +160,7 @@ struct MessageComposerTextViewTests {
     /// The text view here is deliberately NOT wired to the coordinator as its
     /// delegate, so what is measured is the command path's own reporting rather
     /// than whatever notifications AppKit chose to post.
-    @Test func clearOnAlreadyEmptyTextReportsWithoutAnyNotification() {
+    @Test func clearOnAlreadyEmptyTextReportsWithoutAnyNotification() async {
         let recorder = TextChangeRecorder()
         let coordinator = MessageComposerTextView.Coordinator(
             makeComposer { text, caret, marked in
@@ -170,6 +170,10 @@ struct MessageComposerTextViewTests {
 
         coordinator.applyIfNew(ComposerCommand(token: 1, kind: .clear), to: view)
 
+        #expect(recorder.reports.isEmpty,
+                "a command runs inside updateNSView; nothing may be reported there")
+        await Task.yield()
+
         #expect(recorder.reports.count == 1, "an empty clear still has to report")
         #expect(recorder.reports.first?.text == "")
         #expect(recorder.reports.first?.caret == 0)
@@ -178,7 +182,7 @@ struct MessageComposerTextViewTests {
     }
 
     /// A `.restore` reports too, carrying the text and the caret it just placed.
-    @Test func restoreReportsWithoutAnyNotification() {
+    @Test func restoreReportsWithoutAnyNotification() async {
         let recorder = TextChangeRecorder()
         let coordinator = MessageComposerTextView.Coordinator(
             makeComposer { text, caret, marked in
@@ -188,9 +192,48 @@ struct MessageComposerTextViewTests {
 
         coordinator.applyIfNew(ComposerCommand(token: 1, kind: .restore("draft")), to: view)
 
+        #expect(recorder.reports.isEmpty, "the report is deferred off the update pass")
+        await Task.yield()
+
         #expect(recorder.reports.count == 1)
         #expect(recorder.reports.first?.text == "draft")
         #expect(recorder.reports.first?.caret == 5)
+    }
+
+    /// **An insertion reports late too, and exactly once.**
+    ///
+    /// `.replaceRange` and `.insertAtCaret` go through
+    /// `insertText(_:replacementRange:)`, which posts `didChangeText` and a
+    /// selection change SYNCHRONOUSLY — and the command is applied from inside
+    /// `updateNSView`, so reporting from those notifications writes `draft.text`,
+    /// the completion controller and the argument hint, all of them
+    /// `@Observable` state that sibling views render, during a SwiftUI view
+    /// update. The coordinator is wired as the delegate here precisely so those
+    /// notifications fire; what must come out of them is nothing at all, and one
+    /// report a turn later.
+    @Test func anInsertionReportsOnceOnALaterTurn() async {
+        let recorder = TextChangeRecorder()
+        let coordinator = MessageComposerTextView.Coordinator(
+            makeComposer { text, caret, marked in
+                recorder.reports.append((text, caret, marked))
+            })
+        let view = makeTextView("please /comp")
+        view.delegate = coordinator
+        defer { view.delegate = nil }
+
+        coordinator.applyIfNew(
+            ComposerCommand(
+                token: 1,
+                kind: .replaceRange(NSRange(location: 7, length: 5), with: "/compact ")),
+            to: view)
+
+        #expect(recorder.reports.isEmpty,
+                "AppKit's own notifications must not report from inside the update pass")
+        await Task.yield()
+
+        #expect(recorder.reports.count == 1, "one command, one report")
+        #expect(recorder.reports.first?.text == "please /compact ")
+        #expect(recorder.reports.first?.caret == 16, "the caret follows the insertion")
     }
 
     /// **A "not found" range is refused, not trapped.** A completion whose token

--- a/Tests/TBDAppTests/MessageComposerViewTests.swift
+++ b/Tests/TBDAppTests/MessageComposerViewTests.swift
@@ -1,0 +1,151 @@
+import Foundation
+import TestSupport
+import Testing
+@testable import TBDApp
+import TBDShared
+
+/// The composer view's three decisions that are not layout: what a key pressed
+/// with the menu open means, what the send button says, and where a staged image
+/// lands on disk.
+///
+/// Each one is a static function over its inputs precisely so it can be asserted
+/// without mounting SwiftUI — the view body itself is wiring, and wiring is what
+/// the rest of this PR's suites already pin.
+@MainActor
+@Suite("MessageComposerView")
+struct MessageComposerViewTests {
+
+    // MARK: - Enter versus Tab
+
+    /// **Tab is the accept gesture.** It takes `acceptTarget` — the highlighted
+    /// row, or the first one — whether or not anything is highlighted, which is
+    /// exactly what makes it the way to accept without arrowing first.
+    @Test func tabAcceptsWhetherOrNotARowIsHighlighted() {
+        #expect(
+            MessageComposerView.menuOutcome(for: .menuAccept, selectedIndex: nil) == .accept)
+        #expect(
+            MessageComposerView.menuOutcome(for: .menuAccept, selectedIndex: 2) == .accept)
+    }
+
+    /// **Enter never silently accepts.** With the menu open but nothing
+    /// highlighted, Return sends the message as typed. Taking `rows.first` there
+    /// would rewrite a person's words into a command they never chose — the one
+    /// failure the whole Enter/Tab split exists to prevent.
+    @Test func returnWithNothingHighlightedSubmits() {
+        #expect(
+            MessageComposerView.menuOutcome(
+                for: .menuAcceptOrSubmit, selectedIndex: nil) == .submit)
+    }
+
+    /// Once a row is highlighted — the person arrowed to it — Return means that
+    /// row, as it does in every completion list.
+    @Test func returnWithARowHighlightedAcceptsIt() {
+        #expect(
+            MessageComposerView.menuOutcome(
+                for: .menuAcceptOrSubmit, selectedIndex: 0) == .accept)
+    }
+
+    @Test func theArrowsAndEscapeDriveTheMenu() {
+        #expect(MessageComposerView.menuOutcome(for: .menuUp, selectedIndex: nil) == .moveUp)
+        #expect(MessageComposerView.menuOutcome(for: .menuDown, selectedIndex: 1) == .moveDown)
+        #expect(MessageComposerView.menuOutcome(for: .menuClose, selectedIndex: 1) == .close)
+    }
+
+    /// The menu handler is reached only for menu actions; anything else the
+    /// router resolved is somebody else's business and must not be re-decided
+    /// here.
+    @Test func nonMenuActionsAreNotTheMenusBusiness() {
+        for action: ComposerKeyRouter.Action in [.submit, .newline, .blur, .passThrough] {
+            #expect(
+                MessageComposerView.menuOutcome(for: action, selectedIndex: 0) == .ignore,
+                "\(action) must not be handled as a menu action")
+        }
+    }
+
+    // MARK: - The button names the target
+
+    /// The send button names the terminal, so an injection is never anonymous.
+    @Test func theButtonNamesTheTargetTerminal() {
+        #expect(
+            MessageComposerView.sendButtonLabel(state: .running, terminalLabel: "worker 3")
+                == "Send to worker 3")
+        #expect(
+            MessageComposerView.sendButtonLabel(
+                state: .notRunning(exited: true), terminalLabel: "worker 3")
+                == "Resume worker 3")
+    }
+
+    /// An unlabelled terminal still gets a name rather than an empty verb.
+    @Test func anUnlabelledTerminalStillReadsAsAName() {
+        #expect(
+            MessageComposerView.sendButtonLabel(state: .running, terminalLabel: nil)
+                == "Send to Claude")
+    }
+
+    /// The not-running note distinguishes a session that left on its own from one
+    /// TBD parked — one wake path, two sentences.
+    @Test func theNotRunningNoteDistinguishesExitFromPark() {
+        let exited = MessageComposerView.notRunningNoteText(exited: true)
+        let parked = MessageComposerView.notRunningNoteText(exited: false)
+        #expect(exited != parked)
+        #expect(exited.contains("exited"))
+        #expect(parked.contains("hibernated"))
+    }
+
+    // MARK: - The attachment write
+
+    /// The PNG lands under the worktree's own attachment directory, derived from
+    /// `TBDConstants` so `TBD_HOME` and the test fence apply, and it is written
+    /// atomically — a half-written file behind a token that is already in the
+    /// message would be sent as a broken path.
+    @Test func aStagedImageIsWrittenUnderTheWorktreesAttachmentDirectory() throws {
+        let root = fencedScratchRoot(prefix: "tbdcomposer")
+        defer { try? FileManager.default.removeItem(atPath: root) }
+        let environment = ["TBD_HOME": root]
+        let worktreeID = UUID()
+        let bytes = Data([0x89, 0x50, 0x4E, 0x47])
+
+        let staged = try MessageComposerView.writeAttachment(
+            bytes, worktreeID: worktreeID, environment: environment)
+
+        #expect(staged.path == TBDConstants.attachmentPath(
+            worktreeID: worktreeID, attachmentID: staged.id, environment: environment))
+        #expect(staged.path.hasPrefix(root))
+        #expect(try Data(contentsOf: URL(fileURLWithPath: staged.path)) == bytes)
+    }
+
+    /// The directory is created on the way, so the first image in a worktree is
+    /// not the one that fails.
+    @Test func theWorktreeDirectoryIsCreatedOnDemand() throws {
+        let root = fencedScratchRoot(prefix: "tbdcomposer")
+        defer { try? FileManager.default.removeItem(atPath: root) }
+        let environment = ["TBD_HOME": root]
+        let worktreeID = UUID()
+        let directory = TBDConstants.attachmentsDir(
+            worktreeID: worktreeID, environment: environment)
+        #expect(!FileManager.default.fileExists(atPath: directory.path))
+
+        _ = try MessageComposerView.writeAttachment(
+            Data([0x01]), worktreeID: worktreeID, environment: environment)
+
+        #expect(FileManager.default.fileExists(atPath: directory.path))
+    }
+
+    /// Two images in one message get two files: the id is minted per write, so
+    /// a second attachment can never overwrite the first.
+    @Test func eachStagedImageGetsItsOwnFile() throws {
+        let root = fencedScratchRoot(prefix: "tbdcomposer")
+        defer { try? FileManager.default.removeItem(atPath: root) }
+        let environment = ["TBD_HOME": root]
+        let worktreeID = UUID()
+
+        let first = try MessageComposerView.writeAttachment(
+            Data([0x01]), worktreeID: worktreeID, environment: environment)
+        let second = try MessageComposerView.writeAttachment(
+            Data([0x02]), worktreeID: worktreeID, environment: environment)
+
+        #expect(first.id != second.id)
+        #expect(first.path != second.path)
+        #expect(try Data(contentsOf: URL(fileURLWithPath: first.path)) == Data([0x01]))
+    }
+}

--- a/Tests/TBDAppTests/MessageComposerViewTests.swift
+++ b/Tests/TBDAppTests/MessageComposerViewTests.swift
@@ -51,6 +51,86 @@ struct MessageComposerViewTests {
         #expect(MessageComposerView.menuOutcome(for: .menuClose, selectedIndex: 1) == .close)
     }
 
+    // MARK: - Enter accepts and sends when the command is the whole message
+
+    /// `/comp` plus Enter runs compact, as it does in the terminal: the token is
+    /// the entire message, so accepting it leaves nothing to write and the same
+    /// keystroke sends.
+    @Test func enterAcceptsAndSendsWhenTheCommandIsTheWholeMessage() {
+        let completed = MessageComposerView.acceptedWholeMessage(
+            text: "/comp", tokenRange: NSRange(location: 0, length: 5),
+            replacement: MessageComposerView.completionReplacement(
+                kind: .command, name: "compact"))
+
+        #expect(completed == "/compact", "the send carries the COMPLETED token")
+        #expect(
+            MessageComposerView.menuOutcome(
+                for: .menuAcceptOrSubmit, selectedIndex: 0,
+                acceptFillsTheMessage: completed != nil) == .acceptAndSubmit)
+    }
+
+    /// A command inside a sentence is part of that sentence. Accepting it
+    /// completes the name and stops; a second Return sends, once the person has
+    /// finished writing.
+    @Test func enterOnlyAcceptsWhenWordsSurroundTheToken() {
+        let completed = MessageComposerView.acceptedWholeMessage(
+            text: "hello /comp", tokenRange: NSRange(location: 6, length: 5),
+            replacement: MessageComposerView.completionReplacement(
+                kind: .command, name: "compact"))
+
+        #expect(completed == nil)
+        #expect(
+            MessageComposerView.menuOutcome(
+                for: .menuAcceptOrSubmit, selectedIndex: 0,
+                acceptFillsTheMessage: completed != nil) == .accept)
+    }
+
+    /// A staged image is text in the box like any other word, so a message
+    /// carrying one is not "just the command" however the words are arranged.
+    @Test func anImageTokenKeepsEnterFromSending() {
+        #expect(
+            MessageComposerView.acceptedWholeMessage(
+                text: "[Image #1] /comp", tokenRange: NSRange(location: 11, length: 5),
+                replacement: MessageComposerView.completionReplacement(
+                    kind: .command, name: "compact")) == nil)
+    }
+
+    /// **Tab never sends**, whatever is in the box. Its meaning is "take the
+    /// obvious completion and keep going"; a Tab that ran a command would be a
+    /// command nobody committed to.
+    @Test func tabNeverSubmitsEvenWhenTheCommandIsTheWholeMessage() {
+        #expect(
+            MessageComposerView.menuOutcome(
+                for: .menuAccept, selectedIndex: 0, acceptFillsTheMessage: true) == .accept)
+        #expect(
+            MessageComposerView.menuOutcome(
+                for: .menuAccept, selectedIndex: nil, acceptFillsTheMessage: true) == .accept)
+    }
+
+    /// With nothing highlighted the message goes as typed, and the whole-message
+    /// question never arises — Enter must not accept a row the person never
+    /// chose just because their text happens to be one token.
+    @Test func enterStillSendsAsTypedWithNothingHighlighted() {
+        #expect(
+            MessageComposerView.menuOutcome(
+                for: .menuAcceptOrSubmit, selectedIndex: nil,
+                acceptFillsTheMessage: true) == .submit)
+    }
+
+    /// A range the text no longer holds — the person kept typing while the menu
+    /// was deciding — yields no message rather than a clamped one. `NSNotFound`
+    /// is `Int.max`, so the bounds check must not add to it.
+    @Test func anOutOfBoundsTokenRangeProducesNoWholeMessage() {
+        #expect(
+            MessageComposerView.acceptedWholeMessage(
+                text: "/comp", tokenRange: NSRange(location: NSNotFound, length: 3),
+                replacement: "/compact ") == nil)
+        #expect(
+            MessageComposerView.acceptedWholeMessage(
+                text: "/comp", tokenRange: NSRange(location: 40, length: 2),
+                replacement: "/compact ") == nil)
+    }
+
     /// The menu handler is reached only for menu actions; anything else the
     /// router resolved is somebody else's business and must not be re-decided
     /// here.

--- a/Tests/TBDAppTests/MessageComposerViewTests.swift
+++ b/Tests/TBDAppTests/MessageComposerViewTests.swift
@@ -92,6 +92,91 @@ struct MessageComposerViewTests {
         #expect(parked.contains("hibernated"))
     }
 
+    // MARK: - The draft a switched terminal gets
+
+    /// Switching to a terminal whose draft is empty **clears** the box. The
+    /// `NSTextView` is reused across the switch, so restoring only non-empty
+    /// drafts would leave the previous terminal's message on screen, addressed
+    /// to a session that never saw it typed.
+    @Test func aTerminalWithAnEmptyDraftClearsTheBox() {
+        #expect(MessageComposerView.restoreCommand(draftText: "") == .clear)
+    }
+
+    @Test func aTerminalWithADraftRestoresIt() {
+        #expect(
+            MessageComposerView.restoreCommand(draftText: "half a sentence")
+                == .restore("half a sentence"))
+    }
+
+    // MARK: - Clicking a thumbnail that is in the message
+
+    /// It moves the caret to that image's token — the token replaced with
+    /// itself, which leaves the text untouched and the insertion point after it.
+    /// It does not open Finder: the thumbnail carries one gesture, and where the
+    /// image sits in the sentence is the question a click on an attached one is
+    /// asking.
+    @Test func clickingAnAttachedThumbnailMovesTheCaretToItsToken() throws {
+        let token = ComposerTokens.text(for: 2)
+        let text = "before \(token) after"
+
+        let command = try #require(
+            MessageComposerView.caretCommand(text: text, number: 2))
+
+        let expected = (text as NSString).range(of: token)
+        #expect(command == .replaceRange(expected, with: token))
+    }
+
+    /// A number the text no longer anchors has nowhere to put the caret, so the
+    /// click does nothing rather than guessing at a position.
+    @Test func aThumbnailWhoseTokenIsGoneMovesNothing() {
+        #expect(MessageComposerView.caretCommand(text: "no tokens here", number: 1) == nil)
+    }
+
+    // MARK: - Removing an image
+
+    /// **Every** occurrence goes. Re-inserting an image twice is how a person
+    /// refers to it twice, and leaving the second copy behind would send a path
+    /// for an image the strip no longer lists.
+    @Test func removingADuplicatedTokenRemovesEveryOccurrence() throws {
+        let token = ComposerTokens.text(for: 1)
+        let text = "a \(token) b \(token) c"
+
+        let command = try #require(
+            MessageComposerView.removalCommand(text: text, number: 1))
+        guard case .replaceRange(let range, let replacement) = command else {
+            Issue.record("expected a range replacement, got \(command)")
+            return
+        }
+        let updated = (text as NSString).replacingCharacters(in: range, with: replacement)
+
+        #expect(updated == "a  b  c")
+        #expect(ComposerTokens.attachedNumbers(in: updated).isEmpty)
+    }
+
+    /// Only that image's tokens. A neighbouring image keeps its anchor, and the
+    /// text outside the removed span is not rewritten at all.
+    @Test func removingOneImageLeavesTheOthersAnchored() throws {
+        let text = "x \(ComposerTokens.text(for: 1)) y \(ComposerTokens.text(for: 2)) "
+            + "z \(ComposerTokens.text(for: 1))"
+
+        let command = try #require(
+            MessageComposerView.removalCommand(text: text, number: 1))
+        guard case .replaceRange(let range, let replacement) = command else {
+            Issue.record("expected a range replacement, got \(command)")
+            return
+        }
+        let updated = (text as NSString).replacingCharacters(in: range, with: replacement)
+
+        #expect(ComposerTokens.attachedNumbers(in: updated) == [2])
+        #expect(updated.hasPrefix("x "))
+    }
+
+    /// An image whose token the person already deleted removes nothing from the
+    /// text — the strip's x still drops the image, but there is no edit to make.
+    @Test func removingAnImageWithNoTokenLeftIssuesNoCommand() {
+        #expect(MessageComposerView.removalCommand(text: "just words", number: 1) == nil)
+    }
+
     // MARK: - The attachment write
 
     /// The PNG lands under the worktree's own attachment directory, derived from

--- a/Tests/TBDDaemonTests/TerminalSessionEventHandlerTests.swift
+++ b/Tests/TBDDaemonTests/TerminalSessionEventHandlerTests.swift
@@ -131,6 +131,51 @@ struct TerminalSessionEventHandlerTests {
             return
         }
         #expect(session.sessionOrderObservedAt == nil)
+        // A hook that reported no incarnation names no spawn, so the delta
+        // carries none either. A consumer scoping a wait to one spawn must be
+        // able to read this as "not this one".
+        #expect(session.sessionIncarnationID == nil)
+    }
+
+    /// The accepted hook's own incarnation rides the delta, which is what lets
+    /// the app scope a wait to the spawn it just asked for. `applySessionStart`
+    /// accepts only when the reported id equals the row's, so this is the id of
+    /// the process that reported in.
+    @Test("an accepted SessionStart broadcasts the incarnation it reported")
+    func acceptedIncarnationRidesTheDelta() async throws {
+        let (terminal, _) = try await makeTerminal()
+        // Rotating the tmux ids is how the row gets a durable incarnation
+        // token; read it back rather than inventing one, because a reported id
+        // that does not equal the row's is rejected outright.
+        try await db.terminals.updateTmuxIDs(id: terminal.id, windowID: "@7", paneID: "%7")
+        let incarnation = try #require(
+            try await db.terminals.get(id: terminal.id)?.sessionIncarnationID)
+        let captured = SessionDeltaCapture()
+        router.subscriptions.addSubscriber { data in
+            captured.append(data)
+            return true
+        }
+        let request = try RPCRequest(
+            method: RPCMethod.terminalSessionEvent,
+            params: TerminalSessionEventParams(
+                terminalID: terminal.id,
+                sessionID: "resumed-id",
+                transcriptPath: nil,
+                source: "startup",
+                sessionIncarnationID: incarnation
+            )
+        )
+        let response = await router.handle(request)
+        #expect(response.success)
+
+        let delta = try #require(captured.values.compactMap {
+            try? JSONDecoder().decode(StateDelta.self, from: $0)
+        }.first)
+        guard case let .terminalSessionUpdated(session) = delta else {
+            Issue.record("expected terminalSessionUpdated")
+            return
+        }
+        #expect(session.sessionIncarnationID == incarnation)
     }
 
     @Test("ignores non-absolute transcriptPath but still updates sessionID")

--- a/Tests/TBDSharedTests/TerminalSessionDeltaCodingTests.swift
+++ b/Tests/TBDSharedTests/TerminalSessionDeltaCodingTests.swift
@@ -18,6 +18,7 @@ struct TerminalSessionDeltaCodingTests {
 
         #expect(delta.terminalID == terminalID)
         #expect(delta.sessionOrderObservedAt == nil)
+        #expect(delta.sessionIncarnationID == nil)
     }
 
     @Test("the session order generation round trips")
@@ -35,5 +36,22 @@ struct TerminalSessionDeltaCodingTests {
             from: JSONEncoder().encode(original))
 
         #expect(decoded.sessionOrderObservedAt == observedAt)
+    }
+
+    @Test("the session incarnation ID round trips")
+    func sessionIncarnationIDRoundTrips() throws {
+        let incarnationID = UUID()
+        let original = TerminalSessionDelta(
+            terminalID: UUID(),
+            worktreeID: UUID(),
+            sessionID: "session",
+            transcriptPath: "/tmp/session.jsonl",
+            sessionIncarnationID: incarnationID)
+
+        let decoded = try JSONDecoder().decode(
+            TerminalSessionDelta.self,
+            from: JSONEncoder().encode(original))
+
+        #expect(decoded.sessionIncarnationID == incarnationID)
     }
 }

--- a/Tests/TestSupport/EventDrivenTestClock.swift
+++ b/Tests/TestSupport/EventDrivenTestClock.swift
@@ -300,7 +300,14 @@ public final class EventDrivenTestClock: Clock, @unchecked Sendable {
     ///     from `waitForSuspension`, whose derivation against `.clockDriven`'s
     ///     240 s limit is documented in `ClockTestSupport.swift` and
     ///     `Tests/CLAUDE.md` ("Population is the scheduler"); the value is kept
-    ///     so that a chain of these still tallies the same way. **On task
+    ///     so that a chain of these still tallies the same way. **Raise it to
+    ///     ``TestDeadlines/saturatedPass`` where the arming is not one hop from
+    ///     the test body** — where reaching the sleep costs a main-actor round
+    ///     trip, or an unstructured task that has to be given a thread first.
+    ///     45 s sits below fast pass 2's measured p90 per-test latency, so such
+    ///     a wait measures the runner rather than the code under test;
+    ///     `ComposerSendCoordinatorTests.theHoldTimesOutOnTheInjectedClock` is
+    ///     the worked example. **On task
     ///     cancellation the wait ends without a diagnostic**: the waiter is
     ///     still released, but the failure belongs to whatever cancelled the
     ///     test, not to this call site.
@@ -500,8 +507,10 @@ public final class EventDrivenTestClock: Clock, @unchecked Sendable {
     /// `timeout` is the same hang guard, exposed here (where
     /// ``advanceWhenArmed(by:sourceLocation:)`` does not expose it) for one
     /// reason: the guard has to be drivable in a self-test, and a proof that
-    /// costs the full 45 s default is a proof nobody keeps. Every production
-    /// call site takes the default.
+    /// costs the full 45 s default is a proof nobody keeps. A production call
+    /// site takes the default unless its arming is gated behind a main-actor
+    /// round trip, where the budget is ``TestDeadlines/saturatedPass`` — see the
+    /// `timeout` note on ``sleeperArmed(timeout:sourceLocation:)``.
     public func requireAdvanceWhenArmed(by duration: Swift.Duration,
                                         timeout: Swift.Duration = .seconds(45),
                                         sourceLocation: SourceLocation = #_sourceLocation) async throws {


### PR DESCRIPTION
## Summary

Somebody watching a live Claude session in the transcript pane can read what the
agent says but cannot answer it there. Answering means switching to the terminal
pane, finding the input box, and typing into it — and when the terminal is busy
repainting, the reply lags behind the conversation it belongs to.

This adds a composer under the live transcript: a multi-line text field that
sends into the running session, completes Claude Code's own slash commands,
skills and subagents as you type, and accepts pasted or dropped images placed
inline among the words. Escape returns focus to the transcript; ⌘/ brings it
back. If the session has parked or exited, the composer wakes it and hands the
message to the spawn it just started, instead of pasting into a shell prompt.

It is the last of a four-PR stack and the only one a user can see.

## Why this shape

Design spec: [`docs/specs/2026-09-05-transcript-composer-design.md`](docs/specs/2026-09-05-transcript-composer-design.md).
The decisions worth naming for a reviewer:

- **The command list comes from the session's own Claude Code binary**, through
  `terminal.completions` (landed in PR B). A command that Claude Code ships, or
  a skill somebody installs into their own project, appears in the menu with no
  TBD release in between. TBD ships no command list of its own.
- **The composer suppresses the dispatch envelope**, because the person is
  speaking in their own voice and not relaying an agent's instruction — and the
  daemon honours that suppression only on a connection it has authenticated as
  this app's: the kernel-reported peer pid of the socket, matched against the
  identity the FD-vending sidecar recorded and re-verified through the daemon's
  one start-time and command-line check. Never on the strength of a declared
  actor field in the request.
- **The message arrives through the existing send path.** Nothing new reaches
  the agent; the payload is the same shape a `tbd terminal send` produces.

Rejected alternatives, from the spec's "Rejected alternatives" section:

- **A SwiftUI-only composer.** No SwiftUI text API exposes marked-text state,
  and marked text is the single fact the Enter-versus-IME decision depends on.
  The multi-line case also takes Up and Down away from the move-command
  modifier. Hence an `NSTextView` behind a representable, with a pure key router
  in front of it.
- **Images as inline rich-text attachments.** Enabling rich text reopens the
  substitution and paste-formatting hazards the submitting editor closed, and a
  plain-text `[Image #N]` token with temporary attributes gives the same visual
  anchor for none of that cost.
- **A chip strip with no inline anchors.** There would be no way to refer to a
  particular image at a point in the sentence.
- **Holding messages until the session is idle.** Claude Code queues typed input
  itself and shows it pending, so immediate injection mirrors what the terminal
  already does.

## What this PR does

At survey altitude, under `Sources/TBDApp/Panes/Transcript/Composer/`:

- **`ComposerKeyRouter`** — a pure function from a key, the modifiers, and
  whether a menu is open, to an action. Enter, Tab, Escape, the arrows, ⌃N/⌃P,
  ⌘↩. Marked text passes everything through untouched.
- **`CompletionTrigger`** — decides from the text and the caret whether a
  completion query is live, and refuses to open where a trigger would be a trap
  (mid-word, inside a path, after a token that is not at a word boundary).
- **`CommandRanker`** — prefix, then subsequence, then a frecency tiebreak; and
  `FrecencyStore`, one global `@MainActor` store over `UserDefaults` with a
  seven-day half-life.
- **`CompletionController`** — the query/loading/rows/no-match state machine over
  the inventory the daemon returns, memoized per query.
- **`MessageComposerTextView`** — the `NSTextView` representable, driven by
  one-shot commands (`replaceRange`, `insertAtCaret`, `restore`, `clear`) so a
  SwiftUI update never writes into AppKit mid-pass.
- **`CompletionOverlayView`** — the menu, opening upward above the field.
- **`AttachmentStrip`** and **`ComposerImagePreparer`** — the thumbnail row, and
  the ImageIO path that downscales, bakes EXIF orientation into the pixels, and
  writes a PNG atomically.
- **`ComposerTokens`**, **`ComposerDraft`**, **`ComposerArgumentHint`** — the
  `[Image #N]` token scanner, the per-terminal draft (text, caret, attachments),
  and the hint shown under the field for a command that takes arguments.
- **`ComposerState`** — hidden / disabled / enabled, resolved from the terminal.
- **`ComposerSendCoordinator`** — the send itself, including the wake path: it
  wakes a parked or exited session, then holds the message until the incarnation
  *that wake minted* reports its own `SessionStart`.
- **`MessageComposerView`** — the assembly, and the mount under the transcript
  table in `TableTranscriptPaneView`, outside the pane's session-identity `.id`
  so a session rollover does not tear the composer down under a half-typed
  message.

Around it: `AppState+Composer` (drafts), `AppState+ComposerFocus` (the composer
and transcript focus registries, and ⌘/ ⌘⌥/), `AppState+SessionStartWaiters`
(the waiter registry the hold parks on, with a latch so a `SessionStart` that
lands before the waiter registers is not missed), two `DaemonClient` methods, and
a draft discard on tab close.

## Not purely app-side

Two lines live outside `Sources/TBDApp/`:

- One additive optional field, `TerminalSessionDelta.sessionIncarnationID`, in
  `Sources/TBDShared/StateDelta.swift`.
- The one argument that populates it, in the daemon's
  `handleTerminalSessionEvent` broadcast
  (`Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift`).

Both are wire-compatible in each direction: the field is optional with a `nil`
default, old JSON decodes, and a new daemon's JSON decodes into an old app. The
in-place profile-swap broadcast deliberately leaves it nil, because a profile
swap is not a `SessionStart` and a consumer scoping a wait to one spawn must
read nil as "not this one", never as "close enough".

The field exists because the `SessionStart` hook is the only fact that says
*this particular spawn* reported in. Polling the terminal row cannot distinguish
the spawn a wake minted from one that started for any other reason, which is
exactly the distinction the hold depends on.

Both files are also touched by PR C. The stack is linear, so there is no
conflict — but a reviewer reading the two diffs side by side should expect to
see the same files.

## Flag & rollout

`transcript_composer_enabled` — the `config` column landed in PR B, with no SQL
`DEFAULT`, so NULL still means "nobody chose". The shipped default lives in one
place, `Config.transcriptComposerEnabledDefault`, and is **false**.

Enable it for the soak in Settings → General, in the Claude section: "Message
composer in the transcript pane".

The gating is **transitive, by design**. Only the `composerMount` decision reads
the flag. `fetchCompletions` and the attachment writer carry no check of their
own, because neither is reachable except from a mounted composer.
`ComposerMountingTests` pins both branches — `theFlagOffMountsNoComposer` is the
negative, `aLiveClaudeTerminalOnALocalWorktreeMounts` the positive.

Graduation: after a soak in which no message reaches a session that is not
running and no draft is lost across a session rollover, flip
`Config.transcriptComposerEnabledDefault` to true — a one-line change that
reaches everybody who never touched the toggle and preserves every explicit
opt-out.

## Decisions

Rulings taken while this branch was built, recorded so a reviewer does not have
to re-derive them:

- **Enter and Tab.** Enter with a row highlighted accepts it, and also *sends*
  when the completed token is the whole message — so `/comp` plus Enter runs
  compact, exactly as it does in the terminal. Enter with nothing highlighted
  sends the text as typed. Tab is the only key that takes the accept target and
  it never sends. The IME guard is live: `hasMarkedText` flows out of the text
  view into the router, and marked text passes every key through.
- **Cmd+Return is routed by `ComposerKeyRouter` only.** The send button carries
  no SwiftUI `.keyboardShortcut`, because a key equivalent is live for the whole
  window: in a split, ⌘↩ typed with focus in the sibling terminal pane fired the
  composer's send. `commandReturnAlwaysSends` pins the surviving site.
- **Two deferred main-actor hops, on purpose.** The composer registers its view
  one turn after `makeNSView`, and the text view reports its state one turn after
  a one-shot command is applied. Both avoid `@Observable` writes during a SwiftUI
  update; both are asserted (`anInsertionReportsOnceOnALaterTurn` asserts nothing
  is reported synchronously and exactly one report lands after the turn).
- **Zero matching rows closes the menu** rather than showing an empty one. One
  character with nothing matched shows no menu at all; "No commands match"
  appears from two characters up.
- **The empty-query list leads with frecency and its tail is alphabetical.** The
  completions wire type carries no source field, so built-ins, user, project and
  plugin commands cannot be grouped yet — see the follow-ups.
- **`FrecencyStore` is `@MainActor`**, matching every other `UserDefaults` holder
  in the tree, with `@Sendable` closures at the seams.
- **`VisualEffectView` was promoted** from a private struct inside
  `JumpMenu/JumpMenuView.swift` to an internal helper in `Helpers/`. The jump
  menu's call site is unchanged; that file is touched by the move and nothing
  else.
- **Two `.swiftlint.yml` exclusions** from the transcript `ScrollView` ban, for
  `CompletionOverlayView` and `AttachmentStrip`, following that rule's own
  self-exemption convention. Both are pane-level chrome mounted beside the
  transcript table, never inside a transcript row card, so neither sits in the
  row-measurement path the rule exists to protect.
- **The hold's timeout says delivery "could not be confirmed"**, not that the
  message was not delivered. The prompt travelled on the respawn's own argv and
  may well have landed; silence means TBD heard nothing *from* the session. The
  message goes back in the box either way.
- **The hold is scoped to one spawn.** It releases only on the terminal's own
  `SessionStart` for the incarnation the wake minted. A no-op wake (the session
  was already running) never enters the hold; a wake that reports no incarnation
  does not hold either.
- **A dropped file becomes an attachment only if it is an image**, by declared
  `UTType` or, for a file whose type says nothing, an ImageIO decode of the first
  8 KB — type only, never a frame count a truncated buffer cannot answer. A text
  drop or paste falls through to AppKit unchanged.

## Dependencies

Merge bottom-up; GitHub retargets each base as the one below it merges.

- **[#821](https://github.com/cheapsteak/tbd/pull/821)** — the design spec.
- **[#822](https://github.com/cheapsteak/tbd/pull/822)** — the not-running
  refusal, the exit stamp (`HibernateReason.exited`, `Terminal.isExitStamped`),
  and the wake prompt the app now passes.
- **[#823](https://github.com/cheapsteak/tbd/pull/823)** — the
  `transcript_composer_enabled` flag and `terminal.completions`.
- **[#824](https://github.com/cheapsteak/tbd/pull/824)** — `parts`,
  peer-authenticated envelope suppression, the awaiting-input gate,
  `TerminalWakeResult.sessionIncarnationID`, and the attachment reconcilers.
  **This PR's base.**

One standing dependency outside the stack: the composer refuses a multi-line or
multi-part message to a holder-backed session until
[#819](https://github.com/cheapsteak/tbd/pull/819)'s bracketed-paste wrapping
lands. That refusal lifts with it, with no change here.

Follow-ups this PR knowingly leaves open:

- **`CompletionCommand.source` on the wire**, so the menu can group built-ins,
  user, project and plugin commands and weight a display name. Needs a small
  protocol change in a later PR.
- **A per-file age leg for attachments in live worktrees** (see Reconciler
  below). It changes what the spec says gets reclaimed and when, so it needs a
  spec amendment and a human decision, not a quiet patch.
- **The sidecar trust anchor is first-client-wins**, noted in PR C. The composer
  inherits it unchanged.
- **`terminal.wake --json` does not print the session incarnation yet**, so the
  CLI cannot do what the app now does. A CLI follow-up.

## Assumptions

Text sitting unsent in the terminal's own input box is invisible to the
composer, and a message sent from here appends to it rather than replacing it.
No signal for that exists outside the rendered screen: Claude Code keeps its
composer in process memory, writes no draft file for a pty-hosted session, and
exposes nothing about it on its peer socket or control protocol. Reading the
screen to find out is exactly what this repo forbids. The design accepts and
documents the limitation rather than warning from a keystroke timestamp that
would be wrong in both directions.

If Claude Code ever does expose its pending input, that warning becomes possible
and this assumption should be revisited.

## Reconciler

The composer writes attachment PNGs under `~/tbd/attachments/<worktreeID>/`.
That resource is not new here, and neither are its reconcilers: PR C landed both
the archive-time unlink and the hourly `reclaimAttachments` leg of `OrphanGC`.
**This PR adds the first writer, not a new kind of resource.**

One gap is worth stating plainly rather than discovering later.
`AttachmentsCollector` reclaims a worktree's attachments directory only once the
worktree row is gone, behind a 14-day floor. A file staged into a long-lived
worktree is therefore never reclaimed while that worktree lives — every pasted
image accumulates until the worktree is archived. For the soak population that
is bounded by hand and by the flag being off; as a permanent answer it is not
good enough, which is why "a per-file age leg for live worktrees" is listed
above as a follow-up needing a spec amendment.

## Evidence & verification

**Live verification is deferred, and this section leads with that.** This
machine is running a live fleet of agent sessions, and the standing rule forbids
restarting the app or the daemon underneath them. Task 14's live pass — restart
the app, drive a stub-backed session, paste an image, watch the wake hold — was
**not run**. Nothing below was exercised against a running app.

That matters more here than it usually would: transcript work in this repo has
greened headless while being visibly broken live, more than once. So each
deferred check is named with the standing test that stands in for it, and none
of them is claimed as a substitute:

- *Deferred: type into the composer and watch the menu open, filter and accept.*
  Stands on `CompletionTriggerTests` (where a trigger opens and where it is a
  trap), `CommandRankerTests` (prefix, subsequence, and the frecency tiebreak
  fixture), and `CompletionControllerTests` —
  `escapeWhileLoadingStaysClosedWhenInventoryArrives` (a menu dismissed while
  the inventory is in flight stays dismissed when it lands) and
  `repeatedUpdatesMemoizeByQuery` (the same query is not re-fetched).
- *Deferred: press each key with the menu open and closed and see what happens.*
  Stands on `ComposerKeyRouterTests`, a table over the router's whole input
  space — menu closed, menu open, marked text, ⇧↩, ⌘↩, ⌃N/⌃P — including
  `commandReturnAlwaysSends` and `returnAndTabAreDistinguishableWithTheMenuOpen`.
- *Deferred: paste and drop images, and see the thumbnails and tokens.* Stands
  on `ComposerImagePreparerTests`, including `orientationIsBakedIntoThePixels`,
  which uses a JPEG fixture carrying a real EXIF orientation of 6 and asserts
  the output pixels are rotated — a fixture built to discriminate, since an
  untagged fixture would only have read the default back.
- *Deferred: park a session, send from the composer, and watch the hold.* Stands
  on two suites. `ComposerSendCoordinatorTests` covers the coordinator's own
  decisions and was mutation-proved (see below):
  `aSessionStartFromAnotherIncarnationDoesNotRelease`,
  `aNoOpWakeSurfacesWithoutEnteringTheHold`, and
  `aWokenWakeWithNoIncarnationDoesNotHold`. `ComposerMountingTests` covers the
  waiter registry underneath it: `anotherIncarnationDoesNotRelease`,
  `anIncarnationlessSessionStartReleasesNobody`, and the latch pair —
  `aSessionStartBeforeTheWaiterStillReleases` (a start that lands before the
  waiter registers is not missed, so the send cannot wait to its timeout) and
  `aLatchedDifferentIncarnationDoesNotReleaseALaterWaiter` (the latch does not
  become a way for the wrong spawn to release a later hold).
- *Deferred: toggle the flag and see the composer appear and vanish.* Stands on
  `ComposerMountingTests`' both-branch pair, plus the remote-worktree,
  non-Claude-terminal, missing-row and hibernated-terminal cases.

**The mutant.** The hold tests were not written and assumed to discriminate;
they were checked against a deliberately wrong implementation in which the hold
is not scoped to the wake's own spawn (`.noOp` and a wake with no incarnation
both mint a substitute and enter the hold, and the hold's answer is discarded so
any start releases it). Against that mutant,
`scripts/test.sh --filter ComposerSendCoordinatorTests` gave **13 tests, 5
failures**: the three coordinator tests named above, plus
`aWakeWhoseSessionNeverStartsFails` and `theHoldTimesOutOnTheInjectedClock`.
`aSessionStartFromAnotherIncarnationDoesNotRelease`, and its registry-level twin
`anotherIncarnationDoesNotRelease`, are the ones a reviewer cannot judge from the
diff: a hold releasing on somebody *else's* `SessionStart` looks identical in the
source to one that does not.

Other RED/GREEN pairs verified by reverting the source and re-running: the
deferred-report change (three synchronous reports before the fix, zero after),
and the timeout copy (all four assertions red against the old sentence).

**Local runs** (filtered, never the full suite — the machine is shared):

- `scripts/swift-safe build --build-tests` — `Build complete!`, no new warnings,
  on every commit's tree.
- `scripts/test.sh --filter "Composer|Completion"` — **287 tests, 33 suites, 0
  failures**.
- `scripts/test.sh --filter "ComposerMountingTests|ComposerStateTests"` — 41
  tests, 0 failures.
- `swiftlint lint --strict` on the touched files — 0 violations.

**CI.** The full suite was dispatched for this branch (`test.yml` fires
automatically only for PRs based on `main`, and this one is stacked):
https://github.com/cheapsteak/tbd/actions/runs/34036456842 — **verdict pending
at the time of writing.**


### Live run, 2026-09-06 — the daemon half is now verified live; the app half still is not

With the user's authorization the fleet's daemon and app were replaced by this
branch's (`scripts/restart.sh` from `composer-d`, `daemon status` reporting
`Build: 79d9e85d (tbd/composer-d-app-composer)`), and a zero-token Claude session was
driven against `scripts/claude-stub.py` on loopback. Full record:
`.superpowers/sdd/2026-09-05-composer-d-app-composer/live-verification-report.md`.

**What that reached, and it is the half below the composer.** The send path this PR
calls is now confirmed live end to end: a three-part payload arrives as one user turn
with the image inline (read out of the session's transcript JSONL, not the screen);
suppression asked for over a socket that is not the app's is refused on the connection
with the daemon naming `peer-pid-is-not-the-apps` — a reason only reachable after the
peer pid resolved *and* the FD-vending sidecar's recorded client was found, so the
sidecar is demonstrably connected with the app recorded against it; the awaiting-input
gate refuses with the prompt's own message and types nothing, while the same payload
without `gateOnAwaitingInput` passes the same standing prompt; and
`terminal.wake` answers `{"woken":true,"sessionIncarnationID":"1FC3EB77-…"}` on the
first call and `{"woken":false}` on the second, with the woken pane's own
`TBD_TERMINAL_INCARNATION_ID` matching. The composer's completions source answers too:
`tbd terminal completions --json` returned 18 agents and 213 commands, `source: "probe"`.

**Task 14 Steps 2–9 remain NOT DRIVEN, and the reason has changed.** It is no longer
the fleet rule — the restart happened. It is that an automated session on this machine
cannot see or reach the app's window: `screencapture` fails with
`could not create image from display` (no Screen Recording grant), `cua-driver` reports
`screen_recording_capturable: false` and its AX walk of TBD's main window returns 1790
elements that are entirely menu bar with no `AXWindow` and no window content, and
`osascript` keystrokes are disabled on this box. Posting blind keystrokes into a fleet
app risks typing into another agent's live session, so nothing was typed. Driving by RPC
instead did not help: `tbd terminal focus --activate` and the `tbd://open?worktree=…`
deep link both succeeded, but `tbd panel list` answered `No tabs found` for a worktree
the app had not been opened on by hand, so `tbd panel open --transcript` had no tab.

What the running binary does confirm: both menu commands exist and are wired —
`Focus Message Composer` (⌘/) and `Focus Transcript` (⌘⌥/) were read out of the live
app's own accessibility tree. Everything below that line still needs a person, and the
report above ends with a step-by-step list of exactly what to press and what to look
for. **The composer flag is left ON on the running daemon**
(`transcriptComposerEnabled: true`) so that pass can start immediately.

**One defect found, and it is reachable from this composer.** PR #824's parts delivery
can place an `[Image #N]` token at the **end** of a message instead of among the words,
and that send can fail to submit — observed twice, both on the first image a Claude Code
process had ever been given, and correct on every repeat within a warmed session. It
looks like a race between the `.parts` arm's back-to-back pastes and Claude Code's
asynchronous image attach. Step 7 of the report's hand-verification list says to watch
for it specifically, because a paste into this composer takes the same path.

[composer-d](https://cheapsteak.github.io/tbd/open/?worktree=3CFAF90E-C785-4CC5-BC83-E703E10064B2)

https://claude.ai/code/session_01E9SPoxoVoApcVmduLiBWik



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a terminal message composer with per-terminal draft restoration and send/resume actions.
  - Added slash-command and at-mention completions with ranking, keyboard navigation, previews, and argument hints.
  - Added image paste/drop support with staged thumbnails, reinsertion, removal, and size validation.
  - Added shortcuts to focus the composer or return focus to the transcript.
  - Added composer availability messaging for unsupported, blocked, or inactive sessions.

- **Bug Fixes**
  - Composer state is now cleared when tabs or terminals are removed.
  - Improved session-start handling for reliable message delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->