### PR TITLE
Feat: stream assistant text into the transcript pane

### DIFF
--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -1403,6 +1403,18 @@ final class AppState {
     /// Published so the Settings control-mode toggle re-renders after
     /// `setControlModeEnabled` refreshes it.
     var daemonCapabilities: DaemonCapabilitiesResult?
+    /// Whether the daemon reports transcript streaming as effective — the
+    /// conjunction of `transcript_streaming_enabled` and `model_proxy_enabled`,
+    /// already resolved daemon-side, so the app never re-derives the pair.
+    ///
+    /// False until capabilities have been fetched, which is the conservative
+    /// reading and the same one `transcriptComposerEnabled` takes: a pane that
+    /// registers no stream file renders exactly what it renders today, while a
+    /// provisional row that appeared and then vanished on the first capability
+    /// fetch would be worse than one that appeared a moment late.
+    var transcriptStreamingEnabled: Bool {
+        daemonCapabilities?.transcriptStreamingEnabled ?? false
+    }
     /// How `loadModelProfiles()` fetches its config-bearing response.
     /// Injectable because `DaemonClient` is concrete, matching the other
     /// settings seams below.

--- a/Sources/TBDApp/Panes/HistoryPaneView.swift
+++ b/Sources/TBDApp/Panes/HistoryPaneView.swift
@@ -400,8 +400,23 @@ struct SessionTranscriptView: View {
     /// One resolution memo per pane. See `TableTranscriptPaneView.linkCache`.
     @State private var historyLinkCache = TranscriptLinkResolverCache()
 
+    /// Session History never shows the model-proxy stream's provisional row.
+    ///
+    /// It reads the same `AppState.sessionTranscripts` store the live pane
+    /// publishes into, and a session listed here can be the very one a live
+    /// pane is streaming — the history list enumerates the worktree's JSONL
+    /// files, the current session's included, and `selectSession` deliberately
+    /// reuses whatever the store already holds rather than refetching. So the
+    /// row is excluded here rather than merely absent by construction: this is
+    /// a record of what the session *was*, and an unconfirmed row that may
+    /// still be withdrawn does not belong in it.
+    ///
+    /// The transcript overlay needs no equivalent: it resolves an item by the
+    /// id a row handed it, and an assistant chat bubble has no overlay
+    /// affordance at all (see `TableTranscriptView.bubbleView`), so no gesture
+    /// can name a provisional row.
     private var messages: [TranscriptItem] {
-        appState.sessionTranscripts[sessionId] ?? []
+        ProvisionalRowComposer.settledOnly(appState.sessionTranscripts[sessionId] ?? [])
     }
 
     private var isLoading: Bool {

--- a/Sources/TBDApp/Panes/Transcript/ProvisionalRetireTimer.swift
+++ b/Sources/TBDApp/Panes/Transcript/ProvisionalRetireTimer.swift
@@ -1,6 +1,7 @@
 import Foundation
 
-/// The one-shot alarm behind ``ProvisionalRowComposer/unconfirmedRetireAfter``.
+/// The one-shot alarms behind ``ProvisionalRowComposer/unconfirmedRetireAfter``,
+/// one per session.
 ///
 /// Every other way a provisional row retires is announced by something the pane
 /// already watches: confirmation rides in on a transcript read, an abort and a
@@ -16,6 +17,17 @@ import Foundation
 /// re-reads the source and re-composes, so it retires the row by simply not
 /// composing it any more, and it is correct even if the row was already gone.
 ///
+/// **Why the state is keyed by session id.** One instance of this actor is
+/// created per run of `appSideLoop`, but the closure that carries it is
+/// installed into `TranscriptPollScheduler`'s single app-wide `onChange` slot —
+/// whichever pane registered last wins, and every session's publish then runs
+/// through that one instance. TBD keeps up to eight panes alive at once, so an
+/// alarm armed for session A and a publish for session B routinely meet inside
+/// the same timer. A single-slot timer would have let B's ordinary transcript
+/// news — which composes no provisional row and therefore takes the disarm
+/// branch — cancel A's alarm, and A's row would never retire. Keying by session
+/// makes a publish for X touch only X's entry.
+///
 /// An actor rather than a `@MainActor` type because the pane's on-change
 /// handler is `@Sendable` and runs off the main actor; only the store write at
 /// the end of a publish needs main.
@@ -23,57 +35,83 @@ actor ProvisionalRetireTimer {
 
     private let clock: any Clock<Duration>
 
-    /// The message id the pending alarm belongs to, or nil when nothing is
-    /// armed. Keyed by message id, not by deadline, so a poll every 100 ms
+    /// One pending alarm: the message id it belongs to, and the sleeping task.
+    ///
+    /// Recorded by message id, not by deadline, so a poll every 100 ms
     /// re-arming for the same message is a no-op rather than a deadline that
     /// keeps sliding forward — the same reason `TranscriptSource` records the
     /// completion instant once.
-    private var armedMessageID: String?
-    private var pending: Task<Void, Never>?
+    private struct Alarm {
+        let messageID: String
+        let task: Task<Void, Never>
+    }
+
+    /// Session id → its pending alarm. At most one alarm per session; sessions
+    /// with nothing armed are absent rather than present-and-nil.
+    private var alarms: [String: Alarm] = [:]
 
     /// Existential `Clock`, last parameter, defaulted — the repo's clock seam.
     init(clock: any Clock<Duration> = ContinuousClock()) {
         self.clock = clock
     }
 
-    /// Arms a single alarm for `messageID`, firing `after` from now.
+    /// Arms a single alarm for `sessionID`'s `messageID`, firing `after` from
+    /// now.
     ///
-    /// Idempotent per message id: re-arming for the id already armed leaves the
-    /// existing alarm exactly where it is. Arming for a *different* id cancels
-    /// the old alarm first, because the row it belonged to is no longer the row
-    /// on screen.
-    func arm(messageID: String, after: Duration, fire: @escaping @Sendable () async -> Void) {
-        guard armedMessageID != messageID else { return }
-        pending?.cancel()
-        armedMessageID = messageID
+    /// Idempotent per session and message id: re-arming for the id already
+    /// armed on that session leaves the existing alarm exactly where it is.
+    /// Arming a *different* id for the same session cancels that session's old
+    /// alarm first, because the row it belonged to is no longer the row on
+    /// screen. Other sessions' alarms are untouched either way.
+    func arm(
+        sessionID: String,
+        messageID: String,
+        after: Duration,
+        fire: @escaping @Sendable () async -> Void
+    ) {
+        guard alarms[sessionID]?.messageID != messageID else { return }
+        alarms[sessionID]?.task.cancel()
         let clock = self.clock
-        pending = Task { [weak self] in
-            try? await clock.sleep(for: after)
-            guard !Task.isCancelled else { return }
-            await self?.clear(messageID)
-            await fire()
-        }
+        alarms[sessionID] = Alarm(
+            messageID: messageID,
+            task: Task { [weak self] in
+                try? await clock.sleep(for: after)
+                guard !Task.isCancelled else { return }
+                await self?.clear(sessionID: sessionID, messageID: messageID)
+                await fire()
+            })
     }
 
-    /// Cancels whatever is armed. Called on every publish that does *not*
-    /// produce a completed row — the row was confirmed, aborted, superseded or
-    /// switched off — and once more when the pane's loop ends, so a torn-down
-    /// pane leaves no sleeping task behind.
-    func disarm() {
-        pending?.cancel()
-        pending = nil
-        armedMessageID = nil
+    /// Cancels whatever is armed **for this session only**. Called on every
+    /// publish that does not produce a completed row for it — the row was
+    /// confirmed, aborted, superseded or switched off. A publish for one
+    /// session must never disturb another's alarm, which is the whole reason
+    /// this takes a session id.
+    func disarm(sessionID: String) {
+        alarms.removeValue(forKey: sessionID)?.task.cancel()
     }
 
-    /// The message id currently armed, or nil. Read-only, for tests — the same
-    /// shape as `TranscriptPollScheduler`'s test accessors.
-    var armedMessage: String? { armedMessageID }
+    /// Cancels every alarm this timer holds. Called once when the pane's loop
+    /// ends, so a torn-down pane leaves no sleeping task behind for any of the
+    /// sessions its instance happened to serve.
+    func disarmAll() {
+        for alarm in alarms.values { alarm.task.cancel() }
+        alarms.removeAll()
+    }
+
+    /// The message id currently armed for `sessionID`, or nil. Read-only, for
+    /// tests — the same shape as `TranscriptPollScheduler`'s test accessors.
+    func armedMessage(sessionID: String) -> String? { alarms[sessionID]?.messageID }
+
+    /// How many sessions have an alarm pending. Read-only, for tests, so the
+    /// "a publish for B armed nothing of its own" half of the two-session case
+    /// is a claim about the whole table rather than about one lookup.
+    var armedSessionCount: Int { alarms.count }
 
     /// Clears the record of an alarm that has just fired, unless a later `arm`
-    /// already replaced it.
-    private func clear(_ messageID: String) {
-        guard armedMessageID == messageID else { return }
-        pending = nil
-        armedMessageID = nil
+    /// already replaced it for that session.
+    private func clear(sessionID: String, messageID: String) {
+        guard alarms[sessionID]?.messageID == messageID else { return }
+        alarms.removeValue(forKey: sessionID)
     }
 }

--- a/Sources/TBDApp/Panes/Transcript/ProvisionalRetireTimer.swift
+++ b/Sources/TBDApp/Panes/Transcript/ProvisionalRetireTimer.swift
@@ -1,21 +1,23 @@
 import Foundation
 
-/// The one-shot alarms behind ``ProvisionalRowComposer/unconfirmedRetireAfter``,
-/// one per session.
+/// The one-shot alarms behind ``ProvisionalRowComposer/unconfirmedRetireAfter``
+/// and ``ProvisionalRowComposer/silentStreamRetireAfter``, one per session.
 ///
 /// Every other way a provisional row retires is announced by something the pane
 /// already watches: confirmation rides in on a transcript read, an abort and a
 /// newer `start` ride in on a stream-file change, and the flag going off
-/// restarts the pane's loop. The 60-second rule is announced by nothing —
-/// the message has *stopped*, so the stream file has gone quiet by definition
-/// and the poll scheduler will report "no news" forever. Without an alarm the
-/// row would stay on screen until some unrelated edit to the session happened
-/// to trigger a publish.
+/// restarts the pane's loop. The two deadline rules are announced by nothing —
+/// a message that has *stopped* leaves a stream file quiet by definition, and a
+/// message whose proxy died mid-turn leaves one quiet in exactly the same way,
+/// so the poll scheduler reports "no news" forever either way. Without an alarm
+/// the row would stay on screen until some unrelated edit to the session
+/// happened to trigger a publish.
 ///
-/// So the pane arms exactly one sleep when it publishes a `.complete` row, and
-/// re-publishes once when it fires. The re-publish is an ordinary publish: it
-/// re-reads the source and re-composes, so it retires the row by simply not
-/// composing it any more, and it is correct even if the row was already gone.
+/// So the pane arms exactly one sleep whenever it publishes a row that has a
+/// deadline, and re-publishes once when it fires. The re-publish is an ordinary
+/// publish: it re-reads the source and re-composes, so it retires the row by
+/// simply not composing it any more, and it is correct even if the row was
+/// already gone.
 ///
 /// **Why the state is keyed by session id.** One instance of this actor is
 /// created per run of `appSideLoop`, but the closure that carries it is
@@ -35,14 +37,18 @@ actor ProvisionalRetireTimer {
 
     private let clock: any Clock<Duration>
 
-    /// One pending alarm: the message id it belongs to, and the sleeping task.
+    /// One pending alarm: the row it belongs to, and the sleeping task.
     ///
-    /// Recorded by message id, not by deadline, so a poll every 100 ms
-    /// re-arming for the same message is a no-op rather than a deadline that
-    /// keeps sliding forward — the same reason `TranscriptSource` records the
-    /// completion instant once.
+    /// The row is identified by its message id *and* the instant it is due,
+    /// never by "how long is left". A poll every 100 ms hands back the same
+    /// pair and is a no-op, so the deadline cannot slide forward under
+    /// repetition — `ProvisionalMessage` carries instants `TranscriptSource`
+    /// holds still for exactly this reason. When a line arrives for a streaming
+    /// message its due instant genuinely moves, and that is the one thing that
+    /// must replace the pending alarm rather than leave it alone.
     private struct Alarm {
         let messageID: String
+        let due: Date
         let task: Task<Void, Never>
     }
 
@@ -55,35 +61,44 @@ actor ProvisionalRetireTimer {
         self.clock = clock
     }
 
-    /// Arms a single alarm for `sessionID`'s `messageID`, firing `after` from
-    /// now.
+    /// Arms a single alarm for `sessionID`'s `messageID`, due at `deadline` and
+    /// firing `after` from now.
     ///
-    /// Idempotent per session and message id: re-arming for the id already
-    /// armed on that session leaves the existing alarm exactly where it is.
-    /// Arming a *different* id for the same session cancels that session's old
-    /// alarm first, because the row it belonged to is no longer the row on
-    /// screen. Other sessions' alarms are untouched either way.
+    /// Idempotent per session, message id and deadline: re-arming the pair
+    /// already armed on that session leaves the existing alarm exactly where it
+    /// is. A *different* id, or the same id whose deadline has moved, cancels
+    /// that session's old alarm first — the first because the row it belonged
+    /// to is no longer the row on screen, the second because a streaming row
+    /// that has just received a line is owed a later wake-up than the one
+    /// pending. Other sessions' alarms are untouched in every case.
+    ///
+    /// `deadline` is the alarm's identity, not a clock this actor reads: the
+    /// sleep is `after` on the injected clock, so a test clock never has to
+    /// agree with `Date`.
     func arm(
         sessionID: String,
         messageID: String,
+        deadline: Date,
         after: Duration,
         fire: @escaping @Sendable () async -> Void
     ) {
-        guard alarms[sessionID]?.messageID != messageID else { return }
+        if let pending = alarms[sessionID],
+           pending.messageID == messageID, pending.due == deadline { return }
         alarms[sessionID]?.task.cancel()
         let clock = self.clock
         alarms[sessionID] = Alarm(
             messageID: messageID,
+            due: deadline,
             task: Task { [weak self] in
                 try? await clock.sleep(for: after)
                 guard !Task.isCancelled else { return }
-                await self?.clear(sessionID: sessionID, messageID: messageID)
+                await self?.clear(sessionID: sessionID, messageID: messageID, due: deadline)
                 await fire()
             })
     }
 
     /// Cancels whatever is armed **for this session only**. Called on every
-    /// publish that does not produce a completed row for it — the row was
+    /// publish that does not produce a row with a deadline for it — the row was
     /// confirmed, aborted, superseded or switched off. A publish for one
     /// session must never disturb another's alarm, which is the whole reason
     /// this takes a session id.
@@ -98,8 +113,8 @@ actor ProvisionalRetireTimer {
     /// closure carrying this instance sits in the scheduler's single app-wide
     /// slot, the table can hold alarms for sessions other panes are showing,
     /// and cancelling one of those strands its provisional row on screen —
-    /// the 60-second rule is announced by nothing, so nothing re-arms it. A
-    /// pane leaving calls ``disarm(sessionID:)`` for its own session instead.
+    /// a deadline rule is announced by nothing, so nothing re-arms it. A pane
+    /// leaving calls ``disarm(sessionID:)`` for its own session instead.
     func disarmAll() {
         for alarm in alarms.values { alarm.task.cancel() }
         alarms.removeAll()
@@ -115,9 +130,11 @@ actor ProvisionalRetireTimer {
     var armedSessionCount: Int { alarms.count }
 
     /// Clears the record of an alarm that has just fired, unless a later `arm`
-    /// already replaced it for that session.
-    private func clear(sessionID: String, messageID: String) {
-        guard alarms[sessionID]?.messageID == messageID else { return }
+    /// already replaced it for that session — a replacement being either a
+    /// different message or the same message with a deadline that has moved.
+    private func clear(sessionID: String, messageID: String, due: Date) {
+        guard let pending = alarms[sessionID],
+              pending.messageID == messageID, pending.due == due else { return }
         alarms.removeValue(forKey: sessionID)
     }
 }

--- a/Sources/TBDApp/Panes/Transcript/ProvisionalRetireTimer.swift
+++ b/Sources/TBDApp/Panes/Transcript/ProvisionalRetireTimer.swift
@@ -91,9 +91,15 @@ actor ProvisionalRetireTimer {
         alarms.removeValue(forKey: sessionID)?.task.cancel()
     }
 
-    /// Cancels every alarm this timer holds. Called once when the pane's loop
-    /// ends, so a torn-down pane leaves no sleeping task behind for any of the
-    /// sessions its instance happened to serve.
+    /// Cancels every alarm this timer holds.
+    ///
+    /// For tests, and for a caller that really is tearing down *everything*
+    /// this timer serves. **Not** for a pane's own teardown: because the
+    /// closure carrying this instance sits in the scheduler's single app-wide
+    /// slot, the table can hold alarms for sessions other panes are showing,
+    /// and cancelling one of those strands its provisional row on screen —
+    /// the 60-second rule is announced by nothing, so nothing re-arms it. A
+    /// pane leaving calls ``disarm(sessionID:)`` for its own session instead.
     func disarmAll() {
         for alarm in alarms.values { alarm.task.cancel() }
         alarms.removeAll()

--- a/Sources/TBDApp/Panes/Transcript/ProvisionalRetireTimer.swift
+++ b/Sources/TBDApp/Panes/Transcript/ProvisionalRetireTimer.swift
@@ -56,12 +56,29 @@ actor ProvisionalRetireTimer {
     private struct Alarm {
         let messageID: String
         let due: Date
+        /// Which arming this alarm is, never reused. The sleeping task captures
+        /// its own and re-checks it after waking; see ``generation``.
+        let generation: UInt64
         let task: Task<Void, Never>
     }
 
     /// Session id → its pending alarm. At most one alarm per session; sessions
     /// with nothing armed are absent rather than present-and-nil.
     private var alarms: [String: Alarm] = [:]
+
+    /// Stamped onto each alarm and never reused, so a woken task can ask "am I
+    /// still the alarm for this session?" and get an answer that survives
+    /// re-arming with identical parameters.
+    ///
+    /// `Task.cancel()` alone cannot answer it. Cancellation is advisory: a task
+    /// that has already returned from its sleep and is on its way back into the
+    /// actor cannot be stopped, so a `disarm` landing in that window would
+    /// otherwise let the alarm fire for a session that has just been forgotten
+    /// — publishing an empty transcript for a session nothing is watching,
+    /// which is the exact hazard the disarm-before-forget ordering exists to
+    /// prevent. Re-entering under this counter closes it: the fire is committed
+    /// inside the actor or not at all.
+    private var generation: UInt64 = 0
 
     /// Existential `Clock`, last parameter, defaulted — the repo's clock seam.
     init(clock: any Clock<Duration> = ContinuousClock()) {
@@ -93,13 +110,23 @@ actor ProvisionalRetireTimer {
            pending.messageID == messageID, pending.due == deadline { return }
         alarms[sessionID]?.task.cancel()
         let clock = self.clock
+        generation &+= 1
+        let generation = self.generation
         alarms[sessionID] = Alarm(
             messageID: messageID,
             due: deadline,
+            generation: generation,
             task: Task { [weak self] in
                 try? await clock.sleep(for: after)
-                guard !Task.isCancelled else { return }
-                await self?.clear(sessionID: sessionID, messageID: messageID, due: deadline)
+                guard let self else { return }
+                // The one gate, taken inside the actor after the sleep: a
+                // `disarm` or a re-arm that landed while this task was waking
+                // has already moved past this generation, and the fire is
+                // dropped. `Task.isCancelled` cannot stand in for it — see
+                // ``generation``.
+                guard await self.claimFire(sessionID: sessionID, generation: generation) else {
+                    return
+                }
                 await fire()
             })
     }
@@ -111,6 +138,11 @@ actor ProvisionalRetireTimer {
     /// `TranscriptPollScheduler.disarmProvisional`. A publish for one session
     /// must never disturb another's alarm, which is the whole reason this takes
     /// a session id.
+    ///
+    /// Dropping the entry is what actually stops the alarm; the cancel is a
+    /// courtesy that shortens the sleep. A task already past its sleep finds no
+    /// entry under its generation when it re-enters and does not fire, so this
+    /// is a real revocation even in the window where cancellation is too late.
     func disarm(sessionID: String) {
         alarms.removeValue(forKey: sessionID)?.task.cancel()
     }
@@ -140,12 +172,18 @@ actor ProvisionalRetireTimer {
     /// is a claim about the whole table rather than about one lookup.
     var armedSessionCount: Int { alarms.count }
 
-    /// Clears the record of an alarm that has just fired, unless a later `arm`
-    /// already replaced it for that session — a replacement being either a
-    /// different message or the same message with a deadline that has moved.
-    private func clear(sessionID: String, messageID: String, due: Date) {
-        guard let pending = alarms[sessionID],
-              pending.messageID == messageID, pending.due == due else { return }
+    /// Whether a woken alarm is still the one armed for its session, clearing
+    /// the record if it is.
+    ///
+    /// False when a `disarm` removed the entry or a later `arm` replaced it —
+    /// a replacement being a different message, the same message with a
+    /// deadline that has moved, or even the identical pair armed afresh, all of
+    /// which carry a newer generation. The caller fires only on true, so the
+    /// decision to publish is taken here, under the actor, rather than by a
+    /// cancellation check the racing `disarm` cannot win.
+    private func claimFire(sessionID: String, generation: UInt64) -> Bool {
+        guard alarms[sessionID]?.generation == generation else { return false }
         alarms.removeValue(forKey: sessionID)
+        return true
     }
 }

--- a/Sources/TBDApp/Panes/Transcript/ProvisionalRetireTimer.swift
+++ b/Sources/TBDApp/Panes/Transcript/ProvisionalRetireTimer.swift
@@ -111,11 +111,11 @@ actor ProvisionalRetireTimer {
         alarms[sessionID]?.task.cancel()
         let clock = self.clock
         generation &+= 1
-        let generation = self.generation
+        let armed = generation
         alarms[sessionID] = Alarm(
             messageID: messageID,
             due: deadline,
-            generation: generation,
+            generation: armed,
             task: Task { [weak self] in
                 try? await clock.sleep(for: after)
                 guard let self else { return }
@@ -124,7 +124,7 @@ actor ProvisionalRetireTimer {
                 // has already moved past this generation, and the fire is
                 // dropped. `Task.isCancelled` cannot stand in for it — see
                 // ``generation``.
-                guard await self.claimFire(sessionID: sessionID, generation: generation) else {
+                guard await self.claimFire(sessionID: sessionID, generation: armed) else {
                     return
                 }
                 await fire()

--- a/Sources/TBDApp/Panes/Transcript/ProvisionalRetireTimer.swift
+++ b/Sources/TBDApp/Panes/Transcript/ProvisionalRetireTimer.swift
@@ -19,16 +19,23 @@ import Foundation
 /// simply not composing it any more, and it is correct even if the row was
 /// already gone.
 ///
-/// **Why the state is keyed by session id.** One instance of this actor is
-/// created per run of `appSideLoop`, but the closure that carries it is
-/// installed into `TranscriptPollScheduler`'s single app-wide `onChange` slot —
-/// whichever pane registered last wins, and every session's publish then runs
-/// through that one instance. TBD keeps up to eight panes alive at once, so an
-/// alarm armed for session A and a publish for session B routinely meet inside
-/// the same timer. A single-slot timer would have let B's ordinary transcript
-/// news — which composes no provisional row and therefore takes the disarm
-/// branch — cancel A's alarm, and A's row would never retire. Keying by session
-/// makes a publish for X touch only X's entry.
+/// **One instance, keyed by session id.** `TranscriptPollScheduler` owns
+/// exactly one of these and creates it with itself; panes take it from there
+/// and never build one. That is not an aesthetic choice. Every publish in the
+/// app runs through the scheduler's single app-wide `onChange` slot, so a pane
+/// that owned its own timer would have installed a fresh instance on every
+/// mount — and a second pane mounting, or a Settings flip restarting every
+/// streaming pane at once, would then route a live row's *next* arm into the
+/// new instance while the pane that would cancel it still held the old one.
+/// The orphan fires after `TranscriptSource.forget` has run and publishes an
+/// empty transcript for a session nothing is watching.
+///
+/// Keying the one instance by session is the other half. TBD keeps up to eight
+/// panes alive at once, so an alarm armed for session A and a publish for
+/// session B routinely meet inside this timer. A single-slot table would have
+/// let B's ordinary transcript news — which composes no provisional row and
+/// therefore takes the disarm branch — cancel A's alarm, and A's row would
+/// never retire. Keying by session makes a publish for X touch only X's entry.
 ///
 /// An actor rather than a `@MainActor` type because the pane's on-change
 /// handler is `@Sendable` and runs off the main actor; only the store write at
@@ -99,9 +106,11 @@ actor ProvisionalRetireTimer {
 
     /// Cancels whatever is armed **for this session only**. Called on every
     /// publish that does not produce a row with a deadline for it — the row was
-    /// confirmed, aborted, superseded or switched off. A publish for one
-    /// session must never disturb another's alarm, which is the whole reason
-    /// this takes a session id.
+    /// confirmed, aborted, superseded or switched off — and once more when the
+    /// last pane holding the session lets it go, through
+    /// `TranscriptPollScheduler.disarmProvisional`. A publish for one session
+    /// must never disturb another's alarm, which is the whole reason this takes
+    /// a session id.
     func disarm(sessionID: String) {
         alarms.removeValue(forKey: sessionID)?.task.cancel()
     }
@@ -109,12 +118,14 @@ actor ProvisionalRetireTimer {
     /// Cancels every alarm this timer holds.
     ///
     /// For tests, and for a caller that really is tearing down *everything*
-    /// this timer serves. **Not** for a pane's own teardown: because the
-    /// closure carrying this instance sits in the scheduler's single app-wide
-    /// slot, the table can hold alarms for sessions other panes are showing,
-    /// and cancelling one of those strands its provisional row on screen —
-    /// a deadline rule is announced by nothing, so nothing re-arms it. A pane
-    /// leaving calls ``disarm(sessionID:)`` for its own session instead.
+    /// this timer serves. **Not** for a pane's own teardown: one instance
+    /// serves the whole app, so the table holds alarms for sessions other panes
+    /// are showing, and cancelling one of those strands its provisional row on
+    /// screen — a deadline rule is announced by nothing, so nothing re-arms it.
+    /// A pane leaving goes through
+    /// `TranscriptPollScheduler.disarmProvisional(sessionID:)`, which reaches
+    /// ``disarm(sessionID:)`` for that one session and only once nobody holds
+    /// it any more.
     func disarmAll() {
         for alarm in alarms.values { alarm.task.cancel() }
         alarms.removeAll()

--- a/Sources/TBDApp/Panes/Transcript/ProvisionalRetireTimer.swift
+++ b/Sources/TBDApp/Panes/Transcript/ProvisionalRetireTimer.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+/// The one-shot alarm behind ``ProvisionalRowComposer/unconfirmedRetireAfter``.
+///
+/// Every other way a provisional row retires is announced by something the pane
+/// already watches: confirmation rides in on a transcript read, an abort and a
+/// newer `start` ride in on a stream-file change, and the flag going off
+/// restarts the pane's loop. The 60-second rule is announced by nothing —
+/// the message has *stopped*, so the stream file has gone quiet by definition
+/// and the poll scheduler will report "no news" forever. Without an alarm the
+/// row would stay on screen until some unrelated edit to the session happened
+/// to trigger a publish.
+///
+/// So the pane arms exactly one sleep when it publishes a `.complete` row, and
+/// re-publishes once when it fires. The re-publish is an ordinary publish: it
+/// re-reads the source and re-composes, so it retires the row by simply not
+/// composing it any more, and it is correct even if the row was already gone.
+///
+/// An actor rather than a `@MainActor` type because the pane's on-change
+/// handler is `@Sendable` and runs off the main actor; only the store write at
+/// the end of a publish needs main.
+actor ProvisionalRetireTimer {
+
+    private let clock: any Clock<Duration>
+
+    /// The message id the pending alarm belongs to, or nil when nothing is
+    /// armed. Keyed by message id, not by deadline, so a poll every 100 ms
+    /// re-arming for the same message is a no-op rather than a deadline that
+    /// keeps sliding forward — the same reason `TranscriptSource` records the
+    /// completion instant once.
+    private var armedMessageID: String?
+    private var pending: Task<Void, Never>?
+
+    /// Existential `Clock`, last parameter, defaulted — the repo's clock seam.
+    init(clock: any Clock<Duration> = ContinuousClock()) {
+        self.clock = clock
+    }
+
+    /// Arms a single alarm for `messageID`, firing `after` from now.
+    ///
+    /// Idempotent per message id: re-arming for the id already armed leaves the
+    /// existing alarm exactly where it is. Arming for a *different* id cancels
+    /// the old alarm first, because the row it belonged to is no longer the row
+    /// on screen.
+    func arm(messageID: String, after: Duration, fire: @escaping @Sendable () async -> Void) {
+        guard armedMessageID != messageID else { return }
+        pending?.cancel()
+        armedMessageID = messageID
+        let clock = self.clock
+        pending = Task { [weak self] in
+            try? await clock.sleep(for: after)
+            guard !Task.isCancelled else { return }
+            await self?.clear(messageID)
+            await fire()
+        }
+    }
+
+    /// Cancels whatever is armed. Called on every publish that does *not*
+    /// produce a completed row — the row was confirmed, aborted, superseded or
+    /// switched off — and once more when the pane's loop ends, so a torn-down
+    /// pane leaves no sleeping task behind.
+    func disarm() {
+        pending?.cancel()
+        pending = nil
+        armedMessageID = nil
+    }
+
+    /// The message id currently armed, or nil. Read-only, for tests — the same
+    /// shape as `TranscriptPollScheduler`'s test accessors.
+    var armedMessage: String? { armedMessageID }
+
+    /// Clears the record of an alarm that has just fired, unless a later `arm`
+    /// already replaced it.
+    private func clear(_ messageID: String) {
+        guard armedMessageID == messageID else { return }
+        pending = nil
+        armedMessageID = nil
+    }
+}

--- a/Sources/TBDApp/Panes/Transcript/ProvisionalRowComposer.swift
+++ b/Sources/TBDApp/Panes/Transcript/ProvisionalRowComposer.swift
@@ -51,6 +51,14 @@ enum ProvisionalRowComposer {
         itemID.hasPrefix(idPrefix)
     }
 
+    /// `items` with any provisional row removed.
+    ///
+    /// The inverse of ``compose``, for the one reader that shares the store
+    /// with the live pane but must never show the row: Session History.
+    static func settledOnly(_ items: [TranscriptItem]) -> [TranscriptItem] {
+        items.filter { !isProvisional(itemID: $0.id) }
+    }
+
     /// Returns `items` with the provisional row appended, or `items` unchanged
     /// when the row is retired.
     ///

--- a/Sources/TBDApp/Panes/Transcript/ProvisionalRowComposer.swift
+++ b/Sources/TBDApp/Panes/Transcript/ProvisionalRowComposer.swift
@@ -88,7 +88,15 @@ enum ProvisionalRowComposer {
         case .aborted:
             return items
         case .complete(let at):
-            guard now.timeIntervalSince(at) <= retireAfterSeconds else { return items }
+            // Strictly less than, so the boundary tick retires rather than
+            // composing a row whose remaining delay is zero. A zero-delay
+            // alarm fires the moment it is armed, and the re-publish it runs
+            // would compose the same row and arm the same zero again — a spin
+            // under a `now` that is frozen or has stepped backwards. Keeping
+            // the row only while the deadline is genuinely in the future makes
+            // "compose keeps it" and "``retireDelay`` has a deadline" the same
+            // condition.
+            guard now.timeIntervalSince(at) < retireAfterSeconds else { return items }
         case .streaming:
             break
         }
@@ -104,12 +112,16 @@ enum ProvisionalRowComposer {
     /// unconfirmed-completion rule, or nil when no such deadline applies.
     ///
     /// Only `.complete` has one. `.streaming` has not stopped yet, and
-    /// `.aborted` was already withdrawn by ``compose``. Clamped at zero rather
-    /// than going negative, so a caller that arms on it fires immediately for a
-    /// deadline that has already passed instead of sleeping backwards.
+    /// `.aborted` was already withdrawn by ``compose``. A deadline that has
+    /// arrived or passed is nil rather than zero: ``compose`` has already
+    /// retired that row, so there is nothing left to wake up for, and arming a
+    /// zero-length sleep would fire instantly into a re-publish that composed
+    /// the same row and armed the same zero again.
     static func retireDelay(phase: ProvisionalMessage.Phase, now: Date) -> Duration? {
         guard case .complete(let at) = phase else { return nil }
-        return .seconds(max(0, retireAfterSeconds - now.timeIntervalSince(at)))
+        let remaining = retireAfterSeconds - now.timeIntervalSince(at)
+        guard remaining > 0 else { return nil }
+        return .seconds(remaining)
     }
 
     /// ``unconfirmedRetireAfter`` as a `TimeInterval`, so the rule is stated

--- a/Sources/TBDApp/Panes/Transcript/ProvisionalRowComposer.swift
+++ b/Sources/TBDApp/Panes/Transcript/ProvisionalRowComposer.swift
@@ -1,0 +1,115 @@
+import Foundation
+import TBDShared
+
+/// Appends the model-proxy stream's in-flight assistant message to a
+/// freshly-read transcript as one **provisional row**, or leaves the transcript
+/// alone when that row has been retired.
+///
+/// Pure and total: same inputs, same output, no I/O and no clock of its own.
+/// The pane owns the reads (`TranscriptSource.provisional`,
+/// `TranscriptSource.hasAssistantMessage`), the merge that runs before this
+/// (`AskUserQuestionMerger`), and `now`.
+///
+/// **Order.** The row is appended last, after the JSONL items and after the
+/// pending `AskUserQuestion` captures the merger synthesises, because it is the
+/// newest thing in the session by construction: the JSONL has not caught up
+/// with it yet, and a pending question was captured before the answer that is
+/// streaming now.
+///
+/// **Identity.** The row's id is the API message id behind
+/// ``idPrefix``, which does three things at once: it cannot collide with a
+/// JSONL item id, it keeps the row's identity stable while its text grows (so
+/// `TranscriptStreamPlan` sees `.updateLast` rather than a rebuild), and it is
+/// what marks the row provisional downstream — `transcriptRenderNodes(from:)`
+/// reads the prefix, nothing else has to be threaded through.
+///
+/// **Retirement.** Four of the five rules are announced by something the pane
+/// already watches. Confirmation arrives with a transcript read, an abort and a
+/// newer `start` (which `StreamFileReader.fold` resolves inside the fold, not
+/// here) arrive with a stream-file change, and the flag going off restarts the
+/// pane's loop. The fifth — a completed message nobody ever confirms — is
+/// announced by nothing at all, which is why ``ProvisionalRetireTimer`` exists.
+enum ProvisionalRowComposer {
+
+    /// How long a *completed* stream message may stay unconfirmed before its
+    /// row is withdrawn.
+    ///
+    /// This is the backstop for a turn the transcript will never mention: a
+    /// side request the tee filter did not recognise, or a proxy that wrote a
+    /// `message_stop` for a request Claude Code never wrote to its JSONL.
+    /// Without it such a row would sit at the bottom of the pane forever.
+    static let unconfirmedRetireAfter: Duration = .seconds(60)
+
+    /// Prefix on the provisional row's item id. Deliberately a prefix of the
+    /// real message id rather than an opaque token, so the row's identity is
+    /// stable across ticks and a reader looking at a log can see which message
+    /// it belonged to.
+    static let idPrefix = "stream:"
+
+    /// Whether a transcript item id belongs to a provisional row.
+    static func isProvisional(itemID: String) -> Bool {
+        itemID.hasPrefix(idPrefix)
+    }
+
+    /// Returns `items` with the provisional row appended, or `items` unchanged
+    /// when the row is retired.
+    ///
+    /// - Parameters:
+    ///   - items: the transcript as it stands — JSONL items with pending
+    ///     `AskUserQuestion` captures already merged in.
+    ///   - provisional: what the stream file currently folds to, or nil when
+    ///     nothing has been tailed for this session.
+    ///   - confirmed: whether the session's own transcript has caught up with a
+    ///     message id. A closure rather than a set so the caller decides how
+    ///     many ids it is worth asking about; today it asks about exactly one.
+    ///   - now: the instant the retire deadline is measured against. The
+    ///     caller's to keep stable across one publish.
+    ///   - streamingEnabled: the resolved streaming flag. Off means no row,
+    ///     whatever the stream file holds.
+    static func compose(
+        items: [TranscriptItem],
+        provisional: ProvisionalMessage?,
+        confirmed: (String) -> Bool,
+        now: Date,
+        streamingEnabled: Bool
+    ) -> [TranscriptItem] {
+        guard streamingEnabled, let provisional else { return items }
+        guard !confirmed(provisional.messageID) else { return items }
+
+        switch provisional.phase {
+        case .aborted:
+            return items
+        case .complete(let at):
+            guard now.timeIntervalSince(at) <= retireAfterSeconds else { return items }
+        case .streaming:
+            break
+        }
+
+        return items + [.assistantText(
+            id: idPrefix + provisional.messageID,
+            text: provisional.text,
+            timestamp: nil,
+            usage: nil)]
+    }
+
+    /// How long from `now` until a row composed for `phase` would retire on the
+    /// unconfirmed-completion rule, or nil when no such deadline applies.
+    ///
+    /// Only `.complete` has one. `.streaming` has not stopped yet, and
+    /// `.aborted` was already withdrawn by ``compose``. Clamped at zero rather
+    /// than going negative, so a caller that arms on it fires immediately for a
+    /// deadline that has already passed instead of sleeping backwards.
+    static func retireDelay(phase: ProvisionalMessage.Phase, now: Date) -> Duration? {
+        guard case .complete(let at) = phase else { return nil }
+        return .seconds(max(0, retireAfterSeconds - now.timeIntervalSince(at)))
+    }
+
+    /// ``unconfirmedRetireAfter`` as a `TimeInterval`, so the rule is stated
+    /// once as a `Duration` (which is what the timer sleeps on) and compared
+    /// against `Date` arithmetic here without a second literal.
+    private static var retireAfterSeconds: TimeInterval {
+        let components = unconfirmedRetireAfter.components
+        return TimeInterval(components.seconds)
+            + TimeInterval(components.attoseconds) / 1_000_000_000_000_000_000
+    }
+}

--- a/Sources/TBDApp/Panes/Transcript/ProvisionalRowComposer.swift
+++ b/Sources/TBDApp/Panes/Transcript/ProvisionalRowComposer.swift
@@ -7,7 +7,7 @@ import TBDShared
 ///
 /// Pure and total: same inputs, same output, no I/O and no clock of its own.
 /// The pane owns the reads (`TranscriptSource.provisional`,
-/// `TranscriptSource.hasAssistantMessage`), the merge that runs before this
+/// `TranscriptSource.hasAssistantText`), the merge that runs before this
 /// (`AskUserQuestionMerger`), and `now`.
 ///
 /// **Order.** The row is appended last, after the JSONL items and after the
@@ -26,8 +26,14 @@ import TBDShared
 /// **Retirement.** Six rules take the row down, and every one of them is
 /// listed here:
 ///
-/// 1. **Confirmed** — the session's own JSONL has caught up with the message
-///    id, so the settled row replaces the provisional one.
+/// 1. **Confirmed** — the session's own JSONL holds the line carrying this
+///    message's text, so the settled row replaces the provisional one.
+///    Deliberately the text-bearing line and not merely the message id: Claude
+///    Code writes one line per content block under a shared id, and they land
+///    at different times, so a message opening with a `thinking` block would
+///    otherwise retire its row while its text was still streaming and leave
+///    nothing in its place. A turn that never writes text at all — one that
+///    only calls tools — is confirmed by nothing and leaves by rule 5.
 /// 2. **Aborted** — the stream file records an `aborted` line for the message.
 /// 3. **Superseded** — a newer message's lines make it the one the fold
 ///    renders, so the older row is no longer the row on screen.
@@ -52,10 +58,12 @@ enum ProvisionalRowComposer {
     /// How long a *completed* stream message may stay unconfirmed before its
     /// row is withdrawn, measured from when the reader first saw the stop.
     ///
-    /// This is the backstop for a turn the transcript will never mention: a
-    /// side request the tee filter did not recognise, or a proxy that wrote a
-    /// `message_stop` for a request Claude Code never wrote to its JSONL.
-    /// Without it such a row would sit at the bottom of the pane forever.
+    /// This is the backstop for a turn the transcript will never confirm: a
+    /// side request the tee filter did not recognise, a proxy that wrote a
+    /// `message_stop` for a request Claude Code never wrote to its JSONL, or a
+    /// turn that ends without a text block at all — one that only calls tools —
+    /// whose JSONL lines carry the message id but never its text. Without it
+    /// such a row would sit at the bottom of the pane forever.
     static let unconfirmedRetireAfter: Duration = .seconds(60)
 
     /// How long a *streaming* message may go without a new line before its row
@@ -105,9 +113,11 @@ enum ProvisionalRowComposer {
     ///     `AskUserQuestion` captures already merged in.
     ///   - provisional: what the stream file currently folds to, or nil when
     ///     nothing has been tailed for this session.
-    ///   - confirmed: whether the session's own transcript has caught up with a
-    ///     message id. A closure rather than a set so the caller decides how
-    ///     many ids it is worth asking about; today it asks about exactly one.
+    ///   - confirmed: whether the session's own transcript holds the
+    ///     text-bearing line for a message id, not merely "a line with this id
+    ///     landed" — `TranscriptSource.hasAssistantText`. A closure rather than
+    ///     a set so the caller decides how many ids it is worth asking about;
+    ///     today it asks about exactly one.
     ///   - now: the instant the retire deadline is measured against. The
     ///     caller's to keep stable across one publish.
     ///   - streamingEnabled: the resolved streaming flag. Off means no row,

--- a/Sources/TBDApp/Panes/Transcript/ProvisionalRowComposer.swift
+++ b/Sources/TBDApp/Panes/Transcript/ProvisionalRowComposer.swift
@@ -23,22 +23,41 @@ import TBDShared
 /// what marks the row provisional downstream — `transcriptRenderNodes(from:)`
 /// reads the prefix, nothing else has to be threaded through.
 ///
-/// **Retirement.** Four of the five rules are announced by something the pane
+/// **Retirement.** Four of the six rules are announced by something the pane
 /// already watches. Confirmation arrives with a transcript read, an abort and a
 /// newer `start` (which `StreamFileReader.fold` resolves inside the fold, not
 /// here) arrive with a stream-file change, and the flag going off restarts the
-/// pane's loop. The fifth — a completed message nobody ever confirms — is
-/// announced by nothing at all, which is why ``ProvisionalRetireTimer`` exists.
+/// pane's loop. The other two — a completed message nobody ever confirms, and a
+/// stream that simply stops arriving — are announced by nothing at all, which
+/// is why ``ProvisionalRetireTimer`` exists. Both are deadlines, they differ
+/// only in what they measure from and how long they allow.
 enum ProvisionalRowComposer {
 
     /// How long a *completed* stream message may stay unconfirmed before its
-    /// row is withdrawn.
+    /// row is withdrawn, measured from when the reader first saw the stop.
     ///
     /// This is the backstop for a turn the transcript will never mention: a
     /// side request the tee filter did not recognise, or a proxy that wrote a
     /// `message_stop` for a request Claude Code never wrote to its JSONL.
     /// Without it such a row would sit at the bottom of the pane forever.
     static let unconfirmedRetireAfter: Duration = .seconds(60)
+
+    /// How long a *streaming* message may go without a new line before its row
+    /// is withdrawn, measured from the last line the reader saw.
+    ///
+    /// A message reaches a terminal phase only when a `stop` or `aborted` line
+    /// is written and decoded. A proxy killed mid-turn writes neither, so the
+    /// fold reports `.streaming` forever and the transcript — which never saw
+    /// that request finish either — will not confirm it. Without a deadline of
+    /// its own that row stays on screen until the pane closes.
+    ///
+    /// Ten minutes, not sixty seconds, because silence is normal here in a way
+    /// it is not after a stop: the tee records text deltas, and a turn
+    /// streaming a large tool-input block emits none of them for minutes while
+    /// the request is perfectly healthy. The proxy's own drain cap is the
+    /// longest a legitimate stream can still be in flight, so a stream quiet
+    /// for longer than that is one nothing is coming back for.
+    static let silentStreamRetireAfter: Duration = .seconds(600)
 
     /// Prefix on the provisional row's item id. Deliberately a prefix of the
     /// real message id rather than an opaque token, so the row's identity is
@@ -83,22 +102,17 @@ enum ProvisionalRowComposer {
     ) -> [TranscriptItem] {
         guard streamingEnabled, let provisional else { return items }
         guard !confirmed(provisional.messageID) else { return items }
-
-        switch provisional.phase {
-        case .aborted:
+        // Nil is `.aborted`, which is withdrawn outright. Otherwise the row
+        // survives strictly *before* its deadline, so the boundary tick
+        // retires rather than composing a row whose remaining delay is zero. A
+        // zero-delay alarm fires the moment it is armed, and the re-publish it
+        // runs would compose the same row and arm the same zero again — a spin
+        // under a `now` that is frozen or has stepped backwards. Keeping the
+        // row only while the deadline is genuinely in the future makes
+        // "compose keeps it" and "``retireDelay`` has a deadline" the same
+        // condition.
+        guard let deadline = retireDeadline(for: provisional), now < deadline else {
             return items
-        case .complete(let at):
-            // Strictly less than, so the boundary tick retires rather than
-            // composing a row whose remaining delay is zero. A zero-delay
-            // alarm fires the moment it is armed, and the re-publish it runs
-            // would compose the same row and arm the same zero again — a spin
-            // under a `now` that is frozen or has stepped backwards. Keeping
-            // the row only while the deadline is genuinely in the future makes
-            // "compose keeps it" and "``retireDelay`` has a deadline" the same
-            // condition.
-            guard now.timeIntervalSince(at) < retireAfterSeconds else { return items }
-        case .streaming:
-            break
         }
 
         return items + [.assistantText(
@@ -108,27 +122,49 @@ enum ProvisionalRowComposer {
             usage: nil)]
     }
 
-    /// How long from `now` until a row composed for `phase` would retire on the
-    /// unconfirmed-completion rule, or nil when no such deadline applies.
+    /// The instant a composed row for `provisional` retires on its own, or nil
+    /// when it is already withdrawn.
     ///
-    /// Only `.complete` has one. `.streaming` has not stopped yet, and
-    /// `.aborted` was already withdrawn by ``compose``. A deadline that has
-    /// arrived or passed is nil rather than zero: ``compose`` has already
-    /// retired that row, so there is nothing left to wake up for, and arming a
-    /// zero-length sleep would fire instantly into a re-publish that composed
-    /// the same row and armed the same zero again.
-    static func retireDelay(phase: ProvisionalMessage.Phase, now: Date) -> Duration? {
-        guard case .complete(let at) = phase else { return nil }
-        let remaining = retireAfterSeconds - now.timeIntervalSince(at)
+    /// `.complete` retires ``unconfirmedRetireAfter`` from the stop the reader
+    /// saw; `.streaming` retires ``silentStreamRetireAfter`` from the last line
+    /// it saw; `.aborted` has no deadline because ``compose`` never gives it a
+    /// row. Both live deadlines move only when their basis does, which is what
+    /// makes this safe to call on every poll: `ProvisionalMessage` carries
+    /// instants `TranscriptSource` holds still, never a fresh `Date()`.
+    ///
+    /// Also the alarm's identity — see ``ProvisionalRetireTimer/arm``. A line
+    /// arriving for a streaming message moves the deadline, and that is exactly
+    /// when the pending alarm must be replaced rather than left alone.
+    static func retireDeadline(for provisional: ProvisionalMessage) -> Date? {
+        switch provisional.phase {
+        case .aborted:
+            return nil
+        case .complete(let at):
+            return at.addingTimeInterval(seconds(unconfirmedRetireAfter))
+        case .streaming:
+            return provisional.lastLineAt.addingTimeInterval(seconds(silentStreamRetireAfter))
+        }
+    }
+
+    /// How long from `now` until ``retireDeadline(for:)`` arrives, or nil when
+    /// there is no deadline or it has already passed.
+    ///
+    /// A deadline that has arrived or passed is nil rather than zero:
+    /// ``compose`` has already retired that row, so there is nothing left to
+    /// wake up for, and arming a zero-length sleep would fire instantly into a
+    /// re-publish that composed the same row and armed the same zero again.
+    static func retireDelay(for provisional: ProvisionalMessage, now: Date) -> Duration? {
+        guard let deadline = retireDeadline(for: provisional) else { return nil }
+        let remaining = deadline.timeIntervalSince(now)
         guard remaining > 0 else { return nil }
         return .seconds(remaining)
     }
 
-    /// ``unconfirmedRetireAfter`` as a `TimeInterval`, so the rule is stated
-    /// once as a `Duration` (which is what the timer sleeps on) and compared
-    /// against `Date` arithmetic here without a second literal.
-    private static var retireAfterSeconds: TimeInterval {
-        let components = unconfirmedRetireAfter.components
+    /// A `Duration` as a `TimeInterval`, so each rule is stated once as the
+    /// `Duration` the timer sleeps on and compared against `Date` arithmetic
+    /// here without a second literal.
+    private static func seconds(_ duration: Duration) -> TimeInterval {
+        let components = duration.components
         return TimeInterval(components.seconds)
             + TimeInterval(components.attoseconds) / 1_000_000_000_000_000_000
     }

--- a/Sources/TBDApp/Panes/Transcript/ProvisionalRowComposer.swift
+++ b/Sources/TBDApp/Panes/Transcript/ProvisionalRowComposer.swift
@@ -23,14 +23,30 @@ import TBDShared
 /// what marks the row provisional downstream — `transcriptRenderNodes(from:)`
 /// reads the prefix, nothing else has to be threaded through.
 ///
-/// **Retirement.** Four of the six rules are announced by something the pane
-/// already watches. Confirmation arrives with a transcript read, an abort and a
-/// newer `start` (which `StreamFileReader.fold` resolves inside the fold, not
-/// here) arrive with a stream-file change, and the flag going off restarts the
-/// pane's loop. The other two — a completed message nobody ever confirms, and a
-/// stream that simply stops arriving — are announced by nothing at all, which
-/// is why ``ProvisionalRetireTimer`` exists. Both are deadlines, they differ
-/// only in what they measure from and how long they allow.
+/// **Retirement.** Six rules take the row down, and every one of them is
+/// listed here:
+///
+/// 1. **Confirmed** — the session's own JSONL has caught up with the message
+///    id, so the settled row replaces the provisional one.
+/// 2. **Aborted** — the stream file records an `aborted` line for the message.
+/// 3. **Superseded** — a newer message's lines make it the one the fold
+///    renders, so the older row is no longer the row on screen.
+/// 4. **Streaming switched off** — the resolved streaming flag is off, whatever
+///    the stream file holds.
+/// 5. **Completed but unconfirmed for 60 s** — ``unconfirmedRetireAfter``,
+///    measured from the stop the reader saw.
+/// 6. **Streaming but silent for 600 s** — ``silentStreamRetireAfter``,
+///    measured from the last line the reader saw, and equal to the proxy's own
+///    drain cap.
+///
+/// The first four are announced by something the pane already watches:
+/// confirmation arrives with a transcript read, an abort and a newer `start`
+/// (which `StreamFileReader.fold` resolves inside the fold, not here) arrive
+/// with a stream-file change, and the flag going off restarts the pane's loop.
+/// The last two — a completed message nobody ever confirms, and a stream that
+/// simply stops arriving — are announced by nothing at all, which is why
+/// ``ProvisionalRetireTimer`` exists. Both are deadlines; they differ only in
+/// what they measure from and how long they allow.
 enum ProvisionalRowComposer {
 
     /// How long a *completed* stream message may stay unconfirmed before its
@@ -56,8 +72,11 @@ enum ProvisionalRowComposer {
     /// streaming a large tool-input block emits none of them for minutes while
     /// the request is perfectly healthy. The proxy's own drain cap is the
     /// longest a legitimate stream can still be in flight, so a stream quiet
-    /// for longer than that is one nothing is coming back for.
-    static let silentStreamRetireAfter: Duration = .seconds(600)
+    /// for longer than that is one nothing is coming back for. It *is* that
+    /// cap — ``TBDShared/ModelProxyLimits/drainCap``, the same constant
+    /// `TBDModelProxy`'s retire drain sleeps on — rather than a second literal
+    /// that happens to agree with it.
+    static let silentStreamRetireAfter: Duration = ModelProxyLimits.drainCap
 
     /// Prefix on the provisional row's item id. Deliberately a prefix of the
     /// real message id rather than an opaque token, so the row's identity is

--- a/Sources/TBDApp/Panes/Transcript/Table/TableTranscriptPaneView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Table/TableTranscriptPaneView.swift
@@ -529,7 +529,7 @@ struct TableTranscriptPaneView: View {
         // A pane that goes away disarms **its own** session's alarm and no
         // other. This instance is reachable from the scheduler's one app-wide
         // `onChange` slot, so it may hold alarms for sessions other panes are
-        // showing, and the 60-second rule is the one retire rule nothing
+        // showing, and the deadline rules are the retire rules nothing
         // re-announces: cancelling another session's alarm here would strand
         // its provisional row on screen forever. The alarms left armed are
         // safe — the sleeping task is retained by its own `fire` closure,
@@ -603,10 +603,11 @@ struct TableTranscriptPaneView: View {
         }
 
         // Arm the deadline only for a row that actually got published and has
-        // actually completed. `compose` has already applied every other retire
-        // rule, so a provisional row that survived it and is `.complete` is
-        // exactly the case nothing else will ever announce. Everything else —
-        // including a row that was just withdrawn — disarms.
+        // one. `compose` has already applied every other retire rule, so a
+        // provisional row that survived it is either a completed message
+        // nobody has confirmed or a stream that has gone quiet — the two cases
+        // nothing else will ever announce. Everything else — including a row
+        // that was just withdrawn — disarms.
         //
         // Both gestures name `sessionID`, and that is load-bearing rather than
         // decorative: one timer instance serves every session that publishes
@@ -615,9 +616,11 @@ struct TableTranscriptPaneView: View {
         // another session's pending retire alarm.
         if let provisional,
            items.last.map({ ProvisionalRowComposer.isProvisional(itemID: $0.id) }) == true,
-           let delay = ProvisionalRowComposer.retireDelay(phase: provisional.phase, now: at) {
+           let deadline = ProvisionalRowComposer.retireDeadline(for: provisional),
+           let delay = ProvisionalRowComposer.retireDelay(for: provisional, now: at) {
             await retireTimer.arm(
-                sessionID: sessionID, messageID: provisional.messageID, after: delay
+                sessionID: sessionID, messageID: provisional.messageID,
+                deadline: deadline, after: delay
             ) {
                 _ = await publish(
                     sessionID: sessionID, state: state, source: source,

--- a/Sources/TBDApp/Panes/Transcript/Table/TableTranscriptPaneView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Table/TableTranscriptPaneView.swift
@@ -459,7 +459,8 @@ struct TableTranscriptPaneView: View {
         let source = appState.transcriptSource
         let state = appState
 
-        // The retire alarms for this run of the loop, disarmed when it ends.
+        // The retire alarms for this run of the loop; this pane's own session
+        // is disarmed when it ends, and no other's.
         // They back the single retire rule no file change can announce; see
         // `ProvisionalRetireTimer`. Its state is keyed by session id because
         // the closure below goes into the scheduler's one app-wide slot and so
@@ -525,11 +526,16 @@ struct TableTranscriptPaneView: View {
                 tier: tier, token: token)
         }
         await scheduler.deregister(sessionID: sid, token: token)
-        // A pane that goes away leaves no sleeping alarm behind, for any of the
-        // sessions this instance served. The publish one would have run is
-        // harmless (it recomposes from the source), but an unbounded number of
-        // them is not.
-        await retireTimer.disarmAll()
+        // A pane that goes away disarms **its own** session's alarm and no
+        // other. This instance is reachable from the scheduler's one app-wide
+        // `onChange` slot, so it may hold alarms for sessions other panes are
+        // showing, and the 60-second rule is the one retire rule nothing
+        // re-announces: cancelling another session's alarm here would strand
+        // its provisional row on screen forever. The alarms left armed are
+        // safe — the sleeping task is retained by its own `fire` closure,
+        // clears itself when it fires, and its callback (`publish`) captures
+        // only `AppState`, the source and this timer, never a view.
+        await retireTimer.disarm(sessionID: sid)
     }
 
     /// One publish: read what the source has for `sessionID`, merge the

--- a/Sources/TBDApp/Panes/Transcript/Table/TableTranscriptPaneView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Table/TableTranscriptPaneView.swift
@@ -110,6 +110,19 @@ struct TableTranscriptPaneView: View {
         terminal?.claudeSessionID
     }
 
+    /// The identity of the current run of `pollLoop`. Every input the loop
+    /// reads once lives here, so a change to any of them restarts it; see
+    /// `TaskKey`.
+    private var taskKey: TaskKey {
+        TaskKey.resolve(
+            terminalID: terminalID,
+            sessionID: currentSessionID,
+            retryToken: retryToken,
+            transcriptPath: terminal?.transcriptPath,
+            streamingEnabled: appState.transcriptStreamingEnabled,
+            terminalStreamPath: terminal?.transcriptStreamPath)
+    }
+
     private var messages: [TranscriptItem] {
         guard let sid = currentSessionID else { return [] }
         return appState.sessionTranscripts[sid] ?? []
@@ -132,10 +145,7 @@ struct TableTranscriptPaneView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .task(id: TaskKey(
-            terminalID: terminalID, sessionID: currentSessionID, retryToken: retryToken,
-            hasTranscriptPath: !(terminal?.transcriptPath ?? "").isEmpty
-        )) {
+        .task(id: taskKey) {
             await pollLoop()
         }
         .onAppear { recordWatchdogContext(count: displayedMessages.count) }
@@ -446,14 +456,15 @@ struct TableTranscriptPaneView: View {
                 state.touchSessionTranscript(sessionID)
             }
         }
-        // The model-proxy stream file this session's terminal was spawned
-        // with, when the daemon reports streaming as effective. Read once: the
-        // path is stamped at spawn and never changes, so a terminal either has
-        // one for its whole life or never gets one, and re-reading it each tier
-        // change would only risk minting a generation for no reason.
-        let streamPath = appState.transcriptStreamingEnabled
-            ? terminal?.transcriptStreamPath
-            : nil
+        // The model-proxy stream file this session's terminal was spawned with,
+        // when the daemon reports streaming as effective. Read once, and taken
+        // from `taskKey` so that the value this loop runs on is by construction
+        // the value its `.task(id:)` was keyed on: the path itself is stamped at
+        // spawn and never changes, but the *flag* in front of it can be flipped
+        // in Settings at any moment, and a flip restarts this loop rather than
+        // being noticed mid-run. Re-reading it on every tier change would only
+        // risk minting a generation for no reason.
+        let streamPath = taskKey.streamPath
 
         // One token per run of this task, so the hold belongs to *this* pane.
         // The deregistration at the bottom happens whenever this task notices
@@ -657,11 +668,47 @@ struct TableTranscriptPaneView: View {
 /// moment the path lands. Only *whether* a path exists is part of the key, never
 /// the path string, so a session's path value can churn without restarting the
 /// loop.
-private struct TaskKey: Equatable {
+/// The identity of one run of the pane's poll loop. `.task(id:)` restarts the
+/// loop whenever this changes, so every input the loop reads *once* has to be
+/// part of it — otherwise the loop keeps running against a stale reading of it
+/// and only an unrelated remount repairs the pane.
+///
+/// `streamPath` is here for exactly that reason: `appSideLoop` resolves the
+/// model-proxy stream file once, at the top, and flipping the Settings toggle
+/// changes what that resolution yields. Without it in the key, turning
+/// "Stream assistant text into the transcript" on would do nothing for a pane
+/// already on screen — which is the direction the soak depends on. Restarting
+/// is cheap and safe here: `TranscriptPollScheduler.register` is idempotent per
+/// token, and it already mints a fresh generation when a path changes.
+///
+/// Internal, not private, so the resolution can be asserted directly rather
+/// than only through a SwiftUI view tree — the same shape, and for the same
+/// reason, as `TranscriptPaneTransport.resolve`.
+struct TaskKey: Equatable {
     let terminalID: UUID
     let sessionID: String?
     let retryToken: Int
     let hasTranscriptPath: Bool
+    /// The stream file this run of the loop will register, or nil when the
+    /// daemon reports streaming off or the terminal was spawned without one.
+    let streamPath: String?
+
+    static func resolve(
+        terminalID: UUID,
+        sessionID: String?,
+        retryToken: Int,
+        transcriptPath: String?,
+        streamingEnabled: Bool,
+        terminalStreamPath: String?
+    ) -> TaskKey {
+        let stream = terminalStreamPath ?? ""
+        return TaskKey(
+            terminalID: terminalID,
+            sessionID: sessionID,
+            retryToken: retryToken,
+            hasTranscriptPath: !(transcriptPath ?? "").isEmpty,
+            streamPath: streamingEnabled && !stream.isEmpty ? stream : nil)
+    }
 }
 
 /// SwiftUI identity for the table transcript representable. Composes the terminal

--- a/Sources/TBDApp/Panes/Transcript/Table/TableTranscriptPaneView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Table/TableTranscriptPaneView.swift
@@ -445,8 +445,10 @@ struct TableTranscriptPaneView: View {
     /// re-declares it whenever its visibility changes; the scheduler never
     /// derives one.
     ///
-    /// `clock` drives both the tier re-declaration wait and the provisional
-    /// row's retire alarm; the repo's clock seam, last parameter, defaulted.
+    /// `clock` drives this loop's own tier re-declaration wait; the repo's
+    /// clock seam, last parameter, defaulted. The provisional row's retire
+    /// alarm sleeps on the *scheduler's* clock instead, because the timer it
+    /// arms into belongs to the scheduler and outlives every pane.
     private func appSideLoop(path: String, clock: any Clock<Duration> = ContinuousClock()) async {
         // Every input this run reads *once* is read here, before the first
         // `await`: `taskKey` is a computed property over `AppState`, so
@@ -459,15 +461,21 @@ struct TableTranscriptPaneView: View {
         let source = appState.transcriptSource
         let state = appState
 
-        // The retire alarms for this run of the loop; this pane's own session
-        // is disarmed when it ends, and no other's.
-        // They back the single retire rule no file change can announce; see
-        // `ProvisionalRetireTimer`. Its state is keyed by session id because
-        // the closure below goes into the scheduler's one app-wide slot and so
-        // sees publishes for every registered session, not just this pane's.
-        let retireTimer = ProvisionalRetireTimer(clock: clock)
+        // The app's one retire timer, taken from the scheduler rather than
+        // built here. It backs the two retire rules no file change can
+        // announce; see `ProvisionalRetireTimer`. A pane must not own one: the
+        // closure below goes into the scheduler's single app-wide slot, so a
+        // second pane mounting — or a Settings flip restarting every streaming
+        // pane at once — would move the arming into a fresh instance while the
+        // first pane still held the only one its teardown could reach. The
+        // orphaned alarm then fires after the session has been forgotten and
+        // publishes an empty transcript for it.
+        let retireTimer = scheduler.provisionalRetire
 
-        await scheduler.setOnChange { [weak state] sessionID in
+        // Installed once for the whole app, not re-seated per mount: the
+        // closure carries nothing of this pane's (see
+        // `TranscriptPollScheduler.onChange`).
+        await scheduler.setOnChangeIfUnset { [weak state] sessionID in
             guard let state else { return }
             await Self.publish(
                 sessionID: sessionID, state: state, source: source, retireTimer: retireTimer)
@@ -525,17 +533,18 @@ struct TableTranscriptPaneView: View {
                 sessionID: sid, path: path, streamPath: streamPath,
                 tier: tier, token: token)
         }
+        // Releasing this pane's hold also cancels the session's retire alarm,
+        // but only when this was the last holder and only ahead of the
+        // source's forget — `deregister` is the one place that knows both.
         await scheduler.deregister(sessionID: sid, token: token)
-        // A pane that goes away disarms **its own** session's alarm and no
-        // other. This instance is reachable from the scheduler's one app-wide
-        // `onChange` slot, so it may hold alarms for sessions other panes are
-        // showing, and the deadline rules are the retire rules nothing
-        // re-announces: cancelling another session's alarm here would strand
-        // its provisional row on screen forever. The alarms left armed are
-        // safe — the sleeping task is retained by its own `fire` closure,
-        // clears itself when it fires, and its callback (`publish`) captures
-        // only `AppState`, the source and this timer, never a view.
-        await retireTimer.disarm(sessionID: sid)
+        // And the pane says so itself, for the case `deregister` returns early
+        // from: a token whose hold was already released while the registration
+        // has since gone away entirely. Never a blanket disarm — the timer
+        // holds alarms for every session, and the scheduler refuses this one
+        // while any pane still has the session registered, because a deadline
+        // rule is announced by nothing and cancelling a live pane's alarm
+        // would strand its row on screen.
+        await scheduler.disarmProvisional(sessionID: sid)
     }
 
     /// One publish: read what the source has for `sessionID`, merge the
@@ -610,9 +619,9 @@ struct TableTranscriptPaneView: View {
         // that was just withdrawn — disarms.
         //
         // Both gestures name `sessionID`, and that is load-bearing rather than
-        // decorative: one timer instance serves every session that publishes
-        // through the scheduler's single on-change slot, so an unkeyed disarm
-        // here would let ordinary transcript news for one session cancel
+        // decorative: the scheduler's one timer instance serves every session
+        // that publishes through its single on-change slot, so an unkeyed
+        // disarm here would let ordinary transcript news for one session cancel
         // another session's pending retire alarm.
         if let provisional,
            items.last.map({ ProvisionalRowComposer.isProvisional(itemID: $0.id) }) == true,

--- a/Sources/TBDApp/Panes/Transcript/Table/TableTranscriptPaneView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Table/TableTranscriptPaneView.swift
@@ -591,7 +591,10 @@ struct TableTranscriptPaneView: View {
         let provisional = snapshot.provisional
 
         // The one id that can matter: the row is retired the moment the JSONL
-        // catches up with it, and no other message id is a candidate for a row.
+        // delivers the line carrying that message's text, and no other message
+        // id is a candidate for a row. Text-bearing rather than id-bearing
+        // because Claude Code writes one line per content block under a shared
+        // id — see `TranscriptSource.hasAssistantText`.
         var confirmedIDs: Set<String> = []
         if let provisional, snapshot.confirmed {
             confirmedIDs = [provisional.messageID]

--- a/Sources/TBDApp/Panes/Transcript/Table/TableTranscriptPaneView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Table/TableTranscriptPaneView.swift
@@ -459,9 +459,11 @@ struct TableTranscriptPaneView: View {
         let source = appState.transcriptSource
         let state = appState
 
-        // One alarm per run of this loop, disarmed when the loop ends. It backs
-        // the single retire rule no file change can announce; see
-        // `ProvisionalRetireTimer`.
+        // The retire alarms for this run of the loop, disarmed when it ends.
+        // They back the single retire rule no file change can announce; see
+        // `ProvisionalRetireTimer`. Its state is keyed by session id because
+        // the closure below goes into the scheduler's one app-wide slot and so
+        // sees publishes for every registered session, not just this pane's.
         let retireTimer = ProvisionalRetireTimer(clock: clock)
 
         await scheduler.setOnChange { [weak state] sessionID in
@@ -523,10 +525,11 @@ struct TableTranscriptPaneView: View {
                 tier: tier, token: token)
         }
         await scheduler.deregister(sessionID: sid, token: token)
-        // A pane that goes away leaves no sleeping alarm behind. The publish it
-        // would have run is harmless (it recomposes from the source), but an
-        // unbounded number of them is not.
-        await retireTimer.disarm()
+        // A pane that goes away leaves no sleeping alarm behind, for any of the
+        // sessions this instance served. The publish one would have run is
+        // harmless (it recomposes from the source), but an unbounded number of
+        // them is not.
+        await retireTimer.disarmAll()
     }
 
     /// One publish: read what the source has for `sessionID`, merge the
@@ -561,16 +564,21 @@ struct TableTranscriptPaneView: View {
         retireTimer: ProvisionalRetireTimer,
         now: @escaping @Sendable () -> Date = { Date() }
     ) async -> [TranscriptItem] {
-        let raw = await source.items(sessionID: sessionID)
-        let merged = await mergePendingQuestions(sessionID: sessionID, raw: raw, state: state)
-        let provisional = await source.provisional(sessionID: sessionID)
+        // One hop onto the source for all three facts: the items, the
+        // provisional message and whether the JSONL has caught up with it. Read
+        // separately, a `refresh` landing between two of the awaits could hand
+        // this publish a transcript from before the settled assistant message
+        // and a confirmation from after it — and it would then show neither the
+        // provisional row nor the settled one.
+        let snapshot = await source.snapshot(sessionID: sessionID)
+        let merged = await mergePendingQuestions(
+            sessionID: sessionID, raw: snapshot.items, state: state)
+        let provisional = snapshot.provisional
 
-        // One confirmation lookup per publish, for the one id that can matter:
-        // the row is retired the moment the JSONL catches up with it, and no
-        // other message id is a candidate for a row.
+        // The one id that can matter: the row is retired the moment the JSONL
+        // catches up with it, and no other message id is a candidate for a row.
         var confirmedIDs: Set<String> = []
-        if let provisional,
-           await source.hasAssistantMessage(sessionID: sessionID, id: provisional.messageID) {
+        if let provisional, snapshot.confirmed {
             confirmedIDs = [provisional.messageID]
         }
 
@@ -593,16 +601,24 @@ struct TableTranscriptPaneView: View {
         // rule, so a provisional row that survived it and is `.complete` is
         // exactly the case nothing else will ever announce. Everything else —
         // including a row that was just withdrawn — disarms.
+        //
+        // Both gestures name `sessionID`, and that is load-bearing rather than
+        // decorative: one timer instance serves every session that publishes
+        // through the scheduler's single on-change slot, so an unkeyed disarm
+        // here would let ordinary transcript news for one session cancel
+        // another session's pending retire alarm.
         if let provisional,
            items.last.map({ ProvisionalRowComposer.isProvisional(itemID: $0.id) }) == true,
            let delay = ProvisionalRowComposer.retireDelay(phase: provisional.phase, now: at) {
-            await retireTimer.arm(messageID: provisional.messageID, after: delay) {
+            await retireTimer.arm(
+                sessionID: sessionID, messageID: provisional.messageID, after: delay
+            ) {
                 _ = await publish(
                     sessionID: sessionID, state: state, source: source,
                     retireTimer: retireTimer, now: now)
             }
         } else {
-            await retireTimer.disarm()
+            await retireTimer.disarm(sessionID: sessionID)
         }
         return items
     }

--- a/Sources/TBDApp/Panes/Transcript/Table/TableTranscriptPaneView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Table/TableTranscriptPaneView.swift
@@ -410,10 +410,10 @@ struct TableTranscriptPaneView: View {
 
     // MARK: - Polling
 
-    private func pollLoop() async {
+    private func pollLoop(clock: any Clock<Duration> = ContinuousClock()) async {
         let transport = TranscriptPaneTransport.resolve(path: terminal?.transcriptPath)
         if case .appSide(let path) = transport {
-            await appSideLoop(path: path)
+            await appSideLoop(path: path, clock: clock)
             return
         }
         var consecutiveFailures = 0
@@ -433,6 +433,10 @@ struct TableTranscriptPaneView: View {
     /// three view consumers — this pane, the history pane and the overlay —
     /// read that store already, so nothing downstream changes.
     ///
+    /// What each publish writes is composed by `publish` below: JSONL items,
+    /// then the daemon's pending `AskUserQuestion` captures, then the
+    /// model-proxy stream's provisional assistant row last.
+    ///
     /// `path` is the already-resolved, non-empty transcript path chosen by
     /// `TranscriptPaneTransport.resolve` — passed in rather than re-read here so
     /// the "no path" case cannot recur inside this loop and strand the pane.
@@ -440,31 +444,40 @@ struct TableTranscriptPaneView: View {
     /// The pane also *declares* its cadence tier (`currentPollTier`) and
     /// re-declares it whenever its visibility changes; the scheduler never
     /// derives one.
-    private func appSideLoop(path: String) async {
+    ///
+    /// `clock` drives both the tier re-declaration wait and the provisional
+    /// row's retire alarm; the repo's clock seam, last parameter, defaulted.
+    private func appSideLoop(path: String, clock: any Clock<Duration> = ContinuousClock()) async {
+        // Every input this run reads *once* is read here, before the first
+        // `await`: `taskKey` is a computed property over `AppState`, so
+        // re-reading it after an actor hop could answer differently from the
+        // value `.task(id:)` keyed this run on, and the loop would then be
+        // running against a resolution nothing restarts it for.
+        let key = taskKey
         guard let sid = currentSessionID else { return }
         let scheduler = appState.transcriptPollScheduler
         let source = appState.transcriptSource
         let state = appState
 
+        // One alarm per run of this loop, disarmed when the loop ends. It backs
+        // the single retire rule no file change can announce; see
+        // `ProvisionalRetireTimer`.
+        let retireTimer = ProvisionalRetireTimer(clock: clock)
+
         await scheduler.setOnChange { [weak state] sessionID in
             guard let state else { return }
-            let raw = await source.items(sessionID: sessionID)
-            let items = await Self.mergePendingQuestions(
-                sessionID: sessionID, raw: raw, state: state)
-            await MainActor.run {
-                state.sessionTranscripts[sessionID] = items
-                state.touchSessionTranscript(sessionID)
-            }
+            await Self.publish(
+                sessionID: sessionID, state: state, source: source, retireTimer: retireTimer)
         }
         // The model-proxy stream file this session's terminal was spawned with,
-        // when the daemon reports streaming as effective. Read once, and taken
-        // from `taskKey` so that the value this loop runs on is by construction
-        // the value its `.task(id:)` was keyed on: the path itself is stamped at
+        // when the daemon reports streaming as effective. Taken from the
+        // `TaskKey` captured above, so the value this loop registers is the same
+        // value its `.task(id:)` was keyed on: the path itself is stamped at
         // spawn and never changes, but the *flag* in front of it can be flipped
         // in Settings at any moment, and a flip restarts this loop rather than
         // being noticed mid-run. Re-reading it on every tier change would only
         // risk minting a generation for no reason.
-        let streamPath = taskKey.streamPath
+        let streamPath = key.streamPath
 
         // One token per run of this task, so the hold belongs to *this* pane.
         // The deregistration at the bottom happens whenever this task notices
@@ -479,11 +492,8 @@ struct TableTranscriptPaneView: View {
 
         // Publish once immediately so the pane is not blank until the first tick.
         await source.refresh(sessionID: sid, path: path)
-        let raw = await source.items(sessionID: sid)
-        let items = await Self.mergePendingQuestions(
-            sessionID: sid, raw: raw, state: appState)
-        appState.sessionTranscripts[sid] = items
-        appState.touchSessionTranscript(sid)
+        let items = await Self.publish(
+            sessionID: sid, state: state, source: source, retireTimer: retireTimer)
         if !items.isEmpty { hasShownInitialMessages = true }
 
         // Hold the task open so `.task(id:)` teardown deregisters on disappear,
@@ -502,7 +512,6 @@ struct TableTranscriptPaneView: View {
         // costs at most a handful of extra `stat`s.
         //
         // `clock.sleep`, never `Task.sleep`: the latter is a lint error here.
-        let clock = ContinuousClock()
         while !Task.isCancelled {
             try? await clock.sleep(for: .seconds(1))
             if Task.isCancelled { break }
@@ -514,6 +523,88 @@ struct TableTranscriptPaneView: View {
                 tier: tier, token: token)
         }
         await scheduler.deregister(sessionID: sid, token: token)
+        // A pane that goes away leaves no sleeping alarm behind. The publish it
+        // would have run is harmless (it recomposes from the source), but an
+        // unbounded number of them is not.
+        await retireTimer.disarm()
+    }
+
+    /// One publish: read what the source has for `sessionID`, merge the
+    /// daemon's pending `AskUserQuestion` captures, append the model-proxy
+    /// stream's provisional row, write the result into `AppState`, and arm or
+    /// disarm the one-shot that retires a completed-but-unconfirmed row.
+    ///
+    /// Returns what it published, for the one caller that needs it — the
+    /// initial publish, which latches `hasShownInitialMessages`.
+    ///
+    /// `nonisolated static` for the same reason `mergePendingQuestions` is:
+    /// it runs from the scheduler's `@Sendable` on-change closure, and `View`'s
+    /// `@MainActor` would otherwise drag the merge's index build onto main.
+    /// Only the store write needs main, and it says so.
+    ///
+    /// **Why the streaming flag is read here rather than captured from the
+    /// pane's `TaskKey`.** The scheduler holds exactly one on-change closure
+    /// for the whole app, whichever pane registered last, and it is passed the
+    /// session that changed — the closures have to stay interchangeable between
+    /// panes (see `TranscriptPollScheduler.onChange`). A closure carrying one
+    /// pane's resolved flag would decide for sessions belonging to other panes,
+    /// and a pane with no stream file of its own never restarts on a flag flip,
+    /// so the value it captured could be arbitrarily stale. The flag is
+    /// app-wide (`DaemonCapabilities`), so reading it fresh on the main actor
+    /// is both correct and race-free; what is per-pane is the *stream path*,
+    /// and that stays in the `TaskKey`.
+    @discardableResult
+    nonisolated static func publish(
+        sessionID: String,
+        state: AppState,
+        source: TranscriptSource,
+        retireTimer: ProvisionalRetireTimer,
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) async -> [TranscriptItem] {
+        let raw = await source.items(sessionID: sessionID)
+        let merged = await mergePendingQuestions(sessionID: sessionID, raw: raw, state: state)
+        let provisional = await source.provisional(sessionID: sessionID)
+
+        // One confirmation lookup per publish, for the one id that can matter:
+        // the row is retired the moment the JSONL catches up with it, and no
+        // other message id is a candidate for a row.
+        var confirmedIDs: Set<String> = []
+        if let provisional,
+           await source.hasAssistantMessage(sessionID: sessionID, id: provisional.messageID) {
+            confirmedIDs = [provisional.messageID]
+        }
+
+        let streamingEnabled = await MainActor.run { state.transcriptStreamingEnabled }
+        let at = now()
+        let items = ProvisionalRowComposer.compose(
+            items: merged,
+            provisional: provisional,
+            confirmed: { confirmedIDs.contains($0) },
+            now: at,
+            streamingEnabled: streamingEnabled)
+
+        await MainActor.run {
+            state.sessionTranscripts[sessionID] = items
+            state.touchSessionTranscript(sessionID)
+        }
+
+        // Arm the deadline only for a row that actually got published and has
+        // actually completed. `compose` has already applied every other retire
+        // rule, so a provisional row that survived it and is `.complete` is
+        // exactly the case nothing else will ever announce. Everything else —
+        // including a row that was just withdrawn — disarms.
+        if let provisional,
+           items.last.map({ ProvisionalRowComposer.isProvisional(itemID: $0.id) }) == true,
+           let delay = ProvisionalRowComposer.retireDelay(phase: provisional.phase, now: at) {
+            await retireTimer.arm(messageID: provisional.messageID, after: delay) {
+                _ = await publish(
+                    sessionID: sessionID, state: state, source: source,
+                    retireTimer: retireTimer, now: now)
+            }
+        } else {
+            await retireTimer.disarm()
+        }
+        return items
     }
 
     /// This pane's cadence tier right now: foreground while its worktree is on

--- a/Sources/TBDApp/Panes/Transcript/Table/TableTranscriptPaneView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Table/TableTranscriptPaneView.swift
@@ -446,6 +446,15 @@ struct TableTranscriptPaneView: View {
                 state.touchSessionTranscript(sessionID)
             }
         }
+        // The model-proxy stream file this session's terminal was spawned
+        // with, when the daemon reports streaming as effective. Read once: the
+        // path is stamped at spawn and never changes, so a terminal either has
+        // one for its whole life or never gets one, and re-reading it each tier
+        // change would only risk minting a generation for no reason.
+        let streamPath = appState.transcriptStreamingEnabled
+            ? terminal?.transcriptStreamPath
+            : nil
+
         // One token per run of this task, so the hold belongs to *this* pane.
         // The deregistration at the bottom happens whenever this task notices
         // its own cancellation, which can be well after a replacement pane for
@@ -454,7 +463,7 @@ struct TableTranscriptPaneView: View {
         let token = TranscriptPaneToken()
         var tier = currentPollTier()
         await TranscriptPaneRegistration.apply(
-            sessionID: sid, path: path,
+            sessionID: sid, path: path, streamPath: streamPath,
             tier: tier, token: token, scheduler: scheduler)
 
         // Publish once immediately so the pane is not blank until the first tick.
@@ -489,7 +498,9 @@ struct TableTranscriptPaneView: View {
             let latest = currentPollTier()
             guard latest != tier else { continue }
             tier = latest
-            await scheduler.register(sessionID: sid, path: path, tier: tier, token: token)
+            await scheduler.register(
+                sessionID: sid, path: path, streamPath: streamPath,
+                tier: tier, token: token)
         }
         await scheduler.deregister(sessionID: sid, token: token)
     }

--- a/Sources/TBDApp/Panes/Transcript/Table/TableTranscriptView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Table/TableTranscriptView.swift
@@ -318,7 +318,8 @@ struct TableTranscriptView: NSViewRepresentable {
             let key = ComposedKey(id: node.id, version: node.contentVersion)
             if let cached = composedCache[key] { return cached }
             let composed = TranscriptBubbleGeometry.composedBlocks(
-                for: item, badgeUsage: node.badgeUsage, linkResolver: context.linkResolver)
+                for: item, badgeUsage: node.badgeUsage, linkResolver: context.linkResolver,
+                isProvisional: node.isProvisional)
             composedCache[key] = composed
             return composed
         }

--- a/Sources/TBDApp/Panes/Transcript/Table/TranscriptBubbleCellView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Table/TranscriptBubbleCellView.swift
@@ -236,6 +236,16 @@ enum TranscriptBubbleGeometry {
         }
     }
 
+    /// Trailing mark on the model-proxy stream's provisional row: this answer
+    /// is still arriving and the transcript has not confirmed it yet.
+    ///
+    /// Appended to the message text before rendering rather than drawn as
+    /// separate chrome, so it inherits the bubble's font, colour and line
+    /// wrapping and adds no layout node — the row measures and re-renders
+    /// exactly as it did before. U+258D LEFT FIVE EIGHTHS BLOCK, the same glyph
+    /// a terminal draws for a bar cursor.
+    static let provisionalCursor = "\u{258D}"
+
     /// The message's blocks: rendered markdown split at GFM tables, with the
     /// token-usage badge (when present) appended to the LAST prose block — or, if
     /// the message ends in a table (or has no prose), a trailing prose block
@@ -244,10 +254,12 @@ enum TranscriptBubbleGeometry {
     static func composedBlocks(
         for item: TranscriptItem,
         badgeUsage: TokenUsage?,
-        linkResolver: TranscriptPathResolver?
+        linkResolver: TranscriptPathResolver?,
+        isProvisional: Bool = false
     ) -> [MessageBlock] {
         var blocks = MarkdownAttributedRenderer.renderBlocks(
-            text(for: item), theme: .chatBubble, linkResolver: linkResolver)
+            text(for: item) + (isProvisional ? provisionalCursor : ""),
+            theme: .chatBubble, linkResolver: linkResolver)
         guard let usage = badgeUsage else { return blocks }
 
         let badge = NSAttributedString(

--- a/Sources/TBDApp/Panes/Transcript/TranscriptRenderNode.swift
+++ b/Sources/TBDApp/Panes/Transcript/TranscriptRenderNode.swift
@@ -56,13 +56,26 @@ struct TranscriptRenderNode: Identifiable, Equatable {
     /// corrects it.
     let contentVersion: UInt64
 
-    init(id: String, kind: Kind, badgeUsage: TokenUsage?) {
+    /// True for the model-proxy stream's provisional assistant row — the one
+    /// row in the list whose text is still arriving and which the transcript
+    /// JSONL has not confirmed. The bubble draws a trailing cursor for it and
+    /// nothing else changes.
+    ///
+    /// Derived from the item id's `stream:` prefix by
+    /// `transcriptRenderNodes(from:)`, so no extra state has to be threaded
+    /// through the projection, and defaulted so every other construction site
+    /// — including the tests that build nodes by hand — is unchanged.
+    let isProvisional: Bool
+
+    init(id: String, kind: Kind, badgeUsage: TokenUsage?, isProvisional: Bool = false) {
         self.id = id
         self.kind = kind
         self.badgeUsage = badgeUsage
+        self.isProvisional = isProvisional
         var hasher = Hasher()
         hasher.combine(kind)
         hasher.combine(badgeUsage)
+        hasher.combine(isProvisional)
         self.contentVersion = UInt64(bitPattern: Int64(hasher.finalize()))
     }
 
@@ -145,7 +158,14 @@ nonisolated func transcriptRenderNodes(from items: [TranscriptItem]) -> [Transcr
 
         switch item {
         case .userPrompt, .assistantText, .peerMessage:
-            out.append(TranscriptRenderNode(id: item.id, kind: .chatBubble(item), badgeUsage: badge))
+            // The `stream:` prefix is what marks a row provisional; see
+            // `ProvisionalRowComposer.idPrefix`. Only a chat bubble can carry
+            // it — the composer only ever appends `.assistantText`.
+            out.append(TranscriptRenderNode(
+                id: item.id,
+                kind: .chatBubble(item),
+                badgeUsage: badge,
+                isProvisional: ProvisionalRowComposer.isProvisional(itemID: item.id)))
 
         case .systemReminder(let id, let kind, let text, let ts, let source, let truncatedTo):
             if kind == .skillBody {

--- a/Sources/TBDApp/TranscriptSource/StreamFileReader.swift
+++ b/Sources/TBDApp/TranscriptSource/StreamFileReader.swift
@@ -23,6 +23,14 @@ struct ProvisionalMessage: Equatable, Sendable {
     /// The message's text blocks concatenated in ascending block index.
     let text: String
     let phase: Phase
+    /// When the reader last saw a line for this message.
+    ///
+    /// The reader's clock, not the proxy's, and the same caller-stability rule
+    /// as `.complete(at:)`: it moves only when a line actually arrives, so the
+    /// deadline a silent `.streaming` row retires on does not slide forward on
+    /// every poll. `StreamFileReader.fold` stamps it with the `now` it is
+    /// handed and `TranscriptSource` is what holds it still.
+    let lastLineAt: Date
 }
 
 /// Folds the tagged lines of one terminal's stream file into the single
@@ -55,11 +63,14 @@ struct StreamFileReader: Sendable {
     /// from when the reader *first saw* the stop. So a caller that has already
     /// observed a stop must pass back the instant it recorded then, not a fresh
     /// `Date()` — folding the same lines with a moving `now` would push the
-    /// deadline forward on every poll and the row would never retire.
+    /// deadline forward on every poll and the row would never retire. The same
+    /// applies to `lastLineAt`, which this call stamps with `now` and which the
+    /// ten-minute silent-stream rule measures from.
     static func fold(lines: [ModelProxyStreamLine], now: Date) -> ProvisionalMessage? {
         guard let chosen = select(from: accumulate(lines)) else { return nil }
         return ProvisionalMessage(
-            messageID: chosen.messageID, text: chosen.text, phase: chosen.phase(now: now))
+            messageID: chosen.messageID, text: chosen.text, phase: chosen.phase(now: now),
+            lastLineAt: now)
     }
 
     /// The id of the most recent message in these lines by the same ranking

--- a/Sources/TBDApp/TranscriptSource/StreamFileReader.swift
+++ b/Sources/TBDApp/TranscriptSource/StreamFileReader.swift
@@ -57,6 +57,29 @@ struct StreamFileReader: Sendable {
     /// `Date()` — folding the same lines with a moving `now` would push the
     /// deadline forward on every poll and the row would never retire.
     static func fold(lines: [ModelProxyStreamLine], now: Date) -> ProvisionalMessage? {
+        guard let chosen = select(from: accumulate(lines)) else { return nil }
+        return ProvisionalMessage(
+            messageID: chosen.messageID, text: chosen.text, phase: chosen.phase(now: now))
+    }
+
+    /// The id of the most recent message in these lines by the same ranking
+    /// `fold` uses — the order the message's first line appears — or nil when
+    /// there are no lines.
+    ///
+    /// Exists so callers that must reason about *which* message is the current
+    /// one — the retained-line cap, which may never evict it — rank by the same
+    /// rule the fold does instead of approximating it with the owner of the
+    /// last line. The two answers part company exactly when messages
+    /// interleave, which is the case the position ranking was written for: an
+    /// older message that keeps appending after a newer one has started owns
+    /// the last line while the newer one is the current turn.
+    static func mostRecentMessageID(in lines: [ModelProxyStreamLine]) -> String? {
+        mostRecent(accumulate(lines))?.messageID
+    }
+
+    /// Groups the lines by message id, recording each message's rank by where
+    /// its first line appears.
+    private static func accumulate(_ lines: [ModelProxyStreamLine]) -> [Accumulator] {
         var accumulators: [String: Accumulator] = [:]
         var nextPosition = 0
 
@@ -76,25 +99,38 @@ struct StreamFileReader: Sendable {
             case let .text(_, index, text):
                 accumulators[id]?.deltasByBlock[index, default: []].append(text)
             case .stop:
-                accumulators[id]?.phase = .complete(at: now)
+                accumulators[id]?.terminal = .stopped
             case let .aborted(_, reason):
-                accumulators[id]?.phase = .aborted(reason: reason)
+                accumulators[id]?.terminal = .aborted(reason: reason)
             }
         }
+        return Array(accumulators.values)
+    }
 
-        let candidates = Array(accumulators.values)
-        let mostRecentWithText = candidates
-            .filter { !$0.text.isEmpty }
-            .max { $0.position < $1.position }
-        let mostRecentStarted = candidates
-            .filter { $0.hasStart }
-            .max { $0.position < $1.position }
-        guard let chosen = mostRecentWithText ?? mostRecentStarted else { return nil }
-        return ProvisionalMessage(messageID: chosen.messageID, text: chosen.text, phase: chosen.phase)
+    /// The one message worth rendering: the most recent with text, else the
+    /// most recently started.
+    private static func select(from candidates: [Accumulator]) -> Accumulator? {
+        mostRecent(candidates.filter { !$0.text.isEmpty })
+            ?? mostRecent(candidates.filter(\.hasStart))
+    }
+
+    /// The ranking itself, in one place: latest first line wins. Every notion
+    /// of "most recent" in this file and in the retained-line cap goes through
+    /// here, so none of them can drift apart.
+    private static func mostRecent(_ candidates: [Accumulator]) -> Accumulator? {
+        candidates.max { $0.position < $1.position }
     }
 
     /// What one message id has accumulated so far.
     private struct Accumulator {
+        /// How a message ended, if it has. Dateless on purpose: `.complete`
+        /// carries the instant the *reader* saw the stop, which is the
+        /// caller's `now` and not a property of the lines.
+        enum Terminal {
+            case stopped
+            case aborted(reason: String)
+        }
+
         let messageID: String
         /// Rank of this message's first line in the file, so "most recent"
         /// needs no timestamps.
@@ -103,12 +139,20 @@ struct StreamFileReader: Sendable {
         /// The last terminal line wins: `stop` and `aborted` each overwrite
         /// whatever was here, so a tee that gave up and then saw the real end
         /// reports the end.
-        var phase: ProvisionalMessage.Phase = .streaming
+        var terminal: Terminal?
         var hasStart = false
 
         /// Blocks in ascending index, deltas within a block in arrival order.
         var text: String {
             deltasByBlock.sorted { $0.key < $1.key }.flatMap { $0.value }.joined()
+        }
+
+        func phase(now: Date) -> ProvisionalMessage.Phase {
+            switch terminal {
+            case nil: return .streaming
+            case .stopped?: return .complete(at: now)
+            case let .aborted(reason)?: return .aborted(reason: reason)
+            }
         }
     }
 }

--- a/Sources/TBDApp/TranscriptSource/StreamFileReader.swift
+++ b/Sources/TBDApp/TranscriptSource/StreamFileReader.swift
@@ -1,0 +1,114 @@
+import Foundation
+import TBDShared
+
+/// The assistant message a pane renders from the proxy's stream file, before
+/// the session's transcript JSONL has caught up.
+///
+/// It is provisional in the strict sense: everything here is superseded the
+/// moment the same `messageID` shows up in the transcript, at which point the
+/// row is retired and the real transcript item takes over.
+struct ProvisionalMessage: Equatable, Sendable {
+    enum Phase: Equatable, Sendable {
+        /// Lines are still arriving, or the message ended in a way nobody
+        /// wrote down (a proxy killed mid-turn leaves exactly this).
+        case streaming
+        /// A `message_stop` was seen. `at` is when the *reader* first saw it,
+        /// not the proxy's clock — see `StreamFileReader.fold`.
+        case complete(at: Date)
+        /// The stream ended without a `message_stop`.
+        case aborted(reason: String)
+    }
+
+    let messageID: String
+    /// The message's text blocks concatenated in ascending block index.
+    let text: String
+    let phase: Phase
+}
+
+/// Folds the tagged lines of one terminal's stream file into the single
+/// message worth rendering.
+///
+/// Pure and I/O-free: the caller owns the file, the tailing, and the clock.
+struct StreamFileReader: Sendable {
+
+    /// Folds the lines seen so far into the message to render, or nil when
+    /// there is nothing worth showing yet.
+    ///
+    /// **Which message.** Lines of two messages interleave in the file when two
+    /// parent requests are in flight against one route, so the fold groups by
+    /// message id and then picks the most recent message that has text. "Most
+    /// recent" is by position in the file — the order the message's first line
+    /// appears — not by the `at` of its `start`, because file order is what the
+    /// tee actually controls. When no message has text yet, the most recently
+    /// started one is returned with empty text, so a pane can show that a turn
+    /// has begun. When no message has either text or a `start`, the result is
+    /// nil: there is nothing a reader could render.
+    ///
+    /// **Torn heads.** A `text` line whose message has no `start` still counts,
+    /// keyed by the id the line itself carries. Truncation happens only when
+    /// nothing is in flight, but a reader resuming mid-file can still see a
+    /// head whose `start` it never read, and dropping that message would blank
+    /// a pane that has text to show.
+    ///
+    /// **`now` is the caller's to keep stable.** `.complete(at:)` records the
+    /// `now` handed to this call, and the 60-second unconfirmed rule measures
+    /// from when the reader *first saw* the stop. So a caller that has already
+    /// observed a stop must pass back the instant it recorded then, not a fresh
+    /// `Date()` — folding the same lines with a moving `now` would push the
+    /// deadline forward on every poll and the row would never retire.
+    static func fold(lines: [ModelProxyStreamLine], now: Date) -> ProvisionalMessage? {
+        var accumulators: [String: Accumulator] = [:]
+        var nextPosition = 0
+
+        for line in lines {
+            let id = line.message
+            if accumulators[id] == nil {
+                accumulators[id] = Accumulator(messageID: id, position: nextPosition)
+                nextPosition += 1
+            }
+            switch line {
+            case .start:
+                accumulators[id]?.hasStart = true
+            case .block:
+                // A block with no deltas contributes no text and no ordering
+                // of its own — the `text` lines carry their own index.
+                break
+            case let .text(_, index, text):
+                accumulators[id]?.deltasByBlock[index, default: []].append(text)
+            case .stop:
+                accumulators[id]?.phase = .complete(at: now)
+            case let .aborted(_, reason):
+                accumulators[id]?.phase = .aborted(reason: reason)
+            }
+        }
+
+        let candidates = Array(accumulators.values)
+        let mostRecentWithText = candidates
+            .filter { !$0.text.isEmpty }
+            .max { $0.position < $1.position }
+        let mostRecentStarted = candidates
+            .filter { $0.hasStart }
+            .max { $0.position < $1.position }
+        guard let chosen = mostRecentWithText ?? mostRecentStarted else { return nil }
+        return ProvisionalMessage(messageID: chosen.messageID, text: chosen.text, phase: chosen.phase)
+    }
+
+    /// What one message id has accumulated so far.
+    private struct Accumulator {
+        let messageID: String
+        /// Rank of this message's first line in the file, so "most recent"
+        /// needs no timestamps.
+        let position: Int
+        var deltasByBlock: [Int: [String]] = [:]
+        /// The last terminal line wins: `stop` and `aborted` each overwrite
+        /// whatever was here, so a tee that gave up and then saw the real end
+        /// reports the end.
+        var phase: ProvisionalMessage.Phase = .streaming
+        var hasStart = false
+
+        /// Blocks in ascending index, deltas within a block in arrival order.
+        var text: String {
+            deltasByBlock.sorted { $0.key < $1.key }.flatMap { $0.value }.joined()
+        }
+    }
+}

--- a/Sources/TBDApp/TranscriptSource/TranscriptPaneRegistration.swift
+++ b/Sources/TBDApp/TranscriptSource/TranscriptPaneRegistration.swift
@@ -17,6 +17,12 @@ import Foundation
 /// file still registers and still polls — so it never influences the branch, it
 /// is only carried. The transcript path remains the sole gate, and a pane with
 /// a stream file but no transcript path deregisters like any other.
+///
+/// An empty `streamPath` means the same thing as nil and is normalised to it
+/// here, the way the transcript path's own guard treats `""` as "no path":
+/// `Terminal.transcriptStreamPath` reaches the app as a decoded string, and a
+/// registration carrying `""` would have the scheduler stat the pane's working
+/// directory on every tick forever.
 enum TranscriptPaneRegistration {
     static func apply(
         sessionID: String,
@@ -30,8 +36,9 @@ enum TranscriptPaneRegistration {
             await scheduler.deregister(sessionID: sessionID, token: token)
             return
         }
+        let stream = (streamPath?.isEmpty ?? true) ? nil : streamPath
         await scheduler.register(
-            sessionID: sessionID, path: path, streamPath: streamPath,
+            sessionID: sessionID, path: path, streamPath: stream,
             tier: tier, token: token)
     }
 }

--- a/Sources/TBDApp/TranscriptSource/TranscriptPaneRegistration.swift
+++ b/Sources/TBDApp/TranscriptSource/TranscriptPaneRegistration.swift
@@ -11,10 +11,17 @@ import Foundation
 ///
 /// `token` identifies the calling pane on both branches, so the guarded one
 /// releases that pane's own hold and nobody else's — see `TranscriptPaneToken`.
+///
+/// `streamPath` rides along on the registering branch: the model-proxy stream
+/// file is optional in a way the transcript path is not — a pane with no stream
+/// file still registers and still polls — so it never influences the branch, it
+/// is only carried. The transcript path remains the sole gate, and a pane with
+/// a stream file but no transcript path deregisters like any other.
 enum TranscriptPaneRegistration {
     static func apply(
         sessionID: String,
         path: String?,
+        streamPath: String? = nil,
         tier: TranscriptPollTier,
         token: TranscriptPaneToken,
         scheduler: TranscriptPollScheduler
@@ -23,7 +30,9 @@ enum TranscriptPaneRegistration {
             await scheduler.deregister(sessionID: sessionID, token: token)
             return
         }
-        await scheduler.register(sessionID: sessionID, path: path, tier: tier, token: token)
+        await scheduler.register(
+            sessionID: sessionID, path: path, streamPath: streamPath,
+            tier: tier, token: token)
     }
 }
 

--- a/Sources/TBDApp/TranscriptSource/TranscriptPollScheduler.swift
+++ b/Sources/TBDApp/TranscriptSource/TranscriptPollScheduler.swift
@@ -65,15 +65,20 @@ actor TranscriptPollScheduler {
 
     private struct Registration {
         var path: String
+        /// The terminal's model-proxy stream file, when the pane declared one.
+        /// Nil is the ordinary case — transcript streaming off, a session that
+        /// was never routed through the proxy, or a pre-streaming daemon — and
+        /// means this registration never touches a second file.
+        var streamPath: String?
         /// Every pane holding this session open right now, and the tier each
         /// one declared. Held inside the entry, so it is dropped whole when the
         /// last holder leaves — nothing accumulates per retired pane.
         var holders: [TranscriptPaneToken: TranscriptPollTier]
         /// Which incarnation of this session id this registration is. Minted
-        /// when the entry is created and again when its path changes — the two
-        /// cases where work already in flight was computed against something
-        /// this entry no longer is — so such a tick can recognise itself as
-        /// stale. See `finishTick`. Holders coming and going do not mint one:
+        /// when the entry is created and again when either of its paths changes
+        /// — the cases where work already in flight was computed against
+        /// something this entry no longer is — so such a tick can recognise
+        /// itself as stale. See `finishTick`. Holders coming and going do not mint one:
         /// the entry is still the same entry, and a tick that outlives one of
         /// several holders is still owed to the rest.
         var generation: UInt64
@@ -146,24 +151,34 @@ actor TranscriptPollScheduler {
     /// Idempotent per token: a pane re-declaring its tier updates its own hold
     /// rather than taking a second one, which is what makes the holder set
     /// bounded by "panes currently open", not by "tier changes ever made".
+    ///
+    /// `streamPath` is the model-proxy stream file this pane wants tailed
+    /// alongside the transcript, or nil for none. It defaults to nil so a
+    /// caller with no interest in streaming — every caller before this feature
+    /// — reads the same as it always did.
     func register(
-        sessionID: String, path: String, tier: TranscriptPollTier, token: TranscriptPaneToken
+        sessionID: String, path: String, streamPath: String? = nil,
+        tier: TranscriptPollTier, token: TranscriptPaneToken
     ) {
         var registration: Registration
         if let existing = registrations[sessionID] {
             registration = existing
-            if registration.path != path {
+            if registration.path != path || registration.streamPath != streamPath {
                 // The same session id under a different file. Whatever a tick
                 // in flight built, it built against the old path; mint a new
-                // incarnation so it can tell.
+                // incarnation so it can tell. A changed stream path counts for
+                // the same reason: the offsets and lines the source holds
+                // describe a file this registration no longer names.
                 lastGeneration += 1
                 registration.generation = lastGeneration
                 registration.path = path
+                registration.streamPath = streamPath
             }
         } else {
             lastGeneration += 1
             registration = Registration(
-                path: path, holders: [:], generation: lastGeneration, task: nil)
+                path: path, streamPath: streamPath, holders: [:],
+                generation: lastGeneration, task: nil)
         }
         registration.holders[token] = tier
         registrations[sessionID] = registration
@@ -239,6 +254,7 @@ actor TranscriptPollScheduler {
         guard var registration = registrations[sessionID] else { return }
         registration.task?.cancel()
         let path = registration.path
+        let streamPath = registration.streamPath
         // Carried by the task, not re-read from `registrations` inside it: the
         // whole point is to compare against what the registry says *later*.
         // Restarting a task (`setAppActive`, a re-declared tier, a holder
@@ -257,7 +273,9 @@ actor TranscriptPollScheduler {
             while !Task.isCancelled {
                 try? await clock.sleep(for: interval)
                 if Task.isCancelled { return }
-                await self?.tick(sessionID: sessionID, path: path, generation: generation)
+                await self?.tick(
+                    sessionID: sessionID, path: path, streamPath: streamPath,
+                    generation: generation)
             }
         }
         registrations[sessionID] = registration
@@ -270,12 +288,29 @@ actor TranscriptPollScheduler {
     /// cancellation check of its own. So the generation is re-checked on both
     /// sides of it — before, to skip work a cancelled task no longer owes, and
     /// again in `finishTick`, which is where the interesting case lives.
-    private func tick(sessionID: String, path: String, generation: UInt64) async {
+    ///
+    /// A registration that names a stream file refreshes it in the same tick,
+    /// at the same cadence: the provisional message is the same pane's content
+    /// as the transcript rows, and giving it a timer of its own would be a
+    /// second cadence policy to keep in step with this one. Either file
+    /// changing is news — the two are folded into one `hasNews` so a stream
+    /// delta with no transcript change still reaches the pane, which is the
+    /// whole point of streaming.
+    private func tick(
+        sessionID: String, path: String, streamPath: String?, generation: UInt64
+    ) async {
         guard registrations[sessionID]?.generation == generation else { return }
         let change = await source.refresh(sessionID: sessionID, path: path)
-        await finishTick(
-            sessionID: sessionID, generation: generation,
-            hasNews: !(change?.isEmpty ?? true))
+        var hasNews = !(change?.isEmpty ?? true)
+        if let streamPath {
+            // Not folded into the expression above: `||` short-circuits, and a
+            // transcript change must not skip the stream refresh — the tail
+            // would fall behind exactly when the session is busiest.
+            let streamChanged = await source.refreshStream(
+                sessionID: sessionID, path: streamPath, now: Date())
+            hasNews = hasNews || streamChanged
+        }
+        await finishTick(sessionID: sessionID, generation: generation, hasNews: hasNews)
     }
 
     /// The far side of one tick: decide whether what the refresh just did still

--- a/Sources/TBDApp/TranscriptSource/TranscriptPollScheduler.swift
+++ b/Sources/TBDApp/TranscriptSource/TranscriptPollScheduler.swift
@@ -132,6 +132,16 @@ actor TranscriptPollScheduler {
         registrations[sessionID]?.holders.count ?? 0
     }
 
+    /// The model-proxy stream file `sessionID` is registered to tail, or nil
+    /// when it has none (or is not registered at all).
+    ///
+    /// Read-only, and here so a test can pin what a registration actually
+    /// carries rather than infer it from a tick's side effects. Nothing in the
+    /// app reads it.
+    func registeredStreamPath(sessionID: String) -> String? {
+        registrations[sessionID]?.streamPath
+    }
+
     /// The generation of the live registration for `sessionID`, or nil when it
     /// is not registered.
     ///

--- a/Sources/TBDApp/TranscriptSource/TranscriptPollScheduler.swift
+++ b/Sources/TBDApp/TranscriptSource/TranscriptPollScheduler.swift
@@ -105,10 +105,22 @@ actor TranscriptPollScheduler {
     /// would keep a torn-down pane's closure alive.
     private var onChange: (@Sendable (String) async -> Void)?
     private let source: TranscriptSource
+    /// The instant a stream refresh stamps its lines with.
+    ///
+    /// A date seam rather than the clock seam beside it, because what this
+    /// produces is *data*: `TranscriptSource` stores it and the provisional
+    /// row's retire deadlines are later measured against it. `Duration` is
+    /// behavior, `Date` is data — see the repo's clock-and-date-seam rule.
+    private let now: @Sendable () -> Date
     private let clock: any Clock<Duration>
 
-    init(source: TranscriptSource, clock: any Clock<Duration> = ContinuousClock()) {
+    init(
+        source: TranscriptSource,
+        now: @escaping @Sendable () -> Date = { Date() },
+        clock: any Clock<Duration> = ContinuousClock()
+    ) {
         self.source = source
+        self.now = now
         self.clock = clock
     }
 
@@ -317,7 +329,7 @@ actor TranscriptPollScheduler {
             // transcript change must not skip the stream refresh — the tail
             // would fall behind exactly when the session is busiest.
             let streamChanged = await source.refreshStream(
-                sessionID: sessionID, path: streamPath, now: Date())
+                sessionID: sessionID, path: streamPath, now: now())
             hasNews = hasNews || streamChanged
         }
         await finishTick(sessionID: sessionID, generation: generation, hasNews: hasNews)

--- a/Sources/TBDApp/TranscriptSource/TranscriptPollScheduler.swift
+++ b/Sources/TBDApp/TranscriptSource/TranscriptPollScheduler.swift
@@ -98,11 +98,12 @@ actor TranscriptPollScheduler {
     /// registrations hold a copy, so nothing accumulates per retired session.
     private var lastGeneration: UInt64 = 0
     private var appActive = true
-    /// One handler for every registration, not one per session. Each pane sets
-    /// the same closure and it is passed the session id that changed, so a
-    /// later pane overwriting an earlier one's handler is harmless — they are
-    /// interchangeable. Do not "fix" this into a per-session dictionary; that
-    /// would keep a torn-down pane's closure alive.
+    /// One handler for every registration, not one per session. It is passed
+    /// the session id that changed, and it carries nothing belonging to the
+    /// pane that installed it — so the first pane to mount installs it and
+    /// every later one finds it already there (see ``setOnChangeIfUnset``). Do
+    /// not "fix" this into a per-session dictionary; that would keep a
+    /// torn-down pane's closure alive.
     private var onChange: (@Sendable (String) async -> Void)?
     private let source: TranscriptSource
     /// The instant a stream refresh stamps its lines with.
@@ -114,6 +115,21 @@ actor TranscriptPollScheduler {
     private let now: @Sendable () -> Date
     private let clock: any Clock<Duration>
 
+    /// The app's one provisional-row retire timer, created with this scheduler
+    /// and on its clock.
+    ///
+    /// It lives here because its lifetime is the *registration's*, not any
+    /// pane's. An alarm is armed by a publish, and every publish in the app
+    /// runs through the single ``onChange`` slot above; a pane that mounts,
+    /// remounts, or is restarted by a Settings flip must therefore find the
+    /// same instance the previous one armed into, or a session's live alarm
+    /// ends up in one instance while the pane that would cancel it holds
+    /// another — and the orphan then fires after ``deregister`` has already
+    /// forgotten the session, publishing an empty transcript for it.
+    /// `nonisolated` because it is an immutable `Sendable` actor reference:
+    /// `publish` can take it without a hop through this actor.
+    nonisolated let provisionalRetire: ProvisionalRetireTimer
+
     init(
         source: TranscriptSource,
         now: @escaping @Sendable () -> Date = { Date() },
@@ -122,6 +138,7 @@ actor TranscriptPollScheduler {
         self.source = source
         self.now = now
         self.clock = clock
+        self.provisionalRetire = ProvisionalRetireTimer(clock: clock)
     }
 
     var registeredSessionIDs: Set<String> { Set(registrations.keys) }
@@ -164,8 +181,40 @@ actor TranscriptPollScheduler {
         registrations[sessionID]?.generation
     }
 
-    func setOnChange(_ handler: @escaping @Sendable (String) async -> Void) {
+    /// Installs the change handler, unless one is already installed.
+    ///
+    /// Deliberately not a plain setter. Panes call this on every mount and the
+    /// closures are interchangeable — none of them carries anything belonging
+    /// to the pane that built it — so re-seating one buys nothing, and the
+    /// habit of re-seating it is what let a per-pane object ride into this slot
+    /// and split one session's alarms across two instances. Keeping the first
+    /// closure is safe: it holds `AppState` weakly, plus the same source and
+    /// retire timer this scheduler already owns, and no view.
+    func setOnChangeIfUnset(_ handler: @escaping @Sendable (String) async -> Void) {
+        guard onChange == nil else { return }
         onChange = handler
+    }
+
+    /// Cancels the provisional retire alarm for `sessionID` — unless a pane is
+    /// still holding that session registered.
+    ///
+    /// The guard is the whole point. The viewer-slot LRU permits two panes onto
+    /// one session, and a deadline rule is announced by nothing: cancelling an
+    /// alarm a surviving pane's row still depends on strands that row on screen
+    /// until the pane closes. So the gesture belongs to the *last* holder
+    /// leaving, and a departing pane that is not the last one asks for it in
+    /// vain.
+    ///
+    /// ``deregister`` makes this call itself, after dropping the registration
+    /// and **before** `TranscriptSource.forget` — the ordering is load-bearing.
+    /// An alarm that survives into the forget wakes up, publishes what the
+    /// source no longer has, and writes an empty transcript into
+    /// `AppState.sessionTranscripts`, where `AppState+History.selectSession`
+    /// reads `[]` as a cached answer and never refetches from disk. Session
+    /// History for that session would then read empty for good.
+    func disarmProvisional(sessionID: String) async {
+        guard registrations[sessionID] == nil else { return }
+        await provisionalRetire.disarm(sessionID: sessionID)
     }
 
     /// Adds `token`'s hold on `sessionID`, at the tier that pane declares.
@@ -250,6 +299,11 @@ actor TranscriptPollScheduler {
     /// Making the teardown conditional on the holder set emptying settles the
     /// two-panes-on-one-session case by the same stroke: either may leave, and
     /// the session keeps polling for whoever is left.
+    ///
+    /// The provisional retire alarm is cancelled here too, on the same
+    /// last-holder branch and ahead of the forget — the only place that knows
+    /// both that nobody is watching any more and that the source is about to
+    /// drop what the alarm would republish. See ``disarmProvisional``.
     func deregister(sessionID: String, token: TranscriptPaneToken) async {
         guard var registration = registrations[sessionID] else { return }
         guard registration.holders.removeValue(forKey: token) != nil else { return }
@@ -263,6 +317,8 @@ actor TranscriptPollScheduler {
         }
         registration.task?.cancel()
         registrations.removeValue(forKey: sessionID)
+        // Before the forget, never after it: see `disarmProvisional`.
+        await disarmProvisional(sessionID: sessionID)
         await source.forget(sessionID: sessionID)
     }
 

--- a/Sources/TBDApp/TranscriptSource/TranscriptSource.swift
+++ b/Sources/TBDApp/TranscriptSource/TranscriptSource.swift
@@ -83,6 +83,16 @@ actor TranscriptSource {
         /// first saw the stop — would never come due. Reset when the message
         /// id changes, because the new message has not completed yet.
         var completedAt: Date?
+        /// The `now` at which this reader last saw a line arrive for the
+        /// message `provisional` names.
+        ///
+        /// The ten-minute silent-stream rule measures from here, so it must
+        /// move when a line lands and stay put when a poll finds nothing —
+        /// stamping it with a fresh `Date()` every tick would push that
+        /// deadline forward forever, exactly as re-stamping `completedAt`
+        /// would push the 60-second one. Reset when the message id changes,
+        /// because the deadline belongs to the message, not to the session.
+        var lastLineAt: Date?
     }
 
     private var streamEntries: [String: StreamEntry] = [:]
@@ -358,7 +368,8 @@ actor TranscriptSource {
         // A line that will not decode is skipped, not fatal: the tailer can
         // catch a partial append, and a newer proxy can write a `type` this
         // build does not know.
-        working.lines.append(contentsOf: read.lines.compactMap(ModelProxyStreamLine.decode(line:)))
+        let decoded = read.lines.compactMap(ModelProxyStreamLine.decode(line:))
+        working.lines.append(contentsOf: decoded)
         working.lines = Self.capped(working.lines)
 
         let previous = working.provisional
@@ -368,20 +379,30 @@ actor TranscriptSource {
         }
 
         if previous?.messageID != folded.messageID {
-            // A different message now holds the row, and it has not been seen
-            // to complete before this fold.
+            // A different message now holds the row, and it has neither been
+            // seen to complete nor been timed from before this fold.
             working.completedAt = nil
+            working.lastLineAt = nil
         }
-        var stabilized = folded
+        // Only a line that actually arrived for *this* message restarts its
+        // silence. Lines that belong to another in-flight message do not, and
+        // a tick that decoded nothing at all leaves the deadline where it was.
+        if working.lastLineAt == nil
+            || decoded.contains(where: { $0.message == folded.messageID }) {
+            working.lastLineAt = now
+        }
+
+        var phase = folded.phase
         if case .complete = folded.phase {
             if let firstSeen = working.completedAt {
-                stabilized = ProvisionalMessage(
-                    messageID: folded.messageID, text: folded.text,
-                    phase: .complete(at: firstSeen))
+                phase = .complete(at: firstSeen)
             } else {
                 working.completedAt = now
             }
         }
+        let stabilized = ProvisionalMessage(
+            messageID: folded.messageID, text: folded.text, phase: phase,
+            lastLineAt: working.lastLineAt ?? now)
 
         working.provisional = stabilized
         streamEntries[sessionID] = working

--- a/Sources/TBDApp/TranscriptSource/TranscriptSource.swift
+++ b/Sources/TBDApp/TranscriptSource/TranscriptSource.swift
@@ -282,8 +282,14 @@ actor TranscriptSource {
     func refreshStream(sessionID: String, path: String, now: Date) -> Bool {
         var entry = streamEntries[sessionID]
         if let existing = entry, existing.path != path {
-            // A different file under the same session id. Nothing read from the
-            // old one describes the new one.
+            // A different file under the same session id, so the *working* copy
+            // starts empty: nothing read from the old one describes the new one.
+            //
+            // The stored entry is deliberately not cleared here. If the new file
+            // cannot be stat'd or read below, this returns without writing
+            // anything back and the old path's provisional keeps the row — an
+            // unreadable file is no news, never "the answer was withdrawn". The
+            // switch takes effect on the first tick the new file can be read.
             entry = nil
         }
         var working = entry ?? StreamEntry(
@@ -362,21 +368,34 @@ actor TranscriptSource {
     ///
     /// Only a message that has already ended is dropped: an in-flight one is
     /// still being appended to, and removing its head would leave the fold
-    /// rendering a torn suffix of the very turn on screen. So a single
-    /// pathologically long turn is allowed to exceed the ceiling rather than be
-    /// mangled — the ceiling is a defence against accumulation across turns,
-    /// which is the shape that actually grows without bound.
+    /// rendering a torn suffix of the very turn on screen.
+    ///
+    /// The **newest** message is never dropped either, ended or not — which is
+    /// also what keeps the cap inert while a single message is the only one
+    /// resident. A long turn crosses the ceiling and then ends on the same tick
+    /// its `stop` lands; dropping it there would fold to nothing, and the stored
+    /// provisional would be stranded at `.streaming` holding a partial answer
+    /// that nothing can ever complete. So a single pathologically long turn is
+    /// allowed past the ceiling rather than be mangled or lost — the ceiling is
+    /// a defence against accumulation *across* turns, which is the shape that
+    /// actually grows without bound.
     private static func capped(_ lines: [ModelProxyStreamLine]) -> [ModelProxyStreamLine] {
         guard lines.count > maxStreamLines else { return lines }
         var kept = lines
-        while kept.count > maxStreamLines, let oldest = oldestEndedMessage(in: kept) {
+        while kept.count > maxStreamLines,
+              let newest = kept.last?.message,
+              let oldest = oldestEndedMessage(in: kept, excluding: newest) {
             kept.removeAll { $0.message == oldest }
         }
         return kept
     }
 
-    /// The id of the earliest-appearing message that has a terminal line.
-    private static func oldestEndedMessage(in lines: [ModelProxyStreamLine]) -> String? {
+    /// The id of the earliest-appearing message that has a terminal line,
+    /// ignoring `newest` — the message the last line belongs to, which the
+    /// caller must keep whether or not it has ended.
+    private static func oldestEndedMessage(
+        in lines: [ModelProxyStreamLine], excluding newest: String
+    ) -> String? {
         var ended: Set<String> = []
         for line in lines {
             switch line {
@@ -385,6 +404,7 @@ actor TranscriptSource {
             case .start, .block, .text: break
             }
         }
+        ended.remove(newest)
         guard !ended.isEmpty else { return nil }
         return lines.first { ended.contains($0.message) }?.message
     }

--- a/Sources/TBDApp/TranscriptSource/TranscriptSource.swift
+++ b/Sources/TBDApp/TranscriptSource/TranscriptSource.swift
@@ -259,6 +259,31 @@ actor TranscriptSource {
         entries[sessionID]?.transcript.hasAssistantMessage(id: id) ?? false
     }
 
+    /// Everything one publish needs about `sessionID`, read in a single hop
+    /// onto this actor.
+    ///
+    /// `items`, `provisional` and the provisional's confirmation are three
+    /// facts about one instant, and gathering them with three separate awaits
+    /// let a `refresh` land between them: a publish could then read the
+    /// transcript from *before* the settled assistant message arrived and the
+    /// confirmation from *after* it, and show neither the provisional row nor
+    /// the settled one. Nothing suspends inside this method, so the three
+    /// answers are necessarily consistent with each other.
+    ///
+    /// `confirmed` is `hasAssistantMessage` for the provisional's own id, and
+    /// false when there is no provisional — no other message id is ever a
+    /// candidate for a row, so the caller needs no other lookup.
+    func snapshot(
+        sessionID: String
+    ) -> (items: [TranscriptItem], provisional: ProvisionalMessage?, confirmed: Bool) {
+        let entry = entries[sessionID]
+        let provisional = streamEntries[sessionID]?.provisional
+        let confirmed = provisional.map {
+            entry?.transcript.hasAssistantMessage(id: $0.messageID) ?? false
+        } ?? false
+        return (entry?.transcript.items ?? [], provisional, confirmed)
+    }
+
     /// Bring `sessionID`'s provisional message up to date with the stream file
     /// at `path`. Returns whether the provisional actually changed.
     ///

--- a/Sources/TBDApp/TranscriptSource/TranscriptSource.swift
+++ b/Sources/TBDApp/TranscriptSource/TranscriptSource.swift
@@ -57,6 +57,45 @@ actor TranscriptSource {
 
     private var entries: [String: Entry] = [:]
 
+    /// What an entry knows about one terminal's model-proxy stream file.
+    ///
+    /// Deliberately separate from `Entry`: the two files are different files
+    /// with different lifetimes — the transcript JSONL belongs to the Claude
+    /// session and the stream file to the terminal — and a session can have
+    /// one, both or neither. Nothing here resets the other.
+    private struct StreamEntry {
+        var path: String
+        var offset: UInt64
+        var lastSize: UInt64
+        /// Every line decoded so far, in file order. Bounded by the proxy's
+        /// own per-message truncation, and defensively by `maxStreamLines`.
+        var lines: [ModelProxyStreamLine]
+        var provisional: ProvisionalMessage?
+        /// The `now` this reader recorded the FIRST time a fold reported
+        /// `.complete` for the message `provisional` names, reused on every
+        /// later fold of the same message.
+        ///
+        /// `StreamFileReader.fold` stamps `.complete(at:)` with whatever `now`
+        /// it is handed and says the stability of that value is the caller's
+        /// to keep. This is where it is kept: without it every poll would
+        /// re-stamp the completion instant with a fresh `Date()`, and the
+        /// 60-second unconfirmed rule — which measures from when the reader
+        /// first saw the stop — would never come due. Reset when the message
+        /// id changes, because the new message has not completed yet.
+        var completedAt: Date?
+    }
+
+    private var streamEntries: [String: StreamEntry] = [:]
+
+    /// Defensive ceiling on one session's retained stream lines.
+    ///
+    /// The proxy truncates the file when nothing is in flight, so in practice
+    /// the retained set is one turn's deltas. This bounds the pathological case
+    /// — a proxy that never truncates, or a reader that never sees it happen —
+    /// by dropping the oldest message that has already ended, which is the only
+    /// content nothing can still be appended to.
+    private static let maxStreamLines = 10_000
+
     /// Reads the verification window back off disk. Injected so a test can make
     /// the capture fail without racing the filesystem: in production the window
     /// is lost only when the file is replaced or removed in the instant between
@@ -84,8 +123,15 @@ actor TranscriptSource {
     /// app reads it.
     var trackedSessionCount: Int { entries.count }
 
-    /// Drops everything built for `sessionID`. The next `refresh` for that id
-    /// starts over from byte zero.
+    /// How many sessions have a stream-file tail resident right now. Read-only,
+    /// and here for the same reason as `trackedSessionCount`: so a test can
+    /// assert the bound rather than trust a comment. Nothing in the app reads
+    /// it.
+    var trackedStreamSessionCount: Int { streamEntries.count }
+
+    /// Drops everything built for `sessionID` — the transcript AND the
+    /// provisional message tailed from the stream file. The next `refresh` or
+    /// `refreshStream` for that id starts over from byte zero.
     ///
     /// `TranscriptPollScheduler` is the only production caller, from two
     /// places: `deregister`, and `finishTick` for a poll whose refresh landed
@@ -94,6 +140,7 @@ actor TranscriptSource {
     /// it.
     func forget(sessionID: String) {
         entries.removeValue(forKey: sessionID)
+        streamEntries.removeValue(forKey: sessionID)
     }
 
     /// Bring `sessionID` up to date with `path`.
@@ -191,6 +238,155 @@ actor TranscriptSource {
         }
         entries[sessionID] = working
         return change
+    }
+
+    // MARK: - Model proxy stream file
+
+    /// The message currently worth rendering from `sessionID`'s stream file, or
+    /// nil when nothing has been tailed for it.
+    func provisional(sessionID: String) -> ProvisionalMessage? {
+        streamEntries[sessionID]?.provisional
+    }
+
+    /// Whether the session's own transcript has caught up with the assistant
+    /// message `id` — the signal that retires a provisional row in favour of
+    /// the real transcript item.
+    ///
+    /// False for a session with no transcript entry at all, which is the
+    /// conservative reading: nothing has been read, so nothing confirms
+    /// anything.
+    func hasAssistantMessage(sessionID: String, id: String) -> Bool {
+        entries[sessionID]?.transcript.hasAssistantMessage(id: id) ?? false
+    }
+
+    /// Bring `sessionID`'s provisional message up to date with the stream file
+    /// at `path`. Returns whether the provisional actually changed.
+    ///
+    /// **An unreadable file is no news, never a blank row.** A failed stat or a
+    /// failed read returns false and leaves the prior provisional exactly as it
+    /// was — the file is written by a separate process that can be replacing,
+    /// truncating or not-yet-creating it, and none of that is evidence the
+    /// message on screen is gone.
+    ///
+    /// **A fold that finds nothing is no news either.** The proxy truncates the
+    /// file when nothing is in flight, so an empty file means "no turn running"
+    /// — not "the answer you are showing was withdrawn". The provisional row is
+    /// retired by confirmation from the transcript or by the unconfirmed
+    /// deadline, never by the stream file going quiet.
+    ///
+    /// `now` is the instant this poll happened. It is handed to
+    /// `StreamFileReader.fold` only for a message that has just completed;
+    /// a message already recorded as complete keeps the instant it was first
+    /// seen to complete (`StreamEntry.completedAt`).
+    @discardableResult
+    func refreshStream(sessionID: String, path: String, now: Date) -> Bool {
+        var entry = streamEntries[sessionID]
+        if let existing = entry, existing.path != path {
+            // A different file under the same session id. Nothing read from the
+            // old one describes the new one.
+            entry = nil
+        }
+        var working = entry ?? StreamEntry(
+            path: path, offset: 0, lastSize: 0, lines: [], provisional: nil, completedAt: nil)
+
+        guard let attrs = try? FileManager.default.attributesOfItem(atPath: path),
+              let size = (attrs[.size] as? NSNumber)?.uint64Value else {
+            Self.log.debug(
+                "stream stat failed, retaining prior provisional session=\(sessionID, privacy: .public)")
+            return false
+        }
+
+        // The shrink rule: the proxy truncates this file in place, so a file
+        // shorter than what we have consumed — or shorter than we last saw it —
+        // is a new file's worth of content at the same path. Resume from zero
+        // and drop the lines the old content produced, or the fold would splice
+        // a retired turn onto the new one.
+        if size < working.offset || size < working.lastSize {
+            Self.log.debug(
+                "stream file shrank, restarting session=\(sessionID, privacy: .public)")
+            working.offset = 0
+            working.lines = []
+        }
+
+        // A file that is exactly the size we last saw has had nothing appended,
+        // and the fold is a pure function of the lines — so there is nothing to
+        // read and nothing that could have changed. Skips one open-and-read per
+        // tick per visible pane, which at the 100 ms foreground cadence is the
+        // difference worth having.
+        if entry != nil, size == working.lastSize { return false }
+
+        guard let read = TranscriptFileWindow.read(path: path, from: working.offset) else {
+            Self.log.debug(
+                "stream read failed, retaining prior provisional session=\(sessionID, privacy: .public)")
+            return false
+        }
+
+        working.offset = read.newOffset
+        working.lastSize = size
+        working.path = path
+        // A line that will not decode is skipped, not fatal: the tailer can
+        // catch a partial append, and a newer proxy can write a `type` this
+        // build does not know.
+        working.lines.append(contentsOf: read.lines.compactMap(ModelProxyStreamLine.decode(line:)))
+        working.lines = Self.capped(working.lines)
+
+        let previous = working.provisional
+        guard let folded = StreamFileReader.fold(lines: working.lines, now: now) else {
+            streamEntries[sessionID] = working
+            return false
+        }
+
+        if previous?.messageID != folded.messageID {
+            // A different message now holds the row, and it has not been seen
+            // to complete before this fold.
+            working.completedAt = nil
+        }
+        var stabilized = folded
+        if case .complete = folded.phase {
+            if let firstSeen = working.completedAt {
+                stabilized = ProvisionalMessage(
+                    messageID: folded.messageID, text: folded.text,
+                    phase: .complete(at: firstSeen))
+            } else {
+                working.completedAt = now
+            }
+        }
+
+        working.provisional = stabilized
+        streamEntries[sessionID] = working
+        return previous != working.provisional
+    }
+
+    /// Drops whole messages from the head until the retained lines are back
+    /// under `maxStreamLines`, oldest ended message first.
+    ///
+    /// Only a message that has already ended is dropped: an in-flight one is
+    /// still being appended to, and removing its head would leave the fold
+    /// rendering a torn suffix of the very turn on screen. So a single
+    /// pathologically long turn is allowed to exceed the ceiling rather than be
+    /// mangled — the ceiling is a defence against accumulation across turns,
+    /// which is the shape that actually grows without bound.
+    private static func capped(_ lines: [ModelProxyStreamLine]) -> [ModelProxyStreamLine] {
+        guard lines.count > maxStreamLines else { return lines }
+        var kept = lines
+        while kept.count > maxStreamLines, let oldest = oldestEndedMessage(in: kept) {
+            kept.removeAll { $0.message == oldest }
+        }
+        return kept
+    }
+
+    /// The id of the earliest-appearing message that has a terminal line.
+    private static func oldestEndedMessage(in lines: [ModelProxyStreamLine]) -> String? {
+        var ended: Set<String> = []
+        for line in lines {
+            switch line {
+            case let .stop(message): ended.insert(message)
+            case let .aborted(message, _): ended.insert(message)
+            case .start, .block, .text: break
+            }
+        }
+        guard !ended.isEmpty else { return nil }
+        return lines.first { ended.contains($0.message) }?.message
     }
 
     /// Whether the bytes `entry` has already consumed still read the same.

--- a/Sources/TBDApp/TranscriptSource/TranscriptSource.swift
+++ b/Sources/TBDApp/TranscriptSource/TranscriptSource.swift
@@ -258,15 +258,21 @@ actor TranscriptSource {
         streamEntries[sessionID]?.provisional
     }
 
-    /// Whether the session's own transcript has caught up with the assistant
-    /// message `id` — the signal that retires a provisional row in favour of
-    /// the real transcript item.
+    /// Whether the session's own transcript holds the assistant line that
+    /// carries message `id`'s **text** — the signal that retires a provisional
+    /// row in favour of the real transcript item.
+    ///
+    /// The message id alone is not that signal. Claude Code writes one JSONL
+    /// line per content block under a shared `message.id`, and they land at
+    /// different times, so a message opening with a `thinking` block puts its
+    /// id in the JSONL while its text is still streaming. Retiring then would
+    /// take the row down with no settled item to replace it.
     ///
     /// False for a session with no transcript entry at all, which is the
     /// conservative reading: nothing has been read, so nothing confirms
     /// anything.
-    func hasAssistantMessage(sessionID: String, id: String) -> Bool {
-        entries[sessionID]?.transcript.hasAssistantMessage(id: id) ?? false
+    func hasAssistantText(sessionID: String, id: String) -> Bool {
+        entries[sessionID]?.transcript.hasAssistantText(id: id) ?? false
     }
 
     /// Everything one publish needs about `sessionID`, read in a single hop
@@ -280,7 +286,7 @@ actor TranscriptSource {
     /// the settled one. Nothing suspends inside this method, so the three
     /// answers are necessarily consistent with each other.
     ///
-    /// `confirmed` is `hasAssistantMessage` for the provisional's own id, and
+    /// `confirmed` is `hasAssistantText` for the provisional's own id, and
     /// false when there is no provisional — no other message id is ever a
     /// candidate for a row, so the caller needs no other lookup.
     func snapshot(
@@ -289,7 +295,7 @@ actor TranscriptSource {
         let entry = entries[sessionID]
         let provisional = streamEntries[sessionID]?.provisional
         let confirmed = provisional.map {
-            entry?.transcript.hasAssistantMessage(id: $0.messageID) ?? false
+            entry?.transcript.hasAssistantText(id: $0.messageID) ?? false
         } ?? false
         return (entry?.transcript.items ?? [], provisional, confirmed)
     }

--- a/Sources/TBDApp/TranscriptSource/TranscriptSource.swift
+++ b/Sources/TBDApp/TranscriptSource/TranscriptSource.swift
@@ -395,8 +395,8 @@ actor TranscriptSource {
     /// still being appended to, and removing its head would leave the fold
     /// rendering a torn suffix of the very turn on screen.
     ///
-    /// The **newest** message is never dropped either, ended or not — which is
-    /// also what keeps the cap inert while a single message is the only one
+    /// The **most recent** message is never dropped either, ended or not — which
+    /// is also what keeps the cap inert while a single message is the only one
     /// resident. A long turn crosses the ceiling and then ends on the same tick
     /// its `stop` lands; dropping it there would fold to nothing, and the stored
     /// provisional would be stranded at `.streaming` holding a partial answer
@@ -404,11 +404,21 @@ actor TranscriptSource {
     /// allowed past the ceiling rather than be mangled or lost — the ceiling is
     /// a defence against accumulation *across* turns, which is the shape that
     /// actually grows without bound.
+    ///
+    /// "Most recent" is `StreamFileReader.mostRecentMessageID` — the message
+    /// whose first line appears latest, the same ranking the fold picks with —
+    /// and not the owner of the last retained line. Those diverge exactly when
+    /// two parent requests interleave: an older message that keeps appending
+    /// after a newer one has started and stopped owns the last line, so ranking
+    /// by it protects the *older* turn and evicts every line of the newer one,
+    /// which is the message the fold is rendering. Ranking by first-line
+    /// position instead means eviction can only ever move the row forward to a
+    /// later turn, never rewind it to an earlier one.
     private static func capped(_ lines: [ModelProxyStreamLine]) -> [ModelProxyStreamLine] {
         guard lines.count > maxStreamLines else { return lines }
         var kept = lines
         while kept.count > maxStreamLines,
-              let newest = kept.last?.message,
+              let newest = StreamFileReader.mostRecentMessageID(in: kept),
               let oldest = oldestEndedMessage(in: kept, excluding: newest) {
             kept.removeAll { $0.message == oldest }
         }
@@ -416,8 +426,8 @@ actor TranscriptSource {
     }
 
     /// The id of the earliest-appearing message that has a terminal line,
-    /// ignoring `newest` — the message the last line belongs to, which the
-    /// caller must keep whether or not it has ended.
+    /// ignoring `newest` — the most recent message by first-line position,
+    /// which the caller must keep whether or not it has ended.
     private static func oldestEndedMessage(
         in lines: [ModelProxyStreamLine], excluding newest: String
     ) -> String? {

--- a/Sources/TBDModelProxy/ControlEndpoints.swift
+++ b/Sources/TBDModelProxy/ControlEndpoints.swift
@@ -87,7 +87,7 @@ final class ControlEndpoints: Sendable {
         streamsInFlight: @escaping @Sendable () -> Int,
         contact: LastDaemonContact = LastDaemonContact(),
         pollInterval: Duration = .milliseconds(250),
-        drainCap: Duration = .seconds(600),
+        drainCap: Duration = ModelProxyLimits.drainCap,
         clock: any Clock<Duration> = ContinuousClock()
     ) {
         self.routes = routes

--- a/Sources/TBDShared/ModelProxy/ModelProxyLimits.swift
+++ b/Sources/TBDShared/ModelProxy/ModelProxyLimits.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// Bounds two sides of the model-proxy feature have to agree on, stated once.
+///
+/// A limit belongs here when the proxy and the app each reason about it and
+/// their answers must match. Anything only one side reads stays where it is
+/// read.
+public enum ModelProxyLimits {
+
+    /// The longest a legitimate stream can still be in flight.
+    ///
+    /// Two readers, one number. The proxy sleeps on it: a retired proxy closes
+    /// its listener and then waits this long for the streams already running on
+    /// it, after which it exits whether they finished or not
+    /// (`ControlEndpoints`). The app measures against it: a provisional row
+    /// whose stream has produced no line for this long is one nothing is coming
+    /// back for, so the row is withdrawn
+    /// (`ProvisionalRowComposer.silentStreamRetireAfter`).
+    ///
+    /// The app's rule is only sound while the two are equal — a shorter window
+    /// would withdraw a row whose proxy is still legitimately draining, and a
+    /// longer one would leave a row on screen after every proxy that could
+    /// still feed it has exited. So they are one constant rather than two
+    /// literals that happen to agree.
+    public static let drainCap: Duration = .seconds(600)
+}

--- a/Sources/TBDShared/Transcript/IncrementalTranscript.swift
+++ b/Sources/TBDShared/Transcript/IncrementalTranscript.swift
@@ -16,8 +16,14 @@ import Foundation
 ///
 /// Raw line dictionaries are deliberately not retained. Holding every parsed
 /// `[String: Any]` for a large session would cost more memory than this design
-/// saves in transfer; only the built items, the result index, and the rows of
-/// tool calls that might still be patched are kept.
+/// saves in transfer; only the built items, the result index, the rows of tool
+/// calls that might still be patched, and `assistantMessageIDs` are kept.
+///
+/// `assistantMessageIDs` is the one retained set with no upper bound of its
+/// own: it holds one short API `message.id` string per distinct assistant
+/// message and never removes one, so it grows with the length of the session.
+/// Nothing prunes it — the whole struct is dropped when
+/// `TranscriptSource.forget` runs for the session, which is what bounds it.
 public struct IncrementalTranscript: Sendable {
 
     /// What one `ingest` changed, so a caller can publish narrowly instead of

--- a/Sources/TBDShared/Transcript/IncrementalTranscript.swift
+++ b/Sources/TBDShared/Transcript/IncrementalTranscript.swift
@@ -17,13 +17,14 @@ import Foundation
 /// Raw line dictionaries are deliberately not retained. Holding every parsed
 /// `[String: Any]` for a large session would cost more memory than this design
 /// saves in transfer; only the built items, the result index, the rows of tool
-/// calls that might still be patched, and `assistantMessageIDs` are kept.
+/// calls that might still be patched, and the two message-id sets are kept.
 ///
-/// `assistantMessageIDs` is the one retained set with no upper bound of its
-/// own: it holds one short API `message.id` string per distinct assistant
-/// message and never removes one, so it grows with the length of the session.
-/// Nothing prunes it — the whole struct is dropped when
-/// `TranscriptSource.forget` runs for the session, which is what bounds it.
+/// `assistantMessageIDs` and `assistantTextMessageIDs` are the retained sets
+/// with no upper bound of their own: each holds one short API `message.id`
+/// string per distinct assistant message and never removes one, so they grow
+/// with the length of the session. Nothing prunes them — the whole struct is
+/// dropped when `TranscriptSource.forget` runs for the session, which is what
+/// bounds them.
 public struct IncrementalTranscript: Sendable {
 
     /// What one `ingest` changed, so a caller can publish narrowly instead of
@@ -86,6 +87,26 @@ public struct IncrementalTranscript: Sendable {
     /// absorbs that.
     private var assistantMessageIDs: Set<String> = []
 
+    /// The subset of ``assistantMessageIDs`` whose lines have delivered a
+    /// **text** block — that is, the ids for which `buildItems` has produced an
+    /// `.assistantText` item.
+    ///
+    /// Kept apart from "seen at all" because the two answer different
+    /// questions, and only this one can retire a streamed message's row. Claude
+    /// Code writes one line per content block under a shared `message.id`, and
+    /// those lines land at different times: a message that opens with a
+    /// `thinking` block has its id in the JSONL while its text is still
+    /// streaming. Retiring on the id alone would take the row down with nothing
+    /// to replace it — the settled text item does not exist yet — and the user
+    /// would watch live text vanish mid-turn.
+    ///
+    /// "Carries text" follows `buildItems`' own rule rather than the raw block
+    /// type: a `text` block whose string is empty builds no item, so it
+    /// confirms nothing. A message that never emits text at all — a turn that
+    /// only calls tools — is therefore never confirmed here, and its row leaves
+    /// by the composer's 60-second unconfirmed deadline instead.
+    private var assistantTextMessageIDs: Set<String> = []
+
     /// One tool-call row held for a possible later patch: the line's original
     /// JSON text plus the stable id `buildItems` was given for it.
     private struct RetainedRow: Sendable {
@@ -103,13 +124,30 @@ public struct IncrementalTranscript: Sendable {
     /// nothing and nothing public can depend on the count.
     var assistantMessageIDCount: Int { assistantMessageIDs.count }
 
+    /// How many distinct assistant message ids have delivered text. Internal
+    /// and read-only, the counterpart of ``assistantMessageIDCount``, so a test
+    /// can assert the two sets differ rather than only that one lookup does.
+    var assistantTextMessageIDCount: Int { assistantTextMessageIDs.count }
+
     public init() {}
 
     /// Whether a non-sidechain assistant line carrying this API `message.id`
-    /// has been ingested. A streamed message is confirmed — and its provisional
-    /// row retired — when this turns true.
+    /// has been ingested — the id seen at all, on any content block.
+    ///
+    /// Not the confirmation signal: see ``hasAssistantText(id:)``, which is
+    /// what retires a streamed message's provisional row.
     public func hasAssistantMessage(id: String) -> Bool {
         assistantMessageIDs.contains(id)
+    }
+
+    /// Whether the JSONL holds a non-sidechain assistant line for this API
+    /// `message.id` that carries the message's **text**.
+    ///
+    /// This is confirmation. It turns true exactly when the settled
+    /// `.assistantText` item for the message is in ``items``, so a caller can
+    /// retire the streamed row and show the settled one in the same breath.
+    public func hasAssistantText(id: String) -> Bool {
+        assistantTextMessageIDs.contains(id)
     }
 
     @discardableResult
@@ -136,6 +174,9 @@ public struct IncrementalTranscript: Sendable {
                let message = json["message"] as? [String: Any],
                let messageID = message["id"] as? String {
                 assistantMessageIDs.insert(messageID)
+                if Self.carriesAssistantText(message) {
+                    assistantTextMessageIDs.insert(messageID)
+                }
             }
 
             if json["type"] as? String == "user",
@@ -212,5 +253,21 @@ public struct IncrementalTranscript: Sendable {
         return content
             .filter { ($0["type"] as? String) == "tool_use" }
             .compactMap { $0["id"] as? String }
+    }
+
+    /// Whether an assistant `message` object carries what `buildItems` turns
+    /// into an `.assistantText` item.
+    ///
+    /// Deliberately the same two shapes and the same emptiness rule the parser
+    /// applies: a plain-string `content`, or a `text` block, in either case
+    /// non-empty. Anything looser would confirm a message whose settled text
+    /// item does not exist, which is the whole hazard this set was split out to
+    /// avoid.
+    private static func carriesAssistantText(_ message: [String: Any]) -> Bool {
+        if let string = message["content"] as? String { return !string.isEmpty }
+        guard let blocks = message["content"] as? [[String: Any]] else { return false }
+        return blocks.contains { block in
+            (block["type"] as? String) == "text" && !(((block["text"] as? String) ?? "").isEmpty)
+        }
     }
 }

--- a/Sources/TBDShared/Transcript/IncrementalTranscript.swift
+++ b/Sources/TBDShared/Transcript/IncrementalTranscript.swift
@@ -61,6 +61,24 @@ public struct IncrementalTranscript: Sendable {
     /// Lines ingested so far, for the `line-N` stable-id fallback. Must count
     /// the same lines the whole-file parser counts, or ids diverge.
     private var lineCursor = 0
+    /// The API `message.id` of every assistant line ingested so far, so a
+    /// streamed message can be confirmed as landed in the JSONL by a set
+    /// lookup rather than a scan of `items`.
+    ///
+    /// Read from the row alone — no cross-row state — so it costs nothing
+    /// beyond the walk `ingest` already performs and does not touch
+    /// `buildItems`' purity.
+    ///
+    /// Sidechain rows are excluded deliberately: a subagent's messages carry
+    /// their own ids and must never confirm a parent session's streamed
+    /// message. `buildItems` drops sidechain rows for a different reason (they
+    /// are not part of the displayed transcript); the exclusion here is its own
+    /// rule and is applied at ingest.
+    ///
+    /// Claude Code writes one assistant line **per content block**, all sharing
+    /// the same `message.id`, so an id is commonly inserted several times. A set
+    /// absorbs that.
+    private var assistantMessageIDs: Set<String> = []
 
     /// One tool-call row held for a possible later patch: the line's original
     /// JSON text plus the stable id `buildItems` was given for it.
@@ -74,7 +92,19 @@ public struct IncrementalTranscript: Sendable {
     /// `@testable` can assert the bound and nothing public can depend on it.
     var retainedToolCallRowCount: Int { toolCallRowByID.count }
 
+    /// How many distinct assistant message ids have been recorded. Internal and
+    /// read-only, so `@testable` can assert that a row carrying no id records
+    /// nothing and nothing public can depend on the count.
+    var assistantMessageIDCount: Int { assistantMessageIDs.count }
+
     public init() {}
+
+    /// Whether a non-sidechain assistant line carrying this API `message.id`
+    /// has been ingested. A streamed message is confirmed — and its provisional
+    /// row retired — when this turns true.
+    public func hasAssistantMessage(id: String) -> Bool {
+        assistantMessageIDs.contains(id)
+    }
 
     @discardableResult
     public mutating func ingest(lines: [String]) -> Change {
@@ -94,6 +124,13 @@ public struct IncrementalTranscript: Sendable {
             rawLines.append(json)
             rawText.append(line)
             stableIDs.append((json["uuid"] as? String) ?? "line-\(lineCursor)")
+
+            if json["type"] as? String == "assistant",
+               json["isSidechain"] as? Bool != true,
+               let message = json["message"] as? [String: Any],
+               let messageID = message["id"] as? String {
+                assistantMessageIDs.insert(messageID)
+            }
 
             if json["type"] as? String == "user",
                let message = json["message"] as? [String: Any],

--- a/Tests/TBDAppTests/ProvisionalRowComposerTests.swift
+++ b/Tests/TBDAppTests/ProvisionalRowComposerTests.swift
@@ -233,8 +233,9 @@ struct ProvisionalRowComposerTests {
     @Test("the retire window is 60 seconds and the prefix is stream:")
     func constantsAreWhatTheDesignDeclares() {
         #expect(ProvisionalRowComposer.unconfirmedRetireAfter == .seconds(60))
-        #expect(ProvisionalRowComposer.silentStreamRetireAfter == .seconds(600),
-                "the silent-stream window is the proxy's own drain cap")
+        #expect(ProvisionalRowComposer.silentStreamRetireAfter == ModelProxyLimits.drainCap,
+                "the silent-stream window IS the proxy's own drain cap, not a copy of it")
+        #expect(ModelProxyLimits.drainCap == .seconds(600))
         #expect(ProvisionalRowComposer.idPrefix == "stream:")
         #expect(ProvisionalRowComposer.isProvisional(itemID: "stream:msg_a"))
         #expect(!ProvisionalRowComposer.isProvisional(itemID: "msg_a"))

--- a/Tests/TBDAppTests/ProvisionalRowComposerTests.swift
+++ b/Tests/TBDAppTests/ProvisionalRowComposerTests.swift
@@ -879,6 +879,166 @@ struct ProvisionalRowPublishTests {
         return path
     }
 
+    // MARK: - Confirmation comes with the text, not with the id
+
+    /// One assistant line of the captured session: the line itself, the
+    /// `message.id` it carries, and whether it delivers a non-empty `text`
+    /// block. Claude Code writes one line per content block under a shared id,
+    /// so these three facts are what every case below is stated in.
+    private struct CaptureLine {
+        let text: String
+        let messageID: String
+        let carriesText: Bool
+    }
+
+    /// The assistant lines of `incremental-transcript-sample.jsonl`, a real
+    /// captured session. Real lines rather than hand-built ones because the
+    /// whole hazard is the shape Claude Code actually writes: this capture
+    /// holds a message written as a thinking line and then, separately, a text
+    /// line, and another that only ever calls tools.
+    ///
+    /// `subdirectory:` is required here: this target registers its fixtures
+    /// with `.copy`, which preserves the `Fixtures/` directory.
+    private static func assistantCaptureLines() throws -> [CaptureLine] {
+        let url = try #require(Bundle.module.url(
+            forResource: "incremental-transcript-sample", withExtension: "jsonl",
+            subdirectory: "Fixtures"))
+        let content = try String(contentsOf: url, encoding: .utf8)
+        return try content.components(separatedBy: "\n").filter { !$0.isEmpty }
+            .compactMap { line -> CaptureLine? in
+                guard let data = line.data(using: .utf8),
+                      let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                      json["type"] as? String == "assistant",
+                      let message = json["message"] as? [String: Any],
+                      let id = message["id"] as? String else { return nil }
+                let blocks = (message["content"] as? [[String: Any]]) ?? []
+                let carriesText = blocks.contains {
+                    ($0["type"] as? String) == "text"
+                        && !((($0["text"] as? String) ?? "").isEmpty)
+                }
+                return CaptureLine(text: line, messageID: id, carriesText: carriesText)
+            }
+    }
+
+    /// A directory holding a stream file for `messageID` that has started and
+    /// is streaming text, with no terminal line — a turn still in flight, which
+    /// is exactly when the JSONL's first line for it can land.
+    private static func streamingTurn(messageID: String) throws -> (dir: String, stream: String) {
+        let dir = fencedScratchRoot(prefix: "tbdprov")
+        try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        let path = dir + "/stream.jsonl"
+        let lines = try [
+            ModelProxyStreamLine.start(message: messageID, at: Self.t0),
+            .text(message: messageID, index: 0, text: "I've read it and"),
+        ].map { try $0.encodedLine() + "\n" }.joined()
+        try lines.write(toFile: path, atomically: true, encoding: .utf8)
+        return (dir, path)
+    }
+
+    private static func append(_ text: String, to path: String) throws {
+        let handle = try FileHandle(forWritingTo: URL(fileURLWithPath: path))
+        defer { try? handle.close() }
+        try handle.seekToEnd()
+        try handle.write(contentsOf: Data(text.utf8))
+    }
+
+    /// The settled assistant-text strings in a published transcript — what the
+    /// withdrawn provisional row is supposed to be replaced by.
+    private static func settledTexts(_ items: [TranscriptItem]) -> [String] {
+        items.compactMap { item in
+            if case .assistantText(let id, let text, _, _) = item,
+               !ProvisionalRowComposer.isProvisional(itemID: id) { return text }
+            return nil
+        }
+    }
+
+    /// The row must not be withdrawn by a line that carries the message id but
+    /// none of its text.
+    ///
+    /// Claude Code writes one JSONL line per content block under a shared
+    /// `message.id`, and they land at different times — a text block's line was
+    /// measured arriving up to 25 s after an earlier block's. So a message that
+    /// opens with a `thinking` block puts its id in the JSONL while its text is
+    /// still streaming. Retiring on the id would take the row down with nothing
+    /// to replace it: the user watches live text vanish mid-turn, which is
+    /// worse than the lag this feature exists to close.
+    @Test("a thinking-only line leaves the row up; the text line retires it and replaces it")
+    func onlyTheTextLineRetiresTheRow() async throws {
+        let suite = "tbd-provisional-publish-\(UUID().uuidString)"
+        defer { Self.removeSuite(suite) }
+        let capture = try Self.assistantCaptureLines()
+        let split = try #require(capture.first { candidate in
+            capture.filter { $0.messageID == candidate.messageID }.count >= 2
+        }, "capture must hold a message written across two lines")
+        let lines = capture.filter { $0.messageID == split.messageID }
+        let thinking = try #require(lines.first)
+        let text = try #require(lines.last)
+        #expect(thinking.carriesText == false, "its first line must be the thinking one")
+        #expect(text.carriesText, "and its last the text one, or this proves nothing")
+
+        let files = try Self.streamingTurn(messageID: split.messageID)
+        let transcriptPath = files.dir + "/transcript.jsonl"
+        try (thinking.text + "\n").write(toFile: transcriptPath, atomically: true, encoding: .utf8)
+
+        let source = TranscriptSource()
+        #expect(await source.refreshStream(sessionID: "s1", path: files.stream, now: Self.t0))
+        await source.refresh(sessionID: "s1", path: transcriptPath)
+        let state = await Self.makeState(streaming: true, suite: suite)
+        let timer = ProvisionalRetireTimer(clock: TestClock())
+        let t0 = Self.t0
+
+        let midStream = await TableTranscriptPaneView.publish(
+            sessionID: "s1", state: state, source: source, retireTimer: timer, now: { t0 })
+        #expect(midStream.last?.id == "stream:" + split.messageID,
+                "the thinking line carries the id, and must not take the row down")
+        #expect(Self.settledTexts(midStream).isEmpty,
+                "there is no settled text item that could have replaced it")
+
+        try Self.append(text.text + "\n", to: transcriptPath)
+        await source.refresh(sessionID: "s1", path: transcriptPath)
+
+        let settled = await TableTranscriptPaneView.publish(
+            sessionID: "s1", state: state, source: source, retireTimer: timer, now: { t0 })
+        #expect(settled.contains { ProvisionalRowComposer.isProvisional(itemID: $0.id) } == false,
+                "the text line confirms, so the row is withdrawn")
+        #expect(Self.settledTexts(settled).isEmpty == false,
+                "and the JSONL's own item is in the very same publish")
+        #expect(await timer.armedMessage(sessionID: "s1") == nil,
+                "a withdrawn row leaves no alarm behind")
+    }
+
+    /// The same rule from the other side. A turn that only calls tools writes
+    /// its id on every line and never a text block, so nothing confirms it and
+    /// its row leaves by the 60-second unconfirmed deadline instead — never by
+    /// a `tool_use` line arriving while the answer is still streaming.
+    @Test("a tool_use line does not retire the row either")
+    func aToolUseLineDoesNotRetireTheRow() async throws {
+        let suite = "tbd-provisional-publish-\(UUID().uuidString)"
+        defer { Self.removeSuite(suite) }
+        let capture = try Self.assistantCaptureLines()
+        let textless = try #require(capture.first { candidate in
+            capture.filter { $0.messageID == candidate.messageID }.allSatisfy { !$0.carriesText }
+        }, "capture must hold a message that only ever calls tools")
+
+        let files = try Self.streamingTurn(messageID: textless.messageID)
+        let transcriptPath = files.dir + "/transcript.jsonl"
+        try (textless.text + "\n").write(toFile: transcriptPath, atomically: true, encoding: .utf8)
+
+        let source = TranscriptSource()
+        #expect(await source.refreshStream(sessionID: "s1", path: files.stream, now: Self.t0))
+        await source.refresh(sessionID: "s1", path: transcriptPath)
+        let state = await Self.makeState(streaming: true, suite: suite)
+        let timer = ProvisionalRetireTimer(clock: TestClock())
+        let t0 = Self.t0
+
+        let published = await TableTranscriptPaneView.publish(
+            sessionID: "s1", state: state, source: source, retireTimer: timer, now: { t0 })
+        #expect(published.last?.id == "stream:" + textless.messageID,
+                "a line with the id but no text confirms nothing")
+        #expect(await timer.armedMessage(sessionID: "s1") == textless.messageID,
+                "and the row keeps its own deadline, which is what will retire it")
+    }
+
     /// The publish path's own off branch: the same source and the same
     /// completed message, with capabilities reporting streaming off.
     @Test("publishing with streaming off writes no provisional row and arms nothing")
@@ -1109,5 +1269,136 @@ struct ProvisionalRetireTimerTests {
         // Give a cancelled task every chance to run before asserting it did not.
         for _ in 0..<50 { await Task.yield() }
         #expect(await log.count == 0)
+    }
+
+    // MARK: - The window cancellation cannot close
+
+    /// `Task.cancel()` is advisory: an alarm whose sleep has already returned
+    /// is on its way back into the actor and cannot be stopped there. So the
+    /// decision to fire is taken *inside* the actor, against the generation the
+    /// alarm was armed with — and this test removes cancellation from the
+    /// picture entirely to prove that check is what does the work.
+    ///
+    /// `GatedClock`'s sleeps ignore cancellation and end only when the test
+    /// releases them, so the alarm below genuinely wakes after its session was
+    /// forgotten. Without the re-entry check it would publish an empty
+    /// transcript for a session nothing is watching.
+    @Test("an alarm disarmed while it sleeps does not fire when its sleep returns anyway")
+    func aDisarmedAlarmDoesNotFireWhenItsSleepReturns() async {
+        let clock = GatedClock()
+        let timer = ProvisionalRetireTimer(clock: clock)
+        let log = FireLog()
+
+        await timer.arm(
+            sessionID: "s1", messageID: "msg_a", deadline: Self.due, after: .seconds(60)
+        ) { await log.record() }
+        await clock.waitForSleepers(1)
+
+        await timer.disarm(sessionID: "s1")
+        await clock.release()
+
+        let woke = await pollUntilTrue(timeout: .seconds(10)) { await clock.wakeCount == 1 }
+        #expect(woke == .satisfied, "the alarm really did wake, or this proves nothing")
+        for _ in 0..<50 { await Task.yield() }
+        #expect(await log.count == 0, "a forgotten session must not be published for")
+        #expect(await timer.armedSessionCount == 0)
+    }
+
+    /// Why the check is a generation and not the pair the alarm records. A pane
+    /// that disarms and then re-arms the identical message at the identical
+    /// deadline — a row withdrawn and composed again on the next poll — leaves
+    /// two alarms that `messageID` and `due` cannot tell apart. Only the one
+    /// armed last may fire.
+    @Test("an alarm re-armed identically fires once, for the arming that is current")
+    func aReArmedIdenticalAlarmFiresOnlyForTheCurrentArming() async {
+        let clock = GatedClock()
+        let timer = ProvisionalRetireTimer(clock: clock)
+        let stale = FireLog()
+        let current = FireLog()
+
+        await timer.arm(
+            sessionID: "s1", messageID: "msg_a", deadline: Self.due, after: .seconds(60)
+        ) { await stale.record() }
+        await clock.waitForSleepers(1)
+        await timer.disarm(sessionID: "s1")
+        await timer.arm(
+            sessionID: "s1", messageID: "msg_a", deadline: Self.due, after: .seconds(60)
+        ) { await current.record() }
+        await clock.waitForSleepers(2)
+
+        await clock.release()
+
+        let fired = await pollUntilTrue(timeout: .seconds(10)) { await current.count == 1 }
+        #expect(fired == .satisfied, "the arming that is current fires")
+        for _ in 0..<50 { await Task.yield() }
+        #expect(await stale.count == 0,
+                "and the forgotten one does not, though its message and deadline match")
+        #expect(await current.count == 1, "once, not twice")
+    }
+}
+
+/// A clock whose sleeps end only when the test releases them, and which ignores
+/// cancellation entirely.
+///
+/// `TestClock` cannot express the ordering the two cases above need. They must
+/// hold an alarm mid-sleep while the test reaches into the actor, and then have
+/// that sleep return *normally*: a cancelled sleep would let the alarm bail out
+/// for a reason that has nothing to do with the check under test, and it is
+/// precisely because cancellation is advisory that the check exists.
+private final class GatedClock: Clock, @unchecked Sendable {
+    typealias Instant = ContinuousClock.Instant
+
+    private let gate = SleepGate()
+
+    var now: Instant { ContinuousClock().now }
+    var minimumResolution: Duration { .zero }
+
+    func sleep(until deadline: Instant, tolerance: Duration?) async throws {
+        await gate.wait()
+    }
+
+    /// Returns once at least `count` sleeps have begun.
+    func waitForSleepers(_ count: Int) async { await gate.waitForArrivals(count) }
+
+    /// Ends every sleep in progress, and every sleep that starts afterwards.
+    func release() async { await gate.release() }
+
+    /// How many sleeps have *returned*, so a test can prove the alarm woke
+    /// rather than assert on a fire that never had the chance to happen.
+    var wakeCount: Int { get async { await gate.wakeCount } }
+
+    private actor SleepGate {
+        private var isOpen = false
+        private var sleepers: [CheckedContinuation<Void, Never>] = []
+        private var arrivals = 0
+        private var watchers: [(needed: Int, continuation: CheckedContinuation<Void, Never>)] = []
+        private(set) var wakeCount = 0
+
+        func wait() async {
+            arrivals += 1
+            let ready = watchers.filter { arrivals >= $0.needed }
+            watchers.removeAll { arrivals >= $0.needed }
+            for watcher in ready { watcher.continuation.resume() }
+            if !isOpen {
+                await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                    sleepers.append(continuation)
+                }
+            }
+            wakeCount += 1
+        }
+
+        func release() {
+            isOpen = true
+            let waiting = sleepers
+            sleepers.removeAll()
+            for continuation in waiting { continuation.resume() }
+        }
+
+        func waitForArrivals(_ count: Int) async {
+            guard arrivals < count else { return }
+            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                watchers.append((count, continuation))
+            }
+        }
     }
 }

--- a/Tests/TBDAppTests/ProvisionalRowComposerTests.swift
+++ b/Tests/TBDAppTests/ProvisionalRowComposerTests.swift
@@ -140,6 +140,18 @@ struct ProvisionalRowComposerTests {
             provisional: completed, now: Self.t0.addingTimeInterval(61))
         #expect(atSixtyOne == Self.settled,
                 "61 s after the stop nothing is ever going to confirm it")
+
+        // The boundary belongs to the retired side. A row kept at exactly the
+        // deadline would come with a zero-length alarm that fires the instant
+        // it is armed, re-publishes, composes the same row and arms zero
+        // again — a spin whenever `now` is frozen or steps backwards.
+        let atExactlySixty = Self.compose(
+            provisional: completed, now: Self.t0.addingTimeInterval(60))
+        #expect(atExactlySixty == Self.settled,
+                "the boundary tick retires the row rather than composing a zero-delay one")
+        #expect(ProvisionalRowComposer.retireDelay(
+            phase: completed.phase, now: Self.t0.addingTimeInterval(60)) == nil,
+                "and asks for no alarm, so the two rules agree at the boundary")
     }
 
     /// The deadline measures from the completion instant, so a row that
@@ -234,8 +246,8 @@ struct ProvisionalRowComposerTests {
         #expect(ProvisionalRowComposer.retireDelay(
             phase: .complete(at: Self.t0), now: Self.t0.addingTimeInterval(45)) == .seconds(15))
         #expect(ProvisionalRowComposer.retireDelay(
-            phase: .complete(at: Self.t0), now: Self.t0.addingTimeInterval(600)) == .seconds(0),
-                "a deadline already past is clamped at zero, never negative")
+            phase: .complete(at: Self.t0), now: Self.t0.addingTimeInterval(600)) == nil,
+                "a deadline already past asks for no alarm at all, never a zero-length one")
     }
 }
 
@@ -624,6 +636,40 @@ struct ProvisionalRetireTimerTests {
         let fired = await pollUntilTrue(timeout: .seconds(10)) { await first.count == 1 }
         #expect(fired == .satisfied, "s1's alarm was untouched by s2's disarm")
         #expect(await second.count == 0, "and s2's really was cancelled")
+    }
+
+    /// The teardown gesture itself. A pane whose loop ends disarms its own
+    /// session and nothing else, because this instance is reachable from the
+    /// scheduler's single app-wide slot and may hold alarms for sessions other
+    /// panes are showing. The 60-second rule is announced by nothing, so an
+    /// alarm cancelled here would never be re-armed and its row would stay on
+    /// screen for good.
+    @Test("a teardown disarm leaves another session's alarm to fire exactly once")
+    func teardownDisarmLeavesOtherSessionsArmed() async {
+        let clock = TestClock()
+        let timer = ProvisionalRetireTimer(clock: clock)
+        let leaving = FireLog()
+        let staying = FireLog()
+
+        await timer.arm(sessionID: "s1", messageID: "msg_a", after: .seconds(60)) {
+            await leaving.record()
+        }
+        await timer.arm(sessionID: "s2", messageID: "msg_b", after: .seconds(60)) {
+            await staying.record()
+        }
+
+        // What `appSideLoop` now does when its pane goes away.
+        await timer.disarm(sessionID: "s1")
+        #expect(await timer.armedSessionCount == 1, "only the leaving pane's session was disarmed")
+        #expect(await timer.armedMessage(sessionID: "s2") == "msg_b")
+
+        await clock.advanceWhenSuspended(by: .seconds(61))
+        let fired = await pollUntilTrue(timeout: .seconds(10)) { await staying.count == 1 }
+        #expect(fired == .satisfied, "s2's backstop survived the other pane's teardown")
+        #expect(await leaving.count == 0, "and the torn-down session's own alarm was cancelled")
+
+        await clock.advance(by: .seconds(600))
+        #expect(await staying.count == 1, "exactly once — nothing re-arms a fired backstop")
     }
 
     @Test("disarmAll cancels every session's alarm")

--- a/Tests/TBDAppTests/ProvisionalRowComposerTests.swift
+++ b/Tests/TBDAppTests/ProvisionalRowComposerTests.swift
@@ -23,8 +23,10 @@ struct ProvisionalRowComposerTests {
         .assistantText(id: "msg_old", text: "an older answer", timestamp: t0),
     ]
 
-    private static func streaming(_ text: String, id: String = "msg_a") -> ProvisionalMessage {
-        ProvisionalMessage(messageID: id, text: text, phase: .streaming)
+    private static func streaming(
+        _ text: String, id: String = "msg_a", lastLineAt: Date = t0
+    ) -> ProvisionalMessage {
+        ProvisionalMessage(messageID: id, text: text, phase: .streaming, lastLineAt: lastLineAt)
     }
 
     /// Nothing is confirmed. The default for tests that are about some other
@@ -121,7 +123,7 @@ struct ProvisionalRowComposerTests {
     func abortedMessageIsRetired() {
         let items = Self.compose(provisional: ProvisionalMessage(
             messageID: "msg_a", text: "half an ans",
-            phase: .aborted(reason: "upstream closed")))
+            phase: .aborted(reason: "upstream closed"), lastLineAt: Self.t0))
 
         #expect(items == Self.settled)
     }
@@ -129,7 +131,8 @@ struct ProvisionalRowComposerTests {
     @Test("a completed but unconfirmed message is retired after the deadline")
     func completedMessageRetiresAfterTheDeadline() {
         let completed = ProvisionalMessage(
-            messageID: "msg_a", text: "Hello, world", phase: .complete(at: Self.t0))
+            messageID: "msg_a", text: "Hello, world", phase: .complete(at: Self.t0),
+            lastLineAt: Self.t0)
 
         let atFiftyNine = Self.compose(
             provisional: completed, now: Self.t0.addingTimeInterval(59))
@@ -150,7 +153,7 @@ struct ProvisionalRowComposerTests {
         #expect(atExactlySixty == Self.settled,
                 "the boundary tick retires the row rather than composing a zero-delay one")
         #expect(ProvisionalRowComposer.retireDelay(
-            phase: completed.phase, now: Self.t0.addingTimeInterval(60)) == nil,
+            for: completed, now: Self.t0.addingTimeInterval(60)) == nil,
                 "and asks for no alarm, so the two rules agree at the boundary")
     }
 
@@ -160,7 +163,8 @@ struct ProvisionalRowComposerTests {
     func deadlineIsMeasuredFromCompletion() {
         let longDone = ProvisionalMessage(
             messageID: "msg_a", text: "Hello",
-            phase: .complete(at: Self.t0.addingTimeInterval(-3600)))
+            phase: .complete(at: Self.t0.addingTimeInterval(-3600)),
+            lastLineAt: Self.t0.addingTimeInterval(-3600))
 
         #expect(Self.compose(provisional: longDone) == Self.settled)
     }
@@ -229,6 +233,8 @@ struct ProvisionalRowComposerTests {
     @Test("the retire window is 60 seconds and the prefix is stream:")
     func constantsAreWhatTheDesignDeclares() {
         #expect(ProvisionalRowComposer.unconfirmedRetireAfter == .seconds(60))
+        #expect(ProvisionalRowComposer.silentStreamRetireAfter == .seconds(600),
+                "the silent-stream window is the proxy's own drain cap")
         #expect(ProvisionalRowComposer.idPrefix == "stream:")
         #expect(ProvisionalRowComposer.isProvisional(itemID: "stream:msg_a"))
         #expect(!ProvisionalRowComposer.isProvisional(itemID: "msg_a"))
@@ -236,18 +242,86 @@ struct ProvisionalRowComposerTests {
 
     // MARK: - The alarm's delay
 
-    @Test("only a completed message asks for a retire alarm")
-    func onlyCompletionSchedulesAnAlarm() {
-        #expect(ProvisionalRowComposer.retireDelay(phase: .streaming, now: Self.t0) == nil)
+    @Test("every phase but aborted asks for a retire alarm, each on its own rule")
+    func eachPhaseSchedulesItsOwnAlarm() {
+        let completed = ProvisionalMessage(
+            messageID: "msg_a", text: "done", phase: .complete(at: Self.t0),
+            lastLineAt: Self.t0)
+
         #expect(ProvisionalRowComposer.retireDelay(
-            phase: .aborted(reason: "x"), now: Self.t0) == nil)
+            for: ProvisionalMessage(
+                messageID: "msg_a", text: "half",
+                phase: .aborted(reason: "x"), lastLineAt: Self.t0),
+            now: Self.t0) == nil,
+                "an aborted row was never composed, so there is nothing to wake up for")
+
+        #expect(ProvisionalRowComposer.retireDelay(for: completed, now: Self.t0) == .seconds(60))
         #expect(ProvisionalRowComposer.retireDelay(
-            phase: .complete(at: Self.t0), now: Self.t0) == .seconds(60))
+            for: completed, now: Self.t0.addingTimeInterval(45)) == .seconds(15))
         #expect(ProvisionalRowComposer.retireDelay(
-            phase: .complete(at: Self.t0), now: Self.t0.addingTimeInterval(45)) == .seconds(15))
-        #expect(ProvisionalRowComposer.retireDelay(
-            phase: .complete(at: Self.t0), now: Self.t0.addingTimeInterval(600)) == nil,
+            for: completed, now: Self.t0.addingTimeInterval(600)) == nil,
                 "a deadline already past asks for no alarm at all, never a zero-length one")
+
+        // The silent-stream rule. Measured from the last line, ten minutes
+        // wide, and restarted by a line rather than by the poll that noticed
+        // it: the second reading below is the same message a minute later
+        // whose line arrived a minute later too.
+        #expect(ProvisionalRowComposer.retireDelay(
+            for: Self.streaming("Hel"), now: Self.t0) == .seconds(600))
+        #expect(ProvisionalRowComposer.retireDelay(
+            for: Self.streaming("Hel"), now: Self.t0.addingTimeInterval(540)) == .seconds(60))
+        #expect(ProvisionalRowComposer.retireDelay(
+            for: Self.streaming("Hello", lastLineAt: Self.t0.addingTimeInterval(60)),
+            now: Self.t0.addingTimeInterval(60)) == .seconds(600),
+                "a new line restarts the window rather than shortening it")
+        #expect(ProvisionalRowComposer.retireDelay(
+            for: Self.streaming("Hel"), now: Self.t0.addingTimeInterval(600)) == nil)
+    }
+
+    // MARK: - The silent-stream rule
+
+    /// The case the 60-second rule cannot reach: a proxy killed mid-turn writes
+    /// neither `stop` nor `aborted`, so the fold reports `.streaming` forever
+    /// and the JSONL — which never saw that request finish either — will not
+    /// confirm it. Without a deadline of its own the row is on screen for good.
+    ///
+    /// What discriminates: with a deadline only for `.complete`, every
+    /// assertion below that expects the row *gone* fails, because a streaming
+    /// row was composed unconditionally.
+    @Test("a streaming message with no terminal line is retired at the drain cap")
+    func silentStreamingMessageRetiresAtTheDrainCap() {
+        let quiet = Self.streaming("half an answer")
+
+        #expect(Self.compose(provisional: quiet, now: Self.t0.addingTimeInterval(599)).last?.id
+                == "stream:msg_a",
+                "a stream can be quiet for minutes while a tool-input block streams")
+        #expect(Self.compose(provisional: quiet, now: Self.t0.addingTimeInterval(600))
+                == Self.settled,
+                "the boundary tick retires, the same way the completion rule does")
+        #expect(Self.compose(provisional: quiet, now: Self.t0.addingTimeInterval(601))
+                == Self.settled)
+        #expect(ProvisionalRowComposer.retireDelay(
+            for: quiet, now: Self.t0.addingTimeInterval(600)) == nil,
+                "and asks for no alarm, so the two rules agree at the boundary")
+    }
+
+    /// The window is restarted by each line, not by the message: the same
+    /// message nine minutes in, having just produced a delta, is owed a fresh
+    /// ten minutes rather than the minute that was left.
+    @Test("a new line restarts the silent-stream window")
+    func aNewLineRestartsTheSilentStreamWindow() {
+        let nineMinutesIn = Self.t0.addingTimeInterval(540)
+        let stale = Self.streaming("half an answer")
+        let refreshed = Self.streaming("half an answer, and more", lastLineAt: nineMinutesIn)
+
+        #expect(Self.compose(provisional: stale, now: nineMinutesIn.addingTimeInterval(61))
+                == Self.settled,
+                "without a new line the original window runs out")
+        #expect(Self.compose(provisional: refreshed, now: nineMinutesIn.addingTimeInterval(61))
+                .last?.id == "stream:msg_a",
+                "with one, the row is still the best thing to show")
+        #expect(ProvisionalRowComposer.retireDeadline(for: refreshed)
+                == nineMinutesIn.addingTimeInterval(600))
     }
 }
 
@@ -495,31 +569,180 @@ struct ProvisionalRowPublishTests {
                 "and B's transcript is untouched by it")
     }
 
-    /// A still-streaming row arms nothing: it has not stopped, so the file it
-    /// came from is still moving and the poll scheduler is still reporting it.
-    @Test("a streaming row arms no alarm")
-    func aStreamingRowArmsNoAlarm() async throws {
+    /// A stream file with one text line and no terminal line — a turn in
+    /// flight, or a proxy that died before writing its `stop`. The two look
+    /// identical from here, which is the whole reason the silent-stream rule
+    /// exists.
+    ///
+    /// What discriminates: before the rule, a streaming row armed nothing, so
+    /// the alarm assertion below read nil and the row stayed on screen for
+    /// good.
+    @Test("a streaming row arms the silent-stream alarm and is withdrawn by it")
+    func aStreamingRowIsWithdrawnByTheSilentStreamAlarm() async throws {
         let suite = "tbd-provisional-publish-\(UUID().uuidString)"
         defer { Self.removeSuite(suite) }
+        let path = try Self.streamFileWithOneTextLine()
+        let source = TranscriptSource()
+        #expect(await source.refreshStream(sessionID: "s1", path: path, now: Self.t0))
+
+        let state = await Self.makeState(streaming: true, suite: suite)
+        let clock = TestClock()
+        let timer = ProvisionalRetireTimer(clock: clock)
+        let date = MovableDate(Self.t0)
+
+        let published = await TableTranscriptPaneView.publish(
+            sessionID: "s1", state: state, source: source,
+            retireTimer: timer, now: { date.now })
+        #expect(published.last?.id == "stream:msg_a")
+        #expect(await timer.armedMessage(sessionID: "s1") == "msg_a",
+                "a stream that may never end must still be on a deadline")
+
+        // Nine minutes of silence is not enough: a healthy turn streaming a
+        // large tool-input block emits no text deltas for exactly this long.
+        date.advance(by: 540)
+        await clock.advanceWhenSuspended(by: .seconds(540))
+        #expect(await Self.publishedIDs(state) == ["stream:msg_a"],
+                "the row must survive right up to the drain cap")
+
+        date.advance(by: 61)
+        await clock.advance(by: .seconds(61))
+        let withdrawn = await pollUntilTrue(timeout: .seconds(10)) {
+            await Self.publishedIDs(state).isEmpty
+        }
+        #expect(withdrawn == .satisfied, "the alarm's re-publish must withdraw the row")
+        #expect(await timer.armedMessage(sessionID: "s1") == nil, "and it does not re-arm itself")
+    }
+
+    /// The window belongs to the last line, so a delta arriving inside it buys
+    /// the row another full ten minutes — and the pending alarm has to be
+    /// replaced, not left alone, even though the message id has not changed.
+    ///
+    /// What discriminates: with the alarm keyed by message id alone, the
+    /// re-publish after the append is a no-op, the original alarm fires at its
+    /// original deadline, and the row is withdrawn while its stream is still
+    /// producing.
+    @Test("a line arriving inside the window re-arms the silent-stream alarm")
+    func aNewLineReArmsTheSilentStreamAlarm() async throws {
+        let suite = "tbd-provisional-publish-\(UUID().uuidString)"
+        defer { Self.removeSuite(suite) }
+        let path = try Self.streamFileWithOneTextLine()
+        let source = TranscriptSource()
+        #expect(await source.refreshStream(sessionID: "s1", path: path, now: Self.t0))
+
+        let state = await Self.makeState(streaming: true, suite: suite)
+        let clock = TestClock()
+        let timer = ProvisionalRetireTimer(clock: clock)
+        let date = MovableDate(Self.t0)
+
+        await TableTranscriptPaneView.publish(
+            sessionID: "s1", state: state, source: source,
+            retireTimer: timer, now: { date.now })
+        #expect(await timer.armedMessage(sessionID: "s1") == "msg_a")
+
+        // Nine minutes in, one more delta lands and the source re-reads it.
+        date.advance(by: 540)
+        await clock.advanceWhenSuspended(by: .seconds(540))
+        let more = try ModelProxyStreamLine
+            .text(message: "msg_a", index: 0, text: "lo").encodedLine()
+        let handle = try FileHandle(forWritingTo: URL(fileURLWithPath: path))
+        try handle.seekToEnd()
+        try handle.write(contentsOf: Data((more + "\n").utf8))
+        try handle.close()
+        #expect(await source.refreshStream(sessionID: "s1", path: path, now: date.now))
+        await TableTranscriptPaneView.publish(
+            sessionID: "s1", state: state, source: source,
+            retireTimer: timer, now: { date.now })
+
+        // Past the *original* deadline. The row is still there, because the
+        // append moved it.
+        date.advance(by: 61)
+        await clock.advanceWhenSuspended(by: .seconds(61))
+        #expect(await Self.publishedIDs(state) == ["stream:msg_a"],
+                "the original window expired, but the line that arrived replaced it")
+        #expect(await timer.armedMessage(sessionID: "s1") == "msg_a",
+                "and the replacement alarm is still pending")
+    }
+
+    /// The handoff production actually performs, which the single-instance
+    /// two-session test does not reach: `appSideLoop` builds a **new**
+    /// `ProvisionalRetireTimer` on every pane mount and drops it into the
+    /// scheduler's single `onChange` slot, so a remount leaves the previous
+    /// instance's alarm pending with nothing left holding it.
+    ///
+    /// The property being pinned is that this is safe: a fired alarm only ever
+    /// runs an ordinary publish, which recomputes from the source and the
+    /// state, so it retires the row it should retire regardless of which
+    /// instance woke up — and it touches no other session on the way.
+    @Test("a retire alarm survives a remount onto a second timer and lands on its own session")
+    func aRemountedPaneStillRetiresTheRightSession() async throws {
+        let suite = "tbd-provisional-publish-\(UUID().uuidString)"
+        defer { Self.removeSuite(suite) }
+        let date = MovableDate(Self.t0)
+        let source = try await Self.sourceWithCompletedMessage(now: Self.t0)
+        try await Self.addPlainTranscript(to: source, sessionID: "s2")
+        let state = await Self.makeState(streaming: true, suite: suite)
+        let clock = TestClock()
+
+        // Mount one: the pane's own timer arms A's 60-second backstop.
+        let firstTimer = ProvisionalRetireTimer(clock: clock)
+        await TableTranscriptPaneView.publish(
+            sessionID: "s1", state: state, source: source,
+            retireTimer: firstTimer, now: { date.now })
+        #expect(await firstTimer.armedMessage(sessionID: "s1") == "msg_a")
+
+        // The remount. A second instance takes the scheduler's on-change slot;
+        // the first is unreachable from the app but its alarm is still asleep.
+        date.advance(by: 30)
+        await clock.advanceWhenSuspended(by: .seconds(30))
+        let secondTimer = ProvisionalRetireTimer(clock: clock)
+        await TableTranscriptPaneView.publish(
+            sessionID: "s1", state: state, source: source,
+            retireTimer: secondTimer, now: { date.now })
+        #expect(await secondTimer.armedMessage(sessionID: "s1") == "msg_a",
+                "the new instance arms the same row for the remainder of its window")
+        #expect(await Self.publishedIDs(state) == ["stream:msg_a"])
+
+        // A publish for another session through the new instance, the case the
+        // keying exists for.
+        await TableTranscriptPaneView.publish(
+            sessionID: "s2", state: state, source: source,
+            retireTimer: secondTimer, now: { date.now })
+        #expect(await secondTimer.armedMessage(sessionID: "s1") == "msg_a",
+                "B's publish through the new timer must not disarm A")
+
+        date.advance(by: 31)
+        await clock.advance(by: .seconds(31))
+        let withdrawn = await pollUntilTrue(timeout: .seconds(10)) {
+            await Self.publishedIDs(state).isEmpty
+        }
+        #expect(withdrawn == .satisfied,
+                "whichever instance woke up, the re-publish retires A's row")
+        #expect(await Self.publishedIDs(state, session: "s2").isEmpty == false,
+                "and B's transcript is untouched by either instance")
+        // Both alarms were due at the same virtual instant and clear themselves
+        // as they fire, so this is polled rather than read once: which of the
+        // two finishes first is not something the test gets to decide.
+        let cleared = await pollUntilTrue(timeout: .seconds(10)) {
+            // Read both, then compare: `&&` takes its right side as a
+            // nonisolated autoclosure, which cannot await an actor's property.
+            let abandoned = await firstTimer.armedSessionCount
+            let live = await secondTimer.armedSessionCount
+            return abandoned == 0 && live == 0
+        }
+        #expect(cleared == .satisfied,
+                "neither the abandoned instance nor the live one re-arms after firing")
+    }
+
+    /// One text line, no terminal line: what a stream in flight and a proxy
+    /// killed mid-turn both leave on disk.
+    private static func streamFileWithOneTextLine() throws -> String {
         let dir = fencedScratchRoot(prefix: "tbdprov")
         try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
         let path = dir + "/stream.jsonl"
         let line = try ModelProxyStreamLine
             .text(message: "msg_a", index: 0, text: "Hel").encodedLine()
         try (line + "\n").write(toFile: path, atomically: true, encoding: .utf8)
-        let source = TranscriptSource()
-        #expect(await source.refreshStream(sessionID: "s1", path: path, now: Self.t0))
-
-        let state = await Self.makeState(streaming: true, suite: suite)
-        let timer = ProvisionalRetireTimer(clock: TestClock())
-        let t0 = Self.t0
-
-        let published = await TableTranscriptPaneView.publish(
-            sessionID: "s1", state: state, source: source,
-            retireTimer: timer, now: { t0 })
-
-        #expect(published.last?.id == "stream:msg_a")
-        #expect(await timer.armedMessage(sessionID: "s1") == nil)
+        return path
     }
 
     /// The publish path's own off branch: the same source and the same
@@ -543,9 +766,15 @@ struct ProvisionalRowPublishTests {
     }
 }
 
-/// `ProvisionalRetireTimer` on its own: the one-shot behind the 60-second rule.
+/// `ProvisionalRetireTimer` on its own: the one-shot behind both deadline rules.
 @Suite("ProvisionalRetireTimer", .clockDriven, .serialized)
 struct ProvisionalRetireTimerTests {
+
+    private static let t0 = Date(timeIntervalSince1970: 1_700_000_000)
+    /// The instant every alarm below is nominally due. It is the alarm's
+    /// identity, never a clock the timer reads — the sleeping is all done on
+    /// the injected `TestClock`, which is why these two never have to agree.
+    private static let due = t0.addingTimeInterval(60)
 
     private actor FireLog {
         private(set) var count = 0
@@ -558,7 +787,7 @@ struct ProvisionalRetireTimerTests {
         let timer = ProvisionalRetireTimer(clock: clock)
         let log = FireLog()
 
-        await timer.arm(sessionID: "s1", messageID: "msg_a", after: .seconds(60)) { await log.record() }
+        await timer.arm(sessionID: "s1", messageID: "msg_a", deadline: Self.due, after: .seconds(60)) { await log.record() }
         #expect(await timer.armedMessage(sessionID: "s1") == "msg_a")
 
         await clock.advanceWhenSuspended(by: .seconds(59))
@@ -582,15 +811,52 @@ struct ProvisionalRetireTimerTests {
         let timer = ProvisionalRetireTimer(clock: clock)
         let log = FireLog()
 
-        await timer.arm(sessionID: "s1", messageID: "msg_a", after: .seconds(60)) { await log.record() }
+        await timer.arm(sessionID: "s1", messageID: "msg_a", deadline: Self.due, after: .seconds(60)) { await log.record() }
         await clock.advanceWhenSuspended(by: .seconds(59))
-        // A poll one second before the deadline re-arms with the remaining 1 s.
-        // If that replaced the alarm, the fire below would be 60 s away.
-        await timer.arm(sessionID: "s1", messageID: "msg_a", after: .seconds(1)) { await log.record() }
+        // A poll one second before the deadline re-arms with the *same* due
+        // instant and the remaining 1 s. The due instant is the identity, so
+        // this is a no-op; if the shrinking delay replaced the alarm instead,
+        // the fire below would be 60 s away.
+        await timer.arm(
+            sessionID: "s1", messageID: "msg_a", deadline: Self.due, after: .seconds(1)
+        ) { await log.record() }
 
         await clock.advance(by: .seconds(2))
         let fired = await pollUntilTrue(timeout: .seconds(10)) { await log.count >= 1 }
         #expect(fired == .satisfied)
+        #expect(await log.count == 1, "one alarm, not two")
+    }
+
+    /// The other half of that rule, and what the silent-stream window needs: a
+    /// line arriving for the message already armed genuinely moves its due
+    /// instant, and the pending alarm must give way to the later one.
+    ///
+    /// What discriminates: keyed by message id alone, the second arm below is
+    /// a no-op, the first alarm fires at 60 s, and a row whose stream is still
+    /// producing is withdrawn underneath it.
+    @Test("re-arming the same message at a later deadline replaces the alarm")
+    func reArmingAtALaterDeadlineReplacesTheAlarm() async {
+        let clock = TestClock()
+        let timer = ProvisionalRetireTimer(clock: clock)
+        let log = FireLog()
+
+        await timer.arm(
+            sessionID: "s1", messageID: "msg_a", deadline: Self.due, after: .seconds(60)
+        ) { await log.record() }
+        await clock.advanceWhenSuspended(by: .seconds(30))
+        await timer.arm(
+            sessionID: "s1", messageID: "msg_a",
+            deadline: Self.due.addingTimeInterval(60), after: .seconds(60)
+        ) { await log.record() }
+
+        await clock.advanceWhenSuspended(by: .seconds(31))
+        for _ in 0..<50 { await Task.yield() }
+        #expect(await log.count == 0, "the original deadline no longer belongs to anything")
+        #expect(await timer.armedMessage(sessionID: "s1") == "msg_a")
+
+        await clock.advance(by: .seconds(30))
+        let fired = await pollUntilTrue(timeout: .seconds(10)) { await log.count == 1 }
+        #expect(fired == .satisfied, "the replacement fires on the later deadline")
         #expect(await log.count == 1, "one alarm, not two")
     }
 
@@ -601,8 +867,8 @@ struct ProvisionalRetireTimerTests {
         let first = FireLog()
         let second = FireLog()
 
-        await timer.arm(sessionID: "s1", messageID: "msg_a", after: .seconds(60)) { await first.record() }
-        await timer.arm(sessionID: "s1", messageID: "msg_b", after: .seconds(60)) { await second.record() }
+        await timer.arm(sessionID: "s1", messageID: "msg_a", deadline: Self.due, after: .seconds(60)) { await first.record() }
+        await timer.arm(sessionID: "s1", messageID: "msg_b", deadline: Self.due, after: .seconds(60)) { await second.record() }
         #expect(await timer.armedMessage(sessionID: "s1") == "msg_b")
 
         await clock.advanceWhenSuspended(by: .seconds(61))
@@ -620,10 +886,10 @@ struct ProvisionalRetireTimerTests {
         let first = FireLog()
         let second = FireLog()
 
-        await timer.arm(sessionID: "s1", messageID: "msg_a", after: .seconds(60)) {
+        await timer.arm(sessionID: "s1", messageID: "msg_a", deadline: Self.due, after: .seconds(60)) {
             await first.record()
         }
-        await timer.arm(sessionID: "s2", messageID: "msg_b", after: .seconds(60)) {
+        await timer.arm(sessionID: "s2", messageID: "msg_b", deadline: Self.due, after: .seconds(60)) {
             await second.record()
         }
         #expect(await timer.armedSessionCount == 2, "two sessions, two alarms")
@@ -651,10 +917,10 @@ struct ProvisionalRetireTimerTests {
         let leaving = FireLog()
         let staying = FireLog()
 
-        await timer.arm(sessionID: "s1", messageID: "msg_a", after: .seconds(60)) {
+        await timer.arm(sessionID: "s1", messageID: "msg_a", deadline: Self.due, after: .seconds(60)) {
             await leaving.record()
         }
-        await timer.arm(sessionID: "s2", messageID: "msg_b", after: .seconds(60)) {
+        await timer.arm(sessionID: "s2", messageID: "msg_b", deadline: Self.due, after: .seconds(60)) {
             await staying.record()
         }
 
@@ -679,10 +945,10 @@ struct ProvisionalRetireTimerTests {
         let first = FireLog()
         let second = FireLog()
 
-        await timer.arm(sessionID: "s1", messageID: "msg_a", after: .seconds(60)) {
+        await timer.arm(sessionID: "s1", messageID: "msg_a", deadline: Self.due, after: .seconds(60)) {
             await first.record()
         }
-        await timer.arm(sessionID: "s2", messageID: "msg_b", after: .seconds(60)) {
+        await timer.arm(sessionID: "s2", messageID: "msg_b", deadline: Self.due, after: .seconds(60)) {
             await second.record()
         }
         await timer.disarmAll()
@@ -700,7 +966,7 @@ struct ProvisionalRetireTimerTests {
         let timer = ProvisionalRetireTimer(clock: clock)
         let log = FireLog()
 
-        await timer.arm(sessionID: "s1", messageID: "msg_a", after: .seconds(60)) { await log.record() }
+        await timer.arm(sessionID: "s1", messageID: "msg_a", deadline: Self.due, after: .seconds(60)) { await log.record() }
         await clock.advanceWhenSuspended(by: .seconds(1))
         await timer.disarm(sessionID: "s1")
         #expect(await timer.armedMessage(sessionID: "s1") == nil)

--- a/Tests/TBDAppTests/ProvisionalRowComposerTests.swift
+++ b/Tests/TBDAppTests/ProvisionalRowComposerTests.swift
@@ -1,0 +1,526 @@
+import Clocks
+import Foundation
+import Testing
+@testable import TBDApp
+@testable import TBDShared
+import TestSupport
+
+/// `ProvisionalRowComposer` — the step that decides whether the model-proxy
+/// stream's in-flight message is on screen, and where in the list it sits.
+///
+/// Pure, so every test here is a plain value assertion: the composer has no
+/// files, no clock and no `AppState`. The wiring that feeds it is exercised
+/// separately in `ProvisionalRowPublishTests` below.
+@Suite("ProvisionalRowComposer")
+struct ProvisionalRowComposerTests {
+
+    private static let t0 = Date(timeIntervalSince1970: 1_700_000_000)
+
+    /// Two settled JSONL rows, so "appended last" is a real claim about order
+    /// rather than a statement about a one-element array.
+    private static let settled: [TranscriptItem] = [
+        .userPrompt(id: "u1", text: "explain the fold", timestamp: t0),
+        .assistantText(id: "msg_old", text: "an older answer", timestamp: t0),
+    ]
+
+    private static func streaming(_ text: String, id: String = "msg_a") -> ProvisionalMessage {
+        ProvisionalMessage(messageID: id, text: text, phase: .streaming)
+    }
+
+    /// Nothing is confirmed. The default for tests that are about some other
+    /// retire rule, so a stray confirmation cannot make them pass vacuously.
+    private static let nothingConfirmed: @Sendable (String) -> Bool = { _ in false }
+
+    /// The text of an `.assistantText` row, read straight off the case so this
+    /// suite stays free of the `@MainActor` rendering helpers.
+    private static func assistantText(_ item: TranscriptItem?) -> String? {
+        guard let item, case .assistantText(_, let text, _, _) = item else { return nil }
+        return text
+    }
+
+    private static func compose(
+        items: [TranscriptItem] = settled,
+        provisional: ProvisionalMessage?,
+        confirmed: @escaping (String) -> Bool = nothingConfirmed,
+        now: Date = t0,
+        streamingEnabled: Bool = true
+    ) -> [TranscriptItem] {
+        ProvisionalRowComposer.compose(
+            items: items, provisional: provisional, confirmed: confirmed,
+            now: now, streamingEnabled: streamingEnabled)
+    }
+
+    // MARK: - Appearing and growing
+
+    @Test("a streaming message appears as the last row, with the stream id prefix")
+    func streamingMessageAppears() {
+        let items = Self.compose(provisional: Self.streaming("Hello"))
+
+        #expect(items.count == Self.settled.count + 1)
+        #expect(Array(items.dropLast()) == Self.settled,
+                "the settled transcript must be passed through untouched")
+        guard let last = items.last,
+              case .assistantText(let id, let text, let timestamp, let usage) = last else {
+            Issue.record("expected a trailing assistantText row, got \(String(describing: items.last))")
+            return
+        }
+        #expect(id == "stream:msg_a")
+        #expect(id.hasPrefix(ProvisionalRowComposer.idPrefix))
+        #expect(text == "Hello")
+        #expect(timestamp == nil, "the row carries no timestamp — the JSONL has not stamped it yet")
+        #expect(usage == nil)
+    }
+
+    /// The identity has to hold still while the text grows, or the table
+    /// rebuilds instead of re-rendering its last row.
+    @Test("a growing message keeps one row identity and updates its text")
+    func growingMessageKeepsItsIdentity() {
+        let first = Self.compose(provisional: Self.streaming("Hel"))
+        let second = Self.compose(provisional: Self.streaming("Hello, world"))
+
+        #expect(first.count == second.count)
+        #expect(first.last?.id == second.last?.id)
+        #expect(Self.assistantText(second.last) == "Hello, world")
+    }
+
+    /// The empty-text case is deliberate, not an oversight: `StreamFileReader`
+    /// reports a message that has started and said nothing so a reader can see
+    /// that a turn has begun. The row is a bare cursor until the first delta.
+    @Test("a started message with no text yet still gets a row")
+    func startedButSilentStillGetsARow() {
+        let items = Self.compose(provisional: Self.streaming(""))
+
+        #expect(items.last?.id == "stream:msg_a")
+        #expect(Self.assistantText(items.last) == "")
+    }
+
+    // MARK: - Retiring
+
+    /// The ordinary end of a turn: the JSONL catches up, the real row lands,
+    /// and the provisional one must be gone in the same publish — not one row
+    /// later, or the answer renders twice.
+    @Test("a confirmed message is replaced by its JSONL row, not shown twice")
+    func confirmedMessageIsReplaced() {
+        let landed = Self.settled + [
+            .assistantText(id: "msg_a", text: "Hello, world", timestamp: Self.t0),
+        ]
+
+        let items = Self.compose(
+            items: landed,
+            provisional: Self.streaming("Hello, world"),
+            confirmed: { $0 == "msg_a" })
+
+        #expect(items == landed, "the composer must add nothing once the id is confirmed")
+        #expect(!items.contains { ProvisionalRowComposer.isProvisional(itemID: $0.id) },
+                "no provisional row survives confirmation")
+        #expect(items.contains { $0.id == "msg_a" },
+                "and the settled row it was standing in for is present")
+    }
+
+    @Test("an aborted message is retired")
+    func abortedMessageIsRetired() {
+        let items = Self.compose(provisional: ProvisionalMessage(
+            messageID: "msg_a", text: "half an ans",
+            phase: .aborted(reason: "upstream closed")))
+
+        #expect(items == Self.settled)
+    }
+
+    @Test("a completed but unconfirmed message is retired after the deadline")
+    func completedMessageRetiresAfterTheDeadline() {
+        let completed = ProvisionalMessage(
+            messageID: "msg_a", text: "Hello, world", phase: .complete(at: Self.t0))
+
+        let atFiftyNine = Self.compose(
+            provisional: completed, now: Self.t0.addingTimeInterval(59))
+        #expect(atFiftyNine.last?.id == "stream:msg_a",
+                "59 s after the stop the row is still the best thing to show")
+
+        let atSixtyOne = Self.compose(
+            provisional: completed, now: Self.t0.addingTimeInterval(61))
+        #expect(atSixtyOne == Self.settled,
+                "61 s after the stop nothing is ever going to confirm it")
+    }
+
+    /// The deadline measures from the completion instant, so a row that
+    /// completed long before this publish is already gone on its first render.
+    @Test("the deadline is measured from the completion instant, not from first sight")
+    func deadlineIsMeasuredFromCompletion() {
+        let longDone = ProvisionalMessage(
+            messageID: "msg_a", text: "Hello",
+            phase: .complete(at: Self.t0.addingTimeInterval(-3600)))
+
+        #expect(Self.compose(provisional: longDone) == Self.settled)
+    }
+
+    @Test("nothing tailed yet means nothing appended")
+    func noProvisionalMeansNoRow() {
+        #expect(Self.compose(provisional: nil) == Self.settled)
+    }
+
+    // MARK: - The flag
+
+    /// The off branch of the feature's gate. Everything else about the input is
+    /// exactly the appearing case, so this can only pass because the flag was
+    /// read.
+    @Test("streaming off never produces a row")
+    func streamingOffProducesNoRow() {
+        #expect(Self.compose(provisional: Self.streaming("Hello"), streamingEnabled: false)
+                == Self.settled)
+        #expect(Self.compose(provisional: Self.streaming("Hello"), streamingEnabled: true).count
+                == Self.settled.count + 1,
+                "and the same input with the flag on does produce one")
+    }
+
+    // MARK: - Order
+
+    /// The pane composes in three layers — JSONL, then the daemon's pending
+    /// `AskUserQuestion` captures, then this. A question captured by the
+    /// `PreToolUse` hook was captured *before* the answer now streaming, so the
+    /// provisional row belongs after it.
+    @Test("the row sorts after a pending AskUserQuestion synthetic item")
+    func rowSortsAfterAPendingQuestion() {
+        let merged = AskUserQuestionMerger.merge(
+            jsonlItems: Self.settled,
+            pending: [PendingAskUserQuestion(
+                toolUseID: "toolu_1",
+                inputJSON: #"{"questions":[]}"#,
+                timestamp: Self.t0)])
+        #expect(merged.items.last?.id == "toolu_1", "fixture check: the merger appends the capture")
+
+        let items = Self.compose(items: merged.items, provisional: Self.streaming("Hello"))
+
+        #expect(items.count == merged.items.count + 1)
+        #expect(items.last?.id == "stream:msg_a")
+        #expect(items[items.count - 2].id == "toolu_1",
+                "the synthetic question keeps its place directly above the provisional row")
+    }
+
+    // MARK: - The declared constants
+
+    @Test("the retire window is 60 seconds and the prefix is stream:")
+    func constantsAreWhatTheDesignDeclares() {
+        #expect(ProvisionalRowComposer.unconfirmedRetireAfter == .seconds(60))
+        #expect(ProvisionalRowComposer.idPrefix == "stream:")
+        #expect(ProvisionalRowComposer.isProvisional(itemID: "stream:msg_a"))
+        #expect(!ProvisionalRowComposer.isProvisional(itemID: "msg_a"))
+    }
+
+    // MARK: - The alarm's delay
+
+    @Test("only a completed message asks for a retire alarm")
+    func onlyCompletionSchedulesAnAlarm() {
+        #expect(ProvisionalRowComposer.retireDelay(phase: .streaming, now: Self.t0) == nil)
+        #expect(ProvisionalRowComposer.retireDelay(
+            phase: .aborted(reason: "x"), now: Self.t0) == nil)
+        #expect(ProvisionalRowComposer.retireDelay(
+            phase: .complete(at: Self.t0), now: Self.t0) == .seconds(60))
+        #expect(ProvisionalRowComposer.retireDelay(
+            phase: .complete(at: Self.t0), now: Self.t0.addingTimeInterval(45)) == .seconds(15))
+        #expect(ProvisionalRowComposer.retireDelay(
+            phase: .complete(at: Self.t0), now: Self.t0.addingTimeInterval(600)) == .seconds(0),
+                "a deadline already past is clamped at zero, never negative")
+    }
+}
+
+/// The trailing cursor: how a reader tells the provisional row from a settled
+/// one. Two hops — the presentation marks the node, the bubble draws the mark —
+/// and both are asserted, because either alone renders nothing.
+@MainActor
+@Suite("ProvisionalRowPresentation")
+struct ProvisionalRowPresentationTests {
+
+    @Test("a stream: item builds a node marked provisional and a plain one does not")
+    func streamPrefixMarksTheNode() {
+        let presentation = TranscriptPresentation.build(
+            items: [
+                .assistantText(id: "msg_old", text: "settled", timestamp: nil),
+                .assistantText(id: "stream:msg_a", text: "arriving", timestamp: nil),
+            ],
+            memo: TranscriptPresentationMemo())
+
+        #expect(presentation.nodes.count == 2)
+        #expect(presentation.nodes[0].isProvisional == false)
+        #expect(presentation.nodes[1].isProvisional)
+    }
+
+    /// Two rows with identical text but different provisional-ness must not
+    /// collide in the composed-blocks cache, which is keyed on
+    /// `(id, contentVersion)`.
+    @Test("the provisional mark is part of a node's content version")
+    func provisionalMarkIsPartOfTheContentVersion() {
+        let kind = TranscriptRenderNode.Kind.chatBubble(
+            .assistantText(id: "x", text: "same text", timestamp: nil))
+        let plain = TranscriptRenderNode(id: "x", kind: kind, badgeUsage: nil)
+        let marked = TranscriptRenderNode(id: "x", kind: kind, badgeUsage: nil, isProvisional: true)
+
+        #expect(plain.contentVersion != marked.contentVersion)
+        #expect(plain != marked)
+    }
+
+    @Test("the bubble draws a trailing cursor only for a provisional node")
+    func bubbleDrawsTheCursorOnlyWhenProvisional() {
+        let item = TranscriptItem.assistantText(id: "stream:msg_a", text: "Hello", timestamp: nil)
+
+        let plain = TranscriptBubbleGeometry.composedBlocks(
+            for: item, badgeUsage: nil, linkResolver: nil)
+        let marked = TranscriptBubbleGeometry.composedBlocks(
+            for: item, badgeUsage: nil, linkResolver: nil, isProvisional: true)
+
+        #expect(Self.prose(plain) == "Hello")
+        #expect(Self.prose(marked) == "Hello" + TranscriptBubbleGeometry.provisionalCursor)
+    }
+
+    private static func prose(_ blocks: [MessageBlock]) -> String {
+        blocks.compactMap { block -> String? in
+            guard case .prose(let string) = block else { return nil }
+            return string.string
+        }.joined()
+    }
+}
+
+/// A `Date` a test can move, for the `now` seam `TableTranscriptPaneView.publish`
+/// takes. `TestClock` moves virtual *durations*; this moves the wall clock the
+/// retire comparison is made against, and the two have to be moved together —
+/// the alarm decides *when* to re-publish, the composer decides what the
+/// re-publish shows.
+///
+/// File scope, and `@unchecked Sendable` over a lock, because the `now` closure
+/// crosses into the alarm's detached task.
+private final class MovableDate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: Date
+    init(_ value: Date) { self.value = value }
+    var now: Date {
+        lock.lock(); defer { lock.unlock() }
+        return value
+    }
+    func advance(by seconds: TimeInterval) {
+        lock.lock(); defer { lock.unlock() }
+        value = value.addingTimeInterval(seconds)
+    }
+}
+
+/// The publish step in `TableTranscriptPaneView` — the seam where the composer,
+/// the source and the retire alarm meet.
+///
+/// Driven directly rather than through a SwiftUI view tree, the same shape as
+/// `TaskKey.resolve`: `publish` is where the four inputs are actually gathered,
+/// and a view host would add nothing but flakiness.
+///
+/// The suite is deliberately NOT `@MainActor`. `publish` is `nonisolated` — the
+/// isolation it actually runs under in the app, since the scheduler's on-change
+/// closure is `@Sendable` — and every read of `AppState` here goes through an
+/// explicit `MainActor.run` helper, which is also what keeps the bounded-poll
+/// conditions free of main-actor captures.
+@Suite("ProvisionalRowPublish", .clockDriven, .serialized)
+struct ProvisionalRowPublishTests {
+
+    private static let t0 = Date(timeIntervalSince1970: 1_700_000_000)
+
+    @MainActor
+    private static func makeState(streaming: Bool, suite: String) -> AppState {
+        let state = AppState(userDefaults: UserDefaults(suiteName: suite)!)
+        state.daemonCapabilities = DaemonCapabilitiesResult(
+            controlModeEnabled: false, transcriptStreamingEnabled: streaming)
+        return state
+    }
+
+    private static func removeSuite(_ suite: String) {
+        UserDefaults(suiteName: suite)?.removePersistentDomain(forName: suite)
+    }
+
+    private static func publishedIDs(_ state: AppState) async -> [String] {
+        await MainActor.run { (state.sessionTranscripts["s1"] ?? []).map(\.id) }
+    }
+
+    /// Writes one complete-and-unconfirmed message into a real stream file and
+    /// has the source tail it. No transcript file at all, so
+    /// `hasAssistantMessage` is false — which is exactly the unconfirmed case.
+    private static func sourceWithCompletedMessage(now: Date) async throws -> TranscriptSource {
+        let dir = fencedScratchRoot(prefix: "tbdprov")
+        try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        let path = dir + "/stream.jsonl"
+        let lines = try [
+            ModelProxyStreamLine.start(message: "msg_a", at: now),
+            .text(message: "msg_a", index: 0, text: "Hello, world"),
+            .stop(message: "msg_a"),
+        ].map { try $0.encodedLine() + "\n" }.joined()
+        try lines.write(toFile: path, atomically: true, encoding: .utf8)
+
+        let source = TranscriptSource()
+        #expect(await source.refreshStream(sessionID: "s1", path: path, now: now))
+        return source
+    }
+
+    /// The finding the alarm exists for: once a message stops, the stream file
+    /// goes quiet, so no poll will ever report news for it again and nothing
+    /// else would ever take the row down.
+    @Test("a completed row is withdrawn by the alarm, 60 s later and not before")
+    func theAlarmWithdrawsACompletedRow() async throws {
+        let suite = "tbd-provisional-publish-\(UUID().uuidString)"
+        defer { Self.removeSuite(suite) }
+        let date = MovableDate(Self.t0)
+        let source = try await Self.sourceWithCompletedMessage(now: Self.t0)
+        let state = await Self.makeState(streaming: true, suite: suite)
+        let clock = TestClock()
+        let timer = ProvisionalRetireTimer(clock: clock)
+
+        let published = await TableTranscriptPaneView.publish(
+            sessionID: "s1", state: state, source: source,
+            retireTimer: timer, now: { date.now })
+        #expect(published.last?.id == "stream:msg_a")
+        #expect(await Self.publishedIDs(state) == ["stream:msg_a"])
+        #expect(await timer.armedMessage == "msg_a", "the completed row armed the alarm")
+
+        // 59 s of virtual time. The alarm is armed for 60, so nothing fires and
+        // the row is still on screen.
+        date.advance(by: 59)
+        await clock.advanceWhenSuspended(by: .seconds(59))
+        #expect(await Self.publishedIDs(state) == ["stream:msg_a"],
+                "the row must survive right up to the deadline")
+
+        // Past it. The alarm's re-publish re-composes, and the composer's own
+        // 60-second rule is what drops the row.
+        date.advance(by: 2)
+        await clock.advance(by: .seconds(2))
+        let withdrawn = await pollUntilTrue(timeout: .seconds(10)) {
+            await Self.publishedIDs(state).isEmpty
+        }
+        #expect(withdrawn == .satisfied, "the alarm's re-publish must withdraw the row")
+        #expect(await timer.armedMessage == nil, "and it does not re-arm itself")
+    }
+
+    /// A still-streaming row arms nothing: it has not stopped, so the file it
+    /// came from is still moving and the poll scheduler is still reporting it.
+    @Test("a streaming row arms no alarm")
+    func aStreamingRowArmsNoAlarm() async throws {
+        let suite = "tbd-provisional-publish-\(UUID().uuidString)"
+        defer { Self.removeSuite(suite) }
+        let dir = fencedScratchRoot(prefix: "tbdprov")
+        try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        let path = dir + "/stream.jsonl"
+        let line = try ModelProxyStreamLine
+            .text(message: "msg_a", index: 0, text: "Hel").encodedLine()
+        try (line + "\n").write(toFile: path, atomically: true, encoding: .utf8)
+        let source = TranscriptSource()
+        #expect(await source.refreshStream(sessionID: "s1", path: path, now: Self.t0))
+
+        let state = await Self.makeState(streaming: true, suite: suite)
+        let timer = ProvisionalRetireTimer(clock: TestClock())
+        let t0 = Self.t0
+
+        let published = await TableTranscriptPaneView.publish(
+            sessionID: "s1", state: state, source: source,
+            retireTimer: timer, now: { t0 })
+
+        #expect(published.last?.id == "stream:msg_a")
+        #expect(await timer.armedMessage == nil)
+    }
+
+    /// The publish path's own off branch: the same source and the same
+    /// completed message, with capabilities reporting streaming off.
+    @Test("publishing with streaming off writes no provisional row and arms nothing")
+    func publishingWithStreamingOffWritesNoRow() async throws {
+        let suite = "tbd-provisional-publish-\(UUID().uuidString)"
+        defer { Self.removeSuite(suite) }
+        let source = try await Self.sourceWithCompletedMessage(now: Self.t0)
+        let state = await Self.makeState(streaming: false, suite: suite)
+        let timer = ProvisionalRetireTimer(clock: TestClock())
+        let t0 = Self.t0
+
+        let published = await TableTranscriptPaneView.publish(
+            sessionID: "s1", state: state, source: source,
+            retireTimer: timer, now: { t0 })
+
+        #expect(published.isEmpty)
+        #expect(await Self.publishedIDs(state).isEmpty)
+        #expect(await timer.armedMessage == nil)
+    }
+}
+
+/// `ProvisionalRetireTimer` on its own: the one-shot behind the 60-second rule.
+@Suite("ProvisionalRetireTimer", .clockDriven, .serialized)
+struct ProvisionalRetireTimerTests {
+
+    private actor FireLog {
+        private(set) var count = 0
+        func record() { count += 1 }
+    }
+
+    @Test("the alarm fires once, after the delay and not before")
+    func alarmFiresOnceAfterTheDelay() async {
+        let clock = TestClock()
+        let timer = ProvisionalRetireTimer(clock: clock)
+        let log = FireLog()
+
+        await timer.arm(messageID: "msg_a", after: .seconds(60)) { await log.record() }
+        #expect(await timer.armedMessage == "msg_a")
+
+        await clock.advanceWhenSuspended(by: .seconds(59))
+        #expect(await log.count == 0, "59 s is inside the window")
+
+        await clock.advance(by: .seconds(2))
+        let fired = await pollUntilTrue(timeout: .seconds(10)) { await log.count == 1 }
+        #expect(fired == .satisfied, "the alarm must fire once past the deadline")
+        #expect(await timer.armedMessage == nil, "and clear itself so a later arm is not a no-op")
+
+        // Nothing re-arms it, so no second fire can arrive.
+        await clock.advance(by: .seconds(600))
+        #expect(await log.count == 1)
+    }
+
+    /// The idempotence that keeps a 100 ms poll from pushing the deadline
+    /// forever: a re-arm for the id already armed must leave the alarm alone.
+    @Test("re-arming the same message does not push the deadline out")
+    func reArmingTheSameMessageIsANoOp() async {
+        let clock = TestClock()
+        let timer = ProvisionalRetireTimer(clock: clock)
+        let log = FireLog()
+
+        await timer.arm(messageID: "msg_a", after: .seconds(60)) { await log.record() }
+        await clock.advanceWhenSuspended(by: .seconds(59))
+        // A poll one second before the deadline re-arms with the remaining 1 s.
+        // If that replaced the alarm, the fire below would be 60 s away.
+        await timer.arm(messageID: "msg_a", after: .seconds(1)) { await log.record() }
+
+        await clock.advance(by: .seconds(2))
+        let fired = await pollUntilTrue(timeout: .seconds(10)) { await log.count >= 1 }
+        #expect(fired == .satisfied)
+        #expect(await log.count == 1, "one alarm, not two")
+    }
+
+    @Test("arming a different message replaces the alarm")
+    func armingADifferentMessageReplacesTheAlarm() async {
+        let clock = TestClock()
+        let timer = ProvisionalRetireTimer(clock: clock)
+        let first = FireLog()
+        let second = FireLog()
+
+        await timer.arm(messageID: "msg_a", after: .seconds(60)) { await first.record() }
+        await timer.arm(messageID: "msg_b", after: .seconds(60)) { await second.record() }
+        #expect(await timer.armedMessage == "msg_b")
+
+        await clock.advanceWhenSuspended(by: .seconds(61))
+        let fired = await pollUntilTrue(timeout: .seconds(10)) { await second.count == 1 }
+        #expect(fired == .satisfied)
+        #expect(await first.count == 0, "the superseded message's alarm was cancelled")
+    }
+
+    @Test("disarming cancels a pending alarm")
+    func disarmingCancelsThePendingAlarm() async {
+        let clock = TestClock()
+        let timer = ProvisionalRetireTimer(clock: clock)
+        let log = FireLog()
+
+        await timer.arm(messageID: "msg_a", after: .seconds(60)) { await log.record() }
+        await clock.advanceWhenSuspended(by: .seconds(1))
+        await timer.disarm()
+        #expect(await timer.armedMessage == nil)
+
+        await clock.advance(by: .seconds(600))
+        // Give a cancelled task every chance to run before asserting it did not.
+        for _ in 0..<50 { await Task.yield() }
+        #expect(await log.count == 0)
+    }
+}

--- a/Tests/TBDAppTests/ProvisionalRowComposerTests.swift
+++ b/Tests/TBDAppTests/ProvisionalRowComposerTests.swift
@@ -967,9 +967,10 @@ struct ProvisionalRowPublishTests {
         let suite = "tbd-provisional-publish-\(UUID().uuidString)"
         defer { Self.removeSuite(suite) }
         let capture = try Self.assistantCaptureLines()
-        let split = try #require(capture.first { candidate in
+        let firstSplit = capture.first { candidate in
             capture.filter { $0.messageID == candidate.messageID }.count >= 2
-        }, "capture must hold a message written across two lines")
+        }
+        let split = try #require(firstSplit, "capture must hold a message written across two lines")
         let lines = capture.filter { $0.messageID == split.messageID }
         let thinking = try #require(lines.first)
         let text = try #require(lines.last)
@@ -999,8 +1000,10 @@ struct ProvisionalRowPublishTests {
 
         let settled = await TableTranscriptPaneView.publish(
             sessionID: "s1", state: state, source: source, retireTimer: timer, now: { t0 })
-        #expect(settled.contains { ProvisionalRowComposer.isProvisional(itemID: $0.id) } == false,
-                "the text line confirms, so the row is withdrawn")
+        let stillProvisional = settled.contains(where: {
+            ProvisionalRowComposer.isProvisional(itemID: $0.id)
+        })
+        #expect(stillProvisional == false, "the text line confirms, so the row is withdrawn")
         #expect(Self.settledTexts(settled).isEmpty == false,
                 "and the JSONL's own item is in the very same publish")
         #expect(await timer.armedMessage(sessionID: "s1") == nil,
@@ -1016,9 +1019,11 @@ struct ProvisionalRowPublishTests {
         let suite = "tbd-provisional-publish-\(UUID().uuidString)"
         defer { Self.removeSuite(suite) }
         let capture = try Self.assistantCaptureLines()
-        let textless = try #require(capture.first { candidate in
+        let firstTextless = capture.first { candidate in
             capture.filter { $0.messageID == candidate.messageID }.allSatisfy { !$0.carriesText }
-        }, "capture must hold a message that only ever calls tools")
+        }
+        let textless = try #require(
+            firstTextless, "capture must hold a message that only ever calls tools")
 
         let files = try Self.streamingTurn(messageID: textless.messageID)
         let transcriptPath = files.dir + "/transcript.jsonl"
@@ -1397,7 +1402,7 @@ private final class GatedClock: Clock, @unchecked Sendable {
         func waitForArrivals(_ count: Int) async {
             guard arrivals < count else { return }
             await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-                watchers.append((count, continuation))
+                watchers.append((needed: count, continuation: continuation))
             }
         }
     }

--- a/Tests/TBDAppTests/ProvisionalRowComposerTests.swift
+++ b/Tests/TBDAppTests/ProvisionalRowComposerTests.swift
@@ -346,8 +346,25 @@ struct ProvisionalRowPublishTests {
         UserDefaults(suiteName: suite)?.removePersistentDomain(forName: suite)
     }
 
-    private static func publishedIDs(_ state: AppState) async -> [String] {
-        await MainActor.run { (state.sessionTranscripts["s1"] ?? []).map(\.id) }
+    private static func publishedIDs(
+        _ state: AppState, session: String = "s1"
+    ) async -> [String] {
+        await MainActor.run { (state.sessionTranscripts[session] ?? []).map(\.id) }
+    }
+
+    /// A second session with an ordinary transcript and no stream file at all —
+    /// the "plain transcript news" case whose publish composes no provisional
+    /// row and therefore takes `publish`'s disarm branch.
+    private static let userLine = #"{"type":"user","uuid":"b1","timestamp":"2026-08-26T10:00:00.000Z","message":{"role":"user","content":"unrelated"}}"#
+
+    private static func addPlainTranscript(
+        to source: TranscriptSource, sessionID: String
+    ) async throws {
+        let dir = fencedScratchRoot(prefix: "tbdprov")
+        try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        let path = dir + "/transcript.jsonl"
+        try (Self.userLine + "\n").write(toFile: path, atomically: true, encoding: .utf8)
+        #expect(await source.refresh(sessionID: sessionID, path: path)?.appended.count == 1)
     }
 
     /// Writes one complete-and-unconfirmed message into a real stream file and
@@ -387,7 +404,7 @@ struct ProvisionalRowPublishTests {
             retireTimer: timer, now: { date.now })
         #expect(published.last?.id == "stream:msg_a")
         #expect(await Self.publishedIDs(state) == ["stream:msg_a"])
-        #expect(await timer.armedMessage == "msg_a", "the completed row armed the alarm")
+        #expect(await timer.armedMessage(sessionID: "s1") == "msg_a", "the completed row armed the alarm")
 
         // 59 s of virtual time. The alarm is armed for 60, so nothing fires and
         // the row is still on screen.
@@ -404,7 +421,66 @@ struct ProvisionalRowPublishTests {
             await Self.publishedIDs(state).isEmpty
         }
         #expect(withdrawn == .satisfied, "the alarm's re-publish must withdraw the row")
-        #expect(await timer.armedMessage == nil, "and it does not re-arm itself")
+        #expect(await timer.armedMessage(sessionID: "s1") == nil, "and it does not re-arm itself")
+    }
+
+    /// The scheduler holds **one** on-change closure for the whole app, so every
+    /// registered session's publish runs through whichever pane's timer was
+    /// installed last — and TBD keeps up to eight panes alive at once. Session
+    /// A's completed row arms a 60-second alarm; session B then gets ordinary
+    /// transcript news inside that window, which composes no provisional row
+    /// and so takes `publish`'s disarm branch. With one alarm slot for the
+    /// whole app, B's publish cancelled A's alarm and A's row never retired.
+    @Test("a publish for another session leaves this session's retire alarm alone")
+    func anotherSessionsPublishDoesNotDisarmThisOne() async throws {
+        let suite = "tbd-provisional-publish-\(UUID().uuidString)"
+        defer { Self.removeSuite(suite) }
+        let date = MovableDate(Self.t0)
+        let source = try await Self.sourceWithCompletedMessage(now: Self.t0)
+        try await Self.addPlainTranscript(to: source, sessionID: "s2")
+        let state = await Self.makeState(streaming: true, suite: suite)
+        let clock = TestClock()
+        let timer = ProvisionalRetireTimer(clock: clock)
+
+        await TableTranscriptPaneView.publish(
+            sessionID: "s1", state: state, source: source,
+            retireTimer: timer, now: { date.now })
+        #expect(await timer.armedMessage(sessionID: "s1") == "msg_a")
+
+        // Half-way through A's window, B publishes. Same `publish`, same timer
+        // instance, no provisional of its own.
+        date.advance(by: 30)
+        await clock.advanceWhenSuspended(by: .seconds(30))
+        await TableTranscriptPaneView.publish(
+            sessionID: "s2", state: state, source: source,
+            retireTimer: timer, now: { date.now })
+
+        let bIDs = await Self.publishedIDs(state, session: "s2")
+        #expect(bIDs.isEmpty == false, "B's publish really did run and write B's transcript")
+        #expect(bIDs.allSatisfy { !$0.hasPrefix(ProvisionalRowComposer.idPrefix) },
+                "and it composed no provisional row of its own")
+        #expect(await timer.armedMessage(sessionID: "s1") == "msg_a",
+                "B's publish must not disarm A's alarm")
+        #expect(await timer.armedMessage(sessionID: "s2") == nil,
+                "nor arm one of its own")
+        #expect(await timer.armedSessionCount == 1, "exactly A's alarm, and nothing else")
+        #expect(await Self.publishedIDs(state) == ["stream:msg_a"])
+
+        // A's alarm still fires on A's original schedule, 60 s from when it was
+        // armed: 29 s more is inside the window, 2 s past it is not.
+        date.advance(by: 29)
+        await clock.advanceWhenSuspended(by: .seconds(29))
+        #expect(await Self.publishedIDs(state) == ["stream:msg_a"],
+                "still inside A's window")
+
+        date.advance(by: 2)
+        await clock.advance(by: .seconds(2))
+        let withdrawn = await pollUntilTrue(timeout: .seconds(10)) {
+            await Self.publishedIDs(state).isEmpty
+        }
+        #expect(withdrawn == .satisfied, "A's row must retire on A's own deadline")
+        #expect(await Self.publishedIDs(state, session: "s2").isEmpty == false,
+                "and B's transcript is untouched by it")
     }
 
     /// A still-streaming row arms nothing: it has not stopped, so the file it
@@ -431,7 +507,7 @@ struct ProvisionalRowPublishTests {
             retireTimer: timer, now: { t0 })
 
         #expect(published.last?.id == "stream:msg_a")
-        #expect(await timer.armedMessage == nil)
+        #expect(await timer.armedMessage(sessionID: "s1") == nil)
     }
 
     /// The publish path's own off branch: the same source and the same
@@ -451,7 +527,7 @@ struct ProvisionalRowPublishTests {
 
         #expect(published.isEmpty)
         #expect(await Self.publishedIDs(state).isEmpty)
-        #expect(await timer.armedMessage == nil)
+        #expect(await timer.armedMessage(sessionID: "s1") == nil)
     }
 }
 
@@ -470,8 +546,8 @@ struct ProvisionalRetireTimerTests {
         let timer = ProvisionalRetireTimer(clock: clock)
         let log = FireLog()
 
-        await timer.arm(messageID: "msg_a", after: .seconds(60)) { await log.record() }
-        #expect(await timer.armedMessage == "msg_a")
+        await timer.arm(sessionID: "s1", messageID: "msg_a", after: .seconds(60)) { await log.record() }
+        #expect(await timer.armedMessage(sessionID: "s1") == "msg_a")
 
         await clock.advanceWhenSuspended(by: .seconds(59))
         #expect(await log.count == 0, "59 s is inside the window")
@@ -479,7 +555,7 @@ struct ProvisionalRetireTimerTests {
         await clock.advance(by: .seconds(2))
         let fired = await pollUntilTrue(timeout: .seconds(10)) { await log.count == 1 }
         #expect(fired == .satisfied, "the alarm must fire once past the deadline")
-        #expect(await timer.armedMessage == nil, "and clear itself so a later arm is not a no-op")
+        #expect(await timer.armedMessage(sessionID: "s1") == nil, "and clear itself so a later arm is not a no-op")
 
         // Nothing re-arms it, so no second fire can arrive.
         await clock.advance(by: .seconds(600))
@@ -494,11 +570,11 @@ struct ProvisionalRetireTimerTests {
         let timer = ProvisionalRetireTimer(clock: clock)
         let log = FireLog()
 
-        await timer.arm(messageID: "msg_a", after: .seconds(60)) { await log.record() }
+        await timer.arm(sessionID: "s1", messageID: "msg_a", after: .seconds(60)) { await log.record() }
         await clock.advanceWhenSuspended(by: .seconds(59))
         // A poll one second before the deadline re-arms with the remaining 1 s.
         // If that replaced the alarm, the fire below would be 60 s away.
-        await timer.arm(messageID: "msg_a", after: .seconds(1)) { await log.record() }
+        await timer.arm(sessionID: "s1", messageID: "msg_a", after: .seconds(1)) { await log.record() }
 
         await clock.advance(by: .seconds(2))
         let fired = await pollUntilTrue(timeout: .seconds(10)) { await log.count >= 1 }
@@ -513,14 +589,63 @@ struct ProvisionalRetireTimerTests {
         let first = FireLog()
         let second = FireLog()
 
-        await timer.arm(messageID: "msg_a", after: .seconds(60)) { await first.record() }
-        await timer.arm(messageID: "msg_b", after: .seconds(60)) { await second.record() }
-        #expect(await timer.armedMessage == "msg_b")
+        await timer.arm(sessionID: "s1", messageID: "msg_a", after: .seconds(60)) { await first.record() }
+        await timer.arm(sessionID: "s1", messageID: "msg_b", after: .seconds(60)) { await second.record() }
+        #expect(await timer.armedMessage(sessionID: "s1") == "msg_b")
 
         await clock.advanceWhenSuspended(by: .seconds(61))
         let fired = await pollUntilTrue(timeout: .seconds(10)) { await second.count == 1 }
         #expect(fired == .satisfied)
         #expect(await first.count == 0, "the superseded message's alarm was cancelled")
+    }
+
+    /// The keying itself, at the level below the publish test: one session's
+    /// disarm must leave every other session's alarm exactly where it is.
+    @Test("an alarm is scoped to its session and survives another session's disarm")
+    func alarmsAreScopedToTheirSession() async {
+        let clock = TestClock()
+        let timer = ProvisionalRetireTimer(clock: clock)
+        let first = FireLog()
+        let second = FireLog()
+
+        await timer.arm(sessionID: "s1", messageID: "msg_a", after: .seconds(60)) {
+            await first.record()
+        }
+        await timer.arm(sessionID: "s2", messageID: "msg_b", after: .seconds(60)) {
+            await second.record()
+        }
+        #expect(await timer.armedSessionCount == 2, "two sessions, two alarms")
+
+        await timer.disarm(sessionID: "s2")
+        #expect(await timer.armedMessage(sessionID: "s1") == "msg_a")
+        #expect(await timer.armedMessage(sessionID: "s2") == nil)
+
+        await clock.advanceWhenSuspended(by: .seconds(61))
+        let fired = await pollUntilTrue(timeout: .seconds(10)) { await first.count == 1 }
+        #expect(fired == .satisfied, "s1's alarm was untouched by s2's disarm")
+        #expect(await second.count == 0, "and s2's really was cancelled")
+    }
+
+    @Test("disarmAll cancels every session's alarm")
+    func disarmAllCancelsEverything() async {
+        let clock = TestClock()
+        let timer = ProvisionalRetireTimer(clock: clock)
+        let first = FireLog()
+        let second = FireLog()
+
+        await timer.arm(sessionID: "s1", messageID: "msg_a", after: .seconds(60)) {
+            await first.record()
+        }
+        await timer.arm(sessionID: "s2", messageID: "msg_b", after: .seconds(60)) {
+            await second.record()
+        }
+        await timer.disarmAll()
+        #expect(await timer.armedSessionCount == 0)
+
+        await clock.advance(by: .seconds(600))
+        for _ in 0..<50 { await Task.yield() }
+        #expect(await first.count == 0)
+        #expect(await second.count == 0)
     }
 
     @Test("disarming cancels a pending alarm")
@@ -529,10 +654,10 @@ struct ProvisionalRetireTimerTests {
         let timer = ProvisionalRetireTimer(clock: clock)
         let log = FireLog()
 
-        await timer.arm(messageID: "msg_a", after: .seconds(60)) { await log.record() }
+        await timer.arm(sessionID: "s1", messageID: "msg_a", after: .seconds(60)) { await log.record() }
         await clock.advanceWhenSuspended(by: .seconds(1))
-        await timer.disarm()
-        #expect(await timer.armedMessage == nil)
+        await timer.disarm(sessionID: "s1")
+        #expect(await timer.armedMessage(sessionID: "s1") == nil)
 
         await clock.advance(by: .seconds(600))
         // Give a cancelled task every chance to run before asserting it did not.

--- a/Tests/TBDAppTests/ProvisionalRowComposerTests.swift
+++ b/Tests/TBDAppTests/ProvisionalRowComposerTests.swift
@@ -196,6 +196,22 @@ struct ProvisionalRowComposerTests {
                 "the synthetic question keeps its place directly above the provisional row")
     }
 
+    // MARK: - Session History
+
+    /// Session History reads the same `AppState.sessionTranscripts` store the
+    /// live pane publishes into, and the session it is showing can be the one a
+    /// live pane is streaming. `settledOnly` is what keeps the unconfirmed row
+    /// out of a record of what the session was.
+    @Test("settledOnly drops the provisional row and keeps everything else in order")
+    func settledOnlyDropsTheProvisionalRow() {
+        let withRow = Self.compose(provisional: Self.streaming("Hello"))
+        #expect(withRow.count == Self.settled.count + 1, "fixture check: a row is present")
+
+        #expect(ProvisionalRowComposer.settledOnly(withRow) == Self.settled)
+        #expect(ProvisionalRowComposer.settledOnly(Self.settled) == Self.settled,
+                "a transcript with no provisional row passes through unchanged")
+    }
+
     // MARK: - The declared constants
 
     @Test("the retire window is 60 seconds and the prefix is stream:")

--- a/Tests/TBDAppTests/ProvisionalRowComposerTests.swift
+++ b/Tests/TBDAppTests/ProvisionalRowComposerTests.swift
@@ -663,17 +663,156 @@ struct ProvisionalRowPublishTests {
                 "and the replacement alarm is still pending")
     }
 
-    /// The handoff production actually performs, which the single-instance
-    /// two-session test does not reach: `appSideLoop` builds a **new**
-    /// `ProvisionalRetireTimer` on every pane mount and drops it into the
-    /// scheduler's single `onChange` slot, so a remount leaves the previous
-    /// instance's alarm pending with nothing left holding it.
+    /// What a mounting pane does to get a retire timer, in one place: it takes
+    /// the scheduler's. `appSideLoop` has exactly this line, and the tests
+    /// below drive it once per pane so "a second pane mounted" is the gesture
+    /// production makes rather than a claim about it.
+    private static func timerForMountingPane(
+        _ scheduler: TranscriptPollScheduler
+    ) -> ProvisionalRetireTimer {
+        scheduler.provisionalRetire
+    }
+
+    /// The handoff production actually performs. Panes mount, remount and are
+    /// restarted wholesale by a Settings flip, and every one of them publishes
+    /// through the scheduler's single `onChange` slot.
     ///
-    /// The property being pinned is that this is safe: a fired alarm only ever
-    /// runs an ordinary publish, which recomputes from the source and the
-    /// state, so it retires the row it should retire regardless of which
-    /// instance woke up — and it touches no other session on the way.
-    @Test("a retire alarm survives a remount onto a second timer and lands on its own session")
+    /// What discriminates: while a pane built its own `ProvisionalRetireTimer`
+    /// per mount, the two handles below were different objects, the row's
+    /// re-arm landed in the one the *second* pane installed, and the first
+    /// pane's teardown reached only its own. The orphan then outlived
+    /// `TranscriptSource.forget` and republished an empty transcript for a
+    /// session nothing was watching — which `AppState+History.selectSession`
+    /// caches as an answer, so Session History for it read empty for good.
+    @Test("a pane that tore down leaves no orphan alarm for a later mount to fire")
+    func aTornDownPaneLeavesNoOrphanAlarm() async throws {
+        let suite = "tbd-provisional-publish-\(UUID().uuidString)"
+        defer { Self.removeSuite(suite) }
+        let path = try Self.streamFileWithOneTextLine()
+        let source = TranscriptSource()
+        #expect(await source.refreshStream(sessionID: "s1", path: path, now: Self.t0))
+        let state = await Self.makeState(streaming: true, suite: suite)
+        let clock = TestClock()
+        let date = MovableDate(Self.t0)
+        let scheduler = TranscriptPollScheduler(source: source, clock: clock)
+
+        // Pane A mounts on the streaming session and publishes: a row with a
+        // ten-minute silent-stream deadline, and an alarm to match.
+        let paneA = TranscriptPaneToken()
+        let timerA = Self.timerForMountingPane(scheduler)
+        await scheduler.register(
+            sessionID: "s1", path: path, streamPath: path,
+            tier: .background, token: paneA)
+        await TableTranscriptPaneView.publish(
+            sessionID: "s1", state: state, source: source,
+            retireTimer: timerA, now: { date.now })
+        #expect(await timerA.armedMessage(sessionID: "s1") == "msg_a")
+
+        // Pane B mounts — a second pane, or the same pane restarted by a
+        // Settings flip. It takes a timer the way every pane does.
+        let timerB = Self.timerForMountingPane(scheduler)
+        #expect(timerA === timerB, "a pane mounting must not mint a second timer")
+
+        // Nine minutes in, a line arrives for A's row and it re-arms — through
+        // the handle the pane that mounted last is holding.
+        date.advance(by: 540)
+        let more = try ModelProxyStreamLine
+            .text(message: "msg_a", index: 0, text: "lo").encodedLine()
+        let handle = try FileHandle(forWritingTo: URL(fileURLWithPath: path))
+        try handle.seekToEnd()
+        try handle.write(contentsOf: Data((more + "\n").utf8))
+        try handle.close()
+        #expect(await source.refreshStream(sessionID: "s1", path: path, now: date.now))
+        await TableTranscriptPaneView.publish(
+            sessionID: "s1", state: state, source: source,
+            retireTimer: timerB, now: { date.now })
+        #expect(await Self.publishedIDs(state) == ["stream:msg_a"])
+
+        // A tears down: the hold goes, the alarm goes with it, and the source
+        // forgets the session — the real teardown sequence, in its real order.
+        await scheduler.deregister(sessionID: "s1", token: paneA)
+        await scheduler.disarmProvisional(sessionID: "s1")
+        #expect(await timerB.armedSessionCount == 0,
+                "the re-armed alarm was reachable from the departing pane's teardown")
+
+        // Past every deadline either arm could have set.
+        await clock.advance(by: .seconds(1_200))
+        let published = await pollUntilTrue(timeout: .seconds(1)) {
+            await Self.publishedIDs(state) != ["stream:msg_a"]
+        }
+        #expect(published == .timedOut,
+                "nothing may publish for a session that has been forgotten")
+        #expect(await Self.publishedIDs(state) == ["stream:msg_a"])
+    }
+
+    /// Two panes, two sessions, one timer — the arrangement the app is in
+    /// whenever more than one transcript is open. Each session's row must
+    /// retire on its own rule and its own instant, and neither may take the
+    /// other down on the way.
+    ///
+    /// The rules are deliberately different: A completed and unconfirmed (60 s
+    /// from its stop), B streaming and quiet (600 s from its last line). A
+    /// timer that kept one alarm for the whole app, or one deadline for the
+    /// whole table, fails between the two advances below.
+    @Test("two sessions arm and retire independently through the one timer")
+    func twoSessionsRetireIndependently() async throws {
+        let suite = "tbd-provisional-publish-\(UUID().uuidString)"
+        defer { Self.removeSuite(suite) }
+        let source = try await Self.sourceWithCompletedMessage(now: Self.t0)
+        let streamingPath = try Self.streamFileWithOneTextLine()
+        #expect(await source.refreshStream(sessionID: "s2", path: streamingPath, now: Self.t0))
+        let state = await Self.makeState(streaming: true, suite: suite)
+        let clock = TestClock()
+        let date = MovableDate(Self.t0)
+        let scheduler = TranscriptPollScheduler(source: source, clock: clock)
+        let timer = Self.timerForMountingPane(scheduler)
+
+        await TableTranscriptPaneView.publish(
+            sessionID: "s1", state: state, source: source,
+            retireTimer: timer, now: { date.now })
+        // A's alarm is the only sleeper on this clock, so waiting for one
+        // proves *it* is armed before any virtual time moves. B's may register
+        // a moment later, which is why the advance that fires it is generous
+        // rather than exact; A's is not, because "A retires on its own minute"
+        // is the claim being made.
+        await clock.waitForSuspension()
+        await TableTranscriptPaneView.publish(
+            sessionID: "s2", state: state, source: source,
+            retireTimer: timer, now: { date.now })
+        #expect(await Self.publishedIDs(state) == ["stream:msg_a"])
+        #expect(await Self.publishedIDs(state, session: "s2") == ["stream:msg_a"])
+        #expect(await timer.armedSessionCount == 2, "one timer, two live alarms")
+
+        // A's minute is up; B's ten are not.
+        date.advance(by: 61)
+        await clock.advance(by: .seconds(61))
+        let aWithdrawn = await pollUntilTrue(timeout: .seconds(10)) {
+            await Self.publishedIDs(state).isEmpty
+        }
+        #expect(aWithdrawn == .satisfied, "A retires on the unconfirmed rule")
+        #expect(await Self.publishedIDs(state, session: "s2") == ["stream:msg_a"],
+                "and B's row is untouched by it")
+        #expect(await timer.armedMessage(sessionID: "s2") == "msg_a",
+                "B's alarm is still pending on its own, longer window")
+
+        // And B's, on its own deadline rather than A's.
+        date.advance(by: 540)
+        await clock.advance(by: .seconds(700))
+        let bWithdrawn = await pollUntilTrue(timeout: .seconds(10)) {
+            await Self.publishedIDs(state, session: "s2").isEmpty
+        }
+        #expect(bWithdrawn == .satisfied, "B retires on the silent-stream rule")
+        let cleared = await pollUntilTrue(timeout: .seconds(10)) {
+            await timer.armedSessionCount == 0
+        }
+        #expect(cleared == .satisfied, "and neither alarm re-arms after firing")
+    }
+
+    /// A remount, which used to be the moment a second timer appeared. Now it
+    /// is the moment a pane finds the alarm the previous one armed, and the
+    /// property to pin is that the row retires exactly once, on the deadline it
+    /// was given before the remount.
+    @Test("a remounted pane finds the same timer and retires the row it inherited")
     func aRemountedPaneStillRetiresTheRightSession() async throws {
         let suite = "tbd-provisional-publish-\(UUID().uuidString)"
         defer { Self.removeSuite(suite) }
@@ -682,33 +821,35 @@ struct ProvisionalRowPublishTests {
         try await Self.addPlainTranscript(to: source, sessionID: "s2")
         let state = await Self.makeState(streaming: true, suite: suite)
         let clock = TestClock()
+        let scheduler = TranscriptPollScheduler(source: source, clock: clock)
 
-        // Mount one: the pane's own timer arms A's 60-second backstop.
-        let firstTimer = ProvisionalRetireTimer(clock: clock)
+        // Mount one arms A's 60-second backstop.
+        let mounted = Self.timerForMountingPane(scheduler)
         await TableTranscriptPaneView.publish(
             sessionID: "s1", state: state, source: source,
-            retireTimer: firstTimer, now: { date.now })
-        #expect(await firstTimer.armedMessage(sessionID: "s1") == "msg_a")
+            retireTimer: mounted, now: { date.now })
+        #expect(await mounted.armedMessage(sessionID: "s1") == "msg_a")
 
-        // The remount. A second instance takes the scheduler's on-change slot;
-        // the first is unreachable from the app but its alarm is still asleep.
+        // The remount, half-way through the window.
         date.advance(by: 30)
         await clock.advanceWhenSuspended(by: .seconds(30))
-        let secondTimer = ProvisionalRetireTimer(clock: clock)
+        let remounted = Self.timerForMountingPane(scheduler)
+        #expect(remounted === mounted, "a remount finds the timer, it does not build one")
         await TableTranscriptPaneView.publish(
             sessionID: "s1", state: state, source: source,
-            retireTimer: secondTimer, now: { date.now })
-        #expect(await secondTimer.armedMessage(sessionID: "s1") == "msg_a",
-                "the new instance arms the same row for the remainder of its window")
+            retireTimer: remounted, now: { date.now })
+        #expect(await remounted.armedMessage(sessionID: "s1") == "msg_a",
+                "the row it inherited is still armed, on its original deadline")
+        #expect(await remounted.armedSessionCount == 1)
         #expect(await Self.publishedIDs(state) == ["stream:msg_a"])
 
-        // A publish for another session through the new instance, the case the
+        // A publish for another session through the same timer, the case the
         // keying exists for.
         await TableTranscriptPaneView.publish(
             sessionID: "s2", state: state, source: source,
-            retireTimer: secondTimer, now: { date.now })
-        #expect(await secondTimer.armedMessage(sessionID: "s1") == "msg_a",
-                "B's publish through the new timer must not disarm A")
+            retireTimer: remounted, now: { date.now })
+        #expect(await remounted.armedMessage(sessionID: "s1") == "msg_a",
+                "B's publish must not disarm A")
 
         date.advance(by: 31)
         await clock.advance(by: .seconds(31))
@@ -716,21 +857,13 @@ struct ProvisionalRowPublishTests {
             await Self.publishedIDs(state).isEmpty
         }
         #expect(withdrawn == .satisfied,
-                "whichever instance woke up, the re-publish retires A's row")
+                "the row retires on the deadline it was given before the remount")
         #expect(await Self.publishedIDs(state, session: "s2").isEmpty == false,
-                "and B's transcript is untouched by either instance")
-        // Both alarms were due at the same virtual instant and clear themselves
-        // as they fire, so this is polled rather than read once: which of the
-        // two finishes first is not something the test gets to decide.
+                "and B's transcript is untouched")
         let cleared = await pollUntilTrue(timeout: .seconds(10)) {
-            // Read both, then compare: `&&` takes its right side as a
-            // nonisolated autoclosure, which cannot await an actor's property.
-            let abandoned = await firstTimer.armedSessionCount
-            let live = await secondTimer.armedSessionCount
-            return abandoned == 0 && live == 0
+            await remounted.armedSessionCount == 0
         }
-        #expect(cleared == .satisfied,
-                "neither the abandoned instance nor the live one re-arms after firing")
+        #expect(cleared == .satisfied, "and nothing re-arms after firing")
     }
 
     /// One text line, no terminal line: what a stream in flight and a proxy

--- a/Tests/TBDAppTests/StreamFileReaderTests.swift
+++ b/Tests/TBDAppTests/StreamFileReaderTests.swift
@@ -192,6 +192,30 @@ struct StreamFileReaderTests {
             == .complete(at: Self.now.addingTimeInterval(60)))
     }
 
+    /// The successor exists but has said nothing yet, and the message before
+    /// it finished. Selection is "most recent *with text*", so the finished
+    /// message keeps the row — and it must keep its `.complete` phase too, or a
+    /// pane would show a settled answer as though it were still streaming and
+    /// C4's retire rules would never start their clock.
+    @Test("A completed message survives an empty successor, phase intact")
+    func completedMessageOutlivesAnEmptySuccessor() {
+        let folded = StreamFileReader.fold(
+            lines: [
+                .start(message: "msg_a", at: Self.started),
+                .text(message: "msg_a", index: 0, text: "the answer"),
+                .stop(message: "msg_a"),
+                .start(message: "msg_b", at: Self.started.addingTimeInterval(1)),
+            ],
+            now: Self.now
+        )
+
+        #expect(folded == ProvisionalMessage(
+            messageID: "msg_a",
+            text: "the answer",
+            phase: .complete(at: Self.now)
+        ))
+    }
+
     // MARK: - Degenerate input
 
     @Test("No lines folds to nil")

--- a/Tests/TBDAppTests/StreamFileReaderTests.swift
+++ b/Tests/TBDAppTests/StreamFileReaderTests.swift
@@ -26,7 +26,8 @@ struct StreamFileReaderTests {
             now: Self.now
         )
 
-        #expect(folded == ProvisionalMessage(messageID: "msg_a", text: "Hello, world", phase: .streaming))
+        #expect(folded == ProvisionalMessage(
+            messageID: "msg_a", text: "Hello, world", phase: .streaming, lastLineAt: Self.now))
     }
 
     /// The blocks arrive interleaved and out of order on purpose: the reader
@@ -64,7 +65,8 @@ struct StreamFileReaderTests {
             now: Self.now
         )
 
-        #expect(folded == ProvisionalMessage(messageID: "msg_new", text: "fresh", phase: .streaming))
+        #expect(folded == ProvisionalMessage(
+            messageID: "msg_new", text: "fresh", phase: .streaming, lastLineAt: Self.now))
     }
 
     /// Two parents in flight against one route interleave their lines. The
@@ -83,7 +85,8 @@ struct StreamFileReaderTests {
             now: Self.now
         )
 
-        #expect(folded == ProvisionalMessage(messageID: "msg_b", text: "bbb", phase: .streaming))
+        #expect(folded == ProvisionalMessage(
+            messageID: "msg_b", text: "bbb", phase: .streaming, lastLineAt: Self.now))
     }
 
     @Test("A started message with no text yet wins only when nothing else has text")
@@ -92,7 +95,8 @@ struct StreamFileReaderTests {
             lines: [.start(message: "msg_a", at: Self.started), .block(message: "msg_a", index: 0)],
             now: Self.now
         )
-        #expect(onlyStarted == ProvisionalMessage(messageID: "msg_a", text: "", phase: .streaming))
+        #expect(onlyStarted == ProvisionalMessage(
+            messageID: "msg_a", text: "", phase: .streaming, lastLineAt: Self.now))
 
         let alongsideText = StreamFileReader.fold(
             lines: [
@@ -103,7 +107,8 @@ struct StreamFileReaderTests {
             ],
             now: Self.now
         )
-        #expect(alongsideText == ProvisionalMessage(messageID: "msg_a", text: "has text", phase: .streaming))
+        #expect(alongsideText == ProvisionalMessage(
+            messageID: "msg_a", text: "has text", phase: .streaming, lastLineAt: Self.now))
     }
 
     /// Truncation happens only when nothing is in flight, but a reader that
@@ -122,7 +127,8 @@ struct StreamFileReaderTests {
         #expect(folded == ProvisionalMessage(
             messageID: "msg_torn",
             text: "orphan text",
-            phase: .complete(at: Self.now)
+            phase: .complete(at: Self.now),
+            lastLineAt: Self.now
         ))
     }
 
@@ -156,7 +162,8 @@ struct StreamFileReaderTests {
         #expect(folded == ProvisionalMessage(
             messageID: "msg_a",
             text: "partial",
-            phase: .aborted(reason: "upstream connection dropped")
+            phase: .aborted(reason: "upstream connection dropped"),
+            lastLineAt: Self.now
         ))
     }
 
@@ -212,7 +219,8 @@ struct StreamFileReaderTests {
         #expect(folded == ProvisionalMessage(
             messageID: "msg_a",
             text: "the answer",
-            phase: .complete(at: Self.now)
+            phase: .complete(at: Self.now),
+            lastLineAt: Self.now
         ))
     }
 
@@ -246,7 +254,8 @@ struct StreamFileReaderTests {
         #expect(StreamFileReader.fold(lines: decoded, now: Self.now) == ProvisionalMessage(
             messageID: "msg_a",
             text: "before-after",
-            phase: .complete(at: Self.now)
+            phase: .complete(at: Self.now),
+            lastLineAt: Self.now
         ))
     }
 }

--- a/Tests/TBDAppTests/StreamFileReaderTests.swift
+++ b/Tests/TBDAppTests/StreamFileReaderTests.swift
@@ -1,0 +1,228 @@
+import Foundation
+import Testing
+@testable import TBDApp
+@testable import TBDShared
+
+/// The fold from tagged stream-file lines to the one message the app renders:
+/// which message wins, how its text is assembled, and how it ends.
+@Suite("StreamFileReader")
+struct StreamFileReaderTests {
+
+    private static let now = Date(timeIntervalSince1970: 1_700_000_000)
+    private static let started = Date(timeIntervalSince1970: 1_699_999_999)
+
+    // MARK: - Text assembly
+
+    @Test("Deltas of one block concatenate in arrival order")
+    func deltasConcatenateInArrivalOrder() {
+        let folded = StreamFileReader.fold(
+            lines: [
+                .start(message: "msg_a", at: Self.started),
+                .block(message: "msg_a", index: 0),
+                .text(message: "msg_a", index: 0, text: "Hel"),
+                .text(message: "msg_a", index: 0, text: "lo, "),
+                .text(message: "msg_a", index: 0, text: "world"),
+            ],
+            now: Self.now
+        )
+
+        #expect(folded == ProvisionalMessage(messageID: "msg_a", text: "Hello, world", phase: .streaming))
+    }
+
+    /// The blocks arrive interleaved and out of order on purpose: the reader
+    /// must order by block index, not by the order the deltas landed.
+    @Test("Text blocks concatenate by ascending index, not arrival order")
+    func blocksConcatenateByIndexOrder() {
+        let folded = StreamFileReader.fold(
+            lines: [
+                .start(message: "msg_a", at: Self.started),
+                .block(message: "msg_a", index: 2),
+                .text(message: "msg_a", index: 2, text: "third"),
+                .block(message: "msg_a", index: 0),
+                .text(message: "msg_a", index: 0, text: "first"),
+                .text(message: "msg_a", index: 2, text: "-tail"),
+                .text(message: "msg_a", index: 1, text: "second"),
+            ],
+            now: Self.now
+        )
+
+        #expect(folded?.text == "firstsecondthird-tail")
+    }
+
+    // MARK: - Which message wins
+
+    @Test("A later start supersedes the earlier message")
+    func laterStartSupersedes() {
+        let folded = StreamFileReader.fold(
+            lines: [
+                .start(message: "msg_old", at: Self.started),
+                .text(message: "msg_old", index: 0, text: "stale"),
+                .stop(message: "msg_old"),
+                .start(message: "msg_new", at: Self.started),
+                .text(message: "msg_new", index: 0, text: "fresh"),
+            ],
+            now: Self.now
+        )
+
+        #expect(folded == ProvisionalMessage(messageID: "msg_new", text: "fresh", phase: .streaming))
+    }
+
+    /// Two parents in flight against one route interleave their lines. The
+    /// most recently started message that has text is the one to render.
+    @Test("Interleaved two-message lines pick the most recent that has text")
+    func interleavedLinesPickMostRecentWithText() {
+        let folded = StreamFileReader.fold(
+            lines: [
+                .start(message: "msg_a", at: Self.started),
+                .text(message: "msg_a", index: 0, text: "aaa"),
+                .start(message: "msg_b", at: Self.started),
+                .text(message: "msg_a", index: 0, text: "AAA"),
+                .text(message: "msg_b", index: 0, text: "bbb"),
+                .text(message: "msg_a", index: 0, text: "!"),
+            ],
+            now: Self.now
+        )
+
+        #expect(folded == ProvisionalMessage(messageID: "msg_b", text: "bbb", phase: .streaming))
+    }
+
+    @Test("A started message with no text yet wins only when nothing else has text")
+    func startedWithoutTextWinsOnlyWhenAloneInHavingNone() {
+        let onlyStarted = StreamFileReader.fold(
+            lines: [.start(message: "msg_a", at: Self.started), .block(message: "msg_a", index: 0)],
+            now: Self.now
+        )
+        #expect(onlyStarted == ProvisionalMessage(messageID: "msg_a", text: "", phase: .streaming))
+
+        let alongsideText = StreamFileReader.fold(
+            lines: [
+                .start(message: "msg_a", at: Self.started),
+                .text(message: "msg_a", index: 0, text: "has text"),
+                .start(message: "msg_b", at: Self.started),
+                .block(message: "msg_b", index: 0),
+            ],
+            now: Self.now
+        )
+        #expect(alongsideText == ProvisionalMessage(messageID: "msg_a", text: "has text", phase: .streaming))
+    }
+
+    /// Truncation happens only when nothing is in flight, but a reader that
+    /// resumed mid-file still sees a head whose `start` is gone. Such a message
+    /// counts, keyed by the id its own lines carry.
+    @Test("A message whose start was truncated away still counts")
+    func tornHeadWithoutStartStillCounts() {
+        let folded = StreamFileReader.fold(
+            lines: [
+                .text(message: "msg_torn", index: 0, text: "orphan text"),
+                .stop(message: "msg_torn"),
+            ],
+            now: Self.now
+        )
+
+        #expect(folded == ProvisionalMessage(
+            messageID: "msg_torn",
+            text: "orphan text",
+            phase: .complete(at: Self.now)
+        ))
+    }
+
+    // MARK: - Phase
+
+    @Test("stop completes the message at the fold's now")
+    func stopCompletesAtNow() {
+        let folded = StreamFileReader.fold(
+            lines: [
+                .start(message: "msg_a", at: Self.started),
+                .text(message: "msg_a", index: 0, text: "done"),
+                .stop(message: "msg_a"),
+            ],
+            now: Self.now
+        )
+
+        #expect(folded?.phase == .complete(at: Self.now))
+    }
+
+    @Test("aborted carries its reason")
+    func abortedCarriesReason() {
+        let folded = StreamFileReader.fold(
+            lines: [
+                .start(message: "msg_a", at: Self.started),
+                .text(message: "msg_a", index: 0, text: "partial"),
+                .aborted(message: "msg_a", reason: "upstream connection dropped"),
+            ],
+            now: Self.now
+        )
+
+        #expect(folded == ProvisionalMessage(
+            messageID: "msg_a",
+            text: "partial",
+            phase: .aborted(reason: "upstream connection dropped")
+        ))
+    }
+
+    @Test("The last terminal line for a message wins")
+    func lastTerminalLineWins() {
+        let folded = StreamFileReader.fold(
+            lines: [
+                .start(message: "msg_a", at: Self.started),
+                .text(message: "msg_a", index: 0, text: "partial"),
+                .aborted(message: "msg_a", reason: "tee gave up"),
+                .stop(message: "msg_a"),
+            ],
+            now: Self.now
+        )
+
+        #expect(folded?.phase == .complete(at: Self.now))
+    }
+
+    /// A fold is stable in `now`: the caller records the instant it first saw
+    /// the stop and passes the same value back, so the 60-second unconfirmed
+    /// rule measures from first sight rather than from the latest poll.
+    @Test("The same lines and the same now fold to the same completion instant")
+    func foldIsStableInNow() {
+        let lines: [ModelProxyStreamLine] = [
+            .start(message: "msg_a", at: Self.started),
+            .text(message: "msg_a", index: 0, text: "done"),
+            .stop(message: "msg_a"),
+        ]
+
+        #expect(StreamFileReader.fold(lines: lines, now: Self.now)
+            == StreamFileReader.fold(lines: lines, now: Self.now))
+        #expect(StreamFileReader.fold(lines: lines, now: Self.now.addingTimeInterval(60))?.phase
+            == .complete(at: Self.now.addingTimeInterval(60)))
+    }
+
+    // MARK: - Degenerate input
+
+    @Test("No lines folds to nil")
+    func emptyFoldsToNil() {
+        #expect(StreamFileReader.fold(lines: [], now: Self.now) == nil)
+    }
+
+    @Test("Lines that carry no message and no start fold to nil")
+    func blocksWithoutTextOrStartFoldToNil() {
+        #expect(StreamFileReader.fold(lines: [.block(message: "msg_a", index: 0)], now: Self.now) == nil)
+    }
+
+    /// Exercises the whole path a tailer takes: raw text lines through
+    /// `decode`, one of them garbage, the survivors folded.
+    @Test("A malformed line is skipped and the rest still fold")
+    func malformedLinesAreSkipped() throws {
+        let raw = try [
+            ModelProxyStreamLine.start(message: "msg_a", at: Self.started).encodedLine(),
+            ModelProxyStreamLine.text(message: "msg_a", index: 0, text: "before").encodedLine(),
+            #"{"type":"text","message":"msg_a","index":0,"tex"#,  // a line caught mid-append
+            ModelProxyStreamLine.text(message: "msg_a", index: 0, text: "-after").encodedLine(),
+            ModelProxyStreamLine.stop(message: "msg_a").encodedLine(),
+        ]
+
+        let decoded = raw.compactMap(ModelProxyStreamLine.decode(line:))
+        #expect(decoded.count == raw.count - 1)
+
+        #expect(StreamFileReader.fold(lines: decoded, now: Self.now) == ProvisionalMessage(
+            messageID: "msg_a",
+            text: "before-after",
+            phase: .complete(at: Self.now)
+        ))
+    }
+}

--- a/Tests/TBDAppTests/TranscriptPaneRegistrationTests.swift
+++ b/Tests/TBDAppTests/TranscriptPaneRegistrationTests.swift
@@ -62,4 +62,31 @@ struct TranscriptPaneRegistrationTests {
         #expect(TranscriptPaneTransport.resolve(path: "/tmp/session.jsonl")
                 == .appSide(path: "/tmp/session.jsonl"))
     }
+
+    /// An empty stream path means "no stream file", the same as nil — otherwise
+    /// the registration would have every tick stat `""` forever.
+    @Test("an empty stream path registers as no stream path at all")
+    func emptyStreamPathIsCarriedAsNil() async {
+        let scheduler = TranscriptPollScheduler(source: TranscriptSource())
+        let pane = TranscriptPaneToken()
+        await TranscriptPaneRegistration.apply(
+            sessionID: "s1", path: "/tmp/whatever", streamPath: "",
+            tier: .foreground, token: pane, scheduler: scheduler)
+        #expect(await scheduler.registeredSessionIDs == ["s1"])
+        #expect(await scheduler.registeredStreamPath(sessionID: "s1") == nil)
+        await scheduler.deregister(sessionID: "s1", token: pane)
+    }
+
+    /// The other half, so the normalisation above cannot pass by dropping every
+    /// stream path.
+    @Test("a usable stream path is carried through to the registration")
+    func usableStreamPathIsCarried() async {
+        let scheduler = TranscriptPollScheduler(source: TranscriptSource())
+        let pane = TranscriptPaneToken()
+        await TranscriptPaneRegistration.apply(
+            sessionID: "s1", path: "/tmp/whatever", streamPath: "/tmp/stream.jsonl",
+            tier: .foreground, token: pane, scheduler: scheduler)
+        #expect(await scheduler.registeredStreamPath(sessionID: "s1") == "/tmp/stream.jsonl")
+        await scheduler.deregister(sessionID: "s1", token: pane)
+    }
 }

--- a/Tests/TBDAppTests/TranscriptPollSchedulerTests.swift
+++ b/Tests/TBDAppTests/TranscriptPollSchedulerTests.swift
@@ -1,6 +1,9 @@
+import Clocks
 import Foundation
 import Testing
 @testable import TBDApp
+@testable import TBDShared
+import TestSupport
 
 @Suite("TranscriptPollPolicy")
 struct TranscriptPollPolicyTests {
@@ -374,5 +377,64 @@ struct TranscriptPollSchedulerTests {
 
         await scheduler.deregister(sessionID: "s1", token: warm)
         #expect(await scheduler.registeredSessionIDs.isEmpty)
+    }
+}
+
+/// The scheduler's stream leg: the one tick that reads a second file and
+/// stamps what it reads with an instant the provisional row's retire deadlines
+/// are later measured against.
+///
+/// Its own suite because it drives a real poll task on a `TestClock`, which
+/// wants the clock-driven traits the registration tests above have no use for.
+@Suite("TranscriptPollSchedulerStream", .clockDriven, .serialized)
+struct TranscriptPollSchedulerStreamTests {
+
+    private static let transcriptLine = #"{"type":"user","uuid":"a","timestamp":"2026-08-26T10:00:00.000Z","message":{"role":"user","content":"hello"}}"#
+
+    /// A transcript and a stream file in one fenced directory. The stream file
+    /// carries a single text line and no terminal line, so what the tick reads
+    /// is a `.streaming` message whose deadline is measured from this stamp.
+    private static func files() throws -> (transcript: String, stream: String) {
+        let dir = fencedScratchRoot(prefix: "tbdsched")
+        try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        let transcript = dir + "/transcript.jsonl"
+        try (transcriptLine + "\n").write(toFile: transcript, atomically: true, encoding: .utf8)
+        let stream = dir + "/stream.jsonl"
+        let line = try ModelProxyStreamLine
+            .text(message: "msg_a", index: 0, text: "Hel").encodedLine()
+        try (line + "\n").write(toFile: stream, atomically: true, encoding: .utf8)
+        return (transcript, stream)
+    }
+
+    /// What discriminates: the injected date is deliberately years away from
+    /// any wall clock a test machine can be set to, so a bare `Date()` at the
+    /// refresh site cannot produce it. The value is not decoration — it is what
+    /// the silent-stream deadline is measured from, so a scheduler that stamps
+    /// its own `Date()` puts that deadline somewhere no test clock can reach.
+    @Test("a stream tick stamps its lines with the injected date, not the wall clock")
+    func streamTickUsesTheInjectedDate() async throws {
+        let files = try Self.files()
+        let stamp = Date(timeIntervalSince1970: 1_700_000_000)
+        let source = TranscriptSource()
+        let clock = TestClock()
+        let scheduler = TranscriptPollScheduler(
+            source: source, now: { stamp }, clock: clock)
+
+        let pane = TranscriptPaneToken()
+        await scheduler.register(
+            sessionID: "s1", path: files.transcript, streamPath: files.stream,
+            tier: .foreground, token: pane)
+        await clock.advanceWhenSuspended(by: .milliseconds(100))
+
+        let tailed = await pollUntilTrue(timeout: .seconds(10)) {
+            await source.provisional(sessionID: "s1") != nil
+        }
+        #expect(tailed == .satisfied, "the tick must have read the stream file")
+        let provisional = await source.provisional(sessionID: "s1")
+        #expect(provisional?.messageID == "msg_a")
+        #expect(provisional?.lastLineAt == stamp,
+                "the instant the retire deadline is measured from came from the seam")
+
+        await scheduler.deregister(sessionID: "s1", token: pane)
     }
 }

--- a/Tests/TBDAppTests/TranscriptPollSchedulerTests.swift
+++ b/Tests/TBDAppTests/TranscriptPollSchedulerTests.swift
@@ -66,6 +66,80 @@ struct TranscriptPollSchedulerTests {
         #expect(await scheduler.registeredSessionIDs.isEmpty)
     }
 
+    /// The provisional retire alarm's lifetime is the *registration's*, not any
+    /// pane's, and this is the seam that makes it so.
+    ///
+    /// Two claims, and each one fails a different wrong implementation. A pane
+    /// that is not the last holder must not take the alarm down — the survivor
+    /// is still showing the row it belongs to and a deadline rule is announced
+    /// by nothing, so nothing would ever re-arm it. And the last one leaving
+    /// must, because `deregister` forgets the session immediately afterwards
+    /// and an alarm that outlived that would publish an empty transcript for a
+    /// session nobody is watching.
+    @Test("the last holder leaving disarms the session's retire alarm; an earlier one does not")
+    func onlyTheLastHolderDisarmsTheRetireAlarm() async {
+        let scheduler = TranscriptPollScheduler(source: TranscriptSource(), clock: TestClock())
+        let first = TranscriptPaneToken()
+        let second = TranscriptPaneToken()
+        await scheduler.register(
+            sessionID: "s1", path: "/nonexistent", tier: .background, token: first)
+        await scheduler.register(
+            sessionID: "s1", path: "/nonexistent", tier: .background, token: second)
+
+        await scheduler.provisionalRetire.arm(
+            sessionID: "s1", messageID: "msg_a",
+            deadline: Date(timeIntervalSince1970: 1_700_000_060),
+            after: .seconds(60)) {}
+        #expect(await scheduler.provisionalRetire.armedMessage(sessionID: "s1") == "msg_a")
+
+        await scheduler.disarmProvisional(sessionID: "s1")
+        #expect(await scheduler.provisionalRetire.armedMessage(sessionID: "s1") == "msg_a",
+                "asked for while two panes hold the session, the disarm is refused")
+
+        await scheduler.deregister(sessionID: "s1", token: first)
+        #expect(await scheduler.provisionalRetire.armedMessage(sessionID: "s1") == "msg_a",
+                "one pane leaving must not strand the pane that stayed")
+
+        await scheduler.deregister(sessionID: "s1", token: second)
+        #expect(await scheduler.provisionalRetire.armedMessage(sessionID: "s1") == nil,
+                "the last holder leaving takes the alarm with it")
+        #expect(await scheduler.provisionalRetire.armedSessionCount == 0)
+    }
+
+    /// Two schedulers are two apps; one scheduler is one timer, however many
+    /// panes ask it for one. The property the pane relies on when it takes the
+    /// timer instead of building one.
+    @Test("every pane asking one scheduler for a retire timer gets the same instance")
+    func oneSchedulerOwnsOneRetireTimer() {
+        let scheduler = TranscriptPollScheduler(source: TranscriptSource())
+        let other = TranscriptPollScheduler(source: TranscriptSource())
+        #expect(scheduler.provisionalRetire === scheduler.provisionalRetire)
+        #expect(scheduler.provisionalRetire !== other.provisionalRetire)
+    }
+
+    /// The slot holds one closure for the whole app and the closures are
+    /// interchangeable, so the habit of re-seating it per mount buys nothing —
+    /// and that habit is what let a per-pane object ride into it.
+    @Test("a second pane's handler does not displace the first")
+    func theChangeHandlerIsInstalledOnce() async throws {
+        let scheduler = TranscriptPollScheduler(source: TranscriptSource())
+        let first = NotifyRecorder()
+        let second = NotifyRecorder()
+        await scheduler.setOnChangeIfUnset { await first.record($0) }
+        await scheduler.setOnChangeIfUnset { await second.record("second:" + $0) }
+
+        let pane = TranscriptPaneToken()
+        await scheduler.register(
+            sessionID: "s1", path: "/nonexistent", tier: .background, token: pane)
+        let generation = try #require(await scheduler.registeredGeneration(sessionID: "s1"))
+        await scheduler.finishTick(sessionID: "s1", generation: generation, hasNews: true)
+
+        #expect(await first.published == ["s1"])
+        #expect(await second.published.isEmpty)
+
+        await scheduler.deregister(sessionID: "s1", token: pane)
+    }
+
     private static let line = #"{"type":"user","uuid":"a","timestamp":"2026-08-26T10:00:00.000Z","message":{"role":"user","content":"hello"}}"#
 
     private func tempTranscript(_ name: String) throws -> String {
@@ -194,7 +268,7 @@ struct TranscriptPollSchedulerTests {
     func staleTickDoesNotPublish() async throws {
         let scheduler = TranscriptPollScheduler(source: TranscriptSource())
         let recorder = NotifyRecorder()
-        await scheduler.setOnChange { await recorder.record($0) }
+        await scheduler.setOnChangeIfUnset { await recorder.record($0) }
 
         let pane = TranscriptPaneToken()
         await scheduler.register(
@@ -214,7 +288,7 @@ struct TranscriptPollSchedulerTests {
     func liveTickPublishes() async throws {
         let scheduler = TranscriptPollScheduler(source: TranscriptSource())
         let recorder = NotifyRecorder()
-        await scheduler.setOnChange { await recorder.record($0) }
+        await scheduler.setOnChangeIfUnset { await recorder.record($0) }
 
         let pane = TranscriptPaneToken()
         await scheduler.register(
@@ -239,7 +313,7 @@ struct TranscriptPollSchedulerTests {
         let source = TranscriptSource()
         let scheduler = TranscriptPollScheduler(source: source)
         let recorder = NotifyRecorder()
-        await scheduler.setOnChange { await recorder.record($0) }
+        await scheduler.setOnChangeIfUnset { await recorder.record($0) }
 
         let closing = TranscriptPaneToken()
         let reopened = TranscriptPaneToken()
@@ -280,7 +354,7 @@ struct TranscriptPollSchedulerTests {
         let source = TranscriptSource()
         let scheduler = TranscriptPollScheduler(source: source)
         let recorder = NotifyRecorder()
-        await scheduler.setOnChange { await recorder.record($0) }
+        await scheduler.setOnChangeIfUnset { await recorder.record($0) }
 
         // The cadence is beside the point here; the slow tier is what keeps a
         // real poll tick from reaching the recorder while the test runs.
@@ -321,7 +395,7 @@ struct TranscriptPollSchedulerTests {
         let source = TranscriptSource()
         let scheduler = TranscriptPollScheduler(source: source)
         let recorder = NotifyRecorder()
-        await scheduler.setOnChange { await recorder.record($0) }
+        await scheduler.setOnChangeIfUnset { await recorder.record($0) }
 
         let first = TranscriptPaneToken()
         let second = TranscriptPaneToken()

--- a/Tests/TBDAppTests/TranscriptSourceStreamTests.swift
+++ b/Tests/TBDAppTests/TranscriptSourceStreamTests.swift
@@ -329,6 +329,81 @@ struct TranscriptSourceStreamTests {
                 "no part of the only message on screen may be dropped")
     }
 
+    /// Two parent requests in flight: the *older* message owns the last line
+    /// while a *newer* one holds the row.
+    ///
+    /// `msg_a` starts first and keeps appending; `msg_b` starts after it, says
+    /// its piece and stops; then `msg_a` pushes the file past the ceiling. The
+    /// fold renders `msg_b` — the most recent message with text, ranked by
+    /// where its first line appears — so the cap must not evict it.
+    ///
+    /// What discriminates: under the old `kept.last?.message` rule the
+    /// protected message is `msg_a`, the owner of the last line, which leaves
+    /// the already-ended `msg_b` as the oldest evictable message. Every one of
+    /// its lines is dropped and the fold falls back to `msg_a` — the row
+    /// rewinds to the earlier turn. This test then reads `msg_a`, not `msg_b`.
+    @Test("the cap keeps the newer of two interleaved messages, not the last line's owner")
+    func aNewerInterleavedMessageSurvivesTheCeiling() async throws {
+        let path = try Self.scratchDir() + "/stream.jsonl"
+        var lines: [ModelProxyStreamLine] = [
+            .start(message: "msg_a", at: Self.started),
+            .text(message: "msg_a", index: 0, text: "the older answer"),
+            .start(message: "msg_b", at: Self.started.addingTimeInterval(1)),
+            .text(message: "msg_b", index: 0, text: "the newer answer"),
+            .stop(message: "msg_b"),
+        ]
+        for _ in 0..<10_000 {
+            lines.append(.text(message: "msg_a", index: 0, text: "x"))
+        }
+        #expect(lines.count > 10_000, "the fixture must actually cross the ceiling")
+        try Self.write(try Self.lines(lines), to: path)
+
+        let source = TranscriptSource()
+        #expect(await source.refreshStream(sessionID: "s1", path: path, now: Self.t0))
+
+        let provisional = await source.provisional(sessionID: "s1")
+        #expect(provisional?.messageID == "msg_b",
+                "the cap may not evict the message the fold renders")
+        #expect(provisional?.text == "the newer answer",
+                "every line of the newer message must survive the eviction")
+        #expect(provisional?.phase == .complete(at: Self.t0))
+    }
+
+    /// The same interleaving with the names the other way round, and an
+    /// `aborted` end rather than a `stop`: `msg_b` is the one that starts first
+    /// and keeps appending, `msg_a` is the newer message that ends.
+    ///
+    /// What discriminates: as above, the old rule protects the last line's
+    /// owner `msg_b` and evicts the newer `msg_a` wholesale, so this test reads
+    /// `msg_b` and the older text. Ranking by first-line position protects
+    /// `msg_a`, and with nothing else ended the cap drops nothing at all.
+    @Test("the mirrored interleaving keeps the newer message too, aborted or not")
+    func aNewerInterleavedAbortedMessageSurvivesTheCeiling() async throws {
+        let path = try Self.scratchDir() + "/stream.jsonl"
+        var lines: [ModelProxyStreamLine] = [
+            .start(message: "msg_b", at: Self.started),
+            .text(message: "msg_b", index: 0, text: "the older answer"),
+            .start(message: "msg_a", at: Self.started.addingTimeInterval(1)),
+            .text(message: "msg_a", index: 0, text: "the newer answer"),
+            .aborted(message: "msg_a", reason: "the proxy died mid-turn"),
+        ]
+        for _ in 0..<10_000 {
+            lines.append(.text(message: "msg_b", index: 0, text: "x"))
+        }
+        #expect(lines.count > 10_000, "the fixture must actually cross the ceiling")
+        try Self.write(try Self.lines(lines), to: path)
+
+        let source = TranscriptSource()
+        #expect(await source.refreshStream(sessionID: "s1", path: path, now: Self.t0))
+
+        let provisional = await source.provisional(sessionID: "s1")
+        #expect(provisional?.messageID == "msg_a",
+                "the cap may not evict the message the fold renders")
+        #expect(provisional?.text == "the newer answer")
+        #expect(provisional?.phase == .aborted(reason: "the proxy died mid-turn"),
+                "an aborted message counts as ended, and is still the newest")
+    }
+
     // MARK: - Chunk-split equivalence
 
     /// Three messages: two that finished and one that has only started, with

--- a/Tests/TBDAppTests/TranscriptSourceStreamTests.swift
+++ b/Tests/TBDAppTests/TranscriptSourceStreamTests.swift
@@ -577,7 +577,7 @@ struct TranscriptStreamPollSchedulingTests {
         let clock = TestClock()
         let scheduler = TranscriptPollScheduler(source: source, clock: clock)
         let news = NewsLog()
-        await scheduler.setOnChange { sessionID in await news.record(sessionID) }
+        await scheduler.setOnChangeIfUnset { sessionID in await news.record(sessionID) }
 
         // Consume the transcript up front, so nothing there can move and the
         // stream file is the only thing left that can produce news.
@@ -622,7 +622,7 @@ struct TranscriptStreamPollSchedulingTests {
         let clock = TestClock()
         let scheduler = TranscriptPollScheduler(source: source, clock: clock)
         let news = NewsLog()
-        await scheduler.setOnChange { sessionID in await news.record(sessionID) }
+        await scheduler.setOnChangeIfUnset { sessionID in await news.record(sessionID) }
 
         await scheduler.register(
             sessionID: "s1", path: transcriptPath, tier: .background,

--- a/Tests/TBDAppTests/TranscriptSourceStreamTests.swift
+++ b/Tests/TBDAppTests/TranscriptSourceStreamTests.swift
@@ -284,6 +284,38 @@ struct TranscriptSourceStreamTests {
         #expect(provisional?.text.isEmpty == true)
     }
 
+    /// The cap must never take the *newest* message, which is what makes it
+    /// inert while a single turn is the only thing resident.
+    ///
+    /// A long answer crosses the ceiling and then ends on the same tick its
+    /// `stop` lands. Dropping it there leaves nothing to fold, the fold's
+    /// "found nothing keeps the prior provisional" rule takes over, and the row
+    /// is stranded at `.streaming` holding a partial answer that nothing can
+    /// ever complete. This test fails on exactly that path: without the
+    /// exclusion the fold returns nil, `refreshStream` reports no news, and no
+    /// provisional exists at all.
+    @Test("a single message past the ceiling still completes with its full text")
+    func aLoneMessagePastTheCeilingSurvivesItsOwnStop() async throws {
+        let path = try Self.scratchDir() + "/stream.jsonl"
+        var lines: [ModelProxyStreamLine] = [.start(message: "msg_a", at: Self.started)]
+        for _ in 0..<10_001 {
+            lines.append(.text(message: "msg_a", index: 0, text: "x"))
+        }
+        lines.append(.stop(message: "msg_a"))
+        #expect(lines.count > 10_000, "the fixture must actually cross the ceiling")
+        try Self.write(try Self.lines(lines), to: path)
+
+        let source = TranscriptSource()
+        #expect(await source.refreshStream(sessionID: "s1", path: path, now: Self.t0))
+
+        let provisional = await source.provisional(sessionID: "s1")
+        #expect(provisional?.messageID == "msg_a")
+        #expect(provisional?.phase == .complete(at: Self.t0),
+                "the stop arrived in the same tick that crossed the ceiling")
+        #expect(provisional?.text.count == 10_001,
+                "no part of the only message on screen may be dropped")
+    }
+
     // MARK: - Transcript confirmation
 
     private static let assistantLine = #"{"type":"assistant","uuid":"a1","timestamp":"2026-08-26T10:00:00.000Z","message":{"role":"assistant","id":"msg_a","content":[{"type":"text","text":"hi"}]}}"#

--- a/Tests/TBDAppTests/TranscriptSourceStreamTests.swift
+++ b/Tests/TBDAppTests/TranscriptSourceStreamTests.swift
@@ -523,6 +523,20 @@ struct TranscriptSourceStreamTests {
 
     private static let assistantLine = #"{"type":"assistant","uuid":"a1","timestamp":"2026-08-26T10:00:00.000Z","message":{"role":"assistant","id":"msg_a","content":[{"type":"text","text":"hi"}]}}"#
 
+    /// The same message written the way Claude Code actually writes one that
+    /// opens with a thinking block: the thinking line first, on its own, and
+    /// the text line later under the same `message.id`.
+    private static let thinkingLine = #"{"type":"assistant","uuid":"a0","timestamp":"2026-08-26T10:00:00.000Z","message":{"role":"assistant","id":"msg_a","content":[{"type":"thinking","thinking":"weighing it up","signature":"sig"}]}}"#
+
+    /// The settled assistant-text strings among `items` — what confirmation
+    /// promises is on screen where the withdrawn provisional row stood.
+    private static func settledTexts(_ items: [TranscriptItem]) -> [String] {
+        items.compactMap { item in
+            if case .assistantText(_, let text, _, _) = item { return text }
+            return nil
+        }
+    }
+
     /// The confirmation signal C4's retire rule reads. Delegation, but to the
     /// *session's own* transcript: a message another session carries must not
     /// retire this one's row.
@@ -532,14 +546,48 @@ struct TranscriptSourceStreamTests {
         try Self.write(Self.assistantLine + "\n", to: path)
 
         let source = TranscriptSource()
-        #expect(await source.hasAssistantMessage(sessionID: "s1", id: "msg_a") == false,
+        #expect(await source.hasAssistantText(sessionID: "s1", id: "msg_a") == false,
                 "nothing has been read, so nothing confirms anything")
 
         await source.refresh(sessionID: "s1", path: path)
 
-        #expect(await source.hasAssistantMessage(sessionID: "s1", id: "msg_a"))
-        #expect(await source.hasAssistantMessage(sessionID: "s1", id: "msg_absent") == false)
-        #expect(await source.hasAssistantMessage(sessionID: "s2", id: "msg_a") == false)
+        #expect(await source.hasAssistantText(sessionID: "s1", id: "msg_a"))
+        #expect(await source.hasAssistantText(sessionID: "s1", id: "msg_absent") == false)
+        #expect(await source.hasAssistantText(sessionID: "s2", id: "msg_a") == false)
+    }
+
+    /// The snapshot the pane publishes from, over the two-line shape above: the
+    /// thinking line is not confirmation, the text line is, and confirmation
+    /// arrives in the same snapshot as the settled item that replaces the row.
+    @Test("a thinking-only line does not confirm; the text line does, with its item")
+    func onlyTheTextLineConfirmsTheStreamedMessage() async throws {
+        let dir = try Self.scratchDir()
+        let transcriptPath = dir + "/transcript.jsonl"
+        let streamPath = dir + "/stream.jsonl"
+        try Self.write(try Self.lines([
+            .start(message: "msg_a", at: Self.started),
+            .text(message: "msg_a", index: 0, text: "hi"),
+        ]), to: streamPath)
+        try Self.write(Self.thinkingLine + "\n", to: transcriptPath)
+
+        let source = TranscriptSource()
+        #expect(await source.refreshStream(sessionID: "s1", path: streamPath, now: Self.t0))
+        await source.refresh(sessionID: "s1", path: transcriptPath)
+
+        let midStream = await source.snapshot(sessionID: "s1")
+        #expect(midStream.provisional?.messageID == "msg_a")
+        #expect(midStream.confirmed == false,
+                "the id is in the JSONL, but its text is still streaming")
+        #expect(Self.settledTexts(midStream.items).isEmpty,
+                "and there is no settled item to replace the row with")
+
+        try Self.append(Self.assistantLine + "\n", to: transcriptPath)
+        await source.refresh(sessionID: "s1", path: transcriptPath)
+
+        let settled = await source.snapshot(sessionID: "s1")
+        #expect(settled.confirmed, "the text line confirms")
+        #expect(Self.settledTexts(settled.items) == ["hi"],
+                "and the item it built is in the very same snapshot")
     }
 }
 

--- a/Tests/TBDAppTests/TranscriptSourceStreamTests.swift
+++ b/Tests/TBDAppTests/TranscriptSourceStreamTests.swift
@@ -1,0 +1,431 @@
+import Clocks
+import Foundation
+import Testing
+@testable import TBDApp
+@testable import TBDShared
+import TestSupport
+
+/// `TranscriptSource`'s second file: the model-proxy stream file it tails
+/// beside the transcript JSONL, and the provisional message it folds out of it.
+///
+/// Real files on disk throughout — the point of this layer is the tailing, the
+/// offsets and the shrink rule, none of which a hand-built fixture exercises.
+/// Every file lives under the run's fenced scratch root, never `~/tbd`.
+@Suite("TranscriptSourceStream")
+struct TranscriptSourceStreamTests {
+
+    // MARK: - Fixtures
+
+    /// A directory of this test's own, under the root `scripts/test.sh`
+    /// reclaims even when the run is killed.
+    private static func scratchDir() throws -> String {
+        let dir = fencedScratchRoot(prefix: "tbdstream")
+        try FileManager.default.createDirectory(
+            atPath: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private static func write(_ text: String, to path: String) throws {
+        try text.write(toFile: path, atomically: true, encoding: .utf8)
+    }
+
+    /// Appends without replacing the file, so the reader sees growth at one
+    /// inode rather than a substitution.
+    private static func append(_ text: String, to path: String) throws {
+        let handle = try FileHandle(forWritingTo: URL(fileURLWithPath: path))
+        defer { try? handle.close() }
+        try handle.seekToEnd()
+        try handle.write(contentsOf: Data(text.utf8))
+    }
+
+    private static func lines(_ lines: [ModelProxyStreamLine]) throws -> String {
+        try lines.map { try $0.encodedLine() + "\n" }.joined()
+    }
+
+    private static let t0 = Date(timeIntervalSince1970: 1_700_000_000)
+    private static let started = Date(timeIntervalSince1970: 1_699_999_999)
+
+    // MARK: - Growth
+
+    @Test("a growing stream file yields growing text across two refreshes")
+    func growingFileYieldsGrowingText() async throws {
+        let path = try Self.scratchDir() + "/stream.jsonl"
+        try Self.write(try Self.lines([
+            .start(message: "msg_a", at: Self.started),
+            .text(message: "msg_a", index: 0, text: "Hello"),
+        ]), to: path)
+
+        let source = TranscriptSource()
+        #expect(await source.refreshStream(sessionID: "s1", path: path, now: Self.t0))
+        #expect(await source.provisional(sessionID: "s1")?.text == "Hello")
+
+        try Self.append(try Self.lines([
+            .text(message: "msg_a", index: 0, text: ", world"),
+        ]), to: path)
+
+        #expect(await source.refreshStream(sessionID: "s1", path: path, now: Self.t0))
+        #expect(await source.provisional(sessionID: "s1")?.text == "Hello, world")
+    }
+
+    /// A tick over a file nothing has written to is not news. Without this the
+    /// pane would be told to re-render on every 100 ms foreground poll.
+    @Test("a stream file that did not change reports no news")
+    func unchangedFileIsNotNews() async throws {
+        let path = try Self.scratchDir() + "/stream.jsonl"
+        try Self.write(try Self.lines([
+            .start(message: "msg_a", at: Self.started),
+            .text(message: "msg_a", index: 0, text: "Hello"),
+        ]), to: path)
+
+        let source = TranscriptSource()
+        #expect(await source.refreshStream(sessionID: "s1", path: path, now: Self.t0))
+        #expect(await source.refreshStream(sessionID: "s1", path: path, now: Self.t0) == false)
+        #expect(await source.provisional(sessionID: "s1")?.text == "Hello")
+    }
+
+    // MARK: - The shrink rule
+
+    /// The proxy truncates the file in place when nothing is in flight, so the
+    /// next turn starts at byte zero of the same path. Resuming from the old
+    /// offset would splice the retired turn's lines onto the new one.
+    @Test("a truncated stream file restarts and yields the new message")
+    func truncatedFileRestarts() async throws {
+        let path = try Self.scratchDir() + "/stream.jsonl"
+        try Self.write(try Self.lines([
+            .start(message: "msg_old", at: Self.started),
+            .text(message: "msg_old", index: 0, text: "a long since finished answer"),
+            .stop(message: "msg_old"),
+        ]), to: path)
+
+        let source = TranscriptSource()
+        #expect(await source.refreshStream(sessionID: "s1", path: path, now: Self.t0))
+        #expect(await source.provisional(sessionID: "s1")?.messageID == "msg_old")
+
+        // Strictly shorter than what was consumed.
+        try Self.write(try Self.lines([
+            .start(message: "msg_new", at: Self.started),
+            .text(message: "msg_new", index: 0, text: "new"),
+        ]), to: path)
+
+        #expect(await source.refreshStream(sessionID: "s1", path: path, now: Self.t0))
+        let provisional = await source.provisional(sessionID: "s1")
+        #expect(provisional?.messageID == "msg_new")
+        #expect(provisional?.text == "new", "the retired turn's deltas must not survive")
+        #expect(provisional?.phase == .streaming)
+    }
+
+    /// The second leg of the shrink rule, and it is not reachable through the
+    /// first. `offset` stops at the last newline, so a file whose tail is a
+    /// half-written line has `offset < lastSize` — and a replacement landing
+    /// between the two is shorter than the file we last saw while still being
+    /// longer than the bytes we consumed. Without the `size < lastSize` test
+    /// the reader resumes mid-line into content that no longer exists: the
+    /// partial line fails to decode, is skipped, and the pane keeps rendering
+    /// the previous message forever.
+    @Test("a file shorter than the last size but longer than the offset still restarts")
+    func fileShorterThanLastSizeRestarts() async throws {
+        let path = try Self.scratchDir() + "/stream.jsonl"
+        let head = try Self.lines([.text(message: "msg_old", index: 0, text: "old")])
+        // A long half-written line: no trailing newline, so it is withheld and
+        // the offset stays at the end of `head` while the size runs far past it.
+        try Self.write(head + #"{"index":0,"message":"msg_old","text":""# + String(repeating: "x", count: 5_000),
+                       to: path)
+
+        let source = TranscriptSource()
+        #expect(await source.refreshStream(sessionID: "s1", path: path, now: Self.t0))
+        #expect(await source.provisional(sessionID: "s1")?.text == "old")
+
+        let replacement = try Self.lines([
+            .text(message: "msg_new", index: 0, text: String(repeating: "n", count: 200)),
+        ])
+        #expect(replacement.utf8.count > head.utf8.count,
+                "the replacement must be longer than the consumed prefix, or this proves nothing")
+        try Self.write(replacement, to: path)
+
+        #expect(await source.refreshStream(sessionID: "s1", path: path, now: Self.t0))
+        #expect(await source.provisional(sessionID: "s1")?.messageID == "msg_new")
+    }
+
+    // MARK: - Failure handling
+
+    /// An unreadable file is no news, never a blank row: it is written by
+    /// another process that can be replacing it, and a pane must not lose the
+    /// answer on screen because one `stat` lost a race.
+    @Test("an unreadable stream file keeps the prior provisional and reports no news")
+    func unreadableFileKeepsPriorProvisional() async throws {
+        let dir = try Self.scratchDir()
+        let path = dir + "/stream.jsonl"
+        try Self.write(try Self.lines([
+            .start(message: "msg_a", at: Self.started),
+            .text(message: "msg_a", index: 0, text: "still here"),
+        ]), to: path)
+
+        let source = TranscriptSource()
+        #expect(await source.refreshStream(sessionID: "s1", path: path, now: Self.t0))
+
+        try FileManager.default.removeItem(atPath: path)
+        #expect(await source.refreshStream(sessionID: "s1", path: path, now: Self.t0) == false)
+        #expect(await source.provisional(sessionID: "s1")?.text == "still here")
+
+        // A path that never existed reads the same way, including the branch
+        // where the entry's recorded path differs from the one asked for.
+        #expect(await source.refreshStream(
+            sessionID: "s1", path: dir + "/never-written.jsonl", now: Self.t0) == false)
+        #expect(await source.provisional(sessionID: "s1")?.text == "still here")
+    }
+
+    // MARK: - Completion instant
+
+    /// `StreamFileReader.fold` stamps `.complete(at:)` with whatever `now` it
+    /// is handed and leaves the stability of that value to its caller. This is
+    /// the caller. If the instant moved with every poll, the deadline that
+    /// retires an unconfirmed message would never come due.
+    @Test("the completion instant is recorded once and reused on later refreshes")
+    func completionInstantIsStable() async throws {
+        let path = try Self.scratchDir() + "/stream.jsonl"
+        try Self.write(try Self.lines([
+            .start(message: "msg_a", at: Self.started),
+            .text(message: "msg_a", index: 0, text: "the answer"),
+            .stop(message: "msg_a"),
+        ]), to: path)
+
+        let source = TranscriptSource()
+        #expect(await source.refreshStream(sessionID: "s1", path: path, now: Self.t0))
+        #expect(await source.provisional(sessionID: "s1")?.phase == .complete(at: Self.t0))
+
+        let later = Self.t0.addingTimeInterval(120)
+        #expect(await source.refreshStream(sessionID: "s1", path: path, now: later) == false)
+        #expect(await source.provisional(sessionID: "s1")?.phase == .complete(at: Self.t0))
+
+        // A successor that has started but said nothing does not take the row,
+        // and must not restamp the finished message either.
+        try Self.append(try Self.lines([
+            .start(message: "msg_b", at: Self.started.addingTimeInterval(1)),
+        ]), to: path)
+        #expect(await source.refreshStream(sessionID: "s1", path: path, now: later) == false)
+        #expect(await source.provisional(sessionID: "s1")?.phase == .complete(at: Self.t0))
+    }
+
+    /// The reset half of the same rule: the recorded instant belongs to one
+    /// message id, so the next message completes at its own time.
+    @Test("a new message completing gets its own instant")
+    func completionInstantResetsWithTheMessage() async throws {
+        let path = try Self.scratchDir() + "/stream.jsonl"
+        try Self.write(try Self.lines([
+            .start(message: "msg_a", at: Self.started),
+            .text(message: "msg_a", index: 0, text: "first"),
+            .stop(message: "msg_a"),
+        ]), to: path)
+
+        let source = TranscriptSource()
+        #expect(await source.refreshStream(sessionID: "s1", path: path, now: Self.t0))
+
+        let later = Self.t0.addingTimeInterval(120)
+        try Self.append(try Self.lines([
+            .start(message: "msg_b", at: Self.started.addingTimeInterval(1)),
+            .text(message: "msg_b", index: 0, text: "second"),
+            .stop(message: "msg_b"),
+        ]), to: path)
+
+        #expect(await source.refreshStream(sessionID: "s1", path: path, now: later))
+        let provisional = await source.provisional(sessionID: "s1")
+        #expect(provisional?.messageID == "msg_b")
+        #expect(provisional?.phase == .complete(at: later))
+    }
+
+    // MARK: - Retention
+
+    @Test("forgetting a session drops its stream entry too")
+    func forgetDropsTheStreamEntry() async throws {
+        let path = try Self.scratchDir() + "/stream.jsonl"
+        try Self.write(try Self.lines([
+            .start(message: "msg_a", at: Self.started),
+            .text(message: "msg_a", index: 0, text: "hello"),
+        ]), to: path)
+
+        let source = TranscriptSource()
+        #expect(await source.refreshStream(sessionID: "s1", path: path, now: Self.t0))
+        #expect(await source.trackedStreamSessionCount == 1)
+
+        await source.forget(sessionID: "s1")
+
+        #expect(await source.provisional(sessionID: "s1") == nil)
+        #expect(await source.trackedStreamSessionCount == 0,
+                "a deregistered session must leave no stream tail resident")
+    }
+
+    // MARK: - The defensive cap
+
+    /// The ceiling exists for the case the proxy's own truncation does not
+    /// cover, and it drops whole messages that have already ended rather than
+    /// the head of whatever is in flight.
+    ///
+    /// The assertion is arranged so the cap is the only thing that can produce
+    /// it: the finished message is the one with text, so while its lines are
+    /// retained it wins the fold outright. Only once they are gone can the
+    /// started-but-silent successor hold the row.
+    @Test("passing the line ceiling drops the oldest message that has already ended")
+    func theOldestEndedMessageIsDroppedAtTheCeiling() async throws {
+        let path = try Self.scratchDir() + "/stream.jsonl"
+        var lines: [ModelProxyStreamLine] = [.start(message: "msg_a", at: Self.started)]
+        for _ in 0..<9_999 {
+            lines.append(.text(message: "msg_a", index: 0, text: "x"))
+        }
+        lines.append(.stop(message: "msg_a"))
+        lines.append(.start(message: "msg_b", at: Self.started.addingTimeInterval(1)))
+        #expect(lines.count > 10_000, "the fixture must actually cross the ceiling")
+        try Self.write(try Self.lines(lines), to: path)
+
+        let source = TranscriptSource()
+        #expect(await source.refreshStream(sessionID: "s1", path: path, now: Self.t0))
+
+        let provisional = await source.provisional(sessionID: "s1")
+        #expect(provisional?.messageID == "msg_b")
+        #expect(provisional?.text.isEmpty == true)
+    }
+
+    // MARK: - Transcript confirmation
+
+    private static let assistantLine = #"{"type":"assistant","uuid":"a1","timestamp":"2026-08-26T10:00:00.000Z","message":{"role":"assistant","id":"msg_a","content":[{"type":"text","text":"hi"}]}}"#
+
+    /// The confirmation signal C4's retire rule reads. Delegation, but to the
+    /// *session's own* transcript: a message another session carries must not
+    /// retire this one's row.
+    @Test("assistant message confirmation is scoped to the session's own transcript")
+    func assistantMessageConfirmationIsPerSession() async throws {
+        let path = try Self.scratchDir() + "/transcript.jsonl"
+        try Self.write(Self.assistantLine + "\n", to: path)
+
+        let source = TranscriptSource()
+        #expect(await source.hasAssistantMessage(sessionID: "s1", id: "msg_a") == false,
+                "nothing has been read, so nothing confirms anything")
+
+        await source.refresh(sessionID: "s1", path: path)
+
+        #expect(await source.hasAssistantMessage(sessionID: "s1", id: "msg_a"))
+        #expect(await source.hasAssistantMessage(sessionID: "s1", id: "msg_absent") == false)
+        #expect(await source.hasAssistantMessage(sessionID: "s2", id: "msg_a") == false)
+    }
+}
+
+/// The scheduler's half: a registered stream path is refreshed on the same tick
+/// as the transcript, at the same tier cadence, and a change to it alone is
+/// news.
+///
+/// `.clockDriven` is the hang guard for the virtual-time failure mode (a sleep
+/// nobody advances waits forever); `.serialized` because `TestClock.advance`
+/// megayields and clock-driven tests starve each other in parallel.
+@Suite("TranscriptStreamPollScheduling", .clockDriven, .serialized)
+struct TranscriptStreamPollSchedulingTests {
+
+    /// Records which sessions the scheduler announced as changed.
+    private actor NewsLog {
+        private(set) var sessions: [String] = []
+        func record(_ sessionID: String) { sessions.append(sessionID) }
+        var count: Int { sessions.count }
+    }
+
+    private static let userLine = #"{"type":"user","uuid":"a","timestamp":"2026-08-26T10:00:00.000Z","message":{"role":"user","content":"hello"}}"#
+
+    @Test("a registered stream file is polled at the tier cadence, and its change alone is news")
+    func streamChangeAloneIsNews() async throws {
+        let dir = fencedScratchRoot(prefix: "tbdstrsch")
+        try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        let transcriptPath = dir + "/transcript.jsonl"
+        let streamPath = dir + "/stream.jsonl"
+        try (Self.userLine + "\n").write(toFile: transcriptPath, atomically: true, encoding: .utf8)
+        // Present but empty: the terminal was routed through the proxy and no
+        // turn has run yet.
+        try "".write(toFile: streamPath, atomically: true, encoding: .utf8)
+
+        let source = TranscriptSource()
+        let clock = TestClock()
+        let scheduler = TranscriptPollScheduler(source: source, clock: clock)
+        let news = NewsLog()
+        await scheduler.setOnChange { sessionID in await news.record(sessionID) }
+
+        // Consume the transcript up front, so nothing there can move and the
+        // stream file is the only thing left that can produce news.
+        await source.refresh(sessionID: "s1", path: transcriptPath)
+
+        await scheduler.register(
+            sessionID: "s1", path: transcriptPath, streamPath: streamPath,
+            tier: .background, token: TranscriptPaneToken())
+
+        // Exactly one line, written whole: a window is truncated at its last
+        // newline, so a partial append is withheld rather than folded, and the
+        // count below stays a real assertion.
+        let line = try ModelProxyStreamLine
+            .text(message: "msg_a", index: 0, text: "hi from the proxy").encodedLine()
+        let handle = try FileHandle(forWritingTo: URL(fileURLWithPath: streamPath))
+        try handle.seekToEnd()
+        try handle.write(contentsOf: Data((line + "\n").utf8))
+        try handle.close()
+
+        let sawNews = await clock.advanceUntil(
+            "the scheduler to report the stream file's change",
+            by: TranscriptPollPolicy.background
+        ) { await news.count > 0 }
+        #expect(sawNews)
+
+        #expect(await news.sessions == ["s1"],
+                "only the stream file moved, and it moved once")
+        #expect(await source.provisional(sessionID: "s1")?.text == "hi from the proxy",
+                "the tick must have driven refreshStream, not only refresh")
+    }
+
+    /// The off branch: a registration with no stream path touches no second
+    /// file and builds no provisional, however long it polls.
+    @Test("a registration with no stream path never builds a provisional")
+    func noStreamPathBuildsNoProvisional() async throws {
+        let dir = fencedScratchRoot(prefix: "tbdstrsch")
+        try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        let transcriptPath = dir + "/transcript.jsonl"
+        try (Self.userLine + "\n").write(toFile: transcriptPath, atomically: true, encoding: .utf8)
+
+        let source = TranscriptSource()
+        let clock = TestClock()
+        let scheduler = TranscriptPollScheduler(source: source, clock: clock)
+        let news = NewsLog()
+        await scheduler.setOnChange { sessionID in await news.record(sessionID) }
+
+        await scheduler.register(
+            sessionID: "s1", path: transcriptPath, tier: .background,
+            token: TranscriptPaneToken())
+
+        let sawNews = await clock.advanceUntil(
+            "the scheduler to report the transcript's first read",
+            by: TranscriptPollPolicy.background
+        ) { await news.count > 0 }
+        #expect(sawNews, "the transcript itself must still be polled")
+        #expect(await source.provisional(sessionID: "s1") == nil)
+        #expect(await source.trackedStreamSessionCount == 0)
+    }
+
+    /// A changed stream path is a different file, so whatever a tick in flight
+    /// read describes something this registration no longer names — the same
+    /// reason a changed transcript path mints one.
+    @Test("changing the stream path mints a new generation")
+    func changedStreamPathMintsAGeneration() async {
+        let scheduler = TranscriptPollScheduler(source: TranscriptSource())
+        let pane = TranscriptPaneToken()
+
+        await scheduler.register(
+            sessionID: "s1", path: "/a", streamPath: "/stream-a",
+            tier: .background, token: pane)
+        let first = await scheduler.registeredGeneration(sessionID: "s1")
+
+        await scheduler.register(
+            sessionID: "s1", path: "/a", streamPath: "/stream-a",
+            tier: .foreground, token: pane)
+        #expect(await scheduler.registeredGeneration(sessionID: "s1") == first,
+                "re-declaring a tier is the same entry")
+
+        await scheduler.register(
+            sessionID: "s1", path: "/a", streamPath: "/stream-b",
+            tier: .foreground, token: pane)
+        #expect(await scheduler.registeredGeneration(sessionID: "s1") != first)
+
+        await scheduler.deregister(sessionID: "s1", token: pane)
+    }
+}

--- a/Tests/TBDAppTests/TranscriptSourceStreamTests.swift
+++ b/Tests/TBDAppTests/TranscriptSourceStreamTests.swift
@@ -267,6 +267,46 @@ struct TranscriptSourceStreamTests {
                 "a deregistered session must leave no stream tail resident")
     }
 
+    /// The same stability rule as the completion instant, for the deadline a
+    /// row that never stops retires on: it must move when a line for that
+    /// message lands and stay put otherwise, or the ten-minute silent-stream
+    /// window would be pushed forward by the polling itself and never come due.
+    @Test("the last-line instant moves only when a line for that message arrives")
+    func lastLineInstantMovesOnlyWithItsOwnMessage() async throws {
+        let path = try Self.scratchDir() + "/stream.jsonl"
+        try Self.write(try Self.lines([
+            .start(message: "msg_a", at: Self.started),
+            .text(message: "msg_a", index: 0, text: "Hel"),
+        ]), to: path)
+
+        let source = TranscriptSource()
+        #expect(await source.refreshStream(sessionID: "s1", path: path, now: Self.t0))
+        #expect(await source.provisional(sessionID: "s1")?.lastLineAt == Self.t0)
+
+        // A poll that finds the file unchanged reads nothing and moves nothing.
+        let later = Self.t0.addingTimeInterval(120)
+        #expect(await source.refreshStream(sessionID: "s1", path: path, now: later) == false)
+        #expect(await source.provisional(sessionID: "s1")?.lastLineAt == Self.t0)
+
+        // Nor does traffic for a *different* message: `msg_b` starting says
+        // nothing about whether `msg_a` is still alive, and `msg_a` still holds
+        // the row because `msg_b` has produced no text.
+        try Self.append(try Self.lines([
+            .start(message: "msg_b", at: Self.started.addingTimeInterval(1)),
+        ]), to: path)
+        #expect(await source.refreshStream(sessionID: "s1", path: path, now: later) == false)
+        #expect(await source.provisional(sessionID: "s1")?.messageID == "msg_a")
+        #expect(await source.provisional(sessionID: "s1")?.lastLineAt == Self.t0)
+
+        // A delta of its own does move it.
+        try Self.append(try Self.lines([
+            .text(message: "msg_a", index: 0, text: "lo"),
+        ]), to: path)
+        #expect(await source.refreshStream(sessionID: "s1", path: path, now: later))
+        #expect(await source.provisional(sessionID: "s1")?.text == "Hello")
+        #expect(await source.provisional(sessionID: "s1")?.lastLineAt == later)
+    }
+
     // MARK: - The defensive cap
 
     /// The ceiling exists for the case the proxy's own truncation does not

--- a/Tests/TBDAppTests/TranscriptSourceStreamTests.swift
+++ b/Tests/TBDAppTests/TranscriptSourceStreamTests.swift
@@ -5,6 +5,19 @@ import Testing
 @testable import TBDShared
 import TestSupport
 
+/// A deterministic generator, so a failing chunk split is reproducible from
+/// the seed rather than being a coin flip in CI.
+private struct SplitMix64: RandomNumberGenerator {
+    var state: UInt64
+    mutating func next() -> UInt64 {
+        state &+= 0x9E37_79B9_7F4A_7C15
+        var z = state
+        z = (z ^ (z >> 30)) &* 0xBF58_476D_1CE4_E5B9
+        z = (z ^ (z >> 27)) &* 0x94D0_49BB_1331_11EB
+        return z ^ (z >> 31)
+    }
+}
+
 /// `TranscriptSource`'s second file: the model-proxy stream file it tails
 /// beside the transcript JSONL, and the provisional message it folds out of it.
 ///
@@ -314,6 +327,81 @@ struct TranscriptSourceStreamTests {
                 "the stop arrived in the same tick that crossed the ceiling")
         #expect(provisional?.text.count == 10_001,
                 "no part of the only message on screen may be dropped")
+    }
+
+    // MARK: - Chunk-split equivalence
+
+    /// Three messages: two that finished and one that has only started, with
+    /// deltas carrying multi-byte characters and a marker the split chooser
+    /// aims at. The fold's answer is `msg_b` — the most recent message that has
+    /// *text*, since `msg_c` has produced none — completed at the reader's
+    /// `now`.
+    private static let chunkSplitFixture: [ModelProxyStreamLine] = [
+        .start(message: "msg_a", at: started),
+        .block(message: "msg_a", index: 0),
+        .text(message: "msg_a", index: 0, text: "Hello, "),
+        .text(message: "msg_a", index: 0, text: "wörld 🌍 — and a newline\nin the delta"),
+        .stop(message: "msg_a"),
+        .start(message: "msg_b", at: started.addingTimeInterval(1)),
+        .text(message: "msg_b", index: 0, text: "the second answer, SPLITME here, ✓"),
+        .text(message: "msg_b", index: 1, text: " and a second block"),
+        .stop(message: "msg_b"),
+        .start(message: "msg_c", at: started.addingTimeInterval(2)),
+    ]
+
+    /// The property the whole tailing layer exists to hold: **how** the bytes
+    /// arrive cannot change what a pane renders. The proxy's tee writes into
+    /// this file from another process, so a poll can land at any byte offset —
+    /// between two lines, inside a line's JSON, or inside a single multi-byte
+    /// character — and the same file delivered in any chunking must fold to the
+    /// same provisional message as the file read whole.
+    ///
+    /// Two of the splits are chosen rather than drawn, because they are the two
+    /// a naive tailer gets wrong: one lands inside a `text` line's JSON string
+    /// value, one inside the four bytes of an emoji. The rest are drawn from a
+    /// seeded generator, so a failure names the exact byte offsets that produced
+    /// it and can be replayed.
+    @Test(
+        "a file delivered in arbitrary chunks folds to what the whole file folds to",
+        arguments: [UInt64(0x5EED), 0x7A11, 0xC0FF_EE00, 0xD15E_A5E0])
+    func arbitraryChunkSplitsFoldToTheWholeFile(seed: UInt64) async throws {
+        let path = try Self.scratchDir() + "/stream.jsonl"
+        let lines = Self.chunkSplitFixture
+        let data = Data(try Self.lines(lines).utf8)
+
+        // Inside a `text` line's JSON string value, and inside the four bytes
+        // of "🌍". `#require`, not `if let`: a fixture that stopped containing
+        // either would leave this test drawing only ordinary offsets and still
+        // passing.
+        let insideJSONString = try #require(data.range(of: Data("SPLITME".utf8))).lowerBound + 3
+        let insideMultiByte = try #require(data.range(of: Data("🌍".utf8))).lowerBound + 2
+
+        var generator = SplitMix64(state: seed)
+        var offsets: Set<Int> = [insideJSONString, insideMultiByte]
+        for _ in 0..<12 {
+            offsets.insert(Int(generator.next() % UInt64(data.count - 1)) + 1)
+        }
+        let splits = offsets.filter { $0 > 0 && $0 < data.count }.sorted()
+        let replay = "seed=0x\(String(seed, radix: 16)) splits=\(splits) of \(data.count) bytes"
+
+        try Self.write("", to: path)
+        let handle = try FileHandle(forWritingTo: URL(fileURLWithPath: path))
+        defer { try? handle.close() }
+        let source = TranscriptSource()
+        var start = 0
+        for end in splits + [data.count] {
+            try handle.seekToEnd()
+            try handle.write(contentsOf: data.subdata(in: start..<end))
+            start = end
+            _ = await source.refreshStream(sessionID: "s1", path: path, now: Self.t0)
+        }
+
+        let whole = StreamFileReader.fold(lines: lines, now: Self.t0)
+        #expect(whole?.messageID == "msg_b",
+                "the fixture must fold to a completed message, or this proves nothing")
+        #expect(whole?.phase == .complete(at: Self.t0))
+        #expect(await source.provisional(sessionID: "s1") == whole,
+                "chunked delivery must land on the whole-file fold — \(replay)")
     }
 
     // MARK: - Transcript confirmation

--- a/Tests/TBDAppTests/TranscriptStreamingFlagTests.swift
+++ b/Tests/TBDAppTests/TranscriptStreamingFlagTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Testing
+@testable import TBDApp
+import TBDShared
+
+/// `AppState.transcriptStreamingEnabled` — the single place the app asks
+/// whether a transcript pane should tail a model-proxy stream file at all.
+///
+/// Every test constructs `AppState` against a unique throwaway `UserDefaults`
+/// suite and tears it down: TBDApp ships as an unbundled SPM executable, so
+/// `UserDefaults.standard` is the running developer's real `TBDApp.plist`.
+@MainActor
+@Suite("TranscriptStreamingFlag")
+struct TranscriptStreamingFlagTests {
+
+    private func withAppState(_ body: (AppState) async -> Void) async {
+        let name = "tbd-transcript-streaming-flag-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: name)!
+        await body(AppState(userDefaults: defaults))
+        defaults.removePersistentDomain(forName: name)
+    }
+
+    /// The app is launched by `open`, which drops shell env, so capabilities
+    /// are nil until the first RPC lands. Reading that as "off" is what keeps a
+    /// provisional row from appearing and then vanishing a moment later.
+    @Test("capabilities that have not arrived read as off")
+    func nilCapabilitiesReadAsOff() async {
+        await withAppState { state in
+            #expect(state.daemonCapabilities == nil)
+            #expect(state.transcriptStreamingEnabled == false)
+        }
+    }
+
+    @Test("the daemon reporting streaming on turns it on")
+    func capabilityOnEnables() async {
+        await withAppState { state in
+            state.daemonCapabilities = DaemonCapabilitiesResult(
+                controlModeEnabled: false, transcriptStreamingEnabled: true)
+
+            #expect(state.transcriptStreamingEnabled)
+        }
+    }
+
+    /// The off branch is its own assertion rather than an inference from the
+    /// nil case: a property that ignored the field entirely and always returned
+    /// false would pass the nil test too.
+    @Test("the daemon reporting streaming off keeps it off")
+    func capabilityOffDisables() async {
+        await withAppState { state in
+            state.daemonCapabilities = DaemonCapabilitiesResult(
+                controlModeEnabled: false, transcriptStreamingEnabled: false)
+
+            #expect(state.transcriptStreamingEnabled == false)
+        }
+    }
+}

--- a/Tests/TBDAppTests/TranscriptStreamingFlagTests.swift
+++ b/Tests/TBDAppTests/TranscriptStreamingFlagTests.swift
@@ -54,3 +54,62 @@ struct TranscriptStreamingFlagTests {
         }
     }
 }
+
+/// The live transcript pane's `.task(id:)` key.
+///
+/// `appSideLoop` resolves the model-proxy stream file once, at the top of the
+/// run, so whatever that resolution depends on has to be part of the key or the
+/// loop keeps running against a stale reading of it. The flag is the input that
+/// actually moves: a viewer ticks "Stream assistant text into the transcript"
+/// in Settings while a pane is on screen, and off→on is the direction the soak
+/// depends on.
+@Suite("TranscriptPaneTaskKey")
+struct TranscriptPaneTaskKeyTests {
+
+    private static let terminalID = UUID()
+
+    private static func key(streaming: Bool, streamPath: String?) -> TaskKey {
+        TaskKey.resolve(
+            terminalID: terminalID,
+            sessionID: "s1",
+            retryToken: 0,
+            transcriptPath: "/tmp/session.jsonl",
+            streamingEnabled: streaming,
+            terminalStreamPath: streamPath)
+    }
+
+    /// The finding this test pins: with the flag outside the key, turning
+    /// streaming on left an already-open pane registered without a stream path
+    /// until an unrelated remount.
+    @Test("flipping the streaming flag restarts the loop for the same terminal")
+    func flippingTheFlagChangesTheKey() {
+        let off = Self.key(streaming: false, streamPath: "/tmp/stream.jsonl")
+        let on = Self.key(streaming: true, streamPath: "/tmp/stream.jsonl")
+
+        #expect(off != on,
+                "the same terminal must key differently on either side of the flag")
+        #expect(off.streamPath == nil, "the flag off resolves to no stream file")
+        #expect(on.streamPath == "/tmp/stream.jsonl")
+    }
+
+    /// The path is stamped at spawn, but the app can learn it after the pane
+    /// mounts — the terminal row arrives over RPC.
+    @Test("the stream path landing after the pane mounted restarts the loop")
+    func theStreamPathArrivingChangesTheKey() {
+        #expect(Self.key(streaming: true, streamPath: nil)
+                != Self.key(streaming: true, streamPath: "/tmp/stream.jsonl"))
+    }
+
+    /// A terminal that will never have a stream file must not be remounted by
+    /// somebody else's toggle.
+    @Test("a terminal with no stream file keys the same on either side of the flag")
+    func noStreamFileIsInsensitiveToTheFlag() {
+        #expect(Self.key(streaming: false, streamPath: nil)
+                == Self.key(streaming: true, streamPath: nil))
+    }
+
+    @Test("an empty stream path resolves to no stream file")
+    func emptyStreamPathResolvesToNil() {
+        #expect(Self.key(streaming: true, streamPath: "").streamPath == nil)
+    }
+}

--- a/Tests/TBDSharedTests/Transcript/IncrementalTranscriptMessageIDTests.swift
+++ b/Tests/TBDSharedTests/Transcript/IncrementalTranscriptMessageIDTests.swift
@@ -2,8 +2,15 @@ import Foundation
 import Testing
 @testable import TBDShared
 
-/// `IncrementalTranscript.hasAssistantMessage(id:)` — the set lookup that
-/// retires a streamed message's provisional row once the JSONL carries it.
+/// `IncrementalTranscript`'s two message-id sets: `hasAssistantMessage(id:)`,
+/// the id seen on any line, and `hasAssistantText(id:)` — the narrower lookup
+/// that retires a streamed message's provisional row once the JSONL carries the
+/// line bearing that message's text.
+///
+/// The distinction is the point of this suite. Claude Code writes one assistant
+/// line per content block under a shared `message.id`, and the capture below
+/// contains exactly that: a thinking-only line followed, later, by the text
+/// line for the same message.
 ///
 /// Every line here comes from `incremental-transcript-sample.jsonl`, a real
 /// captured Claude Code session. The two cases the capture does not contain —
@@ -30,25 +37,50 @@ struct IncrementalTranscriptMessageIDTests {
         return try #require(String(data: data, encoding: .utf8))
     }
 
-    /// One assistant line: where it sits in the file and the `message.id` it
-    /// carries. A struct, not a tuple, so `\.id` is a usable key path.
+    /// One assistant line: where it sits in the file, the `message.id` it
+    /// carries, and whether its content blocks include a non-empty `text` — the
+    /// three facts every case here is stated in terms of. A struct, not a
+    /// tuple, so `\.id` is a usable key path.
     private struct AssistantRow {
         let index: Int
         let id: String
+        let carriesText: Bool
     }
 
-    /// The assistant lines of a file, in order, each paired with its `message.id`.
+    /// The assistant lines of a file, in order, each paired with its
+    /// `message.id` and whether it delivers text.
     private func assistantIDsByIndex(_ lines: [String]) throws -> [AssistantRow] {
         try lines.indices.compactMap { (idx: Int) -> AssistantRow? in
             let row = try json(of: lines[idx])
             guard row["type"] as? String == "assistant",
                   let message = row["message"] as? [String: Any],
                   let id = message["id"] as? String else { return nil }
-            return AssistantRow(index: idx, id: id)
+            let blocks = (message["content"] as? [[String: Any]]) ?? []
+            let carriesText = blocks.contains {
+                ($0["type"] as? String) == "text" && !((($0["text"] as? String) ?? "").isEmpty)
+            }
+            return AssistantRow(index: idx, id: id, carriesText: carriesText)
         }
     }
 
-    @Test("a message split across two assistant lines is recorded, and only it")
+    /// Whether the transcript has built a settled assistant-text item — what
+    /// confirmation promises is on screen in place of the withdrawn row.
+    private func hasSettledText(_ transcript: IncrementalTranscript) -> Bool {
+        transcript.items.contains {
+            if case .assistantText = $0 { return true }
+            return false
+        }
+    }
+
+    /// The finding this suite exists for: the id arrives before the text does.
+    ///
+    /// The capture's message `msg_011CdaZp7Yk4EfhnpgNgpDKq` is written as a
+    /// thinking-only line and then, separately, a text line. Ingested up to the
+    /// split, the id has been seen and the message is *not* confirmed — because
+    /// confirming there would withdraw a streaming row while its replacement
+    /// did not exist yet. The text line is what confirms, and it brings the
+    /// settled item with it.
+    @Test("the id lands with the first block, but only the text line confirms")
     func recordsIDAcrossAChunkSplit() throws {
         let lines = try fixtureLines()
         let assistants = try assistantIDsByIndex(lines)
@@ -58,26 +90,84 @@ struct IncrementalTranscriptMessageIDTests {
         let repeated = try #require(assistants.first { candidate in
             assistants.filter { $0.id == candidate.id }.count >= 2
         })
-        let occurrences = assistants.filter { $0.id == repeated.id }.map(\.index)
-        let split = occurrences[1]
+        let occurrences = assistants.filter { $0.id == repeated.id }
+        #expect(occurrences.first?.carriesText == false,
+                "the capture's first line for this message must be the thinking one")
+        #expect(occurrences.last?.carriesText == true,
+                "and its last must be the text one, or this proves nothing")
+        let split = occurrences[1].index
 
         var transcript = IncrementalTranscript()
         transcript.ingest(lines: Array(lines[..<split]))
         #expect(transcript.hasAssistantMessage(id: repeated.id),
                 "the first line of the message already carries its id")
+        #expect(transcript.hasAssistantText(id: repeated.id) == false,
+                "a thinking-only line must not confirm a message still streaming its text")
+        #expect(hasSettledText(transcript) == false,
+                "and there is indeed no settled text item to replace the row with")
 
         transcript.ingest(lines: Array(lines[split...]))
         #expect(transcript.hasAssistantMessage(id: repeated.id),
                 "the second chunk must not lose what the first recorded")
+        #expect(transcript.hasAssistantText(id: repeated.id),
+                "the text line confirms")
+        #expect(hasSettledText(transcript),
+                "and the settled item it built is what the row is replaced by")
         #expect(transcript.hasAssistantMessage(id: "msg_01NeverStreamedAnywhere") == false,
                 "an id that never appeared must not be confirmed")
+        #expect(transcript.hasAssistantText(id: "msg_01NeverStreamedAnywhere") == false)
+    }
+
+    /// The other half of the same rule. A turn that only calls tools carries
+    /// its id on every line and never a text block, so it is never confirmed —
+    /// its row leaves by the composer's 60-second unconfirmed deadline instead.
+    @Test("a turn that only calls tools is seen but never confirmed")
+    func toolOnlyTurnIsSeenButNotConfirmed() throws {
+        let lines = try fixtureLines()
+        let assistants = try assistantIDsByIndex(lines)
+        let textless = try #require(assistants.first { candidate in
+            assistants.filter { $0.id == candidate.id }.allSatisfy { !$0.carriesText }
+        }, "capture must hold a message that never delivers text")
+
+        var transcript = IncrementalTranscript()
+        transcript.ingest(lines: lines)
+        #expect(transcript.hasAssistantMessage(id: textless.id),
+                "every line of it was ingested")
+        #expect(transcript.hasAssistantText(id: textless.id) == false,
+                "but nothing it wrote is text, so nothing can replace a streamed row")
+    }
+
+    /// `buildItems` drops a `text` block whose string is empty, so treating one
+    /// as confirmation would reproduce the same hazard in miniature: the row
+    /// withdrawn, and no item where it stood.
+    @Test("an empty text block confirms nothing")
+    func emptyTextBlockDoesNotConfirm() throws {
+        let lines = try fixtureLines()
+        let assistants = try assistantIDsByIndex(lines)
+        let withText = try #require(assistants.first(where: \.carriesText))
+        // Take the real text line and blank the one field that matters.
+        var row = try json(of: lines[withText.index])
+        var message = try #require(row["message"] as? [String: Any])
+        message["content"] = [["type": "text", "text": ""]]
+        row["message"] = message
+
+        var transcript = IncrementalTranscript()
+        transcript.ingest(lines: [try line(from: row)])
+        #expect(transcript.hasAssistantMessage(id: withText.id))
+        #expect(transcript.hasAssistantText(id: withText.id) == false)
+        #expect(hasSettledText(transcript) == false,
+                "the parser built no item for it either, which is why it must not confirm")
     }
 
     @Test("every assistant id in the capture is recorded, whole-file or line at a time")
     func recordsEveryIDLineAtATime() throws {
         let lines = try fixtureLines()
-        let expected = Set(try assistantIDsByIndex(lines).map(\.id))
+        let rows = try assistantIDsByIndex(lines)
+        let expected = Set(rows.map(\.id))
+        let expectedText = Set(rows.filter(\.carriesText).map(\.id))
         #expect(expected.count >= 2, "capture must carry more than one message id")
+        #expect(expectedText.count < expected.count,
+                "capture must hold a textless message, or the two sets cannot be told apart")
 
         var whole = IncrementalTranscript()
         whole.ingest(lines: lines)
@@ -87,9 +177,13 @@ struct IncrementalTranscriptMessageIDTests {
         for id in expected {
             #expect(whole.hasAssistantMessage(id: id))
             #expect(drip.hasAssistantMessage(id: id))
+            #expect(whole.hasAssistantText(id: id) == expectedText.contains(id))
+            #expect(drip.hasAssistantText(id: id) == expectedText.contains(id))
         }
         #expect(whole.assistantMessageIDCount == expected.count)
         #expect(drip.assistantMessageIDCount == expected.count)
+        #expect(whole.assistantTextMessageIDCount == expectedText.count)
+        #expect(drip.assistantTextMessageIDCount == expectedText.count)
     }
 
     @Test("a sidechain assistant line's id is not recorded")
@@ -106,7 +200,9 @@ struct IncrementalTranscriptMessageIDTests {
         transcript.ingest(lines: [try line(from: row)])
         #expect(transcript.hasAssistantMessage(id: assistant.id) == false,
                 "a subagent's message id must never confirm a parent's streamed message")
+        #expect(transcript.hasAssistantText(id: assistant.id) == false)
         #expect(transcript.assistantMessageIDCount == 0)
+        #expect(transcript.assistantTextMessageIDCount == 0)
     }
 
     @Test("an assistant line whose message is plain text records nothing")
@@ -122,7 +218,9 @@ struct IncrementalTranscriptMessageIDTests {
         var transcript = IncrementalTranscript()
         transcript.ingest(lines: [try line(from: row)])
         #expect(transcript.assistantMessageIDCount == 0, "no id on the row, nothing to record")
+        #expect(transcript.assistantTextMessageIDCount == 0)
         #expect(transcript.hasAssistantMessage(id: assistant.id) == false)
+        #expect(transcript.hasAssistantText(id: assistant.id) == false)
         #expect(transcript.items.isEmpty == false, "the row itself must still parse into an item")
     }
 
@@ -130,6 +228,8 @@ struct IncrementalTranscriptMessageIDTests {
     func freshTranscriptAnswersFalse() throws {
         let transcript = IncrementalTranscript()
         #expect(transcript.hasAssistantMessage(id: "msg_011CdaZp7Yk4EfhnpgNgpDKq") == false)
+        #expect(transcript.hasAssistantText(id: "msg_011CdaZp7Yk4EfhnpgNgpDKq") == false)
         #expect(transcript.assistantMessageIDCount == 0)
+        #expect(transcript.assistantTextMessageIDCount == 0)
     }
 }

--- a/Tests/TBDSharedTests/Transcript/IncrementalTranscriptMessageIDTests.swift
+++ b/Tests/TBDSharedTests/Transcript/IncrementalTranscriptMessageIDTests.swift
@@ -1,0 +1,135 @@
+import Foundation
+import Testing
+@testable import TBDShared
+
+/// `IncrementalTranscript.hasAssistantMessage(id:)` — the set lookup that
+/// retires a streamed message's provisional row once the JSONL carries it.
+///
+/// Every line here comes from `incremental-transcript-sample.jsonl`, a real
+/// captured Claude Code session. The two cases the capture does not contain —
+/// a sidechain row, and an assistant row whose message is plain text and so
+/// carries no `id` — are made by editing one field of a real line, and each
+/// says which field.
+@Suite("IncrementalTranscript assistant message ids")
+struct IncrementalTranscriptMessageIDTests {
+
+    private func fixtureLines() throws -> [String] {
+        let url = try #require(Bundle.module.url(
+            forResource: "incremental-transcript-sample", withExtension: "jsonl"))
+        let text = try String(contentsOf: url, encoding: .utf8)
+        return text.components(separatedBy: "\n").filter { !$0.isEmpty }
+    }
+
+    private func json(of line: String) throws -> [String: Any] {
+        let data = try #require(line.data(using: .utf8))
+        return try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    private func line(from json: [String: Any]) throws -> String {
+        let data = try JSONSerialization.data(withJSONObject: json)
+        return try #require(String(data: data, encoding: .utf8))
+    }
+
+    /// One assistant line: where it sits in the file and the `message.id` it
+    /// carries. A struct, not a tuple, so `\.id` is a usable key path.
+    private struct AssistantRow {
+        let index: Int
+        let id: String
+    }
+
+    /// The assistant lines of a file, in order, each paired with its `message.id`.
+    private func assistantIDsByIndex(_ lines: [String]) throws -> [AssistantRow] {
+        try lines.indices.compactMap { (idx: Int) -> AssistantRow? in
+            let row = try json(of: lines[idx])
+            guard row["type"] as? String == "assistant",
+                  let message = row["message"] as? [String: Any],
+                  let id = message["id"] as? String else { return nil }
+            return AssistantRow(index: idx, id: id)
+        }
+    }
+
+    @Test("a message split across two assistant lines is recorded, and only it")
+    func recordsIDAcrossAChunkSplit() throws {
+        let lines = try fixtureLines()
+        let assistants = try assistantIDsByIndex(lines)
+
+        // The capture writes one assistant line per content block, so one
+        // message id appears on two consecutive lines. Split between them.
+        let repeated = try #require(assistants.first { candidate in
+            assistants.filter { $0.id == candidate.id }.count >= 2
+        })
+        let occurrences = assistants.filter { $0.id == repeated.id }.map(\.index)
+        let split = occurrences[1]
+
+        var transcript = IncrementalTranscript()
+        transcript.ingest(lines: Array(lines[..<split]))
+        #expect(transcript.hasAssistantMessage(id: repeated.id),
+                "the first line of the message already carries its id")
+
+        transcript.ingest(lines: Array(lines[split...]))
+        #expect(transcript.hasAssistantMessage(id: repeated.id),
+                "the second chunk must not lose what the first recorded")
+        #expect(transcript.hasAssistantMessage(id: "msg_01NeverStreamedAnywhere") == false,
+                "an id that never appeared must not be confirmed")
+    }
+
+    @Test("every assistant id in the capture is recorded, whole-file or line at a time")
+    func recordsEveryIDLineAtATime() throws {
+        let lines = try fixtureLines()
+        let expected = Set(try assistantIDsByIndex(lines).map(\.id))
+        #expect(expected.count >= 2, "capture must carry more than one message id")
+
+        var whole = IncrementalTranscript()
+        whole.ingest(lines: lines)
+        var drip = IncrementalTranscript()
+        for line in lines { drip.ingest(lines: [line]) }
+
+        for id in expected {
+            #expect(whole.hasAssistantMessage(id: id))
+            #expect(drip.hasAssistantMessage(id: id))
+        }
+        #expect(whole.assistantMessageIDCount == expected.count)
+        #expect(drip.assistantMessageIDCount == expected.count)
+    }
+
+    @Test("a sidechain assistant line's id is not recorded")
+    func ignoresSidechainRows() throws {
+        let lines = try fixtureLines()
+        let assistant = try #require(try assistantIDsByIndex(lines).first)
+        // The capture holds no subagent turn, so take a real assistant line and
+        // flip its `isSidechain` — the one field that distinguishes a subagent's
+        // row from the parent session's.
+        var row = try json(of: lines[assistant.index])
+        row["isSidechain"] = true
+
+        var transcript = IncrementalTranscript()
+        transcript.ingest(lines: [try line(from: row)])
+        #expect(transcript.hasAssistantMessage(id: assistant.id) == false,
+                "a subagent's message id must never confirm a parent's streamed message")
+        #expect(transcript.assistantMessageIDCount == 0)
+    }
+
+    @Test("an assistant line whose message is plain text records nothing")
+    func toleratesStringContentWithNoMessageID() throws {
+        let lines = try fixtureLines()
+        let assistant = try #require(try assistantIDsByIndex(lines).first)
+        // Claude Code writes some assistant rows with a plain-string `content`
+        // and no `message.id` at all. Reproduce that shape by replacing the real
+        // line's `message` object, keeping every other field of the capture.
+        var row = try json(of: lines[assistant.index])
+        row["message"] = ["role": "assistant", "content": "Of course! Please share the function."]
+
+        var transcript = IncrementalTranscript()
+        transcript.ingest(lines: [try line(from: row)])
+        #expect(transcript.assistantMessageIDCount == 0, "no id on the row, nothing to record")
+        #expect(transcript.hasAssistantMessage(id: assistant.id) == false)
+        #expect(transcript.items.isEmpty == false, "the row itself must still parse into an item")
+    }
+
+    @Test("a fresh transcript confirms nothing")
+    func freshTranscriptAnswersFalse() throws {
+        let transcript = IncrementalTranscript()
+        #expect(transcript.hasAssistantMessage(id: "msg_011CdaZp7Yk4EfhnpgNgpDKq") == false)
+        #expect(transcript.assistantMessageIDCount == 0)
+    }
+}

--- a/Tests/TBDSharedTests/Transcript/IncrementalTranscriptMessageIDTests.swift
+++ b/Tests/TBDSharedTests/Transcript/IncrementalTranscriptMessageIDTests.swift
@@ -87,9 +87,10 @@ struct IncrementalTranscriptMessageIDTests {
 
         // The capture writes one assistant line per content block, so one
         // message id appears on two consecutive lines. Split between them.
-        let repeated = try #require(assistants.first { candidate in
+        let firstRepeated = assistants.first { candidate in
             assistants.filter { $0.id == candidate.id }.count >= 2
-        })
+        }
+        let repeated = try #require(firstRepeated)
         let occurrences = assistants.filter { $0.id == repeated.id }
         #expect(occurrences.first?.carriesText == false,
                 "the capture's first line for this message must be the thinking one")
@@ -125,9 +126,11 @@ struct IncrementalTranscriptMessageIDTests {
     func toolOnlyTurnIsSeenButNotConfirmed() throws {
         let lines = try fixtureLines()
         let assistants = try assistantIDsByIndex(lines)
-        let textless = try #require(assistants.first { candidate in
+        let firstTextless = assistants.first { candidate in
             assistants.filter { $0.id == candidate.id }.allSatisfy { !$0.carriesText }
-        }, "capture must hold a message that never delivers text")
+        }
+        let textless = try #require(
+            firstTextless, "capture must hold a message that never delivers text")
 
         var transcript = IncrementalTranscript()
         transcript.ingest(lines: lines)
@@ -144,7 +147,10 @@ struct IncrementalTranscriptMessageIDTests {
     func emptyTextBlockDoesNotConfirm() throws {
         let lines = try fixtureLines()
         let assistants = try assistantIDsByIndex(lines)
-        let withText = try #require(assistants.first(where: \.carriesText))
+        // Hoisted out of `#require`: the macro decomposes a call written inside
+        // it and then cannot prove the argument is non-throwing.
+        let firstWithText = assistants.first(where: \.carriesText)
+        let withText = try #require(firstWithText)
         // Take the real text line and blank the one field that matters.
         var row = try json(of: lines[withText.index])
         var message = try #require(row["message"] as? [String: Any])

--- a/docs/specs/2026-09-05-transcript-streaming-model-proxy-design.md
+++ b/docs/specs/2026-09-05-transcript-streaming-model-proxy-design.md
@@ -519,6 +519,15 @@ retired when:
   lingers for the difference. A shorter window would retire genuine messages
   on a loaded machine; a longer one only delays removing a row nothing
   confirms.
+- a stream that has not stopped goes 10 minutes without a new line, measured
+  from the last line the reader saw and restarted by each one. A message
+  leaves the streaming phase only when a `stop` or `aborted` line is written
+  and read, so a proxy killed mid-turn — which writes neither, and whose
+  request the JSONL will not confirm either — has no other way off the screen.
+  The window is the proxy's own drain cap, the longest a legitimate stream can
+  still be in flight. Sixty seconds would be wrong here: the tee records text
+  deltas, and a healthy turn streaming a large tool-input block emits none for
+  minutes.
 
 `TranscriptStreamPlan.updateLast` already renders a last row whose content
 version changed, so a growing row costs one tail re-render per tick. A subtle
@@ -539,7 +548,9 @@ affordance, and the row is always an assistant bubble.
 ### Failure handling
 
 - An unreadable stream file is no news, never a blank row.
-- A proxy that dies mid-stream leaves a message the 60-second rule retires.
+- A proxy that dies mid-stream leaves a message the 10-minute silent-stream
+  rule retires; one that dies after writing its stop leaves a message the
+  60-second unconfirmed rule retires.
 - A pane whose terminal has no `transcriptStreamPath` registers no stream
   file and behaves exactly as today.
 - The provisional state is dropped on confirmation, retire, and deregistration.
@@ -607,7 +618,8 @@ SSE shape and costs zero tokens.
   live files and unlinks the rest.
 - **App.** The provisional row appears, grows, and is replaced by the
   confirming JSONL line; retires on abort, on a newer message taking the row,
-  and on the 60 s rule; sorts after pending questions; and with streaming off
+  on the 60 s unconfirmed rule and on the 10-minute silent-stream rule
+  (which a new line restarts); sorts after pending questions; and with streaming off
   is never published while the file still updates. Chunk-split equivalence:
   *"a file delivered in arbitrary chunks folds to what the whole file folds
   to"* writes one encoded stream file to disk in seeded-random chunk splits —

--- a/docs/specs/2026-09-05-transcript-streaming-model-proxy-design.md
+++ b/docs/specs/2026-09-05-transcript-streaming-model-proxy-design.md
@@ -498,8 +498,20 @@ on the first text of a newer message, or on the 60-second rule — never on the
 mere appearance of a successor.
 
 The transcript's incremental ingest also records the API `message.id` of every
-assistant line it consumes. That is a row-local read, so it does not violate
-`buildItems`' purity rule, and it makes confirmation a set lookup.
+assistant line it consumes, and separately the ids of the lines that carry a
+`text` block. Both are row-local reads, so they do not violate `buildItems`'
+purity rule, and they make confirmation a set lookup.
+
+The second set is the one confirmation reads, and the distinction is
+load-bearing. Claude Code writes one JSONL line per content block under a
+shared `message.id`, and those lines land at different times — a text block's
+line was measured arriving 25 seconds after an earlier block's. A message that
+opens with a `thinking` block therefore has its id in the JSONL while its text
+is still streaming, so retiring on the id would take the row down with nothing
+to replace it: the settled text item does not exist yet, and the user watches
+live text vanish mid-turn. "Carries text" follows the parser's own rule rather
+than the raw block type — an empty `text` block builds no item and so confirms
+nothing.
 
 ### Publishing
 
@@ -509,11 +521,14 @@ AskUserQuestion captures, then the provisional row last, as
 the resolved streaming flag is on and its message id is unconfirmed. It is
 retired when:
 
-- the JSONL ingests an assistant line with that message id;
+- the JSONL ingests the assistant line that carries that message's text,
+  which is the line that brings the settled item replacing the row. A line
+  carrying the id alone — a thinking block, a tool call — confirms nothing;
 - a newer message with text supersedes it;
 - the stream is aborted;
 - a completed stream stays unconfirmed for 60 seconds, which backstops any
-  side request the tee filter misses. The value sits above the worst JSONL
+  side request the tee filter misses and any turn whose JSONL never carries
+  text at all — one that only calls tools. The value sits above the worst JSONL
   lag measured on a live session, 25 seconds behind a long tool call, with
   room for a slower machine, and its only cost is cosmetic: a stale row
   lingers for the difference. A shorter window would retire genuine messages
@@ -552,7 +567,9 @@ affordance, and the row is always an assistant bubble.
 - An unreadable stream file is no news, never a blank row.
 - A proxy that dies mid-stream leaves a message the 10-minute silent-stream
   rule retires; one that dies after writing its stop leaves a message the
-  60-second unconfirmed rule retires.
+  60-second unconfirmed rule retires. A turn whose JSONL lines carry the
+  message id but never its text is never confirmed, and leaves by that same
+  60-second rule.
 - A pane whose terminal has no `transcriptStreamPath` registers no stream
   file and behaves exactly as today.
 - The provisional state is dropped on confirmation, retire, and deregistration.
@@ -618,8 +635,9 @@ SSE shape and costs zero tokens.
   writes its coupled pair. A pre-migration row reads NULL, an explicit `0`
   survives a flipped default, and NULL follows it. The GC leg keeps young and
   live files and unlinks the rest.
-- **App.** The provisional row appears, grows, and is replaced by the
-  confirming JSONL line; retires on abort, on a newer message taking the row,
+- **App.** The provisional row appears, grows, and is replaced by the JSONL
+  line that carries the message's text — never by one that carries only its
+  id; retires on abort, on a newer message taking the row,
   on the 60 s unconfirmed rule and on the 10-minute silent-stream rule
   (which a new line restarts); sorts after pending questions; and with streaming off
   is never published while the file still updates. Chunk-split equivalence:

--- a/docs/specs/2026-09-05-transcript-streaming-model-proxy-design.md
+++ b/docs/specs/2026-09-05-transcript-streaming-model-proxy-design.md
@@ -484,8 +484,18 @@ foreground, 2 s background, 10 s inactive — and under the same reset rule: a
 file whose size fell below the consumed offset is re-read from byte zero. The
 reader folds the tagged lines into a `ProvisionalMessage`: the message id,
 the concatenated text of its text blocks in index order, and whether it is
-complete, aborted, or still growing. When several messages are present it
-keeps the most recent that has text.
+complete, aborted, or still growing.
+
+When several messages are present, the fold keeps **the most recent message
+that has text** — most recent by position in the file, which is the order the
+tee controls. A message that has only started and produced nothing holds the
+row only when no message has any text at all, so that a pane can show that a
+turn has begun. The consequence matters to the retire rules below: a newer
+`start` does not by itself take the row away from a finished message, because
+until that new message emits its first delta the finished one is still the
+best thing to show. A finished message's row therefore leaves on confirmation,
+on the first text of a newer message, or on the 60-second rule — never on the
+mere appearance of a successor.
 
 The transcript's incremental ingest also records the API `message.id` of every
 assistant line it consumes. That is a row-local read, so it does not violate
@@ -500,7 +510,7 @@ the resolved streaming flag is on and its message id is unconfirmed. It is
 retired when:
 
 - the JSONL ingests an assistant line with that message id;
-- a newer `start` line replaces it;
+- a newer message with text supersedes it;
 - the stream is aborted;
 - a completed stream stays unconfirmed for 60 seconds, which backstops any
   side request the tee filter misses. The value sits above the worst JSONL
@@ -512,8 +522,19 @@ retired when:
 
 `TranscriptStreamPlan.updateLast` already renders a last row whose content
 version changed, so a growing row costs one tail re-render per tick. A subtle
-trailing cursor marks the row provisional. Session History and the transcript
-overlay never register a stream path and never see a provisional row.
+trailing cursor marks the row provisional.
+
+The provisional row lives in the same per-session transcript store the live
+pane publishes into, and **Session History reads that same store** — its
+session list is the daemon's enumeration of the worktree's JSONL files, which
+includes a session a pane is streaming right now, and selecting a session
+deliberately reuses whatever the store already holds rather than refetching.
+So History filters the row out at its read site, by the `stream:` prefix on
+the item id: only settled rows reach it, and a live session read through
+History looks exactly like one read after the fact. The transcript overlay
+needs no such filter, because it resolves an item by an id a row hands it and
+no gesture can hand it a provisional one — assistant bubbles carry no overlay
+affordance, and the row is always an assistant bubble.
 
 ### Failure handling
 
@@ -585,10 +606,14 @@ SSE shape and costs zero tokens.
   survives a flipped default, and NULL follows it. The GC leg keeps young and
   live files and unlinks the rest.
 - **App.** The provisional row appears, grows, and is replaced by the
-  confirming JSONL line; retires on abort, on a newer start, and on the 60 s
-  rule; sorts after pending questions; and with streaming off is never
-  published while the file still updates. Chunk-split equivalence over a
-  captured stream file.
+  confirming JSONL line; retires on abort, on a newer message taking the row,
+  and on the 60 s rule; sorts after pending questions; and with streaming off
+  is never published while the file still updates. Chunk-split equivalence:
+  *"a file delivered in arbitrary chunks folds to what the whole file folds
+  to"* writes one encoded stream file to disk in seeded-random chunk splits —
+  including one inside a `text` line's JSON string and one inside a multi-byte
+  character — refreshing after each write, and requires the provisional it ends
+  on to equal the whole-file fold taken at the same instant.
 - **Live verification, deferred until a restart is permitted on the
   development machine:** the shipped `TBDModelProxy` on a holder terminal
   carries an interactive claude.ai-login turn and the pane shows its text

--- a/docs/specs/2026-09-05-transcript-streaming-model-proxy-design.md
+++ b/docs/specs/2026-09-05-transcript-streaming-model-proxy-design.md
@@ -525,7 +525,9 @@ retired when:
   and read, so a proxy killed mid-turn — which writes neither, and whose
   request the JSONL will not confirm either — has no other way off the screen.
   The window is the proxy's own drain cap, the longest a legitimate stream can
-  still be in flight. Sixty seconds would be wrong here: the tee records text
+  still be in flight — literally that constant (`ModelProxyLimits.drainCap` in
+  `TBDShared`, which both the proxy's retire drain and the pane read), not a
+  second value that happens to agree with it. Sixty seconds would be wrong here: the tee records text
   deltas, and a healthy turn streaming a large tool-input block emits none for
   minutes.
 


### PR DESCRIPTION
## Summary

The transcript pane today shows an assistant message only after Claude Code has written the whole message to the session file, which measured as a lag of up to 25 seconds behind the terminal when a text block waits behind a long tool call. This PR is the app half of closing that gap: when a session runs through the TBD model proxy and streaming is enabled, the pane shows the assistant's text as it is generated, in a provisional row that grows with the stream and is replaced the moment the session file catches up. Nothing is persisted; the JSONL stays the record.

## Why this shape

The app tails a per-terminal stream file the proxy writes, the same way it already tails the JSONL, at the same cadence and through the same scheduler, so the daemon is not in the data path. The provisional row is composed last, after the JSONL items and any pending AskUserQuestion capture, and carries a distinct id prefix so nothing else can mistake it for a settled row. It is retired on six rules. Four are announced by something the pane already watches: the JSONL ingests an assistant line with the same API message id, a newer message with text supersedes it, the stream aborts, or the streaming flag goes off. Two are deadlines a retire timer owns: a completed stream that stays unconfirmed for 60 seconds, which backstops any side request the proxy's filter lets through, and a streaming message that goes ten minutes without a new line, the proxy's own drain cap, which covers a proxy killed mid-turn. Session History reads the same store and can show the live session, so it filters provisional rows at its read site. Design: `docs/specs/2026-09-05-transcript-streaming-model-proxy-design.md`, "The app".

## What this PR does

- `IncrementalTranscript` records the API message id of every non-sidechain assistant line, so confirmation is a set lookup.
- `StreamFileReader` folds the proxy's tagged stream lines into a provisional message, keeping the most recent message that has text.
- `TranscriptSource` and `TranscriptPollScheduler` carry an optional stream path beside the transcript path, with the same shrink-resets rule and the same "unreadable is no news" rule; the pane's task key includes the resolved stream path so a Settings toggle restarts the loop.
- `ProvisionalRowComposer` appends the row and applies the retire rules; a session-scoped `ProvisionalRetireTimer` on an injected clock fires the one re-publish the 60-second rule needs.
- A trailing cursor marks the row provisional; Session History filters it out.
- Spec edits stating the History filter as enforced and the fold's selection rule.

## Flag & rollout

Gated by `transcript_streaming_enabled` resolved as the conjunction with `model_proxy_enabled` on the daemon; with either off the pane registers no stream path and composes nothing. Both default OFF. Enable from Settings > Experimental. Applies to sessions started after the change.

## Evidence & verification

- Every retire condition has a discriminating test, including 59 s kept versus 61 s retired in one test and the exact-60 boundary.
- A two-session test proves another session's publish cannot disarm a pending retire alarm.
- A seeded, randomized chunk-split equivalence test over a stream file, with splits inside a JSON string and inside a multi-byte character, folds to the same result as the whole file.
- Both flag branches are exercised at the composer, the publish path, and the task key.
- The whole suite is green on CI at the branch head, rebased onto main after the proxy binary and the flags landed. Live verification against the real proxy on a holder session follows the daemon PR.

https://claude.ai/code/session_01TggE2eESL3BcvSgFcLZkpk

[model proxy C: app](https://cheapsteak.github.io/tbd/open/?worktree=C968D8D1-3719-4306-8F84-B9462E443595)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added live transcript streaming from model activity, including provisional responses that update as text arrives.
  - Provisional responses display a visual streaming marker and retire after confirmation or timeout.
  - Streaming availability now follows daemon capabilities.
  - Session History excludes unconfirmed provisional responses while the live transcript remains current.

- **Bug Fixes**
  - Improved streamed message ordering, session isolation, file-change detection, and transcript confirmation.

- **Tests**
  - Added comprehensive coverage for streaming, rendering, polling, retirement timing, and message tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
