### PR TITLE
Fix: the model proxy supervisor reaps a drained proxy instead of leaving a zombie

### DIFF
--- a/Sources/TBDDaemon/ModelProxy/ModelProxySupervisor.swift
+++ b/Sources/TBDDaemon/ModelProxy/ModelProxySupervisor.swift
@@ -234,6 +234,16 @@ actor ModelProxySupervisor {
     /// as the proxy still serves a route, and retires it when the last one
     /// goes. Cleared by the flag coming back on.
     private var draining = false
+    /// **The drain is over and the corpse is not collected yet.** The proxy has
+    /// been retired and dropped, so there is nothing left to supervise — but a
+    /// proxy this daemon spawned is its child, and it stays a zombie until
+    /// somebody `waitpid`s it. The watch keeps ticking in this mode and each
+    /// tick does nothing but `drainPendingReap()`; it stops itself the moment
+    /// nothing is pending — collected, or given up on once the attempt budget
+    /// is spent, which spans the ten minutes a retired proxy may legitimately
+    /// take to finish draining and exit. Cleared by the flag coming back on,
+    /// which returns this same watch to normal service.
+    private var reapOnly = false
     /// Route registrations that have written their file but have not yet been
     /// told to the live proxy — or, told to it and not yet answered.
     ///
@@ -379,6 +389,12 @@ actor ModelProxySupervisor {
     var canSpawn: Bool { spawner != nil }
 
     var current: State? { live?.state }
+
+    /// Whether this supervisor's watch is running. True while it is supervising
+    /// a proxy, and true through the reap-only idle a drain leaves behind — the
+    /// watch has one job left there, and its ending is the thing that says the
+    /// dropped child is no longer this daemon's to collect.
+    var isWatching: Bool { watchTask != nil }
 
     /// Everything `daemon.capabilities` reports about the proxy, in one hop.
     ///
@@ -534,6 +550,21 @@ actor ModelProxySupervisor {
                 while it was draining; keeping the proxy and resuming normal service
                 """)
         }
+        // An on-flip during the reap-only idle is the same return to normal
+        // service one step later: the proxy is gone, but the watch this
+        // supervisor is about to need is already running, so leaving the mode is
+        // the whole of it. `start()` below returns early on a supervisor that is
+        // already started, and the tick this watch has already armed reconciles
+        // a fresh proxy. Starting a second watch task here would tick this
+        // supervisor twice for the rest of the daemon's life.
+        if reapOnly {
+            reapOnly = false
+            Self.logger.info(
+                """
+                the model proxy was switched back on for \(self.home.path, privacy: .public) while \
+                its retired predecessor was still being collected; resuming normal service
+                """)
+        }
         await start()
     }
 
@@ -564,6 +595,10 @@ actor ModelProxySupervisor {
     func start() async {
         guard !started else { return }
         started = true
+        // A fresh watch never begins in the reap-only idle: that mode belongs to
+        // the watch a drain left running, and this line is reached only when
+        // there is no watch.
+        reapOnly = false
         await drainPendingReap()
         await reconcile()
         watchTask = Task { [weak self] in
@@ -833,7 +868,37 @@ actor ModelProxySupervisor {
             return
         }
         draining = false
-        await stop()
+        await enterReapOnlyIdle()
+    }
+
+    /// The drain retired the proxy; what is left is collecting its corpse.
+    ///
+    /// **The watch is not stopped here, and that is the whole of this method.**
+    /// A proxy this daemon spawned is its child: `retire()` returns once the
+    /// listener is closed, and the process then drains whatever is in flight for
+    /// up to ten minutes before it exits. Stopping the watch on the retire —
+    /// which is a single `waitpid(WNOHANG)` pass and then nothing — leaves that
+    /// exit uncollected, so the pid sits `<defunct>` in the process table until
+    /// something calls `start()` again, which on the toggle path may be never.
+    /// So the watch stays and ticks for one purpose: `tick` collects, and stops
+    /// the watch itself once nothing is pending.
+    ///
+    /// Nothing is reaped here. The proxy was asked to retire a moment ago and
+    /// cannot have exited yet, and the pass the next tick makes is the same one.
+    private func enterReapOnlyIdle() async {
+        guard !pendingReap.isEmpty else {
+            // An adopted proxy is nobody's child here, so there is nothing to
+            // wait for and the watch has no reason to keep running.
+            await stop()
+            return
+        }
+        reapOnly = true
+        Self.logger.info(
+            """
+            the model proxy for \(self.home.path, privacy: .public) is retired; polling until this \
+            daemon has collected the \(self.pendingReap.count, privacy: .public) child pid(s) it \
+            dropped
+            """)
     }
 
     private func watch() async {
@@ -1225,6 +1290,17 @@ actor ModelProxySupervisor {
         // Before anything else, and even when the supervisor is permanently
         // down: a child we dropped is a zombie until somebody collects it.
         await drainPendingReap()
+        if reapOnly {
+            // A drain retired the proxy and this tick exists only for the pass
+            // above. Nothing else is decided in this mode — there is no proxy to
+            // poll, adopt, or respawn — and the watch stops itself as soon as
+            // the pass has nothing left to do, either because every pid was
+            // collected or because `drainPendingReap` gave up on it.
+            guard pendingReap.isEmpty else { return }
+            reapOnly = false
+            await stop()
+            return
+        }
         guard !permanentlyDown else { return }
         guard let live else {
             await reconcile()

--- a/Tests/TBDDaemonTests/ModelProxy/ModelProxySupervisorTests.swift
+++ b/Tests/TBDDaemonTests/ModelProxy/ModelProxySupervisorTests.swift
@@ -513,6 +513,233 @@ struct ModelProxySupervisorTests {
             "a proxy the supervisor believes it retired must not stay current")
     }
 
+    // MARK: - Collecting what the drain retired
+
+    /// **The bug this section exists for.** A proxy this daemon spawned is its
+    /// child, and `POST /tbd/retire` returns as soon as the listener is closed —
+    /// the process itself is still draining what is in flight and exits some
+    /// seconds later. A supervisor that stopped its watch on the retire made one
+    /// `waitpid(WNOHANG)` pass, found the child still running, and then had
+    /// nothing left that would ever call `waitpid` again: the pid sat
+    /// `<defunct>` until some later `start()`, which on the toggle path may
+    /// never come.
+    ///
+    /// So the watch outlives the retire, in an idle whose only work is the reap
+    /// pass, and the tick after the exit collects it.
+    ///
+    /// Discriminating against the pre-fix code twice over: `isWatching` is false
+    /// there the moment the drain finishes, and with no watch left nothing
+    /// advances the clock into the pass that collects 6600 — `collected()` stays
+    /// empty for as long as the test cares to wait.
+    @Test("the watch outlives the retire and collects the child it dropped")
+    func aDrainedChildIsCollectedByTheWatchThatOutlivesTheRetire() async throws {
+        let fixture = try SupervisorFixture.make()
+        defer { fixture.tearDown() }
+        let clock = EventDrivenTestClock()
+        let spawner = fixture.spawner
+
+        let proxy = try FakeProxyProcess(version: fixture.ownVersion, pid: 6600, home: fixture.home)
+        defer { proxy.stop() }
+        try await fixture.db.config.setModelProxyPort(proxy.port)
+        try await fixture.db.config.setModelProxyEnabled(true)
+        // Denied once so startup spawns rather than adopts: only a child of this
+        // process is ours to `waitpid`, and only a child can be left a zombie.
+        fixture.identity.denyOnce()
+        fixture.identity.admit(pid: 6600, startTime: proxy.processStartTime)
+        await fixture.spawner.answer(.success(pid: 6600, port: proxy.port))
+
+        let supervisor = fixture.supervisor(clock: clock)
+        await supervisor.startIfEnabled()
+        #expect(await supervisor.current?.pid == 6600)
+        #expect(await supervisor.current?.adopted == false, "a child of ours is never adopted")
+
+        // The flag goes off with nothing routed, so the drain finishes on the
+        // gesture: retire, drop, and — the fix — keep the watch.
+        try await fixture.db.config.setModelProxyEnabled(false)
+        await supervisor.beginDraining()
+        #expect(await supervisor.current == nil)
+        #expect(proxy.requests().contains { $0.method == "POST" && $0.path == "/tbd/retire" })
+        #expect(
+            await supervisor.isWatching,
+            "the child is still running, so the watch that will collect it must not have stopped")
+        #expect(
+            await fixture.spawner.collected().isEmpty,
+            "a proxy that has only just been asked to retire has not exited yet")
+
+        // It finishes draining and exits; the next tick is the pass that
+        // collects it, and there is nothing left for the watch to do afterwards.
+        await fixture.spawner.reap(pid: 6600, status: 0)
+        try await clock.requireAdvanceWhenArmed(by: fixture.watchInterval)
+        let collected = try await waitFor(
+            "the drained proxy's exit to be collected",
+            observed: { "collected \(await spawner.collected())" },
+            { await spawner.collected() == [6600] })
+        let stopped = try await waitFor(
+            "the reap-only watch to stop once nothing is pending",
+            { await supervisor.isWatching == false })
+
+        #expect(collected, "the exit of a child this daemon dropped is waited for, not leaked")
+        #expect(stopped)
+        #expect(
+            clock.hasSleeper == false,
+            "a watch that has stopped arms no further sleep — this idle is not a poller forever")
+    }
+
+    /// The other end of the idle: a child that never exits.
+    ///
+    /// `reapAttemptBudget` is 40 attempts, one per 15-second tick — ten minutes,
+    /// which is the cap the proxy itself drains under and so the longest an exit
+    /// can legitimately take. Past it an answer of nothing forever means the pid
+    /// is not this process's to collect, and `drainPendingReap` gives up on it;
+    /// with nothing pending the idle ends and the watch stops. What must not
+    /// happen is a supervisor that polls for a corpse for the rest of the
+    /// daemon's life.
+    ///
+    /// Discriminates against the pre-fix code at the first hop: the watch is
+    /// already stopped there, nothing is armed on the clock, and
+    /// `requireAdvanceWhenArmed` gives up rather than advancing.
+    @Test("a drained child that never exits ends the idle after the attempt budget")
+    func aDrainedChildThatNeverExitsStopsTheWatchAfterTheBudget() async throws {
+        let fixture = try SupervisorFixture.make()
+        defer { fixture.tearDown() }
+        let clock = EventDrivenTestClock()
+
+        let proxy = try FakeProxyProcess(version: fixture.ownVersion, pid: 6610, home: fixture.home)
+        defer { proxy.stop() }
+        try await fixture.db.config.setModelProxyPort(proxy.port)
+        try await fixture.db.config.setModelProxyEnabled(true)
+        fixture.identity.denyOnce()
+        fixture.identity.admit(pid: 6610, startTime: proxy.processStartTime)
+        await fixture.spawner.answer(.success(pid: 6610, port: proxy.port))
+
+        let supervisor = fixture.supervisor(clock: clock)
+        await supervisor.startIfEnabled()
+        try await fixture.db.config.setModelProxyEnabled(false)
+        await supervisor.beginDraining()
+        #expect(await supervisor.isWatching)
+
+        // 39 attempts is one short of the budget. `reapIfExited` reports nothing
+        // for all of them — this child never exits.
+        for _ in 1...39 {
+            try await clock.requireAdvanceWhenArmed(by: fixture.watchInterval)
+        }
+        // The re-arm after the 39th tick is the proof that it finished, so the
+        // assertion below observes the state rather than guessing at it.
+        try await clock.requireSleeperArmed()
+        #expect(
+            await supervisor.isWatching,
+            "one attempt short of the budget, the supervisor is still waiting for the exit")
+
+        try await clock.requireAdvanceWhenArmed(by: fixture.watchInterval)
+        let stopped = try await waitFor(
+            "the idle to end once the attempt budget is spent",
+            { await supervisor.isWatching == false })
+
+        #expect(stopped)
+        #expect(
+            await fixture.spawner.collected().isEmpty,
+            "nothing exited, so nothing was collected — the idle ended by giving up")
+        #expect(clock.hasSleeper == false, "and it armed no further tick")
+    }
+
+    /// The corpse refusal is untouched by the idle. While the pid is pending, a
+    /// listener still answering for it is a dead port with no branch left that
+    /// would revise it — `kill(pid, 0)` succeeds on a zombie and the fake here
+    /// answers exactly as one — so a supervisor restarted mid-idle has to spawn
+    /// afresh rather than take it back.
+    ///
+    /// Discriminating half: `isWatching` after the drain, which is false in the
+    /// pre-fix code because the retire stopped the watch there.
+    @Test("a restart during the reap idle refuses to adopt the corpse")
+    func aRestartDuringTheReapIdleRefusesTheCorpse() async throws {
+        let fixture = try SupervisorFixture.make()
+        defer { fixture.tearDown() }
+
+        let proxy = try FakeProxyProcess(version: fixture.ownVersion, pid: 6620, home: fixture.home)
+        defer { proxy.stop() }
+        try await fixture.db.config.setModelProxyPort(proxy.port)
+        try await fixture.db.config.setModelProxyEnabled(true)
+        fixture.identity.denyOnce()
+        fixture.identity.admit(pid: 6620, startTime: proxy.processStartTime)
+        await fixture.spawner.answer(.success(pid: 6620, port: proxy.port))
+
+        let supervisor = fixture.supervisor()
+        await supervisor.startIfEnabled()
+        try await fixture.db.config.setModelProxyEnabled(false)
+        await supervisor.beginDraining()
+        #expect(await supervisor.isWatching, "the drop queued a child, so the idle is running")
+
+        // A daemon shutdown lands in the middle of the idle, and the daemon that
+        // replaces it starts over. Nothing is advanced across it: the question is
+        // what `start()` decides, not what a later tick corrects.
+        await supervisor.stop()
+        await fixture.spawner.answer(.success(pid: 6621, port: SupervisorFixture.deadPort))
+        await supervisor.start()
+
+        #expect(await supervisor.current?.pid == 6621, "the corpse must not be adopted back")
+        #expect(await supervisor.current?.adopted == false)
+        await supervisor.stop()
+    }
+
+    /// The flag coming back on during the idle is a return to normal service
+    /// through the watch that is already running: the mode is left, `start()`
+    /// finds the supervisor already started and does nothing, and the tick the
+    /// idle had already armed reconciles a fresh proxy.
+    ///
+    /// **One watch task, and the assertion says so.** A second one would tick
+    /// this supervisor twice for the rest of the daemon's life — two status
+    /// polls per interval, two reconciles racing each other for the port.
+    ///
+    /// Discriminates twice against the pre-fix code, where the retire left no
+    /// watch and `startIfEnabled` therefore ran the whole startup algorithm
+    /// itself: the proxy would be current before any tick, and `isWatching`
+    /// after the drain is false.
+    @Test("the flag coming back on during the reap idle resumes on the same watch")
+    func theFlagComingBackOnDuringTheReapIdleResumesNormalService() async throws {
+        let fixture = try SupervisorFixture.make()
+        defer { fixture.tearDown() }
+        let clock = EventDrivenTestClock()
+        let spawner = fixture.spawner
+
+        let proxy = try FakeProxyProcess(version: fixture.ownVersion, pid: 6630, home: fixture.home)
+        defer { proxy.stop() }
+        try await fixture.db.config.setModelProxyPort(proxy.port)
+        try await fixture.db.config.setModelProxyEnabled(true)
+        fixture.identity.denyOnce()
+        fixture.identity.admit(pid: 6630, startTime: proxy.processStartTime)
+        await fixture.spawner.answer(.success(pid: 6630, port: proxy.port))
+
+        let supervisor = fixture.supervisor(clock: clock)
+        await supervisor.startIfEnabled()
+        try await fixture.db.config.setModelProxyEnabled(false)
+        await supervisor.beginDraining()
+        #expect(await supervisor.isWatching)
+
+        // The user changes their mind while the corpse is still uncollected. The
+        // successor is spawned on a dead port: this case is about which task does
+        // the spawning, and a second listener would only add a probe to it.
+        await fixture.spawner.answer(.success(pid: 6631, port: SupervisorFixture.deadPort))
+        try await fixture.db.config.setModelProxyEnabled(true)
+        await supervisor.startIfEnabled()
+        #expect(
+            await supervisor.current == nil,
+            "the running watch does the reconcile; the flip must not start a second startup")
+
+        try await clock.requireAdvanceWhenArmed(by: fixture.watchInterval)
+        let resumed = try await waitFor(
+            "the resumed watch to reconcile a fresh proxy",
+            observed: { "spawn calls \(await spawner.calls())" },
+            { await supervisor.current?.pid == 6631 })
+        try await clock.requireSleeperArmed()
+
+        #expect(resumed)
+        #expect(clock.sleeperCount == 1, "one watch task, so one sleeper — not two")
+        #expect(
+            await fixture.spawner.calls() == [proxy.port, proxy.port],
+            "the successor asks for the port the retired proxy held")
+        await supervisor.stop()
+    }
+
     // MARK: - The drain's own races
 
     /// **The window Important 1 of the final review found.** The immediate

--- a/docs/specs/2026-09-05-transcript-streaming-model-proxy-design.md
+++ b/docs/specs/2026-09-05-transcript-streaming-model-proxy-design.md
@@ -453,9 +453,14 @@ owns the proxy's life on an injected clock:
   running and the proxy keeps being adopted and respawned. Each tick reads
   `routeCount` off the `/tbd/status` poll it already makes; when it reaches
   zero — every routed terminal having retired its route as it exited — the
-  supervisor retires the proxy, drops it, and stops. Turning the flag back on
+  supervisor retires the proxy and drops it. It does not stop there: a proxy
+  this daemon spawned is its child and goes on draining what is in flight for
+  some seconds after its listener closes, so the watch keeps ticking with
+  nothing to do but wait for that exit, and stops once it has collected it or
+  once the ten minutes a drain may take have passed. Turning the flag back on
   while draining simply leaves the mode: nothing was retired, so there is
-  nothing to restart.
+  nothing to restart — and turning it back on while that last exit is still
+  outstanding returns the same watch to normal service.
 
   At startup with the flag off the supervisor starts in draining mode only when
   a routed terminal is still alive — one query, for a terminal row carrying a


### PR DESCRIPTION
## What's broken

With the model proxy flag turned off, the last session routed through the proxy
ended and the daemon did the right thing on the surface: it logged `no routes
left; retiring pid 68087`, and the proxy closed its listener and exited within
seconds. Minutes later `ps` still showed `68087 Z <defunct>`. The daemon spawned
that proxy, so the exited process stays in the process table as a zombie until
its parent waits for it — and nothing did. Anyone who turns the toggle off (or
flips it off and on again over a day) accumulates one zombie per retired proxy,
each holding a pid slot for the life of the daemon.

## Why it happens

`POST /tbd/retire` returns as soon as the proxy has closed its listener and
released its lock. The process is still alive at that point, draining whatever
requests are in flight — for up to the ten minutes its own drain cap allows —
and it exits some seconds later.

The supervisor's drain treated the retire as the end of its job: it made one
non-blocking `waitpid` pass over the pid it had just dropped, found the child
still running (as it always will), and then stopped its watch. The comment on
`stop()` says what a pass leaves behind stays pending "for the next `start()`" —
but on the toggle path there is no next `start()` until the user turns the flag
back on, which may be never. So the one thing that would ever call `waitpid`
again was the thing the drain had just shut down.

## When it broke

PR #842, which added the drain's retire-and-stop path. The reap bookkeeping it
relies on is correct — every abandonment goes through `dropLive()` and is queued
— and the tests covered "the proxy is retired and the watch stops". Nothing
covered who collects the exit that arrives after the watch is gone, because on
every other abandonment path (a version replacement, a respawn, a re-adoption)
the watch is still running and its next tick does it.

## What this PR does

After the drain's retire, the supervisor does not stop its watch. It enters a
reap-only idle: each tick does nothing but the `waitpid(WNOHANG)` pass, and the
watch stops itself the moment nothing is pending — either because the exit was
collected or because the existing 40-attempt budget (40 ticks at 15 s = the ten
minutes a drain may legitimately take) is spent and the pid is given up on. A
proxy that was adopted rather than spawned is nobody's child here, so there is
nothing to wait for and the watch stops on the retire exactly as before.

Turning the flag back on during that idle leaves the mode and returns the watch
that is already running to normal service, through the existing `startIfEnabled`
path: no second watch task, and the tick the idle had already armed does the
reconcile.

Daemon shutdown is unchanged and deliberately so. `stop()` still cancels the
watch and makes a single pass: the proxy is meant to outlive the daemon, and
launchd reaps what it re-parents.

The alternative — blocking on the exit inside the drain — was rejected for the
reason `stop()` already gives: there is nothing to wait *for* within any bound
short enough not to stall the gesture, and the ten-minute cap is the real one.
Polling on the watch that already exists costs one `waitpid` per 15 seconds and
ends by itself.

## Assumptions

Assumes the proxy's own drain cap remains the longest an exit can legitimately
take; the reap budget is sized against it (40 attempts x 15 s). If the proxy's
cap grows past ten minutes, a slow exit would be given up on rather than
collected — the pid is then forgotten (which is what makes a recycled pid
adoptable again), and the zombie would persist until the daemon exits.

## Evidence & verification

The repro is the live observation above: flag off, last routed session ended,
`no routes left; retiring pid 68087` in the log, the proxy gone from the port
seconds later, and `68087 Z <defunct>` still in `ps` minutes after that.

Four new tests in `ModelProxySupervisorTests`, all on the injected clock with no
wall time, each of which fails against the code before this diff:

- **The exit is collected.** A spawned proxy is drained and retired; the watch
  is still running afterwards; the child then exits and the next tick collects
  it, after which the watch has stopped and armed no further sleep. Before the
  fix the watch is gone at the retire, so nothing ever advances into the pass
  that collects the pid and it is never collected.
- **A child that never exits.** 39 ticks leave the supervisor still waiting; the
  40th spends the budget, gives up, and ends the idle. Before the fix the first
  hop finds nothing armed on the clock at all.
- **The corpse refusal is untouched.** A shutdown lands mid-idle and the next
  `start()` refuses to adopt the pid it is still waiting for, spawning afresh.
- **The flag coming back on mid-idle** resumes normal service on the same watch:
  the reconcile happens on the tick that was already armed, and exactly one
  sleeper is on the clock afterwards — not two.

The existing draining tests, including `stopDoesNotRetire` and the flag-flip
races, are unchanged and still green: they adopt their proxy rather than spawn
it, which is precisely the case that has no child to wait for.

Not verified in the running app: reproducing it live means retiring a real proxy
and watching a pid for ten minutes, and the behaviour under test is entirely a
question of who calls `waitpid` and when.

https://claude.ai/code/session_01TggE2eESL3BcvSgFcLZkpk

[proxy reap after drain](https://cheapsteak.github.io/tbd/open/?worktree=C968D8D1-3719-4306-8F84-B9462E443595)
