### PR TITLE
Fix: the model proxy supervisor waits for its port before minting a new one

### DIFF
--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -927,8 +927,16 @@ public final class Daemon: Sendable {
                 // that restarts after the flag went off still has to keep that
                 // port answering — and an install that never turned the flag on
                 // must run nothing at all.
+                //
+                // The read is handed over **unfolded**. Its other caller is the
+                // supervisor's port wait, and the two want opposite answers to
+                // an unreadable terminal table: a drain-only boot must start
+                // nothing, while the wait must assume a session is routed and
+                // keep the port. Folding a failure to `false` here would pick
+                // the first for both, and the second is where that strands live
+                // sessions — see `routedSessionsAlive` on the supervisor.
                 routedSessionsAlive: { [database] in
-                    (try? await database.terminals.hasLiveRoutedSession()) ?? false
+                    try await database.terminals.hasLiveRoutedSession()
                 })
             : nil
         self.modelProxySupervisor = modelProxySupervisor

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -1286,6 +1286,14 @@ public final class Daemon: Sendable {
         // budget, on a machine where the proxy binds pathologically slowly. It
         // is also flag-gated, so nobody running the shipped default pays any of
         // it.
+        //
+        // One case costs more, deliberately. When a session is still routed
+        // against the persisted port and something transient holds it, the
+        // supervisor's port wait adds up to 30 seconds
+        // (`ModelProxySupervisor.defaultPortRetryAttempts` ×
+        // `defaultPortRetryInterval`) trying to keep that port. It is paid in
+        // exactly the case where minting a fresh one would strand a live
+        // session, and in no other.
 
         await modelProxySupervisor?.startIfEnabled()
 

--- a/Sources/TBDDaemon/ModelProxy/LoopbackPortProbe.swift
+++ b/Sources/TBDDaemon/ModelProxy/LoopbackPortProbe.swift
@@ -1,4 +1,5 @@
 import Darwin
+import Dispatch
 import Foundation
 
 /// Who, if anyone, accepts a TCP connection on a loopback port right now.
@@ -16,7 +17,7 @@ enum LoopbackPortOccupancy: Sendable, Equatable {
 /// The one question `ModelProxySupervisor`'s port wait turns on, as a protocol
 /// so a test can force an answer for a port a fake has just released.
 protocol LoopbackPortProbing: Sendable {
-    func occupancy(port: Int) -> LoopbackPortOccupancy
+    func occupancy(port: Int) async -> LoopbackPortOccupancy
 }
 
 /// A plain non-blocking `connect(2)` to `127.0.0.1:<port>`, and nothing else.
@@ -43,12 +44,28 @@ protocol LoopbackPortProbing: Sendable {
 /// with no listener is refused by the same stack — so the bound is only ever
 /// spent on the pathological third case (a listener whose backlog is full),
 /// which is reported as `.undetermined` and treated as a transient.
+///
+/// **The syscalls run on a GCD thread, never on the cooperative pool.** That
+/// pool is only as wide as the machine has cores — three on a CI runner — and a
+/// thread blocked in `poll(2)` there is one the supervisor's actor and every
+/// other task on the machine cannot use for as long as the bound lasts. A
+/// blocking syscall with a hard one-second ceiling is exactly what GCD's global
+/// queue is for, so the probe hops to it and suspends its caller instead.
 struct LoopbackPortProbe: LoopbackPortProbing {
     /// How long a connect that went asynchronous may take before the answer is
     /// `.undetermined`.
     static let connectBoundMilliseconds: Int32 = 1000
 
-    func occupancy(port: Int) -> LoopbackPortOccupancy {
+    func occupancy(port: Int) async -> LoopbackPortOccupancy {
+        await withCheckedContinuation { (continuation: CheckedContinuation<LoopbackPortOccupancy, Never>) in
+            DispatchQueue.global(qos: .utility).async {
+                continuation.resume(returning: LoopbackPortProbe.probe(port: port))
+            }
+        }
+    }
+
+    /// The syscall sequence itself, synchronous and off the cooperative pool.
+    private static func probe(port: Int) -> LoopbackPortOccupancy {
         guard let networkPort = UInt16(exactly: port), networkPort > 0 else {
             return .undetermined("\(port) is not a port number")
         }

--- a/Sources/TBDDaemon/ModelProxy/LoopbackPortProbe.swift
+++ b/Sources/TBDDaemon/ModelProxy/LoopbackPortProbe.swift
@@ -1,0 +1,113 @@
+import Darwin
+import Foundation
+
+/// Who, if anyone, accepts a TCP connection on a loopback port right now.
+enum LoopbackPortOccupancy: Sendable, Equatable {
+    /// The connect was refused: no socket is listening. A transient holder
+    /// of the number (a client socket bound to it) looks exactly like this.
+    case refused
+    /// Something accepted the connection — a listener, ours or a stranger's.
+    case accepted
+    /// Neither answer inside the bound (a listener with a full backlog, or
+    /// an errno that is not ECONNREFUSED). Carried for the log line.
+    case undetermined(String)
+}
+
+/// The one question `ModelProxySupervisor`'s port wait turns on, as a protocol
+/// so a test can force an answer for a port a fake has just released.
+protocol LoopbackPortProbing: Sendable {
+    func occupancy(port: Int) -> LoopbackPortOccupancy
+}
+
+/// A plain non-blocking `connect(2)` to `127.0.0.1:<port>`, and nothing else.
+///
+/// **Why this sits beside `ModelProxyClient` rather than inside it.** The
+/// client speaks the control protocol, and every transport failure it can meet
+/// — a refused connect, a listener that accepts and then says nothing, a
+/// listener that answers something that is not a status document — folds into
+/// one `unreachable` error. That fold is right for the client's callers, who
+/// only ever want "is this a proxy I may adopt". It is wrong for the
+/// supervisor's port wait, which has to tell a *transient holder of the number*
+/// from a *listener*, and the errno is the only discriminator: a refused
+/// connect means nothing is listening, so the number is held by a client socket
+/// that will let go of it and the wait is worth paying; an accepted connect
+/// means a listener, and a listener that failed the adoption identity check
+/// will still be there in two seconds and in thirty.
+///
+/// **The one-second poll bound is a transport deadline, not a sleep.** It is
+/// the same kind of bound as `ModelProxyClient`'s two-second `URLSession`
+/// timeout and takes no injected clock for the same reason: there is nothing
+/// here to fake, the connect either lands or it does not. Loopback answers
+/// instantly in both of the cases this probe exists to tell apart — a listening
+/// socket accepts in the kernel without ever waking its accept loop, and a port
+/// with no listener is refused by the same stack — so the bound is only ever
+/// spent on the pathological third case (a listener whose backlog is full),
+/// which is reported as `.undetermined` and treated as a transient.
+struct LoopbackPortProbe: LoopbackPortProbing {
+    /// How long a connect that went asynchronous may take before the answer is
+    /// `.undetermined`.
+    static let connectBoundMilliseconds: Int32 = 1000
+
+    func occupancy(port: Int) -> LoopbackPortOccupancy {
+        guard let networkPort = UInt16(exactly: port), networkPort > 0 else {
+            return .undetermined("\(port) is not a port number")
+        }
+
+        let descriptor = socket(AF_INET, SOCK_STREAM, 0)
+        guard descriptor >= 0 else { return .undetermined(Self.describe(errno)) }
+        // Always, on every path out: a probe that leaked a descriptor per
+        // attempt would exhaust the daemon's table over a long wait.
+        defer { Darwin.close(descriptor) }
+
+        let flags = fcntl(descriptor, F_GETFL, 0)
+        guard flags >= 0, fcntl(descriptor, F_SETFL, flags | O_NONBLOCK) >= 0 else {
+            return .undetermined(Self.describe(errno))
+        }
+
+        var address = sockaddr_in()
+        address.sin_family = sa_family_t(AF_INET)
+        address.sin_port = in_port_t(networkPort).bigEndian
+        address.sin_addr.s_addr = UInt32(0x7f00_0001).bigEndian
+        let connected = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { generic in
+                Darwin.connect(descriptor, generic, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        if connected == 0 { return .accepted }
+
+        let connectErrno = errno
+        switch connectErrno {
+        case ECONNREFUSED: return .refused
+        case EINPROGRESS: break
+        default: return .undetermined(Self.describe(connectErrno))
+        }
+
+        // The connect went asynchronous, which on loopback still settles in
+        // microseconds. `POLLOUT` is how a non-blocking connect reports that it
+        // has finished, success or failure alike; `SO_ERROR` is what it
+        // finished with.
+        var watched = pollfd(fd: descriptor, events: Int16(POLLOUT), revents: 0)
+        let ready = withUnsafeMutablePointer(to: &watched) { pointer in
+            Darwin.poll(pointer, 1, Self.connectBoundMilliseconds)
+        }
+        guard ready > 0 else {
+            if ready == 0 { return .undetermined("no answer within 1s") }
+            return .undetermined(Self.describe(errno))
+        }
+
+        var pending: Int32 = 0
+        var length = socklen_t(MemoryLayout<Int32>.size)
+        guard getsockopt(descriptor, SOL_SOCKET, SO_ERROR, &pending, &length) == 0 else {
+            return .undetermined(Self.describe(errno))
+        }
+        switch pending {
+        case 0: return .accepted
+        case ECONNREFUSED: return .refused
+        default: return .undetermined(Self.describe(pending))
+        }
+    }
+
+    private static func describe(_ code: Int32) -> String {
+        String(cString: strerror(code))
+    }
+}

--- a/Sources/TBDDaemon/ModelProxy/ModelProxySpawner.swift
+++ b/Sources/TBDDaemon/ModelProxy/ModelProxySpawner.swift
@@ -66,9 +66,10 @@ struct ModelProxySpawner: Sendable {
         /// replace it.
         case lockHeld
         /// The proxy could not bind the port it was asked for. The supervisor
-        /// probes `/tbd/status` on that port from here: a TBD proxy answering
-        /// is adopted, anything else means the port is somebody else's and a
-        /// fresh one is minted (spec, "Port").
+        /// probes `/tbd/status` on that port from here and a TBD proxy
+        /// answering is adopted. Otherwise, while a session is still routed
+        /// against the port, it waits a bounded window for a transient holder
+        /// to let go before it mints a fresh port (spec, "Port").
         case bindFailed(port: Int)
         /// A directory under the home could not be created, or the lock file
         /// could not be opened for a reason other than contention. Respawning

--- a/Sources/TBDDaemon/ModelProxy/ModelProxySupervisor.swift
+++ b/Sources/TBDDaemon/ModelProxy/ModelProxySupervisor.swift
@@ -168,7 +168,18 @@ actor ModelProxySupervisor {
     /// wants from the terminal table and taking the table would make the
     /// supervisor's tests need one. Its default answers "none", which is the
     /// answer that makes a supervisor with nothing injected run nothing.
-    private let routedSessionsAlive: @Sendable () async -> Bool
+    ///
+    /// **It throws rather than folding an unreadable table into "none",
+    /// because the two callers disagree about what an unanswered question
+    /// means.** A drain-only boot that cannot read the table must start
+    /// nothing: erring the other way spawns a proxy for sessions that may not
+    /// exist. The port wait must assume one *is* routed and wait: erring the
+    /// other way mints past a live session, which is the failure the wait
+    /// exists to prevent — and a busy database is exactly the moment a
+    /// contended port is being fought over. One fold here would have to pick
+    /// one of those, so neither is picked here; each caller decides beside
+    /// itself.
+    private let routedSessionsAlive: @Sendable () async throws -> Bool
     /// This daemon's home in the one form both sides compare, computed once.
     ///
     /// `ModelProxyStatus.canonicalHome` resolves symlinks against the
@@ -375,7 +386,7 @@ actor ModelProxySupervisor {
         signaller: any ProcessSignaller = ProductionProcessSignaller(),
         pidFile: any ModelProxyPIDFileReading = ModelProxyPIDFile(),
         portProbe: any LoopbackPortProbing = LoopbackPortProbe(),
-        routedSessionsAlive: @escaping @Sendable () async -> Bool = { false },
+        routedSessionsAlive: @escaping @Sendable () async throws -> Bool = { false },
         clientFactory: @escaping @Sendable (Int) -> ModelProxyClient = { ModelProxyClient(port: $0) },
         watchInterval: Duration = .seconds(15),
         respawnBackoff: [Duration] = [.seconds(1), .seconds(5), .seconds(30)],
@@ -413,7 +424,7 @@ actor ModelProxySupervisor {
     static func production(
         config: ConfigStore,
         home: URL,
-        routedSessionsAlive: @escaping @Sendable () async -> Bool,
+        routedSessionsAlive: @escaping @Sendable () async throws -> Bool,
         environment: [String: String] = ProcessInfo.processInfo.environment,
         clock: any Clock<Duration> = ContinuousClock()
     ) -> ModelProxySupervisor {
@@ -597,11 +608,26 @@ actor ModelProxySupervisor {
     /// routed, and only until they are done.
     private func startDrainingIfSessionsAreRouted() async {
         guard !started else { return }
-        guard await routedSessionsAlive() else {
-            Self.logger.debug(
+        do {
+            guard try await routedSessionsAlive() else {
+                Self.logger.debug(
+                    """
+                    the model proxy is disabled for \(self.home.path, privacy: .public) and no \
+                    session is routed through it; not starting a supervisor
+                    """)
+                return
+            }
+        } catch {
+            // The flag is off, so the only thing a supervisor would do here is
+            // keep a proxy alive for sessions that may not exist. Starting one
+            // on a question nobody answered is a background process nobody
+            // asked for; the next boot asks again.
+            Self.logger.error(
                 """
-                the model proxy is disabled for \(self.home.path, privacy: .public) and no session \
-                is routed through it; not starting a supervisor
+                the model proxy is disabled for \(self.home.path, privacy: .public) and the \
+                terminal table could not be read: \
+                \(error.localizedDescription, privacy: .public); not starting a drain on an \
+                unanswered question
                 """)
             return
         }
@@ -1256,7 +1282,7 @@ actor ModelProxySupervisor {
             if let routedAnswer {
                 routed = routedAnswer
             } else {
-                routed = await routedSessionsAlive()
+                routed = await aSessionIsRoutedOrTheTableCannotSay(port: port)
                 routedAnswer = routed
             }
             guard routed else {
@@ -1319,6 +1345,31 @@ actor ModelProxySupervisor {
         }
     }
 
+    /// The port wait's reading of the gate: **an unanswerable question counts
+    /// as "yes, a session is routed".**
+    ///
+    /// A terminal table too busy to answer is exactly the machine on which a
+    /// contended port is being fought over, so this is the moment the fold
+    /// matters most — and the two mistakes do not cost the same. Waiting out a
+    /// port nothing is routed against delays a boot by thirty seconds; minting
+    /// past one that is strands a live session for the rest of its life. The
+    /// drain-only boot reads the same failure the other way, which is why the
+    /// closure throws rather than deciding for both.
+    private func aSessionIsRoutedOrTheTableCannotSay(port: Int) async -> Bool {
+        do {
+            return try await routedSessionsAlive()
+        } catch {
+            Self.logger.error(
+                """
+                could not read whether a session is still routed against port \
+                \(port, privacy: .public): \(error.localizedDescription, privacy: .public); \
+                assuming one is and waiting, because minting past a routed session is the \
+                failure this wait exists to prevent
+                """)
+            return true
+        }
+    }
+
     /// Gives the port up: mint a fresh one, overwrite the column, and say
     /// plainly what that costs.
     ///
@@ -1368,7 +1419,7 @@ actor ModelProxySupervisor {
     /// *why* it refused; this adds only which of the three cases the probe saw,
     /// at `.debug`, because it is asked once per interval for the whole window.
     private func classifyOccupant(of port: Int) async -> Occupant {
-        switch portProbe.occupancy(port: port) {
+        switch await portProbe.occupancy(port: port) {
         case .refused:
             Self.logger.debug(
                 """

--- a/Sources/TBDDaemon/ModelProxy/ModelProxySupervisor.swift
+++ b/Sources/TBDDaemon/ModelProxy/ModelProxySupervisor.swift
@@ -148,8 +148,21 @@ actor ModelProxySupervisor {
     /// itself is this daemon's to signal.
     private let signaller: any ProcessSignaller
     private let pidFile: any ModelProxyPIDFileReading
+    /// How this daemon asks who is holding a port it could not bind — a plain
+    /// loopback connect, whose errno tells a transient holder of the number
+    /// from a listener. See `LoopbackPortProbe` for why the control client
+    /// cannot answer this question.
+    private let portProbe: any LoopbackPortProbing
     /// Whether any session spawned through the proxy is still alive — one
-    /// database question, asked once, at a boot that finds the flag off.
+    /// database question, asked at a boot that finds the flag off, **and on
+    /// every refused bind**.
+    ///
+    /// The second caller is the port wait: waiting for a held port to come free
+    /// is worth paying only while a session is still routed against it, because
+    /// that session's `ANTHROPIC_BASE_URL` names the port for the rest of its
+    /// life and minting a fresh one strands it. With nothing routed there is
+    /// nothing to strand, and the wait would only delay this daemon's boot and
+    /// the Settings toggle.
     ///
     /// A closure rather than a store, because it is the only thing this actor
     /// wants from the terminal table and taking the table would make the
@@ -188,6 +201,43 @@ actor ModelProxySupervisor {
     /// Giving up after the last step is not permanent: `respawn` says so, and
     /// the next watch tick sees no proxy and starts a fresh burst.
     private let respawnBackoff: [Duration]
+    /// How long the port wait leaves between attempts to bind a port something
+    /// else is holding.
+    ///
+    /// Two seconds because a refused bind is cheap — the proxy exits with
+    /// status 3 within milliseconds of trying — so a finer cadence would only
+    /// churn processes for an answer that cannot arrive faster.
+    private let portRetryInterval: Duration
+    /// How many refused binds the port wait tolerates before it gives the port
+    /// up and mints a fresh one.
+    private let portRetryAttempts: Int
+    /// The shipped cadence and count, named because their **product** is the
+    /// number that has to sit between two other numbers.
+    ///
+    /// The window (2s × 15 = 30s) has to be wider than a transient holder
+    /// typically keeps an ephemeral number. macOS hands TCP ephemeral ports out
+    /// sequentially from one global counter, so a number a retiring or killed
+    /// proxy just freed is often handed to an ordinary short-lived client
+    /// socket before the successor binds; that socket's lifetime is sub-second
+    /// to a few seconds, and 30s clears it comfortably.
+    ///
+    /// It also has to stay well inside the 183 seconds Claude retries a refused
+    /// base URL for (spec, "Failure semantics"), measured from the *worst* path
+    /// that reaches a respawn — the hang ladder, which already spends four
+    /// missed polls (60s) plus `hangSignalKillDelay` ticks (30s) plus one more
+    /// tick to notice the kill (15s) = 105s before the respawn starts. 105 + 30
+    /// = 135s, which leaves roughly 45s for the spawn itself and a watch tick.
+    static let defaultPortRetryInterval: Duration = .seconds(2)
+    static let defaultPortRetryAttempts = 15
+    /// Consecutive probes that find a listener — not this home's proxy, and so
+    /// not adoptable — before the port is given up.
+    ///
+    /// A listener is not a transient: it is bound and accepting, and it will
+    /// still be there in thirty seconds, so spending the whole window on it
+    /// only delays the mint that has to happen anyway. Two sightings rather
+    /// than one because a single accepted connect can be the tail of a holder
+    /// that is closing; a second one an interval later says it is not.
+    private static let foreignListenerPatience = 2
     /// Consecutive missed `/tbd/status` polls, all while the process table
     /// still confirms the proxy, before this daemon treats it as hung rather
     /// than merely slow.
@@ -324,10 +374,13 @@ actor ModelProxySupervisor {
         processIdentity: any ProcessIdentityChecking = ProcessTableIdentityCheck(),
         signaller: any ProcessSignaller = ProductionProcessSignaller(),
         pidFile: any ModelProxyPIDFileReading = ModelProxyPIDFile(),
+        portProbe: any LoopbackPortProbing = LoopbackPortProbe(),
         routedSessionsAlive: @escaping @Sendable () async -> Bool = { false },
         clientFactory: @escaping @Sendable (Int) -> ModelProxyClient = { ModelProxyClient(port: $0) },
         watchInterval: Duration = .seconds(15),
         respawnBackoff: [Duration] = [.seconds(1), .seconds(5), .seconds(30)],
+        portRetryInterval: Duration = ModelProxySupervisor.defaultPortRetryInterval,
+        portRetryAttempts: Int = ModelProxySupervisor.defaultPortRetryAttempts,
         clock: any Clock<Duration> = ContinuousClock()
     ) {
         self.config = config
@@ -337,12 +390,15 @@ actor ModelProxySupervisor {
         self.processIdentity = processIdentity
         self.signaller = signaller
         self.pidFile = pidFile
+        self.portProbe = portProbe
         self.routedSessionsAlive = routedSessionsAlive
         self.canonicalHome = ModelProxyStatus.canonicalHome(home.path)
         self.pidFilePath = ProxyHomePaths(home: home).pidPath
         self.clientFactory = clientFactory
         self.watchInterval = watchInterval
         self.respawnBackoff = respawnBackoff
+        self.portRetryInterval = portRetryInterval
+        self.portRetryAttempts = portRetryAttempts
         self.clock = clock
         self.routes = ModelProxyRouteStore(home: home)
     }
@@ -1084,21 +1140,18 @@ actor ModelProxySupervisor {
             return false
 
         case .bindFailed(let port):
-            // Somebody has the port. A TBD proxy is adopted; anything else
-            // means it was taken while TBD was stopped, and a fresh port is
-            // minted (spec, "Port").
-            if await adoptIfMatching(port: port) { return true }
+            // Somebody has the port. The port wait asks who, adopts a TBD
+            // proxy, and otherwise decides between waiting the holder out and
+            // minting (spec, "Port"). A kernel-assigned port has no wait to
+            // run: there is no persisted number a session could be routed
+            // against, so only the adoption half applies.
             guard requested > 0 else {
+                if await adoptIfMatching(port: port) { return true }
                 Self.logger.error(
                     "the model proxy could not bind a kernel-assigned port; not retrying")
                 return false
             }
-            Self.logger.error(
-                """
-                port \(port, privacy: .public) is held by something that is not a TBD proxy; \
-                minting a fresh one. Sessions spawned against the old port keep it for their life
-                """)
-            return await attemptSpawn(port: 0, decision: .overwrite)
+            return await reclaimPort(port)
 
         case .homeUnusable:
             permanentlyDown = true
@@ -1125,6 +1178,222 @@ actor ModelProxySupervisor {
                 \(error.localizedDescription, privacy: .public)
                 """)
             return false
+        }
+    }
+
+    // MARK: - The port wait
+
+    /// **The port wait** (spec, "Port"): a bounded attempt to keep the port
+    /// this home's sessions are already routed against, before giving it up.
+    ///
+    /// The port is not a detail of this daemon's bookkeeping. It is written
+    /// into every routed session's `ANTHROPIC_BASE_URL` at spawn and read once,
+    /// so a session lives and dies on the number it was given: minting a fresh
+    /// one strands every session on the old port, which then spends Claude's
+    /// 183-second retry budget on a refused connect and fails the turn.
+    ///
+    /// So minting is the last answer here, not the first, and three facts have
+    /// to be established before it:
+    ///
+    ///   - **Is it ours?** Asked first on every pass through the loop, because
+    ///     a proxy that was mid-bind when this daemon's own bind lost can be
+    ///     answering by the time it is probed. Adoption wins outright and costs
+    ///     no wait.
+    ///   - **Is it a listener or a transient?** `portProbe` answers with an
+    ///     errno rather than a fold: a refused connect means nothing is
+    ///     listening, so the number is held by something that will let go of it
+    ///     — macOS hands ephemeral ports out sequentially from one counter, so
+    ///     a number a retire or a kill just freed is routinely handed to a
+    ///     short-lived client socket before the successor binds. An accepted
+    ///     connect that adoption refuses is a foreign listener, which will not
+    ///     let go, and is given up after `foreignListenerPatience` sightings.
+    ///   - **Is anything stranded?** Asked once, and only after the first probe
+    ///     has had its chance to adopt: with no session routed against the port
+    ///     there is nothing to protect, and the wait would only delay this
+    ///     daemon's boot and the Settings toggle.
+    ///
+    /// - Returns: whether a proxy is current afterwards.
+    private func reclaimPort(_ port: Int) async -> Bool {
+        guard let spawner else {
+            Self.logger.info(
+                """
+                no model proxy binary beside this daemon; sessions for \
+                \(self.home.path, privacy: .public) will not be proxied
+                """)
+            return false
+        }
+
+        // One, for the bind that brought us here.
+        var refusedBinds = 1
+        var listenerSightings = 0
+        // The gate is one database question and its answer cannot usefully
+        // change inside a 30-second window, so it is asked at most once — but
+        // lazily, so an adoptable proxy on the first probe is taken without
+        // asking it at all.
+        var routedAnswer: Bool?
+
+        while true {
+            switch await classifyOccupant(of: port) {
+            case .ours:
+                return true
+            case .foreignListener(let detail):
+                listenerSightings += 1
+                if listenerSightings >= Self.foreignListenerPatience {
+                    Self.logger.error(
+                        """
+                        port \(port, privacy: .public) has been held across \
+                        \(listenerSightings, privacy: .public) probes by a listener that is not \
+                        this home's model proxy; it is not going to let go
+                        """)
+                    return await mintReplacement(
+                        for: port, refusedBinds: refusedBinds, reason: detail)
+                }
+            case .transient:
+                listenerSightings = 0
+            }
+
+            let routed: Bool
+            if let routedAnswer {
+                routed = routedAnswer
+            } else {
+                routed = await routedSessionsAlive()
+                routedAnswer = routed
+            }
+            guard routed else {
+                Self.logger.error(
+                    """
+                    port \(port, privacy: .public) is held by something that is not a TBD proxy \
+                    and no session is routed against it, so nothing is stranded; minting a fresh \
+                    port at once
+                    """)
+                return await mintReplacement(
+                    for: port, refusedBinds: refusedBinds,
+                    reason: "no session is routed against it")
+            }
+
+            guard refusedBinds <= portRetryAttempts else {
+                Self.logger.error(
+                    """
+                    port \(port, privacy: .public) did not come free within \
+                    \(self.portRetryAttempts, privacy: .public) attempts; giving up on it
+                    """)
+                return await mintReplacement(
+                    for: port, refusedBinds: refusedBinds,
+                    reason: "it never came free")
+            }
+
+            if permanentlyDown || Task.isCancelled { return false }
+            try? await clock.sleep(for: portRetryInterval)
+            // A cancelled sleep returns instantly, and a cancelled watch must
+            // never mint: the daemon is going away, and the port belongs to the
+            // sessions that outlive it.
+            if Task.isCancelled { return false }
+
+            do {
+                let result = try await spawner.spawn(port: port, home: home)
+                Self.logger.info(
+                    """
+                    port \(port, privacy: .public) came free after \
+                    \(refusedBinds, privacy: .public) refused bind(s); the model proxy is back on it
+                    """)
+                await recordSpawn(
+                    pid: result.pid, port: result.port, requested: port, decision: .keep)
+                return live != nil
+            } catch let error as ModelProxySpawner.Error {
+                guard case .bindFailed = error else {
+                    // Anything but another refused bind is a different question
+                    // and is answered where it already is. It cannot come back
+                    // here: `.bindFailed` is consumed by this loop and never
+                    // reaches `recover` from this call.
+                    return await recover(from: error, requested: port)
+                }
+                refusedBinds += 1
+            } catch {
+                Self.logger.error(
+                    """
+                    could not spawn a model proxy for \(self.home.path, privacy: .public): \
+                    \(error.localizedDescription, privacy: .public)
+                    """)
+                return false
+            }
+        }
+    }
+
+    /// Gives the port up: mint a fresh one, overwrite the column, and say
+    /// plainly what that costs.
+    ///
+    /// `reason` is passed in so the two ways of arriving here — a foreign
+    /// listener, and a budget that ran out — share one outcome line naming both
+    /// ports, which is the line an operator needs when a session that was
+    /// working stops being proxied.
+    private func mintReplacement(for old: Int, refusedBinds: Int, reason: String) async -> Bool {
+        let minted = await attemptSpawn(port: 0, decision: .overwrite)
+        guard minted, let replacement = live?.state.port else {
+            Self.logger.error(
+                """
+                gave up on port \(old, privacy: .public) after \
+                \(refusedBinds, privacy: .public) refused bind(s) \
+                (\(reason, privacy: .public)) and could not mint a replacement either; \
+                no session will be proxied until this daemon reconciles again
+                """)
+            return minted
+        }
+        Self.logger.error(
+            """
+            gave up on port \(old, privacy: .public) after \
+            \(refusedBinds, privacy: .public) refused bind(s) (\(reason, privacy: .public)); \
+            minted port \(replacement, privacy: .public) instead — sessions spawned against port \
+            \(old, privacy: .public) keep it for their life and lose the proxy
+            """)
+        return minted
+    }
+
+    /// What is on the port, in the three shapes the wait branches on.
+    private enum Occupant {
+        /// This home's proxy, and it has just been adopted.
+        case ours
+        /// A listener that answered and failed the adoption identity check.
+        case foreignListener(String)
+        /// Nothing is listening, or the probe could not say — either way the
+        /// number may come free, so it is waited on.
+        case transient(String)
+    }
+
+    /// Asks the port who holds it, and lets adoption have the first word.
+    ///
+    /// **Adoption is tried before anything is concluded from an accepted
+    /// connect**, so a proxy that came up between the failed bind and this
+    /// probe is taken over rather than counted against
+    /// `foreignListenerPatience`. `adoptIfMatching` already logs at `.error`
+    /// *why* it refused; this adds only which of the three cases the probe saw,
+    /// at `.debug`, because it is asked once per interval for the whole window.
+    private func classifyOccupant(of port: Int) async -> Occupant {
+        switch portProbe.occupancy(port: port) {
+        case .refused:
+            Self.logger.debug(
+                """
+                nothing is listening on port \(port, privacy: .public); something transient holds \
+                the number
+                """)
+            return .transient("connect refused")
+        case .undetermined(let detail):
+            // A bounded wait is the conservative answer to an answer we do not
+            // have: waiting out a listener costs a delayed mint, while minting
+            // past a transient strands live sessions.
+            Self.logger.debug(
+                """
+                could not tell who holds port \(port, privacy: .public) \
+                (\(detail, privacy: .public)); waiting it out
+                """)
+            return .transient(detail)
+        case .accepted:
+            if await adoptIfMatching(port: port) { return .ours }
+            Self.logger.debug(
+                """
+                a listener answers on port \(port, privacy: .public) and it is not this home's \
+                model proxy
+                """)
+            return .foreignListener("a listener that is not this home's proxy answers on it")
         }
     }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
@@ -455,7 +455,12 @@ extension RPCRouter {
     /// Both are awaited before this RPC answers, which is what makes the
     /// Settings checkbox's response wait on them. Milliseconds normally, and
     /// bounded in the worst case by the control client's 2-second probe plus
-    /// the spawner's 10-second bind budget. Answering early would be worse than
+    /// the spawner's 10-second bind budget — and, when a session is still
+    /// routed against the persisted port and something transient holds it, by
+    /// the supervisor's port wait of up to 30 seconds
+    /// (`ModelProxySupervisor.defaultPortRetryAttempts` ×
+    /// `defaultPortRetryInterval`), paid only in the case where minting a fresh
+    /// port would strand that session. Answering early would be worse than
     /// the wait: the reply is what the app reloads its capabilities on, and a
     /// reply that landed before the supervisor had a port would render the
     /// toggle's own state wrong.

--- a/Tests/TBDDaemonTests/ModelProxy/LoopbackPortProbeTests.swift
+++ b/Tests/TBDDaemonTests/ModelProxy/LoopbackPortProbeTests.swift
@@ -19,18 +19,18 @@ struct LoopbackPortProbeTests {
     /// `ECONNREFUSED`. That is what a freed ephemeral number held by nothing
     /// looks like.
     @Test("a port with no listener is refused")
-    func aPortWithNoListenerIsRefused() {
-        #expect(LoopbackPortProbe().occupancy(port: 1) == .refused)
+    func aPortWithNoListenerIsRefused() async {
+        #expect(await LoopbackPortProbe().occupancy(port: 1) == .refused)
     }
 
     /// The discriminating half: a real listener on a real loopback port, which
     /// accepts the connection in the kernel without the accept loop having to
     /// answer anything.
     @Test("a port with a listener is accepted")
-    func aPortWithAListenerIsAccepted() throws {
+    func aPortWithAListenerIsAccepted() async throws {
         let server = try LoopbackHTTPTestServer { _ in .ok("{}") }
         defer { server.stop() }
 
-        #expect(LoopbackPortProbe().occupancy(port: server.port) == .accepted)
+        #expect(await LoopbackPortProbe().occupancy(port: server.port) == .accepted)
     }
 }

--- a/Tests/TBDDaemonTests/ModelProxy/LoopbackPortProbeTests.swift
+++ b/Tests/TBDDaemonTests/ModelProxy/LoopbackPortProbeTests.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Testing
+
+@testable import TBDDaemonLib
+
+/// `LoopbackPortProbe` against real sockets, because the whole reason it exists
+/// beside `ModelProxyClient` is an errno the client folds away.
+///
+/// Two answers and nothing in between: the supervisor's port wait waits out a
+/// refused connect and gives up on an accepted one, so a probe that could not
+/// tell them apart would either strand live sessions or leave a home unproxied
+/// behind a listener that is never going to move.
+@Suite("Loopback port probe")
+struct LoopbackPortProbeTests {
+
+    /// Port 1 is privileged: binding it needs root, so nothing in a test runner
+    /// — this suite, a sibling running in parallel, or anything else on the
+    /// machine — can be listening there, and the connect is a prompt
+    /// `ECONNREFUSED`. That is what a freed ephemeral number held by nothing
+    /// looks like.
+    @Test("a port with no listener is refused")
+    func aPortWithNoListenerIsRefused() {
+        #expect(LoopbackPortProbe().occupancy(port: 1) == .refused)
+    }
+
+    /// The discriminating half: a real listener on a real loopback port, which
+    /// accepts the connection in the kernel without the accept loop having to
+    /// answer anything.
+    @Test("a port with a listener is accepted")
+    func aPortWithAListenerIsAccepted() throws {
+        let server = try LoopbackHTTPTestServer { _ in .ok("{}") }
+        defer { server.stop() }
+
+        #expect(LoopbackPortProbe().occupancy(port: server.port) == .accepted)
+    }
+}

--- a/Tests/TBDDaemonTests/ModelProxy/ModelProxySupervisorTests.swift
+++ b/Tests/TBDDaemonTests/ModelProxy/ModelProxySupervisorTests.swift
@@ -865,6 +865,11 @@ struct ModelProxySupervisorTests {
     /// thing holding it is not a TBD proxy. The supervisor must spawn on zero
     /// and **overwrite** the stored port — `ensureModelProxyPort` is
     /// conditional and would leave the stale value in place.
+    ///
+    /// This is the **nobody-routed** branch of the port wait's gate, which is
+    /// why it still mints at once: `routedSessionsAlive` defaults to "none", so
+    /// a fresh port strands nothing. `refusedBindIsRetriedWhileASessionIsRouted`
+    /// is the other branch, where the same refused bind is waited out instead.
     @Test("a persisted port held by a stranger is re-minted")
     func remintsPortWhenHeldByStranger() async throws {
         let fixture = try SupervisorFixture.make()
@@ -883,6 +888,307 @@ struct ModelProxySupervisorTests {
         #expect(
             try await fixture.db.config.get().modelProxyPort == SupervisorFixture.otherDeadPort,
             "the re-mint must overwrite the stale port, not leave it")
+    }
+
+    // MARK: - The port wait
+
+    /// **The port wait's whole reason** (spec, "Port"): a port a routed session
+    /// carries in its `ANTHROPIC_BASE_URL` is not this daemon's to give up
+    /// while something transient holds it.
+    ///
+    /// Before this behaviour existed the sequence below spawned twice — once on
+    /// the persisted port, then immediately on zero — and rewrote the column, so
+    /// every session already routed against the old port spent Claude's
+    /// 183-second retry budget on a refused connect and failed its turn. The
+    /// discriminating observable is therefore the spawner's call list: it must
+    /// read `[deadPort, deadPort, deadPort]` and never contain a zero, and the
+    /// column must still name the port it named at the start.
+    ///
+    /// `deadPort` is a privileged number, so the production `LoopbackPortProbe`
+    /// the fixture delegates to answers `.refused` there through the real
+    /// syscalls — a transient holder, which is what the wait is for.
+    ///
+    /// **The clock handshake.** `start()` does not return until the wait does,
+    /// so it runs in a task of its own and each hop is a
+    /// `requireAdvanceWhenArmed`. Exactly one sleeper can be in the ledger at
+    /// each hop: `start()` has not created the watch yet, and the wait's own
+    /// `clock.sleep` is the only one on this path.
+    @Test("a bind refused on the persisted port is retried on the clock and the port kept")
+    func refusedBindIsRetriedWhileASessionIsRouted() async throws {
+        let fixture = try SupervisorFixture.make()
+        defer { fixture.tearDown() }
+        let clock = EventDrivenTestClock()
+
+        try await fixture.db.config.setModelProxyPort(SupervisorFixture.deadPort)
+        await fixture.spawner.answer(.failure(.bindFailed(port: SupervisorFixture.deadPort)))
+        await fixture.spawner.answer(.failure(.bindFailed(port: SupervisorFixture.deadPort)))
+        await fixture.spawner.answer(.success(pid: 7301, port: SupervisorFixture.deadPort))
+
+        let supervisor = fixture.supervisor(routedSessionsAlive: { true }, clock: clock)
+        let starting = Task { await supervisor.start() }
+        defer { starting.cancel() }
+        try await clock.requireAdvanceWhenArmed(by: ModelProxySupervisor.defaultPortRetryInterval)
+        try await clock.requireAdvanceWhenArmed(by: ModelProxySupervisor.defaultPortRetryInterval)
+        await starting.value
+        await supervisor.stop()
+
+        #expect(
+            await fixture.spawner.calls() == [
+                SupervisorFixture.deadPort, SupervisorFixture.deadPort, SupervisorFixture.deadPort,
+            ],
+            "every attempt asks for the port the routed sessions already carry")
+        let current = await supervisor.current
+        #expect(current?.port == SupervisorFixture.deadPort)
+        #expect(current?.pid == 7301)
+        #expect(
+            try await fixture.db.config.get().modelProxyPort == SupervisorFixture.deadPort,
+            "a port that was waited out and taken back is never rewritten")
+    }
+
+    /// The wait is bounded, and the bound is the other half of the claim: a
+    /// holder that never lets go must not keep this home unproxied forever.
+    ///
+    /// A short `portRetryAttempts` so the budget is reached in three hops
+    /// rather than fifteen. The verdict is that the mint happens **once** —
+    /// a give-up that fell back into the retry loop, or a loop that minted on
+    /// every pass, would show more than one zero in the call list.
+    @Test("a refusal that never clears mints after the budget and rewrites the column once")
+    func refusedBindGivesUpAfterTheBudget() async throws {
+        let fixture = try SupervisorFixture.make()
+        defer { fixture.tearDown() }
+        let clock = EventDrivenTestClock()
+
+        try await fixture.db.config.setModelProxyPort(SupervisorFixture.deadPort)
+        for _ in 0..<4 {
+            await fixture.spawner.answer(.failure(.bindFailed(port: SupervisorFixture.deadPort)))
+        }
+        await fixture.spawner.answer(.success(pid: 7311, port: SupervisorFixture.otherDeadPort))
+
+        let supervisor = fixture.supervisor(
+            routedSessionsAlive: { true }, portRetryAttempts: 3, clock: clock)
+        let starting = Task { await supervisor.start() }
+        defer { starting.cancel() }
+        for _ in 0..<3 {
+            try await clock.requireAdvanceWhenArmed(
+                by: ModelProxySupervisor.defaultPortRetryInterval)
+        }
+        await starting.value
+        await supervisor.stop()
+
+        let calls = await fixture.spawner.calls()
+        #expect(
+            calls == [
+                SupervisorFixture.deadPort, SupervisorFixture.deadPort,
+                SupervisorFixture.deadPort, SupervisorFixture.deadPort, 0,
+            ],
+            "the budgeted attempts all ask for the old port, and only the last mints")
+        #expect(calls.filter { $0 == 0 }.count == 1, "the mint happens once, not once per pass")
+        #expect(
+            try await fixture.db.config.get().modelProxyPort == SupervisorFixture.otherDeadPort,
+            "giving up overwrites the column with the port that was actually taken")
+    }
+
+    /// The shipped window, pinned because its **product** is what has to sit
+    /// between two other numbers.
+    ///
+    /// 2 s × 15 = 30 s. Claude retries a refused base URL for 183 s (spec,
+    /// "Failure semantics"), and the worst path that reaches a respawn is the
+    /// hang ladder — four missed polls (60 s), `hangSignalKillDelay` ticks
+    /// (30 s), one more tick to notice the kill (15 s) = 105 s, which
+    /// `hungProxyEscalatesToSignalsThenRespawns` pins from the other end.
+    /// 105 + 30 = 135 s, leaving roughly 45 s for the spawn itself and a watch
+    /// tick. Widening either constant without redoing that arithmetic is how
+    /// the wait starts outliving the budget it exists to fit inside.
+    @Test("the shipped port wait fits inside Claude's retry budget")
+    func portWaitDefaultsFitTheRetryBudget() {
+        #expect(ModelProxySupervisor.defaultPortRetryInterval == .seconds(2))
+        #expect(ModelProxySupervisor.defaultPortRetryAttempts == 15)
+    }
+
+    /// A listener is not a transient, and the wait must not spend its whole
+    /// window on one.
+    ///
+    /// The occupant here is a real HTTP listener that answers a real status
+    /// document naming **another TBD home** — every other field is a live,
+    /// same-version proxy, so only the identity check refuses it. It accepts
+    /// connections, so it will still be there in thirty seconds.
+    ///
+    /// Two observables discriminate. Before this behaviour the call list read
+    /// `[proxy.port, 0]` with no wait at all; a wait that could not tell a
+    /// listener from a transient would need fifteen hops and thirty seconds of
+    /// virtual time. This takes exactly one interval and one extra attempt.
+    @Test("a foreign listener is given up after two sightings, not the whole budget")
+    func foreignListenerIsGivenUpAfterTwoSightings() async throws {
+        let fixture = try SupervisorFixture.make()
+        defer { fixture.tearDown() }
+        let clock = EventDrivenTestClock()
+
+        let elsewhere = fixture.root.appendingPathComponent("another-install")
+        let proxy = try ForeignHomeProxyProcess(
+            version: fixture.ownVersion, pid: 7320, home: elsewhere.path)
+        defer { proxy.stop() }
+        try await fixture.db.config.setModelProxyPort(proxy.port)
+        await fixture.spawner.answer(.failure(.bindFailed(port: proxy.port)))
+        await fixture.spawner.answer(.failure(.bindFailed(port: proxy.port)))
+        await fixture.spawner.answer(.success(pid: 7321, port: SupervisorFixture.otherDeadPort))
+
+        let supervisor = fixture.supervisor(routedSessionsAlive: { true }, clock: clock)
+        let starting = Task { await supervisor.start() }
+        defer { starting.cancel() }
+        try await clock.requireAdvanceWhenArmed(by: ModelProxySupervisor.defaultPortRetryInterval)
+        await starting.value
+        await supervisor.stop()
+
+        #expect(
+            await fixture.spawner.calls() == [proxy.port, proxy.port, 0],
+            "two sightings, then the mint")
+        #expect(
+            try await fixture.db.config.get().modelProxyPort == SupervisorFixture.otherDeadPort)
+        #expect(
+            clock.now.offset == ModelProxySupervisor.defaultPortRetryInterval,
+            "one interval of virtual time, not the whole window")
+    }
+
+    /// **Adoption keeps the first word.** A refused bind whose occupant passes
+    /// the identity check is this home's own proxy — one that came up between
+    /// the failed bind and the probe — and it is taken over with no wait and no
+    /// mint.
+    ///
+    /// The startup probe is denied once so the spawn is reached at all, exactly
+    /// as `lockHeldProbesAndAdopts` does; the second check admits. This
+    /// discriminates against a wait that concluded "foreign listener" from an
+    /// accepted connect without letting adoption answer first: that shape would
+    /// count the daemon's own proxy as a stranger and eventually mint past it.
+    ///
+    /// That there is no wait is not asserted through the clock but through the
+    /// call itself: `start()` returns without the test ever advancing virtual
+    /// time, and a wait would have parked it on this clock indefinitely.
+    @Test("an occupant that passes identity is adopted without a wait")
+    func refusedBindAdoptsAnOccupantThatPassesIdentity() async throws {
+        let fixture = try SupervisorFixture.make()
+        defer { fixture.tearDown() }
+        let clock = EventDrivenTestClock()
+
+        let proxy = try FakeProxyProcess(version: fixture.ownVersion, pid: 7330, home: fixture.home)
+        defer { proxy.stop() }
+        try await fixture.db.config.setModelProxyPort(proxy.port)
+        fixture.identity.denyOnce()
+        fixture.identity.admit(pid: 7330, startTime: proxy.processStartTime)
+        await fixture.spawner.answer(.failure(.bindFailed(port: proxy.port)))
+
+        let supervisor = fixture.supervisor(routedSessionsAlive: { true }, clock: clock)
+        await supervisor.start()
+        await supervisor.stop()
+
+        let current = await supervisor.current
+        #expect(current?.pid == 7330)
+        #expect(current?.adopted == true)
+        #expect(await fixture.spawner.calls() == [proxy.port], "no second spawn, and no mint")
+        #expect(try await fixture.db.config.get().modelProxyPort == proxy.port)
+    }
+
+    /// The other branch of the wait's gate: with nothing routed against the
+    /// port, nothing is stranded by a fresh one, so the wait is not paid at all.
+    ///
+    /// This is `remintsPortWhenHeldByStranger` said the other way round — that
+    /// one takes the default `routedSessionsAlive`, this one is explicit about
+    /// which fact does the work — and it is what keeps the wait from delaying
+    /// every boot and every Settings toggle on an install with no proxied
+    /// session running. `start()` returning with virtual time never advanced is
+    /// the proof that nothing slept.
+    @Test("with no session routed a refused bind mints at once")
+    func refusedBindMintsAtOnceWithNothingRouted() async throws {
+        let fixture = try SupervisorFixture.make()
+        defer { fixture.tearDown() }
+        let clock = EventDrivenTestClock()
+
+        try await fixture.db.config.setModelProxyPort(SupervisorFixture.deadPort)
+        await fixture.spawner.answer(.failure(.bindFailed(port: SupervisorFixture.deadPort)))
+        await fixture.spawner.answer(.success(pid: 7351, port: SupervisorFixture.otherDeadPort))
+
+        let supervisor = fixture.supervisor(routedSessionsAlive: { false }, clock: clock)
+        await supervisor.start()
+        await supervisor.stop()
+
+        #expect(await fixture.spawner.calls() == [SupervisorFixture.deadPort, 0])
+        #expect(
+            try await fixture.db.config.get().modelProxyPort == SupervisorFixture.otherDeadPort)
+        #expect(clock.now.offset == .zero, "no interval was waited")
+    }
+
+    /// A probe that cannot say who holds the port — a listener whose backlog is
+    /// full, or an errno that is neither success nor `ECONNREFUSED` — is
+    /// treated as a transient and waited out.
+    ///
+    /// The conservative direction is the claim: waiting out a listener costs a
+    /// delayed mint, while minting past a transient strands live sessions. A
+    /// classification that folded `.undetermined` in with `.accepted` would
+    /// give the port up after two probes instead of keeping it.
+    @Test("an undetermined probe is waited out like a refusal")
+    func undeterminedProbeIsWaitedOut() async throws {
+        let fixture = try SupervisorFixture.make()
+        defer { fixture.tearDown() }
+        let clock = EventDrivenTestClock()
+        fixture.portProbe.force(.undetermined("no answer within 1s"))
+
+        try await fixture.db.config.setModelProxyPort(SupervisorFixture.deadPort)
+        await fixture.spawner.answer(.failure(.bindFailed(port: SupervisorFixture.deadPort)))
+        await fixture.spawner.answer(.success(pid: 7361, port: SupervisorFixture.deadPort))
+
+        let supervisor = fixture.supervisor(routedSessionsAlive: { true }, clock: clock)
+        let starting = Task { await supervisor.start() }
+        defer { starting.cancel() }
+        try await clock.requireAdvanceWhenArmed(by: ModelProxySupervisor.defaultPortRetryInterval)
+        await starting.value
+        await supervisor.stop()
+
+        #expect(
+            await fixture.spawner.calls()
+                == [SupervisorFixture.deadPort, SupervisorFixture.deadPort])
+        #expect(await supervisor.current?.pid == 7361)
+        #expect(try await fixture.db.config.get().modelProxyPort == SupervisorFixture.deadPort)
+    }
+
+    /// **A version replacement goes through the wait too.** `POST /tbd/retire`
+    /// answers the moment the listener is closed and the lock is released, and
+    /// the successor binds right behind it — which is precisely the gap in
+    /// which the freed ephemeral number can be handed to an unrelated client
+    /// socket. Minting there would strand every session the retiring proxy was
+    /// serving, which is the population this whole path exists for.
+    ///
+    /// The fake keeps listening after the retire (it is an HTTP server, not a
+    /// proxy), so the port probe is forced to `.refused` to stand in for the
+    /// closed listener; a refused connect never reaches the status endpoint, so
+    /// the still-listening fake cannot be re-adopted behind the failed bind.
+    @Test("a version replace goes through the port wait")
+    func versionReplaceWaitsForThePort() async throws {
+        let fixture = try SupervisorFixture.make()
+        defer { fixture.tearDown() }
+        let clock = EventDrivenTestClock()
+        fixture.portProbe.force(.refused)
+
+        let proxy = try FakeProxyProcess(version: "9999-1", pid: 7340, home: fixture.home)
+        defer { proxy.stop() }
+        try await fixture.db.config.setModelProxyPort(proxy.port)
+        fixture.identity.admit(pid: 7340, startTime: proxy.processStartTime)
+        await fixture.spawner.answer(.failure(.bindFailed(port: proxy.port)))
+        await fixture.spawner.answer(.success(pid: 7341, port: proxy.port))
+
+        let supervisor = fixture.supervisor(routedSessionsAlive: { true }, clock: clock)
+        let starting = Task { await supervisor.start() }
+        defer { starting.cancel() }
+        try await clock.requireAdvanceWhenArmed(by: ModelProxySupervisor.defaultPortRetryInterval)
+        await starting.value
+        await supervisor.stop()
+
+        #expect(
+            proxy.requests().contains { $0.method == "POST" && $0.path == "/tbd/retire" },
+            "the mismatched proxy is still asked to retire")
+        #expect(
+            await fixture.spawner.calls() == [proxy.port, proxy.port],
+            "the successor waits for the port rather than minting past it")
+        #expect(await supervisor.current?.pid == 7341)
+        #expect(try await fixture.db.config.get().modelProxyPort == proxy.port)
     }
 
     /// `.lockHeld` says a live proxy owns this rendezvous. The supervisor
@@ -1329,6 +1635,76 @@ struct ModelProxySupervisorTests {
             "the respawn targets the port the hung proxy held")
 
         await supervisor.stop()
+    }
+
+    /// **The end of the hang ladder is the case the port wait was written
+    /// for.** A SIGKILLed proxy frees its port abruptly, and macOS hands
+    /// ephemeral numbers out sequentially from one counter, so the number is
+    /// routinely re-handed to a short-lived client socket before the successor
+    /// binds. Minting there strands every session the killed proxy was serving
+    /// — the population the ladder took 105 seconds to reach.
+    ///
+    /// The ladder above is walked verbatim up to the kill landing; from there
+    /// the respawn meets a refused bind. The port probe is *forced* to
+    /// `.refused` rather than the fake being stopped: the fake's port is an
+    /// ephemeral number and a suite running in parallel could be handed it,
+    /// which would make the real probe answer `.accepted` for a stranger's
+    /// listener and turn this into the foreign-listener case.
+    ///
+    /// Two hops, and only one sleeper can be in the ledger at each. The first
+    /// is the watch interval, whose tick notices the kill and burns the refused
+    /// bind; the second is the wait's own sleep, and the watch cannot have
+    /// re-armed because it does not do so until `tick` returns. Before this
+    /// behaviour the call list read `[proxy.port, 0]`.
+    @Test("the hang ladder's respawn goes through the port wait")
+    func hangLadderRespawnWaitsForThePort() async throws {
+        let fixture = try SupervisorFixture.make()
+        defer { fixture.tearDown() }
+        let clock = EventDrivenTestClock()
+        // Named here rather than reached through `fixture` below: the
+        // `observed:` closure is `@Sendable`, and the actor is what it needs.
+        let spawner = fixture.spawner
+
+        let proxy = try FakeProxyProcess(version: fixture.ownVersion, pid: 6310, home: fixture.home)
+        defer { proxy.stop() }
+        try await fixture.db.config.setModelProxyPort(proxy.port)
+        fixture.identity.admit(pid: 6310, startTime: proxy.processStartTime)
+
+        let supervisor = fixture.supervisor(routedSessionsAlive: { true }, clock: clock)
+        await supervisor.start()
+        #expect(await supervisor.current?.pid == 6310)
+
+        proxy.failNextStatusResponses(20)
+        // Four misses to SIGTERM, `hangSignalKillDelay` more to SIGKILL.
+        for _ in 1...6 {
+            try await clock.requireAdvanceWhenArmed(by: fixture.watchInterval)
+        }
+        try await clock.requireSleeperArmed()
+        #expect(fixture.signaller.killed() == [6310], "the ladder reached SIGKILL")
+
+        // The kill lands: the process leaves the table, its listener is gone,
+        // and something transient has the number.
+        fixture.portProbe.force(.refused)
+        fixture.identity.forget(pid: 6310)
+        await fixture.spawner.answer(.failure(.bindFailed(port: proxy.port)))
+        await fixture.spawner.answer(.success(pid: 6311, port: proxy.port))
+
+        // Hop 1: the tick that notices the kill and burns the refused bind.
+        try await clock.requireAdvanceWhenArmed(by: fixture.watchInterval)
+        // Hop 2: the port wait's own sleep, the only sleeper on this path.
+        try await clock.requireAdvanceWhenArmed(by: ModelProxySupervisor.defaultPortRetryInterval)
+
+        let landed = try await waitFor(
+            "the successor to take the port back",
+            observed: { "spawn calls \(await spawner.calls())" },
+            { await supervisor.current?.pid == 6311 })
+        await supervisor.stop()
+
+        #expect(landed)
+        #expect(
+            await fixture.spawner.calls() == [proxy.port, proxy.port],
+            "the killed proxy's port is waited out, never minted past")
+        #expect(try await fixture.db.config.get().modelProxyPort == proxy.port)
     }
 
     /// The identity re-check right before every signal is what this pins: a
@@ -1845,6 +2221,7 @@ private struct SupervisorFixture {
     let spawner: StubSpawner
     let identity: StubIdentity
     let signaller: StubSignaller
+    let portProbe: StubPortProbe
     let clock: TestClock<Duration>
     let ownVersion = "12345-1700000000"
     let watchInterval: Duration = .seconds(15)
@@ -1867,6 +2244,7 @@ private struct SupervisorFixture {
             spawner: StubSpawner(),
             identity: StubIdentity(),
             signaller: StubSignaller(),
+            portProbe: StubPortProbe(),
             clock: TestClock())
     }
 
@@ -1887,6 +2265,7 @@ private struct SupervisorFixture {
         clientFactory: @escaping @Sendable (Int) -> ModelProxyClient = {
             ModelProxyClient(port: $0)
         },
+        portRetryAttempts: Int = ModelProxySupervisor.defaultPortRetryAttempts,
         clock overrideClock: (any Clock<Duration>)? = nil
     ) -> ModelProxySupervisor {
         ModelProxySupervisor(
@@ -1896,10 +2275,12 @@ private struct SupervisorFixture {
             ownVersion: ownVersion,
             processIdentity: identity,
             signaller: signaller,
+            portProbe: portProbe,
             routedSessionsAlive: routedSessionsAlive,
             clientFactory: clientFactory,
             watchInterval: watchInterval,
             respawnBackoff: [firstBackoff, .seconds(5)],
+            portRetryAttempts: portRetryAttempts,
             clock: overrideClock ?? clock)
     }
 
@@ -2008,6 +2389,34 @@ private final class StubIdentity: ProcessIdentityChecking, @unchecked Sendable {
             guard let known = admitted[pid] else { return false }
             return abs(known.timeIntervalSince(startTime)) < 0.000_001
         }
+    }
+}
+
+/// The port probe, **real by default**.
+///
+/// Delegating to the production `LoopbackPortProbe` is what keeps the ordinary
+/// cases honest: `SupervisorFixture.deadPort` is a privileged number nothing in
+/// a test runner can be listening on, so it is a prompt `ECONNREFUSED` through
+/// the same syscalls the daemon makes, and a `FakeProxyProcess` is a real
+/// listener on a real loopback port that answers `.accepted` for the same
+/// reason a stranger's proxy would.
+///
+/// A forced answer is for the one shape that cannot be arranged honestly: a
+/// case whose port is an *ephemeral* number a fake has just released, which a
+/// suite running in parallel could be handed in the meantime. There the port's
+/// real occupancy is nobody's to predict, and the fact under test is what the
+/// supervisor does with the answer rather than how it obtained it.
+private final class StubPortProbe: LoopbackPortProbing, @unchecked Sendable {
+    private let lock = NSLock()
+    private var forced: LoopbackPortOccupancy?
+
+    func force(_ occupancy: LoopbackPortOccupancy) {
+        lock.withLock { forced = occupancy }
+    }
+
+    func occupancy(port: Int) -> LoopbackPortOccupancy {
+        if let answer = lock.withLock({ forced }) { return answer }
+        return LoopbackPortProbe().occupancy(port: port)
     }
 }
 

--- a/Tests/TBDDaemonTests/ModelProxy/ModelProxySupervisorTests.swift
+++ b/Tests/TBDDaemonTests/ModelProxy/ModelProxySupervisorTests.swift
@@ -816,6 +816,36 @@ struct ModelProxySupervisorTests {
         #expect(await fixture.spawner.calls().isEmpty)
     }
 
+    /// The third state of the same gate, and the reason it throws instead of
+    /// folding: a terminal table that could not be read is not "nothing is
+    /// routed".
+    ///
+    /// Here the answer is the same as "nothing" — with the flag off, the only
+    /// thing a supervisor would do is keep a proxy alive for sessions that may
+    /// not exist, and starting one on an unanswered question is a background
+    /// process nobody asked for. `reclaimPortWaitsWhenTheGateCannotBeRead`
+    /// pins the *opposite* choice at the other caller, which is exactly why the
+    /// fold cannot live inside the closure.
+    @Test("a flag-off boot whose gate cannot be read starts nothing")
+    func aFlagOffBootWithAnUnreadableGateStartsNothing() async throws {
+        let fixture = try SupervisorFixture.make()
+        defer { fixture.tearDown() }
+
+        let proxy = try FakeProxyProcess(
+            version: fixture.ownVersion, pid: 6205, home: fixture.home, routeCount: 1)
+        defer { proxy.stop() }
+        try await fixture.db.config.setModelProxyPort(proxy.port)
+        fixture.identity.admit(pid: 6205, startTime: proxy.processStartTime)
+
+        let supervisor = fixture.supervisor(routedSessionsAlive: { throw GateUnreadable() })
+        await supervisor.startIfEnabled()
+        await supervisor.stop()
+
+        #expect(await supervisor.current == nil)
+        #expect(proxy.requests().isEmpty, "nothing was even probed")
+        #expect(await fixture.spawner.calls().isEmpty)
+    }
+
     /// **The discriminating half.** `stop()` is shutdown, and a proxy outliving
     /// its daemon is the point of a separate process: the next daemon adopts it
     /// back through the port in the config row. A `stop()` that retired would
@@ -943,6 +973,48 @@ struct ModelProxySupervisorTests {
         #expect(
             try await fixture.db.config.get().modelProxyPort == SupervisorFixture.deadPort,
             "a port that was waited out and taken back is never rewritten")
+    }
+
+    /// **The gate fails closed in the direction that keeps the port.** A
+    /// terminal table too busy to answer is exactly the machine on which a
+    /// contended port is being fought over, and the two mistakes do not cost
+    /// the same: waiting out a port nothing is routed against delays a boot by
+    /// thirty seconds, while minting past one that is strands a live session
+    /// for the rest of its life.
+    ///
+    /// This is `refusedBindIsRetriedWhileASessionIsRouted` with the gate
+    /// throwing instead of answering, and it discriminates against a
+    /// `try? … ?? false` fold on the closure: that reads an unreadable table as
+    /// "nothing is routed" and mints at once, which is the failure the whole
+    /// wait exists to prevent. The other caller wants the opposite answer —
+    /// `aFlagOffBootWithAnUnreadableGateStartsNothing` — which is why the
+    /// closure throws and each caller decides beside itself.
+    @Test("a gate that cannot be read waits rather than mints")
+    func reclaimPortWaitsWhenTheGateCannotBeRead() async throws {
+        let fixture = try SupervisorFixture.make()
+        defer { fixture.tearDown() }
+        let clock = EventDrivenTestClock()
+
+        try await fixture.db.config.setModelProxyPort(SupervisorFixture.deadPort)
+        await fixture.spawner.answer(.failure(.bindFailed(port: SupervisorFixture.deadPort)))
+        await fixture.spawner.answer(.success(pid: 7371, port: SupervisorFixture.deadPort))
+
+        let supervisor = fixture.supervisor(
+            routedSessionsAlive: { throw GateUnreadable() }, clock: clock)
+        let starting = Task { await supervisor.start() }
+        defer { starting.cancel() }
+        try await clock.requireAdvanceWhenArmed(by: ModelProxySupervisor.defaultPortRetryInterval)
+        await starting.value
+        await supervisor.stop()
+
+        #expect(
+            await fixture.spawner.calls()
+                == [SupervisorFixture.deadPort, SupervisorFixture.deadPort],
+            "an unreadable gate waits the holder out; it never mints on zero")
+        #expect(await supervisor.current?.pid == 7371)
+        #expect(
+            try await fixture.db.config.get().modelProxyPort == SupervisorFixture.deadPort,
+            "and the column the routed sessions carry is left alone")
     }
 
     /// The wait is bounded, and the bound is the other half of the claim: a
@@ -2261,7 +2333,7 @@ private struct SupervisorFixture {
     /// otherwise, which is the answer that makes a flag-off boot run nothing —
     /// the shipped install.
     func supervisor(
-        routedSessionsAlive: @escaping @Sendable () async -> Bool = { false },
+        routedSessionsAlive: @escaping @Sendable () async throws -> Bool = { false },
         clientFactory: @escaping @Sendable (Int) -> ModelProxyClient = {
             ModelProxyClient(port: $0)
         },
@@ -2392,6 +2464,14 @@ private final class StubIdentity: ProcessIdentityChecking, @unchecked Sendable {
     }
 }
 
+/// What a terminal table that cannot be read throws.
+///
+/// The production closure's failures are GRDB's — a busy timeout, lock
+/// contention — and nothing in the supervisor inspects the error beyond
+/// logging it, so a bare marker is the honest stand-in: the fact under test is
+/// that the question went unanswered, not what went wrong underneath.
+private struct GateUnreadable: Error {}
+
 /// The port probe, **real by default**.
 ///
 /// Delegating to the production `LoopbackPortProbe` is what keeps the ordinary
@@ -2414,9 +2494,12 @@ private final class StubPortProbe: LoopbackPortProbing, @unchecked Sendable {
         lock.withLock { forced = occupancy }
     }
 
-    func occupancy(port: Int) -> LoopbackPortOccupancy {
+    /// The forced answer is read out from under the lock **before** the
+    /// suspension, never across it: holding an `NSLock` over an `await` blocks
+    /// whatever thread the continuation resumes on.
+    func occupancy(port: Int) async -> LoopbackPortOccupancy {
         if let answer = lock.withLock({ forced }) { return answer }
-        return LoopbackPortProbe().occupancy(port: port)
+        return await LoopbackPortProbe().occupancy(port: port)
     }
 }
 

--- a/docs/specs/2026-09-05-transcript-streaming-model-proxy-design.md
+++ b/docs/specs/2026-09-05-transcript-streaming-model-proxy-design.md
@@ -174,14 +174,38 @@ before touching a socket path, so two daemons on one TBD home cannot both mint.
 On address-in-use the daemon probes the status endpoint on that port and
 adopts only a process that passes the identity check below. Anything else,
 including a proxy that belongs to another TBD home on the same machine after
-an ephemeral-port coincidence, means the port is not this daemon's to use; the
-daemon mints a fresh port and updates the column, and never retires or
-replaces a proxy it did not adopt. Sessions spawned against the old port lose the proxy for their
+an ephemeral-port coincidence, is not this daemon's to use, and is never
+retired or replaced.
+
+Before it gives such a port up, and only while a session is still routed
+against it, the daemon waits for it. The condition is the whole justification:
+with nothing routed there is nothing to strand, and a wait would only delay the
+daemon's boot and the Settings toggle. The question the wait turns on is who
+holds the number, asked with a plain loopback connect. A refused connect means
+nothing is listening, so the holder is transient — macOS hands TCP ephemeral
+ports out sequentially from one global counter (`net.inet.tcp.randomize_ports`
+is 0; across the 16,384 numbers in 49152-65535 a freed number came back after
+16,220 allocations, measured at 0.15 s on an idle machine), so a number a proxy
+has just freed is routinely handed to an ordinary short-lived client socket
+before the successor binds. That is retried every 2 seconds for 30 seconds. An
+accepted connect whose occupant fails the identity check is a foreign listener,
+which is bound and will not let go, so the port is given up after two
+consecutive sightings rather than at the end of the window. Giving up mints a
+fresh port and updates the column.
+
+Thirty seconds is sized against Claude's 183-second retry budget for a refused
+base URL, measured from the worst path that reaches a respawn: the hang ladder
+already spends four missed polls, two ticks after SIGTERM, and one more tick to
+notice the kill — 105 seconds — before the respawn starts, and 105 + 30 leaves
+room for the spawn itself and a watch tick.
+
+Sessions spawned against the old port lose the proxy for their
 remaining life, because Claude reads `ANTHROPIC_BASE_URL` once at start. That
 is the blast radius of a port change. A running proxy holds its port across
 every daemon restart, so one way to reach that radius is a window in which TBD
 was entirely stopped; the other is the gap a retire opens, in which the freed
-number is briefly anyone's.
+number is briefly anyone's — and that gap is what the wait covers, so only a
+holder that outlives the window reaches the blast radius.
 
 ### Control endpoint
 
@@ -714,8 +738,10 @@ SSE shape and costs zero tokens.
   no other header is. An unknown token is refused and nothing reaches the
   stub. The `HEAD` probe and count-tokens are forwarded. A failing tee leaves
   the client's bytes intact. Adopt, spawn, retire, and respawn on an injected
-  clock. Address-in-use against a non-TBD listener mints a new port; against a
-  TBD proxy adopts it. Retire answers before the drain finishes. A signal
+  clock. Address-in-use against a TBD proxy adopts it; against a transient
+  holder, with a session routed, is retried on the clock and keeps the port;
+  against a foreign listener mints sooner; with no session routed mints at
+  once. Retire answers before the drain finishes. A signal
   retires a proxy carrying a stream rather than cutting it, a second signal
   ends the drain, and a signal with nothing in flight exits promptly.
 - **Tee.** A request with `x-claude-code-agent-id`, or with an empty `tools`


### PR DESCRIPTION
## What's broken

A session spawned through the model proxy carries `ANTHROPIC_BASE_URL=http://127.0.0.1:<port>/r/<token>` in its environment for the rest of its life. When the supervisor has to put a successor on that port — after a version-difference retire-and-replace, after the hang ladder kills a wedged proxy, after a crash respawn — and the bind is refused, it mints a fresh port at once and rewrites `config.model_proxy_port`. Every session already routed to the old port is then stranded: Claude retries the refused base URL for about 183 seconds and then fails the turn, on every later turn, until the session is respawned.

This is not a rare race. macOS hands TCP ephemeral ports out sequentially from one global counter (`net.inet.tcp.randomize_ports` is 0), so the number a retire or a kill just freed is the number the next socket on the box is handed. The measurement in PR #845 saw a freed number come back after 16,220 allocations, 0.15 s on an idle machine. Most of the time that next socket is a short-lived client connection that lets go within seconds; occasionally it is a listener. `SO_REUSEADDR` on the proxy's listener does nothing against either.

## Why it happens

`ModelProxySupervisor.recover(from: .bindFailed)` probes the port for a proxy it can adopt and, when nothing adoptable answers, treats the port as somebody else's and mints. That rule was written for the case where TBD had been entirely stopped and the port was taken long ago. It does not distinguish a stranger that will hold the port for days from a client socket that will release it before the next watch tick, and it does not weigh whether anyone is still routed against the port.

## When it broke

PR #842 introduced the supervisor and the mint-on-refusal rule. PR #845 documented the sequential-allocation measurement and fixed the test-side half of the same problem; this is the production-side half.

## What this PR does

Before minting, the supervisor asks who holds the port and, when a routed session still needs it, waits for a transient holder to let go.

- **A loopback connect classifies the occupant** (new `LoopbackPortProbe`). A refused connect means no listener, which is what a client socket holding the number looks like from outside: the transient case. An accepted connect means a listener, which is then status-probed and adopted if it passes the adoption identity check, exactly as before. The raw connect exists beside `ModelProxyClient` because the client folds "refused" and "accepted but silent" into one `unreachable` error, and the errno is the discriminator.
- **The budget is 2 s between attempts, 15 attempts, 30 s in all.** The window has to outlast a client connection's lifetime, sub-second to a few seconds, and stay well inside Claude's 183 s retry budget at the far end of the hang ladder, which already spends 60 s of misses, 30 s to SIGKILL and one 15 s tick to notice before the respawn starts: 105 + 30 = 135 s, leaving about 45 s for the spawn and a watch tick. The constants and the arithmetic live beside `ModelProxySupervisor.defaultPortRetryInterval` / `defaultPortRetryAttempts` and in the spec's "Port" section.
- **A foreign listener is given up sooner.** A listener that is still there on the second probe, one interval later, will not go away, so the port is minted after two consecutive sightings rather than after the full window. The log says which case it was.
- **The wait is gated on a routed session existing** (`routedSessionsAlive`, the same terminal-table question the flag-off boot asks). With nobody routed nothing can be stranded, so the daemon's boot path and the Settings toggle RPC, both of which await the supervisor's start, keep today's immediate mint and their documented worst-case bound. Those two doc comments now state the extra 30 s that applies only when a session is routed.
- **The gate fails closed.** The routed-session predicate is a throwing closure, and each caller picks its own fail direction beside the call: the port wait treats a terminal-table read that throws as "assume a session is routed" and waits, because minting past a routed session is the failure the wait exists to prevent; the flag-off boot treats the same throw as "none" and starts no drain, as it did before, now with a log line saying why.
- **The probe never blocks the actor.** The connect and its bounded poll run on a GCD global queue behind a checked continuation, so the one-second bound in the pathological full-backlog case is spent on a GCD thread and never on the cooperative pool.
- **Every wait is on the supervisor's injected clock**, and a cancelled watch returns without minting.
- **Logging.** `.info` when the port comes free ("port N came free after K refused bind(s)"), `.error` when the supervisor gives up, naming the old port, the new one and the reason, so a stranded-session incident is diagnosable from the log.

Spec: the "Port" section now states the retry-then-mint rule as timeless prose; the Testing section's expectation is updated to match.

## Assumptions

- Assumes a client socket that was handed the freed number releases it within 30 s. A longer-lived client connection (a websocket, an SSH session) is waited out for the full window and then treated as a stranger; sessions routed to the old port are stranded in that case as before.
- Assumes `hasLiveRoutedSession` names every session whose base URL points at the proxy. It is keyed on `transcript_stream_path`, which every routed spawn sets. A read that fails is treated as "routed" by the wait, so the failure direction is a delayed mint, never a stranded session.
- Assumes port 0 binds succeed once the persisted port is given up. If minting fails too, `respawn`'s backoff retries the persisted port and pays another window; that case needs ephemeral-port exhaustion.

## Evidence & verification

No build or test was run on this machine; CI is the verifier for this PR. `swiftlint --strict` over the whole tree reports zero violations.

The repro is the sequence every new test drives: a persisted port, a stub spawner that answers "bind refused" on it, and a supervisor on an event-driven test clock. Before this change that sequence spawned twice, once on the persisted port and once on port 0, and rewrote the column; each test's doc comment names the observable that separates the old behavior from the new one.

New tests in `ModelProxySupervisorTests` (all on the injected clock, one sleeper in the ledger per hop):
- a refusal that clears on the third attempt keeps the persisted port and leaves the column unchanged (spawner calls `[port, port, port]`, never a zero);
- a refusal that never clears mints after the budget and rewrites the column exactly once (three attempts configured, calls `[port ×4, 0]`);
- a foreign listener (a real loopback listener answering a status document for another TBD home) is given up after two sightings: one interval of virtual time, not thirty seconds;
- an occupant that passes identity is adopted with no retry and no mint;
- with no session routed a refused bind mints at once and virtual time never moves (the other branch of the gate; the pre-existing stranger re-mint test covers the same branch with the default predicate);
- an undetermined probe is waited out like a refusal;
- the hang ladder's respawn goes through the wait (ladder walked to SIGKILL, then a refused bind, then the port taken back);
- a version replace goes through the wait (retire seen, successor spawned on the same port after one interval);
- a gate that cannot be read (the predicate throws) waits rather than mints, and a flag-off boot whose gate throws starts nothing (both branches of the fail direction);
- the shipped constants are pinned with the 183 s arithmetic in the comment.

New `LoopbackPortProbeTests`: port 1 is refused through the real syscalls, a real listener is accepted.

Every existing supervisor test is unchanged in behavior: the fixture's `routedSessionsAlive` still defaults to "none", so the pre-existing re-mint test keeps minting immediately, and the fixture's port probe delegates to the production probe unless a test forces an answer for an ephemeral port a fake has released.

https://claude.ai/code/session_01TggE2eESL3BcvSgFcLZkpk
[proxy port retry](https://cheapsteak.github.io/tbd/open/?worktree=725ED104-7EFC-4F42-9FC3-F558B92E3E08)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved model proxy recovery when a requested port is temporarily unavailable.
  - Existing compatible proxies can now be reclaimed, while transient port holders receive a bounded retry period before a new port is assigned.
  - Foreign listeners are detected and handled separately, reducing unnecessary port changes.
  - Failures reading terminal routing information are handled conservatively instead of being treated as no active sessions.

- **Documentation**
  - Updated design and configuration documentation to describe port recovery behavior and potential wait times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->