### PR TITLE
fix(tests): reclaim the fixture holders nothing was sweeping

### DIFF
--- a/Tests/CLAUDE.md
+++ b/Tests/CLAUDE.md
@@ -99,12 +99,22 @@ one can be left behind, and each covers exactly one:
   socket with it, which is precisely why the layer above exists.
 - **A wrapper that is SIGKILLed**, where not even the EXIT trap runs, is
   reclaimed by the *next* run: `reclaim_abandoned_run_roots` gives every sibling
-  `/tmp/tbd-test-home.*` older than a day the same two sweeps and then removes
-  it. No run lasts a day — the nightly stress harness mints one root per
-  iteration — so age alone is a safe discriminator, and every run being a sweep
-  means the machine heals as soon as anybody tests again. It is the named
-  reconciler for fixture holders in the sense
+  `/tmp/tbd-test-home.*` that is both older than a day and has no live owner the
+  same two sweeps, then removes it. Every run being a sweep is what makes the
+  machine heal as soon as anybody tests again, with no timer and no daemon. It
+  is the named reconciler for fixture holders in the sense
   `docs/specs/2026-08-15-named-reconciler-doctrine-design.md` means it.
+
+  **Age is not the whole discriminator, and the missing half is the dangerous
+  one.** No run lasts a day, so age says nobody is coming back — but a run that
+  WEDGES stops writing, so its root ages exactly like an abandoned one while its
+  holder, its tmux servers and its `TBD_HOME` are all still in use. So every run
+  claims its own root on the way in, writing its pid and that pid's kernel start
+  time into `<root>/.run-owner`, and the reconciler skips any root whose claim
+  still checks out. Same identity check as everywhere else here: a pid alone
+  would be a number the kernel is free to reissue. A root with no claim in it
+  predates the mechanism and is reclaimed on age — the one arm that is
+  deliberately not keep-biased, because immortal roots are the leak.
 
 The tmux leg is the one with no teardown remedy: **tmux never unlinks its
 socket file when a server exits.** It unlinks a stale socket lazily instead, at

--- a/Tests/CLAUDE.md
+++ b/Tests/CLAUDE.md
@@ -72,6 +72,40 @@ orphan profile dirs, ~2.9k fake worktrees and ~7,100 dead tmux sockets
 accumulated that way before anyone noticed. Read `swift test …` below
 as `scripts/test.sh …`.
 
+**Two of the things a run leaves behind are processes, and no amount of path
+fencing touches either.** A tmux server outlives the socket that named it, and a
+`TBDHolder` outlives the test process that spawned it *by design* — it calls
+`setsid()` and ignores `SIGHUP` so it can survive the daemon's death
+(`Sources/TBDHolder/Holder.swift`), which means it survives a dead test process
+just as well, re-parents to launchd, and keeps its job running. Nothing in the
+product reclaims a fixture's holder: `OrphanGC`'s rowless-holder collector
+enumerates the real `~/tbd/holders`, and `AgentReaper`'s holder leg works from
+`terminal` rows an in-memory fixture database never had. One measured instance
+ran for 24 hours with its job still looping. Three layers cover the three ways
+one can be left behind, and each covers exactly one:
+
+- **A teardown that runs** kills what its rows name, then sweeps the pids it
+  remembers — refusing any whose kernel start time no longer matches the one
+  recorded at spawn. That identity check is what makes remembering a pid safe:
+  a pid is free the instant its corpse is collected, and on this box the next
+  process to take it is somebody else's. It is the same answer `AgentReaper`
+  gives to the same question.
+- **A run that dies without reaching a teardown** leaves its rendezvous sockets
+  behind, and `cleanup` kills whoever `lsof` says owns each one before the
+  `rm -rf`. **By resource, never by pattern**: the socket path is unique to the
+  run, while a `pkill` on the holder's name would end live production holders
+  and other agents' sessions on the same machine. Note the ordering this
+  implies — a teardown that ran and removed its scratch root has taken the
+  socket with it, which is precisely why the layer above exists.
+- **A wrapper that is SIGKILLed**, where not even the EXIT trap runs, is
+  reclaimed by the *next* run: `reclaim_abandoned_run_roots` gives every sibling
+  `/tmp/tbd-test-home.*` older than a day the same two sweeps and then removes
+  it. No run lasts a day — the nightly stress harness mints one root per
+  iteration — so age alone is a safe discriminator, and every run being a sweep
+  means the machine heals as soon as anybody tests again. It is the named
+  reconciler for fixture holders in the sense
+  `docs/specs/2026-08-15-named-reconciler-doctrine-design.md` means it.
+
 The tmux leg is the one with no teardown remedy: **tmux never unlinks its
 socket file when a server exits.** It unlinks a stale socket lazily instead, at
 bind time, when a new server claims that exact path — and every test mints a
@@ -156,7 +190,8 @@ The wrapper's own guards are regression-tested by `scripts/test.test.sh`, which
 runs in the `lint` CI job: it drives the symlink and ownership refusals on the
 fake home, the post-run mode-000 recheck, the fingerprint's seven arms (five
 roots, two of which are read twice), the tmux socket fence (its `sun_path`
-budget and its kill-server sweep) and the
+budget and its kill-server sweep), the holder sweep and the abandoned-run-root
+reconciler, and the
 shared-lock pin against fixture directories with a stub `swift`, so it takes
 ~11 s, builds nothing, and touches no real store. **Every case there is
 mutation-checked** — the assertion is shown going red against a deliberately

--- a/Tests/TBDDaemonLiveTests/Holder/HolderHibernationLiveTests.swift
+++ b/Tests/TBDDaemonLiveTests/Holder/HolderHibernationLiveTests.swift
@@ -430,6 +430,52 @@ struct HolderHibernationLiveTests {
         #expect(!FileManager.default.fileExists(atPath: fixture.launchArgvPath),
                 "the wake spawned a second holder instead of adopting the live one")
     }
+
+    /// Teardown's second pass, against the branch where the first one has
+    /// nothing to read.
+    ///
+    /// `tearDown` kills what the ROWS still name, which is the right default —
+    /// a park clears the pids off its row precisely because those processes are
+    /// gone, so a teardown working from a remembered list alone would signal
+    /// numbers the kernel has since reissued. But the read can come back empty:
+    /// its gate is bounded, and an expiry returns `[]`. On that branch the
+    /// by-rows sweep kills nothing, and what it failed to kill is a process
+    /// built to outlive this one — `TBDHolder` `setsid`s away and ignores
+    /// `SIGHUP` so it survives the daemon's death, which means it survives a
+    /// dead test process too, re-parents to launchd, and keeps its job running.
+    /// One did, for 24 hours.
+    ///
+    /// **The row is deleted rather than the gate starved**, because what that
+    /// branch means to `tearDown` is "there is no row here to read", and an
+    /// empty terminals table is exactly that — immediately, instead of after a
+    /// two-minute gate this test would otherwise have to sit through.
+    ///
+    /// Reverting `sweepRememberedProcesses` fails this test: both pids are
+    /// still alive when the poll gives up.
+    @Test func tearDownKillsWhatItSpawnedWhenNoRowNamesItAnyMore() async throws {
+        let fixture = try await HibernationFixture.make()
+        defer { fixture.tearDown() }
+        let terminal = try await fixture.spawnHolderRow()
+        let holderPID = try #require(terminal.holderPID)
+        let childPID = try #require(terminal.childPID)
+        #expect(holderProcessIsAlive(holderPID), "the holder never came up")
+        #expect(holderProcessIsAlive(childPID), "the job never came up")
+
+        // The state the expired gate leaves teardown in: a live holder, a live
+        // job, and nothing in the database naming either.
+        try await fixture.db.terminals.delete(id: terminal.id)
+        #expect(try await fixture.db.terminals.list().isEmpty,
+                "the row is still there, so the by-rows sweep would cover this")
+
+        fixture.tearDown()
+
+        #expect(await pollUntil("the holder to be killed by the remembered-pid sweep") {
+            !holderProcessIsAlive(holderPID)
+        })
+        #expect(await pollUntil("the job to be killed by the remembered-pid sweep") {
+            !holderProcessIsAlive(childPID)
+        })
+    }
 }
 
 // MARK: - A process table that never concedes
@@ -556,6 +602,29 @@ private final class HibernationFixture {
     private let home: String
     private let tempDir: URL
     private var torndown = false
+
+    /// A pid this fixture spawned, and the kernel's record of when that pid
+    /// started.
+    ///
+    /// The start time is what makes the pid safe to signal later. A pid is free
+    /// the instant its corpse is collected, and on a box running dozens of
+    /// agent sessions the next process to take it is somebody else's — so
+    /// `tearDown` signals a remembered pid only when the kernel still reports
+    /// the same start instant, which is the answer `AgentReaper` gives to the
+    /// same question about a holder row.
+    private struct SpawnedProcess {
+        let pid: Int32
+        /// nil when the pid was already gone by the time it was recorded, which
+        /// makes it unidentifiable and therefore never signalled.
+        let startedAt: Date?
+        /// Whether this process is a child of the test process itself. The
+        /// holder is — `HolderSpawner` `posix_spawn`s it directly — so its
+        /// corpse must be reaped or it outlives the suite. The job is the
+        /// holder's child, not ours, and the kernel reaps it.
+        let ourChild: Bool
+    }
+
+    private var spawned: [SpawnedProcess] = []
 
     /// A short scratch root under the run root `scripts/test.sh` reclaims: the
     /// rendezvous socket lives under it and `sun_path` is 104 bytes, so a deeper
@@ -726,6 +795,7 @@ private final class HibernationFixture {
                 environment: ["PATH": "/usr/bin:/bin", "TERM": "xterm-256color"],
                 columns: 80,
                 rows: 24))
+        remember(handle)
         _ = try await db.terminals.create(
             id: terminalID,
             worktreeID: worktree.id,
@@ -741,13 +811,43 @@ private final class HibernationFixture {
         return try #require(try await db.terminals.get(id: terminalID))
     }
 
-    /// Kills whatever the ROWS still name, then clears the scratch roots.
+    /// Records the pair this spawn produced, and names it in the run log.
+    ///
+    /// **The log line is the diagnosis, and it is written because one was
+    /// missing.** A holder that outlived a run was found a day later with its
+    /// job still looping, and nothing could be said about how it got there: the
+    /// worktree that ran the suite had been archived and deleted, so there was
+    /// no way to tell a crashed test process from a teardown that ran and
+    /// missed. A pid and the scratch root it belongs to, printed at spawn,
+    /// makes the next occurrence answerable from the run log alone.
+    ///
+    /// stderr rather than `print`, for the same reason `FlakyTestSupport` uses
+    /// it: stdout is Swift Testing's, and both streams reach the tee'd run log.
+    private func remember(_ handle: HolderHandle) {
+        spawned.append(SpawnedProcess(
+            pid: handle.holderPID,
+            startedAt: ProcessStartTime.startTime(pid: handle.holderPID),
+            ourChild: true))
+        spawned.append(SpawnedProcess(
+            pid: handle.childPID,
+            startedAt: ProcessStartTime.startTime(pid: handle.childPID),
+            ourChild: false))
+        let line = "HibernationFixture: holder pid \(handle.holderPID), "
+            + "job pid \(handle.childPID), scratch root \(home)\n"
+        FileHandle.standardError.write(Data(line.utf8))
+    }
+
+    /// Kills whatever the ROWS still name, sweeps whatever they no longer do,
+    /// then clears the scratch roots.
     ///
     /// Reading the rows rather than a list of everything ever spawned is the
     /// safety property: a park clears the pids off its row precisely because
     /// those processes are gone, and a teardown working from a remembered list
     /// would signal numbers the kernel has already handed to somebody else — on
-    /// a box running dozens of agent sessions, to somebody else's work.
+    /// a box running dozens of agent sessions, to somebody else's work. The
+    /// remembered list is still swept, in `sweepRememberedProcesses`, but only
+    /// where the kernel's start time still says the pid is the one this fixture
+    /// spawned — which is how that pass gets the rows' safety without the rows.
     func tearDown() {
         guard !torndown else { return }
         torndown = true
@@ -762,12 +862,57 @@ private final class HibernationFixture {
                 kill(childPID, SIGKILL)
             }
         }
+        sweepRememberedProcesses()
         // Whatever a reader is still draining is named only by the registry, so
         // release them all. Detached because teardown is not async.
         let registry = self.registry
         Task.detached { await registry.releaseAll() }
         try? FileManager.default.removeItem(atPath: home)
         try? FileManager.default.removeItem(at: tempDir)
+    }
+
+    /// The second pass, for the branch where the first one has nothing to work
+    /// from.
+    ///
+    /// **Reading the rows is the right default and it has one hole.**
+    /// `blockingTerminals` waits up to `TestGate.deadline` and returns `[]` on
+    /// expiry — and on that branch the sweep above kills nothing at all, while
+    /// the holder it would have killed is a process built to outlive this one:
+    /// `TBDHolder` calls `setsid()` and ignores `SIGHUP`
+    /// (`Sources/TBDHolder/Holder.swift`) so it survives the daemon's death,
+    /// which means it survives a dead test process just as well. It re-parents
+    /// to launchd and keeps its job running, and nothing in the product
+    /// reclaims it: `OrphanGC` enumerates the real `~/tbd/holders` and
+    /// `AgentReaper` works from `terminal` rows this in-memory database never
+    /// gave anyone. One such holder ran for 24 hours.
+    ///
+    /// So the pids this fixture spawned are remembered as well, and swept here
+    /// — **identity-checked**, which is what makes remembering safe. The reason
+    /// the by-rows pass exists is that a park CLEARS the pids off its row
+    /// precisely because those processes are gone, and a teardown working from
+    /// a remembered list alone would signal numbers the kernel has since handed
+    /// to somebody else's work. Comparing the kernel's start time against the
+    /// one recorded at spawn answers that: a reissued pid reports a different
+    /// instant and is left alone, exactly as `AgentReaper` leaves one alone.
+    ///
+    /// The two passes cannot fight. A pid the rows already accounted for is
+    /// either reaped — `ProcessStartTime` reports nothing and it is skipped —
+    /// or a corpse waiting to be, which a second `SIGKILL` cannot disturb.
+    private func sweepRememberedProcesses() {
+        for process in spawned {
+            guard let anchor = process.startedAt,
+                  let current = ProcessStartTime.startTime(pid: process.pid),
+                  // Both values come from the same kernel field, so a match is
+                  // exact; the tolerance only keeps the comparison from turning
+                  // on floating-point equality.
+                  abs(current.timeIntervalSince(anchor)) < 0.001
+            else { continue }
+            kill(process.pid, SIGKILL)
+            if process.ourChild {
+                var ignored: Int32 = 0
+                _ = waitpid(process.pid, &ignored, 0)
+            }
+        }
     }
 
     /// Reads the terminal rows from a non-async `tearDown`.

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -69,9 +69,12 @@
 # works from `terminal` rows, and a fixture's socket is under a scratch root
 # with no row anywhere. `reclaim_abandoned_run_roots` is the named reconciler
 # for that case (docs/specs/2026-08-15-named-reconciler-doctrine-design.md): at
-# START-UP, every sibling run root older than a day gets the same two sweeps and
-# then `rm -rf`. Every run is a sweep, so the machine heals as soon as anybody
-# tests again.
+# START-UP, every sibling run root that is both older than a day AND has no live
+# owner gets the same two sweeps and then `rm -rf`. Every run is a sweep, so the
+# machine heals as soon as anybody tests again. The liveness half is not
+# redundant with the age half: a WEDGED run stops writing, so it ages exactly
+# like an abandoned one, and only the pid it claimed its root with can tell them
+# apart.
 #
 # READING A PERMISSION-DENIED FAILURE. If a test under this wrapper fails with
 # "You don't have permission to save the file …" or `EACCES`/`NSFileWriteNoPermissionError`
@@ -336,6 +339,14 @@ require_owned_dir_after_mkdir() {
 RUN_ROOT_DIR="/tmp"
 RUN_ROOT_PREFIX="tbd-test-home."
 
+# WHAT A LIVE RUN LEAVES IN ITS ROOT SO NOBODY RECLAIMS IT. Two lines: the
+# wrapper's own pid, and the kernel's start time for that pid as `ps` renders
+# it. The second line is what makes the first safe to read a day later — a pid
+# is free the instant its corpse is collected, and the number is then somebody
+# else's — and it is the same identity check `AgentReaper` applies to a holder
+# row and the fixtures apply to a remembered pid.
+RUN_OWNER_FILE=".run-owner"
+
 # How old a sibling run root has to be before it is certainly abandoned. No run
 # lasts a day — the nightly stress harness mints a fresh root per iteration —
 # so age alone is a safe discriminator, and one that needs no scheduler, no
@@ -454,6 +465,63 @@ sweep_holders() {
   return 0
 }
 
+# The kernel's start time for a pid, as one line with no leading padding.
+#
+# `ps -o lstart=` rather than an elapsed time: an elapsed time is a moving
+# target that has to be compared with a tolerance, while a start INSTANT is a
+# constant that compares by string equality, and equality is what a
+# recycled-pid check needs. Empty for a pid that names nothing.
+#
+# BOTH ENDS ARE TRIMMED because `ps` pads the column on both sides, and the
+# value is written to a file that a later run compares as a string. Trimming
+# only the left would still compare equal — the padding is the same every time —
+# but it would put trailing spaces in the claim file, where the next reader has
+# to know they are there.
+process_start_time() {
+  ps -o lstart= -p "$1" 2>/dev/null | head -1 | sed 's/^ *//; s/ *$//'
+}
+
+# Claims a run root for this process, so no other run reclaims it.
+claim_run_root() {
+  local root="$1"
+  printf '%s\n%s\n' "$$" "$(process_start_time "$$")" > "$root/$RUN_OWNER_FILE" 2>/dev/null || true
+  return 0
+}
+
+# Whether `$1` is a run root whose owner is still alive — the POSITIVE liveness
+# attestation, and the thing that keeps age from being the only discriminator.
+#
+# WHY IT IS NEEDED, GIVEN THAT NO RUN LASTS A DAY. That premise covers every
+# AUTOMATED caller — CI's job timeouts and the nightly harness's per-iteration
+# roots are all far under it — but not a developer who starts a run by hand and
+# walks away from one that WEDGES. `Tests/CLAUDE.md` documents several real hang
+# classes, and a wedged run is exactly the case age cannot see: it stops writing,
+# so its root ages like an abandoned one while its holder, its tmux servers and
+# its `TBD_HOME` are all still in use. Without this check the reclaim would go
+# from "silently leak" to "SIGKILL somebody's live run and delete its state",
+# which is the wrong direction to be wrong in.
+#
+# IT FAILS KEEP-BIASED, LIKE EVERY OTHER IDENTITY CHECK IN THIS FILE: anything
+# short of "this pid is alive AND started when the file says it did" is not
+# proof of life. A missing file is the one case that is NOT keep-biased, and
+# deliberately so — a root with no claim in it was written by a wrapper that
+# predates this attestation, and treating those as immortal would leak exactly
+# the roots this reconciler exists to collect.
+run_root_is_live() {
+  local root="$1" claim="$1/$RUN_OWNER_FILE" pid recorded current
+  [ -f "$claim" ] || return 1
+  pid="$(sed -n 1p "$claim" 2>/dev/null)"
+  recorded="$(sed -n 2p "$claim" 2>/dev/null)"
+  case "$pid" in ''|*[!0-9]*) return 1 ;; esac
+  [ "$pid" -gt 1 ] || return 1
+  kill -0 "$pid" 2>/dev/null || return 1
+  current="$(process_start_time "$pid")"
+  [ -n "$current" ] || return 1
+  [ -n "$recorded" ] || return 1
+  [ "$current" = "$recorded" ] || return 1
+  return 0
+}
+
 # THE RECONCILER FOR THE RUN THAT COULD NOT CLEAN UP AFTER ITSELF.
 #
 # `trap cleanup EXIT` covers a normal exit and a TERMed wrapper alike — bash
@@ -467,9 +535,17 @@ sweep_holders() {
 # fixture holders in the doctrine's sense
 # (`docs/specs/2026-08-15-named-reconciler-doctrine-design.md`): a background
 # pass that enumerates ground truth — the run roots actually on disk — compares
-# it against intent (nothing older than a day is anybody's), and reclaims the
-# difference. Every run is a sweep, so the machine self-heals as soon as anyone
-# tests again, and there is no timer, no daemon and no state to keep.
+# it against intent, and reclaims the difference. Every run is a sweep, so the
+# machine self-heals as soon as anyone tests again, and there is no timer, no
+# daemon and no scheduler.
+#
+# THE DISCRIMINATOR IS TWO-PART, AND THE SECOND HALF IS WHY THIS CAN KILL AT
+# ALL. Age says nobody is coming back — no run lasts a day. `run_root_is_live`
+# says whether anybody is still there, from a claim the owning run writes into
+# its own root. Age alone would be a proxy, and the one case it reads wrong is
+# the expensive one: a WEDGED run stops writing, so its root ages exactly like
+# an abandoned one while everything inside it is still in use. Both must agree
+# before anything is signalled.
 #
 # ORDER MATTERS: the processes go first and the files second, for the same
 # reason the tmux sweep runs before its `rm -rf`. Removing a socket out from
@@ -490,6 +566,9 @@ reclaim_abandoned_run_roots() {
   [ -d "$dir" ] || return 0
   while IFS= read -r root; do
     [ -n "$root" ] || continue
+    # Age says nobody is coming back for it; the claim file can still say
+    # somebody is. A wedged run looks exactly like an abandoned one to `find`.
+    run_root_is_live "$root" && continue
     sweep_tmux_servers "$root"
     sweep_holders "$root"
     rm -rf "$root" 2>/dev/null || true
@@ -852,6 +931,12 @@ reclaim_abandoned_run_roots "$RUN_ROOT_DIR"
 # starts failing at once. `scripts/test.test.sh` asserts the budget so a
 # refactor that moves it cannot land quietly.
 scratch_home="$(mktemp -d "$RUN_ROOT_DIR/${RUN_ROOT_PREFIX}XXXXXXXX")"
+# Claimed IMMEDIATELY, before anything slow happens: everything after this line
+# — the build, the suite, a wait in the admission queue — is time during which
+# this run could wedge, and a claim written later would leave a window in which
+# it looks abandoned. The claim is what stops the reconciler above from ever
+# reclaiming a run that is merely stuck rather than gone.
+claim_run_root "$scratch_home"
 tmux_tmpdir="$scratch_home/tmux"
 
 # CLEANUP IS PROCESSES FIRST, FILES SECOND. `rm -rf` unlinks; it does not kill,

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -48,6 +48,31 @@
 #      every test passed. This is now a backstop rather than the primary
 #      guard; see "WHY THE TRIPWIRE SUPERSEDES THE FINGERPRINT".
 #
+# WHAT THE FENCE CANNOT DO ON ITS OWN: KILL A PROCESS. Containment is about
+# paths, and two of the things a run leaves behind are not files. A tmux server
+# outlives the socket that named it, and a `TBDHolder` outlives the test process
+# that spawned it BY DESIGN — it calls `setsid()` and ignores `SIGHUP` so it can
+# survive the daemon's death (`Sources/TBDHolder/Holder.swift`), which means it
+# survives a killed test process just as well, re-parents to launchd, and keeps
+# its job running. Deleting the scratch root does not touch either one. So
+# `cleanup` sweeps both by resource — a `kill-server` per socket file, and a
+# `kill -9` for whoever `lsof` says holds each holder rendezvous socket — before
+# the `rm -rf`, and never by name pattern: this machine runs live production
+# holders and other people's agents, and a `pkill -f` on the holder's name would
+# end them.
+#
+# AND THE RUN THAT NEVER REACHES ITS OWN TRAP. `trap cleanup EXIT` fires on a
+# fatal signal as well as a normal exit, but nothing in-process runs after a
+# SIGKILL, a panic or a power cut — and a holder inside that abandoned root
+# keeps running with nobody left who remembers it. Nothing in the product
+# reclaims one: `OrphanGC` enumerates the real `~/tbd/holders` and `AgentReaper`
+# works from `terminal` rows, and a fixture's socket is under a scratch root
+# with no row anywhere. `reclaim_abandoned_run_roots` is the named reconciler
+# for that case (docs/specs/2026-08-15-named-reconciler-doctrine-design.md): at
+# START-UP, every sibling run root older than a day gets the same two sweeps and
+# then `rm -rf`. Every run is a sweep, so the machine heals as soon as anybody
+# tests again.
+#
 # READING A PERMISSION-DENIED FAILURE. If a test under this wrapper fails with
 # "You don't have permission to save the file …" or `EACCES`/`NSFileWriteNoPermissionError`
 # on a path ending in `/tbd/…` or `/.claude/…`, that is not a broken machine and
@@ -302,6 +327,175 @@ require_owned_dir_after_mkdir() {
   [ -d "$path" ] || fence_bail "$what is not a directory: $path"
   owner="$(stat -f '%u' "$path")"
   [ "$owner" = "$(id -u)" ] || fence_bail "$what is owned by uid $owner, not $(id -u): $path"
+}
+
+# WHERE A RUN ROOT LIVES, IN ONE PLACE. The mint below and the reconciler above
+# it have to agree on both halves: a reconciler looking in the wrong directory,
+# or for the wrong prefix, sweeps nothing and says nothing about it. `/tmp`
+# rather than `$TMPDIR` for the `sun_path` reason spelled out at the mint.
+RUN_ROOT_DIR="/tmp"
+RUN_ROOT_PREFIX="tbd-test-home."
+
+# How old a sibling run root has to be before it is certainly abandoned. No run
+# lasts a day — the nightly stress harness mints a fresh root per iteration —
+# so age alone is a safe discriminator, and one that needs no scheduler, no
+# daemon and no bookkeeping file. A run still in flight is hours away from it.
+ABANDONED_RUN_ROOT_MINUTES=1440
+
+# THE SWEEP KILLS SERVERS; THE `rm -rf` ONLY REMOVES FILES. Those are not the
+# same leak, and the expensive one is the process: unlinking a socket out from
+# under a live tmux server leaves it running forever with nothing able to reach
+# it. So every socket the run created is issued a `kill-server` BEFORE the
+# scratch dir goes away. Most will already be dead — a dead server's file is
+# still there, because tmux never unlinks one — so errors are ignored throughout.
+#
+# It takes the run root as an argument rather than reading the global, because
+# `reclaim_abandoned_run_roots` runs it against somebody else's abandoned root.
+sweep_tmux_servers() {
+  local root="${1:-}" tmux_bin socket_dir socket
+  tmux_bin="$(command -v tmux || true)"
+  # No tmux on PATH means no server this run could have started.
+  [ -n "$tmux_bin" ] || return 0
+  [ -n "$root" ] || return 0
+  socket_dir="$root/tmux/tmux-$(id -u)"
+  [ -d "$socket_dir" ] || return 0
+  for socket in "$socket_dir"/*; do
+    # `-e` rather than `-S`: it skips the unmatched-glob case, and tmux owns
+    # this directory exclusively, so anything in it is one of its sockets.
+    [ -e "$socket" ] || continue
+    "$tmux_bin" -S "$socket" kill-server >/dev/null 2>&1 || true
+  done
+  return 0
+}
+
+# Every rendezvous socket a holder fixture may have bound under `$1`.
+#
+# Two depths, and both are real. A holder fixture mints its own short root
+# (`fencedScratchRoot`) directly under the run root, so its socket is
+# `<run root>/<prefix>-xxxxxxxx/holders/<uuid>.sock` — depth 3. Anything that
+# spawns a holder through the plain fenced `TBD_HOME` instead lands at
+# `<run root>/sanctioned/tbd/holders/<uuid>.sock` — depth 4. `-maxdepth 4`
+# covers both and bounds the walk, which matters because the sanctioned root
+# also holds profile directories and git checkouts.
+holder_sockets_under() {
+  local root="${1:-}"
+  [ -n "$root" ] || return 0
+  [ -d "$root" ] || return 0
+  # `-H` for the reason spelled out at `reclaim_abandoned_run_roots`: a run root
+  # reached through `/tmp` is reached through a symlink, and find descends into
+  # a symlinked STARTING POINT only when told to.
+  find -H "$root" -maxdepth 4 -path '*/holders/*.sock' 2>/dev/null || true
+}
+
+# THE HOLDER SWEEP, AND WHY `rm -rf` IS NOT ENOUGH ON ITS OWN.
+#
+# A `TBDHolder` is built to outlive the thing that spawned it: it calls
+# `setsid()` and ignores `SIGHUP` on purpose (`Sources/TBDHolder/Holder.swift`),
+# so the death of the test process that spawned it ends neither the holder nor
+# the job it supervises. It re-parents to launchd and keeps running. Nothing in
+# the product reclaims one of these: `OrphanGC`'s rowless-holder collector
+# enumerates the REAL `~/tbd/holders`, a fixture's socket is under this scratch
+# root instead, and `AgentReaper`'s holder leg works from `terminal` rows that a
+# fixture's in-memory database never had. One measured instance ran for 24 hours
+# with its job still looping.
+#
+# BY RESOURCE, NEVER BY PATTERN. This machine runs other people's agents and
+# live production holders, so `pkill -f TBDHolder` would kill somebody's real
+# session. The socket path is unique to this run and lives inside a directory
+# this run created, so the only processes that can hold it open are this run's
+# own — which makes "who has this exact file open" the safe discriminator and
+# the name of the binary an unsafe one.
+#
+# `-a` IS LOAD-BEARING. lsof ORs its selection options by default, so
+# `lsof -t -U <path>` means "every unix-socket holder on the machine, OR this
+# path" and answers with hundreds of pids — every process with any unix socket
+# open, which on this box is most of them. `-a` ANDs them instead. Getting this
+# wrong does not fail loudly; it kills the machine.
+#
+# CHILDREN ARE ENUMERATED BEFORE THE PARENT DIES, because a holder's job
+# re-parents to launchd the moment the holder is gone and no `pgrep -P` can
+# reach it afterwards.
+#
+# WHAT THIS DELIBERATELY DOES NOT COVER, so the layering is not mistaken for a
+# hole. A socket is the only safe handle on a holder, so a holder whose socket
+# is ALREADY GONE is invisible here — and a fixture teardown that ran and missed
+# removes its scratch root, socket included, before this ever looks. That case
+# belongs to the fixture, which remembers the pids it spawned and sweeps them
+# identity-checked (`HibernationFixture.sweepRememberedProcesses`); this sweep
+# owns the case where no teardown ran at all, which is the one where the socket
+# is still there. The alternative — matching the holder's argv or its name —
+# is what must never be done: this machine runs live production holders and
+# other people's agents, and no pattern can tell them from ours.
+sweep_holders() {
+  local root="${1:-}" lsof_bin socket owners pid children child
+  lsof_bin="$(command -v lsof || true)"
+  # No lsof means no way to ask who owns the socket, and guessing is exactly
+  # what this must not do.
+  [ -n "$lsof_bin" ] || return 0
+  while IFS= read -r socket; do
+    [ -n "$socket" ] || continue
+    # A socket whose owner is already gone — the ordinary case, since a holder
+    # that exits cleanly unlinks it and one that was killed leaves the file
+    # behind — answers nothing and costs nothing. `rm -rf` removes the file.
+    owners="$("$lsof_bin" -t -a -U "$socket" 2>/dev/null || true)"
+    [ -n "$owners" ] || continue
+    for pid in $owners; do
+      case "$pid" in ''|*[!0-9]*) continue ;; esac
+      [ "$pid" -gt 1 ] || continue
+      children="$(pgrep -P "$pid" 2>/dev/null || true)"
+      kill -9 "$pid" 2>/dev/null || true
+      for child in $children; do
+        case "$child" in ''|*[!0-9]*) continue ;; esac
+        [ "$child" -gt 1 ] || continue
+        kill -9 "$child" 2>/dev/null || true
+      done
+    done
+  done < <(holder_sockets_under "$root")
+  return 0
+}
+
+# THE RECONCILER FOR THE RUN THAT COULD NOT CLEAN UP AFTER ITSELF.
+#
+# `trap cleanup EXIT` covers a normal exit and a TERMed wrapper alike — bash
+# runs an EXIT trap on a fatal signal too. What no in-process teardown can cover
+# is a SIGKILLed wrapper, a panicked kernel or a machine that lost power
+# mid-run: the trap never runs, the scratch root survives, and any holder inside
+# it keeps running with nobody left who remembers it.
+#
+# So the reclaim for that case is somebody ELSE's run, at start-up, over the
+# siblings this directory has accumulated. It is the named reconciler for
+# fixture holders in the doctrine's sense
+# (`docs/specs/2026-08-15-named-reconciler-doctrine-design.md`): a background
+# pass that enumerates ground truth — the run roots actually on disk — compares
+# it against intent (nothing older than a day is anybody's), and reclaims the
+# difference. Every run is a sweep, so the machine self-heals as soon as anyone
+# tests again, and there is no timer, no daemon and no state to keep.
+#
+# ORDER MATTERS: the processes go first and the files second, for the same
+# reason the tmux sweep runs before its `rm -rf`. Removing a socket out from
+# under a live holder leaves the holder running with nothing able to reach it.
+#
+# `-user` and `-type d` keep it to directories this uid owns — `/tmp` is mode
+# 1777, so anybody can create a name that matches — and a symlink is `-type l`,
+# so a planted one is never followed and never removed.
+#
+# `-H` IS NOT OPTIONAL HERE, AND ITS ABSENCE FAILS SILENTLY. On darwin `/tmp` is
+# itself a symlink to `/private/tmp`, and find will not descend into a symlinked
+# starting point unless told to: without `-H` this enumerates exactly nothing,
+# exits 0, and reclaims nothing, forever. `-H` follows only the paths named on
+# the command line, so a symlink planted INSIDE the directory is still never
+# followed.
+reclaim_abandoned_run_roots() {
+  local dir="${1:-$RUN_ROOT_DIR}" root
+  [ -d "$dir" ] || return 0
+  while IFS= read -r root; do
+    [ -n "$root" ] || continue
+    sweep_tmux_servers "$root"
+    sweep_holders "$root"
+    rm -rf "$root" 2>/dev/null || true
+  done < <(find -H "$dir" -maxdepth 1 -type d -name "$RUN_ROOT_PREFIX*" \
+             -user "$(id -u)" -mmin "+$ABANDONED_RUN_ROOT_MINUTES" 2>/dev/null || true)
+  return 0
 }
 
 # THE SHARED ADMISSION LOCK. The branches mirror `_lock_path()` in
@@ -598,6 +792,12 @@ if [ "$fingerprint" -eq 1 ]; then
   fingerprint_before="$(scripts/tbd-home-fingerprint.sh)"
 fi
 
+# THE SIBLING ROOTS COME FIRST, BEFORE THIS RUN MINTS ONE OF ITS OWN. Running
+# it here rather than at exit is what makes it a reconciler rather than a second
+# teardown: it reclaims what runs that never reached their own trap left behind,
+# and it cannot see — or delete — the root this run is about to create.
+reclaim_abandoned_run_roots "$RUN_ROOT_DIR"
+
 # `/tmp`, not `mktemp -d`'s default `$TMPDIR`: on darwin TMPDIR is a ~50-char
 # path under /var/folders, and `sun_path` for a unix socket caps at ~104 bytes,
 # so `$TMPDIR/<scratch>/sock` can overflow.
@@ -651,35 +851,21 @@ fi
 # this directory any deeper spends that headroom and every live tmux test
 # starts failing at once. `scripts/test.test.sh` asserts the budget so a
 # refactor that moves it cannot land quietly.
-scratch_home="$(mktemp -d /tmp/tbd-test-home.XXXXXXXX)"
+scratch_home="$(mktemp -d "$RUN_ROOT_DIR/${RUN_ROOT_PREFIX}XXXXXXXX")"
 tmux_tmpdir="$scratch_home/tmux"
 
-# THE SWEEP KILLS SERVERS; THE `rm -rf` ONLY REMOVES FILES. Those are not the
-# same leak, and the expensive one is the process: unlinking a socket out from
-# under a live tmux server leaves it running forever with nothing able to reach
-# it. So every socket the run created is issued a `kill-server` BEFORE the
-# scratch dir goes away. Most will already be dead — a dead server's file is
-# still there (see above) — so errors are ignored throughout.
-sweep_tmux_servers() {
-  local tmux_bin socket_dir socket
-  tmux_bin="$(command -v tmux || true)"
-  # No tmux on PATH means no server this run could have started.
-  [ -n "$tmux_bin" ] || return 0
-  # `${var:-}` — defensive under `set -u`. The assignment above precedes the
-  # trap today; this keeps that ordering from being load-bearing.
-  [ -n "${tmux_tmpdir:-}" ] || return 0
-  socket_dir="$tmux_tmpdir/tmux-$(id -u)"
-  [ -d "$socket_dir" ] || return 0
-  for socket in "$socket_dir"/*; do
-    # `-e` rather than `-S`: it skips the unmatched-glob case, and tmux owns
-    # this directory exclusively, so anything in it is one of its sockets.
-    [ -e "$socket" ] || continue
-    "$tmux_bin" -S "$socket" kill-server >/dev/null 2>&1 || true
-  done
-  return 0
+# CLEANUP IS PROCESSES FIRST, FILES SECOND. `rm -rf` unlinks; it does not kill,
+# and both leaks this run can leave behind are processes. A tmux server whose
+# socket is deleted keeps running with nothing able to reach it; a holder
+# `setsid`s away from its spawner on purpose and outlives the whole test process
+# regardless. So both sweeps run BEFORE the scratch dir goes away, and both take
+# it as an argument so `reclaim_abandoned_run_roots` can run the same two passes
+# over a root some earlier run never got to.
+cleanup() {
+  sweep_tmux_servers "$scratch_home"
+  sweep_holders "$scratch_home"
+  rm -rf "$scratch_home"
 }
-
-cleanup() { sweep_tmux_servers; rm -rf "$scratch_home"; }
 # EXIT alone is sufficient, including when this wrapper is killed:
 # `scripts/nightly-flake-stress.sh` TERMs it when its outer deadline fires, and
 # bash runs an EXIT trap on a fatal signal as well as on a normal exit —

--- a/scripts/test.test.sh
+++ b/scripts/test.test.sh
@@ -7,6 +7,14 @@
 # in the macOS `lint` job while the other script harnesses run on `ubuntu-latest`
 # (.github/workflows/test.yml).
 #
+# AND IT MUST BE VERIFIED WITH `/bin/bash`, WHICH ON MACOS IS 3.2. A developer
+# with Homebrew's bash first on `PATH` is running 5.x, where several constructs
+# 3.2 cannot parse work fine — a `case` with an empty-string pattern nested
+# inside `"$( )"` inside another quoted string is the one that has already got
+# through review here. It fails at RUN time, as a syntax error from inside a
+# command substitution, so `bash -n` on 5.x does not see it either. Check with
+# `/bin/bash scripts/test.test.sh`, not `bash scripts/test.test.sh`.
+#
 # ZERO BUILDS, ZERO CPU LOAD, AND IT NEVER TOUCHES THE REAL ~/tbd, ~/.claude,
 # ~/.codex, ~/Library/Logs/TBD OR THE REAL TMUX SOCKET DIRECTORY. Every case
 # here drives the wrapper against a synthetic home under a throwaway fixture
@@ -449,7 +457,19 @@ kill_pids() {
   return 0
 }
 
-dir_exists() { if [ -d "$1" ]; then echo yes; else echo no; fi; }
+dir_exists()  { if [ -d "$1" ]; then echo yes; else echo no; fi; }
+file_exists() { if [ -f "$1" ]; then echo yes; else echo no; fi; }
+
+# Whether `$1` is a decimal pid. A helper rather than an inline `case` inside a
+# command substitution: macOS ships bash 3.2, whose parser cannot handle a
+# `case` with an empty-string pattern nested inside `"$( )"` inside another
+# quoted string, and the failure is a syntax error at RUN time.
+looks_like_a_pid() {
+  case "${1:-}" in
+    ''|*[!0-9]*) echo no ;;
+    *)           echo yes ;;
+  esac
+}
 
 # A short parent for fixture run roots, and it has to be short for the same
 # reason `scripts/test.sh` mints the real one in `/tmp`: a rendezvous socket
@@ -1420,7 +1440,7 @@ test_an_aged_root_with_no_claim_is_reclaimed() {
   old="$(mk_run_root "$roots" "unclaimed")"
   age_run_root "$old"
   assert_eq "the fixture really has no claim in it" "no" \
-    "$(if [ -f "$old/$RUN_OWNER_FILE" ]; then echo yes; else echo no; fi)"
+    "$(file_exists "$old/$RUN_OWNER_FILE")"
   reclaim_abandoned_run_roots "$roots"
   assert_eq "an unclaimed aged root is reclaimed" "no" "$(dir_exists "$old")"
   rm -rf "$roots"
@@ -1438,11 +1458,11 @@ test_a_real_run_claims_its_root_with_its_own_live_pid() {
   assert_ok "the run is unaffected" "$RUN_RC"
   claim="$fix/observed-claim"
   assert_eq "the claim existed during the run" "yes" \
-    "$(if [ -f "$claim" ]; then echo yes; else echo no; fi)"
+    "$(file_exists "$claim")"
   owner="$(sed -n 1p "$claim" 2>/dev/null)"
   recorded="$(sed -n 2p "$claim" 2>/dev/null)"
   assert_eq "it names a pid" "yes" \
-    "$(case "$owner" in ''|*[!0-9]*) echo no ;; *) echo yes ;; esac)"
+    "$(looks_like_a_pid "$owner")"
   # Both halves come from inside the run, because neither is checkable from out
   # here: the wrapper has exited by now, so its pid names nothing and its start
   # time cannot be re-derived. That is the whole reason the claim is written at
@@ -1463,7 +1483,7 @@ test_the_run_root_claim_is_load_bearing() {
   run_script "$mutant" "$fix"
   RUN_ENV=()
   assert_eq "without the claim the run leaves none" "no" \
-    "$(if [ -f "$fix/observed-claim" ]; then echo yes; else echo no; fi)"
+    "$(file_exists "$fix/observed-claim")"
   rmfix "$fix"
 }
 

--- a/scripts/test.test.sh
+++ b/scripts/test.test.sh
@@ -148,6 +148,34 @@ if [ -n "${FAKE_SWIFT_TMUX_SOCKETS:-}" ]; then
   mkdir -p "$socket_dir"
   for socket_name in $FAKE_SWIFT_TMUX_SOCKETS; do : > "$socket_dir/$socket_name"; done
 fi
+# Leave a LIVE holder behind, the way a leaked fixture holder does: a process
+# that owns the rendezvous socket plus a job it supervises, in the parent/child
+# relation `pgrep -P` reads. FAKE_SWIFT_HOLDERS names the fixture roots to mint
+# one under, mirroring `fencedScratchRoot(prefix:)`; each holder's pid pair is
+# appended to "$FAKE_SWIFT_DUMP.holders" as "<holder> <job>".
+if [ -n "${FAKE_SWIFT_HOLDERS:-}" ]; then
+  for holder_name in $FAKE_SWIFT_HOLDERS; do
+    holder_dir="${TBD_TEST_SCRATCH_ROOT:-/nonexistent}/$holder_name/holders"
+    mkdir -p "$holder_dir"
+    "$FAKE_HOLDER_START" "$holder_dir/$holder_name.sock" \
+      "$holder_dir/$holder_name.child" >> "$FAKE_SWIFT_DUMP.holders"
+  done
+fi
+# Leave a DEAD one: the ordinary case, and a genuine orphaned socket inode
+# rather than a regular file standing in for one. A holder that is SIGKILLed
+# never unlinks its socket, so binding one and killing the binder is what
+# actually produces the shape the sweep has to tolerate.
+if [ -n "${FAKE_SWIFT_DEAD_HOLDER_SOCKETS:-}" ]; then
+  for holder_name in $FAKE_SWIFT_DEAD_HOLDER_SOCKETS; do
+    holder_dir="${TBD_TEST_SCRATCH_ROOT:-/nonexistent}/$holder_name/holders"
+    mkdir -p "$holder_dir"
+    # Bind one and SIGKILL it: the same binder the live case uses, killed
+    # before it can unlink anything, which is exactly how a real holder leaves
+    # a socket inode behind.
+    kill -9 $("$FAKE_HOLDER_START" "$holder_dir/$holder_name.sock" \
+      "$holder_dir/$holder_name.child") 2>/dev/null
+  done
+fi
 # Unquoted on purpose: FAKE_SWIFT_RC is a space-separated list.
 fake_swift_codes=(${FAKE_SWIFT_RC:-0})
 fake_swift_index=$((fake_swift_invocation - 1))
@@ -216,6 +244,8 @@ run_script() {
                  -u TBD_SWIFT_HEARTBEAT_SECONDS -u TBD_SWIFT_ALLOW_ORPHAN \
                  -u FAKE_SWIFT_DISARM -u FAKE_SWIFT_LEAK -u FAKE_SWIFT_RC \
                  -u FAKE_SWIFT_TMUX_SOCKETS -u FAKE_SWIFT_TEST_COUNT \
+                 -u FAKE_SWIFT_HOLDERS -u FAKE_SWIFT_DEAD_HOLDER_SOCKETS \
+                 -u FAKE_HOLDER_START \
                  -u TBD_REMOTE_VERIFY -u TBD_REMOTE_VERIFY_YIELD_SECONDS \
                  -u TBD_SWIFT_QUEUE_YIELD_SECONDS \
                  -u FAKE_REMOTE_VERIFY_RC -u FAKE_REMOTE_VERIFY_LOG \
@@ -309,6 +339,117 @@ sun_path_verdict() {
     echo "over (${#path} > $SUN_PATH_BUDGET)"
   fi
 }
+
+# A stand-in for a leaked `TBDHolder`, and for the job it supervises.
+#
+# The real thing cannot be used here: it is a compiled product binary, and this
+# harness builds nothing. What the sweep actually keys on is not the binary at
+# all — it is "who has this rendezvous socket open", so anything that binds the
+# socket and parents a job stands in exactly. `nc -lU` binds it; `exec` keeps the
+# socket's owner and the job's parent the same pid, which is what a real holder
+# is; and `sleep` is the job. Both are `kill -9`able and neither writes anywhere.
+mk_fake_holder() {
+  local fix="$1"
+  mkdir -p "$fix/bin"
+  cat > "$fix/bin/fake-holder" <<'HOLDER'
+#!/usr/bin/env bash
+# $1 rendezvous socket to bind, $2 file to record the job's pid in.
+#
+# The job is started BEFORE the exec so it is the socket owner's own child, the
+# relation the sweep reads with `pgrep -P`, and the pid file is written before
+# the bind so a caller that waits for the socket has a complete pid file.
+#
+# PYTHON RATHER THAN `nc -lU`, WHICH LOOKS LIKE THE OBVIOUS CHOICE AND IS NOT:
+# nc reads its stdin and exits the moment it sees EOF, so a binder started with
+# its stdio detached — which it must be, see `start-fake-holder` — is gone
+# before anything can sweep it, and the case then passes for the wrong reason.
+# A socket that is bound and simply held has no such behaviour.
+sleep 600 &
+echo $! > "$2"
+exec python3 -c '
+import socket, sys, time
+listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+listener.bind(sys.argv[1])
+listener.listen(1)
+time.sleep(3600)
+' "$1"
+HOLDER
+  chmod +x "$fix/bin/fake-holder"
+  cat > "$fix/bin/start-fake-holder" <<'START'
+#!/usr/bin/env bash
+# Starts one stand-in holder and prints "<holder pid> <job pid>".
+#
+# ITS STDIO IS DETACHED, and that is load-bearing rather than tidy: `run_script`
+# reads a run through a command substitution, and a background process holding
+# that pipe open would block the substitution until the process died — which is
+# exactly what the "left alone" cases assert does not happen.
+socket="$1"; child_file="$2"
+"$(dirname "$0")/fake-holder" "$socket" "$child_file" >/dev/null 2>&1 </dev/null &
+holder_pid=$!
+waited=0
+while [ ! -S "$socket" ] && [ "$waited" -lt 100 ]; do sleep 0.05; waited=$((waited + 1)); done
+printf '%s %s\n' "$holder_pid" "$(cat "$child_file" 2>/dev/null)"
+START
+  chmod +x "$fix/bin/start-fake-holder"
+}
+
+# The pid pairs the stub left behind, space-separated on one line.
+holder_pids_of() { tr '\n' ' ' < "$1/swift-invocation.holders" 2>/dev/null | sed 's/ *$//'; }
+
+# Which of the given pids can still be signalled, space-joined. Immediate: for
+# the mutation cases, where the answer is "all of them" and waiting proves
+# nothing.
+live_pids() {
+  local pid out=""
+  for pid in "$@"; do
+    if kill -0 "$pid" 2>/dev/null; then out="${out:+$out }$pid"; fi
+  done
+  printf '%s\n' "$out"
+}
+
+# The same question with a five-second bound, for the cases that assert a pid is
+# GONE. A `kill -9`ed process is a zombie until whoever adopted it reaps it, and
+# `kill -0` answers yes for a zombie — so an immediate check there would be
+# racy in the direction that fails a working sweep.
+pids_still_alive() {
+  local attempts=50 remaining
+  while [ "$attempts" -gt 0 ]; do
+    remaining="$(live_pids "$@")"
+    [ -n "$remaining" ] || break
+    attempts=$((attempts - 1))
+    sleep 0.1
+  done
+  printf '%s\n' "$remaining"
+}
+
+# Never by pattern, here either: every pid this file signals is one it captured.
+kill_pids() {
+  local pid
+  for pid in "$@"; do kill -9 "$pid" 2>/dev/null; done
+  return 0
+}
+
+dir_exists() { if [ -d "$1" ]; then echo yes; else echo no; fi; }
+
+# A short parent for fixture run roots, and it has to be short for the same
+# reason `scripts/test.sh` mints the real one in `/tmp`: a rendezvous socket
+# under it is bound against a 104-byte `sun_path`, and `$TMPDIR` on darwin is a
+# ~49-byte `/var/folders/...` path that leaves no room for one. A stand-in
+# holder under a too-long path dies on the bind, and every assertion about
+# sweeping it then passes for the wrong reason.
+mk_roots_dir() { mktemp -d "/tmp/testsh-roots.XXXXXX"; }
+
+# A run root under `$1`, named the way `mktemp` names a real one.
+mk_run_root() {
+  local root="$1/${RUN_ROOT_PREFIX}$2"
+  mkdir -p "$root"
+  : > "$root/marker"
+  printf '%s\n' "$root"
+}
+
+# Ages a directory past `ABANDONED_RUN_ROOT_MINUTES` without waiting a day for
+# it. 25 hours, so the case is not sitting on the boundary.
+age_run_root() { touch -t "$(date -v-25H +%Y%m%d%H%M)" "$1"; }
 
 # ---------------------------------------------------------------------------
 # 1. The symlink refusal — the guard that could chmod 000 a real ~/tbd
@@ -912,7 +1053,7 @@ test_cleanup_sweeps_the_runs_tmux_servers() {
 # exactly the silent failure: the files are gone and the servers are not.
 test_cleanup_sweep_is_load_bearing() {
   local fix mutant; fix="$(mkfix)"; mk_stub_tmux "$fix"
-  mutant="$(mutant_of "$SCRIPT" 's/sweep_tmux_servers; rm -rf/rm -rf/')"
+  mutant="$(mutant_of "$SCRIPT" '/^  sweep_tmux_servers "\$scratch_home"$/d')"
   RUN_ENV=(PATH="$fix/tmuxbin:$PATH" FAKE_TMUX_LOG="$fix/tmux-invocations"
            FAKE_SWIFT_TMUX_SOCKETS="tbd-sweep-a tbd-sweep-b")
   run_script "$mutant" "$fix"
@@ -958,6 +1099,212 @@ test_fingerprint_detects_a_leaked_tmux_socket() {
   assert_contains "the entry is named" "$RUN_OUT" "+  <tmux-sockets>/tbd-leaked-socket"
   assert_contains "and the fix is named" "$RUN_OUT" "the fix is TMUX_TMPDIR"
   rmfix "$fix"
+}
+
+# ---------------------------------------------------------------------------
+# 6b. The holder sweep, and the reconciler for the run that never reached its
+#     own trap
+#
+# A `TBDHolder` is built to OUTLIVE its spawner: it calls `setsid()` and ignores
+# `SIGHUP` (`Sources/TBDHolder/Holder.swift`) so it can survive the daemon's
+# death. A fixture's holder inherits that, so it survives the test process too,
+# re-parents to launchd, and keeps its job running — and `rm -rf` on the scratch
+# root unlinks its socket without touching it. Nothing in the product reclaims
+# one: `OrphanGC`'s rowless-holder collector enumerates the real `~/tbd/holders`,
+# and `AgentReaper`'s holder leg works from `terminal` rows a fixture's in-memory
+# database never had. One measured instance ran for 24 hours with its job still
+# looping.
+#
+# THE SWEEP IS BY RESOURCE, NEVER BY PATTERN, and that is the constraint the
+# cases here are shaped around: this machine runs live production holders and
+# other people's agents, so a `pkill` on the binary's name would end somebody
+# else's session. Only "who has this exact socket open" is safe.
+# ---------------------------------------------------------------------------
+
+test_cleanup_kills_a_leaked_holder_and_its_job() {
+  local fix pids; fix="$(mkfix)"; mk_fake_holder "$fix"
+  RUN_ENV=(FAKE_SWIFT_HOLDERS="tbdhib-aaaaaaaa"
+           FAKE_HOLDER_START="$fix/bin/start-fake-holder")
+  run_wrapper "$fix"
+  RUN_ENV=()
+  assert_ok "a run that leaked a holder still exits 0" "$RUN_RC"
+  pids="$(holder_pids_of "$fix")"
+  assert_eq "the stub really left a holder AND a job behind" "2" \
+    "$(echo $pids | wc -w | tr -d ' ')"
+  assert_eq "and both are gone once cleanup has run" "" "$(pids_still_alive $pids)"
+  kill_pids $pids
+  rmfix "$fix"
+}
+
+# MUTATION. Drop the sweep and the scratch dir still disappears — which is
+# exactly the silent failure this closes: the socket is gone and the holder is
+# not, so nothing can ever reach it and nothing will ever reclaim it.
+test_the_holder_sweep_is_load_bearing() {
+  local fix mutant pids; fix="$(mkfix)"; mk_fake_holder "$fix"
+  mutant="$(mutant_of "$SCRIPT" '/^  sweep_holders "\$scratch_home"$/d')"
+  RUN_ENV=(FAKE_SWIFT_HOLDERS="tbdhib-bbbbbbbb"
+           FAKE_HOLDER_START="$fix/bin/start-fake-holder")
+  run_script "$mutant" "$fix"
+  RUN_ENV=()
+  assert_ok "the mutant run is green (a sweep is not a correctness gate)" "$RUN_RC"
+  pids="$(holder_pids_of "$fix")"
+  assert_eq "without the sweep the holder and its job outlive the run" \
+    "$pids" "$(live_pids $pids)"
+  kill_pids $pids
+  rmfix "$fix"
+}
+
+# THE ORDINARY CASE, AND THE ONE A NAIVE SWEEP GETS WRONG. Almost every socket
+# the sweep finds has nobody behind it — a holder that exits cleanly unlinks its
+# socket, and one that is killed leaves the file with no owner at all. `lsof`
+# answers nothing and exits non-zero for those, which must be a skip rather than
+# a failed run.
+test_a_holder_socket_with_no_owner_is_swept_without_error() {
+  local fix; fix="$(mkfix)"
+  RUN_ENV=(FAKE_SWIFT_DEAD_HOLDER_SOCKETS="tbdh7-cccccccc")
+  run_wrapper "$fix"
+  RUN_ENV=()
+  assert_ok "an orphaned socket does not fail the run" "$RUN_RC"
+  assert_missing "and nothing is said about it" "$RUN_OUT" "lsof"
+  rmfix "$fix"
+}
+
+# THE AGE FILTER IS THE WHOLE DISCRIMINATOR, so both sides of it are pinned. A
+# run still in flight owns its root, and reclaiming one would delete a `TBD_HOME`
+# a live suite is writing into.
+test_a_run_root_minted_today_is_left_alone() {
+  local roots recent; roots="$(mk_roots_dir)"
+  recent="$(mk_run_root "$roots" "recent")"
+  reclaim_abandoned_run_roots "$roots"
+  assert_eq "a root that could still be in flight survives" "yes" "$(dir_exists "$recent")"
+  rm -rf "$roots"
+}
+
+test_an_abandoned_run_root_is_reclaimed() {
+  local roots old; roots="$(mk_roots_dir)"
+  old="$(mk_run_root "$roots" "abandoned")"
+  age_run_root "$old"
+  reclaim_abandoned_run_roots "$roots"
+  assert_eq "a root older than a day is reclaimed" "no" "$(dir_exists "$old")"
+  rm -rf "$roots"
+}
+
+# MUTATION. Widen the age filter to "anything at all" and a live run's root goes
+# with it — the failure that would make this reconciler far worse than the leak.
+test_the_run_root_age_filter_is_load_bearing() {
+  local mutant roots recent; roots="$(mk_roots_dir)"
+  # `-mmin "+0"` would NOT be a widening: BSD find rounds the age UP to whole
+  # minutes and `+n` is a strict "more than", so a directory seconds old matches
+  # neither bound. Dropping the predicate is the real "no age filter".
+  mutant="$(mutant_of "$SCRIPT" 's/ -mmin "\+\$ABANDONED_RUN_ROOT_MINUTES"//')"
+  recent="$(mk_run_root "$roots" "recent")"
+  # shellcheck source=/dev/null
+  ( source "$mutant"; reclaim_abandoned_run_roots "$roots" )
+  assert_eq "without the age filter a live run's root is destroyed" "no" \
+    "$(dir_exists "$recent")"
+  rm -rf "$roots"
+}
+
+# PROCESSES FIRST, FILES SECOND — the reconciler runs the same two sweeps the
+# EXIT trap does, and this is the case that says so. Removing the root without
+# the sweep would leave the holder running with its socket unlinked, which is
+# the state that produced the 24-hour leak in the first place.
+test_an_abandoned_run_root_has_its_holder_killed_before_it_goes() {
+  local fix roots old pids; fix="$(mkfix)"; mk_fake_holder "$fix"
+  roots="$(mk_roots_dir)"
+  old="$(mk_run_root "$roots" "leaky")"
+  mkdir -p "$old/tbdhib-dddddddd/holders"
+  pids="$("$fix/bin/start-fake-holder" \
+    "$old/tbdhib-dddddddd/holders/dddddddd.sock" "$fix/leaky.child")"
+  # PROVE THE STAND-IN IS UP BEFORE ASSERTING IT WENT DOWN. A binder that died
+  # on its own — a `sun_path` overflow is the way it happens — would make the
+  # sweep assertion below pass with nothing swept.
+  assert_eq "the stand-in holder and its job are up" "$pids" "$(live_pids $pids)"
+  # After the socket exists, or creating it would refresh the root's mtime.
+  age_run_root "$old"
+  reclaim_abandoned_run_roots "$roots"
+  assert_eq "the abandoned root is gone" "no" "$(dir_exists "$old")"
+  assert_eq "and its holder and job went with it" "" "$(pids_still_alive $pids)"
+  kill_pids $pids
+  rm -rf "$roots"
+  rmfix "$fix"
+}
+
+# MUTATION. Reclaim the files without the processes and the leak survives its
+# own cleanup, invisibly.
+test_the_reconcilers_holder_sweep_is_load_bearing() {
+  local fix mutant roots old pids; fix="$(mkfix)"; mk_fake_holder "$fix"
+  mutant="$(mutant_of "$SCRIPT" '/^    sweep_holders "\$root"$/d')"
+  roots="$(mk_roots_dir)"
+  old="$(mk_run_root "$roots" "leaky")"
+  mkdir -p "$old/tbdhib-eeeeeeee/holders"
+  pids="$("$fix/bin/start-fake-holder" \
+    "$old/tbdhib-eeeeeeee/holders/eeeeeeee.sock" "$fix/leaky.child")"
+  assert_eq "the stand-in holder and its job are up" "$pids" "$(live_pids $pids)"
+  age_run_root "$old"
+  # shellcheck source=/dev/null
+  ( source "$mutant"; reclaim_abandoned_run_roots "$roots" )
+  assert_eq "the root is removed either way" "no" "$(dir_exists "$old")"
+  assert_eq "but without the sweep the holder outlives it" "$pids" "$(live_pids $pids)"
+  kill_pids $pids
+  rm -rf "$roots"
+  rmfix "$fix"
+}
+
+# THE CALL SITE, AGAINST THE DIRECTORY IT REALLY WATCHES. `RUN_ROOT_DIR` is
+# `/tmp` — every case in this file already has the wrapper mint its own run root
+# there — so this is the one property no fixture directory can show: that an
+# ordinary run reconciles its siblings on the way in, before it mints a root of
+# its own.
+#
+# The window a concurrent `scripts/test.sh` could reclaim this fixture root in is
+# the ~2 s of the run below, and in the `lint` job that runs this harness no
+# suite runs at all. If it ever does flake, the concurrent run did the sweep's
+# job for it.
+test_a_real_run_reclaims_an_abandoned_sibling_root() {
+  local fix abandoned; fix="$(mkfix)"
+  abandoned="$(mktemp -d "$RUN_ROOT_DIR/${RUN_ROOT_PREFIX}XXXXXXXX")"
+  : > "$abandoned/marker"
+  age_run_root "$abandoned"
+  run_wrapper "$fix"
+  assert_ok "the run itself is unaffected" "$RUN_RC"
+  assert_eq "the abandoned sibling is reclaimed on the way in" "no" \
+    "$(dir_exists "$abandoned")"
+  rm -rf "$abandoned"
+  rmfix "$fix"
+}
+
+# MUTATION. Drop the call and the sibling survives forever, which is the state
+# every run before this one left behind.
+test_the_startup_reconcile_call_is_load_bearing() {
+  local fix mutant abandoned; fix="$(mkfix)"
+  mutant="$(mutant_of "$SCRIPT" '/^reclaim_abandoned_run_roots "\$RUN_ROOT_DIR"$/d')"
+  abandoned="$(mktemp -d "$RUN_ROOT_DIR/${RUN_ROOT_PREFIX}XXXXXXXX")"
+  : > "$abandoned/marker"
+  age_run_root "$abandoned"
+  run_script "$mutant" "$fix"
+  assert_eq "without the call the abandoned sibling survives" "yes" \
+    "$(dir_exists "$abandoned")"
+  rm -rf "$abandoned"
+  rmfix "$fix"
+}
+
+# `-a` IS LOAD-BEARING, AND GETTING IT WRONG DOES NOT FAIL LOUDLY. lsof ORs its
+# selection options, so `lsof -t -U <path>` means "every unix-socket holder on
+# the machine, OR this path" and answers with hundreds of pids — most of the
+# process table on a developer box. The sweep would then `kill -9` all of them.
+# Pinned as text rather than driven, because the only way to drive it is to
+# perform the catastrophe.
+test_the_holder_lookup_ands_its_selectors() {
+  local body; body="$(cat "$SCRIPT")"
+  assert_contains "the socket lookup ANDs -U with the path" "$body" \
+    '"$lsof_bin" -t -a -U "$socket"'
+  assert_missing "and never ORs them" "$body" '"$lsof_bin" -t -U "$socket"'
+  # Comments stripped: the paragraphs above the sweep NAME the pattern kill in
+  # order to refuse it, and matching prose would make this fire on its own
+  # rationale.
+  assert_missing "no pattern kill is ever executed" \
+    "$(printf '%s\n' "$body" | grep -v '^[[:space:]]*#')" "pkill"
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/test.test.sh
+++ b/scripts/test.test.sh
@@ -345,9 +345,10 @@ sun_path_verdict() {
 # The real thing cannot be used here: it is a compiled product binary, and this
 # harness builds nothing. What the sweep actually keys on is not the binary at
 # all — it is "who has this rendezvous socket open", so anything that binds the
-# socket and parents a job stands in exactly. `nc -lU` binds it; `exec` keeps the
-# socket's owner and the job's parent the same pid, which is what a real holder
-# is; and `sleep` is the job. Both are `kill -9`able and neither writes anywhere.
+# socket and parents a job stands in exactly. A four-line `python3` binds and
+# holds it; `exec` keeps the socket's owner and the job's parent the same pid,
+# which is what a real holder is; and `sleep` is the job. Both are `kill -9`able
+# and neither writes anywhere.
 mk_fake_holder() {
   local fix="$1"
   mkdir -p "$fix/bin"

--- a/scripts/test.test.sh
+++ b/scripts/test.test.sh
@@ -176,6 +176,25 @@ if [ -n "${FAKE_SWIFT_DEAD_HOLDER_SOCKETS:-}" ]; then
       "$holder_dir/$holder_name.child") 2>/dev/null
   done
 fi
+# Copy the run's owner claim out while the run is still going. Read from inside
+# the fence, so what it captures is the claim as a LIVE run has it — the only
+# vantage point from which "the pid it names is this run's, and it is alive" is
+# a checkable statement.
+if [ -n "${FAKE_SWIFT_COPY_RUN_CLAIM:-}" ]; then
+  run_claim="${TBD_TEST_SCRATCH_ROOT:-/nonexistent}/.run-owner"
+  cp "$run_claim" "$FAKE_SWIFT_COPY_RUN_CLAIM" 2>/dev/null || true
+  # What the claim SAYS is only half of it; the other half is what the kernel
+  # says about the pid it names, asked here because the wrapper is still alive
+  # at this instant and will not be by the time the case reads any of it.
+  claimed_pid="$(sed -n 1p "$run_claim" 2>/dev/null)"
+  {
+    case "$claimed_pid" in
+      ''|*[!0-9]*) echo "not-a-pid" ;;
+      *) if kill -0 "$claimed_pid" 2>/dev/null; then echo alive; else echo dead; fi ;;
+    esac
+    ps -o lstart= -p "$claimed_pid" 2>/dev/null | head -1 | sed 's/^ *//; s/ *$//'
+  } > "$FAKE_SWIFT_COPY_RUN_CLAIM.observed" 2>/dev/null || true
+fi
 # Unquoted on purpose: FAKE_SWIFT_RC is a space-separated list.
 fake_swift_codes=(${FAKE_SWIFT_RC:-0})
 fake_swift_index=$((fake_swift_invocation - 1))
@@ -245,7 +264,7 @@ run_script() {
                  -u FAKE_SWIFT_DISARM -u FAKE_SWIFT_LEAK -u FAKE_SWIFT_RC \
                  -u FAKE_SWIFT_TMUX_SOCKETS -u FAKE_SWIFT_TEST_COUNT \
                  -u FAKE_SWIFT_HOLDERS -u FAKE_SWIFT_DEAD_HOLDER_SOCKETS \
-                 -u FAKE_HOLDER_START \
+                 -u FAKE_HOLDER_START -u FAKE_SWIFT_COPY_RUN_CLAIM \
                  -u TBD_REMOTE_VERIFY -u TBD_REMOTE_VERIFY_YIELD_SECONDS \
                  -u TBD_SWIFT_QUEUE_YIELD_SECONDS \
                  -u FAKE_REMOTE_VERIFY_RC -u FAKE_REMOTE_VERIFY_LOG \
@@ -451,6 +470,21 @@ mk_run_root() {
 # Ages a directory past `ABANDONED_RUN_ROOT_MINUTES` without waiting a day for
 # it. 25 hours, so the case is not sitting on the boundary.
 age_run_root() { touch -t "$(date -v-25H +%Y%m%d%H%M)" "$1"; }
+
+# A process this file owns, alive until it is killed, standing in for a wrapper
+# whose run has WEDGED rather than died. Echoes its pid.
+start_stub_run() {
+  sleep 600 >/dev/null 2>&1 </dev/null &
+  printf '%s\n' "$!"
+}
+
+# Writes a run root's owner claim by hand: "<pid>" then the kernel's start time
+# for it, which is the two-line shape `claim_run_root` writes.
+write_run_claim() {
+  local root="$1" pid="$2" start="${3:-}"
+  [ -n "$start" ] || start="$(process_start_time "$pid")"
+  printf '%s\n%s\n' "$pid" "$start" > "$root/$RUN_OWNER_FILE"
+}
 
 # ---------------------------------------------------------------------------
 # 1. The symlink refusal — the guard that could chmod 000 a real ~/tbd
@@ -1306,6 +1340,131 @@ test_the_holder_lookup_ands_its_selectors() {
   # rationale.
   assert_missing "no pattern kill is ever executed" \
     "$(printf '%s\n' "$body" | grep -v '^[[:space:]]*#')" "pkill"
+}
+
+# THE SECOND HALF OF THE DISCRIMINATOR. Age says nobody is coming back; the
+# claim file says whether anybody is still there. They are not redundant, and
+# the case that separates them is the expensive one: a run that WEDGES stops
+# writing, so its root ages exactly like an abandoned one while its holder, its
+# tmux servers and its `TBD_HOME` are all still in use. Reclaiming that would
+# `SIGKILL` a live run and delete its state.
+test_an_aged_root_whose_owner_is_alive_is_left_alone() {
+  local roots old owner; roots="$(mk_roots_dir)"
+  old="$(mk_run_root "$roots" "wedged")"
+  owner="$(start_stub_run)"
+  write_run_claim "$old" "$owner"
+  age_run_root "$old"
+  reclaim_abandoned_run_roots "$roots"
+  assert_eq "a wedged run's root survives its own age" "yes" "$(dir_exists "$old")"
+  assert_eq "and its owner is untouched" "$owner" "$(live_pids "$owner")"
+  kill_pids "$owner"
+  rm -rf "$roots"
+}
+
+# MUTATION. Drop the liveness check and age is the only discriminator again —
+# the finding this attestation answers.
+test_the_run_root_liveness_check_is_load_bearing() {
+  local mutant roots old owner; roots="$(mk_roots_dir)"
+  mutant="$(mutant_of "$SCRIPT" '/^    run_root_is_live "\$root" \&\& continue$/d')"
+  old="$(mk_run_root "$roots" "wedged")"
+  owner="$(start_stub_run)"
+  write_run_claim "$old" "$owner"
+  age_run_root "$old"
+  # shellcheck source=/dev/null
+  ( source "$mutant"; reclaim_abandoned_run_roots "$roots" )
+  assert_eq "without the check a live run's root is reclaimed on age alone" "no" \
+    "$(dir_exists "$old")"
+  kill_pids "$owner"
+  rm -rf "$roots"
+}
+
+# THE CLAIM IS ONLY AS GOOD AS ITS IDENTITY CHECK. A pid is free the instant its
+# corpse is collected, so a day-old claim naming a number some unrelated process
+# now holds must not immortalise the root — which is exactly what reading the
+# pid alone would do. The start time is what tells them apart.
+test_an_aged_root_whose_claimed_pid_was_reissued_is_reclaimed() {
+  local roots old owner; roots="$(mk_roots_dir)"
+  old="$(mk_run_root "$roots" "reissued")"
+  owner="$(start_stub_run)"
+  # A live pid, claimed with somebody else's start time: the shape a recycled
+  # pid has, and the one no real process table can be asked to produce.
+  write_run_claim "$old" "$owner" "Thu Jan  1 00:00:00 1970"
+  age_run_root "$old"
+  reclaim_abandoned_run_roots "$roots"
+  assert_eq "a reissued pid does not save the root" "no" "$(dir_exists "$old")"
+  kill_pids "$owner"
+  rm -rf "$roots"
+}
+
+test_an_aged_root_whose_owner_is_dead_is_reclaimed() {
+  local roots old owner; roots="$(mk_roots_dir)"
+  old="$(mk_run_root "$roots" "crashed")"
+  owner="$(start_stub_run)"
+  write_run_claim "$old" "$owner"
+  kill_pids "$owner"
+  # The corpse has to be collected before the pid names nothing; this file's
+  # own shell is its parent, so `wait` is what collects it.
+  wait "$owner" 2>/dev/null
+  age_run_root "$old"
+  reclaim_abandoned_run_roots "$roots"
+  assert_eq "a dead owner's root is reclaimed" "no" "$(dir_exists "$old")"
+  rm -rf "$roots"
+}
+
+# A CLAIM THAT IS NOT THERE IS NOT A KEEP. Roots written by a wrapper that
+# predates this file have none, and treating those as immortal would leak
+# exactly what the reconciler exists to collect. This is the one arm that is
+# deliberately not keep-biased, so it is pinned rather than left to be inferred.
+test_an_aged_root_with_no_claim_is_reclaimed() {
+  local roots old; roots="$(mk_roots_dir)"
+  old="$(mk_run_root "$roots" "unclaimed")"
+  age_run_root "$old"
+  assert_eq "the fixture really has no claim in it" "no" \
+    "$(if [ -f "$old/$RUN_OWNER_FILE" ]; then echo yes; else echo no; fi)"
+  reclaim_abandoned_run_roots "$roots"
+  assert_eq "an unclaimed aged root is reclaimed" "no" "$(dir_exists "$old")"
+  rm -rf "$roots"
+}
+
+# END TO END: a real run claims its own root, with its own live pid, before it
+# does anything slow. Read out of the dump the stub writes, which is taken from
+# inside the run — so the claim is proven to exist while the run is still going,
+# not merely to have been written at some point.
+test_a_real_run_claims_its_root_with_its_own_live_pid() {
+  local fix claim owner recorded; fix="$(mkfix)"
+  RUN_ENV=(FAKE_SWIFT_COPY_RUN_CLAIM="$fix/observed-claim")
+  run_wrapper "$fix"
+  RUN_ENV=()
+  assert_ok "the run is unaffected" "$RUN_RC"
+  claim="$fix/observed-claim"
+  assert_eq "the claim existed during the run" "yes" \
+    "$(if [ -f "$claim" ]; then echo yes; else echo no; fi)"
+  owner="$(sed -n 1p "$claim" 2>/dev/null)"
+  recorded="$(sed -n 2p "$claim" 2>/dev/null)"
+  assert_eq "it names a pid" "yes" \
+    "$(case "$owner" in ''|*[!0-9]*) echo no ;; *) echo yes ;; esac)"
+  # Both halves come from inside the run, because neither is checkable from out
+  # here: the wrapper has exited by now, so its pid names nothing and its start
+  # time cannot be re-derived. That is the whole reason the claim is written at
+  # all — it is the only record that outlives the process it describes.
+  assert_eq "the pid it names was alive while the run was going" "alive" \
+    "$(sed -n 1p "$claim.observed" 2>/dev/null)"
+  assert_eq "and the recorded start time is that pid's real one" \
+    "$(sed -n 2p "$claim.observed" 2>/dev/null)" "$recorded"
+  rmfix "$fix"
+}
+
+# MUTATION. Without the claim the wrapper's own root is indistinguishable from
+# an abandoned one the moment it stops writing.
+test_the_run_root_claim_is_load_bearing() {
+  local fix mutant; fix="$(mkfix)"
+  mutant="$(mutant_of "$SCRIPT" '/^claim_run_root "\$scratch_home"$/d')"
+  RUN_ENV=(FAKE_SWIFT_COPY_RUN_CLAIM="$fix/observed-claim")
+  run_script "$mutant" "$fix"
+  RUN_ENV=()
+  assert_eq "without the claim the run leaves none" "no" \
+    "$(if [ -f "$fix/observed-claim" ]; then echo yes; else echo no; fi)"
+  rmfix "$fix"
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What's broken

A `TBDHolder` process started by a live test — plus the shell job it was
supervising — kept running on a developer machine for **24 hours** after the run
that created it had finished. It was parented to launchd, its worktree had been
archived and deleted, and it had no `terminal` row anywhere. Nothing was going to
end it; it was found by looking at the process table, and killed by hand.

Anyone who runs `scripts/test.sh` can leave one behind. The residue is
developer-machine only — it lives in `/tmp` under a test scratch root, so no user
of the product ever sees it — but it accumulates silently and each one holds a
pty and a looping shell open indefinitely.

## Why it happens

A holder is *built* to outlive whatever started it. `Sources/TBDHolder/Holder.swift`
calls `setsid()` and sets `SIGHUP`/`SIGPIPE` to `SIG_IGN` before it binds
anything, so a holder survives the daemon's death and keeps its session alive.
That is correct behaviour, and it applies just as well when the process that
spawned it is a test: the holder detaches, re-parents to launchd, and the job
keeps looping. Re-parenting is not the bug.

The bug is that **no reclaimer covered it**. Each of the obvious candidates misses
for its own reason:

- **`OrphanGC`.** Its `RowlessHolderCollector` enumerates `<base>/*.sock` for the
  *real* holders directory. A fixture's socket is under its own `/tmp` scratch
  root, so it is not in that listing at all. Separately, the orphan-process phase
  is behind `guard config.gcOrphanProcessesEnabled || dryRun`, whose default is
  `false` — so a `tbd gc sweep --dry-run` REAP line proves nothing here, because
  dry-run bypasses the gate that the real sweep stops at.
- **`AgentReaper`.** Its holder leg keys on `terminal` rows. The fixture builds
  `TBDDatabase(inMemory: true)`, so there has never been a row.
- **`scripts/test.sh`'s EXIT trap.** It *did* run — the scratch root was gone —
  and the holder still outlived it, because the trap only did `rm -rf`. Deleting
  a rendezvous socket does not kill the process listening on it; it just makes it
  unreachable.
- **The fixture's own teardown.** `HibernationFixture.tearDown` kills what its
  rows still name, which is sound and is a deliberate defence against pid reuse.
  But it reads those rows through a bounded gate, and on expiry
  `blockingTerminals` returns `[]` — its own comment concedes that a timeout
  "means the sweep above has nothing to kill by pid". A leak is the designed
  outcome of that branch, even though the fixture knew the pids all along.

## What this PR does

Three layers, one per way a fixture holder can be left behind. Each covers
exactly one, and the split is deliberate rather than defensive duplication.

**1. The fixture remembers what it spawned, identity-checked.**
`HibernationFixture` records each holder and job pid together with
`ProcessStartTime.startTime(pid:)` at spawn, and `tearDown` sweeps that list
after the by-rows pass — signalling a remembered pid only while the kernel still
reports the same start instant. That is the same answer `AgentReaper` gives to
pid reuse, and it is what makes remembering a pid safe on a box where the kernel
reissues them to other people's work. It follows `HolderProcessFixture.tearDown`,
which already killed by remembered handle; this fixture was the outlier. Covers:
**a teardown that ran and missed.**

**2. `sweep_holders` in `scripts/test.sh`'s `cleanup()`.** Before the `rm -rf`,
every `*/holders/*.sock` under the run root is resolved to its owning pid with
`lsof -t -a -U <that exact path>`; that pid's children are enumerated with
`pgrep -P` *first* (a holder's job re-parents to launchd the moment the holder
dies), then all of them are killed. Covers: **a run that died without reaching a
teardown**, where the socket is still on disk.

Two things about it are load-bearing and easy to get wrong:

- **By resource, never by pattern.** This machine runs live production holders
  and other agents' sessions; `pkill -f TBDHolder` would end them. The socket
  path is unique to the run and lives in a directory the run created, so "who has
  this exact file open" is the only safe discriminator.
- **`-a` is not optional.** lsof ORs its selection options, so `lsof -t -U <path>`
  means "every unix-socket holder on the machine, OR this path" — measured here
  at 300-odd pids, most of the process table. `-a` ANDs them. Getting this wrong
  does not fail loudly.

**3. `reclaim_abandoned_run_roots`, a start-of-run reconciler.** Before minting
its own root, a run gives every sibling `/tmp/tbd-test-home.*` that is both older
than 24 h **and** has no live owner the same two sweeps (tmux servers, then
holders), then removes it. Covers: **a SIGKILLed wrapper**, where no in-process
teardown can run at all. Because every run is a sweep, the machine heals as soon
as anybody tests again — no timer, no daemon, no scheduler.

The discriminator is two-part, and the second half is what licenses killing
anything. Age says nobody is *coming back*: no run lasts a day, and the nightly
stress harness mints one root per iteration rather than holding one. But age is a
proxy, and it reads one case exactly backwards — a run that **wedges** stops
writing, so its root ages just like an abandoned one while its holder, its tmux
servers and its `TBD_HOME` are all still in use. CI job timeouts close that for
every automated caller; a developer who starts a run by hand and walks away from
one that hangs is not covered by any of them, and `Tests/CLAUDE.md` documents
real hang classes.

So each run **claims** its root on the way in, writing its own pid and that pid's
kernel start time to `<root>/.run-owner`, and the reconciler skips any root whose
claim still checks out. The start time is what makes a day-old pid safe to read
at all — a bare number is one the kernel is free to have reissued, which is the
same reason `AgentReaper` and layer 1 above check it. Every arm fails keep-biased
except one: a root with **no** claim is reclaimed on age, because those predate
the mechanism and treating them as immortal would leak precisely what this
collects.

Alongside those, the fixture now writes the holder pid, the job pid and the
scratch root to stderr at spawn. The holder that prompted this could not be
diagnosed — its worktree was gone, so a crashed test process and a teardown that
ran and missed were indistinguishable. That line makes the next occurrence
answerable from the run log.

### Who reclaims an orphaned fixture holder

The doctrine's question
([`docs/specs/2026-08-15-named-reconciler-doctrine-design.md`](docs/specs/2026-08-15-named-reconciler-doctrine-design.md)),
answered per death mode:

- **Clean exit** — the fixture's own `tearDown`: the by-rows sweep, then
  `sweepRememberedProcesses` for anything the rows no longer name.
- **TERMed wrapper** — bash runs an EXIT trap on a fatal signal as well as a
  normal exit, so `cleanup` runs and `sweep_holders` kills whoever owns each
  surviving rendezvous socket.
- **SIGKILLed wrapper** (or a panic, or lost power) — nothing in-process runs, so
  the reclaim belongs to somebody else's run: `reclaim_abandoned_run_roots` is the
  named reconciler, sweeping and removing sibling roots older than a day.

The ordering between layers 1 and 2 is worth stating, because it looks redundant
and is not: a teardown that *ran* has already removed its scratch root, socket
included, so layer 2 has nothing left to key on. Layer 2 owns the case where no
teardown ran at all, which is exactly the case where the socket survives.

### Deliberately not touched

`OrphanGC` and `gc_orphan_processes_enabled` are untouched. That is a product
soak flag, not a cleanup lever, and this is developer-machine residue in `/tmp`
that no user ever has.

**No flag, and no spec.** Both rules in CLAUDE.md are about behaviour that
*ships*: a default-off flag is for a product feature that acts autonomously or
destroys state on a user's machine, and a brainstormed spec is for a change to
our theory of the system. Nothing here reaches a user or a daemon — it is
`scripts/`, `Tests/`, and a test fixture, and its entire blast radius is
`/tmp/tbd-test-home.*` on a developer's own box. A DB column gating a shell
script would have nowhere to be read from, and there is no gate worth having in
any case: the reconciler can only act on a directory nobody could still own. This
is a leak fix — the system already intended these processes to be reclaimed, and
nothing about that intent changes here.

## Assumptions

- **A wedged run is still a live process.** The liveness claim is what saves a
  hung run's root, and it identifies that run by pid plus kernel start time. A
  run whose wrapper process is gone while its holders are not — nothing produces
  that today, since the wrapper outlives everything it starts — would be
  reclaimed on age, which is the correct outcome anyway.
- **No run of `scripts/test.sh` lasts 24 hours** *and* leaves no claim. Either
  condition alone is now survivable; it takes both to be reclaimed while live.
- **`lsof` is on `PATH`.** Without it the holder sweep returns without doing
  anything rather than guessing; the leak reverts to today's behaviour rather
  than becoming a wrong kill.
- **A rendezvous socket under a run root belongs to that run.** The root name
  comes from `mktemp`, so no process outside the run can hold one open. This is
  what licenses killing the owner without any further check.

## Evidence & verification

**The repro.** The leak was found in the wild — pid 92079, a `TBDHolder` alive
for 24 hours, parented to launchd, its child still running
`HibernationFixture.termAwareJob`, with the worktree archived and zero terminal
rows. It was reproduced deliberately during this work: running the hibernation
suite against a copy of the fixture with `sweepRememberedProcesses()` removed left
a live holder and a live job behind after the run finished and its scratch root
had been deleted.

**Discriminating evidence.**

- `tearDownKillsWhatItSpawnedWhenNoRowNamesItAnyMore` (tier 3) spawns a real
  holder, deletes the row so the by-rows sweep has nothing to work from — the
  state an expired gate leaves teardown in, without sitting through a two-minute
  gate — tears down, and polls for both pids to disappear. **Verified failing
  with the change reverted**: 4 issues, both pids alive when the polls gave up.
- `scripts/test.test.sh` gains nineteen cases covering both new `test.sh`
  behaviours, seven of them mutation-checked against a deliberately weakened copy
  of the script, per the harness's own "edit a guard, edit its case" rule:
  a socket with a live owner has its process **and** its `pgrep -P` child killed;
  an orphaned socket with no owner is handled without failing the run; a sibling
  root minted today is left alone; one older than a day is reclaimed; an
  abandoned root has its holder killed *before* the root is removed; and the
  `lsof` invocation is pinned as ANDing its selectors, since the only way to
  drive that one is to perform the catastrophe.

  The liveness claim has five of its own: an aged root whose claimed pid is alive
  survives (and its owner is untouched); the same root is reclaimed once that pid
  dies; a **live pid claimed with somebody else's start time** — the recycled-pid
  shape no real process table can be asked for — does not save the root; an aged
  root with no claim is reclaimed; and a real run is shown claiming its own root
  with its own live pid, read from inside the run because the wrapper has exited
  by the time the case looks and neither half is derivable from outside. Dropping
  the check reclaims a live run's root on age alone; dropping the claim leaves the
  run with none.

  Two of those mutations were themselves worth the trouble. `-mmin "+0"` is not a
  widening of the age filter — BSD `find` rounds the age up to whole minutes and
  `+n` is a strict "more than", so a directory seconds old matches neither bound;
  the mutation drops the predicate instead. And the stand-in holder binds its
  socket with `python3` rather than `nc -lU`, because nc reads its stdin and exits
  the moment it sees EOF, so a binder started with its stdio detached died before
  anything could sweep it and the case passed for the wrong reason. Both cases now
  assert the stand-in is actually up before asserting it went down.

**Two silent failures caught while building this**, both worth knowing:

- `find /tmp -maxdepth 1 …` enumerates **nothing**. On darwin `/tmp` is a symlink
  to `/private/tmp`, and find will not descend into a symlinked starting point
  unless told to — it exits 0, reclaims nothing, and says nothing. `-H` is what
  fixes it, and it follows only the paths named on the command line, so a symlink
  planted *inside* the directory is still never followed.
- `lsof -t -U <path>` returns most of the process table, as described above.

**Runs.** `scripts/test.test.sh`: 457 assertions, all green, no build, no real
store touched (~50 s on a loaded developer box against a ~44 s baseline for the
same file before this change). `scripts/test.sh --no-parallel --filter
'HolderHibernationLiveTests|HolderFixtureScratchRootTests'`: 9 tests in 2 suites,
green. `swiftlint --strict`: 0 violations. Full-suite verification is CI's.

[fixture holder sweep](https://cheapsteak.github.io/tbd/open/?worktree=36B92341-FCE7-4BB4-B9B6-493942E4A067)

https://claude.ai/code/session_01VmxVag4BeDdC65msZCawvK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved test-run cleanup for abandoned processes, servers, sockets, and temporary files.
  - Added safeguards to limit cleanup to resources belonging to the relevant test run.
  - Test runs now reclaim abandoned temporary directories at startup after the configured age threshold.
  - Improved cleanup when terminal test records are removed before teardown completes.

- **Documentation**
  - Clarified test-resource lifecycle, teardown, cleanup, and abandoned-run recovery.
  - Updated regression-test coverage for resource sweeping and abandoned-directory reconciliation.
  - Added guidance for running the test suite with macOS Bash 3.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->