### PR TITLE
Fix: A re-adopted holder emulator's screen is untrustworthy and said so to nobody, so the hibernation rail could park over typed input

### DIFF
--- a/Sources/TBDCLI/Commands/TerminalCommands.swift
+++ b/Sources/TBDCLI/Commands/TerminalCommands.swift
@@ -490,6 +490,8 @@ struct TerminalOutput: AsyncParsableCommand {
             // stdout stays exactly the screen text — scripts pipe it, diff it
             // and match on it — so the provenance goes to stderr, where a
             // human and a supervising agent both see it and no pipeline does.
+            // One write, however many caveats the screen carries: they arrive
+            // already joined by newlines, so a reader gets whole lines.
             if let screen = result.screen, let note = Self.stalenessNote(for: screen) {
                 FileHandle.standardError.write(Data("\(note)\n".utf8))
             }
@@ -497,8 +499,8 @@ struct TerminalOutput: AsyncParsableCommand {
         }
     }
 
-    /// What to tell a reader about a screen that did not come from the live
-    /// store, or `nil` when it did.
+    /// What to tell a reader about a screen they cannot read at face value, or
+    /// `nil` when there is nothing to say.
     ///
     /// `tbd terminal output` is one of the consumers the screen contract makes
     /// declare a policy for `.staleDaemon`, and its declared policy is *accept
@@ -509,24 +511,46 @@ struct TerminalOutput: AsyncParsableCommand {
     /// and saying nothing would be the worse of the two, because a supervisor
     /// reading a three-hour-old composer sees a live one.
     ///
+    /// **Two caveats, two notes, and a screen can carry both.** The source says
+    /// which store answered and how old its view is; `contentObserved` says
+    /// whether that store's grid was ever painted by this child. A live
+    /// `daemon` screen from an emulator built over a running child is the case
+    /// the source alone cannot express — nothing about it is stale, and cells
+    /// nobody repainted since the daemon restarted are still text the child
+    /// never wrote. When both hold, the source note comes first: it is the one
+    /// with an age in it, and it is the one a script's existing prefix match
+    /// expects to find.
+    ///
     /// The source is spelled with the enum's own raw value, so the note and the
     /// `--json` field a script correlates against can never drift apart.
     static func stalenessNote(for screen: TerminalScreen) -> String? {
+        var notes: [String] = []
         let age = humaneAge(milliseconds: screen.ageMilliseconds)
         switch screen.source {
         case .daemon:
-            return nil
+            break
         case .viewer:
-            return """
+            notes.append(
+                """
                 note: screen came from the viewer holding this session's pty \
                 (source \(screen.source.rawValue), age \(age))
-                """
+                """)
         case .staleDaemon:
-            return """
+            notes.append(
+                """
                 note: screen is the daemon's emulator as it stood when a viewer attached \
                 (source \(screen.source.rawValue), age \(age))
-                """
+                """)
         }
+        if !screen.contentObserved {
+            notes.append(
+                """
+                note: screen comes from an emulator built over a child that was already \
+                running, so cells the child has not repainted since the daemon restarted \
+                may be stale or blank (contentObserved false)
+                """)
+        }
+        return notes.isEmpty ? nil : notes.joined(separator: "\n")
     }
 
     /// An age a person can judge at a glance: seconds under a minute, minutes

--- a/Sources/TBDDaemon/Holder/HolderReader.swift
+++ b/Sources/TBDDaemon/Holder/HolderReader.swift
@@ -112,6 +112,17 @@ actor HolderReader {
     }
 
     let sessionID: UUID
+    /// Whether this reader's emulator was born with its child — the one fact
+    /// behind both `TerminalScreen.modesObserved` and
+    /// `TerminalScreen.contentObserved`.
+    ///
+    /// Exposed beside the emulator's own copy because the idle sweep needs it
+    /// next to `modeReading().source` and must not pay for a whole-buffer walk
+    /// to get it: `screen(maxLines:)` holds the emulator lock a live session's
+    /// drain thread needs, and the sweep asks this of every idle holder row on
+    /// every pass. `nonisolated` for the same reason it is a `let` — it is
+    /// fixed at construction, so reading it can never race the actor.
+    nonisolated let observedChildFromStart: Bool
     private let descriptor: PTYDescriptor
     private let emulator: HolderEmulator
     private let stopTimeout: Duration
@@ -140,12 +151,19 @@ actor HolderReader {
     /// - Parameter observedChildFromStart: whether this reader's emulator will
     ///   see every byte the child has ever written. `true` at spawn, where the
     ///   child's startup `DECSET`s are still sitting in the pty buffer waiting
-    ///   for the first reader, so the emulator's modes become the child's. It
-    ///   is `false` when the reader is built over a child that was already
-    ///   running — the daemon re-adopting a session across a restart — where
-    ///   the setup has long since been read by somebody else and this emulator
-    ///   holds a fresh terminal's defaults for as long as it lives. Reported
-    ///   as `modesObserved` on every screen and mode reading this reader gives.
+    ///   for the first reader, so the emulator's modes become the child's and
+    ///   its grid is painted by every write the child makes. It is `false` when
+    ///   the reader is built over a child that was already running — the daemon
+    ///   re-adopting a session across a restart — where the setup has long
+    ///   since been read by somebody else, this emulator holds a fresh
+    ///   terminal's defaults for as long as it lives, and its grid starts
+    ///   blank under a TUI that paints only the cells it is changing.
+    ///
+    ///   Reported as **both** `modesObserved` and `contentObserved` on every
+    ///   screen this reader gives, and as `modesObserved` on every mode
+    ///   reading: the flags are unobserved and so are the cells, from the one
+    ///   fact that this emulator was not there when the child started.
+    ///
     ///   Required and named at every construction site, for the same reason
     ///   `take` names it: a default would be right on one path — a test harness
     ///   feeding its own emulator from the start, `true` — and a silent lie on
@@ -174,6 +192,7 @@ actor HolderReader {
         clock: any Clock<Duration> = ContinuousClock()
     ) {
         self.sessionID = sessionID
+        self.observedChildFromStart = observedChildFromStart
         self.stopTimeout = stopTimeout
         self.clock = clock
         self.onEndOfOutput = onEndOfOutput
@@ -187,7 +206,7 @@ actor HolderReader {
             columns: columns,
             rows: rows,
             scrollback: scrollbackLines,
-            modesObserved: observedChildFromStart,
+            observedChildFromStart: observedChildFromStart,
             monotonicNow: monotonicNow,
             reply: { [descriptor] bytes in descriptor.replyBestEffort(bytes) })
     }
@@ -559,9 +578,10 @@ actor HolderReader {
     ///
     /// **What it does not encode is whether the emulator has watched this child
     /// since birth.** A reader draining a session it re-adopted after a restart
-    /// answers `.daemon`, correctly — its lines are live — while its modes are
-    /// a fresh terminal's defaults. That is the separate axis `modesObserved`
-    /// carries.
+    /// answers `.daemon`, correctly — every byte arriving now is parsed live —
+    /// while its modes are a fresh terminal's defaults and its grid holds
+    /// whatever the child has happened to repaint since. That is the separate
+    /// axis `modesObserved` and `contentObserved` carry.
     private var currentSource: TerminalScreen.Source {
         state == .draining ? .daemon : .staleDaemon
     }
@@ -600,14 +620,15 @@ actor HolderReader {
     /// by it — output the viewer never saw and the daemon then throws away.
     /// A stopped reader ignores the feed: its screen has no further readers.
     ///
-    /// **A preamble restores the modes' values and not their provenance.** The
-    /// writer states every mode the capture carries, so the flags after the
-    /// feed are the departing viewer's — but that viewer's emulator was itself
-    /// seeded by *this* reader's attach preamble, so what comes back is what
-    /// this reader handed out. A preamble can carry no more provenance than the
-    /// reader already had. Nothing here therefore moves `modesObserved`: a
-    /// re-adopted session stays unobserved across every attach and handback,
-    /// and only a session this daemon spawned is ever observed.
+    /// **A preamble restores values and not provenance.** The writer states
+    /// every mode the capture carries and repaints the screen it held, so the
+    /// flags and the cells after the feed are the departing viewer's — but that
+    /// viewer's emulator was itself seeded by *this* reader's attach preamble,
+    /// so what comes back is what this reader handed out. A preamble can carry
+    /// no more provenance than the reader already had. Nothing here therefore
+    /// moves `modesObserved` or `contentObserved`: a re-adopted session stays
+    /// unobserved on both axes across every attach and handback, and only a
+    /// session this daemon spawned is ever observed.
     func ingest(preamble: Data) {
         guard state != .stopped, !preamble.isEmpty else { return }
         emulator.feed([UInt8](preamble)[...])
@@ -1291,26 +1312,33 @@ private final class HolderEmulator: @unchecked Sendable {
     ///
     /// `screen` asks nothing at all: it reads the delegate's `DECTCEM` flag.
     private var lastByteAt: ContinuousClock.Instant?
-    /// Whether this emulator's mode flags are observations of the child rather
-    /// than a fresh terminal's defaults — the `modesObserved` every screen and
-    /// mode reading carries.
+    /// Whether this emulator was built with its child, so that both its mode
+    /// flags and its grid are observations rather than a fresh terminal's
+    /// defaults over a blank screen.
+    ///
+    /// One fact with two consequences, and it is reported as both: as
+    /// `modesObserved` on every screen and mode reading, and as
+    /// `contentObserved` on every screen. Unobserved modes are a terminal's
+    /// defaults; unobserved content is a grid whose cells the child has not
+    /// repainted since this emulator existed, and a TUI repaints only what it
+    /// is changing.
     ///
     /// Set at construction by whoever knows how this emulator came to exist,
     /// and never moved afterwards: nothing this emulator can be fed carries
     /// provenance it was not built with, because every preamble in the system
     /// originates from a daemon emulator's own snapshot. Read under
     /// `terminalLock`, like `lastByteAt` and everything else here.
-    private let modesObserved: Bool
+    private let observedChildFromStart: Bool
 
     init(
         columns: Int, rows: Int, scrollback: Int,
-        modesObserved: Bool,
+        observedChildFromStart: Bool,
         monotonicNow: @escaping @Sendable () -> ContinuousClock.Instant,
         reply: @escaping @Sendable (ArraySlice<UInt8>) -> Void
     ) {
         let delegate = ReplyForwardingDelegate(reply: reply)
         self.delegate = delegate
-        self.modesObserved = modesObserved
+        self.observedChildFromStart = observedChildFromStart
         self.monotonicNow = monotonicNow
         self.adoptedAt = monotonicNow()
         self.terminal = Terminal(
@@ -1322,10 +1350,13 @@ private final class HolderEmulator: @unchecked Sendable {
     }
 
     /// Bytes from outside — the drain loop's reads, the quiesce remainder, a
-    /// handback preamble. **None of it marks the modes observed**: the child's
-    /// running output says nothing about the modes it set before this emulator
-    /// existed, so a session that happens to print a lot must not talk its way
-    /// into a provenance it never earned.
+    /// handback preamble. **None of it marks the modes or the content
+    /// observed**: the child's running output says nothing about the modes it
+    /// set or the cells it painted before this emulator existed, so a session
+    /// that happens to print a lot must not talk its way into a provenance it
+    /// never earned. A busy child repaints some of the grid and leaves the rest
+    /// exactly as blank as it found it, which is the state `contentObserved`
+    /// exists to name.
     func feed(_ bytes: ArraySlice<UInt8>) {
         terminal.terminalLock.withLock {
             lastByteAt = monotonicNow()
@@ -1417,7 +1448,8 @@ private final class HolderEmulator: @unchecked Sendable {
                 cursor: cursor,
                 size: TerminalScreen.Size(columns: terminal.cols, rows: terminal.rows),
                 modes: currentModes(),
-                modesObserved: modesObserved,
+                modesObserved: observedChildFromStart,
+                contentObserved: observedChildFromStart,
                 source: source,
                 ageMilliseconds: ageMilliseconds())
         }
@@ -1427,7 +1459,7 @@ private final class HolderEmulator: @unchecked Sendable {
     func modeReading(source: TerminalScreen.Source) -> TerminalModeReading {
         terminal.terminalLock.withLock {
             TerminalModeReading(
-                modes: currentModes(), modesObserved: modesObserved, source: source,
+                modes: currentModes(), modesObserved: observedChildFromStart, source: source,
                 ageMilliseconds: ageMilliseconds())
         }
     }

--- a/Sources/TBDDaemon/Holder/HolderRegistry.swift
+++ b/Sources/TBDDaemon/Holder/HolderRegistry.swift
@@ -576,7 +576,8 @@ actor HolderRegistry {
                 expecting: owner,
                 // The job has only just been forked, and nothing has read its
                 // pty yet, so whatever it says about its modes on startup lands
-                // in this emulator.
+                // in this emulator — and so does every cell it ever paints,
+                // which is what makes this emulator's screen the child's own.
                 observedChildFromStart: true,
                 onEndOfOutput: endOfOutputNotifier(for: terminalID))
         } catch {
@@ -901,11 +902,14 @@ actor HolderRegistry {
                 // The child has been running without this emulator — since the
                 // last daemon, or since a viewer took the pty — so its mode
                 // setup was consumed by somebody else and the fresh terminal
-                // this builds starts on defaults, permanently. A preamble, when
-                // there is one, restores the modes' values and not their
-                // provenance: the viewer that captured it was itself seeded by
-                // this session's attach preamble, so it can hand back no more
-                // than the daemon gave it.
+                // this builds starts on defaults, permanently. Its grid starts
+                // blank for the same reason, and a TUI above it repaints only
+                // the cells it is changing, so the screen this reader projects
+                // holds the child's text only where the child has since written
+                // it. A preamble, when there is one, restores the values and
+                // not their provenance: the viewer that captured it was itself
+                // seeded by this session's attach preamble, so it can hand back
+                // no more than the daemon gave it.
                 observedChildFromStart: false,
                 onEndOfOutput: notifyEndOfOutput,
                 seedingScreenWith: preamble)
@@ -1280,8 +1284,10 @@ actor HolderRegistry {
     ///   have seen every byte its child ever wrote — `true` for a session this
     ///   daemon just spawned, whose startup `DECSET`s are still queued in the
     ///   pty, and `false` for one adopted while it was already running, whose
-    ///   mode setup was read by somebody else long ago. It rides all the way to
-    ///   `TerminalScreen.modesObserved`, and it is named at every call site
+    ///   mode setup was read by somebody else long ago and whose screen this
+    ///   emulator therefore starts blank underneath. It rides all the way to
+    ///   `TerminalScreen.modesObserved` and `TerminalScreen.contentObserved` —
+    ///   one fact, both consequences — and it is named at every call site
     ///   rather than defaulted, because a default is right on one of these two
     ///   paths and a silent lie on the other.
     private static func take(

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator+Holder.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator+Holder.swift
@@ -7,10 +7,11 @@ private let logger = Logger(subsystem: "com.tbd.daemon", category: "Hibernation"
 /// What the park's pending-input rail got when it asked for a holder session's
 /// screen: a screen it may judge, or the refusal that stands in its place.
 ///
-/// A type rather than an optional because the three ways to have no judgeable
-/// screen — no reader, a source the daemon is not the live store for, a
-/// projection that refused — carry different remedies and so different words,
-/// and collapsing them would hand the user a sentence that fits none of them.
+/// A type rather than an optional because the four ways to have no judgeable
+/// screen — no reader, a source the daemon is not the live store for, a live
+/// screen whose emulator never saw the child start, a projection that refused
+/// — carry different remedies and so different words, and collapsing them
+/// would hand the user a sentence that fits none of them.
 enum HolderScreenReading: Sendable {
     case readable(TerminalScreen)
     case refused(String)
@@ -141,25 +142,57 @@ extension HibernationCoordinator {
         "The daemon could not read this session's screen to check for unsent "
         + "input before hibernating"
 
-    /// The refusal a screen's `source` implies, or nil when the daemon may
+    /// The refusal for a live daemon screen whose emulator was built over a
+    /// child that was already running.
+    ///
+    /// The re-adoption case, and the reason the source alone is not enough. An
+    /// emulator the daemon builds across a restart starts blank, and the TUI
+    /// above it paints differentially — it positions the cursor and writes only
+    /// the cells it is changing — so the cells nobody has repainted since hold
+    /// nothing the child ever wrote. The screen is honestly `daemon`, its bytes
+    /// really are being parsed live, and it is still not a screen anyone can
+    /// check for a half-composed prompt: a composer that has gone quiet reads
+    /// as whatever stood there before, and a composer somebody is typing into
+    /// can read as blank.
+    ///
+    /// A fourth string because the remedy is unlike the other three. There is
+    /// no tab to close and nothing lost to re-adopt; the screen becomes
+    /// checkable again the next time this daemon starts the session itself, and
+    /// saying anything else would send somebody chasing a gesture that does not
+    /// help.
+    static let holderContentUnobservedRefusal =
+        "The daemon's emulator for this session was built over a child that was "
+        + "already running — the daemon restarted under it — so its screen can "
+        + "show stale or missing text and cannot be checked for unsent input; it "
+        + "becomes checkable again when this daemon next starts the session"
+
+    /// The refusal a screen's provenance implies, or nil when the daemon may
     /// judge it.
     ///
-    /// The whole policy, in one place, so the park and the idle sweep cannot
-    /// hold different opinions about which sources are judgeable. Both ask this
-    /// question; they differ only in how much of the screen they pay for to get
-    /// the answer.
-    static func holderRefusal(forScreenSource source: TerminalScreen.Source) -> String? {
+    /// The whole policy, both axes, in one place, so the park and the idle
+    /// sweep cannot hold different opinions about which screens are judgeable.
+    /// Both ask this question; they differ only in how much of the screen they
+    /// pay for to get the answer.
+    ///
+    /// The source is asked first because it names an action the user can take
+    /// — close the tab — and a person told to close a tab has somewhere to go.
+    /// A `daemon` screen then still has to answer for its content: `source`
+    /// says which store is rendering live, and `contentObserved` says whether
+    /// that store's grid was ever painted by this child.
+    static func holderRefusal(
+        forScreenSource source: TerminalScreen.Source, contentObserved: Bool
+    ) -> String? {
         switch source {
-        case .daemon: return nil
         case .staleDaemon, .viewer: return holderViewerAttachedRefusal
+        case .daemon: return contentObserved ? nil : holderContentUnobservedRefusal
         }
     }
 
     /// The typed screen the park's rail judges, or the refusal that stands in
     /// its place.
     ///
-    /// One method so the two fail-closed halves and the projection failure are
-    /// stated once and the park reads a single answer.
+    /// One method so the three fail-closed refusals and the projection failure
+    /// are stated once and the park reads a single answer.
     func holderScreenReading(
         terminalID: UUID, registry: HolderRegistry
     ) async -> HolderScreenReading {
@@ -175,15 +208,17 @@ extension HibernationCoordinator {
             return .refused(Self.holderScreenProjectionRefusal)
         }
         guard let screen else { return .refused(Self.holderNoReaderRefusal) }
-        if let refusal = Self.holderRefusal(forScreenSource: screen.source) {
+        if let refusal = Self.holderRefusal(
+            forScreenSource: screen.source, contentObserved: screen.contentObserved) {
             return .refused(refusal)
         }
         return .readable(screen)
     }
 
     /// Whether the screen the park's pending-input rail would have to judge is
-    /// one this daemon may not judge — a viewer holds the pty, or no reader was
-    /// ever adopted for the session.
+    /// one this daemon may not judge — a viewer holds the pty, no reader was
+    /// ever adopted for the session, or the reader's emulator was built over a
+    /// child that was already running and so has never seen the whole screen.
     ///
     /// The same question `performHolderHibernate` asks before its fail-closed
     /// refusals, lifted out so the sweep can ask it *first*.
@@ -191,13 +226,15 @@ extension HibernationCoordinator {
     /// clock, and has no way to see who holds a pty — so the sweep is the only
     /// place with the registry in hand.
     ///
-    /// **It reads the mode half of the oracle, not the whole screen.** `source`
-    /// is one fact taken from one reader under one lock, and
-    /// `HolderReader.modeReading` carries it without the whole-buffer walk that
-    /// `screen(maxLines:)` pays for — the same trade the send path's oracle
-    /// makes, and for the same reason: this runs on every sweep, for every idle
-    /// holder row, and the walk holds the emulator lock a live session's drain
-    /// thread needs. The two therefore agree on the question that decides the
+    /// **It reads the mode half of the oracle, not the whole screen.** Both
+    /// facts the policy turns on are cheap: `source` is one field taken from
+    /// one reader under one lock, which `HolderReader.modeReading` carries
+    /// without the whole-buffer walk that `screen(maxLines:)` pays for, and
+    /// `observedChildFromStart` is fixed at that reader's construction and
+    /// needs no lock at all. The same trade the send path's oracle makes, and
+    /// for the same reason: this runs on every sweep, for every idle holder
+    /// row, and the walk holds the emulator lock a live session's drain thread
+    /// needs. The two therefore agree on the question that decides the
     /// refusal. They can differ on exactly one thing, a screen that will not
     /// project at all: the sweep cannot foresee it, so such a row is armed here
     /// and refused at the park. That is a producer bug rather than a session
@@ -212,11 +249,12 @@ extension HibernationCoordinator {
         if let oracle = holderScreenOracle {
             do {
                 guard let screen = try await oracle(terminalID) else { return true }
-                return Self.holderRefusal(forScreenSource: screen.source) != nil
+                return Self.holderRefusal(
+                    forScreenSource: screen.source, contentObserved: screen.contentObserved) != nil
             } catch {
                 // A refused projection, and the seam answers it the way the
                 // production path below does rather than better: that path
-                // reads only the source and never walks a line, so it cannot
+                // reads two cheap facts and never walks a line, so it cannot
                 // see one. The sweep arms, the park refuses. A seam that
                 // answered `true` here would make a test agree where the
                 // shipped code does not.
@@ -225,7 +263,8 @@ extension HibernationCoordinator {
         }
         guard let reader = await registry.reader(for: terminalID) else { return true }
         let source = await reader.modeReading().source
-        return Self.holderRefusal(forScreenSource: source) != nil
+        return Self.holderRefusal(
+            forScreenSource: source, contentObserved: reader.observedChildFromStart) != nil
     }
 
     /// The screen this daemon holds for a session, or nil when it holds none.
@@ -306,20 +345,25 @@ extension HibernationCoordinator {
         }
 
         // Rail: typed-but-unsent input, read off the typed screen oracle.
-        // Fail-closed on every answer that is not a live daemon-rendered
-        // screen — a source the daemon is not the live store for, no reader at
-        // all, a projection that refused — because each one means the screen
-        // this rail would judge is not the screen the session is showing. Each
-        // answers with its own name: they differ in what the person reading the
-        // refusal can do next.
+        // Fail-closed on every answer that is not a live daemon-rendered screen
+        // of observed content — a source the daemon is not the live store for,
+        // a live screen whose emulator was built over a running child, no
+        // reader at all, a projection that refused — because each one means the
+        // screen this rail would judge is not the screen the session is
+        // showing. Each answers with its own name: they differ in what the
+        // person reading the refusal can do next.
         //
-        // One dependency this rail has and cannot check: after a daemon restart
-        // the emulator it reads is one that has seen only what arrived since
-        // re-adoption, so what it shows of the composer is whatever the
-        // attach-edge jiggle's repaint produced. The rail is relying on a real
-        // geometry change forcing an Ink-style TUI to redraw its composer, and
-        // so on a half-composed prompt being visible again. That is inferred
-        // from how such TUIs redraw on `SIGWINCH`, not measured.
+        // The re-adoption case is the subtle one, and it is why the source is
+        // not the whole question. An emulator the daemon builds across a
+        // restart starts blank over a child that is already painting, and an
+        // Ink-style TUI paints differentially — it moves the cursor and writes
+        // only the cells it is changing. So every cell nobody has repainted
+        // since holds nothing the child ever wrote, and the projection mixes
+        // correct cells with blanks where there is text and stale text where
+        // the session has cleared. Measured in the field: a phantom composer
+        // line stood for over a minute while the real composer was empty. The
+        // screen carries that as `contentObserved`, and this rail refuses it
+        // like every other screen it may not judge.
         let capturedSnapshot: String?
         switch await holderScreenReading(terminalID: terminal.id, registry: registry) {
         case .refused(let refusal):

--- a/Sources/TBDShared/TerminalScreen.swift
+++ b/Sources/TBDShared/TerminalScreen.swift
@@ -171,6 +171,36 @@ public struct TerminalScreen: Codable, Sendable, Equatable {
     /// child happened to re-emit a mode escape of its own after the adoption,
     /// which nothing here can tell.
     public let modesObserved: Bool
+    /// Whether the answering emulator has witnessed everything the child has
+    /// painted.
+    ///
+    /// The second consequence of the fact `modesObserved` reports. That field
+    /// says whether the mode flags are **observations**; this one says whether
+    /// the cells are. They are two fields because they can diverge in
+    /// principle — a full repaint provoked from outside would restore every
+    /// cell and not one mode — and today both are the same construction fact,
+    /// so today they move together.
+    ///
+    /// It is true one way: the emulator was born with the child, so every byte
+    /// the child has ever written was parsed into this grid.
+    ///
+    /// It is false for an emulator built over an *already running* child — the
+    /// daemon re-adopting a session it did not spawn — and it stays false for
+    /// that emulator's whole life. A handback preamble restores the cells'
+    /// *values*, because the snapshot repaints the screen the departing viewer
+    /// held; it raises no provenance, because that viewer's emulator was itself
+    /// seeded by this emulator's own attach snapshot and can hand back no more
+    /// than it was given.
+    ///
+    /// **What `false` means for a reader.** A TUI paints differentially: it
+    /// positions the cursor and writes only the cells it is changing. So every
+    /// cell the child has not rewritten since this emulator was built holds
+    /// nothing the child ever painted — the screen can show blanks where the
+    /// session has text, and stale text where the session has cleared, mixed
+    /// in with the newly painted cells that are perfectly correct. The
+    /// projection cannot tell the three apart, and neither can a consumer
+    /// matching on the text.
+    public let contentObserved: Bool
     public let source: Source
     /// How long ago the answering store's emulator last consumed a byte from
     /// the pty, in milliseconds, on a monotonic clock — never wall time, so no
@@ -253,6 +283,7 @@ public struct TerminalScreen: Codable, Sendable, Equatable {
         size: Size,
         modes: ChildModes,
         modesObserved: Bool,
+        contentObserved: Bool,
         source: Source,
         ageMilliseconds: Int
     ) throws {
@@ -270,6 +301,7 @@ public struct TerminalScreen: Codable, Sendable, Equatable {
         self.size = size
         self.modes = modes
         self.modesObserved = modesObserved
+        self.contentObserved = contentObserved
         self.source = source
         self.ageMilliseconds = ageMilliseconds
     }
@@ -294,7 +326,8 @@ public struct TerminalScreen: Codable, Sendable, Equatable {
     // MARK: - Coding
 
     private enum CodingKeys: String, CodingKey {
-        case lines, viewportStart, cursor, size, modes, modesObserved, source, ageMilliseconds
+        case lines, viewportStart, cursor, size, modes, modesObserved, contentObserved, source
+        case ageMilliseconds
     }
 
     /// Written out field by field rather than synthesised, so the wire form is
@@ -310,6 +343,7 @@ public struct TerminalScreen: Codable, Sendable, Equatable {
         try container.encode(size, forKey: .size)
         try container.encode(modes, forKey: .modes)
         try container.encode(modesObserved, forKey: .modesObserved)
+        try container.encode(contentObserved, forKey: .contentObserved)
         try container.encode(source, forKey: .source)
         try container.encode(ageMilliseconds, forKey: .ageMilliseconds)
     }
@@ -329,6 +363,13 @@ public struct TerminalScreen: Codable, Sendable, Equatable {
     /// field did not exist. An older daemon's screen therefore decodes to the
     /// behaviour it has always had, rather than to a refusal or a wrapping it
     /// never asked for.
+    ///
+    /// **A missing `contentObserved` decodes as observed**, for the same reason
+    /// and with the same consequence: a producer that predates the field could
+    /// not tell a grid it watched from birth apart from one it inherited, so
+    /// `true` is what every consumer assumed while the field did not exist. An
+    /// older daemon's screen decodes to the behaviour it has always had, rather
+    /// than to a refusal it never earned.
     public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         try self.init(
@@ -338,6 +379,7 @@ public struct TerminalScreen: Codable, Sendable, Equatable {
             size: container.decode(Size.self, forKey: .size),
             modes: container.decode(ChildModes.self, forKey: .modes),
             modesObserved: container.decodeIfPresent(Bool.self, forKey: .modesObserved) ?? true,
+            contentObserved: container.decodeIfPresent(Bool.self, forKey: .contentObserved) ?? true,
             source: container.decode(Source.self, forKey: .source),
             ageMilliseconds: container.decode(Int.self, forKey: .ageMilliseconds))
     }

--- a/Tests/TBDCLITests/TerminalOutputStalenessNoteTests.swift
+++ b/Tests/TBDCLITests/TerminalOutputStalenessNoteTests.swift
@@ -23,7 +23,7 @@ import Testing
 struct TerminalOutputStalenessNoteTests {
 
     private static func screen(
-        source: TerminalScreen.Source, ageMilliseconds: Int
+        source: TerminalScreen.Source, ageMilliseconds: Int, contentObserved: Bool = true
     ) throws -> TerminalScreen {
         try TerminalScreen(
             lines: ["composer"],
@@ -33,6 +33,7 @@ struct TerminalOutputStalenessNoteTests {
             modes: TerminalScreen.ChildModes(
                 bracketedPaste: false, applicationCursor: false, alternateScreen: false),
             modesObserved: true,
+            contentObserved: contentObserved,
             source: source,
             ageMilliseconds: ageMilliseconds)
     }
@@ -100,5 +101,58 @@ struct TerminalOutputStalenessNoteTests {
         let stale = try Self.screen(source: .staleDaemon, ageMilliseconds: milliseconds)
         let note = try #require(TerminalOutput.stalenessNote(for: stale))
         #expect(note.hasSuffix("(source staleDaemon, age \(rendered))"), "composed: \(note)")
+    }
+
+    /// The caveat the source cannot express. A daemon that restarts under a
+    /// running session builds its emulator over a child already in flight, so
+    /// the screen is live — nothing about it is stale — while every cell the
+    /// child has not repainted since holds text the child never wrote. A reader
+    /// shown that screen in silence reads a phantom composer line as the
+    /// session's present state, which is exactly what was measured in the
+    /// field.
+    @Test("a live screen whose emulator never saw the child start still carries a note")
+    func contentUnobservedScreenCarriesItsOwnNote() throws {
+        let unobserved = try Self.screen(
+            source: .daemon, ageMilliseconds: 12, contentObserved: false)
+        let note = try #require(TerminalOutput.stalenessNote(for: unobserved))
+
+        #expect(
+            note == """
+                note: screen comes from an emulator built over a child that was already \
+                running, so cells the child has not repainted since the daemon restarted \
+                may be stale or blank (contentObserved false)
+                """,
+            "composed note was: \(note)")
+    }
+
+    /// The other side of that check, and what makes the test above about the
+    /// content provenance rather than about `daemon` screens getting noisy: an
+    /// ordinary live read is still silent.
+    @Test("a live screen whose emulator saw the child start is still silent")
+    func observedLiveScreenStaysSilent() throws {
+        let observed = try Self.screen(
+            source: .daemon, ageMilliseconds: 12, contentObserved: true)
+        #expect(TerminalOutput.stalenessNote(for: observed) == nil)
+    }
+
+    /// Both caveats on one screen — a viewer attached to a session the daemon
+    /// had re-adopted — and both are told. The source note comes first: it is
+    /// the one carrying an age, and it is the one a script's existing prefix
+    /// match expects to find.
+    @Test("a stale, content-unobserved screen carries both notes, source first")
+    func staleAndUnobservedScreenCarriesBothNotes() throws {
+        let both = try Self.screen(
+            source: .staleDaemon, ageMilliseconds: 41 * 60_000 + 3_000, contentObserved: false)
+        let note = try #require(TerminalOutput.stalenessNote(for: both))
+
+        #expect(
+            note == """
+                note: screen is the daemon's emulator as it stood when a viewer attached \
+                (source staleDaemon, age 41m 3s)
+                note: screen comes from an emulator built over a child that was already \
+                running, so cells the child has not repainted since the daemon restarted \
+                may be stale or blank (contentObserved false)
+                """,
+            "composed note was: \(note)")
     }
 }

--- a/Tests/TBDDaemonTests/Holder/HolderTmuxAssumptionGateTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HolderTmuxAssumptionGateTests.swift
@@ -475,14 +475,16 @@ struct HolderTmuxAssumptionGateTests {
 
     /// A screen the rail can judge, without a holder, a pty or an attach.
     ///
-    /// The two facts these tests vary are the ones the rail turns on: the
-    /// `lines`, which `HibernationSafetyChecks.hasPendingInput` reads, and the
-    /// `source`, which decides whether the daemon may read them at all.
-    /// Everything else is a plausible constant, constructed through
-    /// `TerminalScreen`'s own initializer so a fixture cannot state a screen
-    /// the type would refuse.
+    /// The three facts these tests vary are the ones the rail turns on: the
+    /// `lines`, which `HibernationSafetyChecks.hasPendingInput` reads, the
+    /// `source`, which decides whether the daemon is the live store, and
+    /// `contentObserved`, which decides whether that store's grid was ever
+    /// painted by this child. Everything else is a plausible constant,
+    /// constructed through `TerminalScreen`'s own initializer so a fixture
+    /// cannot state a screen the type would refuse.
     private static func screen(
-        lines: [String], source: TerminalScreen.Source = .daemon
+        lines: [String], source: TerminalScreen.Source = .daemon,
+        contentObserved: Bool = true
     ) throws -> TerminalScreen {
         try TerminalScreen(
             lines: lines,
@@ -492,6 +494,7 @@ struct HolderTmuxAssumptionGateTests {
             modes: TerminalScreen.ChildModes(
                 bracketedPaste: true, applicationCursor: false, alternateScreen: false),
             modesObserved: true,
+            contentObserved: contentObserved,
             source: source,
             ageMilliseconds: 0)
     }
@@ -582,6 +585,59 @@ struct HolderTmuxAssumptionGateTests {
         let viewer = try Self.screen(lines: Self.emptyComposer, source: .viewer)
 
         let result = await parkAgainst({ viewer }, db: db, terminal: terminal)
+        #expect(result == .notEligible(reason: HibernationCoordinator.holderViewerAttachedRefusal))
+    }
+
+    /// The re-adoption case: a screen that is live and still unjudgeable.
+    ///
+    /// After a daemon restart the emulator is built over a child that is
+    /// already running, so it starts blank while the TUI above it repaints only
+    /// the cells it is changing. `source` is honestly `daemon` — every byte
+    /// arriving now is parsed live — and the grid is a mixture of correct
+    /// cells, blanks where the session has text, and text the session has since
+    /// cleared. An EMPTY composer deliberately, for the same reason the stale
+    /// test uses one: the refusal must come from the provenance, not from
+    /// anything the lines say, and a blanked composer over a person's
+    /// half-typed message is precisely the screen this rail exists to refuse.
+    @Test("a park refuses a live screen whose emulator never saw the child start")
+    func parkRefusesAContentUnobservedScreen() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setHolderHibernationEnabled(true)
+        let (wt, dir) = try await seedWorktree(db)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let terminal = try await seedClaudeTerminal(
+            db, worktreeID: wt.id, transport: .holder)
+        let before = RowFingerprint(terminal)
+        let unobserved = try Self.screen(
+            lines: Self.emptyComposer, source: .daemon, contentObserved: false)
+
+        let result = await parkAgainst({ unobserved }, db: db, terminal: terminal)
+        #expect(
+            result == .notEligible(reason: HibernationCoordinator.holderContentUnobservedRefusal),
+            "a content-unobserved screen did not fail the rail closed: \(result)")
+
+        let after = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(RowFingerprint(after) == before,
+                "a park refused on an unobserved screen still wrote its intent to the row")
+    }
+
+    /// The order of the two axes, which is policy rather than accident. A
+    /// screen can be both frozen and content-unobserved — a viewer attaches to
+    /// a session the daemon re-adopted — and the refusal a person reads should
+    /// be the one naming an action they can take. Closing the tab is that
+    /// action; "wait for the daemon to start this session" is not.
+    @Test("a stale screen that is also content-unobserved refuses on its source")
+    func parkRefusesAStaleUnobservedScreenOnItsSource() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setHolderHibernationEnabled(true)
+        let (wt, dir) = try await seedWorktree(db)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let terminal = try await seedClaudeTerminal(
+            db, worktreeID: wt.id, transport: .holder)
+        let both = try Self.screen(
+            lines: Self.emptyComposer, source: .staleDaemon, contentObserved: false)
+
+        let result = await parkAgainst({ both }, db: db, terminal: terminal)
         #expect(result == .notEligible(reason: HibernationCoordinator.holderViewerAttachedRefusal))
     }
 
@@ -2713,6 +2769,46 @@ struct HolderTmuxAssumptionGateTests {
             db, logPath: logPath, dates: dates,
             registry: holderRegistry(listing: [terminal]),
             screen: { stale })
+
+        await sweepToTheActMoment(coord, dates: dates)
+        dates.advance(by: 61 + HibernationCoordinator.killDebounce + 1)
+        await coord.sweep()
+
+        let written = try logRows(at: logPath)
+        #expect(written.isEmpty,
+                "the sweep asked for a park it could never have completed: \(written)")
+        let after = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(RowFingerprint(after) == before)
+    }
+
+    /// The content axis of the same agreement. A re-adopted session's screen is
+    /// live, so nothing about its `source` stops the sweep — and the park would
+    /// still refuse it, because the emulator inherited a blank grid under a
+    /// child that repaints only what it is changing. A daemon that restarts
+    /// under a fleet re-adopts every session it finds, so arming here would buy
+    /// a request-and-refusal pair per row per sweep until each one is started
+    /// again. The assertion is on the RECORD being empty, because only the
+    /// record can tell "refused" from "never asked".
+    @Test("the sweep neither arms nor fires a holder row whose screen content is unobserved")
+    func sweepSkipsAHolderRowWithUnobservedContent() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setHolderHibernationEnabled(true)
+        try await db.config.setAutoHibernate(enabled: true, idleMinutes: 1)
+        let (wt, dir) = try await seedWorktree(db)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let terminal = try await seedClaudeTerminal(
+            db, worktreeID: wt.id, transport: .holder)
+        let before = RowFingerprint(terminal)
+        let logPath = try sweepLogPath()
+        let dates = TestDateSource()
+        // A live source and a clear composer, so nothing but the content
+        // provenance can be what stops this.
+        let unobserved = try Self.screen(
+            lines: Self.emptyComposer, source: .daemon, contentObserved: false)
+        let coord = await sweepCoordinator(
+            db, logPath: logPath, dates: dates,
+            registry: holderRegistry(listing: [terminal]),
+            screen: { unobserved })
 
         await sweepToTheActMoment(coord, dates: dates)
         dates.advance(by: 61 + HibernationCoordinator.killDebounce + 1)

--- a/Tests/TBDDaemonTests/HolderScreenContractTests.swift
+++ b/Tests/TBDDaemonTests/HolderScreenContractTests.swift
@@ -400,7 +400,7 @@ import Testing
         #expect(screen.modeReading.ageMilliseconds == 7_000)
     }
 
-    // MARK: - Mode provenance
+    // MARK: - Mode and content provenance
 
     /// The ordinary case, and the one that must not report doubt: an emulator
     /// built with its child sees the startup `DECSET`s, because they are still
@@ -454,6 +454,54 @@ import Testing
                 "the preamble did not restore the mode's value")
         #expect(await harness.reader.modeReading().modesObserved == false)
         #expect(try await harness.reader.screen(maxLines: 8).modesObserved == false)
+    }
+
+    /// The content axis of the same fact, on the emulator that has it: an
+    /// emulator born with its child has parsed every cell that child ever
+    /// painted, so its screen is the child's own screen and a consumer may read
+    /// the text at face value.
+    ///
+    /// A handback does not lower it either, for the reason a handback does not
+    /// lower the modes: the emulator that captured the preamble was seeded from
+    /// this one.
+    @Test("a reader born with its child reports its screen content as observed")
+    func aReaderBornWithItsChildReportsObservedContent() async throws {
+        let harness = try Harness(columns: 40, rows: 8)
+        defer { harness.tearDown() }
+
+        #expect(try await harness.reader.screen(maxLines: 8).contentObserved)
+
+        await harness.reader.ingest(preamble: Self.data("hello from the viewer"))
+
+        #expect(try await harness.reader.screen(maxLines: 8).contentObserved)
+    }
+
+    /// The daemon-restart case, and the defect that put this field in the type.
+    /// The emulator starts blank under a child that is already running, and a
+    /// TUI repaints only the cells it is changing — so the grid holds the
+    /// child's text exactly where the child has since written it, and nothing
+    /// anywhere else. A phantom composer line measured in the field stood for
+    /// over a minute while the real composer was empty.
+    ///
+    /// The preamble here **paints visible text**, deliberately, so the two
+    /// halves can be told apart: the values arrive — the text is in `lines` —
+    /// and the provenance does not follow them, because the viewer that
+    /// captured that screen was itself painted by this reader's own attach
+    /// preamble and can hand back no more than it was given.
+    @Test("a reader built over a running child stays content-unobserved across a preamble")
+    func aReaderOverARunningChildStaysContentUnobservedAcrossAPreamble() async throws {
+        let harness = try Harness(columns: 40, rows: 8, observedChildFromStart: false)
+        defer { harness.tearDown() }
+
+        #expect(try await harness.reader.screen(maxLines: 8).contentObserved == false)
+
+        await harness.reader.ingest(preamble: Self.data("restored composer text"))
+
+        let screen = try await harness.reader.screen(maxLines: 8)
+        #expect(screen.lines.contains { $0.contains("restored composer text") },
+                "the preamble did not restore the screen's text: \(screen.lines)")
+        #expect(screen.contentObserved == false)
+        #expect(try await harness.reader.screen(maxLines: 8).contentObserved == false)
     }
 
     // MARK: - Harness

--- a/Tests/TBDSharedTests/TerminalScreenTests.swift
+++ b/Tests/TBDSharedTests/TerminalScreenTests.swift
@@ -24,6 +24,7 @@ import Testing
         lines: [String],
         viewportStart: Int = 0,
         modesObserved: Bool = true,
+        contentObserved: Bool = true,
         source: TerminalScreen.Source = .daemon,
         ageMilliseconds: Int = 0
     ) throws -> TerminalScreen {
@@ -35,6 +36,7 @@ import Testing
             modes: TerminalScreen.ChildModes(
                 bracketedPaste: false, applicationCursor: false, alternateScreen: false),
             modesObserved: modesObserved,
+            contentObserved: contentObserved,
             source: source,
             ageMilliseconds: ageMilliseconds)
     }
@@ -273,6 +275,7 @@ import Testing
             modes: TerminalScreen.ChildModes(
                 bracketedPaste: true, applicationCursor: true, alternateScreen: false),
             modesObserved: false,
+            contentObserved: false,
             source: .staleDaemon,
             ageMilliseconds: 41)
         #expect(
@@ -314,5 +317,43 @@ import Testing
             """
         let decoded = try JSONDecoder().decode(TerminalScreen.self, from: Data(payload.utf8))
         #expect(decoded.modesObserved)
+    }
+
+    /// The content axis crosses the wire for the same reason the mode axis
+    /// does: the consumer that refuses to park on an unobserved screen reads a
+    /// value that arrived over the socket, and a field dropped in transit turns
+    /// a refusal into a park over somebody's half-typed message.
+    @Test("contentObserved survives a round trip")
+    func contentObservedRoundTrips() throws {
+        for observed in [true, false] {
+            let screen = try Self.make(lines: ["x"], contentObserved: observed)
+            let decoded = try JSONDecoder().decode(
+                TerminalScreen.self, from: try JSONEncoder().encode(screen))
+            #expect(decoded.contentObserved == observed)
+            #expect(decoded == screen)
+        }
+    }
+
+    /// A producer that predates the field could not tell a grid it watched from
+    /// birth apart from one it inherited, so it has no answer to withhold — and
+    /// `true` is what every consumer assumed while the field did not exist. An
+    /// older daemon's screen must decode to the behaviour it has always had,
+    /// not to a refusal nobody asked for.
+    @Test("a payload without contentObserved decodes as observed")
+    func absentContentObservedDecodesAsObserved() throws {
+        let cursor = #"{"row":1,"column":2,"visible":true}"#
+        let size = #"{"columns":80,"rows":24}"#
+        let modes =
+            #"{"bracketedPaste":false,"applicationCursor":false,"alternateScreen":false}"#
+        let payload = """
+            {"lines":["alpha"],"viewportStart":0,"cursor":\(cursor),"size":\(size),\
+            "modes":\(modes),"modesObserved":false,"source":"daemon","ageMilliseconds":5}
+            """
+        let decoded = try JSONDecoder().decode(TerminalScreen.self, from: Data(payload.utf8))
+        #expect(decoded.contentObserved)
+        // The two axes are independent on the wire as well as in the type: a
+        // payload that states one and omits the other must not have its stated
+        // value dragged onto the missing one.
+        #expect(decoded.modesObserved == false)
     }
 }

--- a/docs/specs/2026-08-30-pty-holder-session-transport-design.md
+++ b/docs/specs/2026-08-30-pty-holder-session-transport-design.md
@@ -646,11 +646,16 @@ Everything TBD does through tmux today, and its replacement:
     own, because the remedies differ — a `staleDaemon` or `viewer` screen
     means somebody has the session open and the tab is what to close, a
     session with no reader is one the daemon has lost track of, and a screen
-    that will not project is a defect to fix. Refusing is recoverable; eating
-    a half-composed prompt is not. The idle sweep asks the same question
-    before it arms a row, reading the source alone rather than paying for the
-    lines, so a session the park could never complete costs no
-    request-and-refusal pair on every pass.
+    that will not project is a defect to fix. A live `daemon` screen is also
+    refused, by a name of its own, when its emulator did not observe the child
+    from that child's start — the re-adoption case the screen carries as
+    `contentObserved`: such an emulator inherited a blank grid under a child
+    that repaints only what it is changing, so its screen can show a phantom
+    composer where the session is idle and a blank one where somebody is
+    typing. Refusing is recoverable; eating a half-composed prompt is not. The
+    idle sweep asks the same question before it arms a row, reading those two
+    facts alone rather than paying for the lines, so a session the park could
+    never complete costs no request-and-refusal pair on every pass.
   - **Revive re-anchors the identity check.** The row records when its current
     child started, because a woken session's child is younger than its row and
     every reclaimer that verifies a recorded pid against a start time would

--- a/docs/specs/2026-09-05-child-as-contract-party-design.md
+++ b/docs/specs/2026-09-05-child-as-contract-party-design.md
@@ -159,6 +159,29 @@ stale (`2026-08-30-pty-holder-session-transport-design.md:548-553`).
   which store, and is its screen live — and a re-adopted draining reader is
   honestly `daemon` with `modesObserved: false`, its lines live and its modes
   unobserved.
+- **`contentObserved`** – whether the answering emulator has witnessed
+  everything the child has painted, so a reader can tell a screen the child
+  wrote from a grid that was blank when the emulator inherited it. It comes
+  from the same construction fact as `modesObserved` and is true and false in
+  the same two cases: true for an emulator born with the child at spawn, which
+  has parsed every byte the child has ever written; false, for that emulator's
+  whole life, for one built over an already-running child. A handback preamble
+  restores the cells' *values*, since the snapshot repaints the screen the
+  departing viewer held; it raises no provenance, because that viewer's
+  emulator was seeded by this one's attach snapshot. It is a second field
+  rather than a second reading of `modesObserved` because the two can diverge
+  in principle — a full repaint provoked from outside would restore every cell
+  and not one mode — and because they are what different consumers ask about:
+  the input path asks whether the modes are facts, and the pending-input rail
+  asks whether the cells are. It is orthogonal to `source` in the same way
+  `modesObserved` is: a re-adopted draining reader is honestly `daemon` with
+  both flags false, its bytes parsed live and its screen part inheritance.
+  What `false` costs a reader is worth stating plainly, because a TUI paints
+  differentially — it positions the cursor and writes only the cells it is
+  changing. Every cell the child has not rewritten since the emulator was
+  built holds nothing the child ever painted, so the screen mixes correct
+  newly-painted cells with blanks where the session has text and stale text
+  where the session has cleared, and the projection cannot tell them apart.
 - **`source`** – which store answered: `daemon` (the daemon is the reader and
   rendered its live emulator), `viewer` (a viewer holds the pty and answered a
   pull), or `staleDaemon` (a viewer holds the pty, did not answer, and this is
@@ -250,10 +273,19 @@ is in the consumer, where a reviewer can see it:
   source on the actuation row. This is the one place the design knowingly
   acts on possibly-stale information, and it gets its own section below.
 - **The hibernation pending-input check** – fails closed, as the transport
-  spec rules: a stale screen cannot prove the composer is empty.
+  spec rules: a stale screen cannot prove the composer is empty. It fails
+  closed on the other axis too, refusing a live `daemon` screen whose
+  `contentObserved` is false, because a grid the emulator inherited blank can
+  show a phantom composer where the session is idle and a blank one where
+  somebody is typing — the two mistakes this rail exists to prevent, in one
+  screen. That refusal has a name of its own: there is no tab to close, and
+  the screen becomes checkable again when the daemon next starts the session.
 - **Fleet supervision, `tbd terminal output`** – accept, and surface the
-  source and age. A desk that reads `staleDaemon, 40 minutes` has learned
-  something a string could never tell it.
+  source and age on stderr, plus the content caveat when `contentObserved` is
+  false. A desk that reads `staleDaemon, 40 minutes` has learned something a
+  string could never tell it, and a desk told that cells nobody has repainted
+  since the daemon restarted may be stale or blank will not read a phantom
+  composer line as the session's present state.
 
 ### The same object is the input side's mode oracle
 

--- a/docs/specs/2026-09-05-child-as-contract-party-design.md
+++ b/docs/specs/2026-09-05-child-as-contract-party-design.md
@@ -590,10 +590,10 @@ exists, under a query-time delivery rule that leaves nothing stale.
   re-adoption after a daemon restart, where the emulator is empty — because
   an Ink-style TUI's runtime emits a resize event only on a real geometry
   change, so a bare `SIGWINCH` heals nothing there. It is redundant on attach
-  (`HolderRegistry.swift:1414`: the preamble already carries a current screen
+  (`confirmAttach` in `HolderRegistry.swift`: the preamble already carries a current screen
   from an emulator that was draining continuously, and the viewer already owns
   the size ioctl per the transport spec's "resize follows the reader") and on
-  handback (`:1701`: the preamble carries the app's screen). When it does run,
+  handback (`takeBackFromViewer`: the preamble carries the app's screen). When it does run,
   the grid should move with the tty so the emulator is never at a width the
   child is not, and adoption should assert the size so a stranded width heals.
   Its own spec.

--- a/docs/specs/2026-09-06-holder-readoption-repaint-measurement.md
+++ b/docs/specs/2026-09-06-holder-readoption-repaint-measurement.md
@@ -1,0 +1,240 @@
+# Does re-adoption need its own jiggle? A measurement
+
+**This document is a measurement record, not a design.** It reports what a real
+`claude` binary writes to a real pty across a grow-by-one geometry jiggle,
+a shrink-by-one jiggle, a row jiggle, and no jiggle at all, so that the
+question the pty-holder design has left open — whether daemon re-adoption
+needs a jiggle of its own, and in which shape — rests on evidence. Its
+findings are pinned to one binary at one moment — `claude 2.1.263 (Claude
+Code)`, measured 2026-09-06 on macOS 26.1 — and the section on boundaries
+names what would change them.
+
+## The question
+
+[`2026-08-30-pty-holder-session-transport-design.md`](2026-08-30-pty-holder-session-transport-design.md)
+gives each session a headless emulator that a dedicated reader thread drains
+continuously. [`2026-09-01-holder-repaint-measurement.md`](2026-09-01-holder-repaint-measurement.md)
+established that Claude Code repaints its whole visible viewport, and only
+that, when a jiggle fires — its whole scrollback stays lost regardless.
+[`2026-09-05-child-as-contract-party-design.md`](2026-09-05-child-as-contract-party-design.md)'s
+"Jiggle scoping" out-of-scope bullet names re-adoption as the one edge on
+which the jiggle is load-bearing, because a bare `SIGWINCH` heals nothing on
+an Ink-style runtime that only emits a resize event on a real geometry
+change — and reserves re-scoping the jiggle to cover that edge for its own
+spec.
+
+Reading the code today, that edge carries no jiggle at all. The re-adoption
+path — `HolderRegistry.adoptAll` → `beginAdoption` → `take`
+(`Sources/TBDDaemon/Holder/HolderRegistry.swift`) — rebuilds the emulator and
+starts draining, but never calls `reader.jiggle()`. The only two call sites
+are `confirmAttach` (`HolderRegistry.swift:1538`, viewer attach) and
+`takeBackFromViewer` (`HolderRegistry.swift:1838`, handback) — both edges the
+2026-09-05 spec says the jiggle is redundant on, because a preamble screen
+already exists there.
+
+Live, on a session that survived a daemon restart with no jiggle, `terminal.output`
+(`source: daemon`) showed a phantom composer line persisting 65+ seconds over
+an empty composer, a status bar reduced to the single fragment
+`                    4`, and a missing bottom rule. That is consistent with an
+emulator that came up blank and has recovered only fragments of what a real
+attach would show.
+
+Three questions follow from that observation and from the existing jiggle's
+own shape (`HolderReader.jiggle()`: `cols + 1` held for 10 ms, then restored —
+the emulator's grid is deliberately never resized, per its doc comment,
+because resizing it would reflow contents for nothing and the repaint would
+land at a size the grid was never at):
+
+1. Does 2.1.263 repaint its entire visible viewport on a real geometry
+   change, and does that hold across more than one jiggle shape?
+2. Does the existing shape — a resize the emulator's own grid does not track
+   — corrupt the un-resized grid while the child believes it is a different
+   width, even if the final state comes out clean?
+3. With no jiggle at all, how much of the screen does a blank emulator
+   recover on its own, given only ordinary idle traffic?
+
+## Method
+
+The same design as the prior measurement: a Python harness (`pty.fork`) runs
+the child on a pty at a known size, drains the master continuously into a
+timestamped buffer, and can take a capture boundary at any instant. It is not
+committed. The child is driven through `scripts/claude-stub.py`'s fake model
+API, so every launch answers with one canned 30-line response carrying unique
+marker tokens `ZQM001`…`ZQM030`, at zero token cost.
+
+Four jiggle shapes are compared, all at 24x80:
+
+- **A — grow-by-one, 10 ms** (`cols 80 → 81 → 80`): TBD's exact shape, as
+  written in `HolderReader.jiggle()` today.
+- **B — shrink-by-one** (`cols 80 → 79 → 80`): the alternative the 2026-09-05
+  bullet names — never telling the child a width the grid does not have.
+- **C — row jiggle** (`rows 24 → 23 → 24`): a second axis, to check the
+  finding isn't a columns-only artifact.
+- **D — no jiggle**: the pty sits at 24x80 throughout; only a 15 s wait is
+  applied before the capture boundary.
+
+The decisive comparison, as before, is **screen equivalence**:
+
+- **`screen_full`** — a fresh `pyte` emulator, 24x80, fed the whole byte
+  stream from launch. What an attached terminal would show.
+- **`screen_post`** — a fresh emulator fed only the bytes written after the
+  capture boundary (the jiggle's second edge, or the 15 s mark for shape D).
+  What TBD's daemon shows after adoption.
+
+Rows differing between the two, and which of the 17 markers then visible in
+the viewport (`ZQM014`…`ZQM030`, on a 24-row screen showing the tail of a
+30-line answer) survive into `screen_post`, are the measurements reported
+below.
+
+For shape A, one further comparison isolates the intra-jiggle window: the
+bytes written while the child still believes it is 81 columns are read
+into an 80-column emulator that has not moved (the un-resized grid, as the
+live daemon would be) and separately into an 81-column emulator (a grid
+that tracked the resize). The two are compared against each other and
+against `screen_full` to characterize what a reader landing mid-jiggle would
+see.
+
+One `pyte` patch was required: 0.8.2 forwards `private=True` into
+`select_graphic_rendition` for `CSI ? … m`, and 2.1.263 emits that sequence;
+without the patch the parser raises instead of ignoring the private
+parameter.
+
+## Instrument validation
+
+Run once at 24x80, shape B, before the subject, over 120 marker lines:
+
+- **Positive control — `vim -u NONE -N`, cursor at end of file.** 1,767 bytes
+  written post-jiggle. `screen_post` and `screen_full` were **identical, 0 of
+  24 rows differing**, and all 23 markers visible on the final screen were
+  reconstructed.
+- **Negative control — `bash --noprofile --norc -i`**, after 120 echoed
+  marker lines. 12 bytes written post-jiggle. `screen_post` and `screen_full`
+  differed on **24 of 24 rows**, and no marker was reconstructed.
+
+The gap between a full reconstruction at 1,767 bytes and a total loss at 12
+bytes is the resolution the subject is read against.
+
+## What Claude Code does
+
+**It repaints its entire visible viewport on every geometry change measured,
+regardless of shape, and the grow-by-one shape's un-resized-grid window is
+real but does not survive to the end of the jiggle.**
+
+**Shape A — grow-by-one, TBD's exact shape. Three launches.**
+
+- A1: whole stream 10,653 B, post-boundary 5,843 B, **0 of 24 rows
+  differing**, 17/17 markers, composer row 21 shows `❯`, status row 23 shows
+  `  ⏸ manual mode on · ? for shortcuts · ← for agents`, rows 20 and 22 are
+  full-width `─` rules. A lockstep emulator resized 81-then-80 in step with
+  the tty also reconstructs exactly, 0 differing.
+- A2: 10,612 B / 5,816 B post, 0 of 24, 17/17, lockstep 0.
+- A3 (kept for the intra-jiggle analysis below): 10,050 B / 5,841 B post, 0
+  of 24, 17/17, lockstep 0.
+
+**Shape B — shrink-by-one. Two launches.** B1: 10,618 B / 5,831 B, 0 of 24,
+17/17. B2: 10,619 B / 5,831 B, 0 of 24, 17/17.
+
+**Shape C — row jiggle. One launch.** C1: 9,889 B / 5,679 B, 0 of 24, 17/17.
+
+**Shape D — no jiggle. Two launches.** D1: 31 bytes written in the 15 s
+window, **22 of 24 rows differing** (the two matching rows are blank in
+both screens), 0 of 17 markers present. The 31 bytes are cursor motion and
+one erase-to-end-of-line — `ESC[H`, `CR`, `ESC[62C`, `ESC[19B`, `ESC[K`,
+`ESC[24;1H`, `ESC[22;3H` — which clears the `● high · /effort` hint and
+parks the cursor; they write no content. `screen_post` is 24 empty rows: no
+composer, no status bar, nothing. D2 matches: 31 bytes, 22 of 24 differing, 0
+markers, blank.
+
+**Alternate screen.** All seven launches entered the alternate screen buffer
+— `ESC[?1049h` exactly once, at byte 13, and never followed by
+`ESC[?1049l`. (2.1.258, in the prior measurement, took it only on some
+launches; 2.1.263 took it on every one measured here.)
+
+**The intra-jiggle window, shape A.** A3's raw stream separates the two
+edges. While the child believed it was 81 columns, it wrote 2,908 bytes
+carrying all 17 markers. After the restore ioctl at 80 columns, it wrote a
+further 2,933 bytes, again carrying all 17 markers — and this second half
+alone, fed into a fresh 80-column emulator, reconstructs `screen_full`
+exactly, 0 of 24 rows differing.
+
+Read in the middle, between the two ioctls, the un-resized 80-column grid is
+corrupt: feeding the 81-wide repaint into an 80-column grid that never
+tracked the resize differs from the width-tracking grid on **23 of 24
+rows**. The viewport has shifted up one line — `ZQM014` is pushed off the
+top — and the two full-width `─` rules wrap at 80 columns, leaving stray
+fragments at the left edge: a lone `─` on row 20, and `─ ⏸ manual mode on …`
+on row 23. That is the visual shape of the corruption a reader would see if
+it landed inside the 10 ms window. All three shape-A launches overwrite it
+completely with the second edge.
+
+## What this means for the design
+
+**The fix that ships with this measurement is provenance, not repair.**
+`TerminalScreen.contentObserved` stays false for a re-adopted emulator for
+its whole life; the hibernation pending-input rail refuses such a screen; and
+`tbd terminal output` surfaces the caveat. That holds regardless of what this
+measurement found, because even a perfect repaint cannot be verified from the
+daemon — codex's dialog screens and shells do not repaint on a jiggle, so
+there is no general test the daemon can run to confirm a given repaint
+actually happened. A jiggle can repair a screen for a reader; it cannot raise
+that screen's provenance.
+
+**On repaint fidelity: the jiggle would work on this edge, in any of the
+three shapes measured.** 2.1.263 reconstructs its full visible viewport
+after every jiggle shape tried — columns growing, columns shrinking, rows
+shrinking — 7 of 7 jiggled launches, 0 of 24 rows differing every time, all
+17 on-screen markers recovered every time. Nothing here disqualifies
+grow-by-one on repaint grounds; TBD's existing shape reconstructs the screen
+exactly by the time the jiggle completes.
+
+**But the un-resized grid is genuinely corrupt while the jiggle is in
+flight, and re-adoption is exactly the edge where that matters most.** For
+roughly the 10 ms the tty sits one column wider than the grid, the grid holds
+a shifted, wrapped, wrong screen — 23 of 24 rows off, content pushed up,
+rules fragmented. On the attach and handback edges the existing jiggle
+already covers, that window is harmless: a preamble screen already exists,
+so nobody reads the emulator mid-flight. Re-adoption has no such preamble —
+the emulator is empty until the jiggle runs, so a read that lands inside the
+window, or a jiggle whose restore edge is lost or coalesced (a live 221-cell
+row in a 220-column pty has been observed on this codebase), leaves exactly
+the shifted-and-fragmented screen this measurement produced, not a blank
+one.
+
+**With no jiggle, a re-adopted emulator does not fill itself in.** An idle
+TUI writes essentially nothing on its own — 31 bytes of cursor motion and one
+erase in 15 s, no content, 22 of 24 rows staying wrong. A re-adopted session
+recovers nothing until the user types, and then only whatever the child
+paints differentially from there — which is the mixed stale/blank/correct
+screen the live daemon showed.
+
+**Together, these point at a jiggle on re-adoption in a shape that never
+puts the grid at a size it is not** — shrink-by-one, or resizing the grid in
+lockstep with the tty across both edges, either of which removes the
+corrupt-window risk at no cost measured here (shapes B and C reconstructed
+the screen exactly, same as A). That re-scoping is what the 2026-09-05
+spec's "Jiggle scoping" bullet reserves for its own spec; this measurement is
+the evidence it asked for.
+
+## Boundaries
+
+- **One binary, one day.** `claude 2.1.263`, 2026-09-06. The behavior is a
+  property of that release, not a contract; the prior measurement's binary,
+  2.1.258, differed on how consistently it entered the alternate screen.
+- **Uneven repetition.** Shapes A and B ran three and two launches; C and D
+  ran one and two. The 7/7 and 0-of-24 figures above are exact for what ran,
+  not a claim of a larger sample.
+- **Every jiggle landed on an idle composer with a finished answer.** No
+  trial jiggled mid-stream, during a permission prompt, or during a modal —
+  the prior measurement's codex finding, that a modal state inside a
+  repainting TUI can itself fail to repaint, is the standing warning for
+  those states here too.
+- **Rendered characters only, not attributes.** The comparison is over
+  `pyte`'s screen text. Colors, styles, and cursor shape were not compared.
+- **Direct pty harness, not the daemon.** Everything here runs `pyte`
+  against a raw pty. `HolderReader.jiggle()`, `HolderRegistry.adoptAll`, and
+  SwiftTerm's own emulator were not exercised end to end; the un-resized-grid
+  finding is read from a `pyte` grid built to mimic SwiftTerm's stated
+  behavior (resize the tty, leave the grid alone), not from SwiftTerm itself.
+- **The fake model API.** The answer content, its 30-line length, and its
+  timing are all canned by `scripts/claude-stub.py`; a real model's streaming
+  cadence, and what a jiggle catches mid-stream, are unmeasured.

--- a/docs/specs/2026-09-06-holder-readoption-repaint-measurement.md
+++ b/docs/specs/2026-09-06-holder-readoption-repaint-measurement.md
@@ -196,7 +196,7 @@ already covers, that window is harmless: a preamble screen already exists,
 so nobody reads the emulator mid-flight. Re-adoption has no such preamble —
 the emulator is empty until the jiggle runs, so a read that lands inside the
 window, or a jiggle whose restore edge is lost or coalesced (a live 221-cell
-row in a 220-column pty has been observed on this codebase), leaves exactly
+row in a 220-column pty has been seen in the field on this transport), leaves exactly
 the shifted-and-fragmented screen this measurement produced, not a blank
 one.
 


### PR DESCRIPTION
## What's broken

After a daemon restart, every pty-holder session the daemon re-adopts answers `terminal.output` with a screen that is partly wrong and says nothing about it. Reproduced live today with two Claude Code sessions under one daemon, differing only in whether the daemon's emulator was born with the child or built over a running one:

- The fresh session shows an empty composer and a complete status bar.
- The re-adopted session shows a **phantom composer line** (`❯ Reply with exactly: DONE`) that stood for over 65 seconds while the real composer was empty, a status bar reduced to the single fragment `                    4`, and no bottom rule. Earlier the same day the same defect showed as dropped characters mid-word in scrollback.

Both screens report `source: daemon`, which every consumer reads as authoritative. The one that matters most is the hibernation pending-input rail (#818), which reads this screen to decide whether a session has unsent typed input before parking it. On a re-adopted emulator that screen is wrong in both directions: a phantom composer line makes the rail refuse forever, and a blanked composer makes it park over input that is really there, which is the eat-typed-input failure the `auto_hibernate_enabled` precedent in CLAUDE.md exists for. #818's review flagged the rail's dependence on a re-adopted screen as unverified inference. It is now verified, and it is false.

## Why it happens

Re-adoption (`HolderRegistry.adoptAll` → `beginAdoption` → `take`) builds a fresh `HolderReader` whose emulator starts blank, over a child that has been painting for hours. Claude Code paints differentially in the alternate screen: it positions the cursor and writes only the cells it is changing. So every cell the child does not happen to rewrite keeps whatever the blank emulator had, and the projection becomes a mix of correct newly painted cells, blanks where content exists, and stale text where the child has since cleared.

Two facts sharpen that, both confirmed rather than assumed:

- **No repaint is ever provoked on re-adoption.** The two `reader.jiggle()` call sites are `confirmAttach` (viewer attach) and `takeBackFromViewer` (handback). Those are exactly the two edges the 2026-09-05 spec's "Jiggle scoping" bullet calls redundant, while the edge it calls load-bearing has none. The same bullet reserves re-scoping the jiggle for a spec of its own, so this PR does not move it.
- **A blank emulator recovers nothing on its own.** Measured today against claude 2.1.263 through the zero-token fake model API: with no jiggle, an idle TUI wrote 31 bytes of cursor motion in 15 seconds and the emulator stayed fully blank in both launches. It fills only as the user types and the child paints differentially afterwards.

#828 fixed the mode half of this same provenance hole by adding `modesObserved`, true only for an emulator born with its child. The screen content had no such fact.

## What this PR does

Shapes 1 and 2 from the brief: carry the provenance, and make the consumers fail closed.

- **`TerminalScreen.contentObserved`** (`Sources/TBDShared/TerminalScreen.swift`), beside `modesObserved` and fed from the same `observedChildFromStart` construction fact #828 already plumbs through `HolderRegistry.take` into `HolderReader`. True for an emulator born with its child, false for one built over a running child, fixed for that emulator's life. A handback preamble restores the cells' values and raises no provenance, because the viewer that captured them was seeded by this emulator's own attach snapshot. It is a second field rather than a reuse of `modesObserved` because the two can diverge in principle (a full repaint provoked from outside restores every cell and never a mode) and because different consumers ask different questions. A payload without the key decodes as observed, so an older daemon's screen keeps the behavior it always had. `TerminalModeReading` and the actuation row are untouched: the send path never reads cells.
- **The pending-input rail fails closed** (`Sources/TBDDaemon/Lifecycle/HibernationCoordinator+Holder.swift`). `holderRefusal(forScreenSource:contentObserved:)` is the whole policy on both axes; a live `daemon` screen with unobserved content is refused with a fourth string of its own, because the remedy differs from the other three (there is no tab to close; the screen becomes checkable again when this daemon next starts the session). The park's reading and the sweep's cheap pre-check, in both its oracle and production branches, read the same two facts, so a re-adopted row is neither armed nor written a request-and-refusal pair each sweep. The source refusal is asked first because it names an action the user can take.
- **`tbd terminal output` surfaces the caveat** on stderr, as it already does for a stale or viewer-answered screen; a screen that is both stale and content-unobserved carries both notes, source first. stdout stays exactly the screen text. The `--json` form carries the field.
- **Specs updated in place**: the typed-screen field list and consumer policy in `docs/specs/2026-09-05-child-as-contract-party-design.md`, and the pending-input rail bullet in `docs/specs/2026-08-30-pty-holder-session-transport-design.md`.
- **A measurement record**, `docs/specs/2026-09-06-holder-readoption-repaint-measurement.md`, in the shape of the 2026-09-01 one, for shape 3 of the brief.

**Why it stops at shapes 1 and 2.** Shape 3 asked whether the jiggle can honestly repair the content at the source. The measurement answers the mechanism question: claude 2.1.263 repaints its entire visible viewport on every geometry change tried (grow by one column, shrink by one, shrink by one row: 7 of 7 launches, 0 of 24 rows differing from an always-attached terminal). But the daemon's grow-by-one shape into an emulator grid it never resizes is severely corrupt for the window between its two ioctls (23 of 24 rows wrong, viewport shifted up a row, rule characters wrapped into single-cell fragments, which is the visual signature of the live bug), so a read that lands mid-jiggle or a jiggle whose second ioctl is lost leaves exactly what was observed. A shrink-shaped jiggle, or moving the grid in lockstep, removes that window at no measured cost. Two reasons that is a follow-up rather than this PR: the 2026-09-05 spec explicitly reserves jiggle re-scoping for its own spec, and even a perfect repaint cannot be verified from the daemon (codex's dialog screens and shells do not repaint), so a jiggle can repair a screen for a reader but can never raise `contentObserved`. The flag and the fail-closed rail are the whole answer for the safety-critical consumer; the jiggle would be a reader-facing repair on top. The durable snapshot (#828's deferred follow-up) was not reached for.

No design spec for the fix itself: it restores the typed-screen contract's existing theory (provenance rides with the screen; safety-critical consumers fail closed on anything they cannot judge) to the axis #828 left uncovered.

## Assumptions

- Assumes a screen's content provenance can only be decided at emulator construction. If a future path can prove a complete repaint (it cannot today), `contentObserved` would need a way to be raised, and the rail's refusal would relax with it.
- Assumes the user-visible cost is acceptable during the `holder_hibernation_enabled` soak, and it is worth stating in full. After a daemon restart, every pre-existing holder session is re-adopted with `contentObserved: false` for that child's whole life. The rail sits after the policy checks, so **both the idle sweep and manual "Hibernate now" refuse** such a session; the sweep never arms it, and the menu item stays offered while the park itself refuses with the new message. The only routes back to an observed screen are the session being started again by this daemon (a fresh spawn, or a wake from a park that already happened) or the child exiting on its own. No jiggle changes that, because a repaint cannot be verified from the daemon. Fail-closed is the rail's stated policy for every screen it cannot judge, and this is one; both flags that reach this code default off.
- The production branch of the sweep's pre-check (`holderScreenIsUnreadable` reading `reader.observedChildFromStart` beside `modeReading().source`) is the one newly wired line no test exercises: every coordinator test injects the screen oracle, as the suite always has. The reader-level fact and the policy function are both covered; the join between them is not, and would need a live-registry harness.

## Evidence & verification

- **Repro before the fix**: the two `tbd terminal output --json` reads quoted above, same daemon, same TUI, `modesObserved: true` versus `false`.
- **Discriminating tests**, verified red with the three behavior lines reverted (rail policy, CLI branch, emulator wiring) and green with them in place, on a local filtered run of the four touched suites: a park refuses a `.daemon` screen with an empty composer and `contentObserved: false` with exactly the new reason and no row write; the sweep neither arms nor fires such a row (asserted on the actuation record being empty); a reader built over a running child reports `contentObserved == false` and stays false across a preamble that paints text (the text is asserted present, so values restored and provenance not); `tbd terminal output` emits the content note for a live unobserved screen, stays silent for an observed one, and emits both notes source-first for a stale unobserved one; `contentObserved` round-trips and an absent key decodes as observed. A stale-and-unobserved screen refusing on its source pins the order of the two axes.
- **Measurement**: the harness and per-launch results are in the measurement doc; instrument validated with `vim` (0 differing rows) and `bash` (24 differing rows) before the subject.
- **Not verified live**: the daemon was not restarted from this branch, because the machine-wide daemon slot was held from `main` during this work. CI is the verdict.

https://claude.ai/code/session_01VmxVag4BeDdC65msZCawvK

[holder-screen-provenance](https://cheapsteak.github.io/tbd/open/?worktree=A0BE80FA-7F61-45BD-A764-E4DF0C24FEED)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal screen results now indicate whether content was fully observed from the child’s startup.
  * CLI output can display multiple screen caveats, including stale or unobserved content.
* **Bug Fixes**
  * Hibernation and pending-input operations now refuse potentially incomplete or stale terminal screens, reducing unsafe actions after session re-adoption.
  * Re-adopted sessions no longer incorrectly appear fully observed based solely on restored display content.
* **Documentation**
  * Updated guidance clarifies screen observation, re-adoption behavior, and safety checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->