### PR TITLE
DX: Give the transcript composer stable accessibility identifiers so GUI drivers and tests can find its controls

### DIFF
--- a/Sources/TBDApp/Panes/Transcript/Composer/AttachmentStrip.swift
+++ b/Sources/TBDApp/Panes/Transcript/Composer/AttachmentStrip.swift
@@ -40,6 +40,8 @@ struct AttachmentStrip: View {
                 .padding(.horizontal, 8)
                 .padding(.vertical, 6)
             }
+            .accessibilityElement(children: .contain)
+            .accessibilityIdentifier(ComposerAccessibility.attachments)
         }
     }
 
@@ -68,6 +70,8 @@ struct AttachmentStrip: View {
                 .buttonStyle(.plain)
                 .padding(2)
                 .accessibilityLabel("Remove image \(attachment.number)")
+                .accessibilityIdentifier(
+                    ComposerAccessibility.attachmentRemove(number: attachment.number))
             }
             Text(detached ? "not in message" : "#\(attachment.number)")
                 .font(.system(size: 9))
@@ -88,11 +92,26 @@ struct AttachmentStrip: View {
                 onFocusToken(attachment.number)
             }
         }
-        .accessibilityElement(children: .combine)
+        // `.contain` rather than `.combine`. Combining folds the remove button
+        // into this one element, and a button that is not its own element is a
+        // button neither a driver nor VoiceOver can press separately from the
+        // thumbnail it sits on. The group keeps the sentence it always had, and
+        // carries the thumbnail's own click as an explicit action instead of
+        // relying on the merge to expose it.
+        .accessibilityElement(children: .contain)
         .accessibilityLabel(
             detached
                 ? "Image \(attachment.number), not in message. Click to re-insert."
                 : "Image \(attachment.number), in message. Click to go to it.")
+        .accessibilityIdentifier(
+            ComposerAccessibility.attachmentItem(number: attachment.number))
+        .accessibilityAction {
+            if detached {
+                onReinsert(attachment.number)
+            } else {
+                onFocusToken(attachment.number)
+            }
+        }
     }
 }
 

--- a/Sources/TBDApp/Panes/Transcript/Composer/CompletionOverlayView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Composer/CompletionOverlayView.swift
@@ -54,6 +54,10 @@ struct CompletionOverlayView: View {
             EmptyView()
         } else {
             content
+                // A container, so every row underneath stays individually
+                // addressable rather than collapsing into one element.
+                .accessibilityElement(children: .contain)
+                .accessibilityIdentifier(ComposerAccessibility.menu)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .background(VisualEffectView(material: .menu, blendingMode: .withinWindow))
                 .overlay(
@@ -188,6 +192,10 @@ private struct CompletionRowView: View {
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityLabel)
         .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+        // Named by the command, not by position: the ranking reorders these
+        // rows as the query changes, so an index would name a different row
+        // from one keystroke to the next.
+        .accessibilityIdentifier(ComposerAccessibility.menuRow(command: row.command.name))
     }
 
     private var accessibilityLabel: String {

--- a/Sources/TBDApp/Panes/Transcript/Composer/ComposerAccessibility.swift
+++ b/Sources/TBDApp/Panes/Transcript/Composer/ComposerAccessibility.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// The composer's accessibility identifiers, in one place.
+///
+/// An identifier is **for automation** — a GUI driver, or the offscreen hosting
+/// harness in the test suite, asking the accessibility tree for one control by a
+/// name that does not move when the copy does. That is exactly what a label is
+/// not: a label is the sentence a person hears, and it changes with the wording,
+/// the terminal's name, and the attachment's number. So the two live side by
+/// side here, and nothing reads a label to find a control.
+///
+/// Named constants rather than literals at the call sites for the ordinary
+/// reason: a driver and a test that both spell `composer.send` by hand agree
+/// only until one of them is edited.
+enum ComposerAccessibility {
+    /// The whole composer, as an accessibility container: everything below is
+    /// somewhere inside it.
+    static let root = "composer.root"
+    /// The text view itself — the `NSTextView` inside the representable.
+    static let field = "composer.field"
+    /// The send/resume button, whatever it currently says.
+    static let send = "composer.send"
+    /// The note shown when the session is not running.
+    static let note = "composer.note"
+    /// The blocked banner's sentence, and the button beside it.
+    static let blockedMessage = "composer.blocked.message"
+    static let blockedReveal = "composer.blocked.reveal"
+    /// The banner raised by a failed send or a refused attachment.
+    static let error = "composer.error"
+    /// The completion list, and one row inside it.
+    static let menu = "composer.menu"
+    /// The attachment strip.
+    static let attachments = "composer.attachments"
+
+    /// One completion row, named by its command — the row a driver means is
+    /// "the one for `/compact`", never "the third one down", which moves as the
+    /// ranking does.
+    static func menuRow(command: String) -> String { "composer.menu.row.\(command)" }
+
+    /// One staged image, and its remove button, named by the number the token in
+    /// the message carries.
+    static func attachmentItem(number: Int) -> String {
+        "composer.attachments.item.\(number)"
+    }
+
+    static func attachmentRemove(number: Int) -> String {
+        "composer.attachments.remove.\(number)"
+    }
+}

--- a/Sources/TBDApp/Panes/Transcript/Composer/MessageComposerTextView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Composer/MessageComposerTextView.swift
@@ -165,6 +165,10 @@ struct MessageComposerTextView: NSViewRepresentable {
         textView.autoresizingMask = [.width]
         textView.onImageData = onImageData
         textView.registerForDraggedTypes([.fileURL])
+        // Set here rather than in `updateNSView`: an identifier is a property of
+        // the view, not of a render pass, and a driver looking for the field
+        // must find it on the first one.
+        textView.setAccessibilityIdentifier(ComposerAccessibility.field)
 
         scrollView.documentView = textView
         coordinator.textView = textView

--- a/Sources/TBDApp/Panes/Transcript/Composer/MessageComposerView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Composer/MessageComposerView.swift
@@ -43,6 +43,7 @@ struct MessageComposerView: View {
                     .foregroundStyle(.red)
                     .padding(.horizontal, 10)
                     .padding(.top, 6)
+                    .accessibilityIdentifier(ComposerAccessibility.error)
             }
             if case .blocked(let message) = state {
                 blockedBanner(message)
@@ -53,6 +54,7 @@ struct MessageComposerView: View {
                     .foregroundStyle(.secondary)
                     .padding(.horizontal, 10)
                     .padding(.top, 6)
+                    .accessibilityIdentifier(ComposerAccessibility.note)
             }
             AttachmentStrip(
                 draft: draft,
@@ -115,6 +117,17 @@ struct MessageComposerView: View {
                     }
             }
         }
+        // A container rather than a leaf, and stated rather than left to
+        // SwiftUI: a `VStack` is not an accessibility element at all by default,
+        // so an identifier on it alone would name nothing, and `.combine` would
+        // flatten the field, the button and the banners into one element — the
+        // opposite of what a driver needs. `.contain` keeps every child
+        // addressable and gives the group itself a name to start a walk from.
+        //
+        // After the overlay, so the completion list is inside the composer for a
+        // driver that scopes its search to `composer.root`.
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier(ComposerAccessibility.root)
         .onDisappear {
             // The flag first, and unconditionally: it is what stops a
             // registration still sitting in the deferred queue from installing a
@@ -501,6 +514,9 @@ struct MessageComposerView: View {
         // router owns the key; the button stays clickable.
         .disabled(!state.isEnabled || isSending)
         .help(Self.sendButtonHelp(state: state))
+        // The label is the terminal's name and changes with it; the identifier
+        // does not, which is the whole point of having both.
+        .accessibilityIdentifier(ComposerAccessibility.send)
     }
 
     /// The button names the target, so an injection is never anonymous.
@@ -535,12 +551,16 @@ struct MessageComposerView: View {
     private func blockedBanner(_ message: String) -> some View {
         HStack(spacing: 8) {
             Image(systemName: "hand.raised.fill").foregroundStyle(.orange)
-            Text(message).font(.caption).lineLimit(2)
+            Text(message)
+                .font(.caption)
+                .lineLimit(2)
+                .accessibilityIdentifier(ComposerAccessibility.blockedMessage)
             Spacer(minLength: 0)
             Button("Reveal Terminal") {
                 appState.revealTerminal(terminalID: terminal.id)
             }
             .controlSize(.small)
+            .accessibilityIdentifier(ComposerAccessibility.blockedReveal)
         }
         .padding(.horizontal, 10)
         .padding(.top, 6)

--- a/Tests/TBDAppTests/AccessibilityBridgeSerializedSuites.swift
+++ b/Tests/TBDAppTests/AccessibilityBridgeSerializedSuites.swift
@@ -1,0 +1,102 @@
+import AppKit
+import Testing
+
+/// Parent suite for every suite that turns on macOS's accessibility bridge.
+///
+/// `AXEnhancedUserInterface` is **process-global**: it is set on
+/// `NSApplication.shared`, so one suite flipping it changes what AppKit does for
+/// every other suite running at that moment. All test targets compile into one
+/// process and Swift Testing runs suites in parallel across all of them, so a
+/// suite that sets the flag and walks away leaves it live under everybody else.
+///
+/// That is not hypothetical. The composer identifier suite first shipped setting
+/// the flag and deliberately leaving it on, and
+/// `AccessibilityWindowGeometryGuardTests` — which sets an `NSWindow`'s position
+/// and size through the same accessibility setters and then reads
+/// `window.frame` back — started failing on CI. With enhanced-UI on, AppKit
+/// stops applying an accessibility-driven window move synchronously (it is the
+/// mode window managers switch off before they move anything, for exactly this
+/// reason), so the forwarded value is simply not in the frame yet when the test
+/// looks. The guard is not weakened by that and is not what changed: the flag
+/// legitimately changes AppKit's behavior, so the flag must not be left on.
+///
+/// Two rules follow, and both are needed:
+///
+/// - **Scope the switch.** Turn the bridge on with `withAccessibilityBridge`,
+///   never with a bare set. It records the prior value and restores it in a
+///   `defer`, so the flag is never live outside a test body.
+/// - **Serialize the bodies.** `.serialized` on this parent orders its tests AND
+///   its descendant suites relative to one another, which is what keeps one
+///   suite's open scope from overlapping another suite's accessibility read.
+///   Per-suite `.serialized` alone only orders tests *within* a suite.
+///
+/// To add a suite that touches the accessibility bridge, or that reads back
+/// AppKit behavior the bridge changes, declare it inside an
+/// `extension AccessibilityBridgeSerialized { ... }` so it becomes a nested —
+/// and therefore serialized — child of this suite.
+@Suite(.serialized) enum AccessibilityBridgeSerialized {}
+
+/// The name of the process-global switch, spelled once.
+private let axEnhancedUserInterfaceAttribute = "AXEnhancedUserInterface"
+
+/// Run `body` with macOS's accessibility bridge on, and put the switch back the
+/// way it was found.
+///
+/// SwiftUI builds no accessibility tree at all until a client has asked for one:
+/// with `AXEnhancedUserInterface` clear, a hosting view's accessibility children
+/// are empty no matter what the view declares. A GUI driver sets the flag by
+/// connecting; a test has to set it itself, which is what makes an offscreen
+/// harness measure the same tree a driver will see.
+///
+/// The flag is restored on every exit path — see `AccessibilityBridgeSerialized`
+/// for what leaving it on did.
+@MainActor
+func withAccessibilityBridge<T>(_ body: () async throws -> T) async rethrows -> T {
+    let previous = accessibilityBridgeIsEnabled()
+    setAccessibilityBridge(true)
+    defer { setAccessibilityBridge(previous) }
+    return try await body()
+}
+
+/// Whether the bridge is on right now, read back through the same accessibility
+/// channel that sets it. Answers `false` when the attribute cannot be read,
+/// which is the value a test process starts with and therefore the right one to
+/// restore to.
+@MainActor
+func accessibilityBridgeIsEnabled() -> Bool {
+    let app = NSApplication.shared
+    let selector = Selector(("accessibilityAttributeValue:"))
+    guard app.responds(to: selector),
+          let result = app.perform(selector, with: axEnhancedUserInterfaceAttribute),
+          let number = result.takeUnretainedValue() as? NSNumber
+    else { return false }
+    return number.boolValue
+}
+
+@MainActor
+private func setAccessibilityBridge(_ enabled: Bool) {
+    let app = NSApplication.shared
+    let selector = Selector(("accessibilitySetValue:forAttribute:"))
+    guard app.responds(to: selector) else { return }
+    _ = app.perform(
+        selector, with: NSNumber(value: enabled), with: axEnhancedUserInterfaceAttribute)
+}
+
+extension AccessibilityBridgeSerialized {
+    /// The switch itself: on inside the scope, and back to what it was after —
+    /// the invariant the geometry guard's failure was the symptom of.
+    @MainActor
+    @Suite("accessibility bridge switch")
+    struct AccessibilityBridgeScopeTests {
+        @Test func theBridgeIsOnInsideTheScopeAndRestoredAfterIt() async {
+            _ = NSApplication.shared
+            let before = accessibilityBridgeIsEnabled()
+            await withAccessibilityBridge {
+                #expect(accessibilityBridgeIsEnabled(), "the scope did not turn the bridge on")
+            }
+            #expect(
+                accessibilityBridgeIsEnabled() == before,
+                "the scope left the process-global bridge switch changed")
+        }
+    }
+}

--- a/Tests/TBDAppTests/AccessibilityWindowGeometryGuardTests.swift
+++ b/Tests/TBDAppTests/AccessibilityWindowGeometryGuardTests.swift
@@ -2,115 +2,124 @@ import AppKit
 import Testing
 @testable import TBDApp
 
-@Suite("Accessibility window geometry guard", .serialized)
-@MainActor
-struct AccessibilityWindowGeometryGuardTests {
-    @Test("rejects a non-finite Accessibility position")
-    func rejectsNonFinitePosition() {
-        AccessibilityWindowGeometryGuard.install()
-        let window = makeWindow()
-        let originalFrame = window.frame
+/// Nested under `AccessibilityBridgeSerialized`: this suite does not touch the
+/// accessibility bridge, it is the suite the bridge breaks. It drives an
+/// `NSWindow` through the same accessibility setters the guard swizzles and then
+/// reads `window.frame` back, and with `AXEnhancedUserInterface` on AppKit stops
+/// applying such a move synchronously — so these assertions fail while any other
+/// suite holds the process-global switch open. Serializing it against the suites
+/// that flip that switch is what keeps the two from overlapping.
+extension AccessibilityBridgeSerialized {
+    @Suite("Accessibility window geometry guard", .serialized)
+    @MainActor
+    struct AccessibilityWindowGeometryGuardTests {
+        @Test("rejects a non-finite Accessibility position")
+        func rejectsNonFinitePosition() {
+            AccessibilityWindowGeometryGuard.install()
+            let window = makeWindow()
+            let originalFrame = window.frame
 
-        setAccessibilityValue(
-            NSValue(point: NSPoint(x: -556, y: CGFloat.nan)),
-            selectorName: "accessibilitySetPositionAttribute:",
-            on: window
-        )
+            setAccessibilityValue(
+                NSValue(point: NSPoint(x: -556, y: CGFloat.nan)),
+                selectorName: "accessibilitySetPositionAttribute:",
+                on: window
+            )
 
-        #expect(window.frame == originalFrame)
-    }
+            #expect(window.frame == originalFrame)
+        }
 
-    @Test("forwards a finite Accessibility position")
-    func forwardsFinitePosition() {
-        AccessibilityWindowGeometryGuard.install()
-        let window = makeWindow()
+        @Test("forwards a finite Accessibility position")
+        func forwardsFinitePosition() {
+            AccessibilityWindowGeometryGuard.install()
+            let window = makeWindow()
 
-        setAccessibilityValue(
-            NSValue(point: NSPoint(x: 40, y: 50)),
-            selectorName: "accessibilitySetPositionAttribute:",
-            on: window
-        )
+            setAccessibilityValue(
+                NSValue(point: NSPoint(x: 40, y: 50)),
+                selectorName: "accessibilitySetPositionAttribute:",
+                on: window
+            )
 
-        #expect(window.frame.origin == NSPoint(x: 40, y: 50))
-    }
+            #expect(window.frame.origin == NSPoint(x: 40, y: 50))
+        }
 
-    @Test("rejects a type-mismatched Accessibility position")
-    func rejectsMismatchedPositionValueType() {
-        AccessibilityWindowGeometryGuard.install()
-        let window = makeWindow()
-        let originalFrame = window.frame
+        @Test("rejects a type-mismatched Accessibility position")
+        func rejectsMismatchedPositionValueType() {
+            AccessibilityWindowGeometryGuard.install()
+            let window = makeWindow()
+            let originalFrame = window.frame
 
-        setAccessibilityValue(
-            NSValue(rect: NSRect(x: 1, y: 2, width: 3, height: 4)),
-            selectorName: "accessibilitySetPositionAttribute:",
-            on: window
-        )
+            setAccessibilityValue(
+                NSValue(rect: NSRect(x: 1, y: 2, width: 3, height: 4)),
+                selectorName: "accessibilitySetPositionAttribute:",
+                on: window
+            )
 
-        #expect(window.frame == originalFrame)
-    }
+            #expect(window.frame == originalFrame)
+        }
 
-    @Test("rejects a non-finite Accessibility size")
-    func rejectsNonFiniteSize() {
-        AccessibilityWindowGeometryGuard.install()
-        let window = makeWindow()
-        let originalFrame = window.frame
+        @Test("rejects a non-finite Accessibility size")
+        func rejectsNonFiniteSize() {
+            AccessibilityWindowGeometryGuard.install()
+            let window = makeWindow()
+            let originalFrame = window.frame
 
-        setAccessibilityValue(
-            NSValue(size: NSSize(width: CGFloat.infinity, height: 240)),
-            selectorName: "accessibilitySetSizeAttribute:",
-            on: window
-        )
+            setAccessibilityValue(
+                NSValue(size: NSSize(width: CGFloat.infinity, height: 240)),
+                selectorName: "accessibilitySetSizeAttribute:",
+                on: window
+            )
 
-        #expect(window.frame == originalFrame)
-    }
+            #expect(window.frame == originalFrame)
+        }
 
-    @Test("forwards a finite Accessibility size")
-    func forwardsFiniteSize() {
-        AccessibilityWindowGeometryGuard.install()
-        let window = makeWindow()
-        let originalSize = window.frame.size
+        @Test("forwards a finite Accessibility size")
+        func forwardsFiniteSize() {
+            AccessibilityWindowGeometryGuard.install()
+            let window = makeWindow()
+            let originalSize = window.frame.size
 
-        setAccessibilityValue(
-            NSValue(size: NSSize(width: 420, height: 310)),
-            selectorName: "accessibilitySetSizeAttribute:",
-            on: window
-        )
+            setAccessibilityValue(
+                NSValue(size: NSSize(width: 420, height: 310)),
+                selectorName: "accessibilitySetSizeAttribute:",
+                on: window
+            )
 
-        #expect(window.frame.size != originalSize)
-        #expect(window.frame.width == 420)
-    }
+            #expect(window.frame.size != originalSize)
+            #expect(window.frame.width == 420)
+        }
 
-    @Test("rejects a type-mismatched Accessibility size")
-    func rejectsMismatchedSizeValueType() {
-        AccessibilityWindowGeometryGuard.install()
-        let window = makeWindow()
-        let originalFrame = window.frame
+        @Test("rejects a type-mismatched Accessibility size")
+        func rejectsMismatchedSizeValueType() {
+            AccessibilityWindowGeometryGuard.install()
+            let window = makeWindow()
+            let originalFrame = window.frame
 
-        setAccessibilityValue(
-            NSValue(rect: NSRect(x: 1, y: 2, width: 3, height: 4)),
-            selectorName: "accessibilitySetSizeAttribute:",
-            on: window
-        )
+            setAccessibilityValue(
+                NSValue(rect: NSRect(x: 1, y: 2, width: 3, height: 4)),
+                selectorName: "accessibilitySetSizeAttribute:",
+                on: window
+            )
 
-        #expect(window.frame == originalFrame)
-    }
+            #expect(window.frame == originalFrame)
+        }
 
-    private func makeWindow() -> NSWindow {
-        NSWindow(
-            contentRect: NSRect(x: 10, y: 20, width: 320, height: 240),
-            styleMask: [.titled, .resizable],
-            backing: .buffered,
-            defer: false
-        )
-    }
+        private func makeWindow() -> NSWindow {
+            NSWindow(
+                contentRect: NSRect(x: 10, y: 20, width: 320, height: 240),
+                styleMask: [.titled, .resizable],
+                backing: .buffered,
+                defer: false
+            )
+        }
 
-    private func setAccessibilityValue(
-        _ value: NSValue,
-        selectorName: String,
-        on window: NSWindow
-    ) {
-        let selector = NSSelectorFromString(selectorName)
-        #expect(window.responds(to: selector))
-        _ = window.perform(selector, with: value)
+        private func setAccessibilityValue(
+            _ value: NSValue,
+            selectorName: String,
+            on window: NSWindow
+        ) {
+            let selector = NSSelectorFromString(selectorName)
+            #expect(window.responds(to: selector))
+            _ = window.perform(selector, with: value)
+        }
     }
 }

--- a/Tests/TBDAppTests/ComposerAccessibilityIdentifierTests.swift
+++ b/Tests/TBDAppTests/ComposerAccessibilityIdentifierTests.swift
@@ -1,0 +1,346 @@
+import AppKit
+import Foundation
+import SwiftUI
+import Testing
+@testable import TBDApp
+import TBDShared
+
+/// **The composer's controls can be found by name.** A GUI driver — cua-driver,
+/// an XCUITest-shaped tool, the offscreen harness in this suite — reaches a
+/// control through the accessibility tree, and the only stable handle that tree
+/// carries is the identifier. Labels are not that handle: the send button is
+/// named after whichever terminal it points at, the blocked banner says whatever
+/// the daemon carried, and a thumbnail's sentence changes with its number.
+///
+/// So this suite mounts the real `MessageComposerView` in a real (offscreen)
+/// window, walks the accessibility tree of the hosting view, and asserts the
+/// identifiers are actually in it. Asserting on the *tree* rather than on the
+/// source is the whole point: `.accessibilityIdentifier` on a container SwiftUI
+/// declines to make an element at all is a no-op that reads perfectly well in a
+/// diff, and every assertion here fails against the composer as it stood before
+/// the identifiers were added.
+@MainActor
+@Suite("composer accessibility identifiers")
+struct ComposerAccessibilityIdentifierTests {
+
+    // MARK: - Fixtures
+
+    private static let inventory = TerminalCompletionsResult(
+        commands: (0..<20).map {
+            CompletionCommand(
+                name: "compact\($0)", description: "Compact the conversation, take \($0)")
+        },
+        agents: [], freshness: .fresh, source: .probe)
+
+    private func makeWorktree() -> LocalWorktree {
+        LocalWorktree(Worktree(
+            id: UUID(), repoID: UUID(), name: "wt", displayName: "WT", branch: "main",
+            path: "/tmp/wt", status: .active, tmuxServer: "test-server", location: .local))!
+    }
+
+    private func makeTerminal(worktreeID: UUID) -> Terminal {
+        Terminal(
+            id: UUID(), worktreeID: worktreeID, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            kind: .claude)
+    }
+
+    // MARK: - The harness
+
+    /// A mounted composer in an offscreen window, and what has to be torn down
+    /// after it. The shape is `CompletionOverlayPlacementTests`', for the same
+    /// reason: SwiftUI runs `.task` and lays a hierarchy out only for a view in
+    /// a window that has been shown.
+    private struct Mounted {
+        let window: NSWindow
+        let host: NSHostingView<AnyView>
+        let state: AppState
+        let suiteName: String
+
+        func tearDown() {
+            window.orderOut(nil)
+            UserDefaults.standard.removePersistentDomain(forName: suiteName)
+        }
+    }
+
+    private func mount(
+        state composerState: ComposerState = .running,
+        prepare: (ComposerDraft) -> Void = { _ in }
+    ) -> Mounted {
+        _ = NSApplication.shared
+        // Before the hosting view is made: SwiftUI builds no accessibility tree
+        // at all until a client has asked for one.
+        enableAccessibilityBridge()
+        let suiteName = "ComposerAccessibilityIdentifierTests-\(UUID().uuidString)"
+        let appState = AppState(userDefaults: UserDefaults(suiteName: suiteName)!)
+        appState.composerCompletionsFetcher = { _ in Self.inventory }
+        let worktree = makeWorktree()
+        let terminal = makeTerminal(worktreeID: worktree.id)
+        prepare(appState.composerDraft(for: terminal.id))
+
+        let root = AnyView(
+            VStack(spacing: 0) {
+                // Stands in for the transcript above the composer, so the
+                // completion list has the region it opens out over.
+                Color.clear
+                MessageComposerView(
+                    terminal: terminal, worktree: worktree, state: composerState)
+            }
+            .environment(appState))
+
+        let host = NSHostingView(rootView: root)
+        let window = NSWindow(
+            contentRect: NSRect(x: -20_000, y: -20_000, width: 720, height: 520),
+            styleMask: [.borderless], backing: .buffered, defer: false)
+        window.isReleasedWhenClosed = false
+        window.contentView = host
+        window.orderFront(nil)
+        return Mounted(window: window, host: host, state: appState, suiteName: suiteName)
+    }
+
+    /// One pump of both pumps SwiftUI needs: the main run loop, which drives
+    /// AppKit's layout and display, and the cooperative pool, which drives
+    /// `.task`.
+    private func pump() async {
+        spinRunLoop()
+        await Task.yield()
+    }
+
+    /// Synchronous on purpose: `RunLoop.run(_:before:)` is unavailable from an
+    /// async context, and one turn of the main run loop is exactly what AppKit
+    /// needs to lay out and display what SwiftUI just published.
+    private func spinRunLoop() {
+        _ = RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.004))
+    }
+
+    /// Poll, bounded, for the tree to hold everything named. Returns the last
+    /// set it saw either way, so a failure can print what was actually there.
+    private func settle(
+        _ mounted: Mounted, until wanted: Set<String>, maxPumps: Int = 250
+    ) async -> Set<String> {
+        var seen = axIdentifiers(in: mounted.host)
+        for _ in 0..<maxPumps {
+            if wanted.isSubset(of: seen) { return seen }
+            await pump()
+            seen = axIdentifiers(in: mounted.host)
+        }
+        return seen
+    }
+
+    /// The same poll for a family of identifiers rather than exact names: the
+    /// completion rows are named after the commands the ranker chose, which is
+    /// not something a test should have to predict.
+    private func settle(
+        _ mounted: Mounted, untilAnyHasPrefix prefix: String, maxPumps: Int = 250
+    ) async -> Set<String> {
+        var seen = axIdentifiers(in: mounted.host)
+        for _ in 0..<maxPumps {
+            if seen.contains(where: { $0.hasPrefix(prefix) }) { return seen }
+            await pump()
+            seen = axIdentifiers(in: mounted.host)
+        }
+        return seen
+    }
+
+    private func report(_ mounted: Mounted, _ seen: Set<String>) -> Comment {
+        Comment(rawValue: """
+            the tree held: \(seen.sorted().joined(separator: ", "))
+            \(axTreeDescription(in: mounted.host))
+            """)
+    }
+
+    // MARK: - The core controls
+
+    /// The container, the field, and the button: what any driver needs before it
+    /// can do anything at all with the composer.
+    @Test func theComposerExposesItsContainerFieldAndSendButton() async throws {
+        let mounted = mount()
+        defer { mounted.tearDown() }
+        let wanted: Set<String> = [
+            ComposerAccessibility.root,
+            ComposerAccessibility.field,
+            ComposerAccessibility.send,
+        ]
+        let seen = await settle(mounted, until: wanted)
+        #expect(wanted.isSubset(of: seen), report(mounted, seen))
+    }
+
+    // MARK: - The completion list
+
+    /// The list and its rows, each row addressable on its own. A list that
+    /// exposed only itself would let a driver see the menu and pick nothing out
+    /// of it.
+    @Test func theOpenMenuExposesItselfAndEachRow() async throws {
+        let mounted = mount { $0.text = "/comp" }
+        defer { mounted.tearDown() }
+        let prefix = ComposerAccessibility.menuRow(command: "")
+        let seen = await settle(mounted, untilAnyHasPrefix: prefix)
+
+        #expect(seen.contains(ComposerAccessibility.menu), report(mounted, seen))
+        let rows = seen.filter { $0.hasPrefix(prefix) }
+        #expect(!rows.isEmpty, report(mounted, seen))
+        // Named by command, so two rows are two identifiers rather than one
+        // repeated — the property that makes a specific row selectable.
+        #expect(rows.count > 1, report(mounted, seen))
+        #expect(
+            rows.contains(ComposerAccessibility.menuRow(command: "compact0")),
+            report(mounted, seen))
+    }
+
+    // MARK: - The attachment strip
+
+    /// A staged image, its thumbnail, and its own remove button. The button is
+    /// the one that had to be argued for: an attachment thumbnail was a
+    /// `.combine`d element, which folds the x into the picture and leaves
+    /// nothing to press.
+    @Test func aStagedImageExposesItsThumbnailAndItsRemoveButton() async throws {
+        let mounted = mount { draft in
+            draft.stage(path: "/tmp/tbd-composer-a11y-nonexistent.png", id: UUID())
+        }
+        defer { mounted.tearDown() }
+        let wanted: Set<String> = [
+            ComposerAccessibility.attachments,
+            ComposerAccessibility.attachmentItem(number: 1),
+            ComposerAccessibility.attachmentRemove(number: 1),
+        ]
+        let seen = await settle(mounted, until: wanted)
+        #expect(wanted.isSubset(of: seen), report(mounted, seen))
+    }
+
+    // MARK: - The two banners
+
+    /// Blocked: the sentence, and the button that gets somebody to the dialog.
+    @Test func theBlockedBannerExposesItsMessageAndRevealButton() async throws {
+        let mounted = mount(state: .blocked(message: "Claude is asking something"))
+        defer { mounted.tearDown() }
+        let wanted: Set<String> = [
+            ComposerAccessibility.blockedMessage,
+            ComposerAccessibility.blockedReveal,
+        ]
+        let seen = await settle(mounted, until: wanted)
+        #expect(wanted.isSubset(of: seen), report(mounted, seen))
+    }
+
+    /// Not running: the note explaining that a send resumes the session.
+    @Test func theNotRunningNoteIsExposed() async throws {
+        let mounted = mount(state: .notRunning(exited: true))
+        defer { mounted.tearDown() }
+        let seen = await settle(mounted, until: [ComposerAccessibility.note])
+        #expect(seen.contains(ComposerAccessibility.note), report(mounted, seen))
+    }
+
+    /// And the note is not there when the session is running — so the assertion
+    /// above is about the state and not about a string that is always present.
+    @Test func theNotRunningNoteIsAbsentWhileRunning() async throws {
+        let mounted = mount()
+        defer { mounted.tearDown() }
+        _ = await settle(mounted, until: [ComposerAccessibility.field])
+        let seen = axIdentifiers(in: mounted.host)
+        #expect(!seen.contains(ComposerAccessibility.note), report(mounted, seen))
+        #expect(!seen.contains(ComposerAccessibility.blockedReveal), report(mounted, seen))
+    }
+}
+
+/// Every accessibility identifier in the tree rooted at `view`.
+///
+/// It walks the **accessibility** tree rather than the view hierarchy, because
+/// the question is what an assistive client — or a GUI driver, which is one —
+/// can actually reach. Two things about that tree are not obvious, and both had
+/// to be found by measurement:
+///
+/// - **SwiftUI does not build one until a client asks for it.** Until then
+///   `NSHostingView.accessibilityChildren()` is empty and a walk reports nothing
+///   at all, whatever the view declares. `enableAccessibilityBridge()` flips the
+///   switch a driver flips, and every mount here calls it.
+/// - **SwiftUI's nodes are not `NSAccessibilityProtocol` in Swift's eyes.** They
+///   are `SwiftUI.AccessibilityNode` objects that implement the accessibility
+///   methods without declaring the Objective-C protocol, so `as?` fails on every
+///   one of them and a typed walk silently sees an empty tree. They are reached
+///   the way Objective-C reaches them instead: by selector.
+///
+/// Children are the union of what a node declares and, for an `NSView`, its
+/// subviews — which is how AppKit itself resolves children for a view that has
+/// not overridden them, and how the `NSTextView` inside the composer's
+/// representable is reached.
+///
+/// **It lives here rather than in `Tests/TestSupport/`.** That target is the
+/// daemon's support library — it depends on `TBDDaemonLib` and links into the
+/// daemon suites — and this would drag AppKit into all of them for one
+/// AppKit-only caller. As a top-level function in the app test target it is
+/// already reusable by every suite in it.
+@MainActor
+func axIdentifiers(in view: NSView) -> Set<String> {
+    var found: Set<String> = []
+    axWalk(view) { node, _ in
+        if let identifier = axAttribute(node, "accessibilityIdentifier") as? String,
+           !identifier.isEmpty {
+            found.insert(identifier)
+        }
+    }
+    return found
+}
+
+/// The same walk as an indented outline, so a failure names the tree it found
+/// rather than only the identifier it wanted.
+@MainActor
+func axTreeDescription(in view: NSView) -> String {
+    var lines: [String] = []
+    axWalk(view) { node, depth in
+        let role = axAttribute(node, "accessibilityRole") as? String ?? "-"
+        let identifier = (axAttribute(node, "accessibilityIdentifier") as? String)
+            .map { " id=\($0)" } ?? ""
+        let label = (axAttribute(node, "accessibilityLabel") as? String)
+            .map { " label=\($0.prefix(40))" } ?? ""
+        lines.append(
+            String(repeating: "  ", count: depth) + "\(type(of: node))"
+                + " role=\(role)\(identifier)\(label)")
+    }
+    return lines.joined(separator: "\n")
+}
+
+/// Ask SwiftUI and AppKit to build accessibility trees at all.
+///
+/// `AXEnhancedUserInterface` is the flag an assistive client sets on an
+/// application when it attaches, and SwiftUI's macOS bridge waits for it: with
+/// it clear, a hosting view's accessibility children are empty no matter what
+/// the view declares. A GUI driver sets it by connecting; a test has to set it
+/// itself, which is what makes this harness measure the same tree the driver
+/// will see.
+///
+/// Process-wide and left on. Turning it back off would race the suite's own
+/// parallel tests, and it costs nothing anywhere else — an accessibility tree
+/// nobody reads changes no behavior.
+@MainActor
+func enableAccessibilityBridge() {
+    let selector = Selector(("accessibilitySetValue:forAttribute:"))
+    let app = NSApplication.shared
+    guard app.responds(to: selector) else { return }
+    _ = app.perform(selector, with: NSNumber(value: true), with: "AXEnhancedUserInterface")
+}
+
+/// One accessibility accessor, by selector — see `axIdentifiers(in:)` for why it
+/// cannot simply be a method call on a typed value.
+@MainActor
+private func axAttribute(_ node: NSObject, _ name: String) -> Any? {
+    guard node.responds(to: Selector((name))) else { return nil }
+    return node.value(forKey: name)
+}
+
+/// Depth-first over the accessibility tree, visiting each node once.
+@MainActor
+private func axWalk(_ root: NSView, visit: (NSObject, Int) -> Void) {
+    var seen = Set<ObjectIdentifier>()
+
+    func children(of node: NSObject) -> [Any] {
+        let declared = axAttribute(node, "accessibilityChildren") as? [Any] ?? []
+        return declared + ((node as? NSView)?.subviews ?? [])
+    }
+
+    func step(_ element: Any, _ depth: Int) {
+        guard let node = element as? NSObject else { return }
+        guard seen.insert(ObjectIdentifier(node)).inserted else { return }
+        visit(node, depth)
+        for child in children(of: node) { step(child, depth + 1) }
+    }
+
+    step(root, 0)
+}

--- a/Tests/TBDAppTests/ComposerAccessibilityIdentifierTests.swift
+++ b/Tests/TBDAppTests/ComposerAccessibilityIdentifierTests.swift
@@ -19,224 +19,235 @@ import TBDShared
 /// declines to make an element at all is a no-op that reads perfectly well in a
 /// diff, and every assertion here fails against the composer as it stood before
 /// the identifiers were added.
-@MainActor
-@Suite("composer accessibility identifiers")
-struct ComposerAccessibilityIdentifierTests {
+extension AccessibilityBridgeSerialized {
+    @MainActor
+    @Suite("composer accessibility identifiers")
+    struct ComposerAccessibilityIdentifierTests {
 
-    // MARK: - Fixtures
+        // MARK: - Fixtures
 
-    private static let inventory = TerminalCompletionsResult(
-        commands: (0..<20).map {
-            CompletionCommand(
-                name: "compact\($0)", description: "Compact the conversation, take \($0)")
-        },
-        agents: [], freshness: .fresh, source: .probe)
+        private static let inventory = TerminalCompletionsResult(
+            commands: (0..<20).map {
+                CompletionCommand(
+                    name: "compact\($0)", description: "Compact the conversation, take \($0)")
+            },
+            agents: [], freshness: .fresh, source: .probe)
 
-    private func makeWorktree() -> LocalWorktree {
-        LocalWorktree(Worktree(
-            id: UUID(), repoID: UUID(), name: "wt", displayName: "WT", branch: "main",
-            path: "/tmp/wt", status: .active, tmuxServer: "test-server", location: .local))!
-    }
-
-    private func makeTerminal(worktreeID: UUID) -> Terminal {
-        Terminal(
-            id: UUID(), worktreeID: worktreeID, tmuxWindowID: "@1", tmuxPaneID: "%1",
-            kind: .claude)
-    }
-
-    // MARK: - The harness
-
-    /// A mounted composer in an offscreen window, and what has to be torn down
-    /// after it. The shape is `CompletionOverlayPlacementTests`', for the same
-    /// reason: SwiftUI runs `.task` and lays a hierarchy out only for a view in
-    /// a window that has been shown.
-    private struct Mounted {
-        let window: NSWindow
-        let host: NSHostingView<AnyView>
-        let state: AppState
-        let suiteName: String
-
-        func tearDown() {
-            window.orderOut(nil)
-            UserDefaults.standard.removePersistentDomain(forName: suiteName)
+        private func makeWorktree() -> LocalWorktree {
+            LocalWorktree(Worktree(
+                id: UUID(), repoID: UUID(), name: "wt", displayName: "WT", branch: "main",
+                path: "/tmp/wt", status: .active, tmuxServer: "test-server", location: .local))!
         }
-    }
 
-    private func mount(
-        state composerState: ComposerState = .running,
-        prepare: (ComposerDraft) -> Void = { _ in }
-    ) -> Mounted {
-        _ = NSApplication.shared
-        // Before the hosting view is made: SwiftUI builds no accessibility tree
-        // at all until a client has asked for one.
-        enableAccessibilityBridge()
-        let suiteName = "ComposerAccessibilityIdentifierTests-\(UUID().uuidString)"
-        let appState = AppState(userDefaults: UserDefaults(suiteName: suiteName)!)
-        appState.composerCompletionsFetcher = { _ in Self.inventory }
-        let worktree = makeWorktree()
-        let terminal = makeTerminal(worktreeID: worktree.id)
-        prepare(appState.composerDraft(for: terminal.id))
+        private func makeTerminal(worktreeID: UUID) -> Terminal {
+            Terminal(
+                id: UUID(), worktreeID: worktreeID, tmuxWindowID: "@1", tmuxPaneID: "%1",
+                kind: .claude)
+        }
 
-        let root = AnyView(
-            VStack(spacing: 0) {
-                // Stands in for the transcript above the composer, so the
-                // completion list has the region it opens out over.
-                Color.clear
-                MessageComposerView(
-                    terminal: terminal, worktree: worktree, state: composerState)
+        // MARK: - The harness
+
+        /// A mounted composer in an offscreen window, and what has to be torn down
+        /// after it. The shape is `CompletionOverlayPlacementTests`', for the same
+        /// reason: SwiftUI runs `.task` and lays a hierarchy out only for a view in
+        /// a window that has been shown.
+        private struct Mounted {
+            let window: NSWindow
+            let host: NSHostingView<AnyView>
+            let state: AppState
+            let suiteName: String
+
+            func tearDown() {
+                window.orderOut(nil)
+                UserDefaults.standard.removePersistentDomain(forName: suiteName)
             }
-            .environment(appState))
-
-        let host = NSHostingView(rootView: root)
-        let window = NSWindow(
-            contentRect: NSRect(x: -20_000, y: -20_000, width: 720, height: 520),
-            styleMask: [.borderless], backing: .buffered, defer: false)
-        window.isReleasedWhenClosed = false
-        window.contentView = host
-        window.orderFront(nil)
-        return Mounted(window: window, host: host, state: appState, suiteName: suiteName)
-    }
-
-    /// One pump of both pumps SwiftUI needs: the main run loop, which drives
-    /// AppKit's layout and display, and the cooperative pool, which drives
-    /// `.task`.
-    private func pump() async {
-        spinRunLoop()
-        await Task.yield()
-    }
-
-    /// Synchronous on purpose: `RunLoop.run(_:before:)` is unavailable from an
-    /// async context, and one turn of the main run loop is exactly what AppKit
-    /// needs to lay out and display what SwiftUI just published.
-    private func spinRunLoop() {
-        _ = RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.004))
-    }
-
-    /// Poll, bounded, for the tree to hold everything named. Returns the last
-    /// set it saw either way, so a failure can print what was actually there.
-    private func settle(
-        _ mounted: Mounted, until wanted: Set<String>, maxPumps: Int = 250
-    ) async -> Set<String> {
-        var seen = axIdentifiers(in: mounted.host)
-        for _ in 0..<maxPumps {
-            if wanted.isSubset(of: seen) { return seen }
-            await pump()
-            seen = axIdentifiers(in: mounted.host)
         }
-        return seen
-    }
 
-    /// The same poll for a family of identifiers rather than exact names: the
-    /// completion rows are named after the commands the ranker chose, which is
-    /// not something a test should have to predict.
-    private func settle(
-        _ mounted: Mounted, untilAnyHasPrefix prefix: String, maxPumps: Int = 250
-    ) async -> Set<String> {
-        var seen = axIdentifiers(in: mounted.host)
-        for _ in 0..<maxPumps {
-            if seen.contains(where: { $0.hasPrefix(prefix) }) { return seen }
-            await pump()
-            seen = axIdentifiers(in: mounted.host)
+        private func mount(
+            state composerState: ComposerState = .running,
+            prepare: (ComposerDraft) -> Void = { _ in }
+        ) -> Mounted {
+            _ = NSApplication.shared
+            let suiteName = "ComposerAccessibilityIdentifierTests-\(UUID().uuidString)"
+            let appState = AppState(userDefaults: UserDefaults(suiteName: suiteName)!)
+            appState.composerCompletionsFetcher = { _ in Self.inventory }
+            let worktree = makeWorktree()
+            let terminal = makeTerminal(worktreeID: worktree.id)
+            prepare(appState.composerDraft(for: terminal.id))
+
+            let root = AnyView(
+                VStack(spacing: 0) {
+                    // Stands in for the transcript above the composer, so the
+                    // completion list has the region it opens out over.
+                    Color.clear
+                    MessageComposerView(
+                        terminal: terminal, worktree: worktree, state: composerState)
+                }
+                .environment(appState))
+
+            let host = NSHostingView(rootView: root)
+            let window = NSWindow(
+                contentRect: NSRect(x: -20_000, y: -20_000, width: 720, height: 520),
+                styleMask: [.borderless], backing: .buffered, defer: false)
+            window.isReleasedWhenClosed = false
+            window.contentView = host
+            window.orderFront(nil)
+            return Mounted(window: window, host: host, state: appState, suiteName: suiteName)
         }
-        return seen
-    }
 
-    private func report(_ mounted: Mounted, _ seen: Set<String>) -> Comment {
-        Comment(rawValue: """
-            the tree held: \(seen.sorted().joined(separator: ", "))
-            \(axTreeDescription(in: mounted.host))
-            """)
-    }
-
-    // MARK: - The core controls
-
-    /// The container, the field, and the button: what any driver needs before it
-    /// can do anything at all with the composer.
-    @Test func theComposerExposesItsContainerFieldAndSendButton() async throws {
-        let mounted = mount()
-        defer { mounted.tearDown() }
-        let wanted: Set<String> = [
-            ComposerAccessibility.root,
-            ComposerAccessibility.field,
-            ComposerAccessibility.send,
-        ]
-        let seen = await settle(mounted, until: wanted)
-        #expect(wanted.isSubset(of: seen), report(mounted, seen))
-    }
-
-    // MARK: - The completion list
-
-    /// The list and its rows, each row addressable on its own. A list that
-    /// exposed only itself would let a driver see the menu and pick nothing out
-    /// of it.
-    @Test func theOpenMenuExposesItselfAndEachRow() async throws {
-        let mounted = mount { $0.text = "/comp" }
-        defer { mounted.tearDown() }
-        let prefix = ComposerAccessibility.menuRow(command: "")
-        let seen = await settle(mounted, untilAnyHasPrefix: prefix)
-
-        #expect(seen.contains(ComposerAccessibility.menu), report(mounted, seen))
-        let rows = seen.filter { $0.hasPrefix(prefix) }
-        #expect(!rows.isEmpty, report(mounted, seen))
-        // Named by command, so two rows are two identifiers rather than one
-        // repeated — the property that makes a specific row selectable.
-        #expect(rows.count > 1, report(mounted, seen))
-        #expect(
-            rows.contains(ComposerAccessibility.menuRow(command: "compact0")),
-            report(mounted, seen))
-    }
-
-    // MARK: - The attachment strip
-
-    /// A staged image, its thumbnail, and its own remove button. The button is
-    /// the one that had to be argued for: an attachment thumbnail was a
-    /// `.combine`d element, which folds the x into the picture and leaves
-    /// nothing to press.
-    @Test func aStagedImageExposesItsThumbnailAndItsRemoveButton() async throws {
-        let mounted = mount { draft in
-            draft.stage(path: "/tmp/tbd-composer-a11y-nonexistent.png", id: UUID())
+        /// One pump of both pumps SwiftUI needs: the main run loop, which drives
+        /// AppKit's layout and display, and the cooperative pool, which drives
+        /// `.task`.
+        private func pump() async {
+            spinRunLoop()
+            await Task.yield()
         }
-        defer { mounted.tearDown() }
-        let wanted: Set<String> = [
-            ComposerAccessibility.attachments,
-            ComposerAccessibility.attachmentItem(number: 1),
-            ComposerAccessibility.attachmentRemove(number: 1),
-        ]
-        let seen = await settle(mounted, until: wanted)
-        #expect(wanted.isSubset(of: seen), report(mounted, seen))
-    }
 
-    // MARK: - The two banners
+        /// Synchronous on purpose: `RunLoop.run(_:before:)` is unavailable from an
+        /// async context, and one turn of the main run loop is exactly what AppKit
+        /// needs to lay out and display what SwiftUI just published.
+        private func spinRunLoop() {
+            _ = RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.004))
+        }
 
-    /// Blocked: the sentence, and the button that gets somebody to the dialog.
-    @Test func theBlockedBannerExposesItsMessageAndRevealButton() async throws {
-        let mounted = mount(state: .blocked(message: "Claude is asking something"))
-        defer { mounted.tearDown() }
-        let wanted: Set<String> = [
-            ComposerAccessibility.blockedMessage,
-            ComposerAccessibility.blockedReveal,
-        ]
-        let seen = await settle(mounted, until: wanted)
-        #expect(wanted.isSubset(of: seen), report(mounted, seen))
-    }
+        /// Poll, bounded, for the tree to hold everything named. Returns the last
+        /// set it saw either way, so a failure can print what was actually there.
+        private func settle(
+            _ mounted: Mounted, until wanted: Set<String>, maxPumps: Int = 250
+        ) async -> Set<String> {
+            var seen = axIdentifiers(in: mounted.host)
+            for _ in 0..<maxPumps {
+                if wanted.isSubset(of: seen) { return seen }
+                await pump()
+                seen = axIdentifiers(in: mounted.host)
+            }
+            return seen
+        }
 
-    /// Not running: the note explaining that a send resumes the session.
-    @Test func theNotRunningNoteIsExposed() async throws {
-        let mounted = mount(state: .notRunning(exited: true))
-        defer { mounted.tearDown() }
-        let seen = await settle(mounted, until: [ComposerAccessibility.note])
-        #expect(seen.contains(ComposerAccessibility.note), report(mounted, seen))
-    }
+        /// The same poll for a family of identifiers rather than exact names: the
+        /// completion rows are named after the commands the ranker chose, which is
+        /// not something a test should have to predict.
+        private func settle(
+            _ mounted: Mounted, untilAnyHasPrefix prefix: String, maxPumps: Int = 250
+        ) async -> Set<String> {
+            var seen = axIdentifiers(in: mounted.host)
+            for _ in 0..<maxPumps {
+                if seen.contains(where: { $0.hasPrefix(prefix) }) { return seen }
+                await pump()
+                seen = axIdentifiers(in: mounted.host)
+            }
+            return seen
+        }
 
-    /// And the note is not there when the session is running — so the assertion
-    /// above is about the state and not about a string that is always present.
-    @Test func theNotRunningNoteIsAbsentWhileRunning() async throws {
-        let mounted = mount()
-        defer { mounted.tearDown() }
-        _ = await settle(mounted, until: [ComposerAccessibility.field])
-        let seen = axIdentifiers(in: mounted.host)
-        #expect(!seen.contains(ComposerAccessibility.note), report(mounted, seen))
-        #expect(!seen.contains(ComposerAccessibility.blockedReveal), report(mounted, seen))
+        private func report(_ mounted: Mounted, _ seen: Set<String>) -> Comment {
+            Comment(rawValue: """
+                the tree held: \(seen.sorted().joined(separator: ", "))
+                \(axTreeDescription(in: mounted.host))
+                """)
+        }
+
+        // MARK: - The core controls
+
+        /// The container, the field, and the button: what any driver needs before it
+        /// can do anything at all with the composer.
+        @Test func theComposerExposesItsContainerFieldAndSendButton() async {
+            await withAccessibilityBridge {
+                let mounted = mount()
+                defer { mounted.tearDown() }
+                let wanted: Set<String> = [
+                    ComposerAccessibility.root,
+                    ComposerAccessibility.field,
+                    ComposerAccessibility.send,
+                ]
+                let seen = await settle(mounted, until: wanted)
+                #expect(wanted.isSubset(of: seen), report(mounted, seen))
+            }
+        }
+
+        // MARK: - The completion list
+
+        /// The list and its rows, each row addressable on its own. A list that
+        /// exposed only itself would let a driver see the menu and pick nothing out
+        /// of it.
+        @Test func theOpenMenuExposesItselfAndEachRow() async {
+            await withAccessibilityBridge {
+                let mounted = mount { $0.text = "/comp" }
+                defer { mounted.tearDown() }
+                let prefix = ComposerAccessibility.menuRow(command: "")
+                let seen = await settle(mounted, untilAnyHasPrefix: prefix)
+
+                #expect(seen.contains(ComposerAccessibility.menu), report(mounted, seen))
+                let rows = seen.filter { $0.hasPrefix(prefix) }
+                #expect(!rows.isEmpty, report(mounted, seen))
+                // Named by command, so two rows are two identifiers rather than one
+                // repeated — the property that makes a specific row selectable.
+                #expect(rows.count > 1, report(mounted, seen))
+                #expect(
+                    rows.contains(ComposerAccessibility.menuRow(command: "compact0")),
+                    report(mounted, seen))
+            }
+        }
+
+        // MARK: - The attachment strip
+
+        /// A staged image, its thumbnail, and its own remove button. The button is
+        /// the one that had to be argued for: an attachment thumbnail was a
+        /// `.combine`d element, which folds the x into the picture and leaves
+        /// nothing to press.
+        @Test func aStagedImageExposesItsThumbnailAndItsRemoveButton() async {
+            await withAccessibilityBridge {
+                let mounted = mount { draft in
+                    draft.stage(path: "/tmp/tbd-composer-a11y-nonexistent.png", id: UUID())
+                }
+                defer { mounted.tearDown() }
+                let wanted: Set<String> = [
+                    ComposerAccessibility.attachments,
+                    ComposerAccessibility.attachmentItem(number: 1),
+                    ComposerAccessibility.attachmentRemove(number: 1),
+                ]
+                let seen = await settle(mounted, until: wanted)
+                #expect(wanted.isSubset(of: seen), report(mounted, seen))
+            }
+        }
+
+        // MARK: - The two banners
+
+        /// Blocked: the sentence, and the button that gets somebody to the dialog.
+        @Test func theBlockedBannerExposesItsMessageAndRevealButton() async {
+            await withAccessibilityBridge {
+                let mounted = mount(state: .blocked(message: "Claude is asking something"))
+                defer { mounted.tearDown() }
+                let wanted: Set<String> = [
+                    ComposerAccessibility.blockedMessage,
+                    ComposerAccessibility.blockedReveal,
+                ]
+                let seen = await settle(mounted, until: wanted)
+                #expect(wanted.isSubset(of: seen), report(mounted, seen))
+            }
+        }
+
+        /// Not running: the note explaining that a send resumes the session.
+        @Test func theNotRunningNoteIsExposed() async {
+            await withAccessibilityBridge {
+                let mounted = mount(state: .notRunning(exited: true))
+                defer { mounted.tearDown() }
+                let seen = await settle(mounted, until: [ComposerAccessibility.note])
+                #expect(seen.contains(ComposerAccessibility.note), report(mounted, seen))
+            }
+        }
+
+        /// And the note is not there when the session is running — so the assertion
+        /// above is about the state and not about a string that is always present.
+        @Test func theNotRunningNoteIsAbsentWhileRunning() async {
+            await withAccessibilityBridge {
+                let mounted = mount()
+                defer { mounted.tearDown() }
+                _ = await settle(mounted, until: [ComposerAccessibility.field])
+                let seen = axIdentifiers(in: mounted.host)
+                #expect(!seen.contains(ComposerAccessibility.note), report(mounted, seen))
+                #expect(!seen.contains(ComposerAccessibility.blockedReveal), report(mounted, seen))
+            }
+        }
     }
 }
 
@@ -249,8 +260,8 @@ struct ComposerAccessibilityIdentifierTests {
 ///
 /// - **SwiftUI does not build one until a client asks for it.** Until then
 ///   `NSHostingView.accessibilityChildren()` is empty and a walk reports nothing
-///   at all, whatever the view declares. `enableAccessibilityBridge()` flips the
-///   switch a driver flips, and every mount here calls it.
+///   at all, whatever the view declares. `withAccessibilityBridge` flips the
+///   switch a driver flips, for the length of one test body.
 /// - **SwiftUI's nodes are not `NSAccessibilityProtocol` in Swift's eyes.** They
 ///   are `SwiftUI.AccessibilityNode` objects that implement the accessibility
 ///   methods without declaring the Objective-C protocol, so `as?` fails on every
@@ -295,26 +306,6 @@ func axTreeDescription(in view: NSView) -> String {
                 + " role=\(role)\(identifier)\(label)")
     }
     return lines.joined(separator: "\n")
-}
-
-/// Ask SwiftUI and AppKit to build accessibility trees at all.
-///
-/// `AXEnhancedUserInterface` is the flag an assistive client sets on an
-/// application when it attaches, and SwiftUI's macOS bridge waits for it: with
-/// it clear, a hosting view's accessibility children are empty no matter what
-/// the view declares. A GUI driver sets it by connecting; a test has to set it
-/// itself, which is what makes this harness measure the same tree the driver
-/// will see.
-///
-/// Process-wide and left on. Turning it back off would race the suite's own
-/// parallel tests, and it costs nothing anywhere else — an accessibility tree
-/// nobody reads changes no behavior.
-@MainActor
-func enableAccessibilityBridge() {
-    let selector = Selector(("accessibilitySetValue:forAttribute:"))
-    let app = NSApplication.shared
-    guard app.responds(to: selector) else { return }
-    _ = app.perform(selector, with: NSNumber(value: true), with: "AXEnhancedUserInterface")
 }
 
 /// One accessibility accessor, by selector — see `axIdentifiers(in:)` for why it


### PR DESCRIPTION
## Summary

Anyone driving TBD's UI from outside — a GUI driver such as cua-driver, an
XCUITest-shaped tool, or the repo's own offscreen hosting harness — finds a
control by asking the accessibility tree for it by identifier. A
live-verification pass found the transcript composer had none: the text field,
the send button, the blocked and error banners, the completion rows and the
attachment thumbnails were all anonymous. A driver could see shapes but had
nothing stable to address, and a test could only reach a control by AppKit
class or by matching the sentence a person hears — which changes with the
terminal's name, the daemon's message, and the image's number.

This PR gives every composer control a stable identifier. It is the
prerequisite for driving the composer at all, and it is additive metadata: no
behavior a user sees changes.

## Why this shape

**No spec.** This is UI/test-infrastructure metadata — identifiers plus the
test that proves they land — not a revision to any theory of the system. Per
CLAUDE.md, a minor UI change of this kind needs none.

**Identifiers are not labels, and both stay.** A label is the sentence
VoiceOver reads and it is allowed to change with the copy; an identifier is
the handle automation holds and it must not. Every existing
`.accessibilityLabel` is left exactly as it was, and no identifier was folded
into one.

**One place.** They are `static let`s and small functions on a new
`ComposerAccessibility` enum, so a driver and a test that both mean
`composer.send` are reading the same constant rather than each retyping a
literal.

**Rows are named by command, not by index.** The ranker reorders the
completion list as the query changes, so `composer.menu.row.3` would name a
different row from one keystroke to the next; `composer.menu.row.compact` names
the same one every time.

**Containers are stated, not hoped for.** A SwiftUI `VStack` is not an
accessibility element at all, so an identifier on one alone names nothing.
The composer root, the completion list and the attachment strip declare
`.accessibilityElement(children: .contain)` — which keeps every child
individually addressable, where `.combine` would flatten them into one.

## What this PR does

New file `Sources/TBDApp/Panes/Transcript/Composer/ComposerAccessibility.swift`
holds every identifier:

- `composer.root` — the whole composer, as an accessibility container
- `composer.field` — the `NSTextView`, set in `makeNSView`
- `composer.send` — the send/resume button
- `composer.note` — the not-running note
- `composer.blocked.message`, `composer.blocked.reveal` — the blocked banner's
  sentence and its Reveal Terminal button
- `composer.error` — the banner a failed send or a refused image raises
- `composer.menu` — the completion list
- `composer.menu.row.<command>` — one row per command, e.g.
  `composer.menu.row.compact`
- `composer.attachments` — the attachment strip
- `composer.attachments.item.<n>` — one staged image's thumbnail
- `composer.attachments.remove.<n>` — that image's remove button

The argument hint is not in the list because it is not a view: it is a string
the composer's `NSTextView` draws itself, with no element to identify.

One behavioural change came with the strip. A thumbnail was a `.combine`d
accessibility element, which folds the remove button into the picture and
leaves nothing to press separately — for a driver or for VoiceOver. It is now
a container that keeps the same label and carries the thumbnail's own click as
an explicit accessibility action, so both the thumbnail and its x are
addressable.

No flag: this is additive metadata on views that already existed, it acts on
nothing by itself, and it destroys no state.

## Evidence & verification

New `Tests/TBDAppTests/ComposerAccessibilityIdentifierTests.swift` mounts the
real `MessageComposerView` in an offscreen window — the harness shape
`CompletionOverlayPlacementTests` already uses — and asserts on the
**accessibility tree**, not on the source. Asserting on the tree is the point:
an identifier on a view SwiftUI declines to make an element of is a no-op that
reads perfectly well in a diff.

Two facts about that tree had to be measured rather than assumed, and both are
written down in the helper:

- **SwiftUI builds no accessibility tree until a client asks for one.** With
  `AXEnhancedUserInterface` clear, a hosting view's accessibility children come
  back empty however much the views declare. The harness sets that flag, which
  is exactly what a driver's attaching does — so the test measures the tree the
  driver will see.
- **SwiftUI's nodes do not declare the Objective-C accessibility protocol in
  Swift's eyes.** A typed `as? NSAccessibilityProtocol` walk drops every one of
  them and reports an empty tree. The walk reaches them by selector instead.

RED/GREEN, measured both ways. With the identifiers reverted from `Sources/`
and the suite unchanged, 5 of the 6 tests fail; the sixth is the negative
control (`theNotRunningNoteIsAbsentWhileRunning`), which passes either way and
is what keeps the positive assertions honest — it proves the note assertion is
about the state and not about a string that is always present. With the
identifiers in place all 6 pass.

`scripts/test.sh --filter "ComposerAccessibilityIdentifierTests|CompletionOverlayPlacementTests|MessageComposerViewTests|MessageComposerTextViewTests"`
— 45 tests in 4 suites, 0 failures. `swiftlint --strict` clean across the tree
(0 violations in 1032 files).

The AX walk helper (`axIdentifiers(in:)`, plus a tree-dump used in failure
messages) lives in the test file rather than in `Tests/TestSupport/`: that
target is the daemon's support library and links into the daemon suites, so
putting an AppKit-only helper there would drag AppKit into all of them. As a
top-level function in the app test target it is already reusable by every suite
in it.

### The bridge switch is scoped, and its suites are serialized (d557a18b)

The first push of this branch turned the accessibility bridge on and left it
on. `AXEnhancedUserInterface` is set on `NSApplication.shared`, so it is
process-global, and every test target compiles into one process where Swift
Testing runs suites in parallel — the flag was therefore live under every other
suite in the run. `AccessibilityWindowGeometryGuardTests` drives an `NSWindow`
through the same accessibility setters the guard swizzles and then reads
`window.frame` back, and with enhanced UI on AppKit stops applying such a move
synchronously (it is the mode window managers switch off before they move
anything), so two of its assertions failed on CI in run 34074933464. That is a
real AppKit behavior change rather than a weakness in the guard, so the guard is
unchanged: the fix is that the flag must not be left on. The switch is now
flipped only by `withAccessibilityBridge`, which records the prior value and
restores it in a `defer`, and both suites nest under a new `@Suite(.serialized)
enum AccessibilityBridgeSerialized` — the `TBDHomeSerialized` idiom — so one
suite's open scope can never overlap another suite's accessibility read; the
parent carries a comment saying why, and a test asserts the switch is on inside
the scope and back to its prior value after it. Any future suite that touches
the bridge, or reads back behavior the bridge changes, nests there.
`scripts/test.sh --filter
"AccessibilityWindowGeometryGuardTests|ComposerAccessibilityIdentifierTests|CompletionOverlayPlacementTests|AccessibilityBridgeScopeTests"`
— 17 tests in 5 suites, 0 failures, three runs in a row (and the failure
reproduced locally before the fix, with the guard passing when run alone).

[composer a11y ids](https://cheapsteak.github.io/tbd/open/?worktree=54D89E98-AFA6-4B66-A626-6CE0E0692A5E)
https://claude.ai/code/session_01E9SPoxoVoApcVmduLiBWik


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Accessibility**
  - Added stable accessibility identifiers for the message composer, text field, send control, notices, blocked states, completion menus, attachments, thumbnails, removal controls, and terminal-reveal actions.
  - Improved assistive technology navigation by exposing attachment and completion actions as distinct, identifiable controls.

- **Tests**
  - Added comprehensive accessibility coverage for composer controls, completion rows, attachments, and composer states.
  - Improved reliability of accessibility testing by safely managing shared accessibility settings and serialized test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
