### PR TITLE
Feat: flags and settings for the model proxy and transcript streaming

### DIFF
--- a/Sources/TBDApp/AppState+ModelProfiles.swift
+++ b/Sources/TBDApp/AppState+ModelProfiles.swift
@@ -471,6 +471,73 @@ extension AppState {
         }
     }
 
+    /// Help text for the model-proxy toggle. A stored constant rather than a
+    /// literal in the view so it is assertable: it must say what the switch
+    /// puts in the request path and when the change takes hold, because a
+    /// session's base URL is fixed in the environment it was spawned with and
+    /// nothing already running moves.
+    static let modelProxyHelp = """
+        Routes new Claude sessions through a loopback proxy TBD runs, so TBD \
+        can see the model stream. Applies to sessions started after you change \
+        it. Off by default (soaking).
+        """
+
+    /// Help text for the transcript-streaming toggle. Assertable for the same
+    /// reason as `modelProxyHelp`, and it carries one promise the operator
+    /// cannot see anywhere else: flipping this one switch flips the proxy on
+    /// too, because the stream file it reads is written by nothing else.
+    static let transcriptStreamingHelp = """
+        Shows assistant text in the transcript pane as it is generated, before \
+        it reaches the session file. Turning this on also turns on the model \
+        proxy. Applies to sessions started after you change it.
+        """
+
+    /// Why the transcript-streaming toggle is inert on this daemon. Shown only
+    /// when `modelProxySupported` is false: with no proxy there is no stream
+    /// file, so the switch would change nothing an operator could observe.
+    static let transcriptStreamingUnsupportedCaption =
+        "Needs the TBD model proxy, which this daemon could not start."
+
+    /// Persist the model-proxy gate, then re-fetch capabilities so the Settings
+    /// toggle reflects the daemon's persisted state.
+    ///
+    /// **Applies to sessions started after the call, and to no others.** A
+    /// session's Messages API base URL is fixed in the environment it was
+    /// spawned with, so turning this on never reroutes a running session and
+    /// turning it off never takes a live route away.
+    ///
+    /// Writes one flag. Turning the proxy off also clears transcript streaming,
+    /// but the daemon does that in the same transaction — the read-back is how
+    /// the app learns it happened.
+    func setModelProxyEnabled(_ enabled: Bool) async {
+        do {
+            try await modelProxyFlagSetter(enabled)
+            await refreshDaemonCapabilities()
+        } catch {
+            logger.error("Failed to set model proxy: \(error, privacy: .public)")
+            showAlert("Failed to set the model proxy: \(error.localizedDescription)", isError: true)
+        }
+    }
+
+    /// Persist the transcript-streaming gate, then re-fetch capabilities so the
+    /// Settings toggle reflects the daemon's persisted state. Applies to
+    /// sessions started after the call, for the same reason as the proxy gate.
+    ///
+    /// Sends the gesture unconditionally, including while the proxy is off:
+    /// turning streaming on turns the proxy on too, and that coupling belongs
+    /// to the daemon. An app that pre-empted the write would make this switch a
+    /// no-op on exactly the installs that never opted into the proxy.
+    func setTranscriptStreamingEnabled(_ enabled: Bool) async {
+        do {
+            try await transcriptStreamingFlagSetter(enabled)
+            await refreshDaemonCapabilities()
+        } catch {
+            logger.error("Failed to set transcript streaming: \(error, privacy: .public)")
+            showAlert(
+                "Failed to set transcript streaming: \(error.localizedDescription)", isError: true)
+        }
+    }
+
     /// Persist the worktree auto-trust switch, then re-fetch capabilities so
     /// the Settings toggle reflects the daemon's persisted state. Applies to
     /// the next Claude spawn or wake; never un-trusts an already-seeded path.

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -1501,6 +1501,23 @@ final class AppState {
         { [daemonClient] enabled in
             try await daemonClient.setTranscriptComposerEnabled(enabled: enabled)
         }
+    /// How `setModelProxyEnabled` persists the model-proxy gate — injectable
+    /// for the same reason as `controlModeSetter`.
+    @ObservationIgnored
+    lazy var modelProxyFlagSetter: @MainActor (Bool) async throws -> Void =
+        { [daemonClient] enabled in
+            try await daemonClient.setModelProxyEnabled(enabled: enabled)
+        }
+    /// How `setTranscriptStreamingEnabled` persists the streaming gate —
+    /// injectable for the same reason as `controlModeSetter`. Separate from
+    /// `modelProxyFlagSetter` even though the two flags are coupled: the
+    /// coupling is the daemon's, and an app that wrote both would be guessing
+    /// at a rule it does not own.
+    @ObservationIgnored
+    lazy var transcriptStreamingFlagSetter: @MainActor (Bool) async throws -> Void =
+        { [daemonClient] enabled in
+            try await daemonClient.setTranscriptStreamingEnabled(enabled: enabled)
+        }
     /// How `setClaudeCloudEnabled` persists the Claude cloud gate — injectable
     /// for the same reason as `controlModeSetter`, so the Settings toggle's
     /// success and failure branches are testable without a real daemon.

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -1215,6 +1215,38 @@ actor DaemonClient {
         )
     }
 
+    /// Persist the model-proxy gate (default OFF). Read fresh at spawn time, so
+    /// no daemon restart is needed — but it applies only to sessions started
+    /// after the call: a session's Messages API base URL is fixed in the
+    /// environment it was spawned with. Sending either value is an explicit
+    /// gesture that survives a later change to the shipped default.
+    ///
+    /// Turning it off also clears the transcript-streaming flag; the daemon
+    /// does that itself, in one transaction, so the app writes one value and
+    /// re-reads capabilities to learn what landed.
+    func setModelProxyEnabled(enabled: Bool) async throws {
+        try await callVoidAsync(
+            method: RPCMethod.configSetModelProxyEnabled,
+            params: ConfigSetModelProxyEnabledParams(enabled: enabled)
+        )
+    }
+
+    /// Persist the transcript-streaming gate (default OFF), which decides
+    /// whether the transcript renders a provisional assistant row from the
+    /// proxy's stream file. Applies to sessions started after the call, for the
+    /// same reason as the proxy gate.
+    ///
+    /// Turning it on also sets the model-proxy flag — the daemon couples them,
+    /// because the file this reads does not exist without the proxy — so the
+    /// app sends this one value even while the proxy is off and reads the
+    /// coupled result back out of capabilities.
+    func setTranscriptStreamingEnabled(enabled: Bool) async throws {
+        try await callVoidAsync(
+            method: RPCMethod.configSetTranscriptStreamingEnabled,
+            params: ConfigSetTranscriptStreamingParams(enabled: enabled)
+        )
+    }
+
     /// Persist the Claude cloud sessions gate (default OFF). The daemon builds
     /// its provider manager only at boot, so this takes effect on the next
     /// daemon restart rather than the next gesture.

--- a/Sources/TBDApp/Settings/SettingsView.swift
+++ b/Sources/TBDApp/Settings/SettingsView.swift
@@ -270,6 +270,8 @@ struct GeneralSettingsTab: View {
                     .help("Experimental: best-effort exit idle Claude instances when the machine is about to sleep, so a tmux server that dies during a long sleep has less to recover. Off by default — may interrupt long-running work.")
                 controlModeToggle
                 ptyHolderToggle
+                modelProxyToggle
+                transcriptStreamingToggle
                 hibernateInputVetoToggle
                 autoCloseSetupToggle
                 queuedPromptToggle
@@ -323,6 +325,44 @@ struct GeneralSettingsTab: View {
         .disabled(!supported)
         if !supported {
             Text(AppState.ptyHolderUnsupportedCaption)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    /// Model-proxy opt-in. Reads the persisted flag from `daemon.capabilities`
+    /// and writes via `config.setModelProxyEnabled`. Stays enabled even when
+    /// the daemon reports `modelProxySupported == false`: turning the flag OFF
+    /// has to remain possible on a daemon that cannot start the proxy, which is
+    /// exactly the daemon an operator most wants to stop routing through.
+    @ViewBuilder
+    private var modelProxyToggle: some View {
+        let capabilities = appState.daemonCapabilities
+        Toggle("Route new sessions through the TBD model proxy", isOn: Binding(
+            get: { capabilities?.modelProxyEnabled ?? false },
+            set: { newValue in Task { await appState.setModelProxyEnabled(newValue) } }
+        ))
+        .help(AppState.modelProxyHelp)
+    }
+
+    /// Transcript-streaming opt-in, sitting under the proxy it depends on.
+    /// Reads the persisted flag from `daemon.capabilities` and writes via
+    /// `config.setTranscriptStreamingEnabled` — one write: turning this on also
+    /// turns the proxy on, and the daemon owns that coupling. Disabled with an
+    /// explanation when the daemon could not start a proxy, since the stream
+    /// file this renders is written by nothing else.
+    @ViewBuilder
+    private var transcriptStreamingToggle: some View {
+        let capabilities = appState.daemonCapabilities
+        let supported = capabilities?.modelProxySupported ?? false
+        Toggle("Stream assistant text into the transcript", isOn: Binding(
+            get: { capabilities?.transcriptStreamingEnabled ?? false },
+            set: { newValue in Task { await appState.setTranscriptStreamingEnabled(newValue) } }
+        ))
+        .help(AppState.transcriptStreamingHelp)
+        .disabled(!supported)
+        if !supported {
+            Text(AppState.transcriptStreamingUnsupportedCaption)
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }

--- a/Sources/TBDDaemon/Database/ConfigStore.swift
+++ b/Sources/TBDDaemon/Database/ConfigStore.swift
@@ -906,10 +906,16 @@ public struct ConfigStore: Sendable {
     /// silently re-arm it the next time the proxy came back on. The reverse
     /// coupling lives in `setTranscriptStreamingEnabled`.
     ///
-    /// Both columns are written on every call, because writing either value is
-    /// the explicit gesture that lifts them out of NULL forever after. Applies
-    /// to sessions started after the change: a session's `ANTHROPIC_BASE_URL`
-    /// is fixed in its environment at spawn.
+    /// The proxy column is written on every call. The streaming column is
+    /// written only when the proxy is turned off — that is the one gesture
+    /// here that lifts streaming out of NULL, and it does so as a deliberate
+    /// side effect: the effective value readers see is the conjunction of the
+    /// two columns (`Config.transcriptStreamingEffective`), so streaming must
+    /// never be left holding a stale `1` once the proxy it depends on is off.
+    /// Turning the proxy back **on** leaves streaming untouched — see
+    /// `turningTheProxyOnLeavesStreamingAlone`. Applies to sessions started
+    /// after the change: a session's `ANTHROPIC_BASE_URL` is fixed in its
+    /// environment at spawn.
     public func setModelProxyEnabled(_ enabled: Bool) async throws {
         try await writer.write { db in
             try db.execute(

--- a/Sources/TBDDaemon/Database/ConfigStore.swift
+++ b/Sources/TBDDaemon/Database/ConfigStore.swift
@@ -132,6 +132,29 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     /// through `Config.transcriptComposerEnabledDefault`, never through
     /// `?? false`.
     var transcript_composer_enabled: Bool?
+    /// Gate for routing pty-holder sessions through the TBD model proxy.
+    /// **Genuinely tri-state**, same shape as `transcript_composer_enabled`: the
+    /// `20260907215724_config_model_proxy` migration carries no SQL default, so
+    /// `nil` here means "never chose" rather than "off". Resolve it through
+    /// `Config.modelProxyDefault`, never through `?? false`.
+    var model_proxy_enabled: Bool?
+    /// Gate for the transcript's provisional assistant row. **Genuinely
+    /// tri-state**, same shape as `model_proxy_enabled`: the
+    /// `20260907215725_config_transcript_streaming` migration carries no SQL
+    /// default, so `nil` here means "never chose" rather than "off". Resolve it
+    /// through `Config.transcriptStreamingDefault`, never through `?? false`.
+    ///
+    /// Resolving it is not the whole answer: streaming needs the proxy, so what
+    /// callers act on is `Config.transcriptStreamingEffective`, the conjunction
+    /// with `modelProxyEnabled`.
+    var transcript_streaming_enabled: Bool?
+    /// The loopback port this TBD home's model proxy binds, or nil if none has
+    /// been minted. **Not a flag**, exactly like `holder_owner_token`: NULL
+    /// means "not yet minted", and the mint is the conditional UPDATE in
+    /// `ensureModelProxyPort` rather than a resolved default — the kernel picks
+    /// the first port, and there is no literal the shipped code could fall back
+    /// to that would not collide with whatever already holds it.
+    var model_proxy_port: Int?
     /// The update mode: 'off', 'check' or 'auto'
     /// (design 2026-09-04 §6). **Genuinely tri-state**, same shape as
     /// `gc_retained_transcripts_enabled`: the
@@ -193,6 +216,14 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     ///   `transcript_composer_enabled` — the live-transcript composer's gate,
     ///   which is one switch for the composer UI, its completions probe,
     ///   attachment writes and the attachments GC leg together.
+    /// - Parameter modelProxyDefault: same shape once more, for
+    ///   `model_proxy_enabled` — the gate on routing a session's Messages API
+    ///   traffic through the loopback model proxy.
+    /// - Parameter transcriptStreamingDefault: and its companion, for
+    ///   `transcript_streaming_enabled` — the gate on the transcript's
+    ///   provisional assistant row. Resolved here on its own; what callers act
+    ///   on is `Config.transcriptStreamingEffective`, its conjunction with the
+    ///   proxy flag.
     /// - Parameter updateModeDefault: and truly, finally the last, for
     ///   `update_mode` — the only one of these that is not a Bool, so the
     ///   parameter proves both properties at once: a NULL row follows a changed
@@ -211,9 +242,17 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         remoteDeleteDefault: Bool = Config.remoteDeleteEnabledDefault,
         gcRetainedTranscriptsDefault: Bool = Config.gcRetainedTranscriptsEnabledDefault,
         transcriptComposerDefault: Bool = Config.transcriptComposerEnabledDefault,
+        modelProxyDefault: Bool = Config.modelProxyDefault,
+        transcriptStreamingDefault: Bool = Config.transcriptStreamingDefault,
         updateModeDefault: UpdateMode = Config.updateModeDefault
     ) -> Config {
-        Config(
+        // Assembled in two steps rather than one literal, and deliberately so:
+        // this initializer call reached the Swift type-checker's expression
+        // budget ("unable to type-check this expression in reasonable time")
+        // when the model-proxy fields were passed inline with the rest. The
+        // three resolutions below are the same `?? default` shape as every
+        // argument above; only where they are written changed.
+        var config = Config(
             defaultProfileID: default_profile_id.flatMap(UUID.init(uuidString:)),
             primaryAgentPreference: primary_agent_preference
                 .flatMap(PrimaryAgentPreference.init(rawValue:)) ?? .defaultValue,
@@ -295,6 +334,19 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             // real state and has no default to resolve to.
             holderOwnerToken: holder_owner_token
         )
+        // And once more, for the model proxy's gate — NOT `?? false`.
+        config.modelProxyEnabled = model_proxy_enabled ?? modelProxyDefault
+        // And its companion, for the provisional transcript row's gate — NOT
+        // `?? false`. Resolved on its own here; the conjunction with the proxy
+        // flag lives in `Config.transcriptStreamingEffective`, so a
+        // hand-edited row with streaming on and the proxy off is still
+        // readable as the two separate choices it records.
+        config.transcriptStreamingEnabled =
+            transcript_streaming_enabled ?? transcriptStreamingDefault
+        // Passed straight through, NULL included: "not yet minted" is a real
+        // state and has no default to resolve to.
+        config.modelProxyPort = model_proxy_port
+        return config
     }
 }
 
@@ -303,11 +355,17 @@ public enum ConfigStoreError: LocalizedError, Equatable {
     /// The conditional mint ran and the row still holds no usable token — the
     /// singleton row is missing, or something wrote an empty value over it.
     case holderOwnerTokenUnavailable
+    /// The conditional mint ran and the row still holds no usable port — the
+    /// singleton row is missing, or something wrote a non-positive value over
+    /// it.
+    case modelProxyPortUnavailable
 
     public var errorDescription: String? {
         switch self {
         case .holderOwnerTokenUnavailable:
             return "the config row holds no holder owner token and one could not be minted"
+        case .modelProxyPortUnavailable:
+            return "the config row holds no model proxy port and one could not be minted"
         }
     }
 }
@@ -835,6 +893,115 @@ public struct ConfigStore: Sendable {
                 throw ConfigStoreError.holderOwnerTokenUnavailable
             }
             return stored
+        }
+    }
+
+    /// Persist the model-proxy gate (default OFF, soaking) — whether new
+    /// pty-holder sessions are routed through the loopback proxy.
+    ///
+    /// **Turning it off also turns streaming off**, in the same transaction.
+    /// The provisional transcript row reads a file only the proxy writes, so a
+    /// user who switches the proxy off has switched streaming off whether or
+    /// not they know the second flag exists; leaving streaming set to `1` would
+    /// silently re-arm it the next time the proxy came back on. The reverse
+    /// coupling lives in `setTranscriptStreamingEnabled`.
+    ///
+    /// Both columns are written on every call, because writing either value is
+    /// the explicit gesture that lifts them out of NULL forever after. Applies
+    /// to sessions started after the change: a session's `ANTHROPIC_BASE_URL`
+    /// is fixed in its environment at spawn.
+    public func setModelProxyEnabled(_ enabled: Bool) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE config SET model_proxy_enabled = ? WHERE id = ?",
+                arguments: [enabled, Self.singletonID]
+            )
+            if !enabled {
+                try db.execute(
+                    sql: "UPDATE config SET transcript_streaming_enabled = 0 WHERE id = ?",
+                    arguments: [Self.singletonID]
+                )
+            }
+        }
+    }
+
+    /// Persist the transcript-streaming gate (default OFF, soaking) — whether
+    /// the transcript renders a provisional assistant row from the proxy's
+    /// stream file.
+    ///
+    /// **Turning it on also turns the proxy on**, in the same transaction: the
+    /// file it reads does not exist without the proxy, so asking for streaming
+    /// is asking for both. The reverse coupling lives in
+    /// `setModelProxyEnabled`, and together they are what keeps the pair
+    /// coherent for anyone using the toggles — readers still resolve through
+    /// `Config.transcriptStreamingEffective`, because a hand-edited row can
+    /// hold a combination no gesture here can produce.
+    public func setTranscriptStreamingEnabled(_ enabled: Bool) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE config SET transcript_streaming_enabled = ? WHERE id = ?",
+                arguments: [enabled, Self.singletonID]
+            )
+            if enabled {
+                try db.execute(
+                    sql: "UPDATE config SET model_proxy_enabled = 1 WHERE id = ?",
+                    arguments: [Self.singletonID]
+                )
+            }
+        }
+    }
+
+    /// Return this TBD home's model-proxy port, persisting `candidate` only if
+    /// none has been minted yet.
+    ///
+    /// The `ensureHolderOwnerToken` shape, and for the same reason: two daemons
+    /// starting at once on one `TBD_HOME` must agree on one port, so the
+    /// decision is made by SQLite rather than by the caller. `WHERE
+    /// model_proxy_port IS NULL` means the second writer's UPDATE matches no
+    /// row, and the read-back inside the same transaction returns whichever
+    /// port actually landed.
+    ///
+    /// A non-positive stored value is treated as unminted: zero is the *ask*
+    /// the proxy is spawned with, never an answer, and a hand-edited or
+    /// half-written negative is not a port anything could bind.
+    ///
+    /// - Returns: the port now stored, which may not be `candidate`.
+    /// - Throws: if the row cannot be written or read — including the case
+    ///   where no singleton row exists at all, which no migrated database has.
+    public func ensureModelProxyPort(minting candidate: Int) async throws -> Int {
+        try await writer.write { db in
+            try db.execute(
+                sql: """
+                    UPDATE config SET model_proxy_port = ?
+                     WHERE id = ? AND (model_proxy_port IS NULL OR model_proxy_port <= 0)
+                    """,
+                arguments: [candidate, Self.singletonID]
+            )
+            let stored = try Int.fetchOne(
+                db,
+                sql: "SELECT model_proxy_port FROM config WHERE id = ?",
+                arguments: [Self.singletonID]
+            )
+            guard let stored, stored > 0 else {
+                throw ConfigStoreError.modelProxyPortUnavailable
+            }
+            return stored
+        }
+    }
+
+    /// Overwrite this TBD home's model-proxy port unconditionally.
+    ///
+    /// The re-mint path: an unrelated process took the stored port while TBD
+    /// was stopped, the daemon's status probe found no TBD proxy answering
+    /// there, and the kernel handed out a fresh one. Unconditional where
+    /// `ensureModelProxyPort` is conditional, because here the stored value is
+    /// known to be wrong rather than possibly already right.
+    public func setModelProxyPort(_ port: Int) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE config SET model_proxy_port = ? WHERE id = ?",
+                arguments: [port, Self.singletonID]
+            )
         }
     }
 

--- a/Sources/TBDDaemon/Database/Migrations/20260907215724_config_model_proxy.sql
+++ b/Sources/TBDDaemon/Database/Migrations/20260907215724_config_model_proxy.sql
@@ -1,0 +1,14 @@
+-- Gate for the TBD model proxy: routing a pty-holder session's Messages API
+-- traffic through the loopback proxy, and the per-session tee that proxy
+-- writes.
+--
+-- No DEFAULT clause, deliberately. ADD COLUMN ... DEFAULT would backfill every
+-- existing row, destroying the distinction between "nobody has chosen" (NULL)
+-- and "chose off" (0) — which is what made auto_hibernate_enabled impossible to
+-- graduate without a forcing UPDATE that also reset deliberate opt-ins.
+-- The shipped default lives in exactly one place: Config.modelProxyDefault.
+--
+-- The proxy is useful on its own, independently of the transcript's
+-- provisional row, so it is a separate switch from transcript_streaming_enabled
+-- rather than one flag covering both.
+ALTER TABLE config ADD COLUMN model_proxy_enabled INTEGER;

--- a/Sources/TBDDaemon/Database/Migrations/20260907215725_config_transcript_streaming.sql
+++ b/Sources/TBDDaemon/Database/Migrations/20260907215725_config_transcript_streaming.sql
@@ -1,0 +1,15 @@
+-- Gate for the transcript's provisional assistant row — the row that grows
+-- from the model proxy's stream file and is retired when the JSONL line for
+-- that message lands.
+--
+-- No DEFAULT clause, deliberately. ADD COLUMN ... DEFAULT would backfill every
+-- existing row, destroying the distinction between "nobody has chosen" (NULL)
+-- and "chose off" (0) — which is what made auto_hibernate_enabled impossible to
+-- graduate without a forcing UPDATE that also reset deliberate opt-ins.
+-- The shipped default lives in exactly one place:
+-- Config.transcriptStreamingDefault.
+--
+-- Streaming needs the proxy, so the resolved value is the conjunction of this
+-- column and model_proxy_enabled: a hand-edited row with streaming on and the
+-- proxy off streams nothing.
+ALTER TABLE config ADD COLUMN transcript_streaming_enabled INTEGER;

--- a/Sources/TBDDaemon/Database/Migrations/20260907215726_config_model_proxy_port.sql
+++ b/Sources/TBDDaemon/Database/Migrations/20260907215726_config_model_proxy_port.sql
@@ -1,0 +1,10 @@
+-- The loopback port this TBD home's model proxy binds.
+--
+-- Not a flag: NULL means "not yet minted" rather than "chose off", and there is
+-- no value the shipped code could default it to. The first proxy is spawned
+-- with port zero, reports what the kernel assigned, and the daemon persists it
+-- here; every later proxy is asked to bind the same port. Minting is the
+-- conditional UPDATE in ConfigStore.ensureModelProxyPort(minting:), the shape
+-- ensureHolderOwnerToken already uses, so two daemons on one TBD home cannot
+-- both mint. No DEFAULT clause, for the same reason as the flags above.
+ALTER TABLE config ADD COLUMN model_proxy_port INTEGER;

--- a/Sources/TBDDaemon/Database/Migrations/20260907215727_terminal_transcript_stream_path.sql
+++ b/Sources/TBDDaemon/Database/Migrations/20260907215727_terminal_transcript_stream_path.sql
@@ -1,0 +1,9 @@
+-- The absolute path of the model proxy's stream file for this terminal, or
+-- NULL when the session was never routed through the proxy.
+--
+-- Recorded at spawn, because a session's base URL is fixed in its environment
+-- at start: a terminal either has a stream file for life or never gets one, and
+-- flipping the flags afterwards changes neither. The app registers a tail on
+-- this path; a terminal with NULL here registers no stream and renders exactly
+-- what it renders today.
+ALTER TABLE terminal ADD COLUMN transcript_stream_path TEXT;

--- a/Sources/TBDDaemon/Database/TerminalStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalStore.swift
@@ -67,6 +67,11 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     /// never been through a park/wake cycle, where `createdAt` is still the
     /// right identity anchor — see `Terminal.holderChildStartedAt`.
     var holder_child_started_at: Date?
+    /// Absolute path of the model proxy's transcript stream file for this
+    /// session. NULL on every row spawned without a proxy route, which is
+    /// every row written before the column existed — see
+    /// `Terminal.transcriptStreamPath`.
+    var transcript_stream_path: String?
 
     init(from terminal: Terminal) {
         self.id = terminal.id.uuidString
@@ -101,6 +106,7 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         self.holder_pid = terminal.holderPID
         self.child_pid = terminal.childPID
         self.holder_child_started_at = terminal.holderChildStartedAt
+        self.transcript_stream_path = terminal.transcriptStreamPath
     }
 
     /// Failable decode: skips (returns nil after a logged warning) rather than
@@ -151,7 +157,8 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             transport: transport.flatMap(TerminalTransport.init(rawValue:)) ?? .tmux,
             holderPID: holder_pid,
             childPID: child_pid,
-            holderChildStartedAt: holder_child_started_at
+            holderChildStartedAt: holder_child_started_at,
+            transcriptStreamPath: transcript_stream_path
         )
     }
 }
@@ -304,6 +311,10 @@ struct TerminalReplacementSnapshot: Sendable {
     let kind: TerminalKind?
     let claudeSessionID: String?
     let transcriptPath: String?
+    /// The proxy route the observed process was launched on. Stamped at spawn
+    /// and never changed, so a mismatch here says the row's session was
+    /// replaced under the caller — exactly what the rest of the snapshot says.
+    let transcriptStreamPath: String?
     let profileID: UUID?
     let suspendedAt: Date?
     let hibernatedAt: Date?
@@ -314,6 +325,7 @@ struct TerminalReplacementSnapshot: Sendable {
         kind = terminal.kind
         claudeSessionID = terminal.claudeSessionID
         transcriptPath = terminal.transcriptPath
+        transcriptStreamPath = terminal.transcriptStreamPath
         profileID = terminal.profileID
         suspendedAt = terminal.suspendedAt
         hibernatedAt = terminal.hibernatedAt
@@ -325,6 +337,7 @@ struct TerminalReplacementSnapshot: Sendable {
             && record.kind == kind?.rawValue
             && record.claudeSessionID == claudeSessionID
             && record.transcriptPath == transcriptPath
+            && record.transcript_stream_path == transcriptStreamPath
             && record.profile_id == profileID?.uuidString
             && record.suspendedAt == suspendedAt
             && record.hibernatedAt == hibernatedAt
@@ -336,6 +349,7 @@ struct TerminalReplacementSnapshot: Sendable {
             && terminal.kind == kind
             && terminal.claudeSessionID == claudeSessionID
             && terminal.transcriptPath == transcriptPath
+            && terminal.transcriptStreamPath == transcriptStreamPath
             && terminal.profileID == profileID
             && terminal.suspendedAt == suspendedAt
             && terminal.hibernatedAt == hibernatedAt
@@ -1876,6 +1890,29 @@ public struct TerminalStore: Sendable {
             record.child_pid = childPID
             record.holder_child_started_at = startedAt
             try record.update(db)
+        }
+    }
+
+    /// Record — or clear — the model proxy stream file this terminal's session
+    /// was launched against.
+    ///
+    /// Written once, at spawn, right after the row exists and before the app is
+    /// told about it; `nil` clears the route when a session is spawned without
+    /// one. A single-column `UPDATE` rather than a read-modify-write of the
+    /// whole record on purpose: spawn runs concurrently with the first hooks
+    /// from the process it just started, and rewriting every column here would
+    /// let this write reinstate the session and activity columns those hooks
+    /// had already moved.
+    ///
+    /// A row that has since vanished is a no-op, matching `setProfileID`: the
+    /// terminal this route belonged to is gone, and so is anything that could
+    /// read the route.
+    public func setTranscriptStreamPath(terminalID: UUID, path: String?) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE terminal SET transcript_stream_path = ? WHERE id = ?",
+                arguments: [path, terminalID.uuidString]
+            )
         }
     }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
@@ -420,6 +420,54 @@ extension RPCRouter {
         return .ok()
     }
 
+    /// Persist the model-proxy gate — the default-off soak switch for routing a
+    /// pty-holder session's Messages API traffic through the loopback proxy.
+    /// This is how the soak is turned on: the flag is the feature's only opt-in,
+    /// and leaving it reachable only by hand-editing `~/tbd/state.db` would put
+    /// the sole way to enable it behind a database the project's own rules say
+    /// not to go into.
+    ///
+    /// **It applies to sessions created after the call, and to no others.** A
+    /// session's `ANTHROPIC_BASE_URL` is fixed in its environment at spawn, so
+    /// flipping this on never re-routes a running session and flipping it off
+    /// never un-routes one.
+    ///
+    /// The coupling — turning the proxy off also writes streaming off, in one
+    /// transaction — lives in `ConfigStore.setModelProxyEnabled`, not here, so
+    /// every caller of the store gets it, not only this RPC.
+    func handleConfigSetModelProxyEnabled(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(
+            ConfigSetModelProxyEnabledParams.self, from: paramsData)
+        try await db.config.setModelProxyEnabled(params.enabled)
+        // Reuse the existing config-change channel so the app reloads Config.
+        subscriptions.broadcast(delta: .modelProfilesChanged)
+        return .ok()
+    }
+
+    /// Persist the transcript-streaming gate — the default-off soak switch for
+    /// the transcript's provisional assistant row, read from the file the proxy
+    /// writes.
+    ///
+    /// **It applies to sessions created after the call**, for the same reason
+    /// the proxy gate does: only a session spawned with a route has a stream
+    /// file to read.
+    ///
+    /// The coupling — turning streaming on also writes the proxy on, in one
+    /// transaction — lives in `ConfigStore.setTranscriptStreamingEnabled`. What
+    /// readers act on is `Config.transcriptStreamingEffective`, the conjunction
+    /// of the two columns, because a hand-edited row can hold a combination no
+    /// gesture here can produce.
+    func handleConfigSetTranscriptStreamingEnabled(
+        _ paramsData: Data
+    ) async throws -> RPCResponse {
+        let params = try decoder.decode(
+            ConfigSetTranscriptStreamingParams.self, from: paramsData)
+        try await db.config.setTranscriptStreamingEnabled(params.enabled)
+        // Reuse the existing config-change channel so the app reloads Config.
+        subscriptions.broadcast(delta: .modelProfilesChanged)
+        return .ok()
+    }
+
     /// Persist the update mode — the daemon's only policy about updating
     /// itself, and the default-off gate on a feature that rebuilds and replaces
     /// the whole installation.

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -830,6 +830,10 @@ public final class RPCRouter: Sendable {
                 return try await handleConfigSetPtyHolderEnabled(request.paramsData)
             case RPCMethod.configSetTranscriptComposerEnabled:
                 return try await handleConfigSetTranscriptComposerEnabled(request.paramsData)
+            case RPCMethod.configSetModelProxyEnabled:
+                return try await handleConfigSetModelProxyEnabled(request.paramsData)
+            case RPCMethod.configSetTranscriptStreamingEnabled:
+                return try await handleConfigSetTranscriptStreamingEnabled(request.paramsData)
             case RPCMethod.peerStatus:
                 return try await handlePeerStatus()
             case RPCMethod.gcList:
@@ -896,7 +900,7 @@ public final class RPCRouter: Sendable {
             version = nil
         }
         let config = try await db.config.get()
-        return try RPCResponse(result: DaemonCapabilitiesResult(
+        var result = DaemonCapabilitiesResult(
             controlModeEnabled: enabled,
             tmuxVersion: version?.description,
             controlModeSupported: version.map { $0 >= TmuxVersion.controlModeMinimum } ?? false,
@@ -919,7 +923,22 @@ public final class RPCRouter: Sendable {
             // falls back to tmux silently. Reported so Settings can say so
             // instead of offering a switch that would change nothing.
             ptyHolderSupported: holderRegistry?.canSpawn == true,
-            transcriptComposerEnabled: config.transcriptComposerEnabled))
+            transcriptComposerEnabled: config.transcriptComposerEnabled)
+        // Assigned rather than passed: this initializer's argument list is at
+        // the Swift type-checker's expression budget — adding to it produces
+        // "unable to type-check this expression in reasonable time" — so the
+        // model-proxy fields are set after construction instead.
+        result.modelProxyEnabled = config.modelProxyEnabled
+        // The conjunction, not the raw column: a hand-edited row holding
+        // streaming on with the proxy off streams nothing, and the app should
+        // not have to re-derive that.
+        result.transcriptStreamingEnabled = config.transcriptStreamingEffective
+        // `modelProxySupported`, `modelProxyPort` and `modelProxyVersion` keep
+        // their initializer defaults — false, nil, nil — because there is no
+        // supervisor yet. Until it arrives no daemon can route a session, so
+        // "not supported, no port, no version" is the honest answer rather than
+        // a placeholder, and Settings greys the toggle out on it.
+        return try RPCResponse(result: result)
     }
 
     // MARK: - PR Status

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -746,6 +746,15 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
     /// session was parked, which is exactly the case `createdAt` alone cannot
     /// describe. Cleared with the two pid columns when a row parks.
     public var holderChildStartedAt: Date?
+    /// Absolute path of the model proxy's transcript stream file for this
+    /// session, or nil when the session was never routed through the proxy.
+    ///
+    /// Stamped at spawn and never changed afterwards: a session's base URL is
+    /// fixed in the environment it starts with, so a terminal either has a
+    /// stream file for its whole life or never gets one, and flipping the
+    /// flags later changes neither. A nil here means "register no stream" —
+    /// the app renders exactly what it renders today.
+    public var transcriptStreamPath: String?
 
     /// `activityState` as a fact — value, source, observed-at — or nil.
     ///
@@ -817,7 +826,8 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
                 transport: TerminalTransport = .tmux,
                 holderPID: Int32? = nil,
                 childPID: Int32? = nil,
-                holderChildStartedAt: Date? = nil) {
+                holderChildStartedAt: Date? = nil,
+                transcriptStreamPath: String? = nil) {
         self.id = id
         self.worktreeID = worktreeID
         self.tmuxWindowID = tmuxWindowID
@@ -852,6 +862,7 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
         self.holderPID = holderPID
         self.childPID = childPID
         self.holderChildStartedAt = holderChildStartedAt
+        self.transcriptStreamPath = transcriptStreamPath
     }
 
     enum CodingKeys: String, CodingKey {
@@ -864,6 +875,7 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
         case activityStateSource, activityStateObservedAt, activityStateOrderObservedAt
         case awaitingInputReason, awaitingInputObservedAt
         case transport, holderPID, childPID, holderChildStartedAt
+        case transcriptStreamPath
     }
 
     public init(from decoder: Decoder) throws {
@@ -918,6 +930,7 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
         holderPID = try c.decodeIfPresent(Int32.self, forKey: .holderPID)
         childPID = try c.decodeIfPresent(Int32.self, forKey: .childPID)
         holderChildStartedAt = try c.decodeIfPresent(Date.self, forKey: .holderChildStartedAt)
+        transcriptStreamPath = try c.decodeIfPresent(String.self, forKey: .transcriptStreamPath)
     }
 }
 

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -1644,6 +1644,59 @@ public struct Config: Codable, Sendable, Equatable {
     /// follows the shipped default wherever it goes; a stored name is an
     /// explicit gesture and is honored forever.
     public var updateMode: UpdateMode
+    /// Whether new pty-holder sessions are routed through the TBD model proxy
+    /// (`docs/specs/2026-09-05-transcript-streaming-model-proxy-design.md`,
+    /// "Flags and migrations"): a loopback process the daemon owns, named by
+    /// the session's `ANTHROPIC_BASE_URL`, which forwards the Messages API and
+    /// tees each conversation stream's text into a per-session file.
+    ///
+    /// It ships OFF because it puts a second process in the path of every API
+    /// call a routed session makes, and that process outlives the daemon.
+    ///
+    /// It is a switch of its own rather than half of one: the proxy is useful
+    /// without the transcript's provisional row, so `transcriptStreamingEnabled`
+    /// is a second flag. The two are coupled only in the direction that keeps
+    /// them coherent — turning streaming on turns this on, turning this off
+    /// turns streaming off — and the coupling lives in the `ConfigStore`
+    /// setters, not here.
+    ///
+    /// The gate covers *spawning* only, like `ptyHolderEnabled`: a session's
+    /// base URL is read once at start, so flipping this never reroutes a
+    /// running session.
+    ///
+    /// **Resolved, not stored**, like `transcriptComposerEnabled`: the backing
+    /// column carries no SQL default and stays NULL until somebody touches the
+    /// toggle, so this property is
+    /// `model_proxy_enabled ?? Config.modelProxyDefault`. NULL means "never
+    /// chose" and follows the shipped default wherever it goes; `0`/`1` is an
+    /// explicit gesture and is honored forever.
+    public var modelProxyEnabled: Bool
+    /// Whether the transcript renders a provisional assistant row that grows
+    /// with the model proxy's stream file and is retired when the JSONL line
+    /// for that message lands.
+    ///
+    /// It ships OFF, and it is meaningful only with `modelProxyEnabled`: the
+    /// stream file it reads is written by the proxy. Read
+    /// `transcriptStreamingEffective` rather than this property — a
+    /// hand-edited row with streaming on and the proxy off records two
+    /// choices, and streams nothing.
+    ///
+    /// **Resolved, not stored**, same shape as `modelProxyEnabled`:
+    /// `transcript_streaming_enabled ?? Config.transcriptStreamingDefault`.
+    public var transcriptStreamingEnabled: Bool
+    /// The loopback port this TBD home's model proxy binds, or nil if none has
+    /// been minted.
+    ///
+    /// **Identity, not a preference**, which is why it has no shipped default,
+    /// for the same reason as `holderOwnerToken`: nil genuinely means "not yet
+    /// minted", and any literal the code could fall back to would be a port
+    /// some unrelated process may already hold. The kernel picks the first one
+    /// — the proxy binds port zero and reports what it got — and
+    /// `ConfigStore.ensureModelProxyPort(minting:)` persists it with the
+    /// conditional UPDATE that keeps two daemons starting at once from minting
+    /// two. `setModelProxyPort(_:)` overwrites it, which is what the
+    /// address-in-use re-mint needs.
+    public var modelProxyPort: Int?
     /// Machine-wide remote create-param defaults, keyed by the **provider's
     /// own** `create_params` field names — the fall-through level beneath
     /// `Repo.remoteCreateDefaults`. TBD stores and replays these values
@@ -1747,6 +1800,19 @@ public struct Config: Codable, Sendable, Equatable {
     /// chose is NULL and follows this constant, and every stored mode is an
     /// explicit choice that a default change leaves alone.
     public static let updateModeDefault: UpdateMode = .off
+    /// The shipped default for `modelProxyEnabled`, and the single place it
+    /// lives. The proxy ships off; graduation — after a soak in which no routed
+    /// session lost a turn to the proxy, and no proxy outlived the daemon that
+    /// spawned it without being adopted or reaped — is a change to this
+    /// constant, with no forcing `UPDATE` migration and every explicit opt-out
+    /// left alone.
+    public static let modelProxyDefault = false
+    /// The shipped default for `transcriptStreamingEnabled`, and the single
+    /// place it lives. Streaming ships off and graduates *after* the proxy: a
+    /// provisional row is worth nothing until the thing that feeds it is
+    /// trusted. Graduation is a change to this constant, with no forcing
+    /// `UPDATE` migration and every explicit opt-out left alone.
+    public static let transcriptStreamingDefault = false
 
     public init(defaultProfileID: UUID? = nil,
                 primaryAgentPreference: PrimaryAgentPreference = .defaultValue,
@@ -1787,6 +1853,9 @@ public struct Config: Codable, Sendable, Equatable {
                     Config.gcRetainedTranscriptsEnabledDefault,
                 transcriptComposerEnabled: Bool = Config.transcriptComposerEnabledDefault,
                 updateMode: UpdateMode = Config.updateModeDefault,
+                modelProxyEnabled: Bool = Config.modelProxyDefault,
+                transcriptStreamingEnabled: Bool = Config.transcriptStreamingDefault,
+                modelProxyPort: Int? = nil,
                 remoteCreateDefaults: [String: String] = [:],
                 holderOwnerToken: String? = nil) {
         self.defaultProfileID = defaultProfileID
@@ -1827,6 +1896,9 @@ public struct Config: Codable, Sendable, Equatable {
         self.gcRetainedTranscriptsEnabled = gcRetainedTranscriptsEnabled
         self.transcriptComposerEnabled = transcriptComposerEnabled
         self.updateMode = updateMode
+        self.modelProxyEnabled = modelProxyEnabled
+        self.transcriptStreamingEnabled = transcriptStreamingEnabled
+        self.modelProxyPort = modelProxyPort
         self.remoteCreateDefaults = remoteCreateDefaults
         self.holderOwnerToken = holderOwnerToken
     }
@@ -1945,6 +2017,20 @@ public struct Config: Codable, Sendable, Equatable {
         // whole decode and losing every other field.
         updateMode = (try? c.decode(UpdateMode.self, forKey: .updateMode))
             ?? Config.updateModeDefault
+        // And once more, for the model proxy's gate and the provisional row's:
+        // absent means the sender knew nothing about the flag, which is the
+        // NULL column's situation — follow the shipped default, never a
+        // hardcoded `false`.
+        modelProxyEnabled = try c.decodeIfPresent(
+            Bool.self, forKey: .modelProxyEnabled)
+            ?? Config.modelProxyDefault
+        transcriptStreamingEnabled = try c.decodeIfPresent(
+            Bool.self, forKey: .transcriptStreamingEnabled)
+            ?? Config.transcriptStreamingDefault
+        // Absent means the sender knew nothing about the port — the same state
+        // as an unminted column. Like `holderOwnerToken` there is no shipped
+        // default to fall through to; see the property's note.
+        modelProxyPort = try c.decodeIfPresent(Int.self, forKey: .modelProxyPort)
         // Absent means the sender knew nothing about global create defaults —
         // the same state as an empty map: no opinion at this level, so every
         // field falls through to its provider-declared `default`.
@@ -1958,6 +2044,19 @@ public struct Config: Codable, Sendable, Equatable {
 }
 
 public extension Config {
+    /// Whether transcript streaming is actually on: the conjunction of the two
+    /// flags, and the only form any caller should act on.
+    ///
+    /// Streaming reads a file the proxy writes, so streaming without the proxy
+    /// is not a state that can do anything. The setters keep the pair coherent
+    /// for anyone using the toggles, but a hand-edited row — or a row written
+    /// by a build that had only one of the flags — can still hold streaming on
+    /// with the proxy off, and that row must stream nothing rather than tail a
+    /// file nobody is writing.
+    var transcriptStreamingEffective: Bool {
+        modelProxyEnabled && transcriptStreamingEnabled
+    }
+
     /// Which auto-resume gate governs a `scheduled_resumes` row: the
     /// transient-API-error gate for `ScheduledResume.apiErrorLimitType` rows,
     /// or the hard usage-limit gate for everything else (session/debug/weekly).

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -388,6 +388,19 @@ public enum RPCMethod {
     /// feature's only opt-in. Reading needs no method of its own: `config.get`
     /// already carries the resolved value.
     public static let configSetTranscriptComposerEnabled = "config.setTranscriptComposerEnabled"
+    /// The model-proxy gate (`model_proxy_enabled`) — whether a new pty-holder
+    /// session's Messages API traffic is routed through the loopback proxy.
+    /// Reading needs no method of its own: `config.get` carries the resolved
+    /// value and `daemon.capabilities` carries it beside the supported/port
+    /// facts that explain a greyed-out toggle.
+    public static let configSetModelProxyEnabled = "config.setModelProxyEnabled"
+    /// The transcript-streaming gate (`transcript_streaming_enabled`) — whether
+    /// the transcript renders a provisional assistant row from the proxy's
+    /// stream file. Coupled to `configSetModelProxyEnabled`: streaming on turns
+    /// the proxy on, and the proxy off turns streaming off. Reading needs no
+    /// method of its own, for the same reason.
+    public static let configSetTranscriptStreamingEnabled =
+        "config.setTranscriptStreamingEnabled"
     /// The update mode (`update_mode`) — `off`, `check` or `auto`. The one
     /// policy the daemon holds about updating itself. Reading needs no method
     /// of its own: `config.get` and `daemon.capabilities` both carry the
@@ -1883,6 +1896,38 @@ public struct ConfigSetPtyHolderEnabledParams: Codable, Sendable {
 /// column out of its NULL "never chose" state, so an operator who turns the
 /// feature off stays off when the shipped default graduates.
 public struct ConfigSetTranscriptComposerEnabledParams: Codable, Sendable {
+    public let enabled: Bool
+    public init(enabled: Bool) { self.enabled = enabled }
+}
+
+/// Params for `config.setModelProxyEnabled` — the model-proxy gate (default OFF
+/// during soak), which decides whether a *new* pty-holder session is spawned
+/// with its Messages API base URL pointed at the loopback proxy. Writing either
+/// value is the explicit gesture that lifts the column out of its NULL "never
+/// chose" state, so an operator who turns the feature off stays off when the
+/// shipped default graduates.
+///
+/// Turning it off also writes `transcript_streaming_enabled` off — the daemon
+/// does that in one transaction, because the provisional transcript row reads a
+/// file only the proxy writes.
+public struct ConfigSetModelProxyEnabledParams: Codable, Sendable {
+    public let enabled: Bool
+    public init(enabled: Bool) { self.enabled = enabled }
+}
+
+/// Params for `config.setTranscriptStreamingEnabled` — the transcript-streaming
+/// gate (default OFF during soak), which decides whether the transcript renders
+/// a provisional assistant row from the proxy's stream file. Writing either
+/// value is the explicit gesture that lifts the column out of its NULL "never
+/// chose" state.
+///
+/// Turning it on also writes `model_proxy_enabled` on — the file it reads does
+/// not exist without the proxy, so asking for streaming is asking for both.
+///
+/// Named without the method's trailing `Enabled`: the symmetrical
+/// `ConfigSetTranscriptStreamingEnabledParams` is 41 characters and SwiftLint's
+/// `type_name` rule caps the length at 40.
+public struct ConfigSetTranscriptStreamingParams: Codable, Sendable {
     public let enabled: Bool
     public init(enabled: Bool) { self.enabled = enabled }
 }
@@ -3780,6 +3825,38 @@ public struct DaemonCapabilitiesResult: Codable, Sendable {
     /// it did before. Resolved through `Config.transcriptComposerEnabledDefault`,
     /// so an install that never touched the toggle reports the shipped default.
     public let transcriptComposerEnabled: Bool
+    /// Whether the model-proxy gate (`model_proxy_enabled`) is set. Default OFF
+    /// while it soaks. Read at spawn time, so the Settings toggle reads it back
+    /// from here rather than from a local guess — and a session already running
+    /// keeps the base URL fixed in its environment either way.
+    ///
+    /// `var` rather than `let` deliberately: this type's memberwise initializer
+    /// is at the type-checker's expression budget, so a caller may have to
+    /// construct with the older arguments and assign the newer fields after.
+    public var modelProxyEnabled: Bool
+    /// Whether this daemon could actually route a session through a proxy — a
+    /// live supervisor with a bound port. Computed daemon-side, exactly as
+    /// `ptyHolderSupported` is, so the app never probes loopback itself.
+    ///
+    /// With the flag on and this false, every spawn proceeds unproxied — so
+    /// Settings disables the streaming toggle and says why rather than offering
+    /// a switch that would change nothing.
+    public var modelProxySupported: Bool
+    /// The loopback port the proxy is listening on, or nil when there is none.
+    /// Diagnostic: it is what Settings shows so an operator can curl the
+    /// proxy's own `/tbd/status` without going into `~/tbd/state.db`.
+    public var modelProxyPort: Int?
+    /// The running proxy's build version, or nil when there is none. The
+    /// supervisor retires a proxy whose version differs from the daemon's own
+    /// binary, so a value here that disagrees with the app's version is the
+    /// visible form of "a retire is due".
+    public var modelProxyVersion: String?
+    /// Whether transcript streaming is effective — the *conjunction* of
+    /// `transcript_streaming_enabled` and `model_proxy_enabled`, resolved
+    /// daemon-side. A hand-edited row holding streaming on with the proxy off
+    /// streams nothing, and this field says so rather than making the app
+    /// re-derive the pair.
+    public var transcriptStreamingEnabled: Bool
 
     public init(controlModeEnabled: Bool,
                 tmuxVersion: String? = nil,
@@ -3798,7 +3875,12 @@ public struct DaemonCapabilitiesResult: Codable, Sendable {
                 updateMode: UpdateMode = Config.updateModeDefault,
                 ptyHolderEnabled: Bool = Config.ptyHolderDefault,
                 ptyHolderSupported: Bool = false,
-                transcriptComposerEnabled: Bool = Config.transcriptComposerEnabledDefault) {
+                transcriptComposerEnabled: Bool = Config.transcriptComposerEnabledDefault,
+                modelProxyEnabled: Bool = Config.modelProxyDefault,
+                modelProxySupported: Bool = false,
+                modelProxyPort: Int? = nil,
+                modelProxyVersion: String? = nil,
+                transcriptStreamingEnabled: Bool = Config.transcriptStreamingDefault) {
         self.controlModeEnabled = controlModeEnabled
         self.tmuxVersion = tmuxVersion
         self.controlModeSupported = controlModeSupported
@@ -3817,6 +3899,11 @@ public struct DaemonCapabilitiesResult: Codable, Sendable {
         self.ptyHolderEnabled = ptyHolderEnabled
         self.ptyHolderSupported = ptyHolderSupported
         self.transcriptComposerEnabled = transcriptComposerEnabled
+        self.modelProxyEnabled = modelProxyEnabled
+        self.modelProxySupported = modelProxySupported
+        self.modelProxyPort = modelProxyPort
+        self.modelProxyVersion = modelProxyVersion
+        self.transcriptStreamingEnabled = transcriptStreamingEnabled
     }
 
     public init(from decoder: Decoder) throws {
@@ -3881,6 +3968,21 @@ public struct DaemonCapabilitiesResult: Codable, Sendable {
         transcriptComposerEnabled = try c.decodeIfPresent(
             Bool.self, forKey: .transcriptComposerEnabled)
             ?? Config.transcriptComposerEnabledDefault
+        // New fields for the model proxy. A daemon that does not send
+        // `modelProxyEnabled` runs no proxy at all, so fall through to the
+        // shipped defaults rather than assuming the route is live. `supported`,
+        // `port` and `version` are facts about THIS daemon's running proxy, so
+        // absent values are honestly false/nil — which greys the toggles out on
+        // an older daemon instead of offering switches it would ignore.
+        modelProxyEnabled = try c.decodeIfPresent(
+            Bool.self, forKey: .modelProxyEnabled) ?? Config.modelProxyDefault
+        modelProxySupported = try c.decodeIfPresent(
+            Bool.self, forKey: .modelProxySupported) ?? false
+        modelProxyPort = try c.decodeIfPresent(Int.self, forKey: .modelProxyPort)
+        modelProxyVersion = try c.decodeIfPresent(String.self, forKey: .modelProxyVersion)
+        transcriptStreamingEnabled = try c.decodeIfPresent(
+            Bool.self, forKey: .transcriptStreamingEnabled)
+            ?? Config.transcriptStreamingDefault
     }
 }
 

--- a/Tests/TBDAppTests/ModelProxySettingsTests.swift
+++ b/Tests/TBDAppTests/ModelProxySettingsTests.swift
@@ -1,0 +1,200 @@
+import Foundation
+import Testing
+@testable import TBDApp
+import TBDShared
+
+/// The Settings surface for the two model-proxy gates — the proxy itself, and
+/// the transcript streaming that reads what the proxy writes.
+///
+/// The pairing is the point: the daemon owns the coupling (streaming on turns
+/// the proxy on; the proxy off turns streaming off), and the app's job is only
+/// to send the gesture and read the daemon back. So every test here asserts the
+/// app forwarded the toggled value and re-fetched capabilities — never that it
+/// computed a coupled value of its own.
+///
+/// Every test that constructs `AppState` does so against a unique throwaway
+/// `UserDefaults` suite and tears it down — TBDApp ships as an unbundled SPM
+/// executable, so `UserDefaults.standard` is the running developer's real
+/// `TBDApp.plist`.
+@MainActor
+@Suite("ModelProxySettings")
+struct ModelProxySettingsTests {
+
+    private func withAppState(_ body: (AppState) async -> Void) async {
+        let name = "tbd-model-proxy-settings-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: name)!
+        await body(AppState(userDefaults: defaults))
+        defaults.removePersistentDomain(forName: name)
+    }
+
+    // MARK: - Model proxy gate
+
+    @Test func modelProxySetterPersistsOnAndRefreshesCapabilities() async {
+        await withAppState { state in
+            var written: [Bool] = []
+            var refreshes = 0
+            state.modelProxyFlagSetter = { @MainActor enabled in written.append(enabled) }
+            state.daemonCapabilitiesFetcher = { @MainActor in
+                refreshes += 1
+                return DaemonCapabilitiesResult(
+                    controlModeEnabled: false, modelProxyEnabled: true, modelProxySupported: true)
+            }
+
+            await state.setModelProxyEnabled(true)
+
+            #expect(written == [true])
+            #expect(refreshes == 1, "the toggle must read the daemon back, not its own guess")
+            #expect(state.daemonCapabilities?.modelProxyEnabled == true)
+        }
+    }
+
+    /// The off branch is its own test rather than a second assertion, because
+    /// turning the proxy OFF is the operator's exit from the soak and a setter
+    /// that ignored its argument would pass the on-only test.
+    @Test func modelProxySetterPersistsOffAndRefreshesCapabilities() async {
+        await withAppState { state in
+            var written: [Bool] = []
+            state.modelProxyFlagSetter = { @MainActor enabled in written.append(enabled) }
+            state.daemonCapabilitiesFetcher = { @MainActor in
+                DaemonCapabilitiesResult(
+                    controlModeEnabled: false, modelProxyEnabled: false,
+                    modelProxySupported: true, transcriptStreamingEnabled: false)
+            }
+
+            await state.setModelProxyEnabled(false)
+
+            #expect(written == [false])
+            #expect(state.daemonCapabilities?.modelProxyEnabled == false)
+            #expect(
+                state.daemonCapabilities?.transcriptStreamingEnabled == false,
+                "the daemon's coupled write is what the read-back must show")
+        }
+    }
+
+    /// A write the daemon refused must not be followed by a read-back, and must
+    /// not leave the toggle showing a state nothing persisted.
+    @Test func modelProxySetterSurfacesAFailureAndLeavesCapabilitiesAlone() async {
+        struct Boom: Error {}
+        await withAppState { state in
+            var refreshes = 0
+            state.modelProxyFlagSetter = { @MainActor _ in throw Boom() }
+            state.daemonCapabilitiesFetcher = { @MainActor in
+                refreshes += 1
+                return nil
+            }
+
+            await state.setModelProxyEnabled(true)
+
+            #expect(refreshes == 0, "a failed write must not be followed by a refresh")
+            #expect(state.daemonCapabilities == nil)
+            #expect(state.alertMessage != nil)
+        }
+    }
+
+    // MARK: - Transcript streaming gate
+
+    @Test func streamingSetterPersistsOnAndRefreshesCapabilities() async {
+        await withAppState { state in
+            var written: [Bool] = []
+            var refreshes = 0
+            state.transcriptStreamingFlagSetter = { @MainActor enabled in written.append(enabled) }
+            state.daemonCapabilitiesFetcher = { @MainActor in
+                refreshes += 1
+                return DaemonCapabilitiesResult(
+                    controlModeEnabled: false, modelProxyEnabled: true,
+                    modelProxySupported: true, transcriptStreamingEnabled: true)
+            }
+
+            await state.setTranscriptStreamingEnabled(true)
+
+            #expect(written == [true])
+            #expect(refreshes == 1, "the toggle must read the daemon back, not its own guess")
+            #expect(state.daemonCapabilities?.transcriptStreamingEnabled == true)
+        }
+    }
+
+    @Test func streamingSetterPersistsOffAndRefreshesCapabilities() async {
+        await withAppState { state in
+            var written: [Bool] = []
+            state.transcriptStreamingFlagSetter = { @MainActor enabled in written.append(enabled) }
+            state.daemonCapabilitiesFetcher = { @MainActor in
+                DaemonCapabilitiesResult(
+                    controlModeEnabled: false, modelProxyEnabled: true,
+                    modelProxySupported: true, transcriptStreamingEnabled: false)
+            }
+
+            await state.setTranscriptStreamingEnabled(false)
+
+            #expect(written == [false])
+            #expect(state.daemonCapabilities?.transcriptStreamingEnabled == false)
+            #expect(
+                state.daemonCapabilities?.modelProxyEnabled == true,
+                "turning streaming off leaves the proxy where the operator put it")
+        }
+    }
+
+    /// The coupling lives in the daemon, so the app must send the gesture even
+    /// when the proxy it depends on is currently off — an app that pre-empted
+    /// the write would make "turn streaming on" a no-op on exactly the fleet
+    /// that has never opted in.
+    @Test func streamingSetterFiresEvenWhileTheProxyIsOff() async {
+        await withAppState { state in
+            var written: [Bool] = []
+            state.modelProxyFlagSetter = { @MainActor _ in
+                Issue.record("the streaming toggle must not write the proxy flag itself")
+            }
+            state.transcriptStreamingFlagSetter = { @MainActor enabled in written.append(enabled) }
+            state.daemonCapabilitiesFetcher = { @MainActor in
+                // What the daemon reports after coupling the two columns.
+                DaemonCapabilitiesResult(
+                    controlModeEnabled: false, modelProxyEnabled: true,
+                    modelProxySupported: true, transcriptStreamingEnabled: true)
+            }
+            // The starting point: nobody has ever turned the proxy on.
+            state.daemonCapabilities = DaemonCapabilitiesResult(
+                controlModeEnabled: false, modelProxyEnabled: false,
+                modelProxySupported: true, transcriptStreamingEnabled: false)
+
+            await state.setTranscriptStreamingEnabled(true)
+
+            #expect(written == [true], "the app forwards the gesture regardless of the proxy state")
+            #expect(state.daemonCapabilities?.modelProxyEnabled == true)
+            #expect(state.daemonCapabilities?.transcriptStreamingEnabled == true)
+        }
+    }
+
+    @Test func streamingSetterSurfacesAFailureAndLeavesCapabilitiesAlone() async {
+        struct Boom: Error {}
+        await withAppState { state in
+            var refreshes = 0
+            state.transcriptStreamingFlagSetter = { @MainActor _ in throw Boom() }
+            state.daemonCapabilitiesFetcher = { @MainActor in
+                refreshes += 1
+                return nil
+            }
+
+            await state.setTranscriptStreamingEnabled(true)
+
+            #expect(refreshes == 0, "a failed write must not be followed by a refresh")
+            #expect(state.daemonCapabilities == nil)
+            #expect(state.alertMessage != nil)
+        }
+    }
+
+    // MARK: - Help strings
+
+    /// Both help strings carry a promise the operator acts on — that the change
+    /// applies to sessions started after it, and (for streaming) that it turns
+    /// the proxy on too. Pinned here so a rewrite that drops either has to be
+    /// deliberate.
+    @Test func helpStringsStateWhenTheChangeAppliesAndWhatItTurnsOn() {
+        #expect(AppState.modelProxyHelp.contains("Applies to sessions started after you change it."))
+        #expect(AppState.modelProxyHelp.contains("Off by default (soaking)."))
+        #expect(
+            AppState.transcriptStreamingHelp.contains(
+                "Turning this on also turns on the model proxy."))
+        #expect(
+            AppState.transcriptStreamingHelp.contains(
+                "Applies to sessions started after you change it."))
+    }
+}

--- a/Tests/TBDDaemonTests/Config/ModelProxyConfigRPCTests.swift
+++ b/Tests/TBDDaemonTests/Config/ModelProxyConfigRPCTests.swift
@@ -1,0 +1,203 @@
+import Foundation
+import GRDB
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+import TestSupport
+
+/// The two model-proxy flags reach the daemon through `config.setModelProxyEnabled`
+/// and `config.setTranscriptStreamingEnabled`, and come back to the app through
+/// `daemon.capabilities` — resolved daemon-side, so a Settings toggle and the
+/// daemon can never disagree about which of them last wrote the column.
+///
+/// The coupling the assertions here pin belongs to `ConfigStore`, not to the
+/// handlers; these tests exist to prove the RPC layer actually routes to those
+/// setters rather than to a second, uncoupled write.
+@Suite("Model proxy config RPCs")
+struct ModelProxyConfigRPCTests {
+    let db: TBDDatabase
+    let router: RPCRouter
+
+    init() throws {
+        let db = try TBDDatabase(inMemory: true)
+        self.db = db
+        let tmux = TmuxManager(dryRun: true)
+        self.router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: tmux, hooks: HookResolver()),
+            tmux: tmux,
+            startTime: Date(),
+            actuationLog: makeTestActuationLog(tag: "model-proxy-rpc"))
+    }
+
+    private func capabilities() async throws -> DaemonCapabilitiesResult {
+        let response = await router.handle(RPCRequest(method: RPCMethod.daemonCapabilities))
+        #expect(response.success)
+        return try response.decodeResult(DaemonCapabilitiesResult.self)
+    }
+
+    // MARK: - The proxy gate
+
+    @Test func settingTheProxyOnPersistsIt() async throws {
+        let request = try RPCRequest(
+            method: RPCMethod.configSetModelProxyEnabled,
+            params: ConfigSetModelProxyEnabledParams(enabled: true))
+
+        let response = await router.handle(request)
+
+        #expect(response.success)
+        #expect(try await db.config.get().modelProxyEnabled)
+    }
+
+    /// The coupling in the proxy's direction: switching the proxy off has
+    /// switched streaming off whether or not the operator knows the second flag
+    /// exists, because the provisional row reads a file only the proxy writes.
+    @Test func turningTheProxyOffAlsoTurnsStreamingOff() async throws {
+        _ = await router.handle(try RPCRequest(
+            method: RPCMethod.configSetTranscriptStreamingEnabled,
+            params: ConfigSetTranscriptStreamingParams(enabled: true)))
+        #expect(try await db.config.get().transcriptStreamingEnabled)
+
+        let response = await router.handle(try RPCRequest(
+            method: RPCMethod.configSetModelProxyEnabled,
+            params: ConfigSetModelProxyEnabledParams(enabled: false)))
+
+        #expect(response.success)
+        let config = try await db.config.get()
+        #expect(config.modelProxyEnabled == false)
+        #expect(config.transcriptStreamingEnabled == false)
+    }
+
+    /// And not the other way about: turning the proxy back on is not a request
+    /// for the provisional transcript row, so streaming stays where it was.
+    @Test func turningTheProxyOnLeavesStreamingAlone() async throws {
+        _ = await router.handle(try RPCRequest(
+            method: RPCMethod.configSetModelProxyEnabled,
+            params: ConfigSetModelProxyEnabledParams(enabled: true)))
+
+        let config = try await db.config.get()
+        #expect(config.modelProxyEnabled)
+        #expect(config.transcriptStreamingEnabled == Config.transcriptStreamingDefault)
+    }
+
+    // MARK: - The streaming gate
+
+    /// The coupling in streaming's direction: the file it reads does not exist
+    /// without the proxy, so asking for streaming is asking for both.
+    @Test func turningStreamingOnAlsoTurnsTheProxyOn() async throws {
+        let response = await router.handle(try RPCRequest(
+            method: RPCMethod.configSetTranscriptStreamingEnabled,
+            params: ConfigSetTranscriptStreamingParams(enabled: true)))
+
+        #expect(response.success)
+        let config = try await db.config.get()
+        #expect(config.transcriptStreamingEnabled)
+        #expect(config.modelProxyEnabled)
+    }
+
+    /// Turning streaming off is not a request to stop routing: a session may
+    /// still want the proxy without the transcript's provisional row.
+    @Test func turningStreamingOffLeavesTheProxyAlone() async throws {
+        _ = await router.handle(try RPCRequest(
+            method: RPCMethod.configSetTranscriptStreamingEnabled,
+            params: ConfigSetTranscriptStreamingParams(enabled: true)))
+
+        let response = await router.handle(try RPCRequest(
+            method: RPCMethod.configSetTranscriptStreamingEnabled,
+            params: ConfigSetTranscriptStreamingParams(enabled: false)))
+
+        #expect(response.success)
+        let config = try await db.config.get()
+        #expect(config.transcriptStreamingEnabled == false)
+        #expect(config.modelProxyEnabled)
+    }
+
+    // MARK: - Capabilities
+
+    @Test func capabilitiesStartAtTheShippedDefaults() async throws {
+        let caps = try await capabilities()
+
+        #expect(caps.modelProxyEnabled == Config.modelProxyDefault)
+        #expect(caps.transcriptStreamingEnabled == Config.transcriptStreamingDefault)
+        // No supervisor until Part B2 — so no daemon can route a session yet,
+        // and Settings has what it needs to say so.
+        #expect(caps.modelProxySupported == false)
+        #expect(caps.modelProxyPort == nil)
+        #expect(caps.modelProxyVersion == nil)
+    }
+
+    @Test func capabilitiesReflectTheProxyToggle() async throws {
+        _ = await router.handle(try RPCRequest(
+            method: RPCMethod.configSetModelProxyEnabled,
+            params: ConfigSetModelProxyEnabledParams(enabled: true)))
+
+        let caps = try await capabilities()
+
+        #expect(caps.modelProxyEnabled)
+        // The proxy alone does not stream; the reported value is the conjunction.
+        #expect(caps.transcriptStreamingEnabled == false)
+    }
+
+    @Test func capabilitiesReflectTheStreamingToggle() async throws {
+        _ = await router.handle(try RPCRequest(
+            method: RPCMethod.configSetTranscriptStreamingEnabled,
+            params: ConfigSetTranscriptStreamingParams(enabled: true)))
+
+        let caps = try await capabilities()
+
+        #expect(caps.modelProxyEnabled)
+        #expect(caps.transcriptStreamingEnabled)
+    }
+
+    /// `daemon.capabilities` reports the *effective* value, so a row holding a
+    /// combination no toggle can produce — streaming on, proxy off — is
+    /// reported as not streaming rather than passed to the app to re-derive.
+    @Test func capabilitiesReportTheConjunctionNotTheRawColumn() async throws {
+        try await db.config.setTranscriptStreamingEnabled(true)
+        // Reach past the coupled setter, the way a hand-edited database would.
+        try await db.writerForTests.write { conn in
+            try conn.execute(
+                sql: "UPDATE config SET model_proxy_enabled = 0 WHERE id = ?",
+                arguments: [ConfigStore.singletonID])
+        }
+        #expect(try await db.config.get().transcriptStreamingEnabled)
+
+        let caps = try await capabilities()
+
+        #expect(caps.modelProxyEnabled == false)
+        #expect(caps.transcriptStreamingEnabled == false)
+    }
+
+    /// An older daemon sends none of these keys. It runs no proxy either, so
+    /// the app must fall through to the shipped defaults rather than assume the
+    /// route is live.
+    @Test func anOlderDaemonsPayloadFollowsTheShippedDefaults() throws {
+        let legacy = #"{"controlModeEnabled":false}"#
+
+        let decoded = try JSONDecoder().decode(
+            DaemonCapabilitiesResult.self, from: Data(legacy.utf8))
+
+        #expect(decoded.modelProxyEnabled == Config.modelProxyDefault)
+        #expect(decoded.transcriptStreamingEnabled == Config.transcriptStreamingDefault)
+        #expect(decoded.modelProxySupported == false)
+        #expect(decoded.modelProxyPort == nil)
+        #expect(decoded.modelProxyVersion == nil)
+    }
+
+    /// The port and version are carried, not dropped, once a supervisor fills
+    /// them in — pinned now so B2 wires a field that already round-trips.
+    @Test func portAndVersionRoundTripThroughTheWire() throws {
+        var sent = DaemonCapabilitiesResult(controlModeEnabled: false)
+        sent.modelProxySupported = true
+        sent.modelProxyPort = 47_821
+        sent.modelProxyVersion = "1.2.3"
+
+        let decoded = try JSONDecoder().decode(
+            DaemonCapabilitiesResult.self, from: JSONEncoder().encode(sent))
+
+        #expect(decoded.modelProxySupported)
+        #expect(decoded.modelProxyPort == 47_821)
+        #expect(decoded.modelProxyVersion == "1.2.3")
+    }
+}

--- a/Tests/TBDDaemonTests/Config/ModelProxyFlagTests.swift
+++ b/Tests/TBDDaemonTests/Config/ModelProxyFlagTests.swift
@@ -24,7 +24,9 @@ import Testing
 struct ModelProxyFlagTests {
 
     /// The last migration identifier that predates the columns. Migrating only
-    /// this far reproduces the schema a real pre-flag daemon ran on.
+    /// this far reproduces the schema a real pre-flag daemon ran on. Any
+    /// identifier that predates the four columns would do — this one is just
+    /// whatever landed last before them.
     private static let lastIdentifierBeforeTheFlags = "20260905220000_terminal_holder_child_started_at"
 
     private func fetchConfigRecord(_ db: TBDDatabase) async throws -> ConfigRecord? {
@@ -233,6 +235,27 @@ struct ModelProxyFlagTests {
         #expect(
             try await db.config.get().transcriptStreamingEnabled == false,
             "streaming must stay off until it is asked for again")
+    }
+
+    /// The off-write fires even when streaming was never touched: a fresh row
+    /// has `transcript_streaming_enabled` at NULL, and turning the proxy off
+    /// is still the gesture that lifts it into an explicit `false` — not a
+    /// value that merely happens to resolve to false through the default.
+    @Test func turningTheProxyOffFromAFreshRowWritesStreamingExplicitlyFalse() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let before = try #require(try await fetchConfigRecord(db))
+        #expect(before.transcript_streaming_enabled == nil)
+
+        try await db.config.setModelProxyEnabled(false)
+
+        let after = try #require(try await fetchConfigRecord(db))
+        #expect(
+            after.transcript_streaming_enabled == false,
+            """
+            turning the proxy off from a fresh row must write streaming to an \
+            explicit 0, not leave it NULL — read back \
+            \(String(describing: after.transcript_streaming_enabled)).
+            """)
     }
 
     /// Turning the proxy ON is not coupled: it must leave streaming exactly

--- a/Tests/TBDDaemonTests/Config/ModelProxyFlagTests.swift
+++ b/Tests/TBDDaemonTests/Config/ModelProxyFlagTests.swift
@@ -1,0 +1,313 @@
+import Foundation
+import GRDB
+import Testing
+
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Schema, resolution and coupling guards for the model proxy's two flags and
+/// its port column
+/// (`docs/specs/2026-09-05-transcript-streaming-model-proxy-design.md`,
+/// "Flags and migrations" and "Port").
+///
+/// `config.model_proxy_enabled` and `config.transcript_streaming_enabled` are
+/// added with **no SQL default**, so "never chose" (NULL) stays
+/// distinguishable from "explicitly off". If someone adds a `DEFAULT` clause to
+/// either migration, `nullBeforeAnyGesture` and
+/// `rowWrittenBeforeTheMigrationStillReadsNull` go red — that is their only
+/// job.
+///
+/// The two flags are coupled in one direction each by the setters, and their
+/// conjunction is what any reader acts on; both properties are pinned below,
+/// the conjunction against a row no setter can produce.
+@Suite("ModelProxyFlag")
+struct ModelProxyFlagTests {
+
+    /// The last migration identifier that predates the columns. Migrating only
+    /// this far reproduces the schema a real pre-flag daemon ran on.
+    private static let lastIdentifierBeforeTheFlags = "20260905220000_terminal_holder_child_started_at"
+
+    private func fetchConfigRecord(_ db: TBDDatabase) async throws -> ConfigRecord? {
+        try await db.writerForTests.read { conn in
+            try ConfigRecord.fetchOne(conn, key: ConfigStore.singletonID)
+        }
+    }
+
+    // MARK: - Storage: the columns are genuinely NULL until somebody chooses
+
+    /// **The load-bearing test.** The `config` singleton row is inserted by v1,
+    /// so every install has a row that predates these columns. After the
+    /// migrations that row must read NULL for all three, not `0`.
+    @Test func nullBeforeAnyGesture() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let record = try #require(try await fetchConfigRecord(db))
+        #expect(
+            record.model_proxy_enabled == nil,
+            """
+            config.model_proxy_enabled must be NULL until the toggle is touched \
+            — read back \(String(describing: record.model_proxy_enabled)). A \
+            non-nil value here means the migration grew a DEFAULT clause; \
+            remove it.
+            """)
+        #expect(
+            record.transcript_streaming_enabled == nil,
+            """
+            config.transcript_streaming_enabled must be NULL until the toggle \
+            is touched — read back \
+            \(String(describing: record.transcript_streaming_enabled)).
+            """)
+        #expect(
+            record.model_proxy_port == nil,
+            """
+            config.model_proxy_port must be NULL until a port is minted — read \
+            back \(String(describing: record.model_proxy_port)). Zero is the ask \
+            the proxy is spawned with, never a stored answer.
+            """)
+    }
+
+    @Test func rowWrittenBeforeTheMigrationStillReadsNull() throws {
+        let queue = try DatabaseQueue()
+        let migrator = TBDDatabase.buildMigratorForTests()
+        try migrator.migrate(queue, upTo: Self.lastIdentifierBeforeTheFlags)
+
+        try queue.write { db in
+            try db.execute(
+                sql: "UPDATE config SET auto_create_notes_enabled = 1 WHERE id = ?",
+                arguments: [ConfigStore.singletonID])
+        }
+
+        try migrator.migrate(queue)
+
+        try queue.read { db in
+            let row = try #require(try Row.fetchOne(
+                db, sql: "SELECT * FROM config WHERE id = ?",
+                arguments: [ConfigStore.singletonID]))
+            for column in [
+                "model_proxy_enabled", "transcript_streaming_enabled", "model_proxy_port",
+            ] {
+                let raw: DatabaseValue = row[column]
+                #expect(
+                    raw.isNull,
+                    "\(column) on a config row written before the migration must read NULL, not \(raw)")
+            }
+            #expect(row["auto_create_notes_enabled"] == true)
+        }
+    }
+
+    /// The terminal column ships in the same commit as the config ones and is
+    /// nullable for the same reason: a session either got a stream file at
+    /// spawn or never will.
+    @Test func terminalStreamPathColumnExistsAndIsNullable() throws {
+        let queue = try DatabaseQueue()
+        try TBDDatabase.buildMigratorForTests().migrate(queue)
+        try queue.read { db in
+            #expect(try db.columns(in: "terminal").map(\.name)
+                .contains("transcript_stream_path"))
+            let info = try #require(try Row.fetchAll(db, sql: "PRAGMA table_info(terminal)")
+                .first { $0["name"] == "transcript_stream_path" })
+            #expect(info["notnull"] == 0, "the column must be nullable")
+            let defaultValue: DatabaseValue = info["dflt_value"]
+            #expect(defaultValue.isNull, "the column must carry no SQL DEFAULT, read \(defaultValue)")
+        }
+    }
+
+    // MARK: - Resolution: the three states are distinguishable
+
+    /// NULL follows `Config.modelProxyDefault` wherever it goes; an explicit
+    /// `false` does not. That property is what makes graduation a one-line
+    /// constant change with no forcing `UPDATE` migration.
+    @Test func explicitFalseSurvivesADefaultFlipWhileNullFollowsIt() async throws {
+        let db = try TBDDatabase(inMemory: true)
+
+        let untouched = try #require(try await fetchConfigRecord(db))
+        #expect(untouched.model_proxy_enabled == nil)
+        #expect(untouched.toModel(modelProxyDefault: false).modelProxyEnabled == false)
+        #expect(
+            untouched.toModel(modelProxyDefault: true).modelProxyEnabled,
+            "a never-chosen row must pick up a changed shipped default")
+
+        try await db.config.setModelProxyEnabled(false)
+        let explicitlyOff = try #require(try await fetchConfigRecord(db))
+        #expect(explicitlyOff.model_proxy_enabled == false)
+        #expect(
+            explicitlyOff.toModel(modelProxyDefault: true).modelProxyEnabled == false,
+            "an explicit opt-out must be honored forever, whatever the default becomes")
+    }
+
+    @Test func streamingExplicitFalseSurvivesADefaultFlipWhileNullFollowsIt() async throws {
+        let db = try TBDDatabase(inMemory: true)
+
+        let untouched = try #require(try await fetchConfigRecord(db))
+        #expect(untouched.transcript_streaming_enabled == nil)
+        #expect(
+            untouched.toModel(transcriptStreamingDefault: false)
+                .transcriptStreamingEnabled == false)
+        #expect(
+            untouched.toModel(transcriptStreamingDefault: true).transcriptStreamingEnabled,
+            "a never-chosen row must pick up a changed shipped default")
+
+        try await db.config.setTranscriptStreamingEnabled(false)
+        let explicitlyOff = try #require(try await fetchConfigRecord(db))
+        #expect(explicitlyOff.transcript_streaming_enabled == false)
+        #expect(
+            explicitlyOff.toModel(transcriptStreamingDefault: true)
+                .transcriptStreamingEnabled == false,
+            "an explicit opt-out must be honored forever, whatever the default becomes")
+    }
+
+    /// Isolates the RESOLUTION guard from the STORAGE guard by constructing a
+    /// `ConfigRecord` directly — no database, no migration.
+    @Test func toModelResolvesNullThroughTheInjectedDefaults() {
+        let record = ConfigRecord(
+            id: "unstored", model_proxy_enabled: nil, transcript_streaming_enabled: nil)
+        #expect(record.toModel(modelProxyDefault: false).modelProxyEnabled == false)
+        #expect(
+            record.toModel(modelProxyDefault: true).modelProxyEnabled,
+            "a NULL record must pick up whatever default is injected, not a hardcoded false")
+        #expect(
+            record.toModel(transcriptStreamingDefault: false)
+                .transcriptStreamingEnabled == false)
+        #expect(record.toModel(transcriptStreamingDefault: true).transcriptStreamingEnabled)
+    }
+
+    // MARK: - The shipped defaults, and the wire
+
+    @Test func shippedDefaultsAreOff() async throws {
+        #expect(Config.modelProxyDefault == false)
+        #expect(Config.transcriptStreamingDefault == false)
+        let db = try TBDDatabase(inMemory: true)
+        let config = try await db.config.get()
+        #expect(config.modelProxyEnabled == false)
+        #expect(config.transcriptStreamingEnabled == false)
+        #expect(config.transcriptStreamingEffective == false)
+        #expect(config.modelProxyPort == nil)
+    }
+
+    @Test func configJSONWithoutTheKeysFollowsTheShippedDefaults() throws {
+        let json = #"{"primaryAgentPreference":"claude"}"#
+        let config = try JSONDecoder().decode(Config.self, from: Data(json.utf8))
+        #expect(config.modelProxyEnabled == Config.modelProxyDefault)
+        #expect(config.transcriptStreamingEnabled == Config.transcriptStreamingDefault)
+        #expect(config.modelProxyPort == nil)
+    }
+
+    @Test func configJSONRoundTripsExplicitChoices() throws {
+        var config = Config()
+        config.modelProxyEnabled = true
+        config.transcriptStreamingEnabled = true
+        config.modelProxyPort = 51_234
+        let decoded = try JSONDecoder().decode(
+            Config.self, from: JSONEncoder().encode(config))
+        #expect(decoded.modelProxyEnabled)
+        #expect(decoded.transcriptStreamingEnabled)
+        #expect(decoded.modelProxyPort == 51_234)
+        #expect(decoded.transcriptStreamingEffective)
+    }
+
+    // MARK: - Coupling: one direction each
+
+    /// Asking for streaming is asking for the proxy too, because the file
+    /// streaming reads is the one the proxy writes.
+    @Test func turningStreamingOnTurnsTheProxyOn() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setTranscriptStreamingEnabled(true)
+        let config = try await db.config.get()
+        #expect(config.transcriptStreamingEnabled)
+        #expect(config.modelProxyEnabled, "streaming on must have written the proxy flag on")
+        #expect(config.transcriptStreamingEffective)
+    }
+
+    /// And the reverse: switching the proxy off switches streaming off, so it
+    /// cannot silently re-arm when the proxy next comes on.
+    @Test func turningTheProxyOffTurnsStreamingOff() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setTranscriptStreamingEnabled(true)
+        try await db.config.setModelProxyEnabled(false)
+
+        let config = try await db.config.get()
+        #expect(config.modelProxyEnabled == false)
+        #expect(config.transcriptStreamingEnabled == false)
+        #expect(config.transcriptStreamingEffective == false)
+
+        try await db.config.setModelProxyEnabled(true)
+        #expect(
+            try await db.config.get().transcriptStreamingEnabled == false,
+            "streaming must stay off until it is asked for again")
+    }
+
+    /// Turning the proxy ON is not coupled: it must leave streaming exactly
+    /// where the user left it rather than turning it on as a side effect.
+    @Test func turningTheProxyOnLeavesStreamingAlone() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setModelProxyEnabled(true)
+        let record = try #require(try await fetchConfigRecord(db))
+        #expect(record.model_proxy_enabled == true)
+        #expect(
+            record.transcript_streaming_enabled == nil,
+            "turning the proxy on must not lift streaming out of NULL")
+        #expect(try await db.config.get().transcriptStreamingEffective == false)
+    }
+
+    /// Turning streaming OFF is not coupled either — a user who wants the row
+    /// but not the proxy would have no way back otherwise.
+    @Test func turningStreamingOffLeavesTheProxyAlone() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setModelProxyEnabled(true)
+        try await db.config.setTranscriptStreamingEnabled(false)
+        let config = try await db.config.get()
+        #expect(config.modelProxyEnabled)
+        #expect(config.transcriptStreamingEnabled == false)
+        #expect(config.transcriptStreamingEffective == false)
+    }
+
+    /// The conjunction, against a combination no setter can produce: a
+    /// hand-edited row with streaming on and the proxy off streams nothing.
+    @Test func effectiveIsFalseWhenStreamingIsOnAndTheProxyIsOff() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.writerForTests.write { conn in
+            try conn.execute(
+                sql: """
+                    UPDATE config
+                       SET model_proxy_enabled = 0, transcript_streaming_enabled = 1
+                     WHERE id = ?
+                    """,
+                arguments: [ConfigStore.singletonID])
+        }
+        let config = try await db.config.get()
+        #expect(config.modelProxyEnabled == false)
+        #expect(config.transcriptStreamingEnabled, "the row's own choice is preserved")
+        #expect(
+            config.transcriptStreamingEffective == false,
+            "streaming without the proxy has no file to read and must resolve off")
+    }
+
+    // MARK: - The port
+
+    @Test func ensureModelProxyPortKeepsTheFirstValue() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let first = try await db.config.ensureModelProxyPort(minting: 51_234)
+        #expect(first == 51_234)
+        let second = try await db.config.ensureModelProxyPort(minting: 51_999)
+        #expect(second == 51_234, "the second daemon to ask must get the port already minted")
+        #expect(try await db.config.get().modelProxyPort == 51_234)
+    }
+
+    @Test func setModelProxyPortOverwrites() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        _ = try await db.config.ensureModelProxyPort(minting: 51_234)
+        try await db.config.setModelProxyPort(51_999)
+        #expect(try await db.config.get().modelProxyPort == 51_999)
+        #expect(
+            try await db.config.ensureModelProxyPort(minting: 52_000) == 51_999,
+            "the re-minted port is now the one a later ensure must keep")
+    }
+
+    /// Zero is the ask the proxy is spawned with, never a stored answer, so a
+    /// row holding it is unminted and the next ensure mints over it.
+    @Test func ensureModelProxyPortTreatsANonPositiveStoredValueAsUnminted() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setModelProxyPort(0)
+        #expect(try await db.config.ensureModelProxyPort(minting: 51_234) == 51_234)
+        #expect(try await db.config.get().modelProxyPort == 51_234)
+    }
+}

--- a/Tests/TBDDaemonTests/SQLMigrationLoaderTests.swift
+++ b/Tests/TBDDaemonTests/SQLMigrationLoaderTests.swift
@@ -508,6 +508,10 @@ import Testing
             "20260905120000_config_transcript_composer",
             "20260905213000_config_holder_hibernation",
             "20260905220000_terminal_holder_child_started_at",
+            "20260907215724_config_model_proxy",
+            "20260907215725_config_transcript_streaming",
+            "20260907215726_config_model_proxy_port",
+            "20260907215727_terminal_transcript_stream_path",
         ]
         let found = try SQLMigrationLoader.bundled.get()
         #expect(found.files.map(\.identifier) == expected)

--- a/Tests/TBDDaemonTests/TerminalTranscriptStreamPathStoreTests.swift
+++ b/Tests/TBDDaemonTests/TerminalTranscriptStreamPathStoreTests.swift
@@ -1,0 +1,207 @@
+import Foundation
+import GRDB
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// The Swift half of `terminal.transcript_stream_path`
+/// (`docs/specs/2026-09-05-transcript-streaming-model-proxy-design.md`,
+/// "The daemon" → "Spawn"): the column reaches `Terminal.transcriptStreamPath`
+/// in both directions, a session that was never routed through the proxy reads
+/// nil, and the value survives the wire.
+///
+/// The column is nullable with no SQL default for the same reason the flags
+/// are: a session either got a stream file at spawn or never will, and the row
+/// must be able to say "never" rather than "empty string".
+@Suite("TerminalStore transcript stream path")
+struct TerminalTranscriptStreamPathStoreTests {
+
+    /// The last migration identifier that predates the column. Migrating only
+    /// this far reproduces the schema a real pre-proxy daemon ran on.
+    private static let lastIdentifierBeforeTheColumn = "20260907215726_config_model_proxy_port"
+
+    private func makeTerminal(_ db: TBDDatabase) async throws -> Terminal {
+        let worktree = try await db.worktrees.createScratch(
+            name: "wt", displayName: "wt",
+            path: "/tmp/tbd-nonexistent-\(UUID().uuidString)", tmuxServer: "tbd-test")
+        return try await db.terminals.create(
+            worktreeID: worktree.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "claude", kind: .claude)
+    }
+
+    // MARK: - Storage
+
+    /// Every terminal starts unrouted. Nothing spawns a route by accident.
+    @Test func aFreshRowHasNoStreamPath() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let terminal = try await makeTerminal(db)
+        #expect(terminal.transcriptStreamPath == nil)
+        let row = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(row.transcriptStreamPath == nil)
+    }
+
+    @Test func theSetterWritesAPathThatReadsBack() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let terminal = try await makeTerminal(db)
+        let path = "/tmp/tbd-streams/\(terminal.id.uuidString).jsonl"
+
+        try await db.terminals.setTranscriptStreamPath(terminalID: terminal.id, path: path)
+
+        let row = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(row.transcriptStreamPath == path)
+        let stored = try await db.writerForTests.read { conn in
+            try String.fetchOne(
+                conn, sql: "SELECT transcript_stream_path FROM terminal WHERE id = ?",
+                arguments: [terminal.id.uuidString])
+        }
+        #expect(stored == path, "the model field must land in the snake_case column")
+    }
+
+    @Test func theSetterClearsTheRouteWithNil() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let terminal = try await makeTerminal(db)
+        try await db.terminals.setTranscriptStreamPath(
+            terminalID: terminal.id, path: "/tmp/tbd-streams/a.jsonl")
+
+        try await db.terminals.setTranscriptStreamPath(terminalID: terminal.id, path: nil)
+
+        let row = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(row.transcriptStreamPath == nil)
+    }
+
+    /// The narrow-write property the setter's `UPDATE` exists for: spawn writes
+    /// this column while the process it just started is already firing hooks,
+    /// so the write must not carry the rest of the row back with it.
+    @Test func theSetterLeavesEveryOtherColumnAlone() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let terminal = try await makeTerminal(db)
+        try await db.terminals.updateSession(
+            id: terminal.id, sessionID: "sess-1", transcriptPath: "/tmp/t.jsonl")
+        let before = try #require(try await db.terminals.get(id: terminal.id))
+
+        try await db.terminals.setTranscriptStreamPath(
+            terminalID: terminal.id, path: "/tmp/tbd-streams/b.jsonl")
+
+        let after = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(after.claudeSessionID == before.claudeSessionID)
+        #expect(after.transcriptPath == before.transcriptPath)
+        #expect(after.sessionIncarnationID == before.sessionIncarnationID)
+        #expect(after.activityState == before.activityState)
+        #expect(after.transcriptStreamPath == "/tmp/tbd-streams/b.jsonl")
+    }
+
+    /// A terminal that has vanished is a no-op rather than a throw — the route
+    /// belonged to a row nothing can read any more. Matches `setProfileID`.
+    @Test func theSetterIgnoresAMissingRow() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.terminals.setTranscriptStreamPath(terminalID: UUID(), path: "/tmp/x.jsonl")
+    }
+
+    /// **The load-bearing test.** A terminal row written by a daemon that
+    /// predates the column must read nil after the migration, not an empty
+    /// string — a `DEFAULT ''` clause on the migration would redden this.
+    @Test func aRowWrittenBeforeTheMigrationStillReadsNil() throws {
+        let queue = try DatabaseQueue()
+        let migrator = TBDDatabase.buildMigratorForTests()
+        try migrator.migrate(queue, upTo: Self.lastIdentifierBeforeTheColumn)
+
+        let epoch = Date(timeIntervalSince1970: 1_700_000_000)
+        let repoID = UUID().uuidString
+        let worktreeID = UUID().uuidString
+        let terminalID = UUID().uuidString
+        try queue.write { db in
+            try db.execute(
+                sql: """
+                    INSERT INTO repo (id, path, displayName, defaultBranch, createdAt)
+                    VALUES (?, '/tmp/stream-path-repo', 'Stream', 'main', ?)
+                    """, arguments: [repoID, epoch])
+            try db.execute(
+                sql: """
+                    INSERT INTO worktree
+                        (id, repoID, name, displayName, branch, path, status, createdAt, tmuxServer)
+                    VALUES (?, ?, 'w', 'w', 'main', '/tmp/stream-path-wt',
+                            'active', ?, 'tbd-stream-path')
+                    """, arguments: [worktreeID, repoID, epoch])
+            try db.execute(
+                sql: """
+                    INSERT INTO terminal
+                        (id, worktreeID, tmuxWindowID, tmuxPaneID, createdAt)
+                    VALUES (?, ?, '@1', '%1', ?)
+                    """, arguments: [terminalID, worktreeID, epoch])
+        }
+        let columnsBefore = try queue.read { db in
+            try db.columns(in: "terminal").map(\.name)
+        }
+        #expect(
+            !columnsBefore.contains("transcript_stream_path"),
+            "the fixture must be written against a schema that predates the column")
+
+        try migrator.migrate(queue)
+
+        try queue.read { db in
+            let row = try #require(try Row.fetchOne(
+                db, sql: "SELECT * FROM terminal WHERE id = ?", arguments: [terminalID]))
+            let raw: DatabaseValue = row["transcript_stream_path"]
+            #expect(
+                raw.isNull,
+                "transcript_stream_path on a pre-migration terminal row must read NULL, not \(raw)")
+
+            let record = try #require(try TerminalRecord.fetchOne(db, key: terminalID))
+            #expect(record.transcript_stream_path == nil)
+            #expect(try #require(record.toModel()).transcriptStreamPath == nil)
+        }
+    }
+
+    // MARK: - The wire
+
+    @Test func terminalJSONWithoutTheKeyDecodesToNil() throws {
+        let json = """
+            {"id":"\(UUID().uuidString)","worktreeID":"\(UUID().uuidString)",
+             "tmuxWindowID":"@1","tmuxPaneID":"%1","createdAt":0}
+            """
+        let decoded = try JSONDecoder().decode(Terminal.self, from: Data(json.utf8))
+        #expect(decoded.transcriptStreamPath == nil)
+    }
+
+    @Test func terminalJSONRoundTripsThePath() throws {
+        let path = "/tmp/tbd-streams/round-trip.jsonl"
+        let terminal = Terminal(
+            worktreeID: UUID(), tmuxWindowID: "@1", tmuxPaneID: "%1",
+            transcriptStreamPath: path)
+        let encoded = try JSONEncoder().encode(terminal)
+        let decoded = try JSONDecoder().decode(Terminal.self, from: encoded)
+        #expect(decoded.transcriptStreamPath == path)
+
+        let unrouted = Terminal(worktreeID: UUID(), tmuxWindowID: "@1", tmuxPaneID: "%1")
+        let unroutedData = try JSONEncoder().encode(unrouted)
+        let unroutedJSON = try #require(
+            JSONSerialization.jsonObject(with: unroutedData) as? [String: Any])
+        #expect(
+            !unroutedJSON.keys.contains("transcriptStreamPath"),
+            "an unrouted terminal must omit the key rather than send a null")
+        let decodedUnrouted = try JSONDecoder().decode(Terminal.self, from: unroutedData)
+        #expect(decodedUnrouted.transcriptStreamPath == nil)
+    }
+
+    // MARK: - The replacement snapshot
+
+    /// The snapshot exists so a command prepared for one launch cannot commit
+    /// against another. The route is part of that launch, so a row whose route
+    /// moved must no longer match.
+    @Test func theReplacementSnapshotNoticesAChangedRoute() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let terminal = try await makeTerminal(db)
+        try await db.terminals.setTranscriptStreamPath(
+            terminalID: terminal.id, path: "/tmp/tbd-streams/first.jsonl")
+        let observed = try #require(try await db.terminals.get(id: terminal.id))
+        let snapshot = TerminalReplacementSnapshot(terminal: observed)
+        #expect(snapshot.transcriptStreamPath == "/tmp/tbd-streams/first.jsonl")
+        #expect(snapshot.matches(observed))
+
+        try await db.terminals.setTranscriptStreamPath(
+            terminalID: terminal.id, path: "/tmp/tbd-streams/second.jsonl")
+
+        let moved = try #require(try await db.terminals.get(id: terminal.id))
+        #expect(!snapshot.matches(moved), "a route that moved is a launch the caller never saw")
+    }
+}


### PR DESCRIPTION
## Summary

TBD is gaining a loopback model proxy that pty-holder sessions can be routed through, and a transcript pane that streams assistant text before the session file has it. This PR is the switchboard for both: the two flags that gate them, the settings a person flips, and the column that tells the app where a session's stream file lives. Nothing here changes how a session runs yet. With both flags left at their defaults, every path added is inert.

## Why this shape

Two flags rather than one, because the proxy is useful on its own and a person may want it without the transcript feature. They are coupled in one direction each: turning streaming on turns the proxy on, since streaming cannot work without it, and turning the proxy off turns streaming off. The daemon owns that coupling inside the config store, so the app and the CLI cannot get it wrong. Each flag is a tri-state column with no SQL default, so an install that never chose follows the shipped default when it graduates, and an explicit opt-out survives. Design: `docs/specs/2026-09-05-transcript-streaming-model-proxy-design.md`, "Flags and migrations" and "Settings".

## What this PR does

- Four migrations: `config.model_proxy_enabled`, `config.transcript_streaming_enabled`, `config.model_proxy_port`, `terminal.transcript_stream_path`, none with a DEFAULT clause.
- `Config` gains the two flags, the port, and `transcriptStreamingEffective`, the conjunction the app renders.
- Two RPCs, `config.setModelProxyEnabled` and `config.setTranscriptStreamingEnabled`, and five capability fields the app reads; the supported/port/version fields stay false and nil until the supervisor lands in the next PR.
- `Terminal.transcriptStreamPath` through the record, the replacement snapshot, and a single-column setter.
- Two Settings toggles beside "Run new sessions without tmux". The streaming toggle is disabled with a caption until a daemon reports the proxy supported.

## Flag & rollout

`model_proxy_enabled` and `transcript_streaming_enabled`, both default OFF, resolved through `Config.modelProxyDefault` and `Config.transcriptStreamingDefault`. Enable for a soak from Settings > Experimental, or over the socket with the two RPCs. Graduation flips each constant, proxy first.

## Evidence & verification

- A pre-migration row reads NULL for all three config columns and nil for the terminal column; an explicit false survives a flipped default constant while NULL follows it.
- The coupling is tested through the store and through the RPC router in all four directions, including the two non-couplings.
- Capabilities report the conjunction: a hand-written row with streaming on and proxy off reports streaming false.
- The Settings setters call their RPC and refresh capabilities; the streaming setter fires even while the proxy is off, since the daemon owns the coupling.
- The whole suite is green on every commit; the branch is restacked on the proxy binary PR it sits above.

https://claude.ai/code/session_01TggE2eESL3BcvSgFcLZkpk

[model proxy B1: flags](https://cheapsteak.github.io/tbd/open/?worktree=C968D8D1-3719-4306-8F84-B9462E443595)
