### PR TITLE
Fix: the retire test tells a squatter from a proxy that never closed

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -407,6 +407,11 @@ let package = Package(
             dependencies: [
                 "TBDModelProxy",
                 "TBDShared",
+                // `pollUntilTrue`, the repo's one bounded poll. It brings
+                // `TBDDaemonLib` in behind it, which nothing else here needs;
+                // the alternative is a seventh hand-rolled poll loop, which is
+                // the thing that helper exists to end.
+                "TestSupport",
                 .product(name: "NIO", package: "swift-nio"),
                 .product(name: "NIOPosix", package: "swift-nio"),
                 .product(name: "NIOHTTP1", package: "swift-nio"),

--- a/Tests/TBDModelProxyTests/ProxyControlTests.swift
+++ b/Tests/TBDModelProxyTests/ProxyControlTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import NIOHTTP1
 import NIOCore
+import TestSupport
 import Testing
 
 @testable import TBDModelProxy
@@ -114,9 +115,10 @@ extension ModelProxySuites {
             // of whatever turn is still running.
             let retired = ProxyFlagBox()
             // Six events a second apart: the stream has to still be running
-            // when the successor binds, and the successor's bind is allowed to
-            // wait out a squatter (see below), so the script's length is the
-            // budget both of those come out of.
+            // when the retire answers, which is what the in-flight count and
+            // the untouched event stream below read. The successor's wait for
+            // the port is deliberately not paid for out of this script's
+            // length; see the wait itself.
             let ticks = (1...6).map { index in
                 (delayMs: 1000, bytes: Array("event: tick\ndata: {\"n\":\(index)}\n\n".utf8))
             }
@@ -150,9 +152,23 @@ extension ModelProxySuites {
                 #expect(harness.server.streamsInFlight == 1, "the stream was cut by the retire")
                 #expect(!retired.value, "the process was handed over before the drain finished")
 
+                // The claim the handshake makes, asserted where no race can
+                // turn it: at the instant the answer lands, a connect to the
+                // port must be refused. Only a listening socket answers one, so
+                // a refusal is proof the listener is gone — and a proxy that
+                // wrote its 200 first and closed afterwards is still accepting
+                // here, however its successor's bind goes. The bind below
+                // cannot carry this claim on its own, because a retire frees
+                // the port and cannot reserve it.
+                #expect(
+                    connectRefused(port: harness.port),
+                    "the port still accepted a connection when the retire answered")
+
                 // The successor takes the port while the first proxy is still
-                // delivering. This is what `SO_REUSEADDR` on the listener buys: the
-                // connections carrying the in-flight streams still hold the port.
+                // delivering. This is what `SO_REUSEADDR` on the listener buys:
+                // the connections carrying the in-flight streams still hold the
+                // port, and a bind those refused would fail on the first
+                // attempt and on every one after it.
                 let successor = ProxyServer(
                     port: harness.port, routes: harness.routes, tee: nil,
                     status: {
@@ -163,41 +179,70 @@ extension ModelProxySuites {
                     },
                     onRetire: {})
                 let bindStarted = ContinuousClock().now
-                var boundPort: Int?
-                var lastBindError: (any Error)?
-                // Retried rather than tried once: an ephemeral port the retire
-                // just freed is a port any concurrently starting listener — in
-                // this process or in another test's child — can be handed, and
-                // that is a squatter, not a broken handshake. Four seconds
-                // rather than one because the squatter is real: it took this
-                // port on two of three CI runs once the suite that spawns real
-                // proxy binaries landed ahead of this one.
+                let bindOutcome = ProxyBindOutcomeBox()
+                // Waited out rather than budgeted, because a retire frees the
+                // port and cannot reserve it. macOS hands ephemeral ports out
+                // sequentially from one global counter — `net.inet.tcp
+                // .randomize_ports` is 0 — across the 16,384 numbers in
+                // 49152-65535, so a freed one comes back around after a single
+                // wrap of that range: 16,220 allocations, measured at 0.15 s on
+                // an idle machine. Beside every other socket-opening test in
+                // the pass, the number this retire just freed is one an
+                // unrelated connect or listener can be handed at once, and
+                // `SO_REUSEADDR` buys nothing against that: a socket that does
+                // not set it refuses a `SO_REUSEADDR` bind, EADDRINUSE, for as
+                // long as it lives. A squatter is somebody else holding a port,
+                // not a broken handshake — which is why the handshake is
+                // asserted above, off the socket the retire answered on, and
+                // why this wait only has to outlast the squatter.
                 //
-                // Widening the allowance does NOT weaken the claim, because the
-                // claim is not "within N seconds" — it is "while the old
-                // streams are still running", and `streamsInFlight == 1` below
-                // is what asserts it. A bind that only succeeded because the
-                // last stream ended fails there, whatever the allowance is.
-                while ContinuousClock().now - bindStarted < .seconds(4) {
+                // Thirty seconds rather than the four this waited before, which
+                // a peer test's listener outlived four times on `main` in one
+                // day. It stays well inside `withProxy`'s 60-second "request"
+                // phase deadline. The "no stream was cut" half of the test does
+                // not come out of this wait either: it is the in-flight count
+                // above and the six events below.
+                let poll = await pollUntilTrue(
+                    timeout: .seconds(30), pollInterval: .milliseconds(50)
+                ) {
                     do {
-                        boundPort = try await withPhaseDeadline("successor bind", seconds: 5) {
-                            try await successor.start()
-                        }
-                        break
+                        bindOutcome.bound(
+                            try await withPhaseDeadline("successor bind", seconds: 5) {
+                                try await successor.start()
+                            })
+                        return true
                     } catch {
-                        lastBindError = error
-                        try? await Task.sleep(nanoseconds: 50_000_000)
+                        bindOutcome.failed(error)
+                        return false
                     }
                 }
                 let bindTook = ContinuousClock().now - bindStarted
-                // Built before the macro, not inside it: `#expect`'s message is
-                // a `Comment`, and a nested closure interpolated into one is
-                // the shape that failed to compile in Task A4.
-                let bindFailure = lastBindError.map { "\($0)" } ?? "no error"
-                #expect(
-                    boundPort == harness.port,
-                    "the successor did not take the port in \(bindTook): \(bindFailure)")
-                #expect(harness.server.streamsInFlight == 1, "the first stream ended early")
+                switch poll {
+                case .satisfied:
+                    #expect(bindOutcome.port == harness.port, "the successor bound some other port")
+                case .cancelled:
+                    // Attribution belongs to whatever cancelled this test, not
+                    // to a wait that was about to succeed.
+                    break
+                case .timedOut:
+                    // Both built before the macro, not inside it: `Issue.record`
+                    // takes a `Comment`, and a nested closure interpolated into
+                    // one is the shape that failed to compile in Task A4.
+                    let bindFailure = bindOutcome.lastError ?? "no error"
+                    // Which kind of squatter, asked the one way a test inside
+                    // the process can: a connect that is answered means
+                    // somebody is listening on the port, a refused one means a
+                    // socket that never listens — a client connection's local
+                    // port, say — holds it.
+                    let holder = connectRefused(port: harness.port)
+                        ? "nothing is listening on it"
+                        : "something is listening on it"
+                    Issue.record(
+                        """
+                        the successor did not take the port in \(bindTook): \(bindFailure); \
+                        \(holder)
+                        """)
+                }
                 await successor.stop()
 
                 // No stream was cut: every scripted event still arrives.
@@ -604,6 +649,27 @@ func forwardStatus(_ harness: ProxyHarness, token: String) async throws -> Int {
 }
 
 /// A counter a `@Sendable` callback can bump from anywhere.
+/// The successor's bind result, carried out of the poll closure that produces
+/// it.
+///
+/// A box rather than two `var`s the closure captures: the capture would be a
+/// mutation from inside an `async` closure, and the boxes this suite already
+/// uses are the shape that answers it.
+final class ProxyBindOutcomeBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var boundPort: Int?
+    private var failure: String?
+
+    /// The port the successor bound, or nil while no attempt has succeeded.
+    var port: Int? { lock.withLock { boundPort } }
+    /// What the last refused bind said, rendered on the spot: the error is only
+    /// ever wanted for a failure message.
+    var lastError: String? { lock.withLock { failure } }
+
+    func bound(_ port: Int) { lock.withLock { boundPort = port } }
+    func failed(_ error: any Error) { lock.withLock { failure = "\(error)" } }
+}
+
 final class ProxyCountBox: @unchecked Sendable {
     private let lock = NSLock()
     private var count = 0

--- a/Tests/TBDModelProxyTests/ProxyControlTests.swift
+++ b/Tests/TBDModelProxyTests/ProxyControlTests.swift
@@ -123,137 +123,185 @@ extension ModelProxySuites {
                 (delayMs: 1000, bytes: Array("event: tick\ndata: {\"n\":\(index)}\n\n".utf8))
             }
 
+            // Carries the still-streaming response body from `body` to
+            // `afterRequest`, which runs after "request"'s deadline has
+            // already been raced and lost interest in the operation — see
+            // `withProxy`'s doc comment for why that hand-off happens through
+            // a captured box rather than a return value.
+            let streamBox = ProxyBytesBox()
+
             try await withProxy(
                 prefix: "pxret",
                 script: { _, _ in FakeUpstream.Script(events: ticks) },
-                onRetire: { retired.set() }
-            ) { harness in
-                var request = URLRequest(url: harness.url("/v1/messages"))
-                request.httpMethod = "POST"
-                request.httpBody = Data(#"{"stream":true}"#.utf8)
-                let (bytes, response) = try await harness.session.bytes(for: request)
-                #expect((response as? HTTPURLResponse)?.statusCode == 200)
-                #expect(harness.server.streamsInFlight == 1)
+                onRetire: { retired.set() },
+                // Only the retire round trip and the connect-refused check —
+                // literally the "request" this phase is named for. The
+                // successor-bind wait and the post-bind drain used to run in
+                // here too, sharing this 60s window three ways; they now run
+                // in `afterRequest`, each under its own budget.
+                body: { harness in
+                    var request = URLRequest(url: harness.url("/v1/messages"))
+                    request.httpMethod = "POST"
+                    request.httpBody = Data(#"{"stream":true}"#.utf8)
+                    let (bytes, response) = try await harness.session.bytes(for: request)
+                    streamBox.put(bytes)
+                    #expect((response as? HTTPURLResponse)?.statusCode == 200)
+                    #expect(harness.server.streamsInFlight == 1)
 
-                let asked = ContinuousClock().now
-                let (body, retireResponse) = try await harness.session.data(
-                    for: controlRequest(port: harness.port, method: "POST", path: "/tbd/retire"))
-                let answered = ContinuousClock().now - asked
+                    let asked = ContinuousClock().now
+                    let (body, retireResponse) = try await harness.session.data(
+                        for: controlRequest(port: harness.port, method: "POST", path: "/tbd/retire"))
+                    let answered = ContinuousClock().now - asked
 
-                #expect((retireResponse as? HTTPURLResponse)?.statusCode == 200)
-                #expect(String(decoding: body, as: UTF8.self) == ControlEndpoints.retiringBody)
-                // Bounded well under the ~6 seconds the stream still has to
-                // run: an answer that waited for the drain could not land this
-                // early. Two seconds rather than 500 ms because the claim is
-                // "before the drain", not "in 500 ms" — and a loaded runner
-                // that took 600 ms to turn one loopback round trip around
-                // would redden a proxy that did exactly the right thing.
-                #expect(answered < .seconds(2), "retire answered after \(answered)")
-                #expect(harness.server.streamsInFlight == 1, "the stream was cut by the retire")
-                #expect(!retired.value, "the process was handed over before the drain finished")
+                    #expect((retireResponse as? HTTPURLResponse)?.statusCode == 200)
+                    #expect(String(decoding: body, as: UTF8.self) == ControlEndpoints.retiringBody)
+                    // Bounded well under the ~6 seconds the stream still has to
+                    // run: an answer that waited for the drain could not land this
+                    // early. Two seconds rather than 500 ms because the claim is
+                    // "before the drain", not "in 500 ms" — and a loaded runner
+                    // that took 600 ms to turn one loopback round trip around
+                    // would redden a proxy that did exactly the right thing.
+                    #expect(answered < .seconds(2), "retire answered after \(answered)")
+                    #expect(harness.server.streamsInFlight == 1, "the stream was cut by the retire")
+                    #expect(!retired.value, "the process was handed over before the drain finished")
 
-                // The claim the handshake makes, asserted where no race can
-                // turn it: at the instant the answer lands, a connect to the
-                // port must be refused. Only a listening socket answers one, so
-                // a refusal is proof the listener is gone — and a proxy that
-                // wrote its 200 first and closed afterwards is still accepting
-                // here, however its successor's bind goes. The bind below
-                // cannot carry this claim on its own, because a retire frees
-                // the port and cannot reserve it.
-                #expect(
-                    connectRefused(port: harness.port),
-                    "the port still accepted a connection when the retire answered")
+                    // The claim the handshake makes, asserted where no race can
+                    // turn it: at the instant the answer lands, a connect to the
+                    // port must be refused. Only a listening socket answers one, so
+                    // a refusal is proof the listener is gone — and a proxy that
+                    // wrote its 200 first and closed afterwards is still accepting
+                    // here, however its successor's bind goes. The bind below
+                    // cannot carry this claim on its own, because a retire frees
+                    // the port and cannot reserve it.
+                    #expect(
+                        connectRefused(port: harness.port),
+                        "the port still accepted a connection when the retire answered")
+                },
+                // Everything here used to be the back half of `body`, stacked
+                // inside `withProxy`'s 60-second "request" phase alongside the
+                // retire round trip and the connect-refused check above. On
+                // fast-pass-2 — the population this suite runs in —
+                // `Tests/CLAUDE.md` measures p90 51.4s and max 55.3s reported
+                // per-test on a green run; a 30-35s bind wait sharing that
+                // window with everything else in `body` had too little
+                // headroom left, and a starved run could trip the generic
+                // `ProxyPhaseTimeout("request", 60)` instead of the bind
+                // wait's own diagnosed message. Running here instead, after
+                // "request" has already returned, gives the bind wait and the
+                // drain each an independent budget that cannot draw on
+                // "request"'s or on each other's.
+                afterRequest: { harness in
+                    let bytes = streamBox.value!
 
-                // The successor takes the port while the first proxy is still
-                // delivering. This is what `SO_REUSEADDR` on the listener buys:
-                // the connections carrying the in-flight streams still hold the
-                // port, and a bind those refused would fail on the first
-                // attempt and on every one after it.
-                let successor = ProxyServer(
-                    port: harness.port, routes: harness.routes, tee: nil,
-                    status: {
-                        ModelProxyStatus(
-                            version: "successor", pid: getpid(), processStartTime: Date(),
-                            port: harness.port, streamsInFlight: 0, routeCount: 0,
-                            home: harness.home)
-                    },
-                    onRetire: {})
-                let bindStarted = ContinuousClock().now
-                let bindOutcome = ProxyBindOutcomeBox()
-                // Waited out rather than budgeted, because a retire frees the
-                // port and cannot reserve it. macOS hands ephemeral ports out
-                // sequentially from one global counter — `net.inet.tcp
-                // .randomize_ports` is 0 — across the 16,384 numbers in
-                // 49152-65535, so a freed one comes back around after a single
-                // wrap of that range: 16,220 allocations, measured at 0.15 s on
-                // an idle machine. Beside every other socket-opening test in
-                // the pass, the number this retire just freed is one an
-                // unrelated connect or listener can be handed at once, and
-                // `SO_REUSEADDR` buys nothing against that: a socket that does
-                // not set it refuses a `SO_REUSEADDR` bind, EADDRINUSE, for as
-                // long as it lives. A squatter is somebody else holding a port,
-                // not a broken handshake — which is why the handshake is
-                // asserted above, off the socket the retire answered on, and
-                // why this wait only has to outlast the squatter.
-                //
-                // Thirty seconds rather than the four this waited before, which
-                // a peer test's listener outlived four times on `main` in one
-                // day. It stays well inside `withProxy`'s 60-second "request"
-                // phase deadline. The "no stream was cut" half of the test does
-                // not come out of this wait either: it is the in-flight count
-                // above and the six events below.
-                let poll = await pollUntilTrue(
-                    timeout: .seconds(30), pollInterval: .milliseconds(50)
-                ) {
-                    do {
-                        bindOutcome.bound(
-                            try await withPhaseDeadline("successor bind", seconds: 5) {
-                                try await successor.start()
-                            })
-                        return true
-                    } catch {
-                        bindOutcome.failed(error)
-                        return false
+                    // The successor takes the port while the first proxy is still
+                    // delivering. This is what `SO_REUSEADDR` on the listener buys:
+                    // the connections carrying the in-flight streams still hold the
+                    // port, and a bind those refused would fail on the first
+                    // attempt and on every one after it.
+                    let successor = ProxyServer(
+                        port: harness.port, routes: harness.routes, tee: nil,
+                        status: {
+                            ModelProxyStatus(
+                                version: "successor", pid: getpid(), processStartTime: Date(),
+                                port: harness.port, streamsInFlight: 0, routeCount: 0,
+                                home: harness.home)
+                        },
+                        onRetire: {})
+                    let bindStarted = ContinuousClock().now
+                    let bindOutcome = ProxyBindOutcomeBox()
+                    // Waited out rather than budgeted, because a retire frees the
+                    // port and cannot reserve it. macOS hands ephemeral ports out
+                    // sequentially from one global counter — `net.inet.tcp
+                    // .randomize_ports` is 0 — across the 16,384 numbers in
+                    // 49152-65535, so a freed one comes back around after a single
+                    // wrap of that range: 16,220 allocations, measured at 0.15 s on
+                    // an idle machine. Beside every other socket-opening test in
+                    // the pass, the number this retire just freed is one an
+                    // unrelated connect or listener can be handed at once, and
+                    // `SO_REUSEADDR` buys nothing against that: a socket that does
+                    // not set it refuses a `SO_REUSEADDR` bind, EADDRINUSE, for as
+                    // long as it lives. A squatter is somebody else holding a port,
+                    // not a broken handshake — which is why the handshake is
+                    // asserted in `body`, off the socket the retire answered on,
+                    // and why this wait only has to outlast the squatter.
+                    //
+                    // Thirty seconds rather than the four this waited before,
+                    // which a peer test's listener outlived four times on `main`
+                    // in one day. It now runs in `afterRequest` (see above) with
+                    // that 30s entirely to itself, rather than sharing
+                    // `withProxy`'s 60-second "request" phase with the retire
+                    // round trip, the connect-refused check, and the drain below.
+                    // The "no stream was cut" half of the test does not come out
+                    // of this wait either: it is the in-flight count above and
+                    // the six events below.
+                    let poll = await pollUntilTrue(
+                        timeout: .seconds(30), pollInterval: .milliseconds(50)
+                    ) {
+                        do {
+                            bindOutcome.bound(
+                                try await withPhaseDeadline("successor bind", seconds: 5) {
+                                    try await successor.start()
+                                })
+                            return true
+                        } catch {
+                            bindOutcome.failed(error)
+                            return false
+                        }
                     }
-                }
-                let bindTook = ContinuousClock().now - bindStarted
-                switch poll {
-                case .satisfied:
-                    #expect(bindOutcome.port == harness.port, "the successor bound some other port")
-                case .cancelled:
-                    // Attribution belongs to whatever cancelled this test, not
-                    // to a wait that was about to succeed.
-                    break
-                case .timedOut:
-                    // Both built before the macro, not inside it: `Issue.record`
-                    // takes a `Comment`, and a nested closure interpolated into
-                    // one is the shape that failed to compile in Task A4.
-                    let bindFailure = bindOutcome.lastError ?? "no error"
-                    // Which kind of squatter, asked the one way a test inside
-                    // the process can: a connect that is answered means
-                    // somebody is listening on the port, a refused one means a
-                    // socket that never listens — a client connection's local
-                    // port, say — holds it.
-                    let holder = connectRefused(port: harness.port)
-                        ? "nothing is listening on it"
-                        : "something is listening on it"
-                    Issue.record(
-                        """
-                        the successor did not take the port in \(bindTook): \(bindFailure); \
-                        \(holder)
-                        """)
-                }
-                await successor.stop()
+                    let bindTook = ContinuousClock().now - bindStarted
+                    switch poll {
+                    case .satisfied:
+                        #expect(bindOutcome.port == harness.port, "the successor bound some other port")
+                    case .cancelled:
+                        // Attribution belongs to whatever cancelled this test, not
+                        // to a wait that was about to succeed.
+                        break
+                    case .timedOut:
+                        // Both built before the macro, not inside it: `Issue.record`
+                        // takes a `Comment`, and a nested closure interpolated into
+                        // one is the shape that failed to compile in Task A4.
+                        let bindFailure = bindOutcome.lastError ?? "no error"
+                        // Which kind of squatter, asked the one way a test inside
+                        // the process can: a connect that is answered means
+                        // somebody is listening on the port, a refused one means a
+                        // socket that never listens — a client connection's local
+                        // port, say — holds it.
+                        let holder = connectRefused(port: harness.port)
+                            ? "nothing is listening on it"
+                            : "something is listening on it"
+                        Issue.record(
+                            """
+                            the successor did not take the port in \(bindTook): \(bindFailure); \
+                            \(holder)
+                            """)
+                    }
+                    await successor.stop()
 
-                // No stream was cut: every scripted event still arrives.
-                var arrived = 0
-                for try await line in bytes.lines where line.hasPrefix("event: ") { arrived += 1 }
-                #expect(arrived == 6)
+                    // No stream was cut: every scripted event still arrives. Its
+                    // own named phase, sized like this file's other body-read
+                    // phases ("raw status" 20s, "redirect read" 25s) rather than
+                    // folded into "request": the six ticks are a second apart and
+                    // already fully sent by the time the bind wait above returns
+                    // (it can run up to 30s against a 6s script), so this mostly
+                    // drains an already-buffered connection. 20s is generous
+                    // scheduling slack for fast-pass-2 without being able to mask
+                    // a real hang — it sits comfortably under that pass's 55.3s
+                    // green-run max (`Tests/CLAUDE.md`).
+                    let arrived = try await withPhaseDeadline("stream drain", seconds: 20) {
+                        () -> Int in
+                        var count = 0
+                        for try await line in bytes.lines where line.hasPrefix("event: ") {
+                            count += 1
+                        }
+                        return count
+                    }
+                    #expect(arrived == 6)
 
-                await waitUntil(
-                    "the drain handed the process over", sample: { retired.value },
-                    isSatisfied: { $0 })
-            }
+                    await waitUntil(
+                        "the drain handed the process over", sample: { retired.value },
+                        isSatisfied: { $0 })
+                }
+            )
         }
 
         @Test("the drain gives up at its cap and hands over anyway")
@@ -668,6 +716,20 @@ final class ProxyBindOutcomeBox: @unchecked Sendable {
 
     func bound(_ port: Int) { lock.withLock { boundPort = port } }
     func failed(_ error: any Error) { lock.withLock { failure = "\(error)" } }
+}
+
+/// Carries a still-open `URLSession.AsyncBytes` stream from `withProxy`'s
+/// "request" phase into `afterRequest`, which needs to keep reading it under
+/// a phase of its own — see the doc comment on `withProxy`.
+final class ProxyBytesBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: URLSession.AsyncBytes?
+
+    /// Force-unwrapped at every call site deliberately: `body` always puts a
+    /// value before `afterRequest` reads one, so a nil here is a broken test
+    /// wiring rather than a condition worth propagating.
+    var value: URLSession.AsyncBytes? { lock.withLock { stored } }
+    func put(_ bytes: URLSession.AsyncBytes) { lock.withLock { stored = bytes } }
 }
 
 final class ProxyCountBox: @unchecked Sendable {

--- a/Tests/TBDModelProxyTests/ProxyControlTests.swift
+++ b/Tests/TBDModelProxyTests/ProxyControlTests.swift
@@ -270,10 +270,11 @@ extension ModelProxySuites {
                             ? "nothing is listening on it"
                             : "something is listening on it"
                         Issue.record(
-                            """
-                            the successor did not take the port in \(bindTook): \(bindFailure); \
-                            \(holder)
-                            """)
+                            Failure(
+                                """
+                                the successor did not take the port in \(bindTook): \(bindFailure); \
+                                \(holder)
+                                """))
                     }
                     await successor.stop()
 
@@ -716,6 +717,16 @@ final class ProxyBindOutcomeBox: @unchecked Sendable {
 
     func bound(_ port: Int) { lock.withLock { boundPort = port } }
     func failed(_ error: any Error) { lock.withLock { failure = "\(error)" } }
+}
+
+/// Failure payload for `Issue.record(_: some Error)`, whose primary console
+/// line is `Caught error: <description>`. `Issue.record(String)` and
+/// `#expect(cond, "…")` both demote their message to a trailing `↳` line that
+/// CI summaries drop (`Tests/CLAUDE.md`, assertion-hygiene rule 4) — the
+/// successor-bind timeout diagnosis has to travel as an error to survive.
+private struct Failure: Error, CustomStringConvertible {
+    let description: String
+    init(_ description: String) { self.description = description }
 }
 
 /// Carries a still-open `URLSession.AsyncBytes` stream from `withProxy`'s

--- a/Tests/TBDModelProxyTests/ProxyControlTests.swift
+++ b/Tests/TBDModelProxyTests/ProxyControlTests.swift
@@ -210,6 +210,18 @@ extension ModelProxySuites {
                                 Failure(
                                     "the retire handshake could not be observed: \(what)"))
                         }
+                    case .unidentified(let what):
+                        // Failed, not excused: nobody was identified, so a proxy
+                        // that answered before it closed is still one of the
+                        // explanations and excusing this would be the way it got
+                        // through.
+                        Issue.record(
+                            Failure(
+                                """
+                                the port was not free when the retire answered and its holder \
+                                would not identify itself — a proxy that answered before it \
+                                closed is still one explanation: \(what)
+                                """))
                     }
                 },
                 // Everything here used to be the back half of `body`, stacked
@@ -322,7 +334,15 @@ extension ModelProxySuites {
                                     \(holder)
                                     """))
                         }
-                        await successor.stop()
+                        // Its own named deadline like every other blocking step
+                        // in `afterRequest`, and for the reason `withProxy`'s
+                        // teardown wraps the identical call: `ProxyServer.stop()`
+                        // closes a listener and then shuts an event-loop group
+                        // down, and outside "request"'s 60 seconds there is no
+                        // outer bound left to catch a wedge in either.
+                        _ = try await withPhaseDeadline("successor stop", seconds: 20) {
+                            await successor.stop()
+                        }
                     }
 
                     // No stream was cut: every scripted event still arrives. Its
@@ -819,16 +839,28 @@ enum ProxyPortHolder: Sendable, CustomStringConvertible {
     /// say all three, so this is the regression the handshake forbids.
     case theProxyUnderTest(pid: Int32)
 
-    /// Something answered and it is not the proxy under test — a peer test's
-    /// listener holding the number this retire just freed. No claim about the
-    /// handshake survives it, and no bind can take a port a stranger holds.
+    /// Somebody else was **positively identified**: either a proxy status
+    /// naming a different pid, port or home, or a holder that had already let
+    /// go by the time the status leg reached it — which the proxy under test
+    /// cannot have been, since it stays alive until teardown. This is the only
+    /// verdict that excuses the observation, and it is reached by recognising a
+    /// stranger rather than by failing to recognise anybody.
     case aStranger(String)
+
+    /// Something is listening and would not say who. The catch-all deliberately
+    /// does **not** land in `.aStranger`: an excused bucket that swallows every
+    /// unexplained answer is the one route by which a broken handshake could
+    /// pass, and this verdict fails the test rather than take that risk. The
+    /// message carries what was actually seen, so a genuine stranger that turns
+    /// up here can be reclassified on evidence instead of by default.
+    case unidentified(String)
 
     var description: String {
         switch self {
         case .nobody: return "nothing is listening on it"
         case .theProxyUnderTest(let pid): return "the proxy under test (pid \(pid)) is listening on it"
         case .aStranger(let what): return what
+        case .unidentified(let what): return what
         }
     }
 }
@@ -855,7 +887,8 @@ func portHolder(port: Int, home: String) async -> ProxyPortHolder {
             for: controlRequest(port: port, method: "GET", path: "/tbd/status"))
         let code = (response as? HTTPURLResponse)?.statusCode ?? 0
         guard code == 200, let reported = try? ModelProxyStatus.decodeStatusResponse(data) else {
-            return .aStranger("something answered HTTP \(code) on \(port), not a proxy status")
+            return .unidentified(
+                "something is listening on \(port) and answered HTTP \(code), not a proxy status")
         }
         // All three, not any one: a peer harness in this same process reports
         // the same pid and the same "test" version, and only its home and the
@@ -869,7 +902,17 @@ func portHolder(port: Int, home: String) async -> ProxyPortHolder {
         }
         return .theProxyUnderTest(pid: reported.pid)
     } catch {
-        return .aStranger("something accepted a connection on \(port) and answered nothing: \(error)")
+        // The two probes are two separate connects, so a holder can let go
+        // between them — and a port that refuses now was not held by the proxy
+        // under test, which stays listening until this test tears it down.
+        // Asking again is what keeps that ordinary race out of the verdict that
+        // fails the build, without widening it into a catch-all.
+        guard !connectRefused(port: port) else {
+            return .aStranger(
+                "something held \(port) for one connect and had let go by the next: \(error)")
+        }
+        return .unidentified(
+            "something is listening on \(port) and answered nothing: \(error)")
     }
 }
 

--- a/Tests/TBDModelProxyTests/ProxyControlTests.swift
+++ b/Tests/TBDModelProxyTests/ProxyControlTests.swift
@@ -129,12 +129,17 @@ extension ModelProxySuites {
             // `withProxy`'s doc comment for why that hand-off happens through
             // a captured box rather than a return value.
             let streamBox = ProxyBytesBox()
+            // Who held the port at the instant the retire answered, carried the
+            // same way and for the same reason: `afterRequest` decides whether
+            // a successor bind is even a meaningful thing to attempt, and no
+            // test can bind a port a stranger holds.
+            let portAfterRetire = ProxyPortHolderBox()
 
             try await withProxy(
                 prefix: "pxret",
                 script: { _, _ in FakeUpstream.Script(events: ticks) },
                 onRetire: { retired.set() },
-                // Only the retire round trip and the connect-refused check —
+                // Only the retire round trip and the port-holder probe —
                 // literally the "request" this phase is named for. The
                 // successor-bind wait and the post-bind drain used to run in
                 // here too, sharing this 60s window three ways; they now run
@@ -165,21 +170,51 @@ extension ModelProxySuites {
                     #expect(harness.server.streamsInFlight == 1, "the stream was cut by the retire")
                     #expect(!retired.value, "the process was handed over before the drain finished")
 
-                    // The claim the handshake makes, asserted where no race can
-                    // turn it: at the instant the answer lands, a connect to the
-                    // port must be refused. Only a listening socket answers one, so
-                    // a refusal is proof the listener is gone — and a proxy that
-                    // wrote its 200 first and closed afterwards is still accepting
-                    // here, however its successor's bind goes. The bind below
-                    // cannot carry this claim on its own, because a retire frees
-                    // the port and cannot reserve it.
-                    #expect(
-                        connectRefused(port: harness.port),
-                        "the port still accepted a connection when the retire answered")
+                    // The claim the handshake makes, asked the one way that
+                    // tells the two explanations of an answered connect apart.
+                    // At the instant the answer lands the port is asked *who*
+                    // holds it, not merely whether somebody does: a proxy that
+                    // wrote its 200 before closing its listener answers a
+                    // `/tbd/status` naming this test's own home, port and pid,
+                    // and nothing else in the process can. A bare refusal check
+                    // could not do this, because a retire frees the port and
+                    // cannot reserve it — an answered connect is as likely to be
+                    // a stranger handed the freed number as it is to be a proxy
+                    // that never closed, and those have opposite verdicts.
+                    let holder = await portHolder(port: harness.port, home: harness.home)
+                    portAfterRetire.put(holder)
+                    switch holder {
+                    case .nobody:
+                        // The listener is gone: the ordering the whole
+                        // supervisor design rests on held.
+                        break
+                    case .theProxyUnderTest(let pid):
+                        Issue.record(
+                            Failure(
+                                """
+                                the retiring proxy (pid \(pid)) was still listening on \
+                                \(harness.port) when its 200 landed: retire answered before \
+                                its listener closed
+                                """))
+                    case .aStranger(let what):
+                        // Nobody's bug, and nothing about the handshake is
+                        // observable through a socket somebody else owns. It is
+                        // recorded rather than swallowed so the rate stays
+                        // visible, and `isIntermittent` because a green run is
+                        // the ordinary outcome — the squat is the exception.
+                        withKnownIssue(
+                            "another listener took the port the retire freed",
+                            isIntermittent: true
+                        ) {
+                            Issue.record(
+                                Failure(
+                                    "the retire handshake could not be observed: \(what)"))
+                        }
+                    }
                 },
                 // Everything here used to be the back half of `body`, stacked
                 // inside `withProxy`'s 60-second "request" phase alongside the
-                // retire round trip and the connect-refused check above. On
+                // retire round trip and the port-holder probe above. On
                 // fast-pass-2 — the population this suite runs in —
                 // `Tests/CLAUDE.md` measures p90 51.4s and max 55.3s reported
                 // per-test on a green run; a 30-35s bind wait sharing that
@@ -193,98 +228,111 @@ extension ModelProxySuites {
                 afterRequest: { harness in
                     let bytes = streamBox.value!
 
-                    // The successor takes the port while the first proxy is still
-                    // delivering. This is what `SO_REUSEADDR` on the listener buys:
-                    // the connections carrying the in-flight streams still hold the
-                    // port, and a bind those refused would fail on the first
-                    // attempt and on every one after it.
-                    let successor = ProxyServer(
-                        port: harness.port, routes: harness.routes, tee: nil,
-                        status: {
-                            ModelProxyStatus(
-                                version: "successor", pid: getpid(), processStartTime: Date(),
-                                port: harness.port, streamsInFlight: 0, routeCount: 0,
-                                home: harness.home)
-                        },
-                        onRetire: {})
-                    let bindStarted = ContinuousClock().now
-                    let bindOutcome = ProxyBindOutcomeBox()
-                    // Waited out rather than budgeted, because a retire frees the
-                    // port and cannot reserve it. macOS hands ephemeral ports out
-                    // sequentially from one global counter — `net.inet.tcp
-                    // .randomize_ports` is 0 — across the 16,384 numbers in
-                    // 49152-65535, so a freed one comes back around after a single
-                    // wrap of that range: 16,220 allocations, measured at 0.15 s on
-                    // an idle machine. Beside every other socket-opening test in
-                    // the pass, the number this retire just freed is one an
-                    // unrelated connect or listener can be handed at once, and
-                    // `SO_REUSEADDR` buys nothing against that: a socket that does
-                    // not set it refuses a `SO_REUSEADDR` bind, EADDRINUSE, for as
-                    // long as it lives. A squatter is somebody else holding a port,
-                    // not a broken handshake — which is why the handshake is
-                    // asserted in `body`, off the socket the retire answered on,
-                    // and why this wait only has to outlast the squatter.
-                    //
-                    // Thirty seconds rather than the four this waited before,
-                    // which a peer test's listener outlived four times on `main`
-                    // in one day. It now runs in `afterRequest` (see above) with
-                    // that 30s entirely to itself, rather than sharing
-                    // `withProxy`'s 60-second "request" phase with the retire
-                    // round trip, the connect-refused check, and the drain below.
-                    // The "no stream was cut" half of the test does not come out
-                    // of this wait either: it is the in-flight count above and
-                    // the six events below.
-                    let poll = await pollUntilTrue(
-                        timeout: .seconds(30), pollInterval: .milliseconds(50)
-                    ) {
-                        do {
-                            bindOutcome.bound(
-                                try await withPhaseDeadline("successor bind", seconds: 5) {
-                                    try await successor.start()
-                                })
-                            return true
-                        } catch {
-                            bindOutcome.failed(error)
-                            return false
+                    // Only worth attempting when the retire actually left the
+                    // port empty. A stranger's listener refuses a
+                    // `SO_REUSEADDR` bind for as long as it lives, and a proxy
+                    // that never closed has already been failed in `body`, so
+                    // in both of those cases this would spend thirty seconds
+                    // re-discovering what the probe already said — and outlive
+                    // the 30-second `timeoutIntervalForResource` on the stream
+                    // still open below, turning one diagnosed failure into
+                    // three.
+                    var portWasFree = false
+                    if case .nobody? = portAfterRetire.value { portWasFree = true }
+
+                    if portWasFree {
+                        // The successor takes the port while the first proxy is still
+                        // delivering. This is what `SO_REUSEADDR` on the listener buys:
+                        // the connections carrying the in-flight streams still hold the
+                        // port, and a bind those refused would fail on the first
+                        // attempt and on every one after it.
+                        let successor = ProxyServer(
+                            port: harness.port, routes: harness.routes, tee: nil,
+                            status: {
+                                ModelProxyStatus(
+                                    version: "successor", pid: getpid(), processStartTime: Date(),
+                                    port: harness.port, streamsInFlight: 0, routeCount: 0,
+                                    home: harness.home)
+                            },
+                            onRetire: {})
+                        let bindStarted = ContinuousClock().now
+                        let bindOutcome = ProxyBindOutcomeBox()
+                        // Waited out rather than budgeted, because a retire frees the
+                        // port and cannot reserve it. macOS hands ephemeral ports out
+                        // sequentially from one global counter — `net.inet.tcp
+                        // .randomize_ports` is 0 — across the 16,384 numbers in
+                        // 49152-65535, so a freed one comes back around after a single
+                        // wrap of that range: 16,220 allocations, measured at 0.15 s on
+                        // an idle machine. Beside every other socket-opening test in
+                        // the pass, the number this retire just freed is one an
+                        // unrelated connect or listener can be handed at once, and
+                        // `SO_REUSEADDR` buys nothing against that: a socket that does
+                        // not set it refuses a `SO_REUSEADDR` bind, EADDRINUSE, for as
+                        // long as it lives. A squatter is somebody else holding a port,
+                        // not a broken handshake — which is why the handshake is
+                        // asserted in `body`, off the socket the retire answered on,
+                        // and why this wait only has to outlast the squatter.
+                        //
+                        // Thirty seconds rather than the four this waited before,
+                        // which a peer test's listener outlived four times on `main`
+                        // in one day. It now runs in `afterRequest` (see above) with
+                        // that 30s entirely to itself, rather than sharing
+                        // `withProxy`'s 60-second "request" phase with the retire
+                        // round trip, the port-holder probe, and the drain below.
+                        // The "no stream was cut" half of the test does not come out
+                        // of this wait either: it is the in-flight count above and
+                        // the six events below.
+                        let poll = await pollUntilTrue(
+                            timeout: .seconds(30), pollInterval: .milliseconds(50)
+                        ) {
+                            do {
+                                bindOutcome.bound(
+                                    try await withPhaseDeadline("successor bind", seconds: 5) {
+                                        try await successor.start()
+                                    })
+                                return true
+                            } catch {
+                                bindOutcome.failed(error)
+                                return false
+                            }
                         }
+                        let bindTook = ContinuousClock().now - bindStarted
+                        switch poll {
+                        case .satisfied:
+                            #expect(bindOutcome.port == harness.port, "the successor bound some other port")
+                        case .cancelled:
+                            // Attribution belongs to whatever cancelled this test, not
+                            // to a wait that was about to succeed.
+                            break
+                        case .timedOut:
+                            // Both built before the macro, not inside it: `Issue.record`
+                            // takes a `Comment`, and a nested closure interpolated into
+                            // one is the shape that failed to compile in Task A4.
+                            let bindFailure = bindOutcome.lastError ?? "no error"
+                            // Who took it in the meantime, asked with the same
+                            // probe `body` uses: the port was empty when the
+                            // retire answered, so anything here arrived after
+                            // that and the message names it rather than leaving
+                            // the next reader to guess.
+                            let holder = await portHolder(port: harness.port, home: harness.home)
+                            Issue.record(
+                                Failure(
+                                    """
+                                    the successor did not take the port in \(bindTook): \(bindFailure); \
+                                    \(holder)
+                                    """))
+                        }
+                        await successor.stop()
                     }
-                    let bindTook = ContinuousClock().now - bindStarted
-                    switch poll {
-                    case .satisfied:
-                        #expect(bindOutcome.port == harness.port, "the successor bound some other port")
-                    case .cancelled:
-                        // Attribution belongs to whatever cancelled this test, not
-                        // to a wait that was about to succeed.
-                        break
-                    case .timedOut:
-                        // Both built before the macro, not inside it: `Issue.record`
-                        // takes a `Comment`, and a nested closure interpolated into
-                        // one is the shape that failed to compile in Task A4.
-                        let bindFailure = bindOutcome.lastError ?? "no error"
-                        // Which kind of squatter, asked the one way a test inside
-                        // the process can: a connect that is answered means
-                        // somebody is listening on the port, a refused one means a
-                        // socket that never listens — a client connection's local
-                        // port, say — holds it.
-                        let holder = connectRefused(port: harness.port)
-                            ? "nothing is listening on it"
-                            : "something is listening on it"
-                        Issue.record(
-                            Failure(
-                                """
-                                the successor did not take the port in \(bindTook): \(bindFailure); \
-                                \(holder)
-                                """))
-                    }
-                    await successor.stop()
 
                     // No stream was cut: every scripted event still arrives. Its
                     // own named phase, sized like this file's other body-read
                     // phases ("raw status" 20s, "redirect read" 25s) rather than
-                    // folded into "request": the six ticks are a second apart and
-                    // already fully sent by the time the bind wait above returns
-                    // (it can run up to 30s against a 6s script), so this mostly
-                    // drains an already-buffered connection. 20s is generous
+                    // folded into "request": the six ticks are a second apart, so
+                    // this either drains a connection the bind wait above has
+                    // already outlived (it can run up to 30s against a 6s
+                    // script) or, when that wait was skipped, reads the last few
+                    // seconds of the script live. 20s is generous
                     // scheduling slack for fast-pass-2 without being able to mask
                     // a real hang — it sits comfortably under that pass's 55.3s
                     // green-run max (`Tests/CLAUDE.md`).
@@ -749,4 +797,91 @@ final class ProxyCountBox: @unchecked Sendable {
 
     var value: Int { lock.withLock { count } }
     func increment() { lock.withLock { count += 1 } }
+}
+
+/// Who is holding a loopback port, asked at the instant a retire answered.
+///
+/// A bare `connectRefused` cannot carry the retire handshake's claim on a
+/// shared runner, because a retire *frees* its port and cannot reserve it:
+/// macOS hands ephemeral ports out sequentially from one global counter, so an
+/// answered connect is as likely to be a stranger that was handed the freed
+/// number as it is to be a proxy that never closed its listener. Those two have
+/// opposite verdicts — one is a bug in `ControlEndpoints.retire`, the other is
+/// nobody's — so the port is asked *who* holds it rather than only *whether*
+/// somebody does.
+enum ProxyPortHolder: Sendable, CustomStringConvertible {
+    /// A connect was refused. Only a listening socket answers one, so this is
+    /// what a closed listener looks like from outside the process.
+    case nobody
+
+    /// `GET /tbd/status` answered naming this process, this test's home and
+    /// this port. Nothing but the proxy that was supposed to have closed can
+    /// say all three, so this is the regression the handshake forbids.
+    case theProxyUnderTest(pid: Int32)
+
+    /// Something answered and it is not the proxy under test — a peer test's
+    /// listener holding the number this retire just freed. No claim about the
+    /// handshake survives it, and no bind can take a port a stranger holds.
+    case aStranger(String)
+
+    var description: String {
+        switch self {
+        case .nobody: return "nothing is listening on it"
+        case .theProxyUnderTest(let pid): return "the proxy under test (pid \(pid)) is listening on it"
+        case .aStranger(let what): return what
+        }
+    }
+}
+
+/// Asks a loopback port who holds it.
+///
+/// A `URLSession` of its own per call, never `harness.session`: that one has a
+/// live keep-alive connection to the retiring proxy, and a pooled reuse would
+/// get its answer from a socket accepted *before* the listener closed — which
+/// is exactly the thing being ruled out.
+func portHolder(port: Int, home: String) async -> ProxyPortHolder {
+    guard !connectRefused(port: port) else { return .nobody }
+    let configuration = URLSessionConfiguration.ephemeral
+    // The same 15 seconds `withProxy` gives its own requests, and generous
+    // rather than snappy on purpose: `.aStranger` is the verdict that *excuses*
+    // a failure, so a probe that gave up early would report a proxy that never
+    // closed as somebody else's problem.
+    configuration.timeoutIntervalForRequest = 15
+    configuration.timeoutIntervalForResource = 15
+    let session = URLSession(configuration: configuration)
+    defer { session.invalidateAndCancel() }
+    do {
+        let (data, response) = try await session.data(
+            for: controlRequest(port: port, method: "GET", path: "/tbd/status"))
+        let code = (response as? HTTPURLResponse)?.statusCode ?? 0
+        guard code == 200, let reported = try? ModelProxyStatus.decodeStatusResponse(data) else {
+            return .aStranger("something answered HTTP \(code) on \(port), not a proxy status")
+        }
+        // All three, not any one: a peer harness in this same process reports
+        // the same pid and the same "test" version, and only its home and the
+        // port it bound tell it apart from this one.
+        guard reported.pid == getpid(), reported.port == port, reported.home == home else {
+            return .aStranger(
+                """
+                another proxy is listening on \(port): pid \(reported.pid), \
+                port \(reported.port), home \(reported.home)
+                """)
+        }
+        return .theProxyUnderTest(pid: reported.pid)
+    } catch {
+        return .aStranger("something accepted a connection on \(port) and answered nothing: \(error)")
+    }
+}
+
+/// The port's holder, carried from `withProxy`'s "request" phase into
+/// `afterRequest` — the same hand-off, and for the same reason, as
+/// `ProxyBytesBox`.
+final class ProxyPortHolderBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: ProxyPortHolder?
+
+    /// Nil until `body` has probed, which every reader of this treats as "not
+    /// free": `afterRequest` runs only after `body` returned.
+    var value: ProxyPortHolder? { lock.withLock { stored } }
+    func put(_ holder: ProxyPortHolder) { lock.withLock { stored = holder } }
 }

--- a/Tests/TBDModelProxyTests/ProxyForwardingTests.swift
+++ b/Tests/TBDModelProxyTests/ProxyForwardingTests.swift
@@ -1015,6 +1015,26 @@ struct ProxyHarness: Sendable {
 /// of them inside a 4,800-test pass is invisible: the runner's stdout is block
 /// buffered, so the log names whichever test flushed last rather than the one
 /// that stopped. A phase that overruns names itself and fails the test instead.
+///
+/// `body` runs inside a single "request" phase (60s), sized for an ordinary
+/// request/response round trip against `Tests/CLAUDE.md`'s fast-pass-2 numbers
+/// (p90 51.4s / max 55.3s reported per-test on a green run). A test whose
+/// follow-on work needs its own, differently-sized budget — a bind that races
+/// a squatter, a multi-second drain — should not stack that work inside
+/// `body`: `withPhaseDeadline` races its operation against a plain
+/// `Task.sleep` timer that starts ticking the moment "request" begins, so
+/// nested phases *share* that 60s wall-clock window rather than getting one
+/// each, and a slow nested phase can trip the generic
+/// `ProxyPhaseTimeout("request", 60)` instead of its own named diagnostic
+/// (this is exactly what happened to the successor-bind wait in
+/// `retireAnswersBeforeDrainAndSuccessorCanBind`). Pass `afterRequest`
+/// instead: it runs after `body` returns, with the harness still live and
+/// before teardown, but outside "request"'s deadline — so it can size its own
+/// phases as siblings, not children, of "request". State `body` opens that
+/// `afterRequest` still needs (a still-streaming response body, say) crosses
+/// between them the way every other cross-closure value in this file does —
+/// a small `@unchecked Sendable` box captured by both — rather than through a
+/// return value, so this signature does not have to grow a generic for it.
 func withProxy(
     prefix: String,
     script: @escaping FakeUpstream.Handler,
@@ -1025,7 +1045,8 @@ func withProxy(
     /// directory is minted in here, after the caller has been called.
     teeFactory: (@Sendable (URL) -> any StreamTeeing)? = nil,
     onRetire: (@Sendable () -> Void)? = nil,
-    body: @escaping @Sendable (ProxyHarness) async throws -> Void
+    body: @escaping @Sendable (ProxyHarness) async throws -> Void,
+    afterRequest: (@Sendable (ProxyHarness) async throws -> Void)? = nil
 ) async throws {
     let upstream = FakeUpstream(script: script)
     let root = proxyScratchRoot(prefix: prefix)
@@ -1113,6 +1134,9 @@ func withProxy(
             routesDir: routesDir, streamsDir: streamsDir, server: server, routes: table,
             session: session, home: canonicalHome)
         try await withPhaseDeadline("request", seconds: 60) { try await body(harness) }
+        if let afterRequest {
+            try await afterRequest(harness)
+        }
         await teardown()
     } catch {
         await teardown()

--- a/Tests/TBDModelProxyTests/ProxyForwardingTests.swift
+++ b/Tests/TBDModelProxyTests/ProxyForwardingTests.swift
@@ -1121,9 +1121,11 @@ func withProxy(
 }
 
 /// A scratch directory under the run root `scripts/test.sh` reclaims, so a
-/// killed test process leaks nothing. Duplicated from `TestSupport`'s
-/// `fencedScratchRoot` rather than imported: that target pulls in
-/// `TBDDaemonLib`, and this one deliberately links only the proxy and NIO.
+/// killed test process leaks nothing. The `URL`-returning sibling of
+/// `TestSupport.fencedScratchRoot` — every caller here composes further path
+/// components onto it — agreeing with it on the fenced root and differing only
+/// in the unfenced fallback, which is `FileManager`'s temporary directory
+/// rather than `/tmp`.
 func proxyScratchRoot(prefix: String) -> URL {
     let fenced = ProcessInfo.processInfo.environment["TBD_TEST_SCRATCH_ROOT"] ?? ""
     let root = fenced.isEmpty ? FileManager.default.temporaryDirectory.path : fenced

--- a/Tests/TBDModelProxyTests/ProxyForwardingTests.swift
+++ b/Tests/TBDModelProxyTests/ProxyForwardingTests.swift
@@ -2,6 +2,7 @@ import CFNetwork
 import Darwin
 import Foundation
 import NIOHTTP1
+import TestSupport
 import Testing
 
 @testable import TBDModelProxy
@@ -336,9 +337,19 @@ extension ModelProxySuites {
             // A script that ended near that moment would let a relay which
             // reported nothing on cancellation still be rescued by the stream
             // finishing on its own, and the test would pass for the wrong reason.
-            // 40 events at 250 ms is 10 seconds of stream against a 5-second wait.
+            // 40 events at 1 s is 40 seconds of stream against the 20-second
+            // waits below. The ratio is what matters and it is a discriminating
+            // threshold rather than a hang guard, so it is sized by moving the
+            // *script* out rather than by shortening the wait: at 250 ms an
+            // event the stream ran out after 10 s, which left only a 5-second
+            // wait, and 5 seconds is inside the scheduling latency fast pass 2
+            // routinely shows — it went red on CI with the count still at 1
+            // while nothing was wrong with the relay. Nothing waits for this
+            // script to finish: the client cuts after the first event, and
+            // `ScriptedUpstreamHandler` stops rescheduling as soon as its
+            // channel goes inactive.
             let events = (1...40).map { index in
-                (delayMs: 250, bytes: Array("event: tick\ndata: {\"n\":\(index)}\n\n".utf8))
+                (delayMs: 1000, bytes: Array("event: tick\ndata: {\"n\":\(index)}\n\n".utf8))
             }
 
             try await withProxy(
@@ -373,18 +384,18 @@ extension ModelProxySuites {
                     }
                 }
                 #expect(seen.contains("event: tick"), "the client never saw a first event")
-                // The stream is still running upstream — two more events at 400 ms
-                // are scripted — so nothing below can be explained by the response
-                // having finished on its own.
+                // The stream is still running upstream — 39 more events, a second
+                // apart, are scripted — so nothing below can be explained by the
+                // response having finished on its own.
                 #expect(harness.upstream.requests.count == 1)
 
-                // Bounded well below the script's own 10 seconds, so a relay that
+                // Bounded well below the script's own 40 seconds, so a relay that
                 // only ends because the upstream ran out of events cannot pass.
                 await waitUntil(
-                    "the relay released its in-flight stream", seconds: 5,
+                    "the relay released its in-flight stream", seconds: 20,
                     sample: { harness.server.streamsInFlight }, isSatisfied: { $0 == 0 })
                 await waitUntil(
-                    "the tee was told the stream ended", seconds: 5,
+                    "the tee was told the stream ended", seconds: 20,
                     sample: { recorder.endCount }, isSatisfied: { $0 == 1 })
                 #expect(recorder.beginCount == 1)
                 // Exactly once: `relayEnd` deduplicates, and a second end would
@@ -939,14 +950,34 @@ struct ProxyWaitTimeout: LocalizedError {
     }
 }
 
+/// Carries a poll's last sample out of the closure that took it, so a timeout
+/// reports the value the wait actually saw rather than one re-read after the
+/// budget expired (`Tests/CLAUDE.md`, "Timeout errors must report observed
+/// state").
+private final class ProxyObservationBox<Observed: Sendable>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: Observed
+
+    init(_ initial: Observed) { stored = initial }
+
+    var value: Observed { lock.withLock { stored } }
+    func put(_ observed: Observed) { lock.withLock { stored = observed } }
+}
+
 /// Samples until `isSatisfied` holds, and records what it last saw if it never
 /// does.
 ///
 /// A poll rather than a signal because the things waited on here — a counter
 /// decremented on an event loop, a tee fed from a task of its own — have no
-/// completion the test can await. The interval is short and the budget
-/// generous, so a passing run costs milliseconds and a broken one names itself
-/// instead of hanging the job.
+/// completion the test can await.
+///
+/// The loop itself is `pollUntilTrue`, the repo's one bounded poll, rather than
+/// a seventh hand-rolled one: this used to sleep through `try? await
+/// Task.sleep`, which cannot tell expiry from cancellation and throws
+/// *instantly* once the task is cancelled — turning a 20 ms poll into a busy
+/// spin over its whole remaining budget on a cooperative thread every other
+/// test in the pass is queued behind. What stays here is the diagnostic, which
+/// is the only part that was ever this helper's own.
 @discardableResult
 func waitUntil<Observed: Sendable>(
     _ what: String,
@@ -954,18 +985,27 @@ func waitUntil<Observed: Sendable>(
     sample: @escaping @Sendable () -> Observed,
     isSatisfied: @escaping @Sendable (Observed) -> Bool
 ) async -> Bool {
-    let deadline = ContinuousClock().now + .seconds(seconds)
-    var last = sample()
-    while !isSatisfied(last) {
-        guard ContinuousClock().now < deadline else {
-            Issue.record(
-                ProxyWaitTimeout(what: what, observed: "\(last)", seconds: seconds))
-            return false
-        }
-        try? await Task.sleep(nanoseconds: 20_000_000)
-        last = sample()
+    let last = ProxyObservationBox(sample())
+    let outcome = await pollUntilTrue(
+        timeout: .seconds(seconds), pollInterval: .milliseconds(20)
+    ) {
+        let observed = sample()
+        last.put(observed)
+        return isSatisfied(observed)
     }
-    return true
+    switch outcome {
+    case .satisfied:
+        return true
+    case .cancelled:
+        // Reported nowhere, per `pollUntilTrue`'s contract: attribution belongs
+        // to whatever cancelled this test, not to a wait that may have been
+        // about to succeed. The `false` is for the two callers that gate a
+        // message on it, and a cancelled test is already ending.
+        return false
+    case .timedOut:
+        Issue.record(ProxyWaitTimeout(what: what, observed: "\(last.value)", seconds: seconds))
+        return false
+    }
 }
 
 // MARK: - Harness

--- a/docs/specs/2026-09-05-transcript-streaming-model-proxy-design.md
+++ b/docs/specs/2026-09-05-transcript-streaming-model-proxy-design.md
@@ -178,9 +178,10 @@ an ephemeral-port coincidence, means the port is not this daemon's to use; the
 daemon mints a fresh port and updates the column, and never retires or
 replaces a proxy it did not adopt. Sessions spawned against the old port lose the proxy for their
 remaining life, because Claude reads `ANTHROPIC_BASE_URL` once at start. That
-is the blast radius of a port change, and it is confined to the window in
-which TBD was entirely stopped: a running proxy holds its port across every
-daemon restart.
+is the blast radius of a port change. A running proxy holds its port across
+every daemon restart, so one way to reach that radius is a window in which TBD
+was entirely stopped; the other is the gap a retire opens, in which the freed
+number is briefly anyone's.
 
 ### Control endpoint
 
@@ -198,6 +199,12 @@ daemon restart.
   file is unlinked only if it is still its own. The successor binds the moment
   the answer arrives. No stream is cut, and the no-listener gap is the
   successor's bind time, far inside Claude's 183-second retry budget.
+  A retire frees the port; it cannot reserve it. Ephemeral ports come from one
+  range every socket on the machine draws from, so an unrelated socket can be
+  handed that number inside the gap — and `SO_REUSEADDR`, which is what lets a
+  successor bind past the predecessor's own lingering connections, does nothing
+  against a socket that does not set it. A successor that loses the race meets
+  the address-in-use path above rather than a broken handshake.
 - `POST /tbd/routes` and `DELETE /tbd/routes/<token>` tell the proxy a route
   file was written or should be dropped, so it need not watch the directory.
 


### PR DESCRIPTION
## What's broken

One test in the model proxy's suite, `retire answers before the drain and a
successor binds the port`, has been reddening `main` for everybody. It failed on
four unrelated PRs on 2026-09-08 — runs 34258054051, 34271037853, 34275440153
and 34284111508 — always with the same line, and always passed on a rerun:

```
Expectation failed: (boundPort → nil) == (harness.port → 49260)
↳ the successor did not take the port in 4.018594166 seconds:
  bind(descriptor:ptr:bytes:): Address already in use) (errno: 48)
```

The cost is not the test: a red required check on somebody else's PR buys a
rerun, twenty minutes, and a small loss of trust in the suite.

## Why it happens

Not the handshake. The proxy's retire does exactly what the spec promises, and
the ordering is enforced by the shape of the code rather than by timing:
`ControlEndpoints.retire()` **awaits** `closeListener()` before it *returns* the
200 (`ControlEndpoints.swift:225-226`), that closure awaits the *listening*
channel's own close future (`ProxyServer.swift:110-113`, `:210-213`, against the
channel `start()` stored at `:169`), and the response is only written once
`await control.handle(…)` has returned (`ProxyServer.swift:392-406`). There is
no path on which a write outruns the close. `ProxyServer.start()` also sets
`SO_REUSEADDR` on the listener, so the connections carrying the retiring proxy's
in-flight streams do not block a successor. Both obvious suspects were checked
and neither holds.

What holds is that **a retire frees its port; it cannot reserve it.** macOS hands
TCP ephemeral ports out sequentially from a single global counter
(`net.inet.tcp.randomize_ports` is `0`) across the 16,384 numbers in
49152–65535, so the number a retire just freed comes back around after one wrap
of that range. Measured on an idle machine: 16,220 allocations, 0.15 s. In a
4,800-test parallel pass where the proxy suites, the holder suites and spawned
proxy binaries are all opening sockets beside each other, the freed number is
one an unrelated `connect()` or listener can be handed immediately — and
`SO_REUSEADDR` buys nothing against that squatter, because a socket that does
*not* set the option refuses a `SO_REUSEADDR` bind with `EADDRINUSE` for as long
as it lives. The test then spent its whole four-second allowance being refused by
a port that had been free the entire time, and blamed the handshake for it.

The test's own comment already suspected a squatter and answered it with a
bigger wall clock. Four seconds was simply less than a peer test's listener
lives.

## What this PR does

Splits the two claims the test was making through one racy observation, and
makes the surviving observation say *who* it saw.

- **The handshake claim is asked as a question with three answers, not one.** At
  the instant the 200 lands, the port is probed: refused, or `GET /tbd/status`
  through a session of its own (never the harness's, whose pooled keep-alive
  connection was accepted *before* the listener closed). A refusal is proof the
  listener is gone. A status naming this process, this test's home and this port
  can only come from the proxy that was supposed to have closed, and fails the
  test with that diagnosis — this is the assertion that still catches a retire
  which answers before it closes. A holder that is **positively identified** as
  somebody else — a proxy status naming a different pid, port or home, or a
  holder that had already let go by the time the status leg reached it, which
  the proxy under test cannot have been since it stays alive until teardown —
  is nobody's bug, and is recorded through `withKnownIssue` (`isIntermittent`)
  so the rate stays visible without reddening a check. A bare `connectRefused`
  could not tell those apart, and they have opposite verdicts.
- **The excused verdict is reached by recognising a stranger, never by failing
  to recognise anybody.** A holder that is listening and will not say who —
  a non-200, an undecodable body, a transport error on a port that is still
  listening — is a fourth verdict that **fails** the test, because a proxy that
  answered before it closed is still one of its explanations and an excused
  catch-all would be exactly the route by which that regression passed. The
  message carries what was seen, so a genuine stranger landing there can be
  reclassified on evidence rather than by default.
- **The successor's bind is only the demonstration that the port is takeable**,
  and it is skipped when the probe said the port is not free — no test can bind
  a port a stranger holds, and a proxy that never closed has already failed
  above. When the port *was* free the bind waits through the repo's one bounded
  poll, `pollUntilTrue`, for thirty seconds; a timeout now names the current
  holder with the same probe rather than reporting only "something is
  listening". `successor.stop()` between the two takes a named
  `withPhaseDeadline` of its own, like every other blocking step out here:
  outside "request"'s 60 seconds there is no outer bound left to catch a wedge
  in a listener close or an event-loop-group shutdown.
- **Skipping that wait also stops a cascade.** A thirty-second bind wait outlives
  the harness session's own thirty-second `timeoutIntervalForResource`, so the
  still-open stream read afterwards died of a `URLSession` timeout and turned one
  diagnosed failure into three. On the skip path the stream is read while it is
  still healthy.
- **`withProxy` gains `afterRequest`**, so the bind wait and the drain run under
  budgets of their own instead of sharing `body`'s 60-second "request" phase
  three ways. `withPhaseDeadline` races a plain timer that starts when "request"
  begins, so nested phases share that window rather than getting one each.
- **`waitUntil` is now `pollUntilTrue` underneath.** It used to sleep through
  `try? await Task.sleep`, which cannot tell expiry from cancellation and throws
  instantly once cancelled — a 20 ms poll becoming a busy spin over its whole
  remaining budget on a cooperative thread every other test in the pass is queued
  behind. Only its diagnostic stays local.
- **One five-second wait in `ProxyForwardingTests` is rebalanced rather than
  raised.** "a client that hangs up mid-stream still ends the relay and the tee"
  waits for the relay to release, and that wait is a *discriminating threshold*:
  it must expire before the script does, or a relay that only ended because the
  upstream ran out of events would pass. Five seconds is inside the scheduling
  latency fast pass 2 routinely shows, and it went red on run 34296850539 with
  the count still at 1. The threshold is fixed by moving the script out — 40
  events at 1 s instead of 250 ms — and the waits to 20 s, keeping the same
  ratio with four times the headroom. Nothing waits for the script to finish:
  the client cuts after the first event and the fake upstream stops rescheduling
  once its channel goes inactive.
- The post-bind `streamsInFlight == 1` assertion is gone, because a patient wait
  may legitimately outlive the six-second script. The "no stream was cut" claim
  is carried where it always really was: the in-flight count read at the moment
  the retire answered, and the six events that still arrive at the end.
- `TBDModelProxyTests` gains a dependency on `TestSupport` for `pollUntilTrue`.
  The alternative was a seventh hand-rolled poll loop, which is the thing that
  helper exists to end. Two comments that described the old dependency set are
  corrected.
- The spec gains two sentences of the same honesty: a retire frees the port
  rather than reserving it, and a port change's blast radius is reachable
  through that gap as well as through a window in which TBD was stopped.

## Assumptions

- Assumes the ephemeral range and the sequential allocator measured above are
  what CI runs on. If a future macOS randomises TCP ephemeral ports, collisions
  get rarer, not commoner, and nothing here breaks.
- Assumes the probe's fifteen seconds — the same budget `withProxy` gives its own
  requests — is enough for a live proxy on loopback to answer. It is sized
  generously on purpose, because "a stranger" is the verdict that *excuses* a
  failure and a probe that gave up early would report a proxy which never closed
  as somebody else's problem.
- Assumes a squatter releases the port inside thirty seconds when the port was
  free at probe time. If it is ever exceeded the failure message now names the
  holder.
- **Not fixed here, and worth its own decision:** the same squatter can cost a
  real installation its port. `ModelProxySupervisor.recover(from: .bindFailed)`
  mints a fresh port on the *first* refusal when nothing adoptable answers, so a
  transient holder in the gap a retire opens changes the port permanently, and
  every session already spawned against the old one loses its proxy for the rest
  of its life (Claude reads `ANTHROPIC_BASE_URL` once). A bounded retry of the
  same port before minting would close that, and it is a change to documented
  failure semantics rather than a test fix.

## Evidence & verification

- **The repro.** The four runs above, all on the same assertion, all green on
  rerun. Attempt 1 of run 34275440153 shows the test failing after 6.045 s with
  the bind refused for 4.13 s of it, while the surrounding log shows holder, PTY
  and app suites running beside it.
- **The failure that forced the discriminating probe.** Run 34296850539 attempt
  2: the connect at the instant of the 200 was *answered*, and the port then
  refused a `SO_REUSEADDR` bind for the whole thirty seconds with "something is
  listening on it". That is consistent with both explanations, and the test as
  written could not say which — which is the gap this PR closes. The code
  reading above rules out the proxy; the remaining in-process TCP listeners in
  fast pass 2 are the proxy suites' own (`FakeUpstream.swift:90`,
  `ProxyForwardingTests.swift:1103`), which the recursive `.serialized` on
  `ModelProxySuites` keeps from running beside this one, and the real proxy
  binaries `ProxyBinaryTests` spawns, which are separate processes and outlive
  their tests. Every one of those now arrives named: a different pid, or a
  different home, or no proxy status at all.
- **Discriminating evidence for the diagnosis**, measured locally on Darwin
  25.1.0 with plain sockets:
  - `net.inet.tcp.randomize_ports: 0`, `portrange.first/last = 49152/65535`; eight
    consecutive `bind(0)` calls returned 60314…60321 — the allocator is a
    sequential counter, and 49260 in the failure is near the bottom of the range
    it wraps to.
  - A freed ephemeral port was re-handed to a new socket after 16,220
    allocations, 0.15 s.
  - A listener that closes while an accepted child of it is still ESTABLISHED
    **does** let a `SO_REUSEADDR` successor bind the same port — so the retiring
    proxy's in-flight streams are not the blocker, and that option is refuted
    rather than assumed.
  - A plain socket with no `SO_REUSEADDR` holding the port **does** refuse a
    `SO_REUSEADDR` bind: `Address already in use (errno 48)`. That is the
    squatter, and it is the exact error CI reported.
- **Independent evidence that `closeListener` really closes.** Two tests in
  `ProxyBinaryTests` retire a *separately spawned* proxy binary and poll
  `connectRefused` on its port until it holds (`:539`, `:637`). Both passed in
  the same run whose in-process connect was answered.
- **The test still fails on a proxy that answers before it closes.** The probe is
  evaluated on the answer, not on the bind, and a retire that wrote its 200 and
  closed afterwards is still accepting there — it now answers its own
  `/tbd/status` and is named as the culprit rather than excused as a squatter.
- `swiftlint --strict` over the whole tree: 0 violations. Tests verified on CI
  rather than locally, per this machine's build rules.

https://claude.ai/code/session_01TggE2eESL3BcvSgFcLZkpk

[proxy retire successor bind](https://cheapsteak.github.io/tbd/open/?worktree=C968D8D1-3719-4306-8F84-B9462E443595)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved proxy transition testing to verify that retired listeners stop accepting connections immediately.
  - Increased resilience when starting successor proxies, with cancellable polling and clearer timeout diagnostics.
  - Improved reliability of long-running stream, relay-release, and tee-completion tests.

- **Documentation**
  - Clarified port availability during proxy retirement, including potential conflicts when another socket claims the freed port.
  - Documented control-endpoint behavior when successor binding fails during the transition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->