### PR TITLE
DX: One offscreen GUI harness for TBDApp tests, and an env-gated render suite for the composer

### DIFF
--- a/Sources/TBDApp/Panes/Transcript/Composer/CompletionOverlayView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Composer/CompletionOverlayView.swift
@@ -27,6 +27,10 @@ struct CompletionOverlayView: View {
     /// so a pointer resting over the list cannot change what Return would take.
     @State private var hoveredIndex: Int?
 
+    /// The list's own width — the composer proposes it, rather than the list
+    /// proposing itself, so this is the one place that width is spelled.
+    static let width: CGFloat = 460
+
     static let rowHeight: CGFloat = 44
     /// The tallest the list ever gets: eight rows, and a scroller past that.
     static var maxHeight: CGFloat {

--- a/Sources/TBDApp/Panes/Transcript/Composer/MessageComposerView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Composer/MessageComposerView.swift
@@ -105,7 +105,7 @@ struct MessageComposerView: View {
             // in the first place.
             if let controller, controller.isOpen {
                 Color.clear
-                    .frame(width: 460, height: 0)
+                    .frame(width: CompletionOverlayView.width, height: 0)
                     .overlay(alignment: .bottomLeading) {
                         CompletionOverlayView(
                             controller: controller,
@@ -113,7 +113,7 @@ struct MessageComposerView: View {
                             // Reached only from an explicit click; hover is
                             // handled inside the overlay and moves nothing.
                             onHighlight: { controller.moveTo(index: $0) })
-                        .frame(width: 460)
+                        .frame(width: CompletionOverlayView.width)
                     }
             }
         }

--- a/Tests/TBDAppTests/CompletionOverlayPlacementTests.swift
+++ b/Tests/TBDAppTests/CompletionOverlayPlacementTests.swift
@@ -10,202 +10,34 @@ import TBDShared
 /// difference between opening upward and opening downward over the text field
 /// is one edge name.
 ///
-/// So this suite mounts the real `MessageComposerView` in a real window, opens
-/// the menu by typing into the real text view, and measures the two frames in
-/// window coordinates. The first shipped guide anchored the overlay's top to the
+/// So this suite mounts the real `MessageComposerView` in a real window through
+/// `ComposerHarness`, opens the menu, and measures the two frames in window
+/// coordinates. The first shipped guide anchored the overlay's top to the
 /// composer's bottom — a list that covered the words being typed and ran off the
 /// bottom of the pane — and every assertion here fails against it.
 @MainActor
 @Suite("completion overlay placement")
 struct CompletionOverlayPlacementTests {
 
-    // MARK: - Fixtures
-
-    /// Enough commands that the list is taller than its eight-row cap, so the
-    /// cap is exercised rather than assumed.
-    private static let inventory = TerminalCompletionsResult(
-        commands: (0..<20).map {
-            CompletionCommand(
-                name: "compact\($0)", description: "Compact the conversation, take \($0)")
-        },
-        agents: [], freshness: .fresh, source: .probe)
-
-    private func makeAppState() -> (AppState, String) {
-        let suiteName = "CompletionOverlayPlacementTests-\(UUID().uuidString)"
-        let state = AppState(userDefaults: UserDefaults(suiteName: suiteName)!)
-        state.composerCompletionsFetcher = { _ in Self.inventory }
-        return (state, suiteName)
-    }
-
-    private func makeWorktree() -> LocalWorktree {
-        LocalWorktree(Worktree(
-            id: UUID(), repoID: UUID(), name: "wt", displayName: "WT", branch: "main",
-            path: "/tmp/wt", status: .active, tmuxServer: "test-server", location: .local))!
-    }
-
-    private func makeTerminal(worktreeID: UUID) -> Terminal {
-        Terminal(
-            id: UUID(), worktreeID: worktreeID, tmuxWindowID: "@1", tmuxPaneID: "%1",
-            kind: .claude)
-    }
-
-    // MARK: - The harness
-
-    /// A mounted composer, pinned to the bottom of an offscreen window with the
-    /// transcript's worth of empty space above it — the shape the pane gives it,
-    /// and the space the list has to be allowed to grow into.
-    private struct Mounted {
-        let window: NSWindow
-        let host: NSHostingView<AnyView>
-        let state: AppState
-        let suiteName: String
-    }
-
-    /// What stands above the composer in the mounted stack.
-    enum Sibling {
-        /// `Color.clear`. Enough to give the list a region to grow into, and all
-        /// the geometry assertions need.
-        case transparent
-        /// A real `NSViewRepresentable` that fills itself solid red — the shape
-        /// of the composer's actual neighbour, `TableTranscriptView`. Ordering a
-        /// SwiftUI overlay against a HOSTED AppKit view is precisely what the
-        /// pane's `.zIndex(1)` states, and a SwiftUI-only sibling cannot pose
-        /// that question: SwiftUI orders its own layers among themselves either
-        /// way.
-        case paintedAppKit
-    }
-
-    private func mount(sibling: Sibling = .transparent) -> Mounted {
-        _ = NSApplication.shared
-        let (state, suiteName) = makeAppState()
-        let worktree = makeWorktree()
-        let terminal = makeTerminal(worktreeID: worktree.id)
-        // The menu is opened through the DRAFT rather than by typing into the
-        // text view afterwards. The composer's own set-up restores the draft as
-        // its first act and reports the restored text back through
-        // `onTextChange`, which is the production path that opens the list — and
-        // it means nothing races the restore. Typing first loses: the restore
-        // lands after it, clears an empty draft over the typed text, and
-        // dismisses the menu again a turn later.
-        state.composerDraft(for: terminal.id).text = "/comp"
-
-        let root = AnyView(
-            VStack(spacing: 0) {
-                // Stands in for the transcript table: the region the list opens
-                // out over.
-                switch sibling {
-                case .transparent:
-                    Color.clear
-                case .paintedAppKit:
-                    SolidRedRepresentable()
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                }
-                MessageComposerView(
-                    terminal: terminal, worktree: worktree, state: .running)
-            }
-            .environment(state))
-
-        let host = NSHostingView(rootView: root)
-        let window = NSWindow(
-            contentRect: NSRect(x: -20_000, y: -20_000, width: 720, height: 520),
-            styleMask: [.borderless], backing: .buffered, defer: false)
-        window.isReleasedWhenClosed = false
-        window.contentView = host
-        // Ordered front, never made key: SwiftUI runs `.task` and lays the
-        // hierarchy out only for a view in a window that has been shown, and the
-        // window sits far off every screen so showing it takes no focus from
-        // whoever is running the suite.
-        window.orderFront(nil)
-        return Mounted(window: window, host: host, state: state, suiteName: suiteName)
-    }
-
-    /// One pump of both pumps SwiftUI needs: the main run loop, which drives
-    /// AppKit's layout and display, and the cooperative pool, which drives
-    /// `.task`. Deliberately no sleep — a bounded poll on an observable is what
-    /// each caller waits on.
-    private func pump() async {
-        spinRunLoop()
-        await Task.yield()
-    }
-
-    /// Synchronous on purpose: `RunLoop.run(_:before:)` is unavailable from an
-    /// async context, and one turn of the main run loop is exactly what AppKit
-    /// needs to lay out and display what SwiftUI just published.
-    private func spinRunLoop() {
-        _ = RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.004))
-    }
-
-    /// Poll for something to become true, bounded. Returns whether it did, so
-    /// callers `#require` it and fail fast with a sentence rather than hanging.
-    private func settle(_ maxPumps: Int = 250, until: () -> Bool) async -> Bool {
-        for _ in 0..<maxPumps {
-            if until() { return true }
-            await pump()
-        }
-        return until()
-    }
-
-    private func descendants<V: NSView>(_ type: V.Type, of view: NSView) -> [V] {
-        var found: [V] = []
-        if let match = view as? V { found.append(match) }
-        for subview in view.subviews { found.append(contentsOf: descendants(type, of: subview)) }
-        return found
-    }
-
-    /// The composer's text view — the only `ComposerTextView` in the tree.
-    private func textView(in host: NSView) -> ComposerTextView? {
-        descendants(ComposerTextView.self, of: host).first
-    }
-
-    /// The completion list. `CompletionOverlayView` backs itself with a
-    /// `.menu`-material `VisualEffectView`, which is an `NSViewRepresentable`
-    /// and therefore a real `NSView` in the hierarchy — the one piece of the
-    /// SwiftUI overlay whose frame AppKit can be asked for.
-    private func overlayView(in host: NSView) -> NSVisualEffectView? {
-        descendants(NSVisualEffectView.self, of: host).first { $0.material == .menu }
-    }
-
-    /// A view's frame in window coordinates, flipped to a top-left origin so
-    /// "above" reads as a smaller `y`. AppKit's window space has its origin at
-    /// the BOTTOM left, and an assertion written in it says the opposite of what
-    /// it looks like it says.
-    private func flippedWindowFrame(_ view: NSView, in window: NSWindow) -> NSRect {
-        let inWindow = view.convert(view.bounds, to: nil)
-        let height = window.contentView?.bounds.height ?? 0
-        return NSRect(
-            x: inWindow.minX, y: height - inWindow.maxY,
-            width: inWindow.width, height: inWindow.height)
-    }
-
     /// Mount a composer whose draft is `/comp`, and wait for its list to reach
     /// full height.
+    ///
+    /// The wait is bounded by a pump count, so a list that never arrives fails
+    /// with the tree it gave up on rather than hanging — `openMenu(typing:)`
+    /// returns whether it settled and `diagnostics()` says what was there.
     private func openMenu(
-        sibling: Sibling = .transparent
-    ) async throws -> (Mounted, NSVisualEffectView, ComposerTextView) {
-        let mounted = mount(sibling: sibling)
-        // The full-height condition is what proves the INVENTORY landed too: a
-        // menu still waiting on it shows one short "Loading commands" row, and
-        // stopping there would measure a placement the eight rows never had.
-        let settled = await settle {
-            guard let overlay = overlayView(in: mounted.host) else { return false }
-            return overlay.bounds.height >= CompletionOverlayView.maxHeight
-        }
-        try #require(settled, .init(rawValue: diagnostics(mounted)))
-        let overlay = try #require(overlayView(in: mounted.host))
-        let field = try #require(textView(in: mounted.host))
+        backdrop: ComposerHarness.Backdrop = .empty
+    ) async throws -> (ComposerHarness, NSVisualEffectView, ComposerTextView) {
+        let harness = try ComposerHarness(
+            name: "CompletionOverlayPlacementTests", backdrop: backdrop)
+        let settled = await harness.openMenu(typing: "/comp")
+        try #require(settled, .init(rawValue: """
+            the completion list never reached its full height. \(harness.diagnostics())
+            """))
+        let overlay = try #require(harness.completionList)
+        let field = try #require(harness.textView)
         try #require(field.string == "/comp", "the draft never reached the text view")
-        return (mounted, overlay, field)
-    }
-
-    /// What the tree actually held when a wait ran out — so a failure names the
-    /// state it gave up in rather than only the state it wanted.
-    private func diagnostics(_ mounted: Mounted) -> String {
-        let effects = descendants(NSVisualEffectView.self, of: mounted.host)
-            .map { "material=\($0.material.rawValue) h=\($0.bounds.height)" }
-        let text = textView(in: mounted.host)?.string ?? "<no text view>"
-        return """
-        the completion list never reached its full height.         text=\(text.debugDescription) effects=\(effects)         views=\(descendants(NSView.self, of: mounted.host).count)
-        """
+        return (harness, overlay, field)
     }
 
     // MARK: - Placement
@@ -214,14 +46,11 @@ struct CompletionOverlayPlacementTests {
     /// edge at or above the field's top edge, so not one pixel of what is being
     /// typed is covered.
     @Test func theListOpensAboveTheTextField() async throws {
-        let (mounted, overlay, field) = try await openMenu()
-        defer {
-            mounted.window.orderOut(nil)
-            UserDefaults.standard.removePersistentDomain(forName: mounted.suiteName)
-        }
+        let (harness, overlay, field) = try await openMenu()
+        defer { harness.tearDown() }
 
-        let listFrame = flippedWindowFrame(overlay, in: mounted.window)
-        let fieldFrame = flippedWindowFrame(field, in: mounted.window)
+        let listFrame = harness.host.flippedWindowFrame(overlay)
+        let fieldFrame = harness.host.flippedWindowFrame(field)
 
         #expect(
             listFrame.maxY <= fieldFrame.minY,
@@ -235,22 +64,22 @@ struct CompletionOverlayPlacementTests {
     /// runs off the bottom of the pane and shows fewer rows than it has. Growing
     /// upward, all eight fit inside the window.
     @Test func theWholeListFitsInsideTheWindow() async throws {
-        let (mounted, overlay, _) = try await openMenu()
-        defer {
-            mounted.window.orderOut(nil)
-            UserDefaults.standard.removePersistentDomain(forName: mounted.suiteName)
-        }
+        let (harness, overlay, _) = try await openMenu()
+        defer { harness.tearDown() }
 
-        let listFrame = flippedWindowFrame(overlay, in: mounted.window)
-        let content = try #require(mounted.window.contentView).bounds
+        let listFrame = harness.host.flippedWindowFrame(overlay)
+        let content = try #require(harness.host.window.contentView).bounds
 
         #expect(listFrame.minY >= 0, "the list is clipped at the top of the pane")
         #expect(listFrame.maxY <= content.height, "the list is clipped at the bottom")
         #expect(
             listFrame.height == CompletionOverlayView.maxHeight,
             "eight rows and no more: \(listFrame.height)")
-        #expect(listFrame.width == 460)
+        #expect(listFrame.width == Self.listWidth)
     }
+
+    /// The list's own width, as the composer's overlay states it.
+    private static let listWidth: CGFloat = 460
 
     // MARK: - The height itself
 
@@ -269,76 +98,6 @@ struct CompletionOverlayPlacementTests {
     }
 
     // MARK: - Paint order
-
-    /// One rendered frame of the mounted hierarchy, addressed in TOP-LEFT pixel
-    /// coordinates so "above" reads as a smaller `y` here too.
-    private struct Capture {
-        let rep: NSBitmapImageRep
-        let host: NSView
-        let scale: CGFloat
-
-        /// `view`'s frame in this capture's pixel space.
-        func pixelFrame(of view: NSView) -> NSRect {
-            let inHost = view.convert(view.bounds, to: host)
-            let top = host.isFlipped ? inHost.minY : host.bounds.height - inHost.maxY
-            return NSRect(
-                x: inHost.minX * scale, y: top * scale,
-                width: inHost.width * scale, height: inHost.height * scale)
-        }
-
-        func color(x: Int, y: Int) -> NSColor? {
-            guard x >= 0, y >= 0, x < rep.pixelsWide, y < rep.pixelsHigh else { return nil }
-            return rep.colorAt(x: x, y: y)?.usingColorSpace(.sRGB)
-        }
-
-        /// The share of pixels in `rect` that match `reference`, sampled on a
-        /// coarse grid — a fraction rather than a single probe, so the verdict
-        /// does not depend on landing between two glyphs.
-        func fraction(in rect: NSRect, matching reference: NSColor) -> Double {
-            var total = 0
-            var matched = 0
-            var y = Int(rect.minY)
-            while y < Int(rect.maxY) {
-                var x = Int(rect.minX)
-                while x < Int(rect.maxX) {
-                    if let color = color(x: x, y: y) {
-                        total += 1
-                        if Self.matches(color, reference) { matched += 1 }
-                    }
-                    x += 4
-                }
-                y += 4
-            }
-            return total == 0 ? 0 : Double(matched) / Double(total)
-        }
-
-        /// Same color to within a hair. Compared against a pixel READ BACK from
-        /// this same capture rather than against a literal, because what a
-        /// deliberate sRGB red comes back as depends on the display's color
-        /// space — on a P3 screen pure red reads as roughly (0.91, 0.28, 0.17).
-        static func matches(_ color: NSColor, _ reference: NSColor) -> Bool {
-            abs(color.redComponent - reference.redComponent) < 0.06
-                && abs(color.greenComponent - reference.greenComponent) < 0.06
-                && abs(color.blueComponent - reference.blueComponent) < 0.06
-        }
-
-        /// Unmistakably the sibling's red rather than an empty capture: a strong
-        /// red channel dominating both of the others.
-        static func isRed(_ color: NSColor) -> Bool {
-            color.redComponent > 0.7
-                && color.redComponent > color.greenComponent * 2
-                && color.redComponent > color.blueComponent * 2
-        }
-    }
-
-    private func capture(_ mounted: Mounted) throws -> Capture {
-        let host: NSView = mounted.host
-        host.layoutSubtreeIfNeeded()
-        let rep = try #require(host.bitmapImageRepForCachingDisplay(in: host.bounds))
-        host.cacheDisplay(in: host.bounds, to: rep)
-        let scale = host.bounds.width > 0 ? CGFloat(rep.pixelsWide) / host.bounds.width : 1
-        return Capture(rep: rep, host: host, scale: scale)
-    }
 
     /// **The list paints over the AppKit view beside it.** The other tests in
     /// this suite measure frames, and a frame is the same whether the list paints
@@ -363,26 +122,27 @@ struct CompletionOverlayPlacementTests {
     /// scrolling table rather than a solid-color `NSView`, and stating the order
     /// is cheaper than depending on declaration order there; the test stays
     /// because it fails loudly if the list ever stops painting over its
-    /// neighbour at all.
+    /// neighbour at all. `OffscreenHost`'s own doc comment records the same
+    /// limitation for every future caller.
     @Test func theListPaintsOverTheAppKitViewBesideIt() async throws {
-        let (mounted, overlay, _) = try await openMenu(sibling: .paintedAppKit)
-        defer {
-            mounted.window.orderOut(nil)
-            UserDefaults.standard.removePersistentDomain(forName: mounted.suiteName)
-        }
+        let (harness, overlay, _) = try await openMenu(
+            backdrop: .custom(AnyView(SolidRedRepresentable())))
+        defer { harness.tearDown() }
         // A few more turns of both pumps so the sibling has been asked to draw.
-        _ = await settle(6) { false }
+        await harness.host.pump(times: Self.extraDrawPumps)
 
-        let shot = try capture(mounted)
+        let shot = try harness.host.capture()
         let list = shot.pixelFrame(of: overlay)
 
         // The control sits BESIDE the list, at the same height: the list is 460pt
         // of a 720pt-wide pane, so everything to its right is untouched sibling,
         // clear of the list's own shadow.
-        let controlX = Int(min(list.maxX + 40 * shot.scale, CGFloat(shot.rep.pixelsWide - 1)))
+        let controlX = Int(min(
+            list.maxX + Self.controlProbeInset * shot.scale,
+            CGFloat(shot.rep.pixelsWide - 1)))
         let controlY = Int(list.midY)
         let control = try #require(shot.color(x: controlX, y: controlY))
-        guard Capture.isRed(control) else {
+        guard Self.isRed(control) else {
             Issue.record("""
                 the AppKit sibling never painted, so this capture proves nothing: \
                 the control pixel at (\(controlX), \(controlY)), beside the list at \
@@ -393,15 +153,36 @@ struct CompletionOverlayPlacementTests {
 
         // Inset past the rounded corners and the hairline stroke; the shadow
         // falls outside the frame already.
-        let interior = list.insetBy(dx: 10 * shot.scale, dy: 10 * shot.scale)
+        let interior = list.insetBy(
+            dx: Self.interiorInset * shot.scale, dy: Self.interiorInset * shot.scale)
         let redFraction = shot.fraction(in: interior, matching: control)
         #expect(
-            redFraction < 0.05,
+            redFraction < Self.maximumRedFraction,
             """
             the completion list is painting UNDER the AppKit view beside it: \
             \(Int(redFraction * 100))% of its interior \(interior) came back the \
             sibling's \(Self.describe(control))
             """)
+    }
+
+    /// Pumps spent after the list has settled, purely so the sibling has been
+    /// asked to draw before the bitmap is taken.
+    private static let extraDrawPumps = 6
+    /// How far to the right of the list the control pixel is read, in points.
+    private static let controlProbeInset: CGFloat = 40
+    /// How far inside the list's frame the interior sample starts, in points —
+    /// past the rounded corners and the hairline stroke.
+    private static let interiorInset: CGFloat = 10
+    /// The share of the list's interior that may come back the sibling's colour
+    /// before the list counts as painting under it.
+    private static let maximumRedFraction = 0.05
+
+    /// Unmistakably the sibling's red rather than an empty capture: a strong red
+    /// channel dominating both of the others.
+    private static func isRed(_ color: NSColor) -> Bool {
+        color.redComponent > 0.7
+            && color.redComponent > color.greenComponent * 2
+            && color.redComponent > color.blueComponent * 2
     }
 
     private static func describe(_ color: NSColor) -> String {
@@ -429,6 +210,11 @@ private final class SolidRedView: NSView {
     }
 }
 
+/// A real `NSViewRepresentable` sibling for the composer, the shape of its
+/// actual neighbour `TableTranscriptView`. Ordering a SwiftUI overlay against a
+/// HOSTED AppKit view is precisely what the pane's `.zIndex(1)` states, and a
+/// SwiftUI-only sibling cannot pose that question: SwiftUI orders its own layers
+/// among themselves either way.
 private struct SolidRedRepresentable: NSViewRepresentable {
     func makeNSView(context: Context) -> SolidRedView { SolidRedView() }
     func updateNSView(_ nsView: SolidRedView, context: Context) {}

--- a/Tests/TBDAppTests/CompletionOverlayPlacementTests.swift
+++ b/Tests/TBDAppTests/CompletionOverlayPlacementTests.swift
@@ -75,11 +75,8 @@ struct CompletionOverlayPlacementTests {
         #expect(
             listFrame.height == CompletionOverlayView.maxHeight,
             "eight rows and no more: \(listFrame.height)")
-        #expect(listFrame.width == Self.listWidth)
+        #expect(listFrame.width == CompletionOverlayView.width)
     }
-
-    /// The list's own width, as the composer's overlay states it.
-    private static let listWidth: CGFloat = 460
 
     // MARK: - The height itself
 

--- a/Tests/TBDAppTests/ComposerAccessibilityIdentifierTests.swift
+++ b/Tests/TBDAppTests/ComposerAccessibilityIdentifierTests.swift
@@ -19,319 +19,146 @@ import TBDShared
 /// declines to make an element at all is a no-op that reads perfectly well in a
 /// diff, and every assertion here fails against the composer as it stood before
 /// the identifiers were added.
+///
+/// **Nested under `AccessibilityBridgeSerialized`, and every body inside
+/// `withAccessibilityBridge`.** SwiftUI builds no accessibility tree until a
+/// client asks for one, the switch that asks is process-wide, and it changes
+/// AppKit's own behavior while it is on — so it is scoped to the body that needs
+/// it, and this suite is ordered against the others that care.
 extension AccessibilityBridgeSerialized {
     @MainActor
     @Suite("composer accessibility identifiers")
     struct ComposerAccessibilityIdentifierTests {
 
-        // MARK: - Fixtures
-
-        private static let inventory = TerminalCompletionsResult(
-            commands: (0..<20).map {
-                CompletionCommand(
-                    name: "compact\($0)", description: "Compact the conversation, take \($0)")
-            },
-            agents: [], freshness: .fresh, source: .probe)
-
-        private func makeWorktree() -> LocalWorktree {
-            LocalWorktree(Worktree(
-                id: UUID(), repoID: UUID(), name: "wt", displayName: "WT", branch: "main",
-                path: "/tmp/wt", status: .active, tmuxServer: "test-server", location: .local))!
-        }
-
-        private func makeTerminal(worktreeID: UUID) -> Terminal {
-            Terminal(
-                id: UUID(), worktreeID: worktreeID, tmuxWindowID: "@1", tmuxPaneID: "%1",
-                kind: .claude)
-        }
-
-        // MARK: - The harness
-
-        /// A mounted composer in an offscreen window, and what has to be torn down
-        /// after it. The shape is `CompletionOverlayPlacementTests`', for the same
-        /// reason: SwiftUI runs `.task` and lays a hierarchy out only for a view in
-        /// a window that has been shown.
-        private struct Mounted {
-            let window: NSWindow
-            let host: NSHostingView<AnyView>
-            let state: AppState
-            let suiteName: String
-
-            func tearDown() {
-                window.orderOut(nil)
-                UserDefaults.standard.removePersistentDomain(forName: suiteName)
-            }
-        }
-
-        private func mount(
-            state composerState: ComposerState = .running,
-            prepare: (ComposerDraft) -> Void = { _ in }
-        ) -> Mounted {
-            _ = NSApplication.shared
-            let suiteName = "ComposerAccessibilityIdentifierTests-\(UUID().uuidString)"
-            let appState = AppState(userDefaults: UserDefaults(suiteName: suiteName)!)
-            appState.composerCompletionsFetcher = { _ in Self.inventory }
-            let worktree = makeWorktree()
-            let terminal = makeTerminal(worktreeID: worktree.id)
-            prepare(appState.composerDraft(for: terminal.id))
-
-            let root = AnyView(
-                VStack(spacing: 0) {
-                    // Stands in for the transcript above the composer, so the
-                    // completion list has the region it opens out over.
-                    Color.clear
-                    MessageComposerView(
-                        terminal: terminal, worktree: worktree, state: composerState)
-                }
-                .environment(appState))
-
-            let host = NSHostingView(rootView: root)
-            let window = NSWindow(
-                contentRect: NSRect(x: -20_000, y: -20_000, width: 720, height: 520),
-                styleMask: [.borderless], backing: .buffered, defer: false)
-            window.isReleasedWhenClosed = false
-            window.contentView = host
-            window.orderFront(nil)
-            return Mounted(window: window, host: host, state: appState, suiteName: suiteName)
-        }
-
-        /// One pump of both pumps SwiftUI needs: the main run loop, which drives
-        /// AppKit's layout and display, and the cooperative pool, which drives
-        /// `.task`.
-        private func pump() async {
-            spinRunLoop()
-            await Task.yield()
-        }
-
-        /// Synchronous on purpose: `RunLoop.run(_:before:)` is unavailable from an
-        /// async context, and one turn of the main run loop is exactly what AppKit
-        /// needs to lay out and display what SwiftUI just published.
-        private func spinRunLoop() {
-            _ = RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.004))
-        }
-
-        /// Poll, bounded, for the tree to hold everything named. Returns the last
-        /// set it saw either way, so a failure can print what was actually there.
-        private func settle(
-            _ mounted: Mounted, until wanted: Set<String>, maxPumps: Int = 250
-        ) async -> Set<String> {
-            var seen = axIdentifiers(in: mounted.host)
-            for _ in 0..<maxPumps {
-                if wanted.isSubset(of: seen) { return seen }
-                await pump()
-                seen = axIdentifiers(in: mounted.host)
-            }
-            return seen
-        }
-
-        /// The same poll for a family of identifiers rather than exact names: the
-        /// completion rows are named after the commands the ranker chose, which is
-        /// not something a test should have to predict.
-        private func settle(
-            _ mounted: Mounted, untilAnyHasPrefix prefix: String, maxPumps: Int = 250
-        ) async -> Set<String> {
-            var seen = axIdentifiers(in: mounted.host)
-            for _ in 0..<maxPumps {
-                if seen.contains(where: { $0.hasPrefix(prefix) }) { return seen }
-                await pump()
-                seen = axIdentifiers(in: mounted.host)
-            }
-            return seen
-        }
-
-        private func report(_ mounted: Mounted, _ seen: Set<String>) -> Comment {
-            Comment(rawValue: """
-                the tree held: \(seen.sorted().joined(separator: ", "))
-                \(axTreeDescription(in: mounted.host))
-                """)
-        }
-
         // MARK: - The core controls
 
-        /// The container, the field, and the button: what any driver needs before it
-        /// can do anything at all with the composer.
-        @Test func theComposerExposesItsContainerFieldAndSendButton() async {
-            await withAccessibilityBridge {
-                let mounted = mount()
-                defer { mounted.tearDown() }
+        /// The container, the field, and the button: what any driver needs before
+        /// it can do anything at all with the composer.
+        @Test func theComposerExposesItsContainerFieldAndSendButton() async throws {
+            try await withAccessibilityBridge {
+                let harness = try ComposerHarness(name: "ComposerAccessibilityIdentifierTests")
+                defer { harness.tearDown() }
                 let wanted: Set<String> = [
                     ComposerAccessibility.root,
                     ComposerAccessibility.field,
                     ComposerAccessibility.send,
                 ]
-                let seen = await settle(mounted, until: wanted)
-                #expect(wanted.isSubset(of: seen), report(mounted, seen))
+                let seen = await harness.settle(untilIdentifiers: wanted)
+                #expect(wanted.isSubset(of: seen), Self.report(harness, seen))
             }
         }
 
         // MARK: - The completion list
 
         /// The list and its rows, each row addressable on its own. A list that
-        /// exposed only itself would let a driver see the menu and pick nothing out
-        /// of it.
-        @Test func theOpenMenuExposesItselfAndEachRow() async {
-            await withAccessibilityBridge {
-                let mounted = mount { $0.text = "/comp" }
-                defer { mounted.tearDown() }
+        /// exposed only itself would let a driver see the menu and pick nothing
+        /// out of it.
+        @Test func theOpenMenuExposesItselfAndEachRow() async throws {
+            try await withAccessibilityBridge {
+                let harness = try ComposerHarness(
+                    name: "ComposerAccessibilityIdentifierTests",
+                    prepare: { $0.draft.text = "/comp" })
+                defer { harness.tearDown() }
                 let prefix = ComposerAccessibility.menuRow(command: "")
-                let seen = await settle(mounted, untilAnyHasPrefix: prefix)
+                let seen = await harness.settle(untilAnyIdentifierHasPrefix: prefix)
 
-                #expect(seen.contains(ComposerAccessibility.menu), report(mounted, seen))
+                #expect(seen.contains(ComposerAccessibility.menu), Self.report(harness, seen))
                 let rows = seen.filter { $0.hasPrefix(prefix) }
-                #expect(!rows.isEmpty, report(mounted, seen))
-                // Named by command, so two rows are two identifiers rather than one
-                // repeated — the property that makes a specific row selectable.
-                #expect(rows.count > 1, report(mounted, seen))
+                #expect(!rows.isEmpty, Self.report(harness, seen))
+                // Named by command, so two rows are two identifiers rather than
+                // one repeated — the property that makes a specific row
+                // selectable.
+                #expect(rows.count > 1, Self.report(harness, seen))
                 #expect(
                     rows.contains(ComposerAccessibility.menuRow(command: "compact0")),
-                    report(mounted, seen))
+                    Self.report(harness, seen))
             }
         }
 
         // MARK: - The attachment strip
 
-        /// A staged image, its thumbnail, and its own remove button. The button is
-        /// the one that had to be argued for: an attachment thumbnail was a
+        /// A staged image, its thumbnail, and its own remove button. The button
+        /// is the one that had to be argued for: an attachment thumbnail was a
         /// `.combine`d element, which folds the x into the picture and leaves
         /// nothing to press.
-        @Test func aStagedImageExposesItsThumbnailAndItsRemoveButton() async {
-            await withAccessibilityBridge {
-                let mounted = mount { draft in
-                    draft.stage(path: "/tmp/tbd-composer-a11y-nonexistent.png", id: UUID())
-                }
-                defer { mounted.tearDown() }
+        @Test func aStagedImageExposesItsThumbnailAndItsRemoveButton() async throws {
+            try await withAccessibilityBridge {
+                // Staged with no file behind it: the strip's structure is the
+                // subject, and a thumbnail that never decodes reaches its final
+                // shape a pump sooner.
+                let harness = try ComposerHarness(
+                    name: "ComposerAccessibilityIdentifierTests",
+                    prepare: { try $0.stage(png: nil) })
+                defer { harness.tearDown() }
                 let wanted: Set<String> = [
                     ComposerAccessibility.attachments,
                     ComposerAccessibility.attachmentItem(number: 1),
                     ComposerAccessibility.attachmentRemove(number: 1),
                 ]
-                let seen = await settle(mounted, until: wanted)
-                #expect(wanted.isSubset(of: seen), report(mounted, seen))
+                let seen = await harness.settle(untilIdentifiers: wanted)
+                #expect(wanted.isSubset(of: seen), Self.report(harness, seen))
             }
         }
 
         // MARK: - The two banners
 
-        /// Blocked: the sentence, and the button that gets somebody to the dialog.
-        @Test func theBlockedBannerExposesItsMessageAndRevealButton() async {
-            await withAccessibilityBridge {
-                let mounted = mount(state: .blocked(message: "Claude is asking something"))
-                defer { mounted.tearDown() }
+        /// Blocked: the sentence, and the button that gets somebody to the
+        /// dialog. Built from the terminal's own `awaitingInputReason`, so the
+        /// state under test is the one the daemon's record would produce.
+        @Test func theBlockedBannerExposesItsMessageAndRevealButton() async throws {
+            try await withAccessibilityBridge {
+                let harness = try ComposerHarness(
+                    name: "ComposerAccessibilityIdentifierTests",
+                    terminal: {
+                        ComposerHarness.blockedTerminal(
+                            worktreeID: $0, message: "Claude is asking something")
+                    })
+                defer { harness.tearDown() }
                 let wanted: Set<String> = [
                     ComposerAccessibility.blockedMessage,
                     ComposerAccessibility.blockedReveal,
                 ]
-                let seen = await settle(mounted, until: wanted)
-                #expect(wanted.isSubset(of: seen), report(mounted, seen))
+                let seen = await harness.settle(untilIdentifiers: wanted)
+                #expect(wanted.isSubset(of: seen), Self.report(harness, seen))
             }
         }
 
         /// Not running: the note explaining that a send resumes the session.
-        @Test func theNotRunningNoteIsExposed() async {
-            await withAccessibilityBridge {
-                let mounted = mount(state: .notRunning(exited: true))
-                defer { mounted.tearDown() }
-                let seen = await settle(mounted, until: [ComposerAccessibility.note])
-                #expect(seen.contains(ComposerAccessibility.note), report(mounted, seen))
+        @Test func theNotRunningNoteIsExposed() async throws {
+            try await withAccessibilityBridge {
+                let harness = try ComposerHarness(
+                    name: "ComposerAccessibilityIdentifierTests",
+                    terminal: { ComposerHarness.parkedTerminal(worktreeID: $0, exited: true) })
+                defer { harness.tearDown() }
+                let seen = await harness.settle(
+                    untilIdentifiers: [ComposerAccessibility.note])
+                #expect(seen.contains(ComposerAccessibility.note), Self.report(harness, seen))
             }
         }
 
-        /// And the note is not there when the session is running — so the assertion
-        /// above is about the state and not about a string that is always present.
-        @Test func theNotRunningNoteIsAbsentWhileRunning() async {
-            await withAccessibilityBridge {
-                let mounted = mount()
-                defer { mounted.tearDown() }
-                _ = await settle(mounted, until: [ComposerAccessibility.field])
-                let seen = axIdentifiers(in: mounted.host)
-                #expect(!seen.contains(ComposerAccessibility.note), report(mounted, seen))
-                #expect(!seen.contains(ComposerAccessibility.blockedReveal), report(mounted, seen))
+        /// And the note is not there when the session is running — so the
+        /// assertion above is about the state and not about a string that is
+        /// always present.
+        @Test func theNotRunningNoteIsAbsentWhileRunning() async throws {
+            try await withAccessibilityBridge {
+                let harness = try ComposerHarness(name: "ComposerAccessibilityIdentifierTests")
+                defer { harness.tearDown() }
+                _ = await harness.settle(untilIdentifiers: [ComposerAccessibility.field])
+                let seen = harness.host.accessibilityIdentifiers()
+                #expect(!seen.contains(ComposerAccessibility.note), Self.report(harness, seen))
+                #expect(
+                    !seen.contains(ComposerAccessibility.blockedReveal),
+                    Self.report(harness, seen))
             }
         }
-    }
-}
 
-/// Every accessibility identifier in the tree rooted at `view`.
-///
-/// It walks the **accessibility** tree rather than the view hierarchy, because
-/// the question is what an assistive client — or a GUI driver, which is one —
-/// can actually reach. Two things about that tree are not obvious, and both had
-/// to be found by measurement:
-///
-/// - **SwiftUI does not build one until a client asks for it.** Until then
-///   `NSHostingView.accessibilityChildren()` is empty and a walk reports nothing
-///   at all, whatever the view declares. `withAccessibilityBridge` flips the
-///   switch a driver flips, for the length of one test body.
-/// - **SwiftUI's nodes are not `NSAccessibilityProtocol` in Swift's eyes.** They
-///   are `SwiftUI.AccessibilityNode` objects that implement the accessibility
-///   methods without declaring the Objective-C protocol, so `as?` fails on every
-///   one of them and a typed walk silently sees an empty tree. They are reached
-///   the way Objective-C reaches them instead: by selector.
-///
-/// Children are the union of what a node declares and, for an `NSView`, its
-/// subviews — which is how AppKit itself resolves children for a view that has
-/// not overridden them, and how the `NSTextView` inside the composer's
-/// representable is reached.
-///
-/// **It lives here rather than in `Tests/TestSupport/`.** That target is the
-/// daemon's support library — it depends on `TBDDaemonLib` and links into the
-/// daemon suites — and this would drag AppKit into all of them for one
-/// AppKit-only caller. As a top-level function in the app test target it is
-/// already reusable by every suite in it.
-@MainActor
-func axIdentifiers(in view: NSView) -> Set<String> {
-    var found: Set<String> = []
-    axWalk(view) { node, _ in
-        if let identifier = axAttribute(node, "accessibilityIdentifier") as? String,
-           !identifier.isEmpty {
-            found.insert(identifier)
+        /// What the tree held, and the tree itself — so a failure names the state
+        /// it gave up in rather than only the identifier it wanted.
+        private static func report(_ harness: ComposerHarness, _ seen: Set<String>) -> Comment {
+            Comment(rawValue: """
+                the tree held: \(seen.sorted().joined(separator: ", "))
+                \(harness.host.accessibilityTreeDescription())
+                """)
         }
     }
-    return found
-}
-
-/// The same walk as an indented outline, so a failure names the tree it found
-/// rather than only the identifier it wanted.
-@MainActor
-func axTreeDescription(in view: NSView) -> String {
-    var lines: [String] = []
-    axWalk(view) { node, depth in
-        let role = axAttribute(node, "accessibilityRole") as? String ?? "-"
-        let identifier = (axAttribute(node, "accessibilityIdentifier") as? String)
-            .map { " id=\($0)" } ?? ""
-        let label = (axAttribute(node, "accessibilityLabel") as? String)
-            .map { " label=\($0.prefix(40))" } ?? ""
-        lines.append(
-            String(repeating: "  ", count: depth) + "\(type(of: node))"
-                + " role=\(role)\(identifier)\(label)")
-    }
-    return lines.joined(separator: "\n")
-}
-
-/// One accessibility accessor, by selector — see `axIdentifiers(in:)` for why it
-/// cannot simply be a method call on a typed value.
-@MainActor
-private func axAttribute(_ node: NSObject, _ name: String) -> Any? {
-    guard node.responds(to: Selector((name))) else { return nil }
-    return node.value(forKey: name)
-}
-
-/// Depth-first over the accessibility tree, visiting each node once.
-@MainActor
-private func axWalk(_ root: NSView, visit: (NSObject, Int) -> Void) {
-    var seen = Set<ObjectIdentifier>()
-
-    func children(of node: NSObject) -> [Any] {
-        let declared = axAttribute(node, "accessibilityChildren") as? [Any] ?? []
-        return declared + ((node as? NSView)?.subviews ?? [])
-    }
-
-    func step(_ element: Any, _ depth: Int) {
-        guard let node = element as? NSObject else { return }
-        guard seen.insert(ObjectIdentifier(node)).inserted else { return }
-        visit(node, depth)
-        for child in children(of: node) { step(child, depth + 1) }
-    }
-
-    step(root, 0)
 }

--- a/Tests/TBDAppTests/ComposerRenderHarness.swift
+++ b/Tests/TBDAppTests/ComposerRenderHarness.swift
@@ -1,0 +1,202 @@
+import AppKit
+import Foundation
+import SwiftUI
+import Testing
+@testable import TBDApp
+import TBDShared
+
+/// Env-gated **render** harness for the transcript composer: one PNG per state
+/// it can be in, at 2x, for a person to look at.
+///
+/// Its subject is the half of a UI that assertions are bad at. Every other
+/// composer suite asks a question with a right answer — does the list open
+/// upward, is the send button reachable — and none of them can tell you that the
+/// blocked banner's icon collides with its message, or that the attachment
+/// thumbnail sits a hair below the text baseline. A render can, and the last one
+/// of these caught exactly that class of defect (#829, the completion list
+/// covering the words being typed) before it shipped.
+///
+/// Inert during a normal run: every test early-returns unless
+/// `TBD_COMPOSER_SHOTS_DIR` names a directory to write into.
+///
+///     TBD_COMPOSER_SHOTS_DIR=/tmp/composer-shots scripts/test.sh \
+///         --filter ComposerRenderHarness
+///
+/// **Each shot asserts it is not blank.** A view that was never laid out renders
+/// as a large, perfectly plausible white rectangle, and a harness that wrote one
+/// out would report success and hand over a picture of nothing. The luminance
+/// variance of the capture has to clear `minLuminanceVariance` before the file
+/// is written, so a broken render fails instead.
+@MainActor
+@Suite("composer render harness")
+struct ComposerRenderHarness {
+
+    /// The four states, as their file names. Numbered so a directory listing
+    /// reads in the order somebody would want to look at them.
+    private enum Shot: String {
+        case menu = "1-menu"
+        case attachment = "2-attachment"
+        case notRunning = "3-not-running"
+        case blocked = "4-blocked"
+    }
+
+    /// Where the PNGs go, or `nil` when the harness is inert.
+    private static var outputDirectory: URL? {
+        let path = ProcessInfo.processInfo.environment["TBD_COMPOSER_SHOTS_DIR"] ?? ""
+        guard !path.isEmpty else { return nil }
+        return URL(fileURLWithPath: path, isDirectory: true)
+    }
+
+    /// Pixels per point. 2x because these are read on a Retina display and a 1x
+    /// capture of 9pt caption text is unreadable.
+    private static let captureScale: CGFloat = 2
+
+    /// Far below anything a real render produces, far above the zero a flat
+    /// field scores. See `OffscreenHost.Capture.luminanceVariance()`.
+    private static let minLuminanceVariance = 0.0005
+
+    /// Pumps spent after the state under test has settled, so the asynchronous
+    /// parts of a composer — a thumbnail decoding off the main thread, the
+    /// strip's own layout pass — have arrived before the shutter.
+    private static let extraDrawPumps = 40
+
+    // MARK: - The four shots
+
+    /// The completion list, open over the transcript, with a half-typed message
+    /// under it — the state the placement suite measures and this one shows.
+    @Test("the open completion menu (gated by TBD_COMPOSER_SHOTS_DIR)")
+    func renderOpenMenu() async throws {
+        guard let directory = Self.outputDirectory else { return }
+        let harness = try ComposerHarness(
+            name: "ComposerRenderHarness", backdrop: .transcriptPreview)
+        defer { harness.tearDown() }
+
+        let opened = await harness.openMenu(typing: "please /comp")
+        try #require(opened, .init(rawValue: """
+            the completion list never reached its full height. \(harness.diagnostics())
+            """))
+
+        try await Self.write(.menu, of: harness, into: directory)
+    }
+
+    /// A staged image: its thumbnail in the strip, and the `[Image #1]` token
+    /// that anchors it in the message.
+    @Test("a staged attachment (gated by TBD_COMPOSER_SHOTS_DIR)")
+    func renderStagedAttachment() async throws {
+        guard let directory = Self.outputDirectory else { return }
+        let png = try Self.sampleImagePNG()
+        let harness = try ComposerHarness(
+            name: "ComposerRenderHarness", backdrop: .transcriptPreview,
+            prepare: { setup in
+                let number = try setup.stage(png: png)
+                setup.draft.text = "What do you make of this? "
+                setup.appendToken(number)
+            })
+        defer { harness.tearDown() }
+
+        let ready = await harness.host.settle {
+            harness.textView?.string.contains(ComposerTokens.text(for: 1)) ?? false
+        }
+        try #require(ready, .init(rawValue: """
+            the staged image's token never reached the text view. \(harness.diagnostics())
+            """))
+
+        try await Self.write(.attachment, of: harness, into: directory)
+    }
+
+    /// A parked session: the note saying a send resumes it, and a send button
+    /// that says so too.
+    @Test("the not-running state (gated by TBD_COMPOSER_SHOTS_DIR)")
+    func renderNotRunning() async throws {
+        guard let directory = Self.outputDirectory else { return }
+        let harness = try ComposerHarness(
+            name: "ComposerRenderHarness",
+            terminal: { ComposerHarness.parkedTerminal(worktreeID: $0, exited: true) },
+            backdrop: .transcriptPreview,
+            prepare: { $0.draft.text = "pick this back up where it stopped" })
+        defer { harness.tearDown() }
+        try await Self.settleField(harness)
+        try await Self.write(.notRunning, of: harness, into: directory)
+    }
+
+    /// A session sitting on a dialog: the banner the daemon's message produced,
+    /// the Reveal Terminal button beside it, and a disabled field.
+    @Test("the blocked state (gated by TBD_COMPOSER_SHOTS_DIR)")
+    func renderBlocked() async throws {
+        guard let directory = Self.outputDirectory else { return }
+        let harness = try ComposerHarness(
+            name: "ComposerRenderHarness",
+            terminal: {
+                ComposerHarness.blockedTerminal(
+                    worktreeID: $0,
+                    message: "Claude needs permission to run `git push`. Answer in the "
+                        + "terminal — the highlighted option is the one Enter commits.")
+            },
+            backdrop: .transcriptPreview)
+        defer { harness.tearDown() }
+        try await Self.settleField(harness)
+        try await Self.write(.blocked, of: harness, into: directory)
+    }
+
+    // MARK: - Shared machinery
+
+    /// Wait for the composer to have mounted at all — the text view is the last
+    /// piece of it to arrive.
+    private static func settleField(_ harness: ComposerHarness) async throws {
+        let mounted = await harness.host.settle { harness.textView != nil }
+        try #require(mounted, .init(rawValue: """
+            the composer never mounted. \(harness.diagnostics())
+            """))
+    }
+
+    /// Capture, check the capture is a picture of something, and write it.
+    private static func write(
+        _ shot: Shot, of harness: ComposerHarness, into directory: URL
+    ) async throws {
+        await harness.host.pump(times: extraDrawPumps)
+        let capture = try harness.host.capture(scale: captureScale)
+        let variance = capture.luminanceVariance()
+        #expect(
+            variance >= minLuminanceVariance,
+            .init(rawValue: """
+                \(shot.rawValue).png is a flat field (luminance variance \(variance)) — \
+                the composer rendered blank rather than being captured
+                """))
+        try capture.writePNG(to: directory.appendingPathComponent("\(shot.rawValue).png"))
+    }
+
+    /// A small, deliberately recognisable PNG for the attachment thumbnail:
+    /// coloured quarters, so a thumbnail that decoded is obvious in the render
+    /// and a placeholder is obvious too. Drawn rather than committed as a
+    /// fixture — it is four rectangles, and a binary in the repository would
+    /// have to be justified.
+    private static func sampleImagePNG() throws -> Data {
+        let side = 128
+        guard let rep = NSBitmapImageRep(
+            bitmapDataPlanes: nil, pixelsWide: side, pixelsHigh: side,
+            bitsPerSample: 8, samplesPerPixel: 4, hasAlpha: true, isPlanar: false,
+            colorSpaceName: .deviceRGB, bytesPerRow: 0, bitsPerPixel: 0),
+            let context = NSGraphicsContext(bitmapImageRep: rep)
+        else { throw OffscreenHostError.couldNotMakeBitmap }
+
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = context
+        let half = CGFloat(side) / 2
+        let quarters: [(NSRect, NSColor)] = [
+            (NSRect(x: 0, y: 0, width: half, height: half), .systemTeal),
+            (NSRect(x: half, y: 0, width: half, height: half), .systemIndigo),
+            (NSRect(x: 0, y: half, width: half, height: half), .systemOrange),
+            (NSRect(x: half, y: half, width: half, height: half), .systemPink),
+        ]
+        for (rect, color) in quarters {
+            color.setFill()
+            rect.fill()
+        }
+        NSGraphicsContext.restoreGraphicsState()
+
+        guard let data = rep.representation(using: .png, properties: [:]) else {
+            throw OffscreenHostError.couldNotEncodePNG
+        }
+        return data
+    }
+}

--- a/Tests/TBDAppTests/ComposerRenderHarness.swift
+++ b/Tests/TBDAppTests/ComposerRenderHarness.swift
@@ -25,8 +25,9 @@ import TBDShared
 /// **Each shot asserts it is not blank.** A view that was never laid out renders
 /// as a large, perfectly plausible white rectangle, and a harness that wrote one
 /// out would report success and hand over a picture of nothing. The luminance
-/// variance of the capture has to clear `minLuminanceVariance` before the file
-/// is written, so a broken render fails instead.
+/// variance of the capture has to clear `OffscreenHostDefaults.minLuminanceVariance`
+/// before the file is written, so a broken render fails instead of landing a
+/// blank PNG beside the real ones.
 @MainActor
 @Suite("composer render harness")
 struct ComposerRenderHarness {
@@ -50,10 +51,6 @@ struct ComposerRenderHarness {
     /// Pixels per point. 2x because these are read on a Retina display and a 1x
     /// capture of 9pt caption text is unreadable.
     private static let captureScale: CGFloat = 2
-
-    /// Far below anything a real render produces, far above the zero a flat
-    /// field scores. See `OffscreenHost.Capture.luminanceVariance()`.
-    private static let minLuminanceVariance = 0.0005
 
     /// Pumps spent after the state under test has settled, so the asynchronous
     /// parts of a composer — a thumbnail decoding off the main thread, the
@@ -150,19 +147,35 @@ struct ComposerRenderHarness {
     }
 
     /// Capture, check the capture is a picture of something, and write it.
+    ///
+    /// The check gates the write for real: a blank capture throws before
+    /// `writePNG` runs, so a broken render never lands a picture of nothing
+    /// beside the three that rendered correctly.
     private static func write(
         _ shot: Shot, of harness: ComposerHarness, into directory: URL
     ) async throws {
         await harness.host.pump(times: extraDrawPumps)
         let capture = try harness.host.capture(scale: captureScale)
         let variance = capture.luminanceVariance()
-        #expect(
-            variance >= minLuminanceVariance,
-            .init(rawValue: """
-                \(shot.rawValue).png is a flat field (luminance variance \(variance)) — \
-                the composer rendered blank rather than being captured
-                """))
+        guard variance >= OffscreenHostDefaults.minLuminanceVariance else {
+            throw RenderError.blankRender(shot: shot, variance: variance)
+        }
         try capture.writePNG(to: directory.appendingPathComponent("\(shot.rawValue).png"))
+    }
+
+    /// What can go wrong writing a shot out. A distinct type, rather than
+    /// `#expect`, because the whole point is that a blank render must stop the
+    /// write rather than merely fail the test alongside it.
+    private enum RenderError: Error, CustomStringConvertible {
+        case blankRender(shot: Shot, variance: Double)
+
+        var description: String {
+            switch self {
+            case let .blankRender(shot, variance):
+                return "\(shot.rawValue).png is a flat field (luminance variance \(variance)) — "
+                    + "the composer rendered blank rather than being captured"
+            }
+        }
     }
 
     /// A small, deliberately recognisable PNG for the attachment thumbnail:

--- a/Tests/TBDAppTests/OffscreenHostLifecycleTests.swift
+++ b/Tests/TBDAppTests/OffscreenHostLifecycleTests.swift
@@ -1,0 +1,88 @@
+import AppKit
+import SwiftUI
+import Testing
+
+/// What `OffscreenHost.tearDown()` has to guarantee, and — just as important —
+/// what it must not try to guarantee.
+///
+/// It has to let go of the hosted tree: a mounted `NSHostingView` and the
+/// ground under it are the expensive half of a mount, and a suite that mounts
+/// several per run must not carry them all to the end of the process.
+///
+/// It must not try to take the window out of `NSApp.windows`. Measured, against
+/// a bare `NSWindow` with no SwiftUI in it at all: a window that has been
+/// ordered front is never deallocated in this process, and the one gesture that
+/// does remove it from that list — flipping `isReleasedWhenClosed` before
+/// `close()` — removes it by sending a `release` ARC never balanced. That is an
+/// over-release of an object still owned, and its use-after-free lands later,
+/// in whatever unrelated test is running when the last real owner lets go: it
+/// reached CI as a signal 11 in a whole-suite run while every narrow local run
+/// stayed green.
+@Suite("offscreen host lifecycle")
+@MainActor
+struct OffscreenHostLifecycleTests {
+    /// Small on purpose: nothing here asks a layout question.
+    private static let hostSize = NSSize(width: 120, height: 80)
+
+    @Test("tearDown releases the hosted tree while the host is still alive")
+    func tearDownReleasesTheHostedTree() {
+        // The mount happens inside a pool of its own, and everything the weak
+        // references are read against happens outside it. Mounting hands out
+        // autoreleased references — from `NSHostingView`'s own construction as
+        // much as from these accessors — and in the enclosing pool those
+        // outlive the whole test, so the tree would read as "still alive"
+        // however thorough teardown was.
+        var host: OffscreenHost<Color>?
+        weak var hostingView: NSView?
+        weak var ground: NSView?
+        autoreleasepool {
+            let mounted = OffscreenHost(root: Color.blue, size: Self.hostSize)
+            hostingView = mounted.hostingView
+            ground = mounted.contentView
+            mounted.tearDown()
+            // Kept alive deliberately: teardown itself has to drop the tree,
+            // not the host's own deallocation at the end of a test.
+            host = mounted
+        }
+        #expect(pumpUntilReleased { hostingView }, "tearDown() left the hosting view mounted")
+        #expect(pumpUntilReleased { ground }, "tearDown() left the ground view mounted")
+        #expect(host != nil, "the host under test was released early")
+    }
+
+    @Test("tearDown leaves the window for AppKit to release")
+    func tearDownLeavesTheWindowForAppKitToRelease() {
+        let host = OffscreenHost(root: Color.blue, size: Self.hostSize)
+        // Strong on purpose, and safe precisely because teardown does not ask
+        // AppKit to release a window this reference owns a share of.
+        let window = host.window
+
+        host.tearDown()
+
+        #expect(window.isVisible == false, "tearDown() left the window on screen")
+        #expect(window.contentView == nil, "tearDown() left the hosted tree in the window")
+        // Membership in `NSApp.windows` is the observable signature of the
+        // ownership question. Measured: an ordered-front window is never
+        // deallocated in this process, so a correct teardown leaves it in that
+        // list, and the one gesture that removes it — flipping
+        // `isReleasedWhenClosed` before `close()` — removes it by sending a
+        // `release` ARC never balanced. A window missing from the list here has
+        // been released once too often, and the use-after-free lands later.
+        #expect(
+            NSApp.windows.contains(window),
+            "tearDown() over-released the window — AppKit dropped it from NSApp.windows")
+    }
+
+    @Test("tearDown is idempotent")
+    func tearDownIsIdempotent() {
+        let host = OffscreenHost(root: Color.blue, size: Self.hostSize)
+        let window = host.window
+
+        host.tearDown()
+        host.tearDown()
+
+        #expect(window.isVisible == false, "a second tearDown() put the window back")
+        #expect(
+            NSApp.windows.contains(window),
+            "a second tearDown() released the window a second time")
+    }
+}

--- a/Tests/TBDAppTests/Support/ComposerHarness.swift
+++ b/Tests/TBDAppTests/Support/ComposerHarness.swift
@@ -48,12 +48,16 @@ final class ComposerHarness {
     /// that a full-height list has somewhere to open.
     static let defaultSize = NSSize(width: 720, height: 520)
 
+    /// More commands than the list's eight-row cap, so the cap is exercised
+    /// rather than assumed.
+    private static let inventoryCommandCount = 20
+
     /// A completions inventory with more commands than the list's eight-row cap,
     /// so the cap is exercised rather than assumed, and every name is derived
     /// from its index so a test can name a row it expects to see.
-    static func inventory(commandCount: Int = 20) -> TerminalCompletionsResult {
+    static func inventory() -> TerminalCompletionsResult {
         TerminalCompletionsResult(
-            commands: (0..<commandCount).map {
+            commands: (0..<inventoryCommandCount).map {
                 CompletionCommand(
                     name: "compact\($0)",
                     description: "Compact the conversation, take \($0)")
@@ -75,11 +79,15 @@ final class ComposerHarness {
     /// access are what the composer restores on appearance.
     var draft: ComposerDraft { appState.composerDraft(for: terminal.id) }
 
+    /// Aqua, always: a suite's capture must not depend on the developer's
+    /// system appearance. No caller has ever needed another one — a suite
+    /// asking a dark-mode question mounts `OffscreenHost` directly, the way
+    /// `WorkbenchSnapshotTests` does.
+    private static let appearance = NSAppearance(named: .aqua)
+
     private let defaults: UserDefaults
     private let suiteName: String
     private let scratchDirectory: URL
-    private let size: NSSize
-    private let appearance: NSAppearance?
     private let backdrop: Backdrop
     private var mounted: OffscreenHost<AnyView>?
 
@@ -98,9 +106,6 @@ final class ComposerHarness {
     init(
         name: String,
         terminal: ((UUID) -> Terminal)? = nil,
-        size: NSSize = ComposerHarness.defaultSize,
-        appearance: NSAppearance? = NSAppearance(named: .aqua),
-        inventory: TerminalCompletionsResult = ComposerHarness.inventory(),
         backdrop: Backdrop = .empty,
         prepare: (Setup) throws -> Void = { _ in }
     ) throws {
@@ -112,7 +117,7 @@ final class ComposerHarness {
         }
         self.defaults = defaults
         appState = AppState(userDefaults: defaults)
-        appState.composerCompletionsFetcher = { _ in inventory }
+        appState.composerCompletionsFetcher = { _ in Self.inventory() }
 
         let worktree = Self.worktree()
         self.worktree = worktree
@@ -121,15 +126,24 @@ final class ComposerHarness {
         state = ComposerState.resolve(
             terminal: terminal, isRemoteWorktree: false, composerEnabled: true)
 
-        self.size = size
-        self.appearance = appearance
         self.backdrop = backdrop
         scratchDirectory = URL(
             fileURLWithPath: fencedScratchRoot(prefix: "tbdcomposer"), isDirectory: true)
 
-        try prepare(Setup(
-            draft: appState.composerDraft(for: terminal.id),
-            scratchDirectory: scratchDirectory))
+        // `prepare` can throw for real — `renderStagedAttachment` writes a
+        // fixture file to disk in it — and when it does, `self` is never
+        // returned, so no caller ever gets a harness whose `tearDown()` could
+        // remove the `UserDefaults` domain just registered above. Remove it
+        // here instead, or a suite whose `prepare` fails leaks one persistent
+        // domain per failure.
+        do {
+            try prepare(Setup(
+                draft: appState.composerDraft(for: terminal.id),
+                scratchDirectory: scratchDirectory))
+        } catch {
+            defaults.removePersistentDomain(forName: suiteName)
+            throw error
+        }
     }
 
     /// Put the window away, drop the defaults suite, and remove anything staged.
@@ -230,7 +244,8 @@ final class ComposerHarness {
     /// The mounted composer, mounting it on first use.
     var host: OffscreenHost<AnyView> {
         if let mounted { return mounted }
-        let host = OffscreenHost(root: root(), size: size, appearance: appearance)
+        let host = OffscreenHost(
+            root: root(), size: Self.defaultSize, appearance: Self.appearance)
         mounted = host
         return host
     }

--- a/Tests/TBDAppTests/Support/ComposerHarness.swift
+++ b/Tests/TBDAppTests/Support/ComposerHarness.swift
@@ -1,0 +1,401 @@
+import AppKit
+import Foundation
+import SwiftUI
+import TBDShared
+import TestSupport
+@testable import TBDApp
+
+/// The transcript composer, mounted the way the pane mounts it, for suites that
+/// have to ask a *drawn* composer a question: where its completion list lands,
+/// what a driver can reach in it, and what each of its four states looks like.
+///
+/// It owns the fixture half of that — an isolated `AppState`, a worktree, a
+/// terminal whose real columns put the composer into the state under test, a
+/// scratch directory for staged images — and delegates the hosting half to
+/// `OffscreenHost`, whose doc comment states what an offscreen mount does and
+/// does not prove.
+///
+/// **Mounting is deferred to the first use of `host`.** Everything the composer
+/// reads on appearance — the draft it restores, the completions inventory it
+/// adopts — has to be in place before SwiftUI runs `.task`, and a harness that
+/// mounted in its initializer would leave a caller no turn in which to put it
+/// there. `prepare` and `openMenu(typing:)` both write before that first mount.
+@MainActor
+final class ComposerHarness {
+
+    // MARK: - Configuration
+
+    /// What stands above the composer in the mounted stack.
+    ///
+    /// The region matters even when it is empty: the completion list opens
+    /// *upward*, out over the transcript, so a composer mounted with nothing
+    /// above it has nowhere to put its rows.
+    enum Backdrop {
+        /// `Color.clear` — a region to grow into, and all a geometry assertion
+        /// needs.
+        case empty
+        /// `TranscriptPreviewStrip`: a few rows of plausible conversation, so a
+        /// rendered composer is shown in the pane it belongs to.
+        case transcriptPreview
+        /// A caller's own view — for a suite whose question is about the
+        /// *neighbour*, such as ordering the SwiftUI overlay against a hosted
+        /// AppKit view.
+        case custom(AnyView)
+    }
+
+    /// The pane geometry the composer suites mount at: wide enough for the
+    /// list's full 460pt width to sit inside it with room to spare, tall enough
+    /// that a full-height list has somewhere to open.
+    static let defaultSize = NSSize(width: 720, height: 520)
+
+    /// A completions inventory with more commands than the list's eight-row cap,
+    /// so the cap is exercised rather than assumed, and every name is derived
+    /// from its index so a test can name a row it expects to see.
+    static func inventory(commandCount: Int = 20) -> TerminalCompletionsResult {
+        TerminalCompletionsResult(
+            commands: (0..<commandCount).map {
+                CompletionCommand(
+                    name: "compact\($0)",
+                    description: "Compact the conversation, take \($0)")
+            },
+            agents: [], freshness: .fresh, source: .probe)
+    }
+
+    // MARK: - The fixture
+
+    let appState: AppState
+    let worktree: LocalWorktree
+    let terminal: Terminal
+    /// Resolved from `terminal`'s own columns by the production rule, never
+    /// asserted into place — so a suite that mounts a blocked composer is
+    /// mounting what the daemon's record would actually produce.
+    let state: ComposerState
+
+    /// This terminal's unsent message. Writes to it before the first `host`
+    /// access are what the composer restores on appearance.
+    var draft: ComposerDraft { appState.composerDraft(for: terminal.id) }
+
+    private let defaults: UserDefaults
+    private let suiteName: String
+    private let scratchDirectory: URL
+    private let size: NSSize
+    private let appearance: NSAppearance?
+    private let backdrop: Backdrop
+    private var mounted: OffscreenHost<AnyView>?
+
+    /// Build the fixture. Nothing is mounted yet.
+    ///
+    /// - Parameters:
+    ///   - name: Names the `UserDefaults` suite and the scratch directory in a
+    ///     listing. Give it the calling suite's name.
+    ///   - terminal: Builds the session the composer points at, given the
+    ///     harness's own worktree id. Defaults to a running Claude terminal;
+    ///     `parkedTerminal` and `blockedTerminal` build the other two states out
+    ///     of the same columns the daemon writes.
+    ///   - backdrop: What stands above the composer.
+    ///   - prepare: Runs before the mount, with the draft and a scratch
+    ///     directory to stage images into.
+    init(
+        name: String,
+        terminal: ((UUID) -> Terminal)? = nil,
+        size: NSSize = ComposerHarness.defaultSize,
+        appearance: NSAppearance? = NSAppearance(named: .aqua),
+        inventory: TerminalCompletionsResult = ComposerHarness.inventory(),
+        backdrop: Backdrop = .empty,
+        prepare: (Setup) throws -> Void = { _ in }
+    ) throws {
+        suiteName = "\(name)-\(UUID().uuidString)"
+        // A suite of its own, never `UserDefaults.standard`: this executable is
+        // unbundled, so "standard" is the developer's real `TBDApp.plist`.
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            fatalError("UserDefaults refused the suite name \(suiteName)")
+        }
+        self.defaults = defaults
+        appState = AppState(userDefaults: defaults)
+        appState.composerCompletionsFetcher = { _ in inventory }
+
+        let worktree = Self.worktree()
+        self.worktree = worktree
+        let terminal = terminal?(worktree.id) ?? Self.runningTerminal(worktreeID: worktree.id)
+        self.terminal = terminal
+        state = ComposerState.resolve(
+            terminal: terminal, isRemoteWorktree: false, composerEnabled: true)
+
+        self.size = size
+        self.appearance = appearance
+        self.backdrop = backdrop
+        scratchDirectory = URL(
+            fileURLWithPath: fencedScratchRoot(prefix: "tbdcomposer"), isDirectory: true)
+
+        try prepare(Setup(
+            draft: appState.composerDraft(for: terminal.id),
+            scratchDirectory: scratchDirectory))
+    }
+
+    /// Put the window away, drop the defaults suite, and remove anything staged.
+    ///
+    /// Safe to call from a `defer`, and safe on a harness that never mounted.
+    func tearDown() {
+        mounted?.tearDown()
+        defaults.removePersistentDomain(forName: suiteName)
+        try? FileManager.default.removeItem(at: scratchDirectory)
+    }
+
+    // MARK: - Preparation
+
+    /// What `prepare` is handed: the draft the composer will restore, and a
+    /// directory to put files in that the harness will remove again.
+    @MainActor
+    struct Setup {
+        let draft: ComposerDraft
+        /// A fresh directory under the run's fenced scratch root. Created on
+        /// demand by `stage(png:)`; removed by `tearDown()`.
+        let scratchDirectory: URL
+
+        /// Stage an image on the draft, and return its `[Image #N]` number.
+        ///
+        /// - Parameter png: The bytes to write. `nil` stages a path with **no
+        ///   file behind it**, which is a real state — an attachment whose file
+        ///   went away — and the one a test that only cares about the strip's
+        ///   structure should use, because it needs no decode to settle.
+        @discardableResult
+        func stage(png: Data?) throws -> Int {
+            let id = UUID()
+            let url = scratchDirectory.appendingPathComponent("\(id).png")
+            if let png {
+                try FileManager.default.createDirectory(
+                    at: scratchDirectory, withIntermediateDirectories: true)
+                try png.write(to: url, options: [.atomic])
+            }
+            return draft.stage(path: url.path, id: id)
+        }
+
+        /// Append an image's token to the draft text, the way inserting at the
+        /// caret would — so the strip shows the thumbnail as *in* the message
+        /// rather than detached.
+        func appendToken(_ number: Int) {
+            draft.text += ComposerTokens.text(for: number)
+        }
+    }
+
+    // MARK: - Terminals
+
+    /// A local worktree for the composer to be scoped to. Local because a remote
+    /// one has no composer at all.
+    static func worktree() -> LocalWorktree {
+        guard let worktree = LocalWorktree(Worktree(
+            id: UUID(), repoID: UUID(), name: "wt", displayName: "WT", branch: "main",
+            path: "/tmp/wt", status: .active, tmuxServer: "test-server", location: .local))
+        else { fatalError("a local worktree fixture failed to build") }
+        return worktree
+    }
+
+    /// A Claude session that is up: `ComposerState.resolve` reads this as
+    /// `.running`.
+    static func runningTerminal(worktreeID: UUID, label: String = "claude") -> Terminal {
+        Terminal(
+            id: UUID(), worktreeID: worktreeID, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: label, kind: .claude)
+    }
+
+    /// A parked session — the columns the daemon writes when the process is
+    /// gone. `exited` distinguishes only *who* ended it, which is the wording
+    /// the note under the field carries.
+    static func parkedTerminal(
+        worktreeID: UUID, exited: Bool, label: String = "claude"
+    ) -> Terminal {
+        Terminal(
+            id: UUID(), worktreeID: worktreeID, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: label, kind: .claude, hibernatedAt: Date(),
+            hibernateReason: exited ? .exited : .manual)
+    }
+
+    /// A session sitting on a dialog: an awaiting-input reason whose
+    /// notification type classifies as `.promptOnScreen`, which is what
+    /// `ComposerState.resolve` reads as blocked.
+    static func blockedTerminal(
+        worktreeID: UUID, message: String, label: String = "claude"
+    ) -> Terminal {
+        Terminal(
+            id: UUID(), worktreeID: worktreeID, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: label, kind: .claude,
+            awaitingInputReason: AwaitingInputReason(
+                message: message, hookEventName: "Notification",
+                notificationType: "permission_prompt"),
+            awaitingInputObservedAt: Date())
+    }
+
+    // MARK: - Mounting
+
+    /// The mounted composer, mounting it on first use.
+    var host: OffscreenHost<AnyView> {
+        if let mounted { return mounted }
+        let host = OffscreenHost(root: root(), size: size, appearance: appearance)
+        mounted = host
+        return host
+    }
+
+    private func root() -> AnyView {
+        AnyView(
+            VStack(spacing: 0) {
+                backdropView
+                MessageComposerView(
+                    terminal: terminal, worktree: worktree, state: state)
+            }
+            .environment(appState))
+    }
+
+    /// Whatever stands above the composer takes the leftover height, so the
+    /// composer keeps the natural height it has in the pane. Without the
+    /// priority two flexible views split the window evenly and the composer
+    /// renders twice as tall as it ever is.
+    @ViewBuilder
+    private var backdropView: some View {
+        Group {
+            switch backdrop {
+            case .empty:
+                Color.clear
+            case .transcriptPreview:
+                TranscriptPreviewStrip()
+            case .custom(let view):
+                view
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .layoutPriority(1)
+    }
+
+    // MARK: - Reaching into the mounted composer
+
+    /// The composer's text view — the only `ComposerTextView` in the tree.
+    var textView: ComposerTextView? {
+        host.firstDescendant(ComposerTextView.self)
+    }
+
+    /// The completion list.
+    ///
+    /// `CompletionOverlayView` backs itself with a `.menu`-material
+    /// `VisualEffectView`, which is an `NSViewRepresentable` and therefore a
+    /// real `NSView` in the hierarchy — the one piece of the SwiftUI overlay
+    /// whose frame AppKit can be asked for.
+    var completionList: NSVisualEffectView? {
+        host.firstDescendant(NSVisualEffectView.self) { $0.material == .menu }
+    }
+
+    /// Open the completion list on `text`, and wait for it to reach full height.
+    ///
+    /// **"Typing" here means the draft-restore path**, not a synthesized
+    /// keystroke, and the difference is not cosmetic. The composer's own set-up
+    /// restores the draft as its first act and reports the restored text back
+    /// through `onTextChange` — the same production route a keystroke takes to
+    /// open the list — so writing the draft before the mount means nothing races
+    /// the restore. Typing after the mount loses: the restore lands on top of
+    /// the typed text, clears it as an empty draft, and dismisses the menu a
+    /// turn later.
+    ///
+    /// Full height, rather than merely present, is what proves the **inventory**
+    /// landed too: a menu still waiting on it shows one short "Loading commands"
+    /// row, and stopping there would measure a placement the eight rows never
+    /// had.
+    ///
+    /// - Returns: whether the list reached full height, so a caller can
+    ///   `#require` it against `diagnostics()`.
+    func openMenu(
+        typing text: String, maxPumps: Int = OffscreenHostDefaults.maxPumps
+    ) async -> Bool {
+        draft.text = text
+        return await host.settle(maxPumps: maxPumps) {
+            guard let list = completionList else { return false }
+            return list.bounds.height >= CompletionOverlayView.maxHeight
+        }
+    }
+
+    /// Poll, bounded, until every identifier in `wanted` is in the accessibility
+    /// tree. Returns the last set it saw either way, so a failure can report
+    /// what was actually there.
+    ///
+    /// Only meaningful inside `withAccessibilityBridge`.
+    func settle(
+        untilIdentifiers wanted: Set<String>,
+        maxPumps: Int = OffscreenHostDefaults.maxPumps
+    ) async -> Set<String> {
+        await settleAccessibility(maxPumps: maxPumps) { wanted.isSubset(of: $0) }
+    }
+
+    /// The same poll for a *family* of identifiers rather than exact names: the
+    /// completion rows are named after the commands the ranker chose, which is
+    /// not something a test should have to predict.
+    func settle(
+        untilAnyIdentifierHasPrefix prefix: String,
+        maxPumps: Int = OffscreenHostDefaults.maxPumps
+    ) async -> Set<String> {
+        await settleAccessibility(maxPumps: maxPumps) { seen in
+            seen.contains { $0.hasPrefix(prefix) }
+        }
+    }
+
+    private func settleAccessibility(
+        maxPumps: Int, until condition: (Set<String>) -> Bool
+    ) async -> Set<String> {
+        var seen = host.accessibilityIdentifiers()
+        for _ in 0..<maxPumps {
+            if condition(seen) { return seen }
+            await host.pump()
+            seen = host.accessibilityIdentifiers()
+        }
+        return seen
+    }
+
+    /// What the tree actually held when a wait ran out — so a failure names the
+    /// state it gave up in rather than only the state it wanted.
+    func diagnostics() -> String {
+        let effects = host.descendants(NSVisualEffectView.self)
+            .map { "material=\($0.material.rawValue) h=\($0.bounds.height)" }
+        let text = textView?.string ?? "<no text view>"
+        return "text=\(text.debugDescription) effects=\(effects) "
+            + "views=\(host.descendants(NSView.self).count)"
+    }
+}
+
+/// A few rows of plausible conversation, standing in for the transcript above
+/// the composer.
+///
+/// A **fixture**, not a preview of the real table: rendering the production
+/// `TableTranscriptView` here would drag its coordinator, its measurement cache
+/// and a session's worth of nodes into a test whose subject is the composer.
+/// What the composer needs from its neighbour is the two things this provides —
+/// a region to open the completion list out over, and something above the field
+/// so a rendered composer is shown in a pane rather than floating on a blank
+/// square.
+struct TranscriptPreviewStrip: View {
+    /// Deliberately dull and generic: this is a public repository, and a fixture
+    /// is the easiest place for somebody's real work to end up in it.
+    private static let exchange: [(speaker: String, text: String)] = [
+        ("You", "Can you pull the retry logic out of the client and test it on its own?"),
+        ("Agent", "Moved it into `RetryPolicy`, with the backoff as an injected clock "
+            + "so the tests do not sleep. Three call sites updated."),
+        ("You", "Good. What happens when the deadline passes mid-attempt?"),
+        ("Agent", "The attempt finishes and the policy refuses the next one — a "
+            + "deadline bounds the waiting, never the work already in flight."),
+    ]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Spacer(minLength: 0)
+            ForEach(Array(Self.exchange.enumerated()), id: \.offset) { _, turn in
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(turn.speaker)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                    Text(turn.text)
+                        .font(.system(size: 12))
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.bottom, 12)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
+    }
+}

--- a/Tests/TBDAppTests/Support/OffscreenHost.swift
+++ b/Tests/TBDAppTests/Support/OffscreenHost.swift
@@ -92,11 +92,11 @@ final class OffscreenHost<Root: View> {
     static var offscreenOrigin: NSPoint { NSPoint(x: -20_000, y: -20_000) }
 
     /// The window the hierarchy lives in. Borderless, offscreen, never key.
-    let window: NSWindow
+    var window: NSWindow { live(mountedWindow, "window") }
 
     /// The hosting view for `Root`, pinned to `contentView` at the requested
     /// size.
-    let hostingView: NSHostingView<Root>
+    var hostingView: NSHostingView<Root> { live(mountedHostingView, "hostingView") }
 
     /// The window's content view: an opaque, layer-backed ground under the
     /// hosting view, and the root every measurement and capture is taken
@@ -106,7 +106,29 @@ final class OffscreenHost<Root: View> {
     /// of it alone comes back transparent wherever the SwiftUI tree did not
     /// paint, which turns "this region is empty" into "this region is whatever
     /// the PNG viewer puts behind alpha".
-    let contentView: NSView
+    var contentView: NSView { live(mountedContentView, "contentView") }
+
+    /// The mount itself, held as `Optional` for one reason: `tearDown()` has to
+    /// be able to **drop** these references. A hosting view and the ground
+    /// under it are released when the last reference to them goes, and a host
+    /// that kept them until its own deallocation would carry a whole SwiftUI
+    /// tree to the end of whatever test mounted it. See `tearDown()`.
+    private var mountedWindow: NSWindow?
+    private var mountedHostingView: NSHostingView<Root>?
+    private var mountedContentView: NSView?
+
+    /// Read one of them, or say plainly that the mount is gone.
+    ///
+    /// A torn-down host is a programming error rather than a state a caller
+    /// handles, so the accessors stay non-optional and this traps: no existing
+    /// call site changes, and a use-after-teardown names itself instead of
+    /// arriving as an empty capture.
+    private func live<T>(_ value: T?, _ name: String) -> T {
+        guard let value else {
+            preconditionFailure("OffscreenHost.\(name) was used after tearDown()")
+        }
+        return value
+    }
 
     /// Mount `root` at `size`.
     ///
@@ -166,31 +188,50 @@ final class OffscreenHost<Root: View> {
             }
         }
 
-        self.hostingView = hosting
-        self.contentView = ground
-        self.window = window
+        mountedHostingView = hosting
+        mountedContentView = ground
+        mountedWindow = window
         window.orderFront(nil)
     }
 
-    /// Take the window back down. Idempotent, and safe to call from a `defer`.
+    /// Take the window down and let the hosted tree go. Idempotent, and safe to
+    /// call from a `defer`; the host is unusable afterwards.
     ///
-    /// `orderOut` alone leaves the window sitting in `NSApp.windows` for the
-    /// rest of the process — the same trap documented at
-    /// `TabBarHitAreaTests.keyViewProxyMaxWidth`, except `close()` alone does
-    /// not clear it either. **Measured**, not merely reasoned: with
-    /// `isReleasedWhenClosed = false`, `NSWindow.close()` removes the window
-    /// from the screen but leaves it in `NSApp.windows` — AppKit only drops a
-    /// window from that list as part of releasing it, so a window told never
-    /// to release itself never leaves the list, no matter how many times
-    /// `close()` runs. Flipping the flag to `true` immediately before closing
-    /// is what actually removes it; a caller's own strong reference to
-    /// `window` (this type keeps one) is enough to survive the release AppKit
-    /// then performs, so nothing here is unsafe to touch afterwards.
+    /// `orderOut` hides the window; clearing `contentView` and dropping the
+    /// references below releases the hosting view and the ground under it.
+    /// **Measured**: both deallocate right here, with the host still alive, and
+    /// they are the expensive half of a mount.
+    ///
+    /// **The `NSWindow` shell does not deallocate, and stays in `NSApp.windows`
+    /// for the life of the process.** Measured against a bare `NSWindow` with
+    /// no SwiftUI in it at all: a window that has been ordered front carries
+    /// dozens of references belonging to AppKit, and neither `close()` nor
+    /// dropping every reference this process owns brings it to zero. What is
+    /// left behind is one hidden, content-less shell per mount, and it is
+    /// AppKit's to release.
+    ///
+    /// `isReleasedWhenClosed` therefore stays `false` — set once at creation,
+    /// never flipped on the way out. Flipping it *does* take the window out of
+    /// `NSApp.windows`, which is what makes it tempting, but it does so by
+    /// sending a `release` ARC never balanced against an object that is still
+    /// owned. The list gets tidier and the ownership becomes wrong: the
+    /// use-after-free lands later, in whatever unrelated test is running when
+    /// the last real owner lets go, which is how it reached CI as a signal 11
+    /// in a whole-suite run while every narrow local run stayed green. Apple's
+    /// guidance for ARC is to leave the flag `false`.
+    ///
+    /// So "did teardown work" is asked of the hosted tree. The window list is
+    /// read only in the negative: a window *missing* from it has been released
+    /// once too often. Both questions are in `OffscreenHostLifecycleTests`, and
+    /// the first is asked through `pumpUntilReleased`.
     func tearDown() {
+        guard let window = mountedWindow else { return }
         window.orderOut(nil)
         window.contentView = nil
-        window.isReleasedWhenClosed = true
         window.close()
+        mountedHostingView = nil
+        mountedContentView = nil
+        mountedWindow = nil
     }
 
     // MARK: - Pumping
@@ -577,4 +618,31 @@ func withDrawingAppearance<T>(
 private func axAttribute(_ node: NSObject, _ name: String) -> Any? {
     guard node.responds(to: Selector((name))) else { return nil }
     return node.value(forKey: name)
+}
+
+/// Poll until `probe` reports its object gone, bounded by a pump count rather
+/// than by elapsed time.
+///
+/// This is how a test asks whether something was actually **released**: a
+/// `weak` reference is the only honest way to ask, because a test that still
+/// holds the object cannot tell "released" from "released once too often". Its
+/// subject is the hosted view tree — see `OffscreenHost.tearDown()` for why the
+/// window shell is not a thing to ask this about.
+///
+/// The pumps are here because AppKit does not necessarily let go on the turn of
+/// the run loop that asked it to: the object can be sitting in an autorelease
+/// pool the next turn drains.
+@MainActor
+func pumpUntilReleased(
+    maxPumps: Int = OffscreenHostDefaults.maxPumps,
+    spin: TimeInterval = OffscreenHostDefaults.runLoopSpin,
+    _ probe: () -> AnyObject?
+) -> Bool {
+    for _ in 0..<maxPumps {
+        if probe() == nil { return true }
+        autoreleasepool {
+            _ = RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(spin))
+        }
+    }
+    return probe() == nil
 }

--- a/Tests/TBDAppTests/Support/OffscreenHost.swift
+++ b/Tests/TBDAppTests/Support/OffscreenHost.swift
@@ -1,0 +1,555 @@
+import AppKit
+import SwiftUI
+
+/// Bounds and step sizes the offscreen host waits and samples with, named
+/// rather than spelled at each call site.
+///
+/// They live on a non-generic type so they can be used as default arguments of
+/// `OffscreenHost`'s methods, which a generic type's own statics cannot.
+enum OffscreenHostDefaults {
+    /// How many pumps a bounded wait spends before giving up.
+    ///
+    /// Each pump is one turn of the run loop capped at `runLoopSpin`, so this is
+    /// a ceiling of roughly a second of real time — long enough for SwiftUI to
+    /// run a `.task`, fetch a fixture inventory and lay out, short enough that a
+    /// suite that will never settle fails with a sentence instead of hanging.
+    static let maxPumps = 250
+
+    /// How long one run-loop spin is allowed to block.
+    static let runLoopSpin: TimeInterval = 0.004
+
+    /// Per-channel slack for `OffscreenHost.Capture.matches(_:_:)`, in unit
+    /// colour components.
+    static let colorTolerance = 0.06
+
+    /// The pixel grid a capture is sampled on: every 4th pixel in both
+    /// directions. Coarse on purpose — the questions asked of a capture are
+    /// "what colour is this region" and "did anything paint at all", and neither
+    /// wants to walk four million pixels.
+    static let sampleStride = 4
+}
+
+/// A SwiftUI view mounted in a real — but offscreen — AppKit window, for the
+/// questions no pure function can answer: where a view actually landed, what an
+/// accessibility client can actually reach, and what the thing actually looks
+/// like once it is drawn.
+///
+/// ## What hosting offscreen proves
+///
+/// - **Real layout.** Frames come from AppKit's own layout pass, in window
+///   coordinates, so a test can assert that one view sits above another rather
+///   than that a modifier was written.
+/// - **Real SwiftUI lifecycle** — but only because the window is *shown*.
+///   SwiftUI lays out a hierarchy and runs its `.task` only for a view in a
+///   window that has been ordered front, so the window is; it sits at
+///   `offscreenOrigin`, far off every display, and is never made key, so
+///   showing it takes no focus from whoever is running the suite.
+/// - **Both pumps.** `pump()` turns the main run loop, which drives AppKit's
+///   layout and display, *and* yields to the cooperative pool, which drives
+///   `.task`. Waiting on only one of the two waits forever.
+/// - **A real accessibility tree**, inside `withAccessibilityBridge` — see
+///   `accessibilityIdentifiers()`, and `AccessibilityBridgeSerialized` for why
+///   that switch is scoped rather than simply set.
+/// - **A real drawn frame**, via `capture()`.
+///
+/// ## What it does not prove
+///
+/// - **AppKit-versus-SwiftUI compositing does not reproduce offscreen.** In an
+///   offscreen `cacheDisplay` of an `NSHostingView`, SwiftUI already orders its
+///   own overlay above a representable sibling declared before it, whether or
+///   not production states that order with `.zIndex`. Measured in
+///   `CompletionOverlayPlacementTests.theListPaintsOverTheAppKitViewBesideIt`,
+///   which comes back pixel-for-pixel identical with the modifier removed. A
+///   capture is a guard on the outcome, never a test that discriminates a
+///   stacking modifier.
+/// - **Nothing about events.** The window is never key, there is no first
+///   responder, and no hit testing happens. A control's *reachability* is an
+///   accessibility question, which this host can ask; a control's *response to
+///   a click* is not.
+/// - **Nothing about elapsed time.** `settle` is bounded by a pump count, never
+///   by wall clock, so behavior that genuinely needs real seconds to pass — an
+///   animation running to completion, a debounce on a real clock — does not
+///   finish here. Inject a clock and test that without a window.
+/// - **Nothing about the display.** The window is on no screen: the backing
+///   scale is 1 unless `capture(scale:)` asks for another, and vibrancy and font
+///   smoothing resolve without a real display's colour space, which is why
+///   colour assertions compare against a pixel read back from the same capture
+///   rather than against a literal.
+@MainActor
+final class OffscreenHost<Root: View> {
+    /// Far enough off every plausible display arrangement that the window is
+    /// never visible, and never steals a click, while still being "shown" as far
+    /// as SwiftUI's lifecycle is concerned.
+    static var offscreenOrigin: NSPoint { NSPoint(x: -20_000, y: -20_000) }
+
+    /// The window the hierarchy lives in. Borderless, offscreen, never key.
+    let window: NSWindow
+
+    /// The hosting view for `Root`, pinned to `contentView` at the requested
+    /// size.
+    let hostingView: NSHostingView<Root>
+
+    /// The window's content view: an opaque, layer-backed ground under the
+    /// hosting view, and the root every measurement and capture is taken
+    /// against.
+    ///
+    /// It exists because a hosting view has no background of its own. A capture
+    /// of it alone comes back transparent wherever the SwiftUI tree did not
+    /// paint, which turns "this region is empty" into "this region is whatever
+    /// the PNG viewer puts behind alpha".
+    let contentView: NSView
+
+    /// Mount `root` at `size`.
+    ///
+    /// - Parameters:
+    ///   - root: The view under test.
+    ///   - size: The content size in points. This is the pane geometry the test
+    ///     is asking about, so it belongs to the caller — there is no default.
+    ///   - appearance: Applied to the window, the ground and the hosting view
+    ///     *before* anything is built, because `NSAttributedString` colours
+    ///     resolve when they are created and do not update afterwards. Aqua by
+    ///     default so a capture does not depend on the developer's system
+    ///     setting; pass `nil` to inherit it deliberately.
+    ///   - background: The ground's colour, resolved inside `appearance`. `nil`
+    ///     leaves the ground clear, for a caller that wants alpha.
+    init(
+        root: Root,
+        size: NSSize,
+        appearance: NSAppearance? = NSAppearance(named: .aqua),
+        background: NSColor? = .controlBackgroundColor
+    ) {
+        // Enough of an application for AppKit to have an app object at all;
+        // `NSHostingView` and `NSWindow` both reach for one.
+        _ = NSApplication.shared
+
+        let hosting = NSHostingView(rootView: root)
+        hosting.translatesAutoresizingMaskIntoConstraints = false
+        let ground = NSView(frame: NSRect(origin: .zero, size: size))
+        ground.wantsLayer = true
+        ground.addSubview(hosting)
+        NSLayoutConstraint.activate([
+            hosting.leadingAnchor.constraint(equalTo: ground.leadingAnchor),
+            hosting.topAnchor.constraint(equalTo: ground.topAnchor),
+            hosting.widthAnchor.constraint(equalToConstant: size.width),
+            hosting.heightAnchor.constraint(equalToConstant: size.height),
+        ])
+
+        let window = NSWindow(
+            contentRect: NSRect(origin: Self.offscreenOrigin, size: size),
+            styleMask: [.borderless], backing: .buffered, defer: false)
+        window.isReleasedWhenClosed = false
+        window.contentView = ground
+
+        if let appearance {
+            window.appearance = appearance
+            ground.appearance = appearance
+            hosting.appearance = appearance
+        }
+        if let background {
+            // Resolved inside the appearance: a dynamic `NSColor` becomes a
+            // fixed `CGColor` the moment it is handed to a layer, and outside
+            // the appearance a dark capture gets a light ground.
+            let paint: () -> Void = { ground.layer?.backgroundColor = background.cgColor }
+            if let appearance {
+                appearance.performAsCurrentDrawingAppearance(paint)
+            } else {
+                paint()
+            }
+        }
+
+        self.hostingView = hosting
+        self.contentView = ground
+        self.window = window
+        window.orderFront(nil)
+    }
+
+    /// Take the window back down. Idempotent, and safe to call from a `defer`.
+    func tearDown() {
+        window.orderOut(nil)
+    }
+
+    // MARK: - Pumping
+
+    /// One turn of each of the two pumps SwiftUI needs.
+    ///
+    /// Deliberately no sleep: what a caller waits on is a bounded poll over an
+    /// observable, never elapsed time.
+    func pump() async {
+        Self.spinRunLoop()
+        await Task.yield()
+    }
+
+    /// Poll for something to become true, bounded by a pump count.
+    ///
+    /// - Returns: whether the condition held, so a caller can `#require` it and
+    ///   fail with a sentence rather than hang.
+    @discardableResult
+    func settle(
+        maxPumps: Int = OffscreenHostDefaults.maxPumps,
+        until condition: () -> Bool
+    ) async -> Bool {
+        for _ in 0..<maxPumps {
+            if condition() { return true }
+            await pump()
+        }
+        return condition()
+    }
+
+    /// Turn the main run loop `count` times, synchronously.
+    ///
+    /// `pump()` is the one to reach for. This exists for a caller that **cannot
+    /// await** — anything building inside `performAsCurrentDrawingAppearance`,
+    /// whose closure is synchronous — and it drives only half of what SwiftUI
+    /// needs: AppKit's layout and display, never a `.task`. A view whose content
+    /// arrives from one will not fill in here.
+    func pumpSynchronously(
+        times count: Int = 1, spin: TimeInterval = OffscreenHostDefaults.runLoopSpin
+    ) {
+        for _ in 0..<count {
+            _ = RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(spin))
+        }
+    }
+
+    /// Spend `count` pumps unconditionally — for the one case a condition cannot
+    /// express: giving a view that has already appeared a few more turns to be
+    /// asked to *draw* before a capture is taken.
+    func pump(times count: Int) async {
+        for _ in 0..<count { await pump() }
+    }
+
+    /// Synchronous on purpose: `RunLoop.run(_:before:)` is unavailable from an
+    /// async context, and one bounded turn of the main run loop is exactly what
+    /// AppKit needs to lay out and display what SwiftUI just published.
+    private static func spinRunLoop() {
+        _ = RunLoop.current.run(
+            mode: .default,
+            before: Date().addingTimeInterval(OffscreenHostDefaults.runLoopSpin))
+    }
+
+    // MARK: - Finding views
+
+    /// Every view of type `V` in the mounted hierarchy, depth first.
+    func descendants<V: NSView>(_ type: V.Type) -> [V] {
+        Self.descendants(type, of: contentView)
+    }
+
+    /// The first view of type `V` that satisfies `predicate`.
+    func firstDescendant<V: NSView>(
+        _ type: V.Type, where predicate: (V) -> Bool = { _ in true }
+    ) -> V? {
+        descendants(type).first(where: predicate)
+    }
+
+    /// The free-standing walk, for a caller that has a subtree rather than a
+    /// host.
+    static func descendants<V: NSView>(_ type: V.Type, of view: NSView) -> [V] {
+        var found: [V] = []
+        if let match = view as? V { found.append(match) }
+        for subview in view.subviews {
+            found.append(contentsOf: descendants(type, of: subview))
+        }
+        return found
+    }
+
+    // MARK: - Geometry
+
+    /// `view`'s frame in window coordinates, flipped to a top-left origin so
+    /// "above" reads as a smaller `y`.
+    ///
+    /// AppKit's window space has its origin at the BOTTOM left, and an assertion
+    /// written in it says the opposite of what it looks like it says.
+    func flippedWindowFrame(_ view: NSView) -> NSRect {
+        let inWindow = view.convert(view.bounds, to: nil)
+        let height = contentView.bounds.height
+        return NSRect(
+            x: inWindow.minX, y: height - inWindow.maxY,
+            width: inWindow.width, height: inWindow.height)
+    }
+
+    // MARK: - Accessibility
+
+    /// Every accessibility identifier the tree exposes.
+    ///
+    /// Meaningful only inside `withAccessibilityBridge`: with the bridge
+    /// off, SwiftUI builds no accessibility tree at all and this returns an
+    /// empty set however the views are annotated.
+    func accessibilityIdentifiers() -> Set<String> {
+        var found: Set<String> = []
+        Self.walkAccessibilityTree(contentView) { node, _ in
+            if let identifier = axAttribute(node, "accessibilityIdentifier") as? String,
+               !identifier.isEmpty {
+                found.insert(identifier)
+            }
+        }
+        return found
+    }
+
+    /// The same walk as an indented outline, so a failure can name the tree it
+    /// found rather than only the identifier it wanted.
+    func accessibilityTreeDescription() -> String {
+        var lines: [String] = []
+        Self.walkAccessibilityTree(contentView) { node, depth in
+            let role = axAttribute(node, "accessibilityRole") as? String ?? "-"
+            let identifier = (axAttribute(node, "accessibilityIdentifier") as? String)
+                .map { " id=\($0)" } ?? ""
+            let label = (axAttribute(node, "accessibilityLabel") as? String)
+                .map { " label=\($0.prefix(40))" } ?? ""
+            lines.append(
+                String(repeating: "  ", count: depth) + "\(type(of: node))"
+                    + " role=\(role)\(identifier)\(label)")
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    /// Depth-first over the **accessibility** tree rather than the view
+    /// hierarchy, visiting each node once.
+    ///
+    /// The question these walks ask is what an assistive client — or a GUI
+    /// driver, which is one — can actually reach, and two things about that tree
+    /// are not obvious. Both had to be found by measurement:
+    ///
+    /// - **SwiftUI's nodes are not `NSAccessibilityProtocol` in Swift's eyes.**
+    ///   They are `SwiftUI.AccessibilityNode` objects that implement the
+    ///   accessibility methods without declaring the Objective-C protocol, so
+    ///   `as?` fails on every one of them and a typed walk silently reports an
+    ///   empty tree. They are reached the way Objective-C reaches them instead:
+    ///   by selector.
+    /// - **Children are the union** of what a node declares and, for an
+    ///   `NSView`, its subviews — which is how AppKit itself resolves children
+    ///   for a view that has not overridden them, and how an `NSTextView` inside
+    ///   a representable is reached at all.
+    private static func walkAccessibilityTree(
+        _ root: NSView, visit: (NSObject, Int) -> Void
+    ) {
+        var seen = Set<ObjectIdentifier>()
+
+        func children(of node: NSObject) -> [Any] {
+            let declared = axAttribute(node, "accessibilityChildren") as? [Any] ?? []
+            return declared + ((node as? NSView)?.subviews ?? [])
+        }
+
+        func step(_ element: Any, _ depth: Int) {
+            guard let node = element as? NSObject else { return }
+            guard seen.insert(ObjectIdentifier(node)).inserted else { return }
+            visit(node, depth)
+            for child in children(of: node) { step(child, depth + 1) }
+        }
+
+        step(root, 0)
+    }
+
+    // MARK: - Drawing
+
+    /// One rendered frame of the mounted hierarchy.
+    ///
+    /// - Parameter scale: pixels per point. `nil` — the default — captures
+    ///   through `cacheDisplay(in:to:)` at the window's own backing scale, which
+    ///   offscreen is 1. An explicit scale renders into a bitmap of that pixel
+    ///   size instead, which is how a 2x asset comes out of a host that is on no
+    ///   Retina display. The two routes are AppKit's own two spellings of the
+    ///   same operation (`cacheDisplay` is documented as
+    ///   `displayRectIgnoringOpacity(_:in:)` into a bitmap context), kept apart
+    ///   only because the default one is the long-proven path and a capture is
+    ///   the last place to take a chance.
+    func capture(scale: CGFloat? = nil) throws -> Capture {
+        contentView.layoutSubtreeIfNeeded()
+        let bounds = contentView.bounds
+        guard bounds.width > 0, bounds.height > 0 else {
+            throw OffscreenHostError.nothingToCapture
+        }
+
+        guard let scale else {
+            guard let rep = contentView.bitmapImageRepForCachingDisplay(in: bounds) else {
+                throw OffscreenHostError.couldNotMakeBitmap
+            }
+            contentView.cacheDisplay(in: bounds, to: rep)
+            return Capture(
+                rep: rep, root: contentView,
+                scale: CGFloat(rep.pixelsWide) / bounds.width)
+        }
+
+        guard let rep = NSBitmapImageRep(
+            bitmapDataPlanes: nil,
+            pixelsWide: Int((bounds.width * scale).rounded()),
+            pixelsHigh: Int((bounds.height * scale).rounded()),
+            bitsPerSample: 8, samplesPerPixel: 4, hasAlpha: true, isPlanar: false,
+            colorSpaceName: .deviceRGB, bytesPerRow: 0, bitsPerPixel: 0)
+        else { throw OffscreenHostError.couldNotMakeBitmap }
+        // The rep's *point* size against its pixel size is what puts the scale
+        // into the context's transform; without it the view draws at 1x into the
+        // top-left quarter of the bitmap.
+        rep.size = bounds.size
+        guard let context = NSGraphicsContext(bitmapImageRep: rep) else {
+            throw OffscreenHostError.couldNotMakeBitmap
+        }
+        contentView.displayIgnoringOpacity(bounds, in: context)
+        return Capture(rep: rep, root: contentView, scale: scale)
+    }
+
+    /// One rendered frame, addressed in TOP-LEFT pixel coordinates so "above"
+    /// reads as a smaller `y` here too.
+    struct Capture {
+        let rep: NSBitmapImageRep
+        /// The view the capture was taken of, and the space `pixelFrame(of:)`
+        /// converts into.
+        let root: NSView
+        /// Pixels per point.
+        let scale: CGFloat
+
+        /// `view`'s frame in this capture's pixel space.
+        func pixelFrame(of view: NSView) -> NSRect {
+            let inRoot = view.convert(view.bounds, to: root)
+            let top = root.isFlipped ? inRoot.minY : root.bounds.height - inRoot.maxY
+            return NSRect(
+                x: inRoot.minX * scale, y: top * scale,
+                width: inRoot.width * scale, height: inRoot.height * scale)
+        }
+
+        /// The colour at one pixel, in sRGB. `nil` outside the bitmap.
+        func color(x: Int, y: Int) -> NSColor? {
+            guard x >= 0, y >= 0, x < rep.pixelsWide, y < rep.pixelsHigh else { return nil }
+            return rep.colorAt(x: x, y: y)?.usingColorSpace(.sRGB)
+        }
+
+        /// The share of pixels in `rect` that match `reference`, sampled on a
+        /// coarse grid — a fraction rather than a single probe, so the verdict
+        /// does not depend on landing between two glyphs.
+        func fraction(in rect: NSRect, matching reference: NSColor) -> Double {
+            var total = 0
+            var matched = 0
+            var y = Int(rect.minY)
+            while y < Int(rect.maxY) {
+                var x = Int(rect.minX)
+                while x < Int(rect.maxX) {
+                    if let color = color(x: x, y: y) {
+                        total += 1
+                        if Self.matches(color, reference) { matched += 1 }
+                    }
+                    x += OffscreenHostDefaults.sampleStride
+                }
+                y += OffscreenHostDefaults.sampleStride
+            }
+            return total == 0 ? 0 : Double(matched) / Double(total)
+        }
+
+        /// How much the picture varies: the variance of per-pixel luminance over
+        /// the whole capture, on the same coarse grid.
+        ///
+        /// It answers one question — **did anything actually render** — and it is
+        /// the question a snapshot suite most needs answered, because a view that
+        /// was never laid out captures as a large, perfectly plausible, perfectly
+        /// blank image. A flat field of any colour scores 0; a screenful of UI
+        /// scores orders of magnitude more.
+        func luminanceVariance() -> Double {
+            var samples = 0
+            var sum = 0.0
+            var sumOfSquares = 0.0
+            var y = 0
+            while y < rep.pixelsHigh {
+                var x = 0
+                while x < rep.pixelsWide {
+                    if let color = color(x: x, y: y) {
+                        // Rec. 601 luma: the weights a person's eye applies, so a
+                        // dark-on-light and a light-on-dark render score alike.
+                        let luminance = 0.299 * color.redComponent
+                            + 0.587 * color.greenComponent
+                            + 0.114 * color.blueComponent
+                        samples += 1
+                        sum += luminance
+                        sumOfSquares += luminance * luminance
+                    }
+                    x += OffscreenHostDefaults.sampleStride
+                }
+                y += OffscreenHostDefaults.sampleStride
+            }
+            guard samples > 0 else { return 0 }
+            let mean = sum / Double(samples)
+            return max(0, sumOfSquares / Double(samples) - mean * mean)
+        }
+
+        /// PNG bytes for this capture.
+        func pngData() throws -> Data {
+            guard let data = rep.representation(using: .png, properties: [:]) else {
+                throw OffscreenHostError.couldNotEncodePNG
+            }
+            return data
+        }
+
+        /// Write this capture out as a PNG, creating the enclosing directory.
+        func writePNG(to url: URL) throws {
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try pngData().write(to: url, options: [.atomic])
+        }
+
+        /// Same colour to within a hair.
+        ///
+        /// Compared against a pixel READ BACK from the same capture rather than
+        /// against a literal, because what a deliberate sRGB red comes back as
+        /// depends on the colour space it was rendered through — on a P3 screen
+        /// pure red reads as roughly (0.91, 0.28, 0.17).
+        static func matches(_ color: NSColor, _ reference: NSColor) -> Bool {
+            let tolerance = OffscreenHostDefaults.colorTolerance
+            return abs(color.redComponent - reference.redComponent) < tolerance
+                && abs(color.greenComponent - reference.greenComponent) < tolerance
+                && abs(color.blueComponent - reference.blueComponent) < tolerance
+        }
+    }
+}
+
+/// What can go wrong between a mounted view and a bitmap. Each case describes
+/// itself, so the diagnostic lands on the primary failure line rather than in a
+/// comment beside it.
+enum OffscreenHostError: Error, CustomStringConvertible {
+    case nothingToCapture
+    case couldNotMakeBitmap
+    case couldNotEncodePNG
+    case drawingAppearanceDidNotRun
+
+    var description: String {
+        switch self {
+        case .nothingToCapture:
+            return "the hosted view has zero width or height — it was never laid out"
+        case .couldNotMakeBitmap:
+            return "AppKit would not make a bitmap for the hosted view"
+        case .couldNotEncodePNG:
+            return "the captured bitmap could not be encoded as a PNG"
+        case .drawingAppearanceDidNotRun:
+            return "the drawing-appearance closure never ran"
+        }
+    }
+}
+
+/// Run `body` with `appearance` installed as the current drawing appearance, or
+/// directly when it is `nil`.
+///
+/// Anything that resolves a dynamic colour — a layer's `backgroundColor`, an
+/// `NSAttributedString`'s text colour — resolves it once, against whatever
+/// appearance is current at that moment, and never updates. So a dark-mode
+/// capture has to be *built* in here, not merely captured in here.
+///
+/// `throws` rather than `rethrows`: the error has to be carried out of a
+/// non-throwing AppKit closure through a `Result`, and Swift's `rethrows` check
+/// is syntactic — it does not accept an error that arrives that way.
+@MainActor
+@discardableResult
+func withDrawingAppearance<T>(
+    _ appearance: NSAppearance?, _ body: () throws -> T
+) throws -> T {
+    guard let appearance else { return try body() }
+    var outcome: Result<T, Error>?
+    appearance.performAsCurrentDrawingAppearance {
+        outcome = Result { try body() }
+    }
+    guard let outcome else { throw OffscreenHostError.drawingAppearanceDidNotRun }
+    return try outcome.get()
+}
+
+/// One accessibility accessor, by selector — see
+/// `OffscreenHost.walkAccessibilityTree` for why it cannot simply be a method
+/// call on a typed value.
+@MainActor
+private func axAttribute(_ node: NSObject, _ name: String) -> Any? {
+    guard node.responds(to: Selector((name))) else { return nil }
+    return node.value(forKey: name)
+}

--- a/Tests/TBDAppTests/Support/OffscreenHost.swift
+++ b/Tests/TBDAppTests/Support/OffscreenHost.swift
@@ -27,6 +27,15 @@ enum OffscreenHostDefaults {
     /// "what colour is this region" and "did anything paint at all", and neither
     /// wants to walk four million pixels.
     static let sampleStride = 4
+
+    /// The threshold `OffscreenHost.Capture.luminanceVariance()` has to clear to
+    /// count as a picture of something rather than a flat field.
+    ///
+    /// Far below anything a real render produces, far above the zero a flat
+    /// field scores — a view that was never laid out renders as a large,
+    /// perfectly plausible blank image, and this is what tells a snapshot suite
+    /// apart from one.
+    static let minLuminanceVariance = 0.0005
 }
 
 /// A SwiftUI view mounted in a real — but offscreen — AppKit window, for the
@@ -164,8 +173,24 @@ final class OffscreenHost<Root: View> {
     }
 
     /// Take the window back down. Idempotent, and safe to call from a `defer`.
+    ///
+    /// `orderOut` alone leaves the window sitting in `NSApp.windows` for the
+    /// rest of the process — the same trap documented at
+    /// `TabBarHitAreaTests.keyViewProxyMaxWidth`, except `close()` alone does
+    /// not clear it either. **Measured**, not merely reasoned: with
+    /// `isReleasedWhenClosed = false`, `NSWindow.close()` removes the window
+    /// from the screen but leaves it in `NSApp.windows` — AppKit only drops a
+    /// window from that list as part of releasing it, so a window told never
+    /// to release itself never leaves the list, no matter how many times
+    /// `close()` runs. Flipping the flag to `true` immediately before closing
+    /// is what actually removes it; a caller's own strong reference to
+    /// `window` (this type keeps one) is enough to survive the release AppKit
+    /// then performs, so nothing here is unsafe to touch afterwards.
     func tearDown() {
         window.orderOut(nil)
+        window.contentView = nil
+        window.isReleasedWhenClosed = true
+        window.close()
     }
 
     // MARK: - Pumping

--- a/Tests/TBDAppTests/WorkbenchSnapshotTests.swift
+++ b/Tests/TBDAppTests/WorkbenchSnapshotTests.swift
@@ -184,48 +184,46 @@ struct WorkbenchSnapshotTests {
                 scrollView.asSwiftUIView()
             }
 
-            let host = OffscreenHost(
-                root: AnyView(
-                    workbenchView
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                        .environment(appState)),
-                size: size,
-                appearance: appearance)
-            let window = host.window
-            // Guarantee teardown on every exit, including the `throw` below —
-            // a `defer` after this point would run before the assertion that
-            // follows it in this same scope could observe the result, so
-            // teardown and the assertion both happen explicitly instead.
-            defer {
-                host.tearDown()
-                // `tearDown()` must actually release the window rather than
-                // merely hide it — with `isReleasedWhenClosed = false` and no
-                // `close()`, every mounted window otherwise stays in
-                // `NSApp.windows` for the process lifetime (see
-                // `OffscreenHost.tearDown()` and the same trap at
-                // `TabBarHitAreaTests.keyViewProxyMaxWidth`). This suite
-                // mounts five of these per run, so a regression here would
-                // leave five orphaned windows behind every `swift test`
-                // invocation.
-                #expect(
-                    !NSApp.windows.contains(window),
-                    "OffscreenHost.tearDown() left its window in NSApp.windows")
-            }
+            // Weak on purpose, and pointed at the hosted tree rather than at
+            // the window: the tree is what costs anything — this suite mounts
+            // five of them per run — and it is the half a teardown can really
+            // release. The window shell AppKit keeps regardless; see
+            // `OffscreenHost.tearDown()` for why asking `NSApp.windows` about
+            // it can only be answered by an over-release.
+            weak var hostedTree: NSView?
+            // The render runs inside a pool of its own so the question after it
+            // can be answered honestly: every `host.hostingView` here hands back
+            // an autoreleased reference, and in the enclosing pool those keep
+            // the tree alive until the whole test ends, whatever teardown did.
+            try autoreleasepool {
+                let host = OffscreenHost(
+                    root: AnyView(
+                        workbenchView
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                            .environment(appState)),
+                    size: size,
+                    appearance: appearance)
+                hostedTree = host.hostingView
+                defer { host.tearDown() }
 
-            // Layout and pump the run loop
-            host.contentView.layoutSubtreeIfNeeded()
-            host.hostingView.layoutSubtreeIfNeeded()
-            host.pumpSynchronously(times: Self.settlePumps, spin: Self.settleSpin)
-            tableCoordinator.precomputeBottomWindow()
-            tableView.layoutSubtreeIfNeeded()
-            host.pumpSynchronously(times: Self.settlePumps, spin: Self.settleSpin)
+                // Layout and pump the run loop
+                host.contentView.layoutSubtreeIfNeeded()
+                host.hostingView.layoutSubtreeIfNeeded()
+                host.pumpSynchronously(times: Self.settlePumps, spin: Self.settleSpin)
+                tableCoordinator.precomputeBottomWindow()
+                tableView.layoutSubtreeIfNeeded()
+                host.pumpSynchronously(times: Self.settlePumps, spin: Self.settleSpin)
 
-            let shot = try host.capture()
-            let variance = shot.luminanceVariance()
-            if variance < OffscreenHostDefaults.minLuminanceVariance {
-                throw RenderError.blankRender(path: path, variance: variance)
+                let shot = try host.capture()
+                let variance = shot.luminanceVariance()
+                if variance < OffscreenHostDefaults.minLuminanceVariance {
+                    throw RenderError.blankRender(path: path, variance: variance)
+                }
+                try shot.writePNG(to: URL(fileURLWithPath: path))
             }
-            try shot.writePNG(to: URL(fileURLWithPath: path))
+            #expect(
+                pumpUntilReleased { hostedTree },
+                "tearDown() left this render's hosting view mounted")
         }
     }
 

--- a/Tests/TBDAppTests/WorkbenchSnapshotTests.swift
+++ b/Tests/TBDAppTests/WorkbenchSnapshotTests.swift
@@ -24,14 +24,6 @@ struct WorkbenchSnapshotTests {
     /// loudly rather than pass and be mistaken for a rendering defect.
     private static let minPlausiblePNGBytes = 20_000
 
-    /// The other half of that guard, and the sharper one: a PNG can be large and
-    /// still be a picture of nothing — a flat field compresses badly once it
-    /// carries any gradient or vibrancy. Luminance variance is near zero for a
-    /// blank capture and two orders of magnitude above this for a screenful of
-    /// transcript, so the threshold sits far below anything a real render
-    /// produces and far above zero.
-    private static let minLuminanceVariance = 0.0005
-
     /// Turns of the run loop between building the hierarchy and capturing it,
     /// and how long each one may block. Synchronous because the whole render
     /// happens inside a drawing-appearance closure, which cannot await.
@@ -199,7 +191,26 @@ struct WorkbenchSnapshotTests {
                         .environment(appState)),
                 size: size,
                 appearance: appearance)
-            defer { host.tearDown() }
+            let window = host.window
+            // Guarantee teardown on every exit, including the `throw` below —
+            // a `defer` after this point would run before the assertion that
+            // follows it in this same scope could observe the result, so
+            // teardown and the assertion both happen explicitly instead.
+            defer {
+                host.tearDown()
+                // `tearDown()` must actually release the window rather than
+                // merely hide it — with `isReleasedWhenClosed = false` and no
+                // `close()`, every mounted window otherwise stays in
+                // `NSApp.windows` for the process lifetime (see
+                // `OffscreenHost.tearDown()` and the same trap at
+                // `TabBarHitAreaTests.keyViewProxyMaxWidth`). This suite
+                // mounts five of these per run, so a regression here would
+                // leave five orphaned windows behind every `swift test`
+                // invocation.
+                #expect(
+                    !NSApp.windows.contains(window),
+                    "OffscreenHost.tearDown() left its window in NSApp.windows")
+            }
 
             // Layout and pump the run loop
             host.contentView.layoutSubtreeIfNeeded()
@@ -211,7 +222,7 @@ struct WorkbenchSnapshotTests {
 
             let shot = try host.capture()
             let variance = shot.luminanceVariance()
-            if variance < Self.minLuminanceVariance {
+            if variance < OffscreenHostDefaults.minLuminanceVariance {
                 throw RenderError.blankRender(path: path, variance: variance)
             }
             try shot.writePNG(to: URL(fileURLWithPath: path))

--- a/Tests/TBDAppTests/WorkbenchSnapshotTests.swift
+++ b/Tests/TBDAppTests/WorkbenchSnapshotTests.swift
@@ -7,8 +7,9 @@ import TBDShared
 /// Renders the Session Workbench transcript UI to PNG at various viewport
 /// sizes and appearance settings for visual review.
 ///
-/// Uses in-process bitmap rendering (`bitmapImageRepForCachingDisplay`) to
-/// avoid screen-capture permission issues.
+/// Hosted offscreen through `OffscreenHost`, which captures in process rather
+/// than through a screen recording — a screenshot API would want a permission
+/// grant no CI machine has.
 @Suite("Workbench snapshot rendering")
 @MainActor
 struct WorkbenchSnapshotTests {
@@ -22,6 +23,20 @@ struct WorkbenchSnapshotTests {
     /// small means we captured an unlaid-out or empty view, which must fail
     /// loudly rather than pass and be mistaken for a rendering defect.
     private static let minPlausiblePNGBytes = 20_000
+
+    /// The other half of that guard, and the sharper one: a PNG can be large and
+    /// still be a picture of nothing — a flat field compresses badly once it
+    /// carries any gradient or vibrancy. Luminance variance is near zero for a
+    /// blank capture and two orders of magnitude above this for a screenful of
+    /// transcript, so the threshold sits far below anything a real render
+    /// produces and far above zero.
+    private static let minLuminanceVariance = 0.0005
+
+    /// Turns of the run loop between building the hierarchy and capturing it,
+    /// and how long each one may block. Synchronous because the whole render
+    /// happens inside a drawing-appearance closure, which cannot await.
+    private static let settlePumps = 5
+    private static let settleSpin: TimeInterval = 0.02
 
     /// Snapshot configurations: (name, width, height, appearance)
     private let configurations: [(String, CGFloat, CGFloat, NSAppearance?)] = [
@@ -110,8 +125,15 @@ struct WorkbenchSnapshotTests {
     }
 
     /// Render the SessionWorkbenchView to a PNG file.
-    /// Appearance must be set BEFORE building views so NSAttributedString colors
-    /// resolve in the correct context (text color does not update dynamically after creation).
+    ///
+    /// **Everything is built inside the appearance**, not merely captured inside
+    /// it: `NSAttributedString` colors resolve in the context that is current
+    /// when they are created and do not update afterwards, so a dark render
+    /// assembled outside `withDrawingAppearance` comes out with light text
+    /// colors. The host's opaque ground is resolved in there too, which is what
+    /// keeps a light backdrop from showing through a dark capture's prose region
+    /// — the defect that made correctly-resolved white prose invisible while
+    /// opaque activity rows and the rail looked fine.
     private func renderWorkbench(
         presentation: TranscriptPresentation,
         appState: AppState,
@@ -119,10 +141,7 @@ struct WorkbenchSnapshotTests {
         appearance: NSAppearance?,
         to path: String
     ) throws {
-        let frame = NSRect(origin: .zero, size: size)
-
-        // Set appearance context before building ANY views so text colors resolve correctly
-        let renderWithAppearance = {
+        try withDrawingAppearance(appearance) {
             // Build the table transcript view
             let context = TranscriptCardContext(
                 terminalID: nil,
@@ -165,7 +184,7 @@ struct WorkbenchSnapshotTests {
             tableCoordinator.tableView = tableView
             tableCoordinator.scrollView = scrollView
 
-            // Set up the workbench view via NSHostingView
+            // Set up the workbench view in an offscreen host
             let workbenchView = SessionWorkbenchView(
                 sections: presentation.indexSections,
                 onOpen: { _ in }
@@ -173,76 +192,29 @@ struct WorkbenchSnapshotTests {
                 scrollView.asSwiftUIView()
             }
 
-            let host = NSHostingView(rootView: AnyView(
-                workbenchView
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .environment(appState)
-            ))
-            host.translatesAutoresizingMaskIntoConstraints = false
-            if let appearance = appearance {
-                host.appearance = appearance
-            }
-
-            let container = NSView(frame: frame)
-            container.wantsLayer = true
-            container.layer?.backgroundColor = NSColor.controlBackgroundColor.cgColor
-            if let appearance = appearance {
-                container.appearance = appearance
-            }
-            container.addSubview(host)
-
-            NSLayoutConstraint.activate([
-                host.leadingAnchor.constraint(equalTo: container.leadingAnchor),
-                host.topAnchor.constraint(equalTo: container.topAnchor),
-                host.widthAnchor.constraint(equalToConstant: size.width),
-                host.heightAnchor.constraint(equalToConstant: size.height)
-            ])
+            let host = OffscreenHost(
+                root: AnyView(
+                    workbenchView
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .environment(appState)),
+                size: size,
+                appearance: appearance)
+            defer { host.tearDown() }
 
             // Layout and pump the run loop
-            container.layoutSubtreeIfNeeded()
-            host.layoutSubtreeIfNeeded()
-            self.pump()
+            host.contentView.layoutSubtreeIfNeeded()
+            host.hostingView.layoutSubtreeIfNeeded()
+            host.pumpSynchronously(times: Self.settlePumps, spin: Self.settleSpin)
             tableCoordinator.precomputeBottomWindow()
             tableView.layoutSubtreeIfNeeded()
-            self.pump()
+            host.pumpSynchronously(times: Self.settlePumps, spin: Self.settleSpin)
 
-            // Capture the bitmap DIRECTLY — deliberately no `NSImage.lockFocus()`
-            // round-trip. `lockFocus` pushes a drawing context that does not
-            // inherit `NSAppearance.current`, so a
-            // `NSColor.controlBackgroundColor.setFill()` backdrop resolves LIGHT
-            // even under darkAqua. That was harmless while assistant bubbles
-            // painted their own background, but this design makes them `.clear`
-            // — so the light backdrop showed through the prose region and the
-            // correctly-resolved dark-mode (white) prose became invisible
-            // against it, while opaque activity rows and the rail looked fine.
-            // Writing the cached rep straight out keeps ONE appearance for the
-            // whole capture; `container`'s layer supplies the opaque ground,
-            // resolved inside this closure.
-            guard let rep = container.bitmapImageRepForCachingDisplay(in: frame) else {
-                throw RenderError.couldNotMakePNG
+            let shot = try host.capture()
+            let variance = shot.luminanceVariance()
+            if variance < Self.minLuminanceVariance {
+                throw RenderError.blankRender(path: path, variance: variance)
             }
-            container.cacheDisplay(in: frame, to: rep)
-            guard let png = rep.representation(using: .png, properties: [:]) else {
-                throw RenderError.couldNotMakePNG
-            }
-            try png.write(to: URL(fileURLWithPath: path))
-        }
-
-        // Execute render inside appearance context so text colors resolve correctly
-        if let appearance = appearance {
-            var error: Error?
-            appearance.performAsCurrentDrawingAppearance {
-                do {
-                    try renderWithAppearance()
-                } catch let e {
-                    error = e
-                }
-            }
-            if let error = error {
-                throw error
-            }
-        } else {
-            try renderWithAppearance()
+            try shot.writePNG(to: URL(fileURLWithPath: path))
         }
     }
 
@@ -258,24 +230,18 @@ struct WorkbenchSnapshotTests {
         return coordinator
     }
 
-    /// Pump the run loop to allow deferred work to complete.
-    private func pump() {
-        for _ in 0..<5 {
-            RunLoop.current.run(until: Date().addingTimeInterval(0.02))
-        }
-    }
-
     enum RenderError: Error, CustomStringConvertible {
-        case couldNotMakePNG
         case implausiblySmallPNG(name: String, bytes: Int)
+        case blankRender(path: String, variance: Double)
 
         var description: String {
             switch self {
-            case .couldNotMakePNG:
-                return "could not build a PNG representation of the rendered view"
             case let .implausiblySmallPNG(name, bytes):
                 return "\(name).png is only \(bytes) bytes — the view almost certainly "
                     + "rendered blank rather than being captured correctly"
+            case let .blankRender(path, variance):
+                return "the capture for \(path) has luminance variance \(variance) — "
+                    + "it is a flat field, i.e. the view never rendered"
             }
         }
     }

--- a/docs/test-doubles.md
+++ b/docs/test-doubles.md
@@ -2,7 +2,9 @@
 
 TBD's development loop leans on four fakes. Three replace an external
 dependency and one replaces TBD's own state; each answers a different question,
-and picking the wrong one wastes an afternoon, so this is the index.
+and picking the wrong one wastes an afternoon, so this is the index. Two test
+**harnesses** follow them: not fakes of anything, but the rig that mounts the
+real SwiftUI views where a test can measure and photograph them.
 
 - **Fake model API** — `scripts/claude-stub.py`, documented in
   [`fake-model-api.md`](fake-model-api.md). Fakes the Anthropic Messages API on
@@ -31,3 +33,43 @@ and picking the wrong one wastes an afternoon, so this is the index.
   it. Reach for it when a test's behavior turns on the tmux version and must
   not depend on the host's `PATH` or the developer's saved fallback — a live
   tmux is the other tool, and slower.
+
+## Harnesses for the app's own views
+
+- **Offscreen GUI host** — `Tests/TBDAppTests/Support/OffscreenHost.swift`, with
+  the composer-specific fixtures beside it in `ComposerHarness.swift`. Mounts a
+  real SwiftUI view in a real, borderless `NSWindow` placed far off every
+  display, and gives a test the four things only a mounted view has: laid-out
+  frames in window coordinates, a bounded pump that drives both AppKit's run
+  loop and SwiftUI's `.task`, the accessibility tree a GUI driver would see, and
+  a drawn bitmap. Reach for it when the question is *where something landed* or
+  *what a driver can reach* — `CompletionOverlayPlacementTests` and
+  `ComposerAccessibilityIdentifierTests` are the worked examples.
+  - **Two things it does not prove**, both measured rather than assumed.
+    AppKit-versus-SwiftUI compositing does not reproduce offscreen: SwiftUI
+    already orders its overlay above a representable sibling declared before it,
+    with or without the `.zIndex` production states, so a capture guards the
+    outcome and never discriminates a stacking modifier. And nothing about
+    elapsed time: waits are bounded by pump count, so an animation or a
+    real-clock debounce does not finish here.
+  - **The accessibility tree costs something to ask for.** SwiftUI builds none
+    until a client sets `AXEnhancedUserInterface`, which is process-wide and
+    changes AppKit's own behavior while it is on. `withAccessibilityBridge`
+    scopes it to one body and restores it; every suite that turns it on, and
+    every suite that would be misled by it, is nested under the serialized
+    `AccessibilityBridgeSerialized`.
+- **Composer render harness** — `Tests/TBDAppTests/ComposerRenderHarness.swift`.
+  Env-gated on `TBD_COMPOSER_SHOTS_DIR`: inert during a normal run, and with the
+  variable set it writes `1-menu.png`, `2-attachment.png`, `3-not-running.png`
+  and `4-blocked.png` at 2x into that directory, one per state the composer can
+  be in.
+
+        TBD_COMPOSER_SHOTS_DIR=/tmp/composer-shots scripts/test.sh \
+            --filter ComposerRenderHarness
+
+  Reach for it for the half of a UI assertions are bad at — a banner colliding
+  with its message, a thumbnail off the baseline. Its predecessor caught the
+  completion list covering the words being typed (#829) before that shipped.
+  Each shot asserts its own capture is not a flat field before writing it, so a
+  view that never laid out fails rather than handing over a plausible white
+  rectangle.


### PR DESCRIPTION
Stacked on #831.

## Summary

Somebody writing a test for a SwiftUI view in this app — where did it land, can a driver reach it, what does it actually look like — has to mount that view in a real window and drive it. Three suites had each worked that out separately and kept a private copy: a borderless offscreen `NSWindow`, an `NSHostingView`, a pump that turns both the run loop and the cooperative pool, a bounded settle, a subview walk, a `cacheDisplay` capture. Each copy knew only what its own suite needed, none of them said what the technique proves and what it does not, and the fourth suite to need one would have written a fourth copy.

There is now one, `OffscreenHost`, with its contract written down, plus `ComposerHarness` for the composer's own fixtures. And the render harness that caught the completion list covering the words being typed (#829) — which was thrown away with the branch that produced it — is back, kept, and env-gated.

## Why this shape

No spec: this is test infrastructure. It adds no product behavior, no flag and no database column, and it changes no theory of the system — the three refactored suites make exactly the assertions they made before.

The decisions worth naming:

- **`Tests/TBDAppTests/Support/`, not `Tests/TestSupport/`.** That target depends on `TBDDaemonLib` and links into the daemon suites; putting AppKit and SwiftUI in it would drag them into every one of those for two AppKit-only callers.
- **The contract is half the deliverable.** `OffscreenHost`'s doc comment states what an offscreen mount proves and — the part a copied helper never carries — what it does not: AppKit-versus-SwiftUI compositing does not reproduce offscreen (measured: the placement suite's paint-order capture is pixel-for-pixel identical with the production `.zIndex` removed, so it guards an outcome and does not discriminate a modifier); nothing about events, since the window is never key; nothing about elapsed time, since every wait is bounded by a pump count rather than a clock.
- **Composer state comes from the terminal's own columns.** The harness builds a `Terminal` with `hibernatedAt` or `awaitingInputReason` set and runs `ComposerState.resolve` over it, rather than handing the view a state value directly, so a suite mounting a blocked composer is mounting what the daemon's record would actually produce.
- **The blank-render guard is the render suite's whole discipline.** A view that was never laid out captures as a large, perfectly plausible white rectangle. Every shot's luminance variance has to clear a named threshold before the file is written, and `WorkbenchSnapshotTests` gains the same check beside its existing PNG-size floor — a big PNG can still be a picture of nothing.
- **`TableTranscriptHarness` is left alone.** Its two hosting sites are an oracle that measures a row through `NSHostingController.sizeThatFits` with no window at all, and a ground-truth render pinned to that oracle's height. Neither is a mounted-in-a-window view, which is the only thing the host offers, and its env gate is untouched.

## What this PR does

- **`Tests/TBDAppTests/Support/OffscreenHost.swift`** — generic over `View`. Mounts at a caller-given size on an opaque, appearance-resolved ground; `pump()` / `settle(maxPumps:until:)` / `pumpSynchronously(times:spin:)`; `descendants` and `firstDescendant`; `flippedWindowFrame(_:)` so "above" reads as a smaller `y`; `accessibilityIdentifiers()` and `accessibilityTreeDescription()` over the walk moved out of the identifiers suite (by selector, because SwiftUI's nodes do not declare `NSAccessibilityProtocol`); `capture(scale:)` returning a `Capture` with `pixelFrame(of:)`, `color(x:y:)`, `fraction(in:matching:)`, `luminanceVariance()` and `writePNG(to:)`. `withDrawingAppearance` carries the trap that dynamic colours resolve once, at creation.
- **`Tests/TBDAppTests/Support/ComposerHarness.swift`** — isolated `AppState` on a `UserDefaults(suiteName:)` with teardown, a local worktree, running / parked / blocked terminal builders, a `prepare` hook that stages images into a `fencedScratchRoot` directory the harness removes, `openMenu(typing:)`, the text-view and completion-list lookups, and the two accessibility settles. Plus `TranscriptPreviewStrip`, a deliberately dull fixture conversation that stands in for the transcript above the composer.
- **The three suites move onto it**, assertions unchanged (see below).
- **`Tests/TBDAppTests/ComposerRenderHarness.swift`** — inert unless `TBD_COMPOSER_SHOTS_DIR` is set; writes `1-menu.png`, `2-attachment.png`, `3-not-running.png`, `4-blocked.png` at 2x.
- **`docs/test-doubles.md`** gains a "Harnesses for the app's own views" section: both entries, the env var, and the compositing caveat.

## Evidence & verification

`scripts/test.sh --filter "CompletionOverlayPlacementTests|ComposerAccessibilityIdentifierTests|WorkbenchSnapshotTests|MessageComposerViewTests|ComposerRenderHarness|AccessibilityBridgeScopeTests|AccessibilityWindowGeometryGuardTests"` — **46 tests in 8 suites, zero failures**, both with `TBD_COMPOSER_SHOTS_DIR` set (four PNGs written) and without it (no directory created, the render tests inert). `swiftlint --strict` over the repository: 0 violations in 1036 files.

Assertion counts before and after the refactor, from a grep of `#expect` / `#require` / `Issue.record` / `throw`:

- `ComposerAccessibilityIdentifierTests` — 10 → 10.
- `CompletionOverlayPlacementTests` — 18 → 17 assertions. The one that moved: `try #require(host.bitmapImageRepForCachingDisplay(...))` is now `OffscreenHostError.couldNotMakeBitmap`, thrown inside `capture()`, which names itself on the failure line.
- `WorkbenchSnapshotTests` — 4 → 3 raised failures, and strictly stronger. Its two `RenderError.couldNotMakePNG` throws became one `OffscreenHostError` inside the host; the new `RenderError.blankRender` variance check is added on top of the PNG-size floor it kept.

The four renders were inspected by eye, not merely produced: the completion list opens above the field with `please /comp` visible under it; the staged attachment shows its thumbnail, its `#1` caption and the `[Image #1]` token in the message; the parked session shows "Claude exited in this terminal. Sending will resume the session." over a **Resume claude** button; the blocked session shows the permission sentence with **Reveal Terminal** beside it and a disabled send.

[composer harness](https://cheapsteak.github.io/tbd/open/?worktree=73F947A5-C6BD-4A6A-8120-965909BE8733)
https://claude.ai/code/session_01E9SPoxoVoApcVmduLiBWik


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved coverage for composer placement, accessibility, rendering, attachments, blocked sessions, and inactive sessions.
  - Added offscreen rendering checks that capture screenshots and reject blank or flat images.
  - Updated workbench snapshot testing for more reliable layout, appearance, and rendering validation.
  - Standardized completion menu width checks.
  - Added lifecycle coverage for reliable offscreen test cleanup.

- **Documentation**
  - Expanded testing guidance for SwiftUI view harnesses, offscreen hosting, accessibility timing, and screenshot capture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
