### PR TITLE
Fix: scrolling up in a terminal replaced the draft with a past message

### DIFF
--- a/Sources/TBDApp/Terminal/TBDTerminalView.swift
+++ b/Sources/TBDApp/Terminal/TBDTerminalView.swift
@@ -509,6 +509,26 @@ class TBDTerminalView: TerminalView {
         return (col, row)
     }
 
+    /// Converts a window-coordinate point to terminal grid (col, row), clamping
+    /// a point outside the grid to the nearest cell instead of failing.
+    ///
+    /// The view's bounds are a little larger than the grid: there is a slack
+    /// strip below the last row and a sliver right of the last column. A caller
+    /// that must act on every event landing inside the view — the scroll
+    /// monitor, which may not decline an event — needs a cell for those points
+    /// too. `gridPosition(atWindowLocation:)` keeps its `nil` for callers that
+    /// genuinely want "not on a cell".
+    func gridPositionClamped(atWindowLocation windowPoint: CGPoint) -> (col: Int, row: Int) {
+        let dims = terminalDimensions
+        return TerminalWheelRouting.clampedGrid(
+            localPoint: convert(windowPoint, from: nil),
+            boundsHeight: bounds.height,
+            cell: cellDimensions(),
+            cols: dims.cols,
+            rows: dims.rows
+        )
+    }
+
     // MARK: - Mouse click pass-through
     // Track mouseDown position to distinguish clicks from drags.
     // Single clicks are forwarded to tmux for pane switching;

--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -1553,6 +1553,20 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
             // in TBDTerminalView. Instead, a local event monitor intercepts
             // scroll events and forwards them to tmux as mouse button presses.
             //
+            // The monitor may never hand an event back once it has decided the
+            // event is ours (pointer inside a visible terminal, no overlay).
+            // We turn SwiftTerm's own mouse reporting off (`allowMouseReporting
+            // = false` at attach), and its `scrollWheel` reacts to that by
+            // falling back to alternate-screen scrolling: it synthesizes Up /
+            // Down cursor keys. tmux drives the outer terminal on the alternate
+            // screen, so that fallback fires every time, and the keys land in
+            // the pane as if typed — Claude Code's composer reads Up as prompt
+            // history, so a scroll wipes out whatever draft was in the box.
+            // TerminalWheelRouting therefore classifies every event as forward
+            // (send mouse buttons to tmux) or swallow (drop it); only events
+            // that are not ours pass through. Do not reintroduce a decline path
+            // for events over the terminal.
+            //
             // Visibility filter: the `tv.window != nil` guard inside the
             // closure rejects events when the terminal isn't currently part of
             // the visible UI. This is load-bearing for the worktree keep-alive
@@ -1568,35 +1582,56 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
             let ref = WeakTerminalRef(terminalView)
             scrollMonitor = NSEvent.addLocalMonitorForEvents(matching: .scrollWheel) { event in
                 let deltaY = event.deltaY
+                let scrollingDeltaY = event.scrollingDeltaY
                 let location = event.locationInWindow
-                guard deltaY != 0 else { return event }
 
                 let consumed = MainActor.assumeIsolated { [weak self] in
                     guard let self else { return false }
                     guard let tv = ref.view as? TBDTerminalView else { return false }
                     guard tv.window != nil else { return false }
-                    // Short-circuit when a SwiftUI overlay is open on top of this
-                    // terminal — pass the event through so the overlay can handle it.
-                    if self.shouldSuppressEvents() { return false }
-                    let point = tv.convert(location, from: nil)
-                    guard tv.bounds.contains(point) else { return false }
+                    // An overlay on top of this terminal owns the event, and so
+                    // does whatever sits under a pointer outside our bounds.
+                    let overlayOpen = self.shouldSuppressEvents()
+                    let pointerInside = tv.bounds.contains(tv.convert(location, from: nil))
+
+                    // Reject somebody else's event before taking the terminal
+                    // lock. Whether the event passes through never depends on
+                    // mouse reporting, so the placeholder below cannot change
+                    // this answer — it only distinguishes forward from swallow.
+                    guard TerminalWheelRouting.disposition(
+                        deltaY: deltaY,
+                        scrollingDeltaY: scrollingDeltaY,
+                        overlayOpen: overlayOpen,
+                        pointerInside: pointerInside,
+                        mouseReportingOn: false
+                    ) != .passThrough else { return false }
 
                     // Use actual scroll position so tmux routes to the correct pane.
                     // Grid math runs OUTSIDE the lock (view API); the mouseMode
-                    // guard and the sends ride one `withTerminal` block — the
+                    // read and the sends ride one `withTerminal` block — the
                     // same calls, under the same lock, as SwiftTerm's own
-                    // native mouse-reporting path.
-                    guard let (col, row) = tv.gridPosition(atWindowLocation: location) else { return false }
+                    // native mouse-reporting path. The position is clamped
+                    // rather than nil-checked: the slack strip below the last
+                    // row is still inside the terminal, and declining a wheel
+                    // event there would hand it to SwiftTerm's cursor keys.
+                    let (col, row) = tv.gridPositionClamped(atWindowLocation: location)
 
-                    let isUp = deltaY > 0
-                    let lines = max(1, Int(abs(deltaY)))
                     return tv.withTerminal { term -> Bool in
-                        guard term.mouseMode != .off else { return false }
+                        let disposition = TerminalWheelRouting.disposition(
+                            deltaY: deltaY,
+                            scrollingDeltaY: scrollingDeltaY,
+                            overlayOpen: overlayOpen,
+                            pointerInside: pointerInside,
+                            mouseReportingOn: term.mouseMode != .off
+                        )
+                        // Anything that reaches here is ours, so it is consumed
+                        // either way; `.swallow` just has nothing to send.
+                        guard case let .forward(button, count) = disposition else { return true }
                         let buttonFlags = term.encodeButton(
-                            button: isUp ? 4 : 5,
+                            button: button,
                             release: false, shift: false, meta: false, control: false
                         )
-                        for _ in 0..<lines {
+                        for _ in 0..<count {
                             term.sendEvent(buttonFlags: buttonFlags, x: col, y: row)
                         }
                         return true

--- a/Sources/TBDApp/Terminal/TerminalWheelRouting.swift
+++ b/Sources/TBDApp/Terminal/TerminalWheelRouting.swift
@@ -1,0 +1,80 @@
+import CoreGraphics
+
+/// Decides what happens to a scroll-wheel event that arrives over a
+/// tmux-attached terminal, and where in the grid a forwarded event lands.
+///
+/// The routing rule this type exists to enforce: a wheel event over a visible,
+/// tmux-attached terminal is **never** handed back to AppKit. TBD turns
+/// SwiftTerm's own mouse reporting off (`allowMouseReporting = false`) and
+/// forwards wheel motion to tmux itself. SwiftTerm's `scrollWheel`, reached by
+/// any event we decline, then falls back to its alternate-screen behaviour and
+/// translates the wheel into Up/Down cursor keys. tmux runs the outer terminal
+/// on the alternate screen, so that fallback always fires, and the agent in the
+/// pane reads those keys as typing — Claude Code's composer maps Up to prompt
+/// history, so a scroll silently replaces whatever draft was in the box. Every
+/// event that is ours is therefore either forwarded as a mouse button or
+/// dropped; only events that are not ours pass through.
+///
+/// The logic is pure so each branch can be tested without an NSView, a window,
+/// or a live terminal.
+enum TerminalWheelRouting {
+    /// What the scroll monitor should do with one event.
+    enum Disposition: Equatable {
+        /// Not ours: the pointer is elsewhere, an overlay owns the event, or
+        /// the event carries no vertical motion at all. Hand it back to AppKit.
+        case passThrough
+        /// Ours, but tmux has not enabled mouse reporting, so there is nothing
+        /// to forward. Drop it rather than letting SwiftTerm see it.
+        case swallow
+        /// Ours: forward `count` presses of `button` (4 = up, 5 = down) to tmux.
+        case forward(button: Int, count: Int)
+    }
+
+    /// Classifies one wheel event.
+    ///
+    /// - Parameters:
+    ///   - deltaY: `NSEvent.deltaY` — line-granularity motion.
+    ///   - scrollingDeltaY: `NSEvent.scrollingDeltaY` — the point-granularity
+    ///     motion SwiftTerm's own override reads. An event with a zero
+    ///     `deltaY` and a nonzero `scrollingDeltaY` still becomes cursor keys
+    ///     downstream, so it counts as motion here.
+    ///   - overlayOpen: whether a SwiftUI overlay is on top of the terminal.
+    ///   - pointerInside: whether the pointer is within the terminal's bounds.
+    ///   - mouseReportingOn: whether tmux has mouse reporting enabled.
+    nonisolated static func disposition(
+        deltaY: CGFloat,
+        scrollingDeltaY: CGFloat,
+        overlayOpen: Bool,
+        pointerInside: Bool,
+        mouseReportingOn: Bool
+    ) -> Disposition {
+        guard deltaY != 0 || scrollingDeltaY != 0 else { return .passThrough }
+        guard !overlayOpen, pointerInside else { return .passThrough }
+        guard mouseReportingOn else { return .swallow }
+
+        let isUp = deltaY != 0 ? deltaY > 0 : scrollingDeltaY > 0
+        let count = max(1, Int(abs(deltaY)))
+        return .forward(button: isUp ? 4 : 5, count: count)
+    }
+
+    /// Converts a view-local point to a grid cell, clamped into the grid.
+    ///
+    /// Mirrors `TBDTerminalView.gridPosition(atWindowLocation:)`, except that a
+    /// point outside the grid resolves to the nearest cell instead of `nil`.
+    /// The slack strip below the last row and the sliver right of the last
+    /// column are both inside the view's bounds but outside the grid, and a
+    /// wheel event there must still be forwarded rather than declined.
+    nonisolated static func clampedGrid(
+        localPoint: CGPoint,
+        boundsHeight: CGFloat,
+        cell: (width: CGFloat, height: CGFloat),
+        cols: Int,
+        rows: Int
+    ) -> (col: Int, row: Int) {
+        guard cols > 0, rows > 0, cell.width > 0, cell.height > 0 else { return (0, 0) }
+
+        let rawCol = Int(localPoint.x / cell.width)
+        let rawRow = Int((boundsHeight - localPoint.y) / cell.height)
+        return (col: min(max(rawCol, 0), cols - 1), row: min(max(rawRow, 0), rows - 1))
+    }
+}

--- a/Tests/TBDAppTests/TerminalWheelRoutingTests.swift
+++ b/Tests/TBDAppTests/TerminalWheelRoutingTests.swift
@@ -1,0 +1,187 @@
+import CoreGraphics
+import Foundation
+import Testing
+@testable import TBDApp
+
+@Suite("Terminal wheel routing")
+struct TerminalWheelRoutingTests {
+    private func disposition(
+        deltaY: CGFloat = 0,
+        scrollingDeltaY: CGFloat = 0,
+        overlayOpen: Bool = false,
+        pointerInside: Bool = true,
+        mouseReportingOn: Bool = true
+    ) -> TerminalWheelRouting.Disposition {
+        TerminalWheelRouting.disposition(
+            deltaY: deltaY,
+            scrollingDeltaY: scrollingDeltaY,
+            overlayOpen: overlayOpen,
+            pointerInside: pointerInside,
+            mouseReportingOn: mouseReportingOn
+        )
+    }
+
+    @Test("scrolling up forwards mouse button 4")
+    func upForwardsButtonFour() {
+        #expect(disposition(deltaY: 1) == .forward(button: 4, count: 1))
+    }
+
+    @Test("scrolling down forwards mouse button 5")
+    func downForwardsButtonFive() {
+        #expect(disposition(deltaY: -1) == .forward(button: 5, count: 1))
+    }
+
+    @Test("line count comes from the magnitude of deltaY, and is at least one")
+    func countTracksDeltaMagnitude() {
+        #expect(disposition(deltaY: 3.9) == .forward(button: 4, count: 3))
+        #expect(disposition(deltaY: -7) == .forward(button: 5, count: 7))
+        #expect(disposition(deltaY: 0.25) == .forward(button: 4, count: 1))
+        #expect(disposition(deltaY: -0.25) == .forward(button: 5, count: 1))
+    }
+
+    @Test("a precise-scroll event with no line delta still forwards")
+    func scrollingDeltaAloneForwards() {
+        // SwiftTerm's own scrollWheel reads scrollingDeltaY, so an event with
+        // deltaY == 0 would become cursor keys if we handed it back.
+        #expect(disposition(deltaY: 0, scrollingDeltaY: 4) == .forward(button: 4, count: 1))
+        #expect(disposition(deltaY: 0, scrollingDeltaY: -4) == .forward(button: 5, count: 1))
+    }
+
+    @Test("an event with no vertical motion passes through")
+    func noMotionPassesThrough() {
+        #expect(disposition(deltaY: 0, scrollingDeltaY: 0) == .passThrough)
+    }
+
+    @Test("an open overlay owns the event")
+    func overlayPassesThrough() {
+        #expect(disposition(deltaY: 3, overlayOpen: true) == .passThrough)
+        #expect(disposition(deltaY: 0, scrollingDeltaY: 3, overlayOpen: true) == .passThrough)
+    }
+
+    @Test("a pointer outside the terminal passes through")
+    func outsidePassesThrough() {
+        #expect(disposition(deltaY: 3, pointerInside: false) == .passThrough)
+    }
+
+    @Test("with tmux mouse reporting off the event is swallowed, never passed through")
+    func mouseReportingOffSwallows() {
+        // The regression: a passed-through event reaches SwiftTerm, which
+        // translates it into Up/Down cursor keys on the alternate screen, and
+        // Claude Code's composer reads Up as prompt-history recall.
+        let up = disposition(deltaY: 3, mouseReportingOn: false)
+        #expect(up == .swallow)
+        #expect(up != .passThrough)
+
+        let down = disposition(deltaY: -3, mouseReportingOn: false)
+        #expect(down == .swallow)
+        #expect(down != .passThrough)
+    }
+
+    @Test("a wheel event over the terminal is never handed back to AppKit")
+    func ourEventsAreNeverPassedThrough() {
+        let deltas: [CGFloat] = [-8, -1, -0.4, 0, 0.4, 1, 8]
+        for deltaY in deltas {
+            for scrollingDeltaY in deltas {
+                for mouseReportingOn in [true, false] {
+                    let result = disposition(
+                        deltaY: deltaY,
+                        scrollingDeltaY: scrollingDeltaY,
+                        overlayOpen: false,
+                        pointerInside: true,
+                        mouseReportingOn: mouseReportingOn
+                    )
+                    let hasMotion = deltaY != 0 || scrollingDeltaY != 0
+                    if hasMotion {
+                        #expect(
+                            result != .passThrough,
+                            "deltaY \(deltaY), scrollingDeltaY \(scrollingDeltaY), reporting \(mouseReportingOn)"
+                        )
+                    } else {
+                        #expect(result == .passThrough)
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Grid clamping
+
+    private static let cell = (width: CGFloat(10), height: CGFloat(20))
+
+    @Test("an interior point matches the unclamped grid math")
+    func interiorPointMatchesUnclampedMath() {
+        // 80 cols x 5 rows, bounds 800 x 100.
+        let grid = TerminalWheelRouting.clampedGrid(
+            localPoint: CGPoint(x: 35, y: 55),
+            boundsHeight: 100,
+            cell: Self.cell,
+            cols: 80,
+            rows: 5
+        )
+        #expect(grid.col == 3)
+        #expect(grid.row == 2)
+    }
+
+    @Test("the slack strip below the last row clamps to the last row")
+    func bottomSlackClampsToLastRow() {
+        // Bounds are 110 tall but only 5 rows of 20 fit, so y < 10 is slack.
+        let grid = TerminalWheelRouting.clampedGrid(
+            localPoint: CGPoint(x: 5, y: 2),
+            boundsHeight: 110,
+            cell: Self.cell,
+            cols: 80,
+            rows: 5
+        )
+        #expect(grid.row == 4)
+        #expect(grid.col == 0)
+    }
+
+    @Test("the sliver right of the last column clamps to the last column")
+    func rightSliverClampsToLastColumn() {
+        let grid = TerminalWheelRouting.clampedGrid(
+            localPoint: CGPoint(x: 806, y: 90),
+            boundsHeight: 100,
+            cell: Self.cell,
+            cols: 80,
+            rows: 5
+        )
+        #expect(grid.col == 79)
+        #expect(grid.row == 0)
+    }
+
+    @Test("a point above or left of the grid clamps to the first cell")
+    func negativePointClampsToOrigin() {
+        let grid = TerminalWheelRouting.clampedGrid(
+            localPoint: CGPoint(x: -30, y: 140),
+            boundsHeight: 100,
+            cell: Self.cell,
+            cols: 80,
+            rows: 5
+        )
+        #expect(grid.col == 0)
+        #expect(grid.row == 0)
+    }
+
+    @Test("a degenerate grid resolves to the origin instead of trapping")
+    func degenerateGridIsSafe() {
+        let noRows = TerminalWheelRouting.clampedGrid(
+            localPoint: CGPoint(x: 40, y: 40),
+            boundsHeight: 100,
+            cell: Self.cell,
+            cols: 80,
+            rows: 0
+        )
+        #expect(noRows.col == 0)
+        #expect(noRows.row == 0)
+
+        let noCell = TerminalWheelRouting.clampedGrid(
+            localPoint: CGPoint(x: 40, y: 40),
+            boundsHeight: 100,
+            cell: (width: 0, height: 0),
+            cols: 80,
+            rows: 5
+        )
+        #expect(noCell.col == 0)
+        #expect(noCell.row == 0)
+    }
+}


### PR DESCRIPTION
## What's broken

Scroll up inside a TBD terminal running Claude Code and the transcript moves as
expected, but whatever you had typed in the composer is gone, replaced by a
prompt you sent earlier. The draft is not recoverable. It happens on ordinary
trackpad and wheel scrolling, and it happens often, because the conditions that
trigger it are common: a slow flick, a pointer resting near the bottom edge of
the terminal, or an agent that has not turned mouse reporting on yet.

## Why it happens

TBD does not let SwiftTerm report mouse events. It sets `allowMouseReporting`
to false on the attached view and installs its own event monitor that turns
wheel motion into tmux mouse buttons 4 and 5. That monitor, though, handed the
event back to AppKit in several cases: when the line delta was zero, when the
pointer sat in the slack strip below the last row or the sliver right of the
last column (the grid lookup returns nothing there, even though the pointer is
inside the view), and when tmux had not enabled mouse reporting.

A handed-back event reaches SwiftTerm's own `scrollWheel`. Because TBD turned
mouse reporting off, SwiftTerm falls back to its alternate-screen scrolling
behaviour and synthesizes Up and Down cursor keys. tmux always drives the outer
terminal on the alternate screen, so that fallback fires every time. The keys go
to tmux, tmux forwards them to the pane, and Claude Code's composer reads Up as
prompt-history recall. The scroll is delivered as typing.

Genuine wheel reports do not do this. When the monitor forwards buttons 4 and 5,
Claude Code scrolls its transcript and leaves the draft alone. The only bad path
is a wheel event reaching SwiftTerm's cursor-key fallback.

## What this PR does

The monitor now enforces one invariant: a wheel event whose pointer is inside a
visible, tmux-attached terminal, with no overlay on top, is never returned to
AppKit. It is forwarded to tmux as a mouse button, or it is swallowed. Only
events that belong to somebody else pass through.

The decision moves into a small pure helper, `TerminalWheelRouting`, so each
branch is testable without a view, a window, or a live terminal. It classifies
an event as pass-through, swallow, or forward with a button and a repeat count.
Motion is now read from both the line delta and the point-granularity delta,
because SwiftTerm's own override reads the latter, so an event with no line
delta would still have become cursor keys. Forwarded events get a grid position
clamped into the grid rather than a nil-checked one, which is what covers the
slack strip. `gridPosition(atWindowLocation:)` keeps its existing nil contract
for callers such as Cmd+Click that genuinely want "not on a cell"; the clamping
lives in a new sibling method.

Overriding `scrollWheel` in `TBDTerminalView` was the obvious alternative and is
not available: SwiftTerm declares it `public override`, not `open`, and the
fork is pinned. Fixing it in the fork would put the behaviour a version bump
away from anyone else's terminal expectations, so the routing rule stays in
TBD's own monitor, with a comment at the monitor explaining why no decline path
may be reintroduced.

Bug fix, no spec needed, per CLAUDE.md.

## Assumptions

Assumes tmux keeps running the outer terminal on the alternate screen. If that
stopped being true, SwiftTerm's fallback would scroll its own buffer instead of
sending cursor keys, and the bug would disappear on its own; the invariant here
stays correct either way.

## Evidence & verification

The repro that identified the mechanism ran in a fenced tmux against a
fake-model Claude 2.1.263. Sending three Up keys with a draft in the composer
produced a "History 1/1" banner and replaced the draft, exactly matching the
reported symptom. Sending genuine wheel mouse reports instead scrolled the
transcript and left the draft intact, which isolates the cursor-key fallback as
the only path that loses typing.

`Tests/TBDAppTests/TerminalWheelRoutingTests.swift` covers every branch: up
forwards button 4, down forwards button 5, the repeat count follows the delta
magnitude and never drops below one, a precise-scroll event with no line delta
still forwards, no motion at all passes through, an open overlay passes through,
a pointer outside passes through, and mouse reporting off swallows rather than
passing through. That last one is the regression test, and it asserts the
disposition is not pass-through rather than only that it is swallow. A further
test sweeps a grid of delta combinations and asserts that an event over the
terminal with any motion never yields pass-through. Grid clamping is covered for
an interior point against the unclamped math, the bottom slack strip, the right
sliver, a negative point, and a degenerate zero-size grid.

Test results on this branch:

```
✔ Test run with 14 tests in 1 suite passed        (--filter TerminalWheelRouting)
✔ Test run with 28 tests in 1 suite passed        (--filter TerminalPanelViewTests)
━ Test run with 3486 tests in 364 suites passed with 11 known issues   (TBDAppTests)
```

`swiftlint --strict` reports 0 violations in 1046 files. `scripts/swift-safe
build` completes clean.

Not verified locally: the change was not exercised in a running app on this
machine, and the daemon was left untouched. The reasoning above rests on the
fenced-tmux repro and the unit tests.

This PR was written by a Claude Code agent on Adam Zionts's behalf. The
maintainer is away, so Adam will carry any review feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGCZ8b4bWY9Yqdpna639SB
[20260810-varying-wildfowl](https://cheapsteak.github.io/tbd/open/?worktree=9C81D24D-12C8-4945-88A7-431D2116B526)
