### PR TITLE
Fix: Stop holder sends after a daemon restart landing in the composer and never submitting

### DIFF
--- a/Sources/TBDDaemon/Actuation/ActuationLog.swift
+++ b/Sources/TBDDaemon/Actuation/ActuationLog.swift
@@ -175,16 +175,17 @@ public actor ActuationLog {
     /// lives in a type this signature does not accept (`ObservedResult`), and
     /// reaches the file only through `appendObservation`.
     ///
-    /// `modeSource` and `modeAgeMilliseconds` are defaulted to nil because only
-    /// one caller has them: a holder send, which composed its bytes against a
-    /// mode oracle and records what it composed against. Every other act passes
-    /// nothing and writes neither key.
+    /// `modeSource`, `modeAgeMilliseconds` and `modesObserved` are defaulted to
+    /// nil because only one caller has them: a holder send, which composed its
+    /// bytes against a mode oracle and records what it composed against. Every
+    /// other act passes nothing and writes none of the three keys.
     func appendOutcome(
         confirms: String,
         result: ActuationOutcome,
         error: String? = nil,
         modeSource: ActuationModeSource? = nil,
-        modeAgeMilliseconds: Int? = nil
+        modeAgeMilliseconds: Int? = nil,
+        modesObserved: Bool? = nil
     ) {
         var row = ActuationRow(actor: .daemon(), kind: .outcome)
         row.id = Self.mintID()
@@ -193,6 +194,7 @@ public actor ActuationLog {
         row.reason = result.reason
         row.modeSource = modeSource
         row.modeAgeMilliseconds = modeAgeMilliseconds
+        row.modesObserved = modesObserved
         row.error = error
         try? appendWithOneRetry(row, failClosed: false)
     }

--- a/Sources/TBDDaemon/Actuation/ActuationRow.swift
+++ b/Sources/TBDDaemon/Actuation/ActuationRow.swift
@@ -336,5 +336,17 @@ struct ActuationRow: Codable, Sendable, Equatable {
     /// `staleDaemon` at 41 minutes and one at 200 milliseconds describe very
     /// different amounts of guessing.
     var modeAgeMilliseconds: Int?
+    /// Whether the answering emulator had witnessed the child's mode setup, or
+    /// was only reporting a fresh terminal's defaults.
+    ///
+    /// Rides with `modeSource` and is absent whenever that is `unavailable`,
+    /// for the same reason the age is: nothing answered, so there is nothing
+    /// whose provenance this could be. `false` says the composition was made
+    /// against defaults rather than against anything the child was seen to do
+    /// — the row's way of saying "this was a guess" about a `daemon` source,
+    /// which `staleDaemon` already says about a suspended one. Between them a
+    /// reader learns both ways a composition can be uninformed: the store
+    /// stopped watching, or it never saw the child start.
+    var modesObserved: Bool?
     var error: String?
 }

--- a/Sources/TBDDaemon/Actuation/RPCRouter+Actuation.swift
+++ b/Sources/TBDDaemon/Actuation/RPCRouter+Actuation.swift
@@ -84,7 +84,7 @@ extension RPCRouter {
     /// the act already ran, so a lost outcome row leaves the request
     /// unconfirmed rather than retroactively refused.
     ///
-    /// The two mode parameters are defaulted so no existing call site changes.
+    /// The three mode parameters are defaulted so no existing call site changes.
     /// Only a holder send passes them, and only for a row written after it
     /// composed something — see `ActuationRow.modeSource`.
     func finishActuation(
@@ -92,11 +92,13 @@ extension RPCRouter {
         _ result: ActuationOutcome,
         error: String? = nil,
         modeSource: ActuationModeSource? = nil,
-        modeAgeMilliseconds: Int? = nil
+        modeAgeMilliseconds: Int? = nil,
+        modesObserved: Bool? = nil
     ) async {
         await actuationLog.appendOutcome(
             confirms: id, result: result, error: error,
-            modeSource: modeSource, modeAgeMilliseconds: modeAgeMilliseconds)
+            modeSource: modeSource, modeAgeMilliseconds: modeAgeMilliseconds,
+            modesObserved: modesObserved)
     }
 
     /// Convenience for handlers whose only post-row failure mode is the daemon

--- a/Sources/TBDDaemon/Holder/HolderReader.swift
+++ b/Sources/TBDDaemon/Holder/HolderReader.swift
@@ -137,6 +137,20 @@ actor HolderReader {
     ///   session's output is exhausted — see `hasReachedEndOfOutput`. It must
     ///   not block, and must not stop this reader inline; the registry's
     ///   reclaimer hops onto the actor instead.
+    /// - Parameter observedChildFromStart: whether this reader's emulator will
+    ///   see every byte the child has ever written. `true` at spawn, where the
+    ///   child's startup `DECSET`s are still sitting in the pty buffer waiting
+    ///   for the first reader, so the emulator's modes become the child's. It
+    ///   is `false` when the reader is built over a child that was already
+    ///   running — the daemon re-adopting a session across a restart — where
+    ///   the setup has long since been read by somebody else and this emulator
+    ///   holds a fresh terminal's defaults for as long as it lives. Reported
+    ///   as `modesObserved` on every screen and mode reading this reader gives.
+    ///   Required and named at every construction site, for the same reason
+    ///   `take` names it: a default would be right on one path — a test harness
+    ///   feeding its own emulator from the start, `true` — and a silent lie on
+    ///   the other, the registry's adoption path, where the honest answer is
+    ///   `false`.
     /// - Parameter monotonicNow: reads the monotonic clock, for the two
     ///   instants the emulator stamps — its adoption and its last consumed
     ///   byte — whose difference is a screen's `age`. It sits *before* `clock`
@@ -155,6 +169,7 @@ actor HolderReader {
         stopTimeout: Duration = HolderReader.defaultStopTimeout,
         readFault: HolderReadFault? = nil,
         onEndOfOutput: (@Sendable () -> Void)? = nil,
+        observedChildFromStart: Bool,
         monotonicNow: @escaping @Sendable () -> ContinuousClock.Instant = { ContinuousClock.now },
         clock: any Clock<Duration> = ContinuousClock()
     ) {
@@ -172,6 +187,7 @@ actor HolderReader {
             columns: columns,
             rows: rows,
             scrollback: scrollbackLines,
+            modesObserved: observedChildFromStart,
             monotonicNow: monotonicNow,
             reply: { [descriptor] bytes in descriptor.replyBestEffort(bytes) })
     }
@@ -540,6 +556,12 @@ actor HolderReader {
     /// `staleDaemon` there. That is not a special case to be excused: an idle
     /// reader's emulator is by definition not being fed, so a screen taken from
     /// it is a frozen one and saying so is the truthful answer.
+    ///
+    /// **What it does not encode is whether the emulator has watched this child
+    /// since birth.** A reader draining a session it re-adopted after a restart
+    /// answers `.daemon`, correctly — its lines are live — while its modes are
+    /// a fresh terminal's defaults. That is the separate axis `modesObserved`
+    /// carries.
     private var currentSource: TerminalScreen.Source {
         state == .draining ? .daemon : .staleDaemon
     }
@@ -577,6 +599,15 @@ actor HolderReader {
     /// *ordered*, and a live byte parsed ahead of the prelude would be erased
     /// by it — output the viewer never saw and the daemon then throws away.
     /// A stopped reader ignores the feed: its screen has no further readers.
+    ///
+    /// **A preamble restores the modes' values and not their provenance.** The
+    /// writer states every mode the capture carries, so the flags after the
+    /// feed are the departing viewer's — but that viewer's emulator was itself
+    /// seeded by *this* reader's attach preamble, so what comes back is what
+    /// this reader handed out. A preamble can carry no more provenance than the
+    /// reader already had. Nothing here therefore moves `modesObserved`: a
+    /// re-adopted session stays unobserved across every attach and handback,
+    /// and only a session this daemon spawned is ever observed.
     func ingest(preamble: Data) {
         guard state != .stopped, !preamble.isEmpty else { return }
         emulator.feed([UInt8](preamble)[...])
@@ -1260,14 +1291,26 @@ private final class HolderEmulator: @unchecked Sendable {
     ///
     /// `screen` asks nothing at all: it reads the delegate's `DECTCEM` flag.
     private var lastByteAt: ContinuousClock.Instant?
+    /// Whether this emulator's mode flags are observations of the child rather
+    /// than a fresh terminal's defaults — the `modesObserved` every screen and
+    /// mode reading carries.
+    ///
+    /// Set at construction by whoever knows how this emulator came to exist,
+    /// and never moved afterwards: nothing this emulator can be fed carries
+    /// provenance it was not built with, because every preamble in the system
+    /// originates from a daemon emulator's own snapshot. Read under
+    /// `terminalLock`, like `lastByteAt` and everything else here.
+    private let modesObserved: Bool
 
     init(
         columns: Int, rows: Int, scrollback: Int,
+        modesObserved: Bool,
         monotonicNow: @escaping @Sendable () -> ContinuousClock.Instant,
         reply: @escaping @Sendable (ArraySlice<UInt8>) -> Void
     ) {
         let delegate = ReplyForwardingDelegate(reply: reply)
         self.delegate = delegate
+        self.modesObserved = modesObserved
         self.monotonicNow = monotonicNow
         self.adoptedAt = monotonicNow()
         self.terminal = Terminal(
@@ -1278,6 +1321,11 @@ private final class HolderEmulator: @unchecked Sendable {
                 scrollback: max(0, scrollback)))
     }
 
+    /// Bytes from outside — the drain loop's reads, the quiesce remainder, a
+    /// handback preamble. **None of it marks the modes observed**: the child's
+    /// running output says nothing about the modes it set before this emulator
+    /// existed, so a session that happens to print a lot must not talk its way
+    /// into a provenance it never earned.
     func feed(_ bytes: ArraySlice<UInt8>) {
         terminal.terminalLock.withLock {
             lastByteAt = monotonicNow()
@@ -1369,6 +1417,7 @@ private final class HolderEmulator: @unchecked Sendable {
                 cursor: cursor,
                 size: TerminalScreen.Size(columns: terminal.cols, rows: terminal.rows),
                 modes: currentModes(),
+                modesObserved: modesObserved,
                 source: source,
                 ageMilliseconds: ageMilliseconds())
         }
@@ -1378,7 +1427,8 @@ private final class HolderEmulator: @unchecked Sendable {
     func modeReading(source: TerminalScreen.Source) -> TerminalModeReading {
         terminal.terminalLock.withLock {
             TerminalModeReading(
-                modes: currentModes(), source: source, ageMilliseconds: ageMilliseconds())
+                modes: currentModes(), modesObserved: modesObserved, source: source,
+                ageMilliseconds: ageMilliseconds())
         }
     }
 

--- a/Sources/TBDDaemon/Holder/HolderRegistry.swift
+++ b/Sources/TBDDaemon/Holder/HolderRegistry.swift
@@ -574,6 +574,10 @@ actor HolderRegistry {
                 terminalID: terminalID,
                 over: spawned.client,
                 expecting: owner,
+                // The job has only just been forked, and nothing has read its
+                // pty yet, so whatever it says about its modes on startup lands
+                // in this emulator.
+                observedChildFromStart: true,
                 onEndOfOutput: endOfOutputNotifier(for: terminalID))
         } catch {
             // The holder is up and supervising a job that no row will ever
@@ -894,6 +898,15 @@ actor HolderRegistry {
                 busyRetryBudget: budget,
                 receiveTimeout: Self.adoptionReceiveTimeout,
                 clock: clock,
+                // The child has been running without this emulator — since the
+                // last daemon, or since a viewer took the pty — so its mode
+                // setup was consumed by somebody else and the fresh terminal
+                // this builds starts on defaults, permanently. A preamble, when
+                // there is one, restores the modes' values and not their
+                // provenance: the viewer that captured it was itself seeded by
+                // this session's attach preamble, so it can hand back no more
+                // than the daemon gave it.
+                observedChildFromStart: false,
                 onEndOfOutput: notifyEndOfOutput,
                 seedingScreenWith: preamble)
         }
@@ -1204,6 +1217,7 @@ actor HolderRegistry {
         busyRetryBudget: Duration,
         receiveTimeout: Duration,
         clock: any Clock<Duration>,
+        observedChildFromStart: Bool,
         onEndOfOutput: (@Sendable () -> Void)?,
         seedingScreenWith preamble: Data = Data()
     ) async throws -> Adoption {
@@ -1215,6 +1229,7 @@ actor HolderRegistry {
                     socketPath: socketPath,
                     expecting: owner,
                     receiveTimeout: receiveTimeout,
+                    observedChildFromStart: observedChildFromStart,
                     onEndOfOutput: onEndOfOutput,
                     seedingScreenWith: preamble)
             } catch HolderClient.Error.rejected(let version) {
@@ -1238,6 +1253,7 @@ actor HolderRegistry {
         socketPath: String,
         expecting owner: HolderOwnerToken,
         receiveTimeout: Duration,
+        observedChildFromStart: Bool,
         onEndOfOutput: (@Sendable () -> Void)?,
         seedingScreenWith preamble: Data = Data()
     ) async throws -> Adoption {
@@ -1245,6 +1261,7 @@ actor HolderRegistry {
             terminalID: terminalID,
             over: HolderClient(socketPath: socketPath, receiveTimeout: receiveTimeout),
             expecting: owner,
+            observedChildFromStart: observedChildFromStart,
             onEndOfOutput: onEndOfOutput,
             seedingScreenWith: preamble)
     }
@@ -1258,10 +1275,20 @@ actor HolderRegistry {
     /// holder serves one client at a time, so a connection kept past the
     /// hand-over would refuse every later verb, a `forget` on the deletion path
     /// above all.
+    ///
+    /// - Parameter observedChildFromStart: whether the reader this builds will
+    ///   have seen every byte its child ever wrote — `true` for a session this
+    ///   daemon just spawned, whose startup `DECSET`s are still queued in the
+    ///   pty, and `false` for one adopted while it was already running, whose
+    ///   mode setup was read by somebody else long ago. It rides all the way to
+    ///   `TerminalScreen.modesObserved`, and it is named at every call site
+    ///   rather than defaulted, because a default is right on one of these two
+    ///   paths and a silent lie on the other.
     private static func take(
         terminalID: UUID,
         over client: HolderClient,
         expecting owner: HolderOwnerToken,
+        observedChildFromStart: Bool,
         onEndOfOutput: (@Sendable () -> Void)? = nil,
         seedingScreenWith preamble: Data = Data()
     ) async throws -> Adoption {
@@ -1310,7 +1337,8 @@ actor HolderRegistry {
             ptyFD: ptyFD,
             columns: grid.columns,
             rows: grid.rows,
-            onEndOfOutput: onEndOfOutput)
+            onEndOfOutput: onEndOfOutput,
+            observedChildFromStart: observedChildFromStart)
         // BEFORE the drain starts, and that ordering is the whole of the
         // handback's fidelity: the preamble's reset prelude erases the display
         // and the scrollback, so a live byte parsed ahead of it would be wiped

--- a/Sources/TBDDaemon/Server/HolderSendComposition.swift
+++ b/Sources/TBDDaemon/Server/HolderSendComposition.swift
@@ -1,4 +1,5 @@
 import Foundation
+import TBDShared
 
 /// Turns one `terminal.send` into the exact bytes the holder transport writes.
 ///
@@ -61,14 +62,49 @@ enum HolderSendComposition {
     /// pressed, and what tmux's `send-keys Enter` sends.
     static let submitByte: UInt8 = 0x0d
 
+    /// Whether to wrap, given what the oracle answered and whether an
+    /// unobserved guess should wrap for this child.
+    ///
+    /// **An observed flag is obeyed either way.** `modes.bracketedPaste` is
+    /// then a fact about the child — it was seen to ask for bracketing, or seen
+    /// not to — so `unobservedShouldWrap` does not enter into it: an observed
+    /// `true` wraps and an observed `false` composes bare, whatever the child
+    /// is running.
+    ///
+    /// **An unobserved reading is a guess**, and where the guess lands depends
+    /// on the child. `modesObserved: false` comes from an emulator built over a
+    /// child that was already running, so its flag is a fresh terminal's
+    /// default and says nothing about the child at all. Wrapping under that
+    /// uncertainty is right only where composing bare would fail *silently* —
+    /// a TUI whose paste-burst heuristic can absorb a bare submitting `\r` into
+    /// the text, leaving the message in the composer with nothing to say why.
+    /// That is the agent sessions, and the caller passes
+    /// `carriesDispatchEnvelope(terminal)` for the flag to name exactly them.
+    ///
+    /// A **shell** composes bare under the same uncertainty, because its line
+    /// editor (readline, zle) submits bare input of any length and has no burst
+    /// heuristic to fool — so a bare send never stalls there. Wrapping a shell
+    /// that never asked for brackets would only hand it markers to print, or a
+    /// line made of them to run, for a stall that cannot happen: markers at a
+    /// `sudo`/`ssh`/`rm -i` prompt answered on garbage, in exchange for nothing.
+    ///
+    /// A `nil` reading composes bare regardless — nothing answered, the write
+    /// is about to fail anyway, and bare bytes are what every child understood
+    /// before any of this existed.
+    static func bracketedPaste(
+        for reading: TerminalModeReading?, unobservedShouldWrap: Bool
+    ) -> Bool {
+        guard let reading else { return false }
+        if reading.modesObserved { return reading.modes.bracketedPaste }
+        return unobservedShouldWrap
+    }
+
     /// - Parameter body: everything the message says, envelope included. The
     ///   envelope goes *inside* the paste, because it is part of the text the
     ///   child is being handed and splitting it out would be a second chunk.
     /// - Parameter submit: whether a Return follows.
-    /// - Parameter bracketedPaste: what the child's mode is, as the oracle
-    ///   answered. `false` when the oracle could not answer at all — bare bytes
-    ///   are what every child understood before this existed, and markers a
-    ///   child never asked for are printed rather than obeyed.
+    /// - Parameter bracketedPaste: whether to wrap, as `bracketedPaste(for:)`
+    ///   decided from the oracle's answer.
     /// - Returns: one `Data`, written in one call, so the message is never
     ///   interleaved with another writer's.
     static func compose(body: String, submit: Bool, bracketedPaste: Bool) -> Data {

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -3228,6 +3228,23 @@ extension RPCRouter {
     /// the child changed since then is invisible here for as long as the viewer
     /// holds it — possibly hours.
     ///
+    /// **A third case is not a window at all.** A reading whose `modesObserved`
+    /// is `false` comes from an emulator built over a child that was already
+    /// running — the daemon re-adopting a session it did not spawn — so its
+    /// flags are a fresh terminal's defaults and say nothing about the child at
+    /// any moment, and no attach or handback since can have changed that. There
+    /// the composition wraps **for an agent session**, because that is where a
+    /// bare send fails silently: the receiving TUI's paste-burst heuristic
+    /// absorbs the `\r` and the message sits in the composer with nothing to
+    /// say why, and printed markers are the visible failure preferred to it. A
+    /// re-adopted **shell** composes bare, because a shell's line editor
+    /// submits bare input of any length and has no burst heuristic to fool, so
+    /// wrapping it would only hand a `sudo`/`ssh`/`rm -i` prompt markers to
+    /// print for a stall that cannot happen.
+    /// `HolderSendComposition.bracketedPaste(for:unobservedShouldWrap:)` owns
+    /// that rule, keyed on `carriesDispatchEnvelope`, and the row's
+    /// `modesObserved` discloses the guess.
+    ///
     /// Both windows are accepted, and the wide one is accepted by ruling: the
     /// design's "Proceeding on stale modes" section weighs a rare wrong
     /// composition against rails that fail closed exactly when supervision most
@@ -3277,9 +3294,10 @@ extension RPCRouter {
         // is possible — the courier decides that, and it fails open.
         let reading = await holderModeReading(terminalID: terminal.id)
         let modeSource = reading.map { ActuationModeSource($0.source) } ?? .unavailable
-        // Absent for `unavailable`: nothing answered, so there is no store
-        // whose age this could be.
+        // Both absent for `unavailable`: nothing answered, so there is no store
+        // whose age or provenance these could be.
         let modeAge = reading?.ageMilliseconds
+        let modesObserved = reading?.modesObserved
 
         // Same envelope rule as the tmux arm, and for the same reasons — see
         // the long comment there. Empty text stays empty: `--text "" --submit`
@@ -3292,7 +3310,8 @@ extension RPCRouter {
                 : text)
         let message = HolderSendComposition.compose(
             body: body, submit: submit,
-            bracketedPaste: reading?.modes.bracketedPaste ?? false)
+            bracketedPaste: HolderSendComposition.bracketedPaste(
+                for: reading, unobservedShouldWrap: Self.carriesDispatchEnvelope(terminal)))
 
         guard !message.isEmpty else {
             // Nothing to write, reached two ways. `--text ""` with no
@@ -3312,7 +3331,8 @@ extension RPCRouter {
             await finishActuation(
                 actuationID, .dispatched,
                 modeSource: composed ? modeSource : nil,
-                modeAgeMilliseconds: composed ? modeAge : nil)
+                modeAgeMilliseconds: composed ? modeAge : nil,
+                modesObserved: composed ? modesObserved : nil)
             return .ok()
         }
 
@@ -3320,7 +3340,8 @@ extension RPCRouter {
         case .viewerWrote, .daemonWrote:
             await finishActuation(
                 actuationID, .dispatched,
-                modeSource: modeSource, modeAgeMilliseconds: modeAge)
+                modeSource: modeSource, modeAgeMilliseconds: modeAge,
+                modesObserved: modesObserved)
             return .ok()
         case .notDelivered(let reason):
             // The transport, not a decision: the daemon tried to write and
@@ -3329,7 +3350,8 @@ extension RPCRouter {
             // composed is a fact about the attempt, not about its success.
             await finishActuation(
                 actuationID, .transportFailed, error: reason,
-                modeSource: modeSource, modeAgeMilliseconds: modeAge)
+                modeSource: modeSource, modeAgeMilliseconds: modeAge,
+                modesObserved: modesObserved)
             return RPCResponse(error: reason)
         }
     }

--- a/Sources/TBDShared/TerminalScreen.swift
+++ b/Sources/TBDShared/TerminalScreen.swift
@@ -151,6 +151,26 @@ public struct TerminalScreen: Codable, Sendable, Equatable {
     public let cursor: Cursor
     public let size: Size
     public let modes: ChildModes
+    /// Whether the answering emulator has witnessed the child's mode setup.
+    ///
+    /// `modes` says what the emulator's flags are; this says whether they are
+    /// **observations** or merely a fresh terminal's defaults. It is true one
+    /// way: the emulator was born with the child, so the startup `DECSET`s
+    /// waiting in the pty buffer for the first reader landed in it and its
+    /// flags are the child's own.
+    ///
+    /// It is false for an emulator built over an *already running* child — the
+    /// daemon re-adopting a session it did not spawn — and it stays false for
+    /// that emulator's whole life. A handback preamble restores the modes'
+    /// *values*, because the snapshot states every mode it carries, set or
+    /// reset; it raises no provenance, because the store that captured it was
+    /// itself seeded by this emulator's own attach preamble and can hand back
+    /// no more than it was given.
+    ///
+    /// So `false` means: read `modes` as defaults, not as facts — unless the
+    /// child happened to re-emit a mode escape of its own after the adoption,
+    /// which nothing here can tell.
+    public let modesObserved: Bool
     public let source: Source
     /// How long ago the answering store's emulator last consumed a byte from
     /// the pty, in milliseconds, on a monotonic clock — never wall time, so no
@@ -180,7 +200,9 @@ public struct TerminalScreen: Codable, Sendable, Equatable {
     /// The three modes, their provenance, and their age — everything the input
     /// path needs and nothing it does not.
     public var modeReading: TerminalModeReading {
-        TerminalModeReading(modes: modes, source: source, ageMilliseconds: ageMilliseconds)
+        TerminalModeReading(
+            modes: modes, modesObserved: modesObserved, source: source,
+            ageMilliseconds: ageMilliseconds)
     }
 
     /// Why a screen could not be constructed.
@@ -230,6 +252,7 @@ public struct TerminalScreen: Codable, Sendable, Equatable {
         cursor: Cursor,
         size: Size,
         modes: ChildModes,
+        modesObserved: Bool,
         source: Source,
         ageMilliseconds: Int
     ) throws {
@@ -246,6 +269,7 @@ public struct TerminalScreen: Codable, Sendable, Equatable {
         self.cursor = cursor
         self.size = size
         self.modes = modes
+        self.modesObserved = modesObserved
         self.source = source
         self.ageMilliseconds = ageMilliseconds
     }
@@ -270,7 +294,7 @@ public struct TerminalScreen: Codable, Sendable, Equatable {
     // MARK: - Coding
 
     private enum CodingKeys: String, CodingKey {
-        case lines, viewportStart, cursor, size, modes, source, ageMilliseconds
+        case lines, viewportStart, cursor, size, modes, modesObserved, source, ageMilliseconds
     }
 
     /// Written out field by field rather than synthesised, so the wire form is
@@ -285,6 +309,7 @@ public struct TerminalScreen: Codable, Sendable, Equatable {
         try container.encode(cursor, forKey: .cursor)
         try container.encode(size, forKey: .size)
         try container.encode(modes, forKey: .modes)
+        try container.encode(modesObserved, forKey: .modesObserved)
         try container.encode(source, forKey: .source)
         try container.encode(ageMilliseconds, forKey: .ageMilliseconds)
     }
@@ -297,6 +322,13 @@ public struct TerminalScreen: Codable, Sendable, Equatable {
     /// Decoding runs the same validation construction does. A screen that
     /// arrives with a control character in it is refused at the boundary rather
     /// than handed on, for the same reason it is refused at the producer.
+    ///
+    /// **A missing `modesObserved` decodes as observed.** A producer that
+    /// predates the field could not tell the two cases apart, so it has no
+    /// answer to withhold — and `true` is what every consumer assumed while the
+    /// field did not exist. An older daemon's screen therefore decodes to the
+    /// behaviour it has always had, rather than to a refusal or a wrapping it
+    /// never asked for.
     public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         try self.init(
@@ -305,6 +337,7 @@ public struct TerminalScreen: Codable, Sendable, Equatable {
             cursor: container.decode(Cursor.self, forKey: .cursor),
             size: container.decode(Size.self, forKey: .size),
             modes: container.decode(ChildModes.self, forKey: .modes),
+            modesObserved: container.decodeIfPresent(Bool.self, forKey: .modesObserved) ?? true,
             source: container.decode(Source.self, forKey: .source),
             ageMilliseconds: container.decode(Int.self, forKey: .ageMilliseconds))
     }
@@ -318,13 +351,22 @@ public struct TerminalScreen: Codable, Sendable, Equatable {
 /// to compose one message would walk the scrollback on every send.
 public struct TerminalModeReading: Sendable, Equatable {
     public let modes: TerminalScreen.ChildModes
+    /// Whether the answering emulator has witnessed the child's mode setup —
+    /// `TerminalScreen.modesObserved`, on the answer the input path actually
+    /// reads. `false` means `modes` are a fresh terminal's defaults rather than
+    /// anything the child was seen to do.
+    public let modesObserved: Bool
     public let source: TerminalScreen.Source
     public let ageMilliseconds: Int
 
     public init(
-        modes: TerminalScreen.ChildModes, source: TerminalScreen.Source, ageMilliseconds: Int
+        modes: TerminalScreen.ChildModes,
+        modesObserved: Bool,
+        source: TerminalScreen.Source,
+        ageMilliseconds: Int
     ) {
         self.modes = modes
+        self.modesObserved = modesObserved
         self.source = source
         self.ageMilliseconds = ageMilliseconds
     }

--- a/Tests/TBDCLITests/TerminalOutputStalenessNoteTests.swift
+++ b/Tests/TBDCLITests/TerminalOutputStalenessNoteTests.swift
@@ -32,6 +32,7 @@ struct TerminalOutputStalenessNoteTests {
             size: TerminalScreen.Size(columns: 80, rows: 24),
             modes: TerminalScreen.ChildModes(
                 bracketedPaste: false, applicationCursor: false, alternateScreen: false),
+            modesObserved: true,
             source: source,
             ageMilliseconds: ageMilliseconds)
     }

--- a/Tests/TBDDaemonLiveTests/Holder/HolderAdoptionTests.swift
+++ b/Tests/TBDDaemonLiveTests/Holder/HolderAdoptionTests.swift
@@ -43,7 +43,8 @@ struct HolderAdoptionTests {
         // away, and the holder, the pty and the job are all untouched.
         let (_, ptyFD) = try await fixture.client.handOverPTY()
         let previous = HolderReader(
-            sessionID: fixture.sessionID, ptyFD: ptyFD, columns: 80, rows: 24)
+            sessionID: fixture.sessionID, ptyFD: ptyFD, columns: 80, rows: 24,
+            observedChildFromStart: true)
         try await previous.start()
         try await previous.write(Data("BEFORE\n".utf8))
         let sawBefore = await pollUntil("the job's answer before the outage") {
@@ -71,6 +72,15 @@ struct HolderAdoptionTests {
         let stored = await registry.reader(for: fixture.sessionID)
         #expect(stored === reader, "the registry did not keep the reader it adopted")
         #expect(holderProcessIsAlive(fixture.handle.childPID))
+
+        // The emulator this adoption built was constructed over a child that
+        // was already running, and no preamble seeded it, so its mode flags are
+        // a fresh terminal's defaults rather than anything the child was seen
+        // to do. Its lines are live — hence `.daemon` — and only its modes are
+        // unobserved, which is the whole reason the two facts are separate.
+        #expect(
+            await reader.modeReading().modesObserved == false,
+            "a re-adopted emulator reported its default modes as observations of the child")
     }
 
     /// The re-adopted emulator is built at the size of the **pty**, not the size
@@ -101,7 +111,8 @@ struct HolderAdoptionTests {
             described.launch.columns == 80 && described.launch.rows == 24,
             "the fixture no longer launches at 80x24, so this test proves nothing")
         let previous = HolderReader(
-            sessionID: fixture.sessionID, ptyFD: ptyFD, columns: 80, rows: 24)
+            sessionID: fixture.sessionID, ptyFD: ptyFD, columns: 80, rows: 24,
+            observedChildFromStart: true)
         try await previous.start()
         await previous.resize(columns: 123, rows: 41)
         await previous.stop()

--- a/Tests/TBDDaemonLiveTests/Holder/HolderJiggleTests.swift
+++ b/Tests/TBDDaemonLiveTests/Holder/HolderJiggleTests.swift
@@ -159,7 +159,8 @@ struct HolderJiggleTests {
         let (_, ptyFD) = try await fixture.client.handOverPTY()
         await fixture.client.close()
         let reader = HolderReader(
-            sessionID: fixture.sessionID, ptyFD: ptyFD, columns: 80, rows: 24)
+            sessionID: fixture.sessionID, ptyFD: ptyFD, columns: 80, rows: 24,
+            observedChildFromStart: true)
         try await reader.start()
         return reader
     }

--- a/Tests/TBDDaemonLiveTests/Holder/HolderJobSignalTests.swift
+++ b/Tests/TBDDaemonLiveTests/Holder/HolderJobSignalTests.swift
@@ -179,7 +179,8 @@ struct HolderJobSignalTests {
         let (_, ptyFD) = try await fixture.client.handOverPTY()
         await fixture.client.close()
         let reader = HolderReader(
-            sessionID: fixture.sessionID, ptyFD: ptyFD, columns: 80, rows: 24)
+            sessionID: fixture.sessionID, ptyFD: ptyFD, columns: 80, rows: 24,
+            observedChildFromStart: true)
         try await reader.start()
         return reader
     }

--- a/Tests/TBDDaemonLiveTests/Holder/HolderReaderTests.swift
+++ b/Tests/TBDDaemonLiveTests/Holder/HolderReaderTests.swift
@@ -75,7 +75,8 @@ struct HolderReaderTests {
         let (_, ptyFD) = try await client.handOverPTY()
         await client.close()
         let reader = HolderReader(
-            sessionID: fixture.sessionID, ptyFD: ptyFD, columns: 80, rows: 24)
+            sessionID: fixture.sessionID, ptyFD: ptyFD, columns: 80, rows: 24,
+            observedChildFromStart: true)
         try await reader.start()
         defer { stopInBackground(reader) }
 
@@ -110,7 +111,8 @@ struct HolderReaderTests {
         let (_, ptyFD) = try await client.handOverPTY()
         await client.close()
         let reader = HolderReader(
-            sessionID: fixture.sessionID, ptyFD: ptyFD, columns: 80, rows: 24)
+            sessionID: fixture.sessionID, ptyFD: ptyFD, columns: 80, rows: 24,
+            observedChildFromStart: true)
         try await reader.start()
         defer { stopInBackground(reader) }
 
@@ -151,7 +153,7 @@ struct HolderReaderTests {
         await client.close()
         let reader = HolderReader(
             sessionID: fixture.sessionID, ptyFD: ptyFD, columns: 80, rows: 24,
-            readFault: fault.seam())
+            readFault: fault.seam(), observedChildFromStart: true)
         try await reader.start()
         defer { stopInBackground(reader) }
 
@@ -185,7 +187,7 @@ struct HolderReaderTests {
         await client.close()
         let reader = HolderReader(
             sessionID: fixture.sessionID, ptyFD: ptyFD, columns: 80, rows: 24,
-            readFault: fault.seam())
+            readFault: fault.seam(), observedChildFromStart: true)
         try await reader.start()
         defer { stopInBackground(reader) }
 
@@ -218,7 +220,7 @@ struct HolderReaderTests {
         await client.close()
         let reader = HolderReader(
             sessionID: fixture.sessionID, ptyFD: ptyFD, columns: 80, rows: 24,
-            readFault: fault.seam())
+            readFault: fault.seam(), observedChildFromStart: true)
         try await reader.start()
         defer { stopInBackground(reader) }
 
@@ -242,7 +244,8 @@ struct HolderReaderTests {
         let (_, ptyFD) = try await client.handOverPTY()
         await client.close()
         let reader = HolderReader(
-            sessionID: fixture.sessionID, ptyFD: ptyFD, columns: 80, rows: 24)
+            sessionID: fixture.sessionID, ptyFD: ptyFD, columns: 80, rows: 24,
+            observedChildFromStart: true)
         try await reader.start()
         defer { stopInBackground(reader) }
 
@@ -269,7 +272,8 @@ struct HolderReaderTests {
         let (_, ptyFD) = try await client.handOverPTY()
         await client.close()
         let reader = HolderReader(
-            sessionID: fixture.sessionID, ptyFD: ptyFD, columns: 80, rows: 24)
+            sessionID: fixture.sessionID, ptyFD: ptyFD, columns: 80, rows: 24,
+            observedChildFromStart: true)
         try await reader.start()
         defer { stopInBackground(reader) }
 
@@ -300,7 +304,8 @@ struct HolderReaderTests {
         let client = fixture.client
         let (_, ptyFD) = try await client.handOverPTY()
         let reader = HolderReader(
-            sessionID: fixture.sessionID, ptyFD: ptyFD, columns: 80, rows: 24)
+            sessionID: fixture.sessionID, ptyFD: ptyFD, columns: 80, rows: 24,
+            observedChildFromStart: true)
         try await reader.start()
         defer { stopInBackground(reader) }
 
@@ -357,7 +362,8 @@ struct HolderReaderTests {
         _ = fcntl(readEnd, F_SETFL, fcntl(readEnd, F_GETFL) | O_NONBLOCK)
 
         let reader = HolderReader(
-            sessionID: UUID(), ptyFD: ends[1], columns: 80, rows: 24)
+            sessionID: UUID(), ptyFD: ends[1], columns: 80, rows: 24,
+            observedChildFromStart: true)
         let neverDrained = await reader.isDraining
         #expect(neverDrained == false)
 

--- a/Tests/TBDDaemonLiveTests/Holder/HolderSpawnGateTests.swift
+++ b/Tests/TBDDaemonLiveTests/Holder/HolderSpawnGateTests.swift
@@ -89,6 +89,15 @@ struct HolderSpawnGateTests {
             FileManager.default.fileExists(atPath: socketPath),
             "no holder rendezvous at \(socketPath) for a holder-transport session")
 
+        // The reader was born with this job, so whatever the job says about its
+        // modes on startup lands in this emulator and its flags are the child's
+        // — the other half of the fact `HolderAdoptionTests` asserts negatively
+        // for a session adopted while it was already running.
+        let reader = try #require(await fixture.registry.reader(for: primary.id))
+        #expect(
+            await reader.modeReading().modesObserved,
+            "a freshly spawned reader reported its child's modes as unobserved")
+
         // The other half of the setup-hook decision: this repo has no setup
         // hook, so on the holder path no tmux server is started for a bare
         // shell — and no `new-window` was ever issued.

--- a/Tests/TBDDaemonTests/Holder/HolderDescriptorInheritanceTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HolderDescriptorInheritanceTests.swift
@@ -138,7 +138,9 @@ struct HolderDescriptorInheritanceTests {
             !Self.isCloseOnExec(pair[0]),
             "the source must be inheritable, or a plain dup would pass this test too")
 
-        let reader = HolderReader(sessionID: UUID(), ptyFD: pair[0], columns: 80, rows: 24)
+        let reader = HolderReader(
+            sessionID: UUID(), ptyFD: pair[0], columns: 80, rows: 24,
+            observedChildFromStart: true)
         let duplicate = try await reader.suspendDraining()
         #expect(duplicate >= 0)
 

--- a/Tests/TBDDaemonTests/Holder/HolderSendCompositionTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HolderSendCompositionTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import TBDShared
 import Testing
 
 @testable import TBDDaemonLib
@@ -299,5 +300,79 @@ import Testing
         #expect(Self.occurrences(of: Self.end, in: composed) == 1)
         #expect(composed.last == 0x0d)
         #expect(composed.dropLast().suffix(Self.end.count) == Self.end)
+    }
+
+    // MARK: - Whether to wrap at all
+
+    private static func reading(
+        bracketedPaste: Bool, modesObserved: Bool, source: TerminalScreen.Source = .daemon
+    ) -> TerminalModeReading {
+        TerminalModeReading(
+            modes: TerminalScreen.ChildModes(
+                bracketedPaste: bracketedPaste, applicationCursor: false,
+                alternateScreen: false),
+            modesObserved: modesObserved,
+            source: source,
+            ageMilliseconds: 0)
+    }
+
+    /// Nothing answered, so there is nothing to reason from. The write is about
+    /// to fail and say so, and bare bytes are what every child understood
+    /// before any of this existed. The child-kind flag cannot change that.
+    @Test("no reading at all composes bare")
+    func noReadingComposesBare() {
+        #expect(HolderSendComposition.bracketedPaste(for: nil, unobservedShouldWrap: true) == false)
+        #expect(
+            HolderSendComposition.bracketedPaste(for: nil, unobservedShouldWrap: false) == false)
+    }
+
+    /// An observed flag is evidence about the child, so it is simply obeyed and
+    /// `unobservedShouldWrap` does not enter into it — asserted with the flag
+    /// set both ways to show it is ignored when the modes are observed.
+    @Test("an observed mode is taken at its word, and the child-kind flag is ignored")
+    func observedModeIsObeyed() {
+        for unobservedShouldWrap in [true, false] {
+            #expect(
+                HolderSendComposition.bracketedPaste(
+                    for: Self.reading(bracketedPaste: true, modesObserved: true),
+                    unobservedShouldWrap: unobservedShouldWrap))
+            #expect(
+                HolderSendComposition.bracketedPaste(
+                    for: Self.reading(bracketedPaste: false, modesObserved: true),
+                    unobservedShouldWrap: unobservedShouldWrap) == false)
+        }
+    }
+
+    /// An unobserved reading is a guess, and where it lands is the caller's
+    /// call: `unobservedShouldWrap: true` is an agent session, whose burst
+    /// heuristic can absorb a bare `\r` silently, so wrapping buys the visible
+    /// failure over the silent one. The flag's own `bracketedPaste` value is
+    /// not evidence of anything and does not move the answer.
+    @Test("an unobserved reading wraps when the caller says to, whatever the flag reads")
+    func unobservedReadingWrapsWhenAsked() {
+        #expect(
+            HolderSendComposition.bracketedPaste(
+                for: Self.reading(bracketedPaste: false, modesObserved: false),
+                unobservedShouldWrap: true))
+        #expect(
+            HolderSendComposition.bracketedPaste(
+                for: Self.reading(bracketedPaste: true, modesObserved: false),
+                unobservedShouldWrap: true))
+    }
+
+    /// The regression this closes: a shell composes bare under the same
+    /// uncertainty, because its line editor submits bare input of any length
+    /// and has no burst heuristic to fool. `unobservedShouldWrap: false`, and
+    /// the guessed `bracketedPaste` value must not talk it back into wrapping.
+    @Test("an unobserved reading stays bare when the caller says not to wrap")
+    func unobservedReadingStaysBareWhenNotAsked() {
+        #expect(
+            HolderSendComposition.bracketedPaste(
+                for: Self.reading(bracketedPaste: false, modesObserved: false),
+                unobservedShouldWrap: false) == false)
+        #expect(
+            HolderSendComposition.bracketedPaste(
+                for: Self.reading(bracketedPaste: true, modesObserved: false),
+                unobservedShouldWrap: false) == false)
     }
 }

--- a/Tests/TBDDaemonTests/Holder/HolderTmuxAssumptionGateTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HolderTmuxAssumptionGateTests.swift
@@ -491,6 +491,7 @@ struct HolderTmuxAssumptionGateTests {
             size: TerminalScreen.Size(columns: 80, rows: 24),
             modes: TerminalScreen.ChildModes(
                 bracketedPaste: true, applicationCursor: false, alternateScreen: false),
+            modesObserved: true,
             source: source,
             ageMilliseconds: 0)
     }
@@ -1511,6 +1512,8 @@ struct HolderTmuxAssumptionGateTests {
         #expect(outcome["modeSource"] as? String == "unavailable")
         #expect(outcome["modeAgeMilliseconds"] == nil,
                 "an unavailable oracle has no store whose age could be recorded")
+        #expect(outcome["modesObserved"] == nil,
+                "an unavailable oracle has no store whose provenance could be recorded")
         let after = try #require(try await db.terminals.get(id: terminal.id))
         #expect(RowFingerprint(after) == before)
         // The strongest half: delivery sits ahead of the whole tmux mechanic,
@@ -1529,6 +1532,7 @@ struct HolderTmuxAssumptionGateTests {
     /// live; this is how the composition's own branches are pinned.
     private func oracle(
         bracketedPaste: Bool,
+        modesObserved: Bool = true,
         source: TerminalScreen.Source = .daemon,
         ageMilliseconds: Int = 0
     ) -> @Sendable (UUID) async -> TerminalModeReading? {
@@ -1538,6 +1542,7 @@ struct HolderTmuxAssumptionGateTests {
                     bracketedPaste: bracketedPaste,
                     applicationCursor: false,
                     alternateScreen: false),
+                modesObserved: modesObserved,
                 source: source,
                 ageMilliseconds: ageMilliseconds)
         }
@@ -1627,6 +1632,102 @@ struct HolderTmuxAssumptionGateTests {
         #expect(!text.contains("\u{1b}[200~"))
         #expect(!text.contains("\u{1b}[201~"))
         #expect(recorded.snapshot().isEmpty)
+
+        let outcome = try #require(await Self.outcomeRow(of: rpc))
+        #expect(outcome["modesObserved"] as? Bool == true, """
+            an observed reading must say so, or a bare send is indistinguishable from a guess \
+            that happened to compose bare
+            """)
+    }
+
+    /// The daemon-restart case, and the reason the second axis exists. A reader
+    /// built over a child that was already running holds a fresh terminal's
+    /// defaults: its `bracketedPaste: false` is not a fact about the child, so
+    /// composing bare on it is the failure nobody can see — the receiver's
+    /// burst heuristic absorbs the `\r` and the message sits in the composer.
+    /// The oracle wraps instead, which at worst prints markers somebody can
+    /// read, and the row discloses that it guessed.
+    ///
+    /// **This is an AGENT session** (`seedClaudeTerminal` seeds a `.claude`
+    /// terminal), which is the only child kind whose bare-send failure is
+    /// silent and so the only one the uncertainty-wrap applies to — its
+    /// shell-kind counterpart is `sendStaysBareForAnUnobservedShell` below.
+    @Test("a send composed against unobserved agent defaults wraps anyway and says so on the row")
+    func sendWrapsForUnobservedDefaults() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let recorded = RecordedTmuxArgs()
+        let (wt, dir) = try await seedWorktree(db)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let terminal = try await seedClaudeTerminal(db, worktreeID: wt.id, transport: .holder)
+        let writes = HolderWrites()
+
+        let rpc = router(db, tmux: deadWindowTmux(recorded))
+        rpc.holderInjectionCourier = writes.courier()
+        rpc.holderModeOracle = oracle(
+            bracketedPaste: false, modesObserved: false, source: .daemon)
+        let response = await rpc.handle(try RPCRequest(
+            method: RPCMethod.terminalSend,
+            params: TerminalSendParams(
+                terminalID: terminal.id, text: "hello", submit: true)))
+
+        #expect(response.success, "error: \(response.error ?? "nil")")
+        let written = try #require(writes.all.first)
+        let text = try #require(String(data: written, encoding: .utf8))
+        #expect(text.hasPrefix("\u{1b}[200~"))
+        #expect(text.hasSuffix("\u{1b}[201~\r"))
+
+        let outcome = try #require(await Self.outcomeRow(of: rpc))
+        #expect(outcome["result"] as? String == "dispatched")
+        // The source alone would read as a live, trustworthy answer — the
+        // emulator IS live, and its lines are judgeable; only its modes are
+        // defaults. That is what the second field is for.
+        #expect(outcome["modeSource"] as? String == "daemon")
+        #expect(outcome["modesObserved"] as? Bool == false)
+    }
+
+    /// The regression guard for the narrowing: a re-adopted **shell** with
+    /// unobserved defaults composes bare, not wrapped.
+    ///
+    /// A shell's line editor (readline, zle) submits bare input of any length
+    /// and has no paste-burst heuristic to fool, so a bare send never stalls
+    /// there — the failure the wrap defends against is a property of the agent
+    /// TUI, not of any holder session. Wrapping a shell that never asked for
+    /// brackets would hand a `sudo`/`ssh`/`rm -i` prompt `ESC[200~` and
+    /// `ESC[201~` to answer on, for no benefit. If the wrap is not scoped to
+    /// agent sessions, this test's `hasPrefix` fails.
+    @Test("a send composed against an unobserved shell's defaults stays bare")
+    func sendStaysBareForAnUnobservedShell() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let recorded = RecordedTmuxArgs()
+        let (wt, dir) = try await seedWorktree(db)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "", tmuxPaneID: "",
+            label: TerminalLabel.shell, kind: .shell, transport: .holder,
+            holderPID: 9101, childPID: 9102)
+        let writes = HolderWrites()
+
+        let rpc = router(db, tmux: deadWindowTmux(recorded))
+        rpc.holderInjectionCourier = writes.courier()
+        rpc.holderModeOracle = oracle(
+            bracketedPaste: false, modesObserved: false, source: .daemon)
+        let response = await rpc.handle(try RPCRequest(
+            method: RPCMethod.terminalSend,
+            params: TerminalSendParams(
+                terminalID: terminal.id, text: "hello", submit: true)))
+
+        #expect(response.success, "error: \(response.error ?? "nil")")
+        let written = try #require(writes.all.first)
+        let text = try #require(String(data: written, encoding: .utf8))
+        #expect(!text.contains("\u{1b}[200~"),
+                "a re-adopted shell was wrapped: the uncertainty-wrap is not scoped to agents")
+        #expect(!text.contains("\u{1b}[201~"))
+        #expect(text.hasSuffix("hello\r"))
+
+        let outcome = try #require(await Self.outcomeRow(of: rpc))
+        #expect(outcome["result"] as? String == "dispatched")
+        #expect(outcome["modeSource"] as? String == "daemon")
+        #expect(outcome["modesObserved"] as? Bool == false)
     }
 
     /// The residue of the whole design, made examinable. When a viewer holds

--- a/Tests/TBDDaemonTests/HolderRenderProjectionTests.swift
+++ b/Tests/TBDDaemonTests/HolderRenderProjectionTests.swift
@@ -176,7 +176,8 @@ import Testing
                 ptyFD: pair[0],
                 columns: columns,
                 rows: rows,
-                scrollbackLines: 200)
+                scrollbackLines: 200,
+                observedChildFromStart: true)
         }
 
         /// Closes this side only. The reader's own end is closed by its

--- a/Tests/TBDDaemonTests/HolderScreenContractTests.swift
+++ b/Tests/TBDDaemonTests/HolderScreenContractTests.swift
@@ -400,6 +400,62 @@ import Testing
         #expect(screen.modeReading.ageMilliseconds == 7_000)
     }
 
+    // MARK: - Mode provenance
+
+    /// The ordinary case, and the one that must not report doubt: an emulator
+    /// built with its child sees the startup `DECSET`s, because they are still
+    /// waiting in the pty for whoever reads first.
+    ///
+    /// A handback does not lower provenance either — the emulator that captured
+    /// the preamble was seeded from this one, so it can take nothing away that
+    /// it did not put there. The ingest here is a `DECRST`, so the *value*
+    /// moves and the provenance must not.
+    @Test("a reader born with its child reports its modes as observed")
+    func aReaderBornWithItsChildReportsObservedModes() async throws {
+        let harness = try Harness(columns: 40, rows: 8)
+        defer { harness.tearDown() }
+
+        #expect(await harness.reader.modeReading().modesObserved)
+        #expect(try await harness.reader.screen(maxLines: 8).modesObserved)
+
+        await harness.reader.ingest(preamble: Self.data("\(Self.esc)[?2004l"))
+
+        #expect(await harness.reader.modeReading().modes.bracketedPaste == false)
+        #expect(await harness.reader.modeReading().modesObserved)
+        #expect(try await harness.reader.screen(maxLines: 8).modesObserved)
+    }
+
+    /// The daemon-restart case, and the reason provenance is fixed at
+    /// construction. Nothing in this emulator ever saw the child start, so its
+    /// flags are a fresh terminal's defaults — and a handback preamble does not
+    /// change that, however much it changes the flags.
+    ///
+    /// **A preamble cannot raise provenance**, because of where it comes from:
+    /// the viewer that captured it was painted by this reader's own attach
+    /// preamble, so what it hands back is what this reader gave it. Treating
+    /// the ingest as proof would turn the guess into a false certainty after
+    /// one open-and-close of a tab, and the next send would compose bare on a
+    /// row claiming the modes were observed.
+    ///
+    /// The preamble here is a **set**, deliberately: `bracketedPaste` moves to
+    /// `true`, so the assertions can tell the restored value apart from the
+    /// provenance that did not follow it.
+    @Test("a reader built over a running child stays unobserved across a preamble")
+    func aReaderOverARunningChildStaysUnobservedAcrossAPreamble() async throws {
+        let harness = try Harness(columns: 40, rows: 8, observedChildFromStart: false)
+        defer { harness.tearDown() }
+
+        #expect(await harness.reader.modeReading().modesObserved == false)
+        #expect(try await harness.reader.screen(maxLines: 8).modesObserved == false)
+
+        await harness.reader.ingest(preamble: Self.data("\(Self.esc)[?2004h"))
+
+        #expect(await harness.reader.modeReading().modes.bracketedPaste == true,
+                "the preamble did not restore the mode's value")
+        #expect(await harness.reader.modeReading().modesObserved == false)
+        #expect(try await harness.reader.screen(maxLines: 8).modesObserved == false)
+    }
+
     // MARK: - Harness
 
     private static func data(_ text: String) -> Data { Data(text.utf8) }
@@ -437,6 +493,7 @@ import Testing
 
         init(
             columns: Int, rows: Int,
+            observedChildFromStart: Bool = true,
             monotonicNow: @escaping @Sendable () -> ContinuousClock.Instant = {
                 ContinuousClock.now
             }
@@ -451,6 +508,7 @@ import Testing
                 columns: columns,
                 rows: rows,
                 scrollbackLines: 200,
+                observedChildFromStart: observedChildFromStart,
                 monotonicNow: monotonicNow)
         }
 

--- a/Tests/TBDSharedTests/TerminalScreenTests.swift
+++ b/Tests/TBDSharedTests/TerminalScreenTests.swift
@@ -23,6 +23,7 @@ import Testing
     private static func make(
         lines: [String],
         viewportStart: Int = 0,
+        modesObserved: Bool = true,
         source: TerminalScreen.Source = .daemon,
         ageMilliseconds: Int = 0
     ) throws -> TerminalScreen {
@@ -33,6 +34,7 @@ import Testing
             size: TerminalScreen.Size(columns: 80, rows: 24),
             modes: TerminalScreen.ChildModes(
                 bracketedPaste: false, applicationCursor: false, alternateScreen: false),
+            modesObserved: modesObserved,
             source: source,
             ageMilliseconds: ageMilliseconds)
     }
@@ -270,11 +272,47 @@ import Testing
             size: TerminalScreen.Size(columns: 80, rows: 24),
             modes: TerminalScreen.ChildModes(
                 bracketedPaste: true, applicationCursor: true, alternateScreen: false),
+            modesObserved: false,
             source: .staleDaemon,
             ageMilliseconds: 41)
         #expect(
             screen.modeReading
                 == TerminalModeReading(
-                    modes: screen.modes, source: .staleDaemon, ageMilliseconds: 41))
+                    modes: screen.modes, modesObserved: false, source: .staleDaemon,
+                    ageMilliseconds: 41))
+    }
+
+    /// The second axis beside `source`, and it has to survive the wire for the
+    /// same reason `source` does: a consumer that composes input reads it, and
+    /// a screen that arrived over the socket is the only form that consumer
+    /// ever sees.
+    @Test("modesObserved survives a round trip")
+    func modesObservedRoundTrips() throws {
+        for observed in [true, false] {
+            let screen = try Self.make(lines: ["x"], modesObserved: observed)
+            let decoded = try JSONDecoder().decode(
+                TerminalScreen.self, from: try JSONEncoder().encode(screen))
+            #expect(decoded.modesObserved == observed)
+            #expect(decoded == screen)
+        }
+    }
+
+    /// A producer that predates the field could not tell the two cases apart,
+    /// so it has no answer to withhold — and `true` is what every consumer
+    /// assumed while the field did not exist. An older daemon's screen must
+    /// therefore decode to the behaviour it has always had, not to a wrapping
+    /// nobody asked for.
+    @Test("a payload without modesObserved decodes as observed")
+    func absentModesObservedDecodesAsObserved() throws {
+        let cursor = #"{"row":1,"column":2,"visible":true}"#
+        let size = #"{"columns":80,"rows":24}"#
+        let modes =
+            #"{"bracketedPaste":false,"applicationCursor":false,"alternateScreen":false}"#
+        let payload = """
+            {"lines":["alpha"],"viewportStart":0,"cursor":\(cursor),"size":\(size),\
+            "modes":\(modes),"source":"daemon","ageMilliseconds":5}
+            """
+        let decoded = try JSONDecoder().decode(TerminalScreen.self, from: Data(payload.utf8))
+        #expect(decoded.modesObserved)
     }
 }

--- a/docs/specs/2026-09-05-child-as-contract-party-design.md
+++ b/docs/specs/2026-09-05-child-as-contract-party-design.md
@@ -143,6 +143,22 @@ stale (`2026-08-30-pty-holder-session-transport-design.md:548-553`).
 - **`modes`** – the child-facing state a writer needs before composing input:
   `bracketedPaste`, `applicationCursor`, `alternateScreen`. Read from the
   emulator that produced the lines, so lines and modes are one observation.
+- **`modesObserved`** – whether the answering emulator has witnessed the
+  child's mode setup, so a reader can tell an observation from a default. It
+  is true one way: the emulator was born with the child at spawn, so the
+  startup `DECSET`s waiting in the pty buffer for the first reader landed in
+  it. It is false one way, and for that emulator's whole life: an emulator
+  built over an already-running child, which is the daemon re-adopting a
+  session it did not spawn. A handback preamble restores the modes' *values*,
+  since the snapshot states each mode it carries — set or reset — as an escape
+  of its own; it raises no provenance, because the store that captured it was
+  itself seeded by this emulator's attach preamble and can hand back no more
+  than the daemon gave it. Every preamble in the transport originates from a
+  daemon emulator's snapshot, so none can carry provenance the reader lacked.
+  The field is orthogonal to `source`, which answers a different question —
+  which store, and is its screen live — and a re-adopted draining reader is
+  honestly `daemon` with `modesObserved: false`, its lines live and its modes
+  unobserved.
 - **`source`** – which store answered: `daemon` (the daemon is the reader and
   rendered its live emulator), `viewer` (a viewer holds the pty and answered a
   pull), or `staleDaemon` (a viewer holds the pty, did not answer, and this is
@@ -337,6 +353,27 @@ person reading the record afterwards that the composition was a guess and
 how old the guess was; the verifier's observation on the same row then says
 whether the guess landed. A refusal would have carried the same honesty at
 the price of the stall; a silent fallback would have carried neither.
+
+Unobserved modes are the same residue reached from the other side, and the
+asymmetry above decides them — but only for the children the asymmetry holds
+for. A reading with `modesObserved: false` carries a fresh terminal's defaults
+rather than anything the child was seen to do, so its `bracketedPaste: false`
+is not evidence of anything. For a session running an agent TUI the oracle
+composes as if bracketed paste were on and records `modesObserved: false` on
+the row, because of the two ways it can be wrong only one leaves a trace: read
+as off when it is on, the TUI's burst heuristic absorbs the `\r` and the
+message sits in the composer with nothing to say why; read as on when it is
+off, the child prints the markers, which somebody can see. Wrapping under
+uncertainty buys the visible failure over the silent one.
+
+The wrap is scoped to those burst-heuristic children, and a re-adopted **shell**
+composes bare. A shell's line editor submits bare input of any length and has
+no heuristic to fool, so a bare send never stalls there; wrapping one that
+never asked for brackets would only hand a `sudo` or `ssh` prompt markers to
+print, or a line made of them to run, in exchange for a stall that cannot
+happen. Uncertainty is a reason to wrap only where composing bare fails
+silently. An *observed* `false` is not uncertainty at all and composes bare for
+any child.
 
 ### What this does not change
 


### PR DESCRIPTION
## What's broken

Restart the daemon, then send a message of 64 or more bytes to any pty-holder session that was already running. The message lands in Claude Code's composer and never submits. Nothing reports a failure: the actuation row says `dispatched` with `modeSource: daemon`, and the age on the row is small because the emulator is being fed. A supervising agent reading that row concludes the send worked.

The dispatch envelope alone is 68 bytes, so every enveloped send is over the threshold before any user text. Every holder session on a machine hits this after every daemon restart, until a viewer attaches and later hands the session back.

Wake from hibernation is not affected. A woken child gets a fresh holder whose reader starts draining before the slot is published, and the startup mode sequence waits in the pty buffer for that first reader.

## Why it happens

Under the holder transport the daemon composes each send against the child's terminal modes: with bracketed paste on it wraps the body in the paste markers and puts the submitting carriage return after the end marker. That wrapping is what keeps the carriage return outside the text once the chunk is large enough for Claude Code's stdin tokenizer to treat it as a paste burst (measured in #819: 63 bytes submits, 64 does not).

The mode comes from the daemon's own terminal emulator for the session. When the daemon restarts, `HolderRegistry` builds a brand-new emulator for every session it re-adopts and seeds it with nothing. A fresh emulator has bracketed paste off. The child set the mode once at startup, into an emulator that died with the old daemon; the pty does not store it, and there is no query the child answers. So the re-adopted emulator holds a terminal's defaults for as long as it lives, and nothing in the reading said so: `source` encodes who is reading now, not whether this emulator has ever seen the child's setup, so a re-adopted, draining emulator answered `daemon` with full confidence and the composition sent bare bytes.

Mode state survives every orderly handoff, because the snapshot preambles carry it: `TerminalSnapshotWriter` states every mode, set or reset, so an attach seeds the viewer and a handback re-seeds the daemon. It is lost only when the emulator holding it dies without handing off, which is the daemon restart.

## What this PR does

Two of the three fix shapes considered, in the order they were tried. It stops at the smaller fix because it removes the observable failure on its own.

**Honest provenance.** `TerminalScreen` and `TerminalModeReading` gain `modesObserved: Bool`, a second axis beside `source`. It is true for an emulator born with its child at spawn and false for one built over a child that was already running, and it never changes for the life of that emulator. A handback preamble restores the modes' values but not their provenance: the viewer's emulator was seeded by this reader's own attach preamble, so it can hand back no more certainty than it was given. That closes a hole a first cut of this change had, where one open-and-close of the tab would have laundered the defaults into an observation. `HolderReader` takes the fact at construction and `HolderRegistry` names it explicitly on both of its paths, spawn and adoption. The actuation row records it beside `modeSource`, so a row for a re-adopted session now reads `modeSource: daemon, modesObserved: false` instead of recording a default as an observation. The wire form is additive: a screen from an older daemon decodes as observed, which is what every consumer assumed before the field existed.

**Compose as if bracketed paste is on when the modes are unobserved.** `HolderSendComposition.bracketedPaste(for:unobservedShouldWrap:)` owns the rule: an observed flag is obeyed either way, an unobserved reading wraps only for a session running an agent TUI, and no reading at all still composes bare. The scope matters: the paste-burst heuristic that absorbs the Enter is an agent-TUI property, so a re-adopted shell composes bare, which its line editor submits at any length. This follows the analysis already committed in the child-as-contract-party spec: read as on when it is off, the child prints the markers and a person sees them; read as off when it is on, the receiver absorbs the carriage return and the message sits in the composer silently. The forced wrap is new behaviour for a re-adopted agent session whose child has bracketed paste off, and it is deliberate: agent TUIs set the mode at startup, so the guess is right in the overwhelming case, and the rare wrong guess prints visible markers rather than swallowing the send.

A fourth `Source` case was considered and rejected. `Source` answers which store produced the screen and whether its lines are live. A re-adopted draining emulator's lines are live and judgeable, so the hibernation pending-input rail, which keys on `Source`, must keep treating it as `daemon`. Only its modes are unobserved, and a separate field says exactly that without touching hibernation.

**Not built: a durable per-session mode record** (persisting modes at the points the daemon already serializes them, and seeding a re-adopted emulator from it). It would turn the restart edge into the attach edge. It is new machinery with its own migration, and the two shapes above already remove the stall for daemon-originated sends, so it is left as a follow-up rather than shipped without a spec. It is also the only shape that would restore the viewer's view of the modes after a restart (see Assumptions).

## Assumptions

- Assumes the snapshot preamble always states bracketed paste and application cursor, set or reset. If `TerminalSnapshotWriter.modeEscapes` ever stops emitting a mode, an ingested preamble would mark modes observed without carrying that one.
- Assumes a re-adopted agent TUI that has bracketed paste off nonetheless shows the markers rather than doing something silent with them. That is the visible failure the policy prefers, and it lasts the emulator's life. A re-adopted shell is not wrapped at all, so this does not touch it.
- The flag says the emulator witnessed the child's setup, not that it saw every later moment. A session seized back from a dead app resumes with the modes it held at the attach and reports them observed; that window is the stale-mode residue the child-as-contract-party spec already accepts, unchanged here.
- A viewer attached to a re-adopted session inherits the same defaults through the attach preamble, so its own SwiftTerm also believes bracketed paste is off. Whether a person's paste into that tab stalls the same way is not verified here and is the first thing the durable mode record follow-up should check.

## Evidence & verification

**Repro, read-only, before the fix.** With the machine-wide daemon started at 11:43, `tbd terminal output --json` on every holder session spawned before that time reported `source: daemon` with all three modes false, while every session spawned after it reported bracketed paste and alternate screen on. Same TUI, same daemon; only adoption differed. The actuation log carries the reported stall: a row at 14:33 today reads `dispatched, modeSource: daemon, modeAgeMilliseconds: 51468` for a send that never submitted.

**Discriminating tests.** Each of these fails with its piece of the fix reverted and passes with it (checked by reverting the four lines and running the narrowed filter: 4 failed, 2 controls passed):

- `HolderTmuxAssumptionGateTests` "a send composed against unobserved defaults wraps anyway and says so on the row": fails with the handler back on `reading?.modes.bracketedPaste ?? false`.
- `HolderAdoptionTests.adoptsALiveHolderAndResumesDraining`: fails with the adoption path passing `observedChildFromStart: true`.
- `HolderScreenContractTests` "a reader built over a running child stays unobserved across a preamble": fails if ingest were to mark modes observed, and pins that the preamble still restores the values.
- `TerminalScreenTests` "a payload without modesObserved decodes as observed": fails with the decode default flipped.

Plus `HolderSendCompositionTests` pins the policy function on all five inputs, `HolderSpawnGateTests.flagOnSpawnsOntoHolder` asserts the spawn path reports observed, and the existing bare-send and unavailable-oracle tests now assert the row field's presence and absence. The filtered run over the eight touched suites passed with 149 tests.

**Live verification.** Restarted the daemon from this branch (announced on the build-queue channel), so every running holder session was re-adopted. `tbd terminal output --json` on two of them then read `source: daemon, modesObserved: false`, modes all false. A 215-byte `tbd terminal send --submit` to one of those sessions (a Claude Code session that had been running for 35 minutes before the restart) arrived in that session as a user turn, and its actuation row reads `dispatched, modeSource: daemon, modeAgeMilliseconds: 57, modesObserved: false`. Repeated after each of two further restarts on the amended commits: a 200-byte and then a 180-byte agent send arrived the same way, rows `dispatched, modeSource: daemon, modesObserved: false`. The shell-stays-bare half has no live shell holder to exercise and rests on `sendStaysBareForAnUnobservedShell`, which fails if the wrap is not scoped to agent sessions. Before this change the same send produced a row that looked identical apart from the missing field, and the message sat in the composer.

https://claude.ai/code/session_01Y99M6gtCLDKDfTCERXooQE

[holder-mode-provenance](https://cheapsteak.github.io/tbd/open/?worktree=5F7A9AB0-6421-4024-933D-9C88250C743F)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Terminal mode information now indicates whether values were observed directly or inferred.
  - Re-adopted sessions preserve mode uncertainty instead of presenting default values as confirmed.
  - Agent sessions with uncertain terminal modes now use bracketed-paste protection, while shell sessions continue sending unwrapped input.
  - Mode observation details are retained in screen data and actuation outcomes.

- **Bug Fixes**
  - Prevents guessed terminal settings from incorrectly controlling input composition.
  - Older saved screen data remains compatible and treats missing observation metadata as observed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->