### PR TITLE
Feat: extra terminals spawn on the pty holder when the flag is on

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -408,6 +408,7 @@ custom_rules:
       - "Sources/TBDDaemon/Lifecycle/WorktreeLifecycle\\+Archive\\.swift"     # archive teardown; covered by worktree.archive / auto-archive-on-merge
       - "Sources/TBDDaemon/Lifecycle/WorktreeLifecycle\\+Forget\\.swift"      # forget teardown; covered by worktree.forget
       - "Sources/TBDDaemon/Lifecycle/WorktreeLifecycle\\+Create\\.swift"      # primary-terminal spawn; covered by worktree.create / scratch.create / revive
+      - "Sources/TBDDaemon/Lifecycle/WorktreeLifecycle\\+SpawnTerminal\\.swift" # the one spawn-and-record step every spawn path calls; covered by the caller's row: terminal.create / terminal.continueInCodex / worktree.create / scratch.create / revive
       - "Sources/TBDDaemon/Lifecycle/WorktreeLifecycle\\+PreSession\\.swift"  # hook-terminal spawn and close; covered by worktree.rerunPreSession / create
       - "Sources/TBDDaemon/Lifecycle/WorktreeLifecycle\\+Reconcile\\.swift"   # the reconcile rail; one row per act at its own entry point
       - "Sources/TBDDaemon/Nightwatch/DeskSessionManager\\.swift"             # the nightwatch-desk rail: its pastes, spawn and close

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -1341,25 +1341,11 @@ extension WorktreeLifecycle {
         let resolvedCols = cols ?? TmuxManager.defaultCols
         let resolvedRows = rows ?? TmuxManager.defaultRows
 
-        // The transport gate. Off is today's behavior, exactly; on puts the
-        // PRIMARY terminal on a holder. It is read once, here, and the decision
-        // is then carried in the row: flipping the flag must never migrate a
-        // running session, because the transport is a property of a live pty
-        // that already exists, not of a preference.
-        //
-        // Both halves of "can this create put a session on a holder" are asked
-        // here, and they are different questions. Mock mode has no registry at
-        // all; a daemon whose `TBDHolder` binary is missing has one that cannot
-        // spawn — it is still built, because adoption reaches an already-running
-        // holder through its socket and must keep working across an upgrade that
-        // moved the binary. Gating on the registry's mere presence would take
-        // the holder path with nothing able to start a holder, and the
-        // `holderExecutableUnavailable` that `spawn` then throws has nothing
-        // catching it: the whole worktree create would fail. Either way the
-        // fallback is tmux, because a worktree that will not open is a worse
-        // answer than one that opens on the old transport.
-        let holderRegistry = self.holderRegistry
-        let useHolderTransport = config.ptyHolderEnabled && holderRegistry?.canSpawn == true
+        // The transport gate, read once here and then carried in the row: the
+        // same decision every other spawn path makes, through the same
+        // function, so the flag cannot mean one thing for a primary terminal
+        // and another for an extra one. See `TerminalSpawnTransport.decide`.
+        let transport = TerminalSpawnTransport.decide(config: config, registry: holderRegistry)
 
         // The tmux server is ensured LAZILY on the holder path, and eagerly —
         // in exactly the place it always was — on the tmux path.
@@ -1388,7 +1374,7 @@ extension WorktreeLifecycle {
             )
             await controlMode?.enableIfGated(serverName: tmuxServer)
         }
-        if !useHolderTransport {
+        if !transport.isHolder {
             try await ensureTmuxServerOnce()
         }
 
@@ -1568,7 +1554,7 @@ extension WorktreeLifecycle {
             // same five-step decision.
             let attachment = await ModelProxyRouteAttachment.attachIfRoutable(
                 terminalID: plannedTerminalID1,
-                isHolderSpawn: useHolderTransport,
+                isHolderSpawn: transport.isHolder,
                 config: config,
                 profileKind: resolvedProfile?.kind,
                 profileBaseURL: resolvedProfile?.baseURL,
@@ -1628,137 +1614,43 @@ extension WorktreeLifecycle {
             primaryLabel = TerminalLabel.claudeCode
         }
         // The two transports diverge for exactly this one spawn, and converge
-        // again on the row below. Everything that decided WHAT to run —
+        // again on the row. Everything that decided WHAT to run —
         // `primaryCommand`, `primaryEnv`, `primarySensitiveEnv`, the size — is
         // shared verbatim, because the env precedence behind it (global < repo
         // < profile, with the spawn builder's auth env merged on top) is subtle
         // and already correct; a second derivation is a second thing to get
-        // wrong.
-        let window1: (windowID: String, paneID: String)
-        let holderHandle: HolderHandle?
-        if useHolderTransport, let holderRegistry {
-            // The route, if there is one, was minted above — before the command
-            // was composed, because the command re-exports the profile's own
-            // routing keys and would otherwise run over it. What is left here
-            // is the spawn itself, and the two undo paths for a route nothing
-            // will ever be started against.
-            do {
-                holderHandle = try await holderRegistry.spawn(
-                    terminalID: plannedTerminalID1,
-                    launch: Self.holderLaunch(
-                        shellCommand: primaryCommand,
-                        env: primaryEnv,
-                        // The route's base URL rides `sensitiveEnv` — the job's
-                        // process environment — and never `env`, which
-                        // `holderLaunch` inlines as `export K='v';` in front of
-                        // the command. `primarySensitiveEnv` is the routed
-                        // environment itself: the attachment is what it was
-                        // composed from.
-                        //
-                        // That is a statement about `holderLaunch`'s two
-                        // dictionaries and nothing more. The token IS in this
-                        // job's argv, because `primaryCommand` carries an
-                        // inline `export ANTHROPIC_BASE_URL=…` of its own, from
-                        // `attachment.builderBaseURL` — the export has to run
-                        // after the shell's rc files or a `.zshrc` takes the
-                        // session off its route. See that method for why `ps`
-                        // visibility is not a widening of the trust boundary.
-                        sensitiveEnv: primarySensitiveEnv,
-                        workingDirectory: worktreePath,
-                        cols: resolvedCols,
-                        rows: resolvedRows,
-                        environment: holderRegistry.environment))
-            } catch {
-                // Nothing was spawned against this route and nothing ever will
-                // be, so retire it from the failing call itself rather than
-                // leaving a file for the sweep. By the token this attachment
-                // minted, never by terminal id: this row has no other route
-                // today, and a lookup would still be the wrong instruction to
-                // leave behind.
-                await ModelProxyRouteAttachment.retire(
-                    primaryAttachment, terminalID: plannedTerminalID1,
-                    supervisor: modelProxySupervisor)
-                throw error
-            }
-            // A holder session has no tmux coordinate. The columns are NOT NULL
-            // from the v1 schema, so they take the empty string — and nothing
-            // may read them back: a holder row is discriminated by `transport`
-            // alone. See `WorktreeLifecycle+Reconcile`'s exemption.
-            window1 = (windowID: "", paneID: "")
-        } else {
-            holderHandle = nil
-            window1 = try await tmux.createWindow(
-                server: tmuxServer,
-                session: "main",
-                cwd: worktreePath,
-                shellCommand: primaryCommand,
-                env: primaryEnv,
-                sensitiveEnv: primarySensitiveEnv,
-                cols: resolvedCols,
-                rows: resolvedRows
-            )
-        }
-        let primaryTransport: TerminalTransport = holderHandle == nil ? .tmux : .holder
-        do {
-            _ = try await db.terminals.create(
-                id: plannedTerminalID1,
-                worktreeID: worktreeID,
-                tmuxWindowID: window1.windowID,
-                tmuxPaneID: window1.paneID,
-                label: primaryLabel,
-                claudeSessionID: primarySessionID,
-                profileID: primaryProfileID,
-                kind: primaryTerminalKind,
-                // Same value the overlay above was built from, written to the
-                // row so the fact outlives this call. A desk woken from
-                // hibernation reuses this row, and the wake site has nothing
-                // else to read.
-                watchDeskRole: watchDeskRole,
-                transport: primaryTransport,
-                holderPID: holderHandle?.holderPID,
-                childPID: holderHandle?.childPID,
-                // The identity anchor for the job just spawned. `createdAt`
-                // would say the same thing today and stop being true the first
-                // time this row is parked and woken, so it is recorded from the
-                // start rather than only on the wake path. Off this type's
-                // injected date seam, not a bare `Date()`: the stamp is
-                // persisted and later compared against a process start time by
-                // `ProcessIdentityCheck`, which is exactly the kind of fact a
-                // test has to be able to pin end to end.
-                holderChildStartedAt: holderHandle == nil ? nil : now(),
-                // Stamped IN the insert, not by a follow-up `UPDATE`:
-                // `TerminalReplacementSnapshot` compares this column, so a row
-                // that exists without it for even one suspension can be
-                // snapshotted by a concurrent caller, and a late stamp would
-                // make every replacement that snapshot authorized reject.
-                transcriptStreamPath: primaryAttachment?.streamPath
-            )
-        } catch {
-            // Best-effort creation-time cleanup on both transports: a resource
-            // that exists with no row naming it is one nothing will ever find
-            // again. On the holder path that means `forget` (the holder closes
-            // the pty master and winds down) and then killing the job by pid,
-            // because holder death is deliberately not child death.
-            if let holderHandle {
-                await holderRegistry?.abandon(
-                    terminalID: plannedTerminalID1, handle: holderHandle)
-                await ModelProxyRouteAttachment.retire(
-                    primaryAttachment, terminalID: plannedTerminalID1,
-                    supervisor: modelProxySupervisor)
-            } else {
-                try? await tmux.killWindow(server: tmuxServer, windowID: window1.windowID)
-            }
-            throw error
-        }
+        // wrong. The divergence itself lives in `spawnTerminal`, which every
+        // spawn path calls.
+        let primaryTerminal = try await spawnTerminal(
+            id: plannedTerminalID1,
+            worktreeID: worktreeID,
+            tmuxServer: tmuxServer,
+            workingDirectory: worktreePath,
+            command: primaryCommand,
+            env: primaryEnv,
+            sensitiveEnv: primarySensitiveEnv,
+            cols: resolvedCols,
+            rows: resolvedRows,
+            label: primaryLabel,
+            claudeSessionID: primarySessionID,
+            profileID: primaryProfileID,
+            kind: primaryTerminalKind,
+            // Same value the overlay above was built from, written to the row
+            // so the fact outlives this call. A desk woken from hibernation
+            // reuses this row, and the wake site has nothing else to read.
+            watchDeskRole: watchDeskRole,
+            transport: transport,
+            attachment: primaryAttachment,
+            modelProxySupervisor: modelProxySupervisor)
         // Recapture reads a tmux pane's screen, so it has nothing to read on a
         // holder session — `paneID` is empty there by construction. Scheduling
         // it anyway would poll a coordinate that can never resolve.
-        if carryover != nil, primaryTransport == .tmux {
+        if carryover != nil, primaryTerminal.transport == .tmux {
             let recapture = sessionRecaptureFactory?(db, tmux)
                 ?? SessionRecaptureScheduler(db: db, tmux: tmux)
             recapture.schedule(
                 terminalID: plannedTerminalID1,
-                paneID: window1.paneID,
+                paneID: primaryTerminal.tmuxPaneID,
                 server: tmuxServer,
                 expectedIncarnationID: nil
             )
@@ -1799,7 +1691,7 @@ extension WorktreeLifecycle {
         // the transport exists to remove. On the tmux path the server exists
         // regardless and the tab is created unconditionally, as it always has
         // been — the flag must not change what the flag-off path does.
-        let wantsSetupTerminal = repo != nil && (!useHolderTransport || setupHookPath != nil)
+        let wantsSetupTerminal = repo != nil && (!transport.isHolder || setupHookPath != nil)
         if let repo, wantsSetupTerminal {
             try await ensureTmuxServerOnce()
             let plannedTerminalID2 = UUID()

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+SpawnTerminal.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+SpawnTerminal.swift
@@ -1,0 +1,221 @@
+import Foundation
+import TBDShared
+
+/// Which transport one spawn is born onto.
+///
+/// Decided once, from the flag and the registry, and then **carried** through
+/// the routing decision, the spawn and the row rather than re-derived at any of
+/// them: the model proxy asks "is this a holder spawn?" before the command is
+/// composed, and the spawn itself answers it after, so two readings of the flag
+/// could disagree between the two and leave a session on a route its row does
+/// not record.
+///
+/// The `.holder` case carries the registry that will run the spawn, so a caller
+/// holding `.holder` provably holds something that can spawn — there is no
+/// state in which the transport says holder and the registry is nil.
+enum TerminalSpawnTransport: Sendable {
+    case tmux
+    case holder(HolderRegistry)
+
+    /// **The transport gate, for every path that creates a session row.**
+    ///
+    /// Off is today's behavior, exactly; on puts the new session on a holder.
+    /// The decision is made at spawn time and the row keeps it for life:
+    /// flipping the flag must never migrate a running session, because the
+    /// transport is a property of a live pty that already exists, not of a
+    /// preference (spec, "Rollout" → "Granularity: spawn time only").
+    ///
+    /// Both halves of "can this spawn put a session on a holder" are asked
+    /// here, and they are different questions. Mock mode has no registry at
+    /// all; a daemon whose `TBDHolder` binary is missing has one that cannot
+    /// spawn — it is still built, because adoption reaches an already-running
+    /// holder through its socket and must keep working across an upgrade that
+    /// moved the binary. Gating on the registry's mere presence would take the
+    /// holder path with nothing able to start a holder, and the
+    /// `holderExecutableUnavailable` that `spawn` then throws has nothing
+    /// catching it: the whole create would fail. Either way the fallback is
+    /// tmux, because a session that will not open is a worse answer than one
+    /// that opens on the old transport.
+    ///
+    /// `config` is optional because the RPC handlers read it with `try?`: a
+    /// config that could not be read is a config in which nobody chose the
+    /// holder, and the fallback is the same tmux.
+    static func decide(config: Config?, registry: HolderRegistry?) -> TerminalSpawnTransport {
+        guard let config, config.ptyHolderEnabled,
+              let registry, registry.canSpawn else { return .tmux }
+        return .holder(registry)
+    }
+
+    /// The `isHolderSpawn` the model proxy's routing decision takes.
+    var isHolder: Bool {
+        if case .holder = self { return true }
+        return false
+    }
+}
+
+extension WorktreeLifecycle {
+    /// **The one place a terminal is spawned and its row written, on either
+    /// transport.**
+    ///
+    /// Every spawn path — the primary terminal at worktree creation, the extra
+    /// terminals `terminal.create` opens, and `terminal.continueInCodex` —
+    /// decides *what* to run on its own (the command, the two environments, the
+    /// label and kind) and hands the result here, because the part that
+    /// diverges by transport is the same at all of them and subtle enough that
+    /// a second copy is a second thing to get wrong: the holder launch
+    /// composition, the row that records the transport and the pids, the stamp
+    /// `ProcessIdentityCheck` later compares, the stream path that has to land
+    /// in the same insert, and the two undo paths for a route nothing will
+    /// ever be started against.
+    ///
+    /// The tmux server is the caller's to ensure, and only on the tmux
+    /// transport: a holder-backed session needs no server at all, and ensuring
+    /// one anyway would resurrect the very resource the transport exists to
+    /// remove. The primary path memoizes that ensure because its setup-hook tab
+    /// can still want a server on the holder path; the RPC handlers make it
+    /// once, under the same lock they call this from.
+    ///
+    /// - Parameters:
+    ///   - env: inlined as `export K='v';` in front of the command on both
+    ///     transports, so it lands after every startup file has run — where
+    ///     code reading `TBD_TERMINAL_ID` from a session expects it.
+    ///   - sensitiveEnv: the spawned *process* environment — tmux's `-e`, or
+    ///     the holder job's environment directly. The route's base URL rides
+    ///     here and never in `env`.
+    ///   - attachment: what the model proxy did with this spawn, or nil for a
+    ///     spawn that never asked it — a shell or a Codex terminal. There is
+    ///     deliberately no empty `Outcome` to pass instead; see
+    ///     `ModelProxyRouteAttachment.Outcome`.
+    ///   - modelProxySupervisor: the caller's own supervisor, passed rather than
+    ///     read from `self` because the router and the lifecycle are wired
+    ///     independently — `WorktreeLifecycle` is a value type, and a test
+    ///     fixture sets the router's supervisor and registry alone — so the
+    ///     caller's is the authoritative one. The registry travels inside
+    ///     `transport` for the same reason.
+    func spawnTerminal(
+        id: UUID,
+        worktreeID: UUID,
+        tmuxServer: String,
+        workingDirectory: String,
+        command: String,
+        env: [String: String],
+        sensitiveEnv: [String: String],
+        cols: Int,
+        rows: Int,
+        label: String?,
+        claudeSessionID: String?,
+        profileID: UUID?,
+        kind: TerminalKind?,
+        watchDeskRole: WatchDeskRole? = nil,
+        transport: TerminalSpawnTransport,
+        attachment: ModelProxyRouteAttachment.Outcome?,
+        modelProxySupervisor: (any ModelProxyRouting)?
+    ) async throws -> Terminal {
+        // The two transports diverge for exactly this one spawn, and converge
+        // again on the row below.
+        let coordinate: (windowID: String, paneID: String)
+        let holderHandle: HolderHandle?
+        switch transport {
+        case .holder(let registry):
+            // The route, if there is one, was minted by the caller — before the
+            // command was composed, because the command re-exports the
+            // profile's own routing keys and would otherwise run over it. What
+            // is left here is the spawn itself, and the two undo paths for a
+            // route nothing will ever be started against.
+            do {
+                holderHandle = try await registry.spawn(
+                    terminalID: id,
+                    launch: Self.holderLaunch(
+                        shellCommand: command,
+                        env: env,
+                        // The route's base URL rides `sensitiveEnv` — the job's
+                        // process environment — and never `env`, which
+                        // `holderLaunch` inlines as `export K='v';` in front of
+                        // the command. The token IS in this job's argv all the
+                        // same, because `command` carries an inline
+                        // `export ANTHROPIC_BASE_URL=…` of its own, from
+                        // `Outcome.builderBaseURL` — the export has to run after
+                        // the shell's rc files or a `.zshrc` takes the session
+                        // off its route. See that method for why `ps`
+                        // visibility is not a widening of the trust boundary.
+                        sensitiveEnv: sensitiveEnv,
+                        workingDirectory: workingDirectory,
+                        cols: cols,
+                        rows: rows,
+                        environment: registry.environment))
+            } catch {
+                // Nothing was spawned against this route and nothing ever will
+                // be, so retire it from the failing call itself rather than
+                // leaving a file for the sweep. By the token this attachment
+                // minted, never by terminal id: this row has no other route
+                // today, and a lookup would still be the wrong instruction to
+                // leave behind.
+                await ModelProxyRouteAttachment.retire(
+                    attachment, terminalID: id, supervisor: modelProxySupervisor)
+                throw error
+            }
+            // A holder session has no tmux coordinate. The columns are NOT NULL
+            // from the v1 schema, so they take the empty string — and nothing
+            // may read them back: a holder row is discriminated by `transport`
+            // alone. See `WorktreeLifecycle+Reconcile`'s exemption.
+            coordinate = (windowID: "", paneID: "")
+        case .tmux:
+            holderHandle = nil
+            coordinate = try await tmux.createWindow(
+                server: tmuxServer,
+                session: "main",
+                cwd: workingDirectory,
+                shellCommand: command,
+                env: env,
+                sensitiveEnv: sensitiveEnv,
+                cols: cols,
+                rows: rows
+            )
+        }
+        do {
+            return try await db.terminals.create(
+                id: id,
+                worktreeID: worktreeID,
+                tmuxWindowID: coordinate.windowID,
+                tmuxPaneID: coordinate.paneID,
+                label: label,
+                claudeSessionID: claudeSessionID,
+                profileID: profileID,
+                kind: kind,
+                watchDeskRole: watchDeskRole,
+                transport: holderHandle == nil ? .tmux : .holder,
+                holderPID: holderHandle?.holderPID,
+                childPID: holderHandle?.childPID,
+                // The identity anchor for the job just spawned. `createdAt`
+                // would say the same thing today and stop being true the first
+                // time this row is parked and woken, so it is recorded from the
+                // start rather than only on the wake path. Off this type's
+                // injected date seam, not a bare `Date()`: the stamp is
+                // persisted and later compared against a process start time by
+                // `ProcessIdentityCheck`, which is exactly the kind of fact a
+                // test has to be able to pin end to end.
+                holderChildStartedAt: holderHandle == nil ? nil : now(),
+                // Stamped IN the insert, not by a follow-up `UPDATE`:
+                // `TerminalReplacementSnapshot` compares this column, so a row
+                // that exists without it for even one suspension can be
+                // snapshotted by a concurrent caller, and a late stamp would
+                // make every replacement that snapshot authorized reject.
+                transcriptStreamPath: attachment?.streamPath
+            )
+        } catch {
+            // Best-effort creation-time cleanup on both transports: a resource
+            // that exists with no row naming it is one nothing will ever find
+            // again. On the holder path that means `forget` (the holder closes
+            // the pty master and winds down) and then killing the job by pid,
+            // because holder death is deliberately not child death.
+            if case .holder(let registry) = transport, let holderHandle {
+                await registry.abandon(terminalID: id, handle: holderHandle)
+                await ModelProxyRouteAttachment.retire(
+                    attachment, terminalID: id, supervisor: modelProxySupervisor)
+            } else {
+                try? await tmux.killWindow(server: tmuxServer, windowID: coordinate.windowID)
+            }
+            throw error
+        }
+    }
+}

--- a/Sources/TBDDaemon/Server/RPCRouter+ContinueInCodexHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ContinueInCodexHandlers.swift
@@ -110,8 +110,13 @@ extension RPCRouter {
             executablePath: preparation.executablePath,
             profileFlag: profileFlag)
 
+        // The transport gate, the same one every other spawn path asks. Codex
+        // is never routed through the model proxy, so there is no attachment
+        // to decide before the command above was composed.
+        let transport = TerminalSpawnTransport.decide(config: config, registry: holderRegistry)
+
         // The import above created Codex state but touched no session; the
-        // tmux calls below are the actuation, so the row goes here.
+        // spawn below is the actuation, so the row goes here.
         let actuationID = try await beginActuation(
             .terminalContinueInCodex, actor: actor,
             target: .local(worktree: worktree.id, terminal: plannedTerminalID),
@@ -122,37 +127,26 @@ extension RPCRouter {
             terminal = try await tmux.withWorktreeServerLock(
                 db: db, worktreeID: worktree.id, allowedStatuses: [worktree.status]
             ) { currentWorktree in
-                _ = try await tmux.ensureServer(
-                    server: currentWorktree.tmuxServer,
-                    session: "main",
-                    cwd: currentWorktree.path,
-                    cols: TmuxManager.defaultCols,
-                    rows: TmuxManager.defaultRows)
-                await self.controlMode?.enableIfGated(
-                    serverName: currentWorktree.tmuxServer)
-                let window = try await tmux.createWindow(
-                    server: currentWorktree.tmuxServer,
-                    session: "main",
-                    cwd: currentWorktree.path,
-                    shellCommand: command,
+                try await prepareTmuxServer(
+                    for: transport, worktree: currentWorktree,
+                    cols: TmuxManager.defaultCols, rows: TmuxManager.defaultRows)
+                return try await lifecycle.spawnTerminal(
+                    id: plannedTerminalID,
+                    worktreeID: currentWorktree.id,
+                    tmuxServer: currentWorktree.tmuxServer,
+                    workingDirectory: currentWorktree.path,
+                    command: command,
                     env: codexEnv,
                     sensitiveEnv: sensitiveEnv,
                     cols: TmuxManager.defaultCols,
-                    rows: TmuxManager.defaultRows)
-                do {
-                    return try await db.terminals.create(
-                        id: plannedTerminalID,
-                        worktreeID: currentWorktree.id,
-                        tmuxWindowID: window.windowID,
-                        tmuxPaneID: window.paneID,
-                        label: TerminalLabel.codex,
-                        kind: .codex)
-                } catch {
-                    try? await tmux.killWindow(
-                        server: currentWorktree.tmuxServer,
-                        windowID: window.windowID)
-                    throw error
-                }
+                    rows: TmuxManager.defaultRows,
+                    label: TerminalLabel.codex,
+                    claudeSessionID: nil,
+                    profileID: nil,
+                    kind: .codex,
+                    transport: transport,
+                    attachment: nil,
+                    modelProxySupervisor: modelProxySupervisor)
             }
         } catch {
             await finishActuation(actuationID, .transportFailed, error: "\(error)")

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -209,6 +209,15 @@ extension RPCRouter {
         // is folded in per-branch once the profile is resolved.
         let createConfig = try? await db.config.get()
 
+        // The transport gate, the same one the primary spawn asks: an extra
+        // terminal honours `pty_holder_enabled` exactly as a worktree's first
+        // one does, and falls back to tmux for exactly the same reasons. A
+        // config that could not be read reads as nobody having chosen the
+        // holder. Decided once, here, so the routing decision below and the
+        // spawn cannot disagree about it.
+        let decidedTransport = TerminalSpawnTransport.decide(
+            config: createConfig, registry: holderRegistry)
+
         // Build env vars available in all TBD terminals
         var env = SystemPromptBuilder.promptLayers(
             repo: repo, worktree: worktree.worktree, scratchInstructions: createConfig?.scratchInstructions,
@@ -272,44 +281,32 @@ extension RPCRouter {
                     db: db, worktreeID: params.worktreeID,
                     allowedStatuses: [worktree.status]
                 ) { currentWorktree in
-                    _ = try await tmux.ensureServer(
-                        server: currentWorktree.tmuxServer,
-                        session: "main",
-                        cwd: currentWorktree.path,
-                        cols: resolvedCols,
-                        rows: resolvedRows)
-                    await self.controlMode?.enableIfGated(
-                        serverName: currentWorktree.tmuxServer)
-                    let window = try await tmux.createWindow(
-                        server: currentWorktree.tmuxServer,
-                        session: "main",
-                        cwd: currentWorktree.path,
-                        shellCommand: CodexSpawnCommandBuilder.build(
+                    try await prepareTmuxServer(
+                        for: decidedTransport, worktree: currentWorktree,
+                        cols: resolvedCols, rows: resolvedRows)
+                    // The holder runs any command, so a Codex terminal takes
+                    // the transport the flag chose exactly as the primary
+                    // path's Codex branch does. No attachment: Codex does not
+                    // talk to the Messages API and is never routed.
+                    return try await lifecycle.spawnTerminal(
+                        id: plannedTerminalID,
+                        worktreeID: params.worktreeID,
+                        tmuxServer: currentWorktree.tmuxServer,
+                        workingDirectory: currentWorktree.path,
+                        command: CodexSpawnCommandBuilder.build(
                             initialPrompt: params.prompt,
                             executablePath: codexPreparation.executablePath),
                         env: codexSpawnEnv,
                         sensitiveEnv: codexEnvOverrides,
                         cols: resolvedCols,
-                        rows: resolvedRows
-                    )
-
-                    do {
-                        return try await db.terminals.create(
-                            id: plannedTerminalID,
-                            worktreeID: params.worktreeID,
-                            tmuxWindowID: window.windowID,
-                            tmuxPaneID: window.paneID,
-                            label: TerminalLabel.codex,
-                            claudeSessionID: nil,
-                            profileID: nil,
-                            kind: .codex
-                        )
-                    } catch {
-                        try? await tmux.killWindow(
-                            server: currentWorktree.tmuxServer,
-                            windowID: window.windowID)
-                        throw error
-                    }
+                        rows: resolvedRows,
+                        label: TerminalLabel.codex,
+                        claudeSessionID: nil,
+                        profileID: nil,
+                        kind: .codex,
+                        transport: decidedTransport,
+                        attachment: nil,
+                        modelProxySupervisor: modelProxySupervisor)
                 }
             }
 
@@ -366,6 +363,14 @@ extension RPCRouter {
                 return RPCResponse(error: message)
             }
         }
+
+        // A login session stays on tmux whatever the flag says. Its whole point
+        // is the auto-`/login` pump `armLoginSession` starts, which reads the
+        // pane's text and types into it through tmux; the holder transport has
+        // no such pump, and a login tab that opened on a holder would sit at
+        // the composer with nothing typing `/login` into it. Every other
+        // terminal takes the decided transport.
+        let transport: TerminalSpawnTransport = isLoginSession ? .tmux : decidedTransport
 
         // Build the spawn command via the pure helper.
         let appendSystemPrompt: String?
@@ -439,6 +444,62 @@ extension RPCRouter {
             )
         }
 
+        // Hoisted out of the `build` call because the model proxy must read
+        // the SAME resolved file the spawn runs with: whether it sets
+        // `env.ANTHROPIC_BASE_URL` decides whether a route can be honored at
+        // all. Resolving it a second time would rewrite the per-session
+        // overlay and could answer about a different file.
+        let overlayPath: String? = isClaudeType
+            ? ClaudeHookOverlay.resolveOverlayPath(
+                fallbackModels: resolvedProfile?.fallbackModels,
+                sessionKey: plannedTerminalID.uuidString,
+                // Repo fragment is file-backed config, read fresh at
+                // spawn time — applies on every spawn path, resume included.
+                repoSettingsJSON: ClaudeHookOverlay.repoSettingsFragment(repoID: repo?.id),
+                // Per-spawn fragment applies to FRESH spawns only; a
+                // resume must not reapply it. Hooks overlay still resolves
+                // for resumes — only extraSettingsJSON goes nil.
+                extraSettingsJSON: params.resumeSessionID == nil ? params.claudeSettingsOverlay : nil
+              )
+            : nil
+
+        // Free-form env overrides for Claude terminals: global < repo <
+        // profile. Shell/custom-cmd terminals are out of scope and get no
+        // overrides, so theirs is empty and the builder's env below stands
+        // alone.
+        let mergedEnvOverrides: [String: String] = isClaudeType
+            ? EnvOverrideResolver.merge(
+                global: createConfig?.envOverrides,
+                repo: repo?.envOverrides,
+                profile: resolvedProfile?.envOverrides)
+            : [:]
+
+        // **The routing decision, before the command is composed** — the same
+        // five steps the primary spawn takes, through the same function, so an
+        // extra Claude terminal on the holder transport is routed exactly as a
+        // primary session is. The builder re-exports the profile's routing
+        // keys inline into the command it returns, and those exports run after
+        // the process environment, so the decision has to exist before `build`
+        // is given its base URL. Only the `.claude` kind ever asks: a shell has
+        // no upstream, and its `nil` here is structural rather than a field
+        // check.
+        let attachment: ModelProxyRouteAttachment.Outcome?
+        if isClaudeType {
+            attachment = await ModelProxyRouteAttachment.attachIfRoutable(
+                terminalID: plannedTerminalID,
+                isHolderSpawn: transport.isHolder,
+                config: createConfig,
+                profileKind: resolvedProfile?.kind,
+                profileBaseURL: resolvedProfile?.baseURL,
+                envOverrides: mergedEnvOverrides,
+                // The SAME resolved overlay the spawn runs with, read above.
+                overlayPath: overlayPath,
+                holderEnvironment: holderRegistry?.environment,
+                supervisor: modelProxySupervisor)
+        } else {
+            attachment = nil
+        }
+
         let spawn = ClaudeSpawnCommandBuilder.build(
             resumeID: params.resumeSessionID,
             freshSessionID: freshSessionID,
@@ -446,91 +507,62 @@ extension RPCRouter {
             initialPrompt: params.prompt,
             profileSecret: resolvedProfile?.secret,
             profileKind: resolvedProfile?.kind,
-            profileBaseURL: resolvedProfile?.baseURL,
+            // The route's own URL on a routed spawn, the profile's otherwise —
+            // and the profile's again for a shell, which has no attachment.
+            // The builder inlines an `export ANTHROPIC_BASE_URL=…` that runs
+            // after the shell's rc files, which is how this endpoint survives
+            // a `.zshrc` that sets one of its own.
+            profileBaseURL: attachment?.builderBaseURL(profile: resolvedProfile?.baseURL)
+                ?? resolvedProfile?.baseURL,
             profileModel: resolvedProfile?.model,
             profileAwsRegion: resolvedProfile?.awsRegion,
             profileAwsProfile: resolvedProfile?.awsProfile,
             profileConfigDir: profileConfigDir,
             cmd: params.cmd,
             shellFallback: ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh",
-            settingsOverlayPath: isClaudeType
-                ? ClaudeHookOverlay.resolveOverlayPath(
-                    fallbackModels: resolvedProfile?.fallbackModels,
-                    sessionKey: plannedTerminalID.uuidString,
-                    // Repo fragment is file-backed config, read fresh at
-                    // spawn time — applies on every spawn path, resume included.
-                    repoSettingsJSON: ClaudeHookOverlay.repoSettingsFragment(repoID: repo?.id),
-                    // Per-spawn fragment applies to FRESH spawns only; a
-                    // resume must not reapply it. Hooks overlay still resolves
-                    // for resumes — only extraSettingsJSON goes nil.
-                    extraSettingsJSON: params.resumeSessionID == nil ? params.claudeSettingsOverlay : nil
-                  )
-                : nil,
+            settingsOverlayPath: overlayPath,
             pluginDirPath: isClaudeType ? PluginDirWriter.pluginDirPath : nil,
             envSettingOverrides: claudeEnvOverrides,
             sessionName: worktree.displayName
         )
 
         // For Claude terminals, layer the builder's auth/routing env ON TOP of
-        // the merged free-form overrides (global < repo < profile) so auth wins.
-        // Shell/custom-cmd terminals are out of scope and get no overrides.
-        let primarySensitiveEnv: [String: String]
-        if isClaudeType {
-            let mergedEnvOverrides = EnvOverrideResolver.merge(
-                global: createConfig?.envOverrides,
-                repo: repo?.envOverrides,
-                profile: resolvedProfile?.envOverrides
-            )
-            primarySensitiveEnv = mergedEnvOverrides.merging(spawn.sensitiveEnv) { _, builder in builder }
-        } else {
-            primarySensitiveEnv = spawn.sensitiveEnv
-        }
+        // the attachment's — the merged free-form overrides plus the route —
+        // so auth wins. Through the attachment's own method, because the
+        // primary and wake paths make the same merge and the order is silent
+        // when it is wrong. A shell has no attachment and gets the builder's
+        // env alone, as it always has.
+        let primarySensitiveEnv = attachment?.launchEnvironment(mergingBuilder: spawn.sensitiveEnv)
+            ?? spawn.sensitiveEnv
         let terminalKind: TerminalKind? = isClaudeType ? .claude : .shell
         let spawnEnv = env
         let spawnProfileID = resolvedProfile?.profileID
-        let (window, terminal, currentServer) = try await actuating(actuationID) {
+        let (terminal, currentServer) = try await actuating(actuationID) {
             try await tmux.withWorktreeServerLock(
                 db: db, worktreeID: params.worktreeID,
                 allowedStatuses: [worktree.status]
             ) { currentWorktree in
-                _ = try await tmux.ensureServer(
-                    server: currentWorktree.tmuxServer,
-                    session: "main",
-                    cwd: currentWorktree.path,
-                    cols: resolvedCols,
-                    rows: resolvedRows)
-                await self.controlMode?.enableIfGated(
-                    serverName: currentWorktree.tmuxServer)
-                let window = try await tmux.createWindow(
-                    server: currentWorktree.tmuxServer,
-                    session: "main",
-                    cwd: currentWorktree.path,
-                    shellCommand: spawn.command,
+                try await prepareTmuxServer(
+                    for: transport, worktree: currentWorktree,
+                    cols: resolvedCols, rows: resolvedRows)
+                let terminal = try await lifecycle.spawnTerminal(
+                    id: plannedTerminalID,
+                    worktreeID: params.worktreeID,
+                    tmuxServer: currentWorktree.tmuxServer,
+                    workingDirectory: currentWorktree.path,
+                    command: spawn.command,
                     env: spawnEnv,
                     sensitiveEnv: primarySensitiveEnv,
                     cols: resolvedCols,
-                    rows: resolvedRows
-                )
-
-                let terminal: Terminal
-                do {
-                    terminal = try await db.terminals.create(
-                        id: plannedTerminalID,
-                        worktreeID: params.worktreeID,
-                        tmuxWindowID: window.windowID,
-                        tmuxPaneID: window.paneID,
-                        label: label,
-                        claudeSessionID: claudeSessionID,
-                        profileID: spawnProfileID,
-                        kind: terminalKind
-                    )
-                } catch {
-                    try? await tmux.killWindow(
-                        server: currentWorktree.tmuxServer,
-                        windowID: window.windowID)
-                    throw error
-                }
-                return (window, terminal, currentWorktree.tmuxServer)
+                    rows: resolvedRows,
+                    label: label,
+                    claudeSessionID: claudeSessionID,
+                    profileID: spawnProfileID,
+                    kind: terminalKind,
+                    transport: transport,
+                    attachment: attachment,
+                    modelProxySupervisor: modelProxySupervisor)
+                return (terminal, currentWorktree.tmuxServer)
             }
         }
 
@@ -541,7 +573,7 @@ extension RPCRouter {
         if isLoginSession, let profile = resolvedProfile {
             await armLoginSession(
                 terminalID: terminal.id,
-                paneID: window.paneID,
+                paneID: terminal.tmuxPaneID,
                 server: currentServer,
                 profile: profile
             )
@@ -549,6 +581,34 @@ extension RPCRouter {
 
         await finishActuation(actuationID, .dispatched)
         return try RPCResponse(result: terminal)
+    }
+
+    /// The tmux half of a spawn's setup, made under the worktree's server lock
+    /// and only on the tmux transport: the server, and the gated control-mode
+    /// connection beside it. A holder-backed session needs no server at all,
+    /// and ensuring one anyway would resurrect the very resource the transport
+    /// exists to remove — the same asymmetry the primary spawn path keeps with
+    /// its memoized ensure.
+    ///
+    /// Through the lifecycle's `TmuxManager`, not the router's: `spawnTerminal`
+    /// creates the window on the lifecycle's, and the server it is created in
+    /// must be the one that was ensured. The daemon wires one manager into
+    /// both; a test fixture that builds two would otherwise ensure a server on
+    /// one and open a window on the other.
+    func prepareTmuxServer(
+        for transport: TerminalSpawnTransport,
+        worktree: LocalWorktree,
+        cols: Int,
+        rows: Int
+    ) async throws {
+        guard !transport.isHolder else { return }
+        _ = try await lifecycle.tmux.ensureServer(
+            server: worktree.tmuxServer,
+            session: "main",
+            cwd: worktree.path,
+            cols: cols,
+            rows: rows)
+        await controlMode?.enableIfGated(serverName: worktree.tmuxServer)
     }
 
     /// Post-spawn wiring for a profile login session:
@@ -1349,44 +1409,32 @@ extension RPCRouter {
         cols: Int,
         rows: Int
     ) async throws -> Terminal {
+        // Revived terminals stay on tmux: a revive restores a session's tab
+        // from history, and the transport it is restored onto is unchanged by
+        // this port. Pinned rather than decided, so the spawn still goes
+        // through the one spawn-and-record step every path shares.
         let terminal = try await tmux.withWorktreeServerLock(
             db: db, worktreeID: worktree.id, allowedStatuses: [worktree.status]
         ) { currentWorktree in
-            _ = try await tmux.ensureServer(
-                server: currentWorktree.tmuxServer,
-                session: "main",
-                cwd: currentWorktree.path,
-                cols: cols,
-                rows: rows)
-            await self.controlMode?.enableIfGated(
-                serverName: currentWorktree.tmuxServer)
-            let window = try await tmux.createWindow(
-                server: currentWorktree.tmuxServer,
-                session: "main",
-                cwd: currentWorktree.path,
-                shellCommand: spawnCommand,
+            try await prepareTmuxServer(
+                for: .tmux, worktree: currentWorktree, cols: cols, rows: rows)
+            return try await lifecycle.spawnTerminal(
+                id: plannedTerminalID,
+                worktreeID: currentWorktree.id,
+                tmuxServer: currentWorktree.tmuxServer,
+                workingDirectory: currentWorktree.path,
+                command: spawnCommand,
                 env: env,
                 sensitiveEnv: sensitiveEnv,
                 cols: cols,
-                rows: rows
-            )
-            do {
-                return try await db.terminals.create(
-                    id: plannedTerminalID,
-                    worktreeID: currentWorktree.id,
-                    tmuxWindowID: window.windowID,
-                    tmuxPaneID: window.paneID,
-                    label: label,
-                    claudeSessionID: claudeSessionID,
-                    profileID: profileID,
-                    kind: kind
-                )
-            } catch {
-                try? await tmux.killWindow(
-                    server: currentWorktree.tmuxServer,
-                    windowID: window.windowID)
-                throw error
-            }
+                rows: rows,
+                label: label,
+                claudeSessionID: claudeSessionID,
+                profileID: profileID,
+                kind: kind,
+                transport: .tmux,
+                attachment: nil,
+                modelProxySupervisor: modelProxySupervisor)
         }
         var order = try await db.worktrees.getTabOrder(worktreeID: worktree.id)
         if !order.contains(terminal.id) { order.append(terminal.id) }
@@ -2578,47 +2626,33 @@ extension RPCRouter {
         cols: Int,
         rows: Int
     ) async throws -> RPCResponse {
-        let (newTerminal, window, currentServer) = try await tmux.withWorktreeServerLock(
+        // A fork tab stays on tmux: it is an in-worktree copy of a session
+        // that is already running, and the transport it is copied onto is
+        // unchanged by this port. Pinned rather than decided, so the spawn
+        // still goes through the one spawn-and-record step every path shares.
+        let (newTerminal, currentServer) = try await tmux.withWorktreeServerLock(
             db: db, worktreeID: worktree.id, allowedStatuses: [worktree.status]
         ) { currentWorktree in
-            _ = try await tmux.ensureServer(
-                server: currentWorktree.tmuxServer,
-                session: "main",
-                cwd: currentWorktree.path,
-                cols: cols,
-                rows: rows)
-            await self.controlMode?.enableIfGated(
-                serverName: currentWorktree.tmuxServer)
-            let window = try await tmux.createWindow(
-                server: currentWorktree.tmuxServer,
-                session: "main",
-                cwd: currentWorktree.path,
-                shellCommand: spawnCommand,
+            try await prepareTmuxServer(
+                for: .tmux, worktree: currentWorktree, cols: cols, rows: rows)
+            let terminal = try await lifecycle.spawnTerminal(
+                id: plannedTerminalID,
+                worktreeID: currentWorktree.id,
+                tmuxServer: currentWorktree.tmuxServer,
+                workingDirectory: currentWorktree.path,
+                command: spawnCommand,
                 env: env,
                 sensitiveEnv: sensitiveEnv,
                 cols: cols,
-                rows: rows
-            )
-
-            let terminal: Terminal
-            do {
-                terminal = try await db.terminals.create(
-                    id: plannedTerminalID,
-                    worktreeID: currentWorktree.id,
-                    tmuxWindowID: window.windowID,
-                    tmuxPaneID: window.paneID,
-                    label: "claude",
-                    claudeSessionID: storedSessionID,
-                    profileID: profileID,
-                    kind: .claude
-                )
-            } catch {
-                try? await tmux.killWindow(
-                    server: currentWorktree.tmuxServer,
-                    windowID: window.windowID)
-                throw error
-            }
-            return (terminal, window, currentWorktree.tmuxServer)
+                rows: rows,
+                label: "claude",
+                claudeSessionID: storedSessionID,
+                profileID: profileID,
+                kind: .claude,
+                transport: .tmux,
+                attachment: nil,
+                modelProxySupervisor: modelProxySupervisor)
+            return (terminal, currentWorktree.tmuxServer)
         }
 
         subscriptions.broadcast(delta: .terminalCreated(TerminalDelta(
@@ -2628,7 +2662,7 @@ extension RPCRouter {
         if scheduleRecapture {
             scheduleSessionRecapture(
                 terminalID: newTerminal.id,
-                paneID: window.paneID,
+                paneID: newTerminal.tmuxPaneID,
                 server: currentServer,
                 expectedIncarnationID: newTerminal.sessionIncarnationID
             )

--- a/Tests/TBDDaemonLiveTests/Holder/HolderSpawnGateTests.swift
+++ b/Tests/TBDDaemonLiveTests/Holder/HolderSpawnGateTests.swift
@@ -582,9 +582,12 @@ private final class RoutingRecorder: ModelProxySupervising, @unchecked Sendable 
     func makeRoute(
         terminalID: UUID, upstream: String, streamingEnabled: Bool
     ) async throws -> ModelProxyRoute {
-        lock.lock(); defer { lock.unlock() }
-        madeStorage.append(Made(
-            terminalID: terminalID, upstream: upstream, streamingEnabled: streamingEnabled))
+        // `withLock` rather than `lock()`/`unlock()`: this method is `async`,
+        // where the unscoped pair is unavailable.
+        lock.withLock {
+            madeStorage.append(Made(
+                terminalID: terminalID, upstream: upstream, streamingEnabled: streamingEnabled))
+        }
         return ModelProxyRoute(
             token: token, terminalID: terminalID,
             upstream: upstream, streamingEnabled: streamingEnabled)
@@ -595,8 +598,7 @@ private final class RoutingRecorder: ModelProxySupervising, @unchecked Sendable 
     }
 
     func retireRoute(token: String, terminalID: UUID) async {
-        lock.lock(); defer { lock.unlock() }
-        retiredStorage.append(token)
+        lock.withLock { retiredStorage.append(token) }
     }
 
     func routeToken(forTerminal terminalID: UUID) async -> String? { nil }

--- a/Tests/TBDDaemonLiveTests/Holder/HolderSpawnGateTests.swift
+++ b/Tests/TBDDaemonLiveTests/Holder/HolderSpawnGateTests.swift
@@ -192,6 +192,139 @@ struct HolderSpawnGateTests {
         #expect(created[1].label == TerminalLabel.setup)
     }
 
+    // MARK: - Extra terminals
+
+    /// `terminal.create` with the flag off: today's behaviour, unchanged — a
+    /// tmux window, a tmux row, no rendezvous anywhere.
+    @Test func terminalCreateFlagOffStaysOnTmux() async throws {
+        let fixture = try await GateFixture.make(flagEnabled: false)
+        defer { fixture.tearDown() }
+
+        let terminal = try await fixture.terminalCreate(
+            TerminalCreateParams(worktreeID: fixture.worktree.id, cmd: "htop"))
+
+        let row = try #require(try await fixture.db.terminals.get(id: terminal.id))
+        #expect(row.transport == .tmux)
+        #expect(!row.tmuxWindowID.isEmpty)
+        #expect(row.holderPID == nil)
+        #expect(row.childPID == nil)
+        let socketPath = try HolderRendezvous.socketPath(
+            sessionID: row.id, environment: fixture.environment)
+        #expect(
+            !FileManager.default.fileExists(atPath: socketPath),
+            "a holder rendezvous was created for a tmux-transport extra terminal")
+    }
+
+    /// `terminal.create` with the flag on: an extra terminal is born onto a
+    /// real holder exactly as a primary is — a holder, a job, a row naming
+    /// both, an empty tmux coordinate, and no tmux server started for it.
+    ///
+    /// A shell command, because the holder runs any command and the gate must
+    /// not be Claude-shaped: a port that routed only `type: .claude` to the
+    /// holder would pass every Claude-typed assertion and leave every plain
+    /// terminal on tmux.
+    @Test func terminalCreateFlagOnSpawnsAnExtraTerminalOntoTheHolder() async throws {
+        let fixture = try await GateFixture.make(flagEnabled: true)
+        defer { fixture.tearDown() }
+
+        let terminal = try await fixture.terminalCreate(
+            TerminalCreateParams(worktreeID: fixture.worktree.id, cmd: "htop"))
+
+        let row = try #require(try await fixture.db.terminals.get(id: terminal.id))
+        #expect(row.transport == .holder)
+        let holderPID = try #require(row.holderPID)
+        let childPID = try #require(row.childPID)
+        #expect(holderPID != childPID)
+        #expect(holderProcessIsAlive(holderPID))
+        #expect(holderProcessIsAlive(childPID))
+        #expect(row.holderChildStartedAt != nil, "the identity anchor was not stamped at spawn")
+        #expect(row.tmuxWindowID.isEmpty)
+        #expect(row.tmuxPaneID.isEmpty)
+        #expect(row.transcriptStreamPath == nil, "a shell was routed through the model proxy")
+
+        let socketPath = try HolderRendezvous.socketPath(
+            sessionID: row.id, environment: fixture.environment)
+        #expect(
+            FileManager.default.fileExists(atPath: socketPath),
+            "no holder rendezvous at \(socketPath) for a holder-transport extra terminal")
+        #expect(await fixture.registry.reader(for: row.id) != nil)
+
+        let issued = fixture.tmuxCommands()
+        #expect(
+            !issued.contains(where: { $0.contains("new-window") }),
+            "the holder path created a tmux window: \(issued)")
+        #expect(
+            !issued.contains(where: { $0.contains("new-session") }),
+            "the holder path started a tmux server: \(issued)")
+    }
+
+    /// An extra Claude terminal on the holder is routed through the model
+    /// proxy exactly as a primary session is: one route minted for this
+    /// terminal, its stream path stamped in the row's insert, and the pids
+    /// beside it.
+    @Test func terminalCreateRoutesAnExtraClaudeTerminalLikeAPrimary() async throws {
+        let fixture = try await GateFixture.make(flagEnabled: true)
+        defer { fixture.tearDown() }
+        try await fixture.db.config.setTranscriptStreamingEnabled(true)
+        let supervisor = RoutingRecorder()
+        fixture.router.modelProxySupervisor = supervisor
+
+        let terminal = try await fixture.terminalCreate(
+            TerminalCreateParams(worktreeID: fixture.worktree.id, type: .claude))
+
+        let row = try #require(try await fixture.db.terminals.get(id: terminal.id))
+        #expect(row.transport == .holder)
+        #expect(row.holderPID != nil)
+        #expect(row.childPID != nil)
+        #expect(row.kind == .claude)
+        let routed = supervisor.made
+        #expect(routed.map(\.terminalID) == [row.id])
+        #expect(routed.first?.streamingEnabled == true)
+        #expect(supervisor.retired.isEmpty, "the route was retired under a spawn that succeeded")
+        let streamPath = try #require(row.transcriptStreamPath)
+        #expect(streamPath == TBDConstants.streamFilePath(
+            terminalID: row.id, environment: fixture.environment))
+    }
+
+    /// A Codex extra terminal takes the holder too, as the primary path's
+    /// Codex branch does. The executable is a stub path: the job is the pinned
+    /// gate shell, which ignores its argv.
+    @Test func terminalCreateFlagOnSpawnsACodexTerminalOntoTheHolder() async throws {
+        let fixture = try await GateFixture.make(flagEnabled: true)
+        defer { fixture.tearDown() }
+
+        let terminal = try await fixture.terminalCreate(
+            TerminalCreateParams(worktreeID: fixture.worktree.id, type: .codex))
+
+        let row = try #require(try await fixture.db.terminals.get(id: terminal.id))
+        #expect(row.transport == .holder)
+        #expect(row.kind == .codex)
+        #expect(row.label == TerminalLabel.codex)
+        #expect(row.holderPID != nil)
+        #expect(row.childPID != nil)
+        #expect(row.transcriptStreamPath == nil, "Codex was routed through the model proxy")
+        #expect(row.tmuxWindowID.isEmpty)
+    }
+
+    /// `terminal.continueInCodex` spawns through the same function, so the
+    /// resumed Codex terminal is born onto the holder with the flag on.
+    @Test func continueInCodexFlagOnSpawnsOntoTheHolder() async throws {
+        let fixture = try await GateFixture.make(flagEnabled: true)
+        defer { fixture.tearDown() }
+        let source = try await fixture.seedClaudeSourceTerminal()
+
+        let terminalID = try await fixture.continueInCodex(terminalID: source.id)
+
+        let row = try #require(try await fixture.db.terminals.get(id: terminalID))
+        #expect(row.transport == .holder)
+        #expect(row.kind == .codex)
+        #expect(row.holderPID != nil)
+        #expect(row.childPID != nil)
+        #expect(row.tmuxWindowID.isEmpty)
+        // The source is preserved, as it always was.
+        #expect(try await fixture.db.terminals.get(id: source.id) != nil)
+    }
+
     // MARK: - The read
 
     /// `terminal.output` on a holder row renders the daemon's emulator, and
@@ -418,6 +551,60 @@ private final class RecaptureProbe: @unchecked Sendable {
     }
 }
 
+// MARK: - A routing recorder
+
+/// A `ModelProxySupervisor` stand-in for the routed extra-terminal case: it
+/// records the routes it was asked to mint and drops, and names a port so the
+/// attachment produces a base URL. No proxy process is started — the job is the
+/// gate shell, and nothing here connects to the URL.
+private final class RoutingRecorder: ModelProxySupervising, @unchecked Sendable {
+    struct Made: Sendable, Equatable {
+        let terminalID: UUID
+        let upstream: String
+        let streamingEnabled: Bool
+    }
+
+    private let lock = NSLock()
+    private var madeStorage: [Made] = []
+    private var retiredStorage: [String] = []
+    let token = "0123456789abcdef0123456789abcdef"
+
+    var made: [Made] {
+        lock.lock(); defer { lock.unlock() }
+        return madeStorage
+    }
+
+    var retired: [String] {
+        lock.lock(); defer { lock.unlock() }
+        return retiredStorage
+    }
+
+    func makeRoute(
+        terminalID: UUID, upstream: String, streamingEnabled: Bool
+    ) async throws -> ModelProxyRoute {
+        lock.lock(); defer { lock.unlock() }
+        madeStorage.append(Made(
+            terminalID: terminalID, upstream: upstream, streamingEnabled: streamingEnabled))
+        return ModelProxyRoute(
+            token: token, terminalID: terminalID,
+            upstream: upstream, streamingEnabled: streamingEnabled)
+    }
+
+    func baseURL(for route: ModelProxyRoute) async -> String? {
+        "http://127.0.0.1:51842/r/\(route.token)"
+    }
+
+    func retireRoute(token: String, terminalID: UUID) async {
+        lock.lock(); defer { lock.unlock() }
+        retiredStorage.append(token)
+    }
+
+    func routeToken(forTerminal terminalID: UUID) async -> String? { nil }
+    func capabilitySnapshot() async -> ModelProxyCapabilitySnapshot { .none }
+    func startIfEnabled() async {}
+    func beginDraining() async {}
+}
+
 // MARK: - Fixture
 
 /// A worktree, a database, a router and a registry, wired the way the daemon
@@ -557,17 +744,20 @@ private final class GateFixture {
             repoID: repo.id, name: "main", branch: "main", path: repoDir.path,
             tmuxServer: TmuxManager.serverName(forRepoPath: repoDir.path))
 
+        // The Claude spawn branches — the primary's and `terminal.create`'s —
+        // seed folder trust and resolve a projects root through this manager.
+        // Injected at the fixture's own scratch root so neither reaches the
+        // developer's store — the seam `Tests/CLAUDE.md` names, rather than a
+        // `setenv`. One instance for the lifecycle and the router, because the
+        // router's Claude branch resolves through its own.
+        let configDirManager = ClaudeProfileConfigDirManager(
+            baseDirectory: URL(fileURLWithPath: home)
+                .appendingPathComponent("profiles", isDirectory: true),
+            hostBaseDirectory: URL(fileURLWithPath: home)
+                .appendingPathComponent("claude", isDirectory: true))
         var lifecycle = WorktreeLifecycle(
             db: db, git: GitManager(), tmux: tmux, hooks: HookResolver(),
-            // The Claude spawn branch below seeds folder trust and resolves a
-            // projects root through this manager. Injected at the fixture's own
-            // scratch root so neither reaches the developer's store — the seam
-            // `Tests/CLAUDE.md` names, rather than a `setenv`.
-            configDirManager: ClaudeProfileConfigDirManager(
-                baseDirectory: URL(fileURLWithPath: home)
-                    .appendingPathComponent("profiles", isDirectory: true),
-                hostBaseDirectory: URL(fileURLWithPath: home)
-                    .appendingPathComponent("claude", isDirectory: true)))
+            configDirManager: configDirManager)
         lifecycle.holderRegistry = registry
         if let recapture {
             lifecycle.sessionRecaptureFactory = { db, tmux in
@@ -576,8 +766,18 @@ private final class GateFixture {
         }
         let router = RPCRouter(
             db: db, lifecycle: lifecycle, tmux: tmux, startTime: Date(),
+            configDirManager: configDirManager,
             actuationLog: makeTestActuationLog())
         router.holderRegistry = registry
+        // Codex is never launched here: the job is the pinned gate shell,
+        // which ignores its argv. The stubs only have to satisfy the handlers'
+        // pre-spawn resolution, so the Codex branches can reach the gate.
+        router.codexExecutableResolver = { "/opt/test/bin/codex" }
+        router.codexHomeEnsurer = {
+            URL(fileURLWithPath: home).appendingPathComponent("codex-home", isDirectory: true)
+        }
+        router.codexProfileFlagResolver = { _ in "--profile" }
+        router.codexSessionImport = { _, _, _, _, _ in "thread-gate-1" }
 
         return GateFixture(
             db: db, router: router, registry: registry, environment: environment,
@@ -623,6 +823,49 @@ private final class GateFixture {
             archivedClaudeSessions: archivedClaudeSessions,
             preSessionTerminalID: nil,
             carryover: carryover)
+    }
+
+    /// The `terminal.create` RPC, through the router, exactly as the app's
+    /// "new terminal" and `tbd terminal create` reach it.
+    func terminalCreate(_ params: TerminalCreateParams) async throws -> Terminal {
+        let response = await router.handle(
+            try RPCRequest(method: RPCMethod.terminalCreate, params: params))
+        if let error = response.error {
+            Issue.record("terminal.create failed: \(error)")
+        }
+        return try response.decodeResult(Terminal.self)
+    }
+
+    /// The `terminal.continueInCodex` RPC, through the router. Returns the
+    /// resumed Codex terminal's id.
+    func continueInCodex(terminalID: UUID) async throws -> UUID {
+        let response = await router.handle(
+            try RPCRequest(
+                method: RPCMethod.terminalContinueInCodex,
+                params: TerminalContinueInCodexParams(terminalID: terminalID)))
+        if let error = response.error {
+            Issue.record("terminal.continueInCodex failed: \(error)")
+        }
+        return try response.decodeResult(TerminalContinueInCodexResult.self).terminalID
+    }
+
+    /// A Claude terminal row with a transcript on disk — what
+    /// `terminal.continueInCodex` imports from. Written directly rather than
+    /// spawned, because only the row and the file are read.
+    func seedClaudeSourceTerminal() async throws -> Terminal {
+        let transcript = "\(home)/source.jsonl"
+        try #"{"type":"user","message":{"content":"continue this"}}"#
+            .write(toFile: transcript, atomically: true, encoding: .utf8)
+        let source = try await db.terminals.create(
+            worktreeID: worktree.id,
+            tmuxWindowID: "@source",
+            tmuxPaneID: "%source",
+            label: TerminalLabel.claudeCode,
+            claudeSessionID: "claude-session",
+            kind: .claude)
+        try await db.terminals.updateSession(
+            id: source.id, sessionID: "claude-session", transcriptPath: transcript)
+        return try #require(try await db.terminals.get(id: source.id))
     }
 
     /// The `terminal.output` RPC, through the router's real handler.

--- a/Tests/TBDDaemonTests/ContinueInCodexRPCTests.swift
+++ b/Tests/TBDDaemonTests/ContinueInCodexRPCTests.swift
@@ -265,4 +265,75 @@ struct ContinueInCodexRPCTests {
         #expect(try await fixture.db.terminals.list(
             worktreeID: fixture.worktree.id) == [source])
     }
+
+    // MARK: - The transport gate
+
+    /// A registry built on `spawner`, with a `TBD_HOME` of its own under the
+    /// run's scratch root — the failing spawn leaves a lock and a log at its
+    /// rendezvous there. Returns that root for the caller's `defer` to remove.
+    private func attachRegistry(to fixture: Fixture, spawner: HolderSpawner?) -> String {
+        let home = fencedScratchRoot(prefix: "tbdcic")
+        fixture.router.holderRegistry = HolderRegistry(
+            owner: HolderOwnerToken(rawValue: "acme-installation"),
+            environment: [
+                "TBD_HOME": home,
+                "PATH": "/usr/bin:/bin",
+                "SHELL": "/bin/sh",
+            ],
+            listTerminals: { [] },
+            spawner: spawner)
+        return home
+    }
+
+    /// The flag on with nothing to spawn with falls back to tmux, the same
+    /// answer every other spawn path gives: the resumed Codex terminal still
+    /// opens, on a window.
+    @Test("with the holder flag on and no spawner, the resumed terminal falls back to tmux")
+    func flagOnWithoutASpawnerFallsBackToTmux() async throws {
+        let fixture = try await makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        try await fixture.db.config.setPtyHolderEnabled(true)
+        let holderHome = attachRegistry(to: fixture, spawner: nil)
+        defer { try? FileManager.default.removeItem(atPath: holderHome) }
+        let source = try await createClaudeSource(in: fixture)
+
+        let response = await fixture.router.handle(try RPCRequest(
+            method: RPCMethod.terminalContinueInCodex,
+            params: TerminalContinueInCodexParams(terminalID: source.id)))
+
+        #expect(response.success, "\(response.error ?? "")")
+        let result = try response.decodeResult(TerminalContinueInCodexResult.self)
+        let target = try #require(try await fixture.db.terminals.get(id: result.terminalID))
+        #expect(target.transport == .tmux)
+        #expect(!target.tmuxWindowID.isEmpty)
+        #expect(target.holderPID == nil)
+        #expect(fixture.recorder.commands.filter { $0.contains("new-window") }.count == 1)
+    }
+
+    /// The flag on with a registry that can spawn takes the holder path — and
+    /// a holder that fails to start fails the request the way a tmux failure
+    /// does: an error, no row, and no window created behind it.
+    @Test("with the holder flag on, a holder spawn failure creates no window and no row")
+    func flagOnHolderSpawnFailureIsAtomic() async throws {
+        let fixture = try await makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        try await fixture.db.config.setPtyHolderEnabled(true)
+        let holderHome = attachRegistry(
+            to: fixture,
+            spawner: HolderSpawner(
+                executableURL: URL(fileURLWithPath: "/nonexistent/TBDHolder")))
+        defer { try? FileManager.default.removeItem(atPath: holderHome) }
+        let source = try await createClaudeSource(in: fixture)
+
+        let response = await fixture.router.handle(try RPCRequest(
+            method: RPCMethod.terminalContinueInCodex,
+            params: TerminalContinueInCodexParams(terminalID: source.id)))
+
+        #expect(
+            response.error?.contains("/nonexistent/TBDHolder") == true,
+            "the resumed terminal did not take the holder path: \(response.error ?? "success")")
+        #expect(!fixture.recorder.commands.contains { $0.contains("new-window") })
+        #expect(try await fixture.db.terminals.list(
+            worktreeID: fixture.worktree.id) == [source])
+    }
 }

--- a/Tests/TBDDaemonTests/Holder/TerminalCreateTransportGateTests.swift
+++ b/Tests/TBDDaemonTests/Holder/TerminalCreateTransportGateTests.swift
@@ -1,0 +1,276 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+import TestSupport
+
+/// The transport gate as `terminal.create` asks it — the branches that need
+/// no `TBDHolder` binary. The branch that does, a real holder behind an extra
+/// terminal, is `HolderSpawnGateTests` in the live target.
+///
+/// Three things are pinned here that the happy path cannot show:
+///
+///   - **A tmux extra terminal is never routed.** With the proxy on and the
+///     holder flag off, the fake supervisor must be asked for nothing — a
+///     route minted for a tmux spawn would be a stream file nothing writes.
+///   - **A registry that cannot spawn falls back to tmux**, exactly as the
+///     primary path does, rather than failing the request or routing a
+///     session that then never starts.
+///   - **A holder spawn that fails retires the route it minted**, from the
+///     failing call itself and by the token it minted, so a refused extra
+///     terminal leaves no route file for the sweep.
+///
+/// The failing spawner is a `HolderSpawner` whose executable does not exist:
+/// `canSpawn` is decided from the spawner's presence alone, so the gate takes
+/// the holder path, and `posix_spawn` then fails before any holder exists.
+@Suite("terminal.create transport gate")
+struct TerminalCreateTransportGateTests {
+
+    // MARK: - Fixture
+
+    private final class TmuxArgvRecorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var argvs: [[String]] = []
+        func record(_ argv: [String]) {
+            lock.lock(); defer { lock.unlock() }
+            argvs.append(argv)
+        }
+        var newWindowCount: Int {
+            lock.lock(); defer { lock.unlock() }
+            return argvs.filter { $0.contains("new-window") }.count
+        }
+    }
+
+    private struct Fixture {
+        let db: TBDDatabase
+        let router: RPCRouter
+        let recorder: TmuxArgvRecorder
+        let supervisor: FakeModelProxySupervisor
+        let environment: [String: String]
+        let worktree: Worktree
+        let home: String
+        let worktreePath: String
+
+        func tearDown() {
+            try? FileManager.default.removeItem(atPath: home)
+            try? FileManager.default.removeItem(atPath: worktreePath)
+        }
+
+        func create(_ params: TerminalCreateParams) async throws -> RPCResponse {
+            await router.handle(try RPCRequest(method: RPCMethod.terminalCreate, params: params))
+        }
+    }
+
+    /// A spawner whose executable is not there. The registry built on it
+    /// reports `canSpawn`, so the gate takes the holder path; the spawn then
+    /// fails at `posix_spawn`, before any holder, socket or lock outlives it.
+    private static func unspawnableSpawner() -> HolderSpawner {
+        HolderSpawner(executableURL: URL(fileURLWithPath: "/nonexistent/TBDHolder"))
+    }
+
+    private static func makeFixture(
+        holderFlag: Bool,
+        proxyFlag: Bool,
+        spawner: HolderSpawner?
+    ) async throws -> Fixture {
+        // Short and under the run's scratch root: the rendezvous socket the
+        // failing spawn would bind lives under it, against `sun_path`'s cap.
+        let home = fencedScratchRoot(prefix: "tbdtcg")
+        let environment = [
+            "TBD_HOME": home,
+            "PATH": "/usr/bin:/bin",
+            "SHELL": "/bin/sh",
+        ]
+        let recorder = TmuxArgvRecorder()
+        let tmux = TmuxManager(dryRun: true, dryRunRecorder: { recorder.record($0) })
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setPtyHolderEnabled(holderFlag)
+        // Streaming turns the proxy on in the same transaction; the routed
+        // branch asserts the stream path, which is what streaming reads.
+        try await db.config.setTranscriptStreamingEnabled(proxyFlag)
+
+        let configDirManager = makeIsolatedConfigDirManager(tag: "terminal-create-gate")
+        let lifecycle = WorktreeLifecycle(
+            db: db, git: GitManager(), tmux: tmux, hooks: HookResolver(),
+            configDirManager: configDirManager)
+        let router = RPCRouter(
+            db: db, lifecycle: lifecycle, tmux: tmux, startTime: Date(),
+            configDirManager: configDirManager,
+            // The login-session case below arms the auto-`/login` pump against
+            // the dry-run tmux; on the router's default delays it would poll
+            // an empty pane for the rest of the run.
+            loginSessions: LoginSessionCoordinator(delays: .init(
+                pumpInitialDelay: .zero,
+                pumpPollInterval: .milliseconds(5),
+                pumpPostSendDelay: .milliseconds(5),
+                pumpTimeout: .milliseconds(50),
+                identityPollInterval: .milliseconds(5),
+                identityPollTimeout: .milliseconds(50))),
+            actuationLog: makeTestActuationLog())
+        router.holderRegistry = HolderRegistry(
+            owner: HolderOwnerToken(rawValue: "acme-installation"),
+            environment: environment,
+            listTerminals: { [] },
+            spawner: spawner)
+        let supervisor = FakeModelProxySupervisor()
+        router.modelProxySupervisor = supervisor
+        router.codexExecutableResolver = { "/opt/test/bin/codex" }
+        router.codexHomeEnsurer = {
+            URL(fileURLWithPath: home).appendingPathComponent("codex-home", isDirectory: true)
+        }
+
+        let repo = try await db.repos.create(
+            path: "/tmp/tbd-tcg-repo-\(UUID().uuidString)",
+            displayName: "acme", defaultBranch: "main")
+        // `terminal.create` refuses to spawn into a missing directory.
+        let worktreePath = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-tcg-wt-\(UUID().uuidString)").path
+        try FileManager.default.createDirectory(
+            atPath: worktreePath, withIntermediateDirectories: true)
+        let worktree = try await db.worktrees.create(
+            repoID: repo.id, name: "wt", branch: "tbd/wt",
+            path: worktreePath, tmuxServer: "tbd-tcg-test")
+        return Fixture(
+            db: db, router: router, recorder: recorder, supervisor: supervisor,
+            environment: environment, worktree: worktree, home: home,
+            worktreePath: worktreePath)
+    }
+
+    private func expectTmuxRow(_ terminal: Terminal, in fixture: Fixture) async throws {
+        let row = try #require(try await fixture.db.terminals.get(id: terminal.id))
+        #expect(row.transport == .tmux)
+        #expect(!row.tmuxWindowID.isEmpty)
+        #expect(row.holderPID == nil)
+        #expect(row.childPID == nil)
+        #expect(row.holderChildStartedAt == nil)
+        #expect(row.transcriptStreamPath == nil)
+        #expect(fixture.recorder.newWindowCount == 1)
+        let socketPath = try HolderRendezvous.socketPath(
+            sessionID: terminal.id, environment: fixture.environment)
+        #expect(
+            !FileManager.default.fileExists(atPath: socketPath),
+            "a holder rendezvous was created for a tmux-transport extra terminal")
+    }
+
+    // MARK: - Flag off
+
+    /// Today's behavior, exactly: a tmux window, a tmux row, and — with the
+    /// proxy on — no route, because only a holder spawn is ever routed.
+    @Test("flag off: an extra Claude terminal spawns onto tmux and is not routed")
+    func flagOffSpawnsOntoTmux() async throws {
+        let fixture = try await Self.makeFixture(
+            holderFlag: false, proxyFlag: true, spawner: Self.unspawnableSpawner())
+        defer { fixture.tearDown() }
+
+        let response = try await fixture.create(
+            TerminalCreateParams(worktreeID: fixture.worktree.id, type: .claude))
+        #expect(response.success, "\(response.error ?? "")")
+        let terminal = try response.decodeResult(Terminal.self)
+        try await expectTmuxRow(terminal, in: fixture)
+        #expect(fixture.supervisor.made.isEmpty, "a tmux spawn was routed")
+        #expect(fixture.supervisor.retired.isEmpty)
+    }
+
+    // MARK: - Flag on, nothing to spawn with
+
+    /// A registry with no spawner — a daemon whose `TBDHolder` binary an
+    /// upgrade moved away. The flag is on and the answer is still tmux, the
+    /// same fallback the primary path takes, and the proxy is asked nothing:
+    /// the gate refused before the routing decision was reached.
+    @Test("flag on with a registry that cannot spawn falls back to tmux")
+    func flagOnWithoutASpawnerFallsBackToTmux() async throws {
+        let fixture = try await Self.makeFixture(
+            holderFlag: true, proxyFlag: true, spawner: nil)
+        defer { fixture.tearDown() }
+
+        let response = try await fixture.create(
+            TerminalCreateParams(worktreeID: fixture.worktree.id, type: .claude))
+        #expect(response.success, "\(response.error ?? "")")
+        let terminal = try response.decodeResult(Terminal.self)
+        try await expectTmuxRow(terminal, in: fixture)
+        #expect(fixture.supervisor.made.isEmpty, "a tmux fallback was routed")
+    }
+
+    // MARK: - Flag on, the holder spawn fails
+
+    /// The request fails the way a tmux spawn failure fails today — an error
+    /// response, no row — and the route minted before the command was
+    /// composed is retired by its own token.
+    @Test("a holder spawn failure fails the request and retires the minted route")
+    func holderSpawnFailureRetiresTheRoute() async throws {
+        let fixture = try await Self.makeFixture(
+            holderFlag: true, proxyFlag: true, spawner: Self.unspawnableSpawner())
+        defer { fixture.tearDown() }
+
+        let response = try await fixture.create(
+            TerminalCreateParams(worktreeID: fixture.worktree.id, type: .claude))
+        #expect(!response.success)
+        #expect(
+            response.error?.contains("/nonexistent/TBDHolder") == true,
+            "the request failed before the holder spawn: \(response.error ?? "")")
+        #expect(fixture.supervisor.made.count == 1, "the routing decision was not made before the spawn")
+        #expect(fixture.supervisor.retired == [fixture.supervisor.token])
+        #expect(try await fixture.db.terminals.list(worktreeID: fixture.worktree.id).isEmpty)
+        #expect(fixture.recorder.newWindowCount == 0, "a failed holder spawn fell through to tmux")
+    }
+
+    /// A shell never asks the proxy: the holder path is taken (the spawn
+    /// fails, which is the proof) and no route is minted or retired, because
+    /// the shell branch has no attachment at all rather than an unproxied one.
+    @Test("a shell extra terminal takes the holder path and is never routed")
+    func shellTakesTheHolderPathUnrouted() async throws {
+        let fixture = try await Self.makeFixture(
+            holderFlag: true, proxyFlag: true, spawner: Self.unspawnableSpawner())
+        defer { fixture.tearDown() }
+
+        let response = try await fixture.create(
+            TerminalCreateParams(worktreeID: fixture.worktree.id, cmd: "htop"))
+        #expect(
+            response.error?.contains("/nonexistent/TBDHolder") == true,
+            "a shell extra terminal did not take the holder path: \(response.error ?? "success")")
+        #expect(fixture.supervisor.made.isEmpty)
+        #expect(fixture.supervisor.retired.isEmpty)
+        #expect(fixture.recorder.newWindowCount == 0)
+    }
+
+    /// The holder runs any command, so a Codex extra terminal takes the
+    /// transport the flag chose, exactly as the primary path's Codex branch
+    /// does — and, like the shell, is never routed.
+    @Test("a Codex extra terminal takes the holder path and is never routed")
+    func codexTakesTheHolderPathUnrouted() async throws {
+        let fixture = try await Self.makeFixture(
+            holderFlag: true, proxyFlag: true, spawner: Self.unspawnableSpawner())
+        defer { fixture.tearDown() }
+
+        let response = try await fixture.create(
+            TerminalCreateParams(worktreeID: fixture.worktree.id, type: .codex))
+        #expect(
+            response.error?.contains("/nonexistent/TBDHolder") == true,
+            "a Codex extra terminal did not take the holder path: \(response.error ?? "success")")
+        #expect(fixture.supervisor.made.isEmpty)
+        #expect(fixture.recorder.newWindowCount == 0)
+    }
+
+    // MARK: - The login tab stays on tmux
+
+    /// A profile login tab is the one extra terminal that stays on tmux with
+    /// the flag on: its auto-`/login` pump reads and types through a tmux
+    /// pane. With a spawner that would fail, success here is the proof that
+    /// the holder path was not taken.
+    @Test("a login session stays on tmux with the flag on")
+    func loginSessionStaysOnTmux() async throws {
+        let fixture = try await Self.makeFixture(
+            holderFlag: true, proxyFlag: false, spawner: Self.unspawnableSpawner())
+        defer { fixture.tearDown() }
+        let profile = try await fixture.db.modelProfiles.create(name: "Login", kind: .oauth)
+
+        let response = try await fixture.create(
+            TerminalCreateParams(
+                worktreeID: fixture.worktree.id, type: .claude,
+                overrideProfileID: profile.id, loginSession: true))
+        #expect(response.success, "\(response.error ?? "")")
+        let terminal = try response.decodeResult(Terminal.self)
+        #expect(terminal.label == TerminalLabel.login)
+        try await expectTmuxRow(terminal, in: fixture)
+    }
+}

--- a/docs/specs/2026-08-30-pty-holder-session-transport-design.md
+++ b/docs/specs/2026-08-30-pty-holder-session-transport-design.md
@@ -922,6 +922,21 @@ flag with a soak and a stated graduation plan.
   and respawn. Live migration (extracting a pty from a running tmux server)
   is rejected; see below.
 
+  The sessions the flag reaches ask it through one gate
+  (`TerminalSpawnTransport.decide`) and spawn through one function
+  (`WorktreeLifecycle.spawnTerminal`): the primary terminal at worktree
+  creation, and the extra terminals `terminal.create` and
+  `terminal.continueInCodex` open — Claude, Codex and shell alike, since the
+  holder runs any command. A wake respawns onto the transport its row
+  recorded. Every other tab still opens on tmux whatever the flag says, and
+  each has its own reason: a profile login tab, because its auto-`/login`
+  pump reads and types through a tmux pane; the setup and pre-session hook
+  tabs, which are hook runners rather than agent surfaces; restored archived
+  sessions, revive-from-history tabs and fork-session tabs, which are not yet
+  ported. Those still spawn through the same function, with the transport
+  pinned to tmux, so the flag reaching them later is a one-line change at
+  each site rather than a second spawn implementation.
+
   The flag therefore gates **spawning, not servicing**: the flag is consulted
   only when a session is created, and both transports' machinery (attach
   paths, the daemon's arbitration and drain, each reconciler's ground-truth

--- a/docs/specs/2026-09-05-transcript-streaming-model-proxy-design.md
+++ b/docs/specs/2026-09-05-transcript-streaming-model-proxy-design.md
@@ -422,7 +422,9 @@ Losing the rc-file defence would be a real failure; this is not one.
 
 The terminal row records `transcriptStreamPath`, the absolute stream file path,
 handed to the app the way `transcriptPath` is. Resume and wake spawns take the
-same branch.
+same branch, and so do the extra terminals `terminal.create` opens: an extra
+Claude terminal born onto the holder transport is routed exactly as a primary
+session is, through the same routing decision and the same row insert.
 
 A spawn with no live proxy proceeds unproxied and logs the omission at error.
 A streaming nicety never blocks or delays a session.


### PR DESCRIPTION
## Summary

With `pty_holder_enabled` on, a worktree's first session and every session woken from hibernation run on the pty-holder transport, but the terminals an operator adds afterwards — the app's "new terminal" button, `tbd terminal create`, and "continue in Codex" — always opened a tmux window. So on a flagged-on install the fleet was mixed by accident rather than by choice: every extra terminal still paid the tmux server it was supposed to be leaving, and none of them could be routed through the model proxy, so no extra Claude terminal ever streamed into the transcript pane. After this PR a new session opened through `terminal.create` or `terminal.continueInCodex` — Claude, Codex or shell — spawns onto a holder exactly as a primary one does, and an extra Claude terminal is proxied and streamed exactly like a primary one.

## Why this shape

No new spec: the holder spec's own rollout rule (`docs/specs/2026-08-30-pty-holder-session-transport-design.md`, "Rollout" → "Granularity: spawn time only") already requires that the flag gate spawning, and the model-proxy spec's "Spawn" section already says resume and wake spawns take the same branch as the create path. This PR brings the two extra-terminal spawn paths into line with rules that were already written; the two spec edits are transcriptions of that fact, not new design.

The primary path's spawn was not factored for reuse: the transport decision, the holder launch composition, the row insert that records transport, pids, the child start stamp and the stream path, and the two undo paths for a minted route all lived inline in `spawnPrimaryTerminalsWhileLocked`. Copying that block into the RPC handlers would have made a third copy of the subtlest code in the transport, so it is extracted instead:

- `TerminalSpawnTransport` (new file `Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+SpawnTerminal.swift`) is the gate. `decide(config:registry:)` returns `.holder(registry)` only when the flag is on **and** the registry can spawn, and `.tmux` otherwise — the same fallback the primary path already made, now in one place. The `.holder` case carries the registry, so a caller holding `.holder` provably holds something that can spawn.
- `WorktreeLifecycle.spawnTerminal(...)` is the one spawn-and-record step. The caller decides *what* to run (command, the two environments, label, kind) and whether the model proxy attached a route; this function spawns on the chosen transport and writes the row, with a holder spawn failure retiring the minted route by its own token and a row-insert failure abandoning the holder or killing the window, exactly as the primary path did.
- Every spawn site in the daemon now goes through it: the primary path, `terminal.create` (all three types), `terminal.continueInCodex`, and — with the transport pinned to `.tmux`, a pure refactor — the revive-from-history and fork-session tabs that used to carry two more byte-identical copies of the tmux block. `RPCRouter+ScratchHandlers.swift` already spawns through `spawnPrimaryTerminals` and needed nothing.

The registry and the supervisor are passed into `spawnTerminal` rather than read from `self`, because the router and the lifecycle are wired independently — `WorktreeLifecycle` is a value type, and test fixtures set the router's registry and supervisor alone — so the caller's is the authoritative one.

One deliberate carve-out: a profile **login tab** (`loginSession: true`) stays on tmux with the flag on. Its whole point is the auto-`/login` pump `armLoginSession` starts, which reads the pane's text and types into it through tmux; the holder transport has no such pump, and a login tab that opened on a holder would sit at the composer with nothing typing `/login`. Porting the pump is separate work.

## What this PR does

- `Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+SpawnTerminal.swift` (new): `TerminalSpawnTransport` and `WorktreeLifecycle.spawnTerminal`.
- `Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift`: the primary spawn's inline transport branch and row insert become one `spawnTerminal` call; the gate reads through `TerminalSpawnTransport.decide`. Same command, environments, overlay, attachment, recapture rule and setup-tab rule as before.
- `Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift`: `handleTerminalCreate` decides the transport once from the config it already reads, hoists the overlay path out of the builder call (the proxy must read the same resolved file the spawn runs with), attaches the model-proxy route before `ClaudeSpawnCommandBuilder.build` and hands the builder the routed URL through `Outcome.builderBaseURL`, merges the launch environment through `Outcome.launchEnvironment`, and spawns through `spawnTerminal` on both the Claude/shell and Codex branches. A new `prepareTmuxServer(for:worktree:cols:rows:)` helper does the server ensure and control-mode wiring only on the tmux transport, under the same worktree lock as before, on the lifecycle's `TmuxManager` so the server ensured and the window created are on one manager. `spawnRevivedTerminal` and `forkSwapNewTab` lose their private copies of the tmux block and call the same two functions with the transport pinned to `.tmux`; their behaviour is unchanged.
- `Sources/TBDDaemon/Server/RPCRouter+ContinueInCodexHandlers.swift`: the same port for the resumed Codex terminal.
- `.swiftlint.yml`: the new file joins the `actuation_primitive_allowlist` as a shared lifecycle internal covered by the caller's row (`terminal.create`, `terminal.continueInCodex`, `worktree.create`, `scratch.create`, revive), the same footing as `WorktreeLifecycle+Create.swift`.
- Specs: one paragraph in the holder spec's "Rollout" section stating which spawns the flag reaches, through the one gate and the one spawn, and naming every tab that still opens on tmux and why (login, the setup and pre-session hook tabs, restored archived sessions, revive-from-history and fork tabs); one sentence in the model-proxy spec's "Spawn" section stating extra terminals are routed like primary sessions.
- Settings help text (`AppState.ptyHolderHelp`, `modelProxyHelp`, `transcriptStreamingHelp`) already says "each new session" / "new Claude sessions" and needed no wording change.

## Flag & rollout

Gated by the existing `pty_holder_enabled` flag, default OFF, and for routing by the existing `model_proxy_enabled` / `transcript_streaming_enabled` pair. **No new flag and no new column.** Enable for the soak with the Settings toggle for the pty-holder transport (or `config.setPtyHolderEnabled` over the socket); running sessions stay where they are and only new spawns move. Graduation is the holder spec's: flip `Config.ptyHolderDefault`. This PR changes nothing about that plan; it removes two paths the flag had not been reaching.

## Assumptions

- The holder runs any command, so a Codex or shell extra terminal on a holder needs nothing the primary path's Codex and shell branches do not already do. Confirmed by reading `spawnPrimaryTerminalsWhileLocked`: its `.shell` and `.codex` cases compose a command and two environments and then take the same transport divergence as `.claude`; the handlers now do the same.
- A login tab's auto-`/login` pump is tmux-only (`armLoginSession` uses `capturePaneOutput` and `sendKeys`). If the pump is ever ported to the holder, the `isLoginSession ? .tmux : decidedTransport` line in `handleTerminalCreate` is the one thing to remove.
- Revive-from-history tabs, fork-session tabs, restored archived sessions and the two hook tabs stay on tmux with the flag on. The first two now spawn through `spawnTerminal` with the transport pinned, so reaching them later is a one-line change at each site; they were not ported here because each needs its own route-attachment and recapture decisions and this PR is scoped to the two extra-terminal RPCs.
- `Daemon.swift` wires `holderRegistry` and `modelProxySupervisor` onto both the lifecycle and the router. `spawnTerminal` takes them as parameters so it does not depend on which copy was wired when.
- A minted route whose spawn is refused by the worktree lock itself (the row archived or removed between the handler's early guard and the lock) is not retired from the failing call; `OrphanGC`'s route-file leg reclaims it on the hourly sweep. The primary path has no such window because nothing between its mint and its spawn can throw.

## Evidence & verification

**Named reconciler.** No new kind of durable resource and no new creation path: the extra terminals create holder rows through the same `HolderRegistry.spawn` and the same `terminals.create` insert the primary path uses, and every holder leg keys on the row's `transport == .holder`, never on which path created it. Read for this PR:

- close: `handleTerminalDelete` in `RPCRouter+TerminalHandlers.swift` takes the holder branch and calls `disposeHolder(for:)`;
- hibernate and wake: `HibernationCoordinator.swift` dispatches `transport == .holder` rows to `performHolderHibernate` and `wakeHolderSection` in `HibernationCoordinator+Holder.swift`, and the wake's route attachment reads the row's transport;
- archive and forget: `WorktreeLifecycle+Archive.swift` and `WorktreeLifecycle+Forget.swift` dispose holder rows per terminal;
- reconcile: `WorktreeLifecycle+Reconcile.swift`'s holder arm;
- reaper: `AgentReaper.sweepHolderChildren` sweeps by each holder row's recorded child pid;
- GC: `OrphanGC.swift`'s holder rendezvous and rowless-holder collectors, its route-file leg, and its model-proxy file collector, which reads live holder rows.

**Tests, both branches of the gate, on the existing fakes and the existing live fixture.**

- `Tests/TBDDaemonTests/Holder/TerminalCreateTransportGateTests.swift` (new, fast pass; a `HolderSpawner` whose executable does not exist makes the registry report `canSpawn` and then fail at `posix_spawn`, and the error names that executable, which is what the failure cases assert on):
  - flag off, proxy on: `terminal.create` of a Claude terminal yields a `.tmux` row with a window, no pids, no stream path, and the fake supervisor is asked for nothing;
  - flag on, registry with no spawner: falls back to `.tmux` the way the primary path does, and nothing is routed;
  - flag on, holder spawn fails: the request fails naming the spawner failure, no row and no window are created, one route was minted before the spawn and it is retired by that token;
  - flag on, shell and Codex extra terminals take the holder path (the error names the holder executable) and are never routed;
  - flag on, a login tab stays on tmux (success against a spawner that would have failed is the proof the holder path was not taken).
- `Tests/TBDDaemonTests/ContinueInCodexRPCTests.swift`: flag on with no spawner falls back to tmux; flag on with a failing holder fails naming the holder executable and creates no window and no row.
- `Tests/TBDDaemonLiveTests/Holder/HolderSpawnGateTests.swift` (real `TBDHolder`, the existing `GateFixture`): `terminal.create` flag off stays on tmux; flag on spawns a shell extra terminal onto a live holder (live holder and child pids, empty tmux coordinate, rendezvous socket present, no `new-window` or `new-session` issued, `holderChildStartedAt` stamped); a Claude extra terminal with streaming on is routed like a primary (one route minted for that terminal id, `transcriptStreamPath` equal to `TBDConstants.streamFilePath` for it, nothing retired); a Codex extra terminal and a `terminal.continueInCodex` resume both land on the holder.

Every pre-existing `terminal.create`, continue-in-Codex, revive, fork, holder gate and model-proxy test is unchanged. `swiftlint --strict` passes over the whole tree. A read-only code review pass over the diff found no compile errors and no flag-off behaviour change; its findings (an overclaiming spec sentence, the two remaining duplicated tmux blocks, fixture cleanup, and failure assertions that could pass vacuously) are all addressed above. No local build or test run was made on this machine; CI is the verifier.

https://claude.ai/code/session_01TggE2eESL3BcvSgFcLZkpk
[holder extra terminals](https://cheapsteak.github.io/tbd/open/?worktree=9274B7ED-3F11-461C-B191-6253B04082F4)
