### PR TITLE
DX: every test pass is watched for stalls, and the daemon pass runs as two steps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -228,18 +228,18 @@ jobs:
 
   test:
     runs-on: macos-26
-    # 90, deliberately NOT sized to this job's 15.3-minute observed worst case
-    # (10.7 median). The four test steps below carry `timeout-minutes` of 25, 15,
-    # 15 and 15 — a 70-minute step budget — and they exist so that a wedged suite
-    # dies on a step that names which pass hung, after that step's own watchdog
-    # has captured the stacks. A job bound at or below 70 would pre-empt all four
-    # and kill the run with the uninformative message those step bounds were
-    # written to avoid. 90 clears the step budget with room for checkout,
+    # 100, deliberately NOT sized to this job's 15.3-minute observed worst case
+    # (10.7 median). The four test steps below carry `timeout-minutes` of 35, 15,
+    # 15 and 15 — an 80-minute step budget — and they exist so that a wedged
+    # suite dies on a step that names which pass hung, after that step's own
+    # watchdog has captured the stacks. A job bound at or below 80 would pre-empt
+    # all four and kill the run with the uninformative message those step bounds
+    # were written to avoid. 100 clears the step budget with room for checkout,
     # `brew install tmux`, the cache restore, the watchdog harness and the final
     # build — none of which is individually timed — while cutting worst-case
-    # occupancy of one of the five macOS slots from six hours to an hour and a
-    # half.
-    timeout-minutes: 90
+    # occupancy of one of the five macOS slots from six hours to about an hour
+    # and forty minutes.
+    timeout-minutes: 100
     # All four test steps below append their `.flaky(issue:)` retry records
     # here (docs/specs/2026-07-24-test-hardening-design.md §7), so one run
     # produces one artifact covering all three fast passes and the quiet pass
@@ -465,9 +465,9 @@ jobs:
       # floor still clears and every step stays green while the new target's
       # tests execute nowhere. Expressing step 2 as "everything except
       # TBDDaemonTests and TBDDaemonLiveTests" closes it — a new target lands
-      # in step 2 automatically and runs. Step 1a takes the A–L half of
+      # in step 2 automatically and runs. Step 1a takes the A–O half of
       # TBDDaemonTests, step 1b takes the REST of TBDDaemonTests as a complement
-      # of 1a rather than as an `[M-Z]` enumeration (a suite renamed to start
+      # of 1a rather than as a `[P-Z]` enumeration (a suite renamed to start
       # with a digit or an underscore would fall out of both halves otherwise),
       # step 2 takes the complement of steps 1+3, the quiet pass takes
       # TBDDaemonLiveTests: no gap, no overlap, nothing to maintain.
@@ -489,11 +489,16 @@ jobs:
       # which is the only number the check can see; don't "correct" them to the
       # listed totals.
       #
-      # The two daemon halves are floored at 1000 and 1500. A local heuristic
-      # count, attributed by declared suite name and undercounting parameterized
-      # tests, puts A–L near 2,100 and M–Z near 3,100; the floors sit
-      # deliberately far below that and will be recalibrated from the counts the
-      # first CI run of this split prints, which is the only source that
+      # The two daemon halves are floored at 1200 and 1500. Where the cut goes
+      # is measured, not guessed: the split's first CI run (34305400310) cut at
+      # `[A-L]` and executed 1918 and 3703 — a third and two thirds, not the
+      # halving the split exists for — with 51 s and 114 s of test time. A local
+      # count of `@Test` attributed to the top-level suite that declares it
+      # predicted 1919 for that same cut, so that heuristic is worth trusting to
+      # within a test; it puts M, N and O at 582 between them, which moves the
+      # cut to `[A-O]` for an expected split near 2,500 / 3,120. The floors sit
+      # deliberately far below either half and will be recalibrated from the
+      # counts this cut's first run prints, which is the only source that
       # measures what actually executes.
       #
       # And the executed count is NOT stable run to run: two CI runs on one PR,
@@ -561,23 +566,35 @@ jobs:
       # puts the failure messages inside it. `scripts/test.sh` forwards
       # unrecognised arguments straight through to `swift test`.
       # ---------------------------------------------------------------------
-      - name: Test (fast parallel pass 1a — TBDDaemonTests A–L)
+      - name: Test (fast parallel pass 1a — TBDDaemonTests A–O)
         id: fast_pass_daemon_a
-        # 25, not 15 like its neighbours: this step runs the FIRST `swift test`,
-        # so it pays the whole test-target compile on top of its own runtime.
-        # Three consecutive warm-cache runs on main measured 2m22s / 3m33s /
-        # 6m02s for the compile alone, and a cold cache (Package.resolved
-        # change, cache eviction) is slower still. The 1200 s watchdog budget
-        # below is what actually bounds a wedge; this bound is the platform
+        # 35, against 15 for its neighbours, because this step runs the FIRST
+        # `swift test` and so pays the whole test-target compile on top of its
+        # own runtime — and because the cost of that compile is dominated by
+        # whether the SwiftPM cache hit.
+        #
+        # Measured over the 45 most recent concluded runs of this workflow
+        # (2026-09-05 to 2026-09-09), the first test step took between 73 s and
+        # 1250 s. The three slowest — 1010 s (run 34255127220), 1115 s
+        # (34267900663) and 1250 s (34255164378) — are exactly the runs whose
+        # "Cache SwiftPM build artifacts" step finished in 1–4 s, which is what
+        # a cache MISS looks like: a hit spends 25–56 s restoring. So 1250 s is
+        # the measured cold-cache figure, and it covers a full 5,529-test daemon
+        # pass, more than this step now runs. Warm-cache runs still spread
+        # 73–996 s, because every run force-rebuilds TBDShared and TBDDaemonLib
+        # and a PR's first run restores only the deps-only fallback key.
+        #
+        # The 1800 s watchdog budget below is what actually bounds a wedge — 45%
+        # above that measured worst case — and this step bound is the platform
         # backstop behind it, sized to clear the budget with room for the
         # sampling and the kill sweep.
-        timeout-minutes: 25
+        timeout-minutes: 35
         run: |
           scripts/ci/watched-test-pass.sh \
-            --name fast-pass-daemon-a --budget-seconds 1200 \
-            --floor 1000 \
+            --name fast-pass-daemon-a --budget-seconds 1800 \
+            --floor 1200 \
             --floor-message 'the --filter regex matched nothing or the target was renamed.' \
-            -- --fingerprint --parallel --filter '^TBDDaemonTests\.[A-L]' \
+            -- --fingerprint --parallel --filter '^TBDDaemonTests\.[A-O]' \
                --xunit-output /tmp/xunit-daemon-a.xml --experimental-xunit-message-failure
 
       - name: Test (fast parallel pass 1b — the rest of TBDDaemonTests)
@@ -590,14 +607,15 @@ jobs:
         # passes take on a run that is already red.
         if: ${{ !cancelled() && (steps.fast_pass_daemon_a.outcome == 'success' || steps.fast_pass_daemon_a.outcome == 'failure') }}
         # 15: the compile is already paid, so this is test runtime plus SPM's
-        # no-op build check. The 600 s budget bounds a wedge; this clears it.
+        # no-op build check — 128 s of step time on the split's first CI run.
+        # The 600 s budget bounds a wedge; this clears it.
         timeout-minutes: 15
         run: |
           scripts/ci/watched-test-pass.sh \
             --name fast-pass-daemon-b --budget-seconds 600 \
             --floor 1500 \
             --floor-message 'the --filter/--skip pair over-matched or the target was renamed.' \
-            -- --fingerprint --parallel --filter '^TBDDaemonTests\.' --skip '^TBDDaemonTests\.[A-L]' \
+            -- --fingerprint --parallel --filter '^TBDDaemonTests\.' --skip '^TBDDaemonTests\.[A-O]' \
                --xunit-output /tmp/xunit-daemon-b.xml --experimental-xunit-message-failure
 
       - name: Test (fast parallel pass 2 — everything except TBDDaemonTests and the live target)
@@ -606,12 +624,12 @@ jobs:
         # and step 2 are COMPLEMENTS" block above. A new test target lands here
         # on its own.
         if: ${{ !cancelled() && (steps.fast_pass_daemon_a.outcome == 'success' || steps.fast_pass_daemon_a.outcome == 'failure') }}
-        # 15. The 30 this step used to carry existed to let the per-test limits
-        # fire first and attribute a hang to a named test, because being killed
-        # by the platform timeout names nothing. The watchdog now does that job
-        # properly and sooner: it bounds the pass at 600 s and hands back the
-        # stacks of whatever was running, so the platform bound only has to clear
-        # the budget plus the sampling and kill sweep.
+        # 15. A step bound wide enough for the per-test limits to fire first and
+        # attribute a hang to a named test would buy nothing now: the watchdog
+        # does that job sooner and with a stack. It bounds the pass at 600 s —
+        # against 71 s of step time on the split's first CI run — so the
+        # platform bound only has to clear the budget plus the sampling and kill
+        # sweep.
         timeout-minutes: 15
         run: |
           scripts/ci/watched-test-pass.sh \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -229,20 +229,20 @@ jobs:
   test:
     runs-on: macos-26
     # 90, deliberately NOT sized to this job's 15.3-minute observed worst case
-    # (10.7 median). The three test steps below carry `timeout-minutes` of 30, 30
-    # and 15 — a 75-minute step budget — and they exist so that a wedged suite
-    # dies on a step that names which pass hung, with the per-test limits given
-    # room to fire first and attribute the hang to a named test. A job bound at
-    # or below 75 would pre-empt all three and kill the run with the
-    # uninformative message those step bounds were written to avoid. 90 clears
-    # the step budget with room for checkout, `brew install tmux`, the cache
-    # restore and the final build — none of which is individually timed — while
-    # cutting worst-case occupancy of one of the five macOS slots from six hours
-    # to an hour and a half.
+    # (10.7 median). The four test steps below carry `timeout-minutes` of 25, 15,
+    # 15 and 15 — a 70-minute step budget — and they exist so that a wedged suite
+    # dies on a step that names which pass hung, after that step's own watchdog
+    # has captured the stacks. A job bound at or below 70 would pre-empt all four
+    # and kill the run with the uninformative message those step bounds were
+    # written to avoid. 90 clears the step budget with room for checkout,
+    # `brew install tmux`, the cache restore, the watchdog harness and the final
+    # build — none of which is individually timed — while cutting worst-case
+    # occupancy of one of the five macOS slots from six hours to an hour and a
+    # half.
     timeout-minutes: 90
-    # All three test steps below append their `.flaky(issue:)` retry records
+    # All four test steps below append their `.flaky(issue:)` retry records
     # here (docs/specs/2026-07-24-test-hardening-design.md §7), so one run
-    # produces one artifact covering both fast passes and the quiet pass
+    # produces one artifact covering all three fast passes and the quiet pass
     # together. Unset locally, where the trait writes nothing.
     #
     # A LITERAL path, not `${{ runner.temp }}`: the `runner` context is not
@@ -365,14 +365,27 @@ jobs:
       # its own command line rather than repeating the number — one cap, one
       # place to change it.
       #
-      # Three sequential steps, one job (docs/specs/2026-07-24-test-hardening-design.md
+      # Four sequential steps, one job (docs/specs/2026-07-24-test-hardening-design.md
       # §4): the tier-3 live suites live in their own target so they can run
       # serially on an otherwise idle machine instead of contending with the
-      # parallel pass. A second *job* would draw from the 5-concurrent-macOS-job
+      # parallel passes. A second *job* would draw from the 5-concurrent-macOS-job
       # cap and re-pay the build, so all passes share this one.
       #
+      # EVERY ONE OF THEM RUNS THROUGH `scripts/ci/watched-test-pass.sh`. That
+      # script gives the pass a pty so its log streams line by line instead of in
+      # 16 KB blocks, bounds the run with a stall watchdog that captures every
+      # thread's stack of the processes executing the tests before the platform
+      # timeout can destroy the evidence, and turns the outcome into a verdict —
+      # the pass's own exit status first, untouched, and only then the floor. Why
+      # a pty, why lineage rather than names, why the argv match, why the cap of
+      # four, why five seconds of `sample`, why 30 seconds of grace, why `tee`
+      # dies last, why the status file is validated and why status precedes the
+      # floor are all in that script's header, with the design in
+      # docs/specs/2026-09-04-quiet-pass-stall-watchdog-design.md. Its harness is
+      # `scripts/ci/watched-test-pass.test.sh`, run by the last step in this job.
+      #
       # ---------------------------------------------------------------------
-      # Why the fast pass is TWO steps instead of one
+      # Why the fast pass is THREE steps instead of one
       #
       # Swift Testing parallelizes every non-serialized test in ONE process with
       # no concurrency cap. All targets compile into that process, so per-test
@@ -396,61 +409,97 @@ jobs:
       # invocation re-pays SPM's no-op build check and process startup. That is
       # the honest figure: a single iteration showed +6 s and it did not hold up
       # across the run. Set against a step that already spends 139-404 s on the
-      # compile, it is a good trade for halving the tail.
+      # compile, it is a good trade for halving the tail. Splitting again pays
+      # that startup cost a third time for the same reason.
       #
       # This is NOT the "sharding across runners" that §1 considered and
       # rejected and §2 lists as a non-goal. That rejection was about extra
       # *jobs*: the 5-concurrent-macOS-job cap, and each shard re-paying the
-      # ~2 min build. These are two sequential `swift test` invocations in ONE
+      # ~2 min build. These are three sequential `swift test` invocations in ONE
       # job sharing ONE build — the same shape this file already uses for the
       # fast/quiet split. It pays neither the job cap nor a second build.
       #
-      # Why step 2 is a COMPLEMENT (`--skip`) and not an enumeration
+      # What forced the third step. On 2026-09-08 nearly every run of this
+      # workflow reddened at least once on a test unrelated to the change under
+      # review, always in the tail of a fast pass — SocketServerSocketOwnership,
+      # AttachReplayOrchestrator, AppearanceDebounce, ArchivedWorktreeSearch,
+      # TerminalTeardownReap, BoundedGateWait, BoundedProcessRunner,
+      # WorktreeArchiveDeletionQueue, HolderLifecycle, TBDHolder — and one PR
+      # needed seven reruns to land. Twelve feature-branch reds classified by
+      # step: five in pass 1/2 and seven in pass 2/2, two of the latter
+      # 30-minute wedges with no stack at all (runs 34174344530 and
+      # 34176996067), where the process went silent about 5 s into the test run
+      # with ~1,965 tests started, none finishing, zero issues recorded and no
+      # time limit firing — the cooperative-pool wedge signature that
+      # `Tests/TestSupport/BoundedGateSupport.swift` describes. Zero reds landed
+      # in the quiet pass, which was then the only step with a watchdog; and
+      # because a red fast pass skipped the steps after it, a single flake hid
+      # the live verdict for the whole run.
       #
-      # The three passes must partition the package exhaustively, and that has
+      # The populations behind that: pass 1 was running ~5,529 tests and pass 2
+      # ~5,269, up from 4,988 and 4,645 on the 2026-09-04 green run of `main`,
+      # and from the ~4,350 and ~2,800 the deadline triple was originally
+      # derived against. Pass-1 test time was 247 s and 231 s on the red runs
+      # against 153 s and 195 s on the green ones, and every hang-catcher in the
+      # suite is sized per scheduling hop — `TestDeadlines.saturatedPass` 90 s,
+      # `TestGate.deadline` 120 s, the clock guards 45 s, the suite limit
+      # 240 s — so the red runs are simply the slow-runner tail of the same
+      # distribution. Re-splitting is the remedy that follows from "population
+      # is the scheduler" (`Tests/CLAUDE.md`); raising the deadlines instead
+      # re-derives four coupled constants and wants a spec first.
+      #
+      # Why step 1b and step 2 are COMPLEMENTS and not enumerations
+      #
+      # The four passes must partition the package exhaustively, and that has
       # to hold *by construction* rather than by anyone remembering to update a
       # list. The spec makes exactly this point about the target boundary in §3
       # ("Enforcement mechanism = target boundary"): it is "compiler-enforced,
       # cannot silently zero-match like a `--filter` regex". A fast pass
-      # expressed as two `--filter` enumerations gives that
+      # expressed as three `--filter` enumerations gives that
       # property up — `swift test --filter` exits GREEN on zero matches, so a
       # newly added `TBDFooTests` would simply appear in no list, run in NO
       # pass, and nothing would go red.
       #
       # The floors cannot cover that hole, and it is worth being precise about
-      # why: adding a target does not *reduce* any listed step's count, so both
-      # floors still clear and both steps stay green while the new target's
+      # why: adding a target does not *reduce* any listed step's count, so every
+      # floor still clears and every step stays green while the new target's
       # tests execute nowhere. Expressing step 2 as "everything except
       # TBDDaemonTests and TBDDaemonLiveTests" closes it — a new target lands
-      # in step 2 automatically and runs. Step 1 takes TBDDaemonTests, step 2
-      # takes the complement of steps 1+3, the quiet pass takes
+      # in step 2 automatically and runs. Step 1a takes the A–L half of
+      # TBDDaemonTests, step 1b takes the REST of TBDDaemonTests as a complement
+      # of 1a rather than as an `[M-Z]` enumeration (a suite renamed to start
+      # with a digit or an underscore would fall out of both halves otherwise),
+      # step 2 takes the complement of steps 1+3, the quiet pass takes
       # TBDDaemonLiveTests: no gap, no overlap, nothing to maintain.
       #
       # Floors: `swift test --list-tests` on 2026-08-28 reports TBDDaemonTests
       # 4354, TBDAppTests 2790, TBDSharedTests 858, TBDCLITests 306,
       # TBDDaemonLiveTests 85 (8393 total). Those numbers are worth reading
-      # next to the ones this comment carried when the split landed —
-      # TBDDaemonTests 2194, 4605 total — because step 1 alone now runs 95% of
-      # what the whole package ran then, and step 1 is where the tail lives.
-      # Halving the in-flight population is what the split bought, and growth
-      # has since spent it: measured on the 2026-08-28 run of `main`, step 1's
-      # median test reported an 85.8 s span (p90 112.1 s, max 132.8 s) and 47%
-      # of its tests spanned longer than the whole 90 s `ciSafeDeadline` that
-      # bounds the handshake waits among them. Re-splitting step 1 is the
-      # remedy that follows from "population is the scheduler"
-      # (`Tests/CLAUDE.md`); raising the deadlines instead re-derives four
-      # coupled constants and wants a spec first. What actually EXECUTES is
-      # slightly lower for step 2 — 3876 on the 2026-08-27 green run, the
-      # most recent one to reach step 2 at all — because a handful of
-      # tests are conditionally skipped at runtime. The floors are set against
-      # the executed counts (the summary line these steps grep), which is the
-      # only number the check can see; don't "correct" them to the listed
-      # totals.
+      # next to the ones this comment carried when the fast/slow split landed —
+      # TBDDaemonTests 2194, 4605 total — because the daemon target alone now
+      # runs nearly twice what the whole package ran then, and it is where the
+      # tail lives: measured on the 2026-08-28 run of `main`, the undivided
+      # daemon pass had a median test reporting an 85.8 s span (p90 112.1 s,
+      # max 132.8 s) and 47% of its tests spanned longer than the whole 90 s
+      # `ciSafeDeadline` that bounds the handshake waits among them. What
+      # actually EXECUTES is slightly lower for step 2 — 3876 on the 2026-08-27
+      # green run, the most recent one to reach step 2 at all — because a
+      # handful of tests are conditionally skipped at runtime. The floors are
+      # set against the executed counts (the summary line these steps grep),
+      # which is the only number the check can see; don't "correct" them to the
+      # listed totals.
       #
-      # And the executed count is NOT stable run to run: two CI runs on this PR,
+      # The two daemon halves are floored at 1000 and 1500. A local heuristic
+      # count, attributed by declared suite name and undercounting parameterized
+      # tests, puts A–L near 2,100 and M–Z near 3,100; the floors sit
+      # deliberately far below that and will be recalibrated from the counts the
+      # first CI run of this split prints, which is the only source that
+      # measures what actually executes.
+      #
+      # And the executed count is NOT stable run to run: two CI runs on one PR,
       # on commits differing only in doc comments (zero tests added,
-      # `--list-tests` unchanged), executed 2194 and 2204 for step 1. The cause
-      # is not established — it is not conditional skips (the only
+      # `--list-tests` unchanged), executed 2194 and 2204 for the daemon pass.
+      # The cause is not established — it is not conditional skips (the only
       # `.enabled(if:)` here is gated on an env var CI does not set) and not
       # parameterization (all `arguments:` are static literals). Left unexplained
       # rather than guessed at. The practical consequence is the point: pin a
@@ -512,77 +561,71 @@ jobs:
       # puts the failure messages inside it. `scripts/test.sh` forwards
       # unrecognised arguments straight through to `swift test`.
       # ---------------------------------------------------------------------
-      - name: Test (fast parallel pass 1/2 — TBDDaemonTests)
-        # A tier-1 test can still hang indefinitely: an over-long TestClock
-        # advance chain wedged for >10 min and `.clockDriven` did NOT bound it
-        # (the hung work sits where the time limit cannot cancel it). Without
-        # this the job falls back to the 6 h default.
-        #
-        # 30, not 10: this step runs the FIRST `swift test`, so it pays the
-        # whole test-target compile, not just the ~30 s of test runtime. Three
-        # consecutive warm-cache runs on main measured 2m22s / 3m33s / 6m02s —
-        # a 10-minute budget is under 2x the observed worst case and a cold
-        # cache (Package.resolved change, cache eviction) would blow through it
-        # and kill a healthy build. This bounds a hang at 1/12 of the default
-        # while staying far above any legitimate run.
-        timeout-minutes: 30
+      - name: Test (fast parallel pass 1a — TBDDaemonTests A–L)
+        id: fast_pass_daemon_a
+        # 25, not 15 like its neighbours: this step runs the FIRST `swift test`,
+        # so it pays the whole test-target compile on top of its own runtime.
+        # Three consecutive warm-cache runs on main measured 2m22s / 3m33s /
+        # 6m02s for the compile alone, and a cold cache (Package.resolved
+        # change, cache eviction) is slower still. The 1200 s watchdog budget
+        # below is what actually bounds a wedge; this bound is the platform
+        # backstop behind it, sized to clear the budget with room for the
+        # sampling and the kill sweep.
+        timeout-minutes: 25
         run: |
-          set -o pipefail
-          scripts/test.sh --fingerprint --parallel --filter '^TBDDaemonTests\.' \
-            --xunit-output /tmp/xunit-daemon.xml --experimental-xunit-message-failure \
-            2>&1 | tee /tmp/fast-pass-daemon.log
-          # `|| true`: with `set -o pipefail` (and GitHub's `bash -e`), a log
-          # with no summary line makes the first `grep` exit 1 and a failing
-          # command substitution in an assignment kills the shell — so the
-          # truncated-run case this floor exists for would die before ever
-          # reaching the `::error::` below.
-          count=$(grep -oE 'Test run with [0-9]+ tests?' /tmp/fast-pass-daemon.log | grep -oE '[0-9]+' | head -1 || true)
-          # `swift test --filter/--skip` exits GREEN on zero matches, so a bad
-          # regex or a renamed target would silently run nothing and pass.
-          if [ -z "$count" ] || [ "$count" -lt 1800 ]; then
-            echo "::error::Fast pass 1/2 ran ${count:-no} tests (floor 1800) — the --filter regex matched nothing or the target was renamed."
-            exit 1
-          fi
-          echo "Fast pass 1/2 (TBDDaemonTests) executed $count tests."
+          scripts/ci/watched-test-pass.sh \
+            --name fast-pass-daemon-a --budget-seconds 1200 \
+            --floor 1000 \
+            --floor-message 'the --filter regex matched nothing or the target was renamed.' \
+            -- --fingerprint --parallel --filter '^TBDDaemonTests\.[A-L]' \
+               --xunit-output /tmp/xunit-daemon-a.xml --experimental-xunit-message-failure
 
-      - name: Test (fast parallel pass 2/2 — everything except TBDDaemonTests and the live target)
-        # Expressed as a COMPLEMENT, not a list of targets — see the "Why step 2
-        # is a COMPLEMENT" block above. A new test target lands here on its own.
-        #
-        # 30, matching step 1. The earlier 15 was justified by "the previous
-        # step already paid the test-target compile, so this one is warm" — but
-        # compile time is no longer the binding constraint. With `.clockDriven`
-        # raised to 4 minutes the per-test worst case went 60 s -> 240 s, and a
-        # wedged `.clockDriven, .serialized` suite pays that *per test, in
-        # series*: FileWatcherTests (11 tests, in this pass) passes 15 minutes
-        # after only four of them. The step would then die on the GitHub
-        # timeout, which names no suite — precisely the uninformative outcome
-        # this `timeout-minutes` exists to prevent. 30 gives the per-test limits
-        # room to fire first and attribute the hang to a named test. (A suite
-        # wedged in *every* test still overruns 30; the aim is to make the
-        # ordinary case report itself, not to bound the pathological one.)
-        timeout-minutes: 30
+      - name: Test (fast parallel pass 1b — the rest of TBDDaemonTests)
+        id: fast_pass_daemon_b
+        # Runs even when 1a went red, but not when the job was cancelled and not
+        # when the build or setup never reached 1a at all. Until this landed, a
+        # red fast pass skipped every step after it, so one flake in the tail of
+        # pass 1 hid the live verdict for the whole run and the next push learned
+        # nothing new. The job still fails; the cost is the +2–4 min the later
+        # passes take on a run that is already red.
+        if: ${{ !cancelled() && (steps.fast_pass_daemon_a.outcome == 'success' || steps.fast_pass_daemon_a.outcome == 'failure') }}
+        # 15: the compile is already paid, so this is test runtime plus SPM's
+        # no-op build check. The 600 s budget bounds a wedge; this clears it.
+        timeout-minutes: 15
         run: |
-          set -o pipefail
-          scripts/test.sh --fingerprint --parallel --skip '^(TBDDaemonTests|TBDDaemonLiveTests)\.' \
-            --xunit-output /tmp/xunit-app.xml --experimental-xunit-message-failure \
-            2>&1 | tee /tmp/fast-pass-app.log
-          # `|| true`: with `set -o pipefail` (and GitHub's `bash -e`), a log
-          # with no summary line makes the first `grep` exit 1 and a failing
-          # command substitution in an assignment kills the shell — so the
-          # truncated-run case this floor exists for would die before ever
-          # reaching the `::error::` below.
-          count=$(grep -oE 'Test run with [0-9]+ tests?' /tmp/fast-pass-app.log | grep -oE '[0-9]+' | head -1 || true)
-          # `swift test --filter/--skip` exits GREEN on zero matches, so an
-          # over-broad skip or a renamed target would silently run nothing and
-          # pass.
-          if [ -z "$count" ] || [ "$count" -lt 1900 ]; then
-            echo "::error::Fast pass 2/2 ran ${count:-no} tests (floor 1900) — the --skip regex over-matched or a target was renamed."
-            exit 1
-          fi
-          echo "Fast pass 2/2 (everything except TBDDaemonTests) executed $count tests."
+          scripts/ci/watched-test-pass.sh \
+            --name fast-pass-daemon-b --budget-seconds 600 \
+            --floor 1500 \
+            --floor-message 'the --filter/--skip pair over-matched or the target was renamed.' \
+            -- --fingerprint --parallel --filter '^TBDDaemonTests\.' --skip '^TBDDaemonTests\.[A-L]' \
+               --xunit-output /tmp/xunit-daemon-b.xml --experimental-xunit-message-failure
+
+      - name: Test (fast parallel pass 2 — everything except TBDDaemonTests and the live target)
+        id: fast_pass_app
+        # Expressed as a COMPLEMENT, not a list of targets — see the "Why step 1b
+        # and step 2 are COMPLEMENTS" block above. A new test target lands here
+        # on its own.
+        if: ${{ !cancelled() && (steps.fast_pass_daemon_a.outcome == 'success' || steps.fast_pass_daemon_a.outcome == 'failure') }}
+        # 15. The 30 this step used to carry existed to let the per-test limits
+        # fire first and attribute a hang to a named test, because being killed
+        # by the platform timeout names nothing. The watchdog now does that job
+        # properly and sooner: it bounds the pass at 600 s and hands back the
+        # stacks of whatever was running, so the platform bound only has to clear
+        # the budget plus the sampling and kill sweep.
+        timeout-minutes: 15
+        run: |
+          scripts/ci/watched-test-pass.sh \
+            --name fast-pass-app --budget-seconds 600 \
+            --floor 1900 \
+            --floor-message 'the --skip regex over-matched or a target was renamed.' \
+            -- --fingerprint --parallel --skip '^(TBDDaemonTests|TBDDaemonLiveTests)\.' \
+               --xunit-output /tmp/xunit-app.xml --experimental-xunit-message-failure
 
       - name: Test (quiet pass — tier-3 live suites, serial, idle machine)
+        id: quiet_pass
+        # Runs on a red fast pass for the same reason 1b and 2 do: the live
+        # suites are the ones a fast-pass flake most often hides.
+        if: ${{ !cancelled() && (steps.fast_pass_daemon_a.outcome == 'success' || steps.fast_pass_daemon_a.outcome == 'failure') }}
         # `--no-parallel` is REQUIRED and is not the same as omitting
         # `--parallel`. SwiftPM's `--parallel` governs XCTest's process-level
         # sharding; Swift Testing parallelizes suites in-process on its own and
@@ -593,342 +636,46 @@ jobs:
         # flag they run strictly one at a time (24 s). Serial execution on an
         # idle machine IS this step; do not "optimize" the flag away.
         #
-        # The pty (`script -q /dev/null`) is what makes this step's log arrive
-        # in real time. On the serial path SwiftPM relays the test binary's
-        # output through `print($0, terminator: "")` on its own stdout
-        # (`SwiftTestCommand.runTestProducts`). `scripts/test.sh` runs
-        # `scripts/swift-safe` with no pipe of its own and `swift-safe`
-        # `os.execv`s `swift`, so whatever this step hands the script becomes
-        # SwiftPM's stdout directly. Piping into `tee` makes that stdout a pipe,
-        # and C stdio then fully buffers it in 16 KB blocks (a pipe's
-        # `st_blksize` on macOS). This pass emits roughly 16 KB per minute, so
-        # the log lagged the run by about a minute and was cut at an arbitrary
-        # byte boundary: runs 33797806278 (stalled) and 33787142345 (green) both
-        # stopped at exactly byte 16384, mid-way through the same
-        # `keepsTheReaderForAJobThatIsStillRunning()` line. The last line a
-        # wedged step showed was the buffer boundary, not the hung test. The
-        # fast passes only look real-time because they emit 16 KB a second.
-        # A pty makes SwiftPM's stdout a terminal, so C stdio line-buffers it
-        # and every line lands as it is produced. The pty translates `\n` to
-        # `\r\n`, which is harmless both to the runner log and to the
-        # `grep -oE 'Test run with [0-9]+ tests?'` floor check below. `script`
-        # propagates the child's exit status, `< /dev/null` guarantees nothing
-        # ever waits on the pty for input, and `TERM=dumb` keeps SwiftPM's build
-        # progress line-oriented instead of cursor-rewriting animations.
-        #
-        # The watchdog exists because GitHub's step timeout leaves no evidence.
-        # A stall here is a thread blocked somewhere no Swift Testing time limit
-        # can reach, so the step timeout is the only bound, and being killed by
-        # it records nothing about which test or which frame. So the pipeline
-        # runs in the background and a loop watches it: a healthy pass takes
-        # about 2 minutes (`Test run with 179 tests in 37 suites passed after
-        # 116.847 seconds`), the budget is six times that, and it lands three
-        # minutes short of `timeout-minutes` so sampling and artifact upload
-        # have room.
-        #
-        # On expiry the whole machine's process listing is written first and
-        # unconditionally. The runner is single-tenant, so that listing is both
-        # the record of the fixture's holder, tmux and job processes and the way
-        # we learn what anything is really called. The processes to sample are
-        # then found structurally, by descending the pipeline subshell's own
-        # tree with `pgrep -P`, and never by name: a CI probe of this watchdog
-        # matched `pgrep -x TBDPackageTests` against a live pass and
-        # found nothing, because the swift-testing binary does not run under its
-        # bundle name. A name match fails silently — it samples nothing and
-        # reports success at having collected nothing — whereas a tree walk
-        # finds whatever the pipeline actually spawned. The test binary is
-        # picked out of those descendants by matching `swiftpm-testing`,
-        # `xctest` or `TBDPackageTests` anywhere in the full argv from
-        # `ps -o command=`, not against a name: SwiftPM's
-        # `TestRunner.args(forTestAt:)` runs a swift-testing bundle as
-        # `<toolchain>/swiftpm-testing-helper --test-bundle-path <bundle> …
-        # --testing-library swift-testing` and an XCTest bundle as
-        # `<toolchain>/xctest <bundle>`, so the process executing the tests is
-        # the helper and never carries the bundle's own name — and the kernel
-        # truncates `p_comm` to 15 characters, which would render the helper as
-        # `swiftpm-testing` anyway. Matching unanchored against argv — read
-        # with `-ww` so ps never clips the long toolchain path — sidesteps both
-        # the truncation and the path prefix. When no descendant matches, every
-        # descendant that is not known plumbing
-        # (`script`, the shells, `tee`, `sleep`, python, `swift-safe`) is worth
-        # a stack, and the list is short enough that sampling all of them costs
-        # nothing. `/usr/bin/sample` — part of macOS, present on the runner
-        # image — captures every thread's stack of each target, and only then
-        # are those pids killed, by the pid we captured. Five seconds of it, at
-        # sample's 1 ms interval, is what it takes to show a blocked thread's
-        # stack unambiguously: a parked thread looks identical in every sample
-        # so a longer capture buys nothing, while a shorter one risks reading a
-        # scheduler blip as the stall — and symbolicating the ~200 MB debug
-        # helper still finishes well inside the three-minute margin. The 30 s
-        # between SIGTERM and SIGKILL is likewise sized to a job: it is what
-        # `scripts/test.sh`'s EXIT trap gets to run its tmux `kill-server` sweep
-        # and fence checks, generous against the few seconds those take and
-        # still inside that same margin.
-        # timeout-minutes so a wedged tmux test can't eat the job's 6 h default.
+        # A healthy pass reports `Test run with 179 tests in 37 suites passed
+        # after 116.847 seconds`, so the 720 s budget is six times a normal run
+        # and still three minutes short of this bound — room for the sampling and
+        # the artifact upload. The whole expiry path was measured at 42 s.
         timeout-minutes: 15
         run: |
-          set -o pipefail
-          stall_budget_seconds=720
-          rm -f /tmp/quiet-pass.rc
-          (
-            # This subshell's only job is to run the pipeline and record its
-            # status, so errexit is wrong here: on a red run it would abort the
-            # subshell before the `echo` below and discard the very status we
-            # came to capture (a real failure, or swift-safe's 75/76).
-            set +e
-            TERM=dumb script -q /dev/null scripts/test.sh --fingerprint --filter '^TBDDaemonLiveTests\.' --no-parallel \
-              --xunit-output /tmp/xunit-quiet.xml --experimental-xunit-message-failure \
-              < /dev/null 2>&1 | tee /tmp/quiet-pass.log
-            echo "${PIPESTATUS[0]}" > /tmp/quiet-pass.rc
-          ) &
-          pipeline=$!
-          waited=0
-          while kill -0 "$pipeline" 2>/dev/null && [ "$waited" -lt "$stall_budget_seconds" ]; do
-            sleep 5
-            waited=$((waited + 5))
-          done
-          # Collect a process tree by parent pid, so targets are found by
-          # lineage from the pipeline rather than by executable name.
-          descendants() {
-            local parent="$1" child
-            for child in $(pgrep -P "$parent" || true); do
-              echo "$child"
-              descendants "$child"
-            done
-          }
-          if kill -0 "$pipeline" 2>/dev/null; then
-            echo "::error::Quiet pass has been running for ${stall_budget_seconds}s and is being sampled before it is killed."
-            {
-              echo "=== whole-machine process listing at stall (budget ${stall_budget_seconds}s) ==="
-              ps -ww -axo pid,ppid,pgid,stat,%cpu,etime,comm,command || true
-            } > /tmp/quiet-pass-stall-ps.txt
-            kids=$(descendants "$pipeline" || true)
-            {
-              echo
-              echo "=== descendants of the pipeline subshell (pid $pipeline) ==="
-            } >> /tmp/quiet-pass-stall-ps.txt
-            if [ -n "$kids" ]; then
-              kid_list=$(printf '%s\n' "$kids" | paste -sd, -)
-              ps -ww -o pid,ppid,pgid,stat,%cpu,etime,comm,command -p "$kid_list" >> /tmp/quiet-pass-stall-ps.txt || true
-            else
-              echo "(none)" >> /tmp/quiet-pass-stall-ps.txt
-            fi
-            # Both selection paths below take at most `sample_target_cap`
-            # processes, in walk order (parents before children, so SwiftPM's
-            # driver comes ahead of the compiler processes it spawns — in a stall
-            # during compilation the driver's own stack is the more informative
-            # one). A match count is not a process count: during compilation the
-            # bundle path `.build/<triple>/debug/TBDPackageTests.build/…` appears
-            # in the argv of every concurrent compiler process, so the argv match
-            # can select a dozen at once, and at ~5 s of serial sampling each
-            # that would eat the 180 s margin and leave the step to be killed by
-            # `timeout-minutes` after all. Whatever a cap drops is recorded in
-            # the ps file, and the whole-machine listing written above still
-            # names every matching process, so nothing disappears from the
-            # artifact — only from the sampling.
-            #
-            # Measured on a probe of the fallback path with the argv match
-            # disabled (run 33902144920): three of the four slots used —
-            # SwiftPM's `swift-test` driver at 87 KB, `swiftpm-testing-helper` at
-            # 796 KB symbolicated, and a fixture `TBDHolder` that exited
-            # mid-sample and was reported as failed — and the whole expiry path,
-            # from the whole-machine ps through the tree walk, the three serial
-            # samples and the SIGTERM sweep to the step exiting, took 42 s.
-            sample_target_cap=4
-            targets=""
-            primary_taken=0
-            primary_skipped=0
-            for pid in $kids; do
-              argv=$(ps -ww -o command= -p "$pid" 2>/dev/null || true)
-              case "$argv" in
-                *swiftpm-testing*|*xctest*|*TBDPackageTests*) ;;
-                *) continue ;;
-              esac
-              if [ "$primary_taken" -lt "$sample_target_cap" ]; then
-                targets="$targets $pid"
-                primary_taken=$((primary_taken + 1))
-              else
-                primary_skipped=$((primary_skipped + 1))
-              fi
-            done
-            if [ "$primary_skipped" -gt 0 ]; then
-              echo "(primary sampling capped at $sample_target_cap targets; $primary_skipped further candidates skipped)" >> /tmp/quiet-pass-stall-ps.txt
-            fi
-            if [ -z "$targets" ]; then
-              fallback_taken=0
-              fallback_skipped=0
-              for pid in $kids; do
-                comm=$(ps -o comm= -p "$pid" 2>/dev/null || true)
-                case "${comm##*/}" in
-                  ""|script|bash|sh|tee|sleep|Python|python3|swift-safe) continue ;;
-                esac
-                if [ "$fallback_taken" -lt "$sample_target_cap" ]; then
-                  targets="$targets $pid"
-                  fallback_taken=$((fallback_taken + 1))
-                else
-                  fallback_skipped=$((fallback_skipped + 1))
-                fi
-              done
-              if [ "$fallback_skipped" -gt 0 ]; then
-                echo "(fallback sampling capped at $sample_target_cap targets; $fallback_skipped further candidates skipped)" >> /tmp/quiet-pass-stall-ps.txt
-              fi
-            fi
-            if [ -z "$targets" ]; then
-              echo "The pipeline has no sampleable descendants — /tmp/quiet-pass-stall-ps.txt carries the whole-machine listing instead."
-            else
-              {
-                echo
-                echo "=== sampled processes ==="
-              } >> /tmp/quiet-pass-stall-ps.txt
-              for pid in $targets; do
-                ps -ww -o pid,comm,command -p "$pid" >> /tmp/quiet-pass-stall-ps.txt || true
-                sample "$pid" 5 -mayDie -file "/tmp/quiet-pass-stall-sample-$pid.txt" || echo "sample $pid failed"
-              done
-              for pid in $targets; do
-                kill -KILL "$pid" 2>/dev/null || true
-              done
-            fi
-            # The sampled targets were SIGKILLed the moment their stacks were
-            # captured — they are wedged, and the sweep below is the graceful
-            # pass, for the plumbing that can still clean up after itself — so
-            # they are filtered out of every order built from here on. Even
-            # though `kill` on a dead pid is harmless, signalling one is inert at
-            # best and reaches whatever reused the number at worst.
-            is_target() {
-              local needle="$1" candidate
-              for candidate in $targets; do
-                if [ "$candidate" = "$needle" ]; then
-                  return 0
-                fi
-              done
-              return 1
-            }
-            is_direct_child() {
-              local needle="$1" child
-              for child in $direct_children; do
-                if [ "$child" = "$needle" ]; then
-                  return 0
-                fi
-              done
-              return 1
-            }
-            # The order is built from a walk taken at the moment it is needed
-            # rather than from any earlier snapshot: sampling several targets
-            # takes 20 s or more and the grace window below is another 30 s, so
-            # a list captured before either would miss whatever the pipeline
-            # spawned in the meantime.
-            #
-            # `tee` is a direct child of the subshell and owns the far end of
-            # the log pipe, so anything still writing when `tee` dies writes to
-            # a closed pipe — and the EXIT trap's cleanup output is exactly what
-            # the log wants. The order is therefore built explicitly rather than
-            # by reversing the walk. The walk is preorder — `script`, then all
-            # of script's subtree, then the sibling `tee` — so a plain reversal
-            # would signal `tee` first, precisely backwards. Instead: everything
-            # below the direct children goes first (that subset reversed, so
-            # deepest-first), then the direct children other than `tee`, then
-            # `tee`.
-            build_kill_order() {
-              local pid comm remaining="" deeper_first="" direct_others="" tee_pids=""
-              kids=$(descendants "$pipeline" || true)
-              for pid in $kids; do
-                if is_target "$pid"; then
-                  continue
-                fi
-                remaining="$remaining $pid"
-              done
-              kids="$remaining"
-              direct_children=$(pgrep -P "$pipeline" || true)
-              for pid in $kids; do
-                if is_direct_child "$pid"; then
-                  continue
-                fi
-                deeper_first="$pid $deeper_first"
-              done
-              for pid in $direct_children; do
-                comm=$(ps -o comm= -p "$pid" 2>/dev/null || true)
-                case "${comm##*/}" in
-                  tee) tee_pids="$tee_pids $pid" ;;
-                  *) direct_others="$direct_others $pid" ;;
-                esac
-              done
-              kill_order="$deeper_first $direct_others $tee_pids"
-            }
-            # Take the pipeline down within a bounded 30 s instead of leaving
-            # `wait` to block until `timeout-minutes` fires — the very outcome
-            # this budget exists to avoid. Killing the sampled targets is not
-            # enough on its own: with no targets found nothing has been killed
-            # at all, and even when the helper dies its parents (`script`,
-            # `swift-test`, `scripts/test.sh`) can outlive it. SIGTERM goes
-            # first so `scripts/test.sh`'s EXIT trap still runs its tmux and
-            # fence cleanup.
-            build_kill_order
-            for pid in $kill_order; do
-              kill -TERM "$pid" 2>/dev/null || true
-            done
-            teardown_waited=0
-            while kill -0 "$pipeline" 2>/dev/null && [ "$teardown_waited" -lt 30 ]; do
-              sleep 1
-              teardown_waited=$((teardown_waited + 1))
-            done
-            if kill -0 "$pipeline" 2>/dev/null; then
-              # The escalation rebuilds the order instead of reusing the one the
-              # SIGTERM sweep signalled: that grace window is exactly when the
-              # EXIT trap runs, and its tmux and fence cleanup spawns processes
-              # of its own that the earlier order knows nothing about.
-              build_kill_order
-              for pid in $kill_order; do
-                kill -KILL "$pid" 2>/dev/null || true
-              done
-              kill -KILL "$pipeline" 2>/dev/null || true
-            fi
-            wait "$pipeline" || true
-            exit 1
-          fi
-          wait "$pipeline" || true
-          rc=$(cat /tmp/quiet-pass.rc 2>/dev/null || echo 1)
-          # An unreadable status fails closed, the same way the floor below
-          # guards its own empty `count`: the `|| echo 1` covers only a missing
-          # file, and a writer that died mid-write leaves an empty or
-          # non-numeric one, on which `[ "$rc" -ne 0 ]` errors — and an erroring
-          # `if` condition reads as false, letting a failed run walk on to the
-          # floor check as though it had succeeded.
-          case "$rc" in
-            ''|*[!0-9]*)
-              echo "::error::Quiet pass left no readable exit status (got '$rc'); treating the run as failed."
-              exit 1 ;;
-          esac
-          # The status comes first: it is the pipeline's own verdict and has to
-          # reach the job untouched — a build error, an early crash, or
-          # swift-safe's 75 and 76 all log fewer than 35 tests, and reporting
-          # them through the floor's message would both misdiagnose them and
-          # flatten them to a generic 1. The floor only means anything for a run
-          # that claims to have succeeded.
-          if [ "$rc" -ne 0 ]; then
-            echo "::error::Quiet pass exited $rc"
-            exit "$rc"
-          fi
-          # `|| true`: with `set -o pipefail` (and GitHub's `bash -e`), a log
-          # with no summary line makes the first `grep` exit 1 and a failing
-          # command substitution in an assignment kills the shell — so the
-          # truncated-run case this floor exists for would die before ever
-          # reaching the `::error::` below.
-          count=$(grep -oE 'Test run with [0-9]+ tests?' /tmp/quiet-pass.log | grep -oE '[0-9]+' | head -1 || true)
-          if [ -z "$count" ] || [ "$count" -lt 35 ]; then
-            echo "::error::Quiet pass ran ${count:-no} tests (floor 35) — the --filter regex matched nothing or the target was renamed."
-            exit 1
-          fi
-          echo "Quiet pass executed $count tests."
+          scripts/ci/watched-test-pass.sh \
+            --name quiet-pass --budget-seconds 720 \
+            --floor 35 \
+            --floor-message 'the --filter regex matched nothing or the target was renamed.' \
+            -- --fingerprint --filter '^TBDDaemonLiveTests\.' --no-parallel \
+               --xunit-output /tmp/xunit-quiet.xml --experimental-xunit-message-failure
 
+      # The watchdog's own harness: fixture directories, a stub `scripts/test.sh`
+      # and a stub `sample`, no build, no real store touched, ~40 s. It lives in
+      # THIS job rather than joining the Linux collection in `plans-guard`
+      # because everything it drives is BSD — `script(1)` takes different
+      # arguments on Linux, `ps` there is GNU, and `sample` does not exist at
+      # all. That is the same reason the fence harness sits in `lint`, which is
+      # deliberately left alone.
+      #
+      # It runs LAST, and with `!cancelled()` rather than `always()`, so a bug in
+      # the harness can never pre-empt or hide the verdict of the passes above
+      # it: by the time it runs, every test step has already reported.
+      - name: Test the stall watchdog
+        if: ${{ !cancelled() }}
+        run: /bin/bash scripts/ci/watched-test-pass.test.sh
+
+      # Every watched pass writes its stall files as `<name>-stall-*.txt`, so one
+      # glob collects whichever pass wedged.
+      #
       # `ignore`, not the `warn` its neighbours use: a green run deliberately
       # produces no stall files, so absence here is the normal case rather than
       # a sign that the wiring broke.
-      - name: Upload quiet-pass stall diagnostics
+      - name: Upload stall diagnostics
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: quiet-pass-stall-diagnostics
-          path: /tmp/quiet-pass-stall-*.txt
+          name: test-stall-diagnostics
+          path: /tmp/*-stall-*.txt
           if-no-files-found: ignore
           retention-days: 14
 
@@ -949,6 +696,12 @@ jobs:
       # believe a run happened at all — without it a green remote verdict reads
       # as a truncated suite. `warn` on absence, matching the metrics upload
       # above: a missing file means the wiring broke and that must be visible.
+      #
+      # The glob already covers the fourth file the daemon split added:
+      # `scripts/remote_verify.py` discovers results with `rglob("*.xml")` over
+      # the unpacked artifact (`result_files`) and sums whatever it finds, so
+      # splitting or renaming a pass needs no change there — only that each pass
+      # keeps writing its XML under `/tmp/xunit-*.xml`.
       - name: Upload xUnit results
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -668,7 +668,8 @@ jobs:
                --xunit-output /tmp/xunit-quiet.xml --experimental-xunit-message-failure
 
       # The watchdog's own harness: fixture directories, a stub `scripts/test.sh`
-      # and a stub `sample`, no build, no real store touched, ~40 s. It lives in
+      # and a stub `sample`, no build, no real store touched, ~90 s — most of it
+      # the 30-second grace window the escalation case exists to measure. It lives in
       # THIS job rather than joining the Linux collection in `plans-guard`
       # because everything it drives is BSD — `script(1)` takes different
       # arguments on Linux, `ps` there is GNU, and `sample` does not exist at

--- a/Tests/CLAUDE.md
+++ b/Tests/CLAUDE.md
@@ -247,7 +247,7 @@ because it is mostly suspended waiting for a turn. Population went 3013 → 4536
 in three weeks. Two consequences, both load-bearing.
 
 **The fast pass is three sequential steps in one job.** `test.yml` runs
-`--filter '^TBDDaemonTests\.[A-L]'` (1a), then that filter's complement within
+`--filter '^TBDDaemonTests\.[A-O]'` (1a), then that filter's complement within
 the daemon target (1b), then
 `--skip '^(TBDDaemonTests|TBDDaemonLiveTests)\.'` (2), all sharing one build.
 Halving the in-flight population halves the tail: measured under induced load
@@ -256,7 +256,13 @@ with arms interleaved, means over 5 iterations, p90 26.4 s → 14.6 s and p50
 re-pays SPM's no-op build check and process startup). Quote that figure, not the
 +6 s a single iteration showed; it did not survive the other four. Splitting the
 daemon target again pays that startup cost a third time and buys the same
-halving on the half where the tail actually lives. This is not
+halving on the half where the tail actually lives. **Where the cut goes is
+measured, not guessed:** cut at `[A-L]` the two halves executed 1918 and 3703,
+which is a third and two thirds rather than a halving, so the cut moved to
+`[A-O]`. A local count of `@Test` attributed to the top-level suite that
+declares it predicted 1919 for that same cut, so use it — it is accurate to
+within a test — and re-cut from the counts CI prints whenever the halves drift
+apart again. This is not
 the "sharding across runners" that
 `docs/specs/2026-07-24-test-hardening-design.md` §1 rejected and §2 lists as a
 non-goal — that was about extra *jobs* paying the 5-concurrent-macOS-job cap and
@@ -267,7 +273,7 @@ silently zero-match like a `--filter` regex": `swift test --filter` exits GREEN
 on zero matches, so a new `TBDFooTests` named in no list would run in
 **no** pass with nothing going red — and the floors could not catch that,
 because adding a target reduces no existing step's count. Written as
-complements, 1b absorbs any daemon suite that falls outside `[A-L]` (including
+complements, 1b absorbs any daemon suite that falls outside `[A-O]` (including
 one renamed to start with a digit) and step 2 absorbs any new target, so the
 four passes partition the package by construction. The per-step floors have a
 narrower job: catching a target that *is* named in one of these regexes

--- a/Tests/CLAUDE.md
+++ b/Tests/CLAUDE.md
@@ -246,29 +246,33 @@ total wall time on green runs as well as red — a trivial test "takes" 16–29 
 because it is mostly suspended waiting for a turn. Population went 3013 → 4536
 in three weeks. Two consequences, both load-bearing.
 
-**The fast pass is two sequential steps in one job.** `test.yml` runs
-`--filter '^TBDDaemonTests\.'` then
-`--skip '^(TBDDaemonTests|TBDDaemonLiveTests)\.'`, sharing one build.
+**The fast pass is three sequential steps in one job.** `test.yml` runs
+`--filter '^TBDDaemonTests\.[A-L]'` (1a), then that filter's complement within
+the daemon target (1b), then
+`--skip '^(TBDDaemonTests|TBDDaemonLiveTests)\.'` (2), all sharing one build.
 Halving the in-flight population halves the tail: measured under induced load
 with arms interleaved, means over 5 iterations, p90 26.4 s → 14.6 s and p50
 8.8 s → 7.6 s, for **+26 s** of wall time (56 s → 82 s — the second invocation
 re-pays SPM's no-op build check and process startup). Quote that figure, not the
-+6 s a single iteration showed; it did not survive the other four. This is not
++6 s a single iteration showed; it did not survive the other four. Splitting the
+daemon target again pays that startup cost a third time and buys the same
+halving on the half where the tail actually lives. This is not
 the "sharding across runners" that
 `docs/specs/2026-07-24-test-hardening-design.md` §1 rejected and §2 lists as a
 non-goal — that was about extra *jobs* paying the 5-concurrent-macOS-job cap and
-a second ~2 min build. **Step 2 is a complement, not an enumeration, and that
-is deliberate.** Two `--filter` lists would have reintroduced the hazard the
-spec's §3 names when it calls the target boundary "compiler-enforced, cannot
+a second ~2 min build. **Steps 1b and 2 are complements, not enumerations, and
+that is deliberate.** Three `--filter` lists would have reintroduced the hazard
+the spec's §3 names when it calls the target boundary "compiler-enforced, cannot
 silently zero-match like a `--filter` regex": `swift test --filter` exits GREEN
-on zero matches, so a new `TBDFooTests` named in neither list would run in
-**neither** pass with nothing going red — and the floors could not catch that,
-because adding a target reduces no existing step's count. Written as a
-complement, step 2 absorbs any new target automatically, and the three passes
-partition the package by construction. The per-step floors have a narrower job:
-catching a target that *is* named in one of these regexes collapsing or being
-renamed, where the regex would zero-match or over-skip its way to a green run
-of nothing. Keep them updated.
+on zero matches, so a new `TBDFooTests` named in no list would run in
+**no** pass with nothing going red — and the floors could not catch that,
+because adding a target reduces no existing step's count. Written as
+complements, 1b absorbs any daemon suite that falls outside `[A-L]` (including
+one renamed to start with a digit) and step 2 absorbs any new target, so the
+four passes partition the package by construction. The per-step floors have a
+narrower job: catching a target that *is* named in one of these regexes
+collapsing or being renamed, where the regex would zero-match or over-skip its
+way to a green run of nothing. Keep them updated.
 
 **Wall-clock handshake deadlines are hang-catchers sized against the population
 of the day.** `ciSafeDeadline` (`Tests/TBDDaemonTests/ControlModeTestSupport.swift`)

--- a/docs/specs/2026-09-04-quiet-pass-stall-watchdog-design.md
+++ b/docs/specs/2026-09-04-quiet-pass-stall-watchdog-design.md
@@ -224,11 +224,11 @@ hide a pass's verdict.
 
 | Constant | Value | Basis |
 | --- | --- | --- |
-| fast pass 1a budget | 1200 s | cold-cache compile up to ~6 min + ~4 min of tests |
-| fast pass 1a `timeout-minutes` | 25 min | budget + sampling margin |
-| fast pass 1b budget | 600 s | tests only; healthy 3–4 min |
+| fast pass 1a budget | 1800 s | 1.45× the 1250 s cold-cache first pass measured over 45 runs |
+| fast pass 1a `timeout-minutes` | 35 min | budget + sampling margin |
+| fast pass 1b budget | 600 s | tests only; 128 s of step time measured |
 | fast pass 1b `timeout-minutes` | 15 min | budget + sampling margin |
-| fast pass 2 budget | 600 s | tests only; healthy 3–4 min |
+| fast pass 2 budget | 600 s | tests only; 71 s of step time measured |
 | fast pass 2 `timeout-minutes` | 15 min | budget + sampling margin |
 | quiet pass budget | 720 s | 6 × the 117 s healthy pass |
 | quiet pass `timeout-minutes` | 15 min | platform bound |
@@ -241,12 +241,21 @@ The healthy quiet pass reports `Test run with 179 tests in 37 suites passed
 after 116.847 seconds`, so its budget is six times a normal run and still three
 minutes short of the step timeout.
 
-The fast-pass budgets are sized against what those steps actually spend. Only 1a
-pays the test-target compile: three consecutive warm-cache runs on main measured
-2m22s, 3m33s and 6m02s for it, and a cold cache is slower, so 1a's budget covers
-a slow compile plus a full run of tests. 1b and 2 run against a warm build and
-finish in three to four minutes when healthy, so 600 s is comfortably more than
-double a healthy run while still ending a wedge inside the step's own bound. The
+The fast-pass budgets are sized against what those steps actually spend, and 1a
+is the only one that pays the test-target compile. Measured over the 45 most
+recent concluded runs of `test.yml` (2026-09-05 to 2026-09-09), the first test
+step took between 73 s and 1250 s. The three slowest — 1010 s (run 34255127220),
+1115 s (34267900663) and 1250 s (34255164378) — are exactly the runs whose
+"Cache SwiftPM build artifacts" step finished in 1 to 4 seconds, which is what a
+cache MISS looks like; a hit spends 25 to 56 seconds restoring. So 1250 s is the
+measured cold-cache figure, over a full 5,529-test daemon pass — more than 1a
+now runs — and 1800 s clears it by 45%. The warm-cache runs still spread
+73–996 s, because every run force-rebuilds TBDShared and TBDDaemonLib and a PR's
+first run restores only the deps-only fallback key, so a budget sized to the
+warm median would end healthy runs. 1b and 2 run against that warm build and
+measured 128 s and 71 s of step time on the split's first CI run, so 600 s is
+several times a healthy run while still ending a wedge inside the step's own
+bound. The
 step timeouts sit above their budgets by only the margin the expiry path needs:
 a step bound wide enough for per-test limits to fire first would buy nothing,
 because the watchdog names the test sooner and with a stack.

--- a/docs/specs/2026-09-04-quiet-pass-stall-watchdog-design.md
+++ b/docs/specs/2026-09-04-quiet-pass-stall-watchdog-design.md
@@ -247,10 +247,9 @@ pays the test-target compile: three consecutive warm-cache runs on main measured
 a slow compile plus a full run of tests. 1b and 2 run against a warm build and
 finish in three to four minutes when healthy, so 600 s is comfortably more than
 double a healthy run while still ending a wedge inside the step's own bound. The
-step timeouts sit above their budgets by the margin the expiry path needs; the
-30-minute bounds the fast passes used to carry existed to let per-test limits
-fire first and name a test, and the watchdog does that job both sooner and with
-a stack.
+step timeouts sit above their budgets by only the margin the expiry path needs:
+a step bound wide enough for per-test limits to fire first would buy nothing,
+because the watchdog names the test sooner and with a stack.
 
 Five seconds of sampling is what it takes to show a blocked thread
 unambiguously: a parked thread looks identical in every sample, so more buys

--- a/docs/specs/2026-09-04-quiet-pass-stall-watchdog-design.md
+++ b/docs/specs/2026-09-04-quiet-pass-stall-watchdog-design.md
@@ -71,6 +71,8 @@ where the process stopped producing, and it still names no frame.
 - **Any doubt fails closed.** An unreadable status, an unattributable stall, a
   sampling failure — none of them may pass for success.
 - **Nothing is killed by name.** Signals go to pids the step itself observed.
+- **A red pass does not suppress the verdict of the passes behind it.** One
+  flake must cost one pass, not the whole run's information.
 
 ## Scope
 
@@ -80,10 +82,11 @@ parallel pass wedged on the cooperative pool is exactly the case a per-test
 `.timeLimit` cannot reach, because cancellation cannot reach a blocked thread —
 so the step timeout is the only bound there too, and it records as little.
 
-The two fast-pass wedges above are the evidence for that scope. Before them the
-quiet pass was the only watched step, and it was also the only step that never
-produced an unexplained red: every stall that cost a rerun landed where no
-watchdog was looking.
+The evidence for that scope is where the damage falls. The unexplained reds and
+both stack-less wedges belong to the fast passes; the watched step accounts for
+none of them. A watchdog on one step therefore instruments the passes that fail
+least, which is the wrong way round, and it costs a healthy run nothing to watch
+all four.
 
 ## The mechanism
 
@@ -183,7 +186,10 @@ still alive — a fresh walk, a rebuilt order, SIGKILL to each pid, and SIGKILL 
 the subshell itself. Both sweeps rebuild rather than reuse, because sampling and
 the grace window are each long enough for the tree to change underneath a
 snapshot; the EXIT trap's own cleanup spawns processes during exactly that
-window. The script then waits for the subshell and exits 1.
+window. Each order is written into the ps file before it is acted on, because an
+ordering nobody can observe is an ordering nobody can check — and on a real
+stall it also tells a reader which processes each sweep reached. The script then
+waits for the subshell and exits 1.
 
 ### The verdict path
 
@@ -212,13 +218,51 @@ case rather than evidence of broken wiring.
 
 `scripts/ci/watched-test-pass.test.sh` drives the script against fixture
 directories with a stub `scripts/test.sh` and a stub `sample`: no build, no
-SwiftPM, nothing real touched, about 40 seconds. It covers a green pass handing
+SwiftPM, nothing real touched, about 90 seconds. It covers a green pass handing
 back its count, a 76 and an ordinary red status returned untouched, a run under
 the floor and a run with no summary line at all, a stall through the primary
-argv match and a stall through the fallback selection, and two malformed
-invocations. It runs as the last step of the `test` job, on macOS because
-everything it drives is BSD, and with `!cancelled()` so a harness bug can never
-hide a pass's verdict.
+argv match and a stall through the fallback selection, six candidates against a
+cap of four, a pipeline that outlives the grace window, the sweep order with a
+mutation that reverses it, and two malformed invocations. Most of its runtime is
+the grace window itself, which the escalation case has to wait out to measure.
+It runs as the last step of the `test` job, on macOS because everything it
+drives is BSD, and with `!cancelled()` so a harness bug can never hide a pass's
+verdict.
+
+Two fixture shapes in it are worth knowing, because both were arrived at the
+hard way. A sleeper standing in for a wedged test process must not be named
+`sleep`, or the fallback skips it as plumbing and the case asserts nothing. And
+a pipeline that outlives the grace window cannot be modelled by stopping the pty
+wrapper: a stopped process does not hold a fatal signal pending here, the kernel
+wakes it to die, so the sweep's SIGTERM takes it down and the subshell finishes
+inside the grace like any healthy teardown. Stopping the subshell itself is the
+shape that works, because the sweep signals only that subshell's descendants.
+
+## A red pass does not hide the passes behind it
+
+1b, pass 2 and the quiet pass run whenever pass 1a REPORTED — success or failure
+alike. Each carries
+`if: !cancelled() && (steps.<1a>.outcome == 'success' || steps.<1a>.outcome == 'failure')`
+against 1a's step id.
+
+GitHub's default step semantics skip everything after a failed step, and that
+turns one flake into a blackout: a handshake timeout in the tail of a fast pass
+suppresses every later pass, so the run reports one failure and nothing about
+the state of the rest of the package, and the rerun starts from the same
+ignorance. The quiet pass is the step this hurts most, because it runs last and
+is the one a fast-pass flake most reliably hides — the tier-3 live suites are
+also the ones whose failures a reader most wants to see.
+
+The cost is two to four minutes of runner time on a run that is already red, and
+nothing at all on a green one. The job still fails: these conditions decide
+whether a step *runs*, not what the job concludes.
+
+`always()` would be the wrong condition in two directions. A cancelled job must
+stop, not keep spending a rationed macOS slot on passes nobody is waiting for.
+And a run whose build or setup never reached 1a would fail every later pass on
+the same cause, turning one legible error into four illegible ones. Gating on
+1a's own outcome says exactly what is meant: the passes behind a step that
+reported get to report too.
 
 ## Numbers, and what each rests on
 

--- a/docs/specs/2026-09-04-quiet-pass-stall-watchdog-design.md
+++ b/docs/specs/2026-09-04-quiet-pass-stall-watchdog-design.md
@@ -1,18 +1,25 @@
-# Quiet-pass stall watchdog: making a wedged CI test run name its test
+# Test-pass stall watchdog: making a wedged CI test run name its test
 
-The `test` workflow runs the tier-3 live suites in their own step — serially,
-on an otherwise idle runner, because those suites drive real tmux servers and
-real child processes and contend with each other if run in parallel. That step
-sometimes stalls. GitHub kills it at its 15-minute `timeout-minutes`, and what
-lands in the run log is a truncated list of test names, no failing assertion,
-and nothing that identifies where the run stopped. Each occurrence costs fifteen
-minutes of a rationed macOS runner and reddens a pull request that has nothing
-to do with the defect.
+The `test` workflow runs the package in four passes in one job: three parallel
+fast passes that share a build, and a quiet pass that runs the tier-3 live
+suites serially on an otherwise idle runner, because those suites drive real
+tmux servers and real child processes and contend with each other if run in
+parallel. Any of those passes can stall. GitHub kills the step at its
+`timeout-minutes`, and what lands in the run log is a truncated list of test
+names, no failing assertion, and nothing that identifies where the run stopped.
+Each occurrence costs a rationed macOS runner and reddens a pull request that
+has nothing to do with the defect.
 
-Three stalls are on record. Two sit on trees that predate the
-`Process.waitUntilExit()` cross-thread hang fixed in #789 and are consistent
-with it. The third is on a tree that carries that fix, so it is a different
-site, and no one can say which — the evidence to locate it was never captured.
+The stalls on record come in two shapes. In the quiet pass, three: two sit on
+trees that predate the `Process.waitUntilExit()` cross-thread hang fixed in
+#789 and are consistent with it, and the third is on a tree that carries that
+fix, so it is a different site and no one can say which — the evidence to locate
+it was never captured. In the fast passes, two 30-minute wedges with no stack at
+all (runs 34174344530 and 34176996067), where the process went silent about five
+seconds into the test run with roughly 1,965 tests started, none finishing, zero
+issues recorded and no time limit firing: the cooperative-pool wedge signature
+that `Tests/TestSupport/BoundedGateSupport.swift` describes, where every thread
+the pool has is parked on a gate and nothing can reach a `signal()`.
 
 This design does not fix the stall. It makes the next one hand over the stacks
 of every thread in the process running the tests, plus a picture of the machine
@@ -45,6 +52,11 @@ at which a stalled run's log would stop. A line adjacent to one of those
 boundaries is evidence of nothing; the natural reading — "the last line names
 the hung test" — is wrong by construction.
 
+The fast passes emit roughly 16 KB a second, so their logs look real-time
+whether or not they are buffered. That makes buffering invisible there and it
+makes nothing about a wedge visible: when a fast pass goes silent, the log ends
+where the process stopped producing, and it still names no frame.
+
 ## Requirements
 
 - **The log streams as the run produces it.** A stalled step's last line must
@@ -60,11 +72,39 @@ the hung test" — is wrong by construction.
   sampling failure — none of them may pass for success.
 - **Nothing is killed by name.** Signals go to pids the step itself observed.
 
+## Scope
+
+All four test steps are watched, and each carries its own budget, floor and
+file names. Nothing about the mechanism is specific to the serial pass: a
+parallel pass wedged on the cooperative pool is exactly the case a per-test
+`.timeLimit` cannot reach, because cancellation cannot reach a blocked thread —
+so the step timeout is the only bound there too, and it records as little.
+
+The two fast-pass wedges above are the evidence for that scope. Before them the
+quiet pass was the only watched step, and it was also the only step that never
+produced an unexplained red: every stall that cost a rerun landed where no
+watchdog was looking.
+
 ## The mechanism
+
+One script carries it: `scripts/ci/watched-test-pass.sh`. Each step names a
+pass, a budget, a floor and the floor's explanation, and forwards the rest to
+`scripts/test.sh`:
+
+```
+scripts/ci/watched-test-pass.sh --name <name> --budget-seconds <N> \
+  --floor <N> --floor-message '<text>' [--out-dir <dir>] \
+  -- <arguments forwarded to scripts/test.sh>
+```
+
+`--name` names the log, the status file and the stall files, and names the pass
+in every message, so a reader of the job log knows which pass spoke. `--out-dir`
+defaults to `/tmp`, which is what CI uses; the harness points it at a fixture
+directory.
 
 ### Streaming the log
 
-The step hands `scripts/test.sh` a pty: `TERM=dumb script -q /dev/null …
+The script hands `scripts/test.sh` a pty: `TERM=dumb script -q /dev/null …
 < /dev/null`. C stdio line-buffers a terminal, so each line lands as it is
 produced. Nothing between the pty and SwiftPM re-pipes the stream —
 `scripts/test.sh` invokes `scripts/swift-safe` without a pipe of its own, and
@@ -83,12 +123,12 @@ nor the step's own `grep` over the summary line.
 The pipeline runs in a background subshell that begins with `set +e` — its only
 job is to run the pipeline and record `PIPESTATUS[0]` to a status file, and
 errexit would abort it before the `echo` on exactly the runs whose status
-matters most. The step's foreground shell polls the subshell with `kill -0` in
-5-second steps up to `stall_budget_seconds`.
+matters most. The script's foreground shell polls the subshell with `kill -0` in
+5-second steps up to the budget.
 
 ### Finding what to sample
 
-On expiry the step writes a whole-machine `ps` listing first and
+On expiry the script writes a whole-machine `ps` listing first and
 unconditionally. The runner is single-tenant, so that listing is both the record
 of the fixture's holder, tmux and job processes and the way a reader learns what
 anything is really called.
@@ -143,7 +183,7 @@ still alive — a fresh walk, a rebuilt order, SIGKILL to each pid, and SIGKILL 
 the subshell itself. Both sweeps rebuild rather than reuse, because sampling and
 the grace window are each long enough for the tree to change underneath a
 snapshot; the EXIT trap's own cleanup spawns processes during exactly that
-window. The step then waits for the subshell and exits 1.
+window. The script then waits for the subshell and exits 1.
 
 ### The verdict path
 
@@ -154,32 +194,63 @@ false, which would let a failed run walk on as though it had succeeded. Anything
 unreadable exits 1 with its own message.
 
 The status check comes before the floor check on `Test run with N tests`. A
-build error, an early crash, or swift-safe's 75 and 76 all log fewer than 35
-tests; reporting them through the floor's message would both misdiagnose them
+build error, an early crash, or swift-safe's 75 and 76 all log fewer tests than
+any floor; reporting them through the floor's message would both misdiagnose them
 and flatten them to a generic 1. The floor keeps its own job — catching a run
 that claims success while having executed nothing — for runs that claim success.
 
 ### The artifact
 
-An `if: always()` step uploads `/tmp/quiet-pass-stall-*.txt` as
-`quiet-pass-stall-diagnostics` with `if-no-files-found: ignore`. `ignore` rather
-than the `warn` its neighbours use: a green run deliberately produces no stall
-files, so absence is the normal case rather than evidence of broken wiring.
+An `if: always()` step uploads `/tmp/*-stall-*.txt` as
+`test-stall-diagnostics` with `if-no-files-found: ignore`. One glob collects
+whichever pass wedged, because every pass writes `<name>-stall-ps.txt` and
+`<name>-stall-sample-<pid>.txt`. `ignore` rather than the `warn` its neighbours
+use: a green run deliberately produces no stall files, so absence is the normal
+case rather than evidence of broken wiring.
+
+### The harness
+
+`scripts/ci/watched-test-pass.test.sh` drives the script against fixture
+directories with a stub `scripts/test.sh` and a stub `sample`: no build, no
+SwiftPM, nothing real touched, about 40 seconds. It covers a green pass handing
+back its count, a 76 and an ordinary red status returned untouched, a run under
+the floor and a run with no summary line at all, a stall through the primary
+argv match and a stall through the fallback selection, and two malformed
+invocations. It runs as the last step of the `test` job, on macOS because
+everything it drives is BSD, and with `!cancelled()` so a harness bug can never
+hide a pass's verdict.
 
 ## Numbers, and what each rests on
 
 | Constant | Value | Basis |
 | --- | --- | --- |
-| `stall_budget_seconds` | 720 s | 6 × the 117 s healthy pass |
-| step `timeout-minutes` | 15 min | platform bound |
-| margin left after the budget | 180 s | 42 s used at worst measurement |
+| fast pass 1a budget | 1200 s | cold-cache compile up to ~6 min + ~4 min of tests |
+| fast pass 1a `timeout-minutes` | 25 min | budget + sampling margin |
+| fast pass 1b budget | 600 s | tests only; healthy 3–4 min |
+| fast pass 1b `timeout-minutes` | 15 min | budget + sampling margin |
+| fast pass 2 budget | 600 s | tests only; healthy 3–4 min |
+| fast pass 2 `timeout-minutes` | 15 min | budget + sampling margin |
+| quiet pass budget | 720 s | 6 × the 117 s healthy pass |
+| quiet pass `timeout-minutes` | 15 min | platform bound |
+| margin left after the quiet budget | 180 s | 42 s used at worst measurement |
 | `sample` duration per target | 5 s | ~5000 stacks at 1 ms |
 | SIGTERM → SIGKILL grace | 30 s | cleanup takes a few seconds |
 | sample-target cap (both paths) | 4 | 3 used in the measured probe |
 
-The healthy pass reports `Test run with 179 tests in 37 suites passed after
-116.847 seconds`, so the budget is six times a normal run and still three
+The healthy quiet pass reports `Test run with 179 tests in 37 suites passed
+after 116.847 seconds`, so its budget is six times a normal run and still three
 minutes short of the step timeout.
+
+The fast-pass budgets are sized against what those steps actually spend. Only 1a
+pays the test-target compile: three consecutive warm-cache runs on main measured
+2m22s, 3m33s and 6m02s for it, and a cold cache is slower, so 1a's budget covers
+a slow compile plus a full run of tests. 1b and 2 run against a warm build and
+finish in three to four minutes when healthy, so 600 s is comfortably more than
+double a healthy run while still ending a wedge inside the step's own bound. The
+step timeouts sit above their budgets by the margin the expiry path needs; the
+30-minute bounds the fast passes used to carry existed to let per-test limits
+fire first and name a test, and the watchdog does that job both sooner and with
+a stack.
 
 Five seconds of sampling is what it takes to show a blocked thread
 unambiguously: a parked thread looks identical in every sample, so more buys
@@ -195,14 +266,6 @@ arrive with its own runner timestamp (33803510307), and that a name match finds
 nothing against a live pass, which is what moved target selection to lineage and
 argv (33803510307, then 33805317227 sampling the helper by pid and uploading the
 artifact).
-
-## Scope
-
-Only the quiet pass gets the pty and the watchdog. The two fast passes run the
-parallel, in-process suites; they have never stalled, and they emit output fast
-enough that buffering is invisible. Every stall on record is in the serial live
-target. A fast-pass stall would be a different defect and earns its own
-instrumentation on its own evidence.
 
 ## Who reclaims the orphans
 
@@ -221,23 +284,24 @@ that made it.
   ever daemonised the runner, the tree walk would find nothing sampleable, the
   step would say so, and the whole-machine listing would still show where the
   process went.
-- **`script(1)` propagates the child's non-zero exit status on macOS.** Verified
+- **`script(1)` propagates the child's exit status on macOS.** Verified
   locally (`script -q /dev/null /bin/sh -c 'exit 3'` returns 3) and in Apple's
-  `shell_cmds` source; the success direction is confirmed by a green CI run. The
-  failure direction can be confirmed on demand with a throwaway commit that makes
-  `scripts/test.sh` exit non-zero. If it ever stopped holding, a red run would
-  surface as an unreadable or zero status — and the validation above fails
-  closed, so the failure mode is a spurious red, not a false green.
+  `shell_cmds` source; the success direction is confirmed by a green CI run, and
+  the harness asserts both a 3 and a 76 reaching the caller through the pty. If
+  it ever stopped holding, a red run would surface as an unreadable or zero
+  status — and the validation above fails closed, so the failure mode is a
+  spurious red, not a false green.
 
 ## Reading a stall report
 
-Download the `quiet-pass-stall-diagnostics` artifact from the failed run.
-`quiet-pass-stall-sample-<pid>.txt` carries every thread's stack of the process
+Download the `test-stall-diagnostics` artifact from the failed run.
+`<pass>-stall-sample-<pid>.txt` carries every thread's stack of the process
 that was executing tests; the parked thread's frames name the file and line the
-run is blocked in. `quiet-pass-stall-ps.txt` carries the machine listing, the
+run is blocked in. `<pass>-stall-ps.txt` carries the machine listing, the
 pipeline's descendants and the sampled processes, which is where the fixture's
 holder, tmux and job processes appear and where the cap's skipped-candidate line
-would be. The step log names the budget it waited and the pids it sampled.
+would be. The step log names the pass, the budget it waited and the pids it
+sampled.
 
 ## Rejected alternatives
 
@@ -252,6 +316,15 @@ would be. The step log names the budget it waited and the pids it sampled.
   flush knob. A pty is the mechanism the platform actually offers.
 - **Lowering `timeout-minutes`.** It would end the stall sooner and record
   exactly as much as it does today, which is nothing.
+- **Watching only the serial pass.** The premise was that the parallel passes
+  never stall and emit output fast enough for buffering to be invisible. The
+  second half is true and the first is not: a cooperative-pool wedge parks every
+  thread the pool has, no per-test time limit can reach it, and the two 30-minute
+  fast-pass wedges produced no stack at all. One script watching every pass costs
+  a step nothing on a healthy run.
+- **Inlining the watchdog in each step's YAML.** Four copies of a hundred lines
+  of shell, drifting apart, with no way to test any of them. A script has a
+  harness; a `run:` block does not.
 - **Changing the eight blocking `waitpid(…, 0)` sites in the fixtures.** The
   leading hypothesis was the holder fixture's teardown, and it does not hold on
   the merits: the holder detaches with its own `setsid()`, keeps no controlling

--- a/scripts/ci/watched-test-pass.sh
+++ b/scripts/ci/watched-test-pass.sh
@@ -394,6 +394,16 @@ if kill -0 "$pipeline" 2>/dev/null; then
       deeper_first="$pid $deeper_first"
     done
     for pid in $direct_children; do
+      # The same `is_target` skip the deep walk above applies, so a sampled
+      # target is filtered out of EVERY order rather than only most of them.
+      # By construction the direct children are `script` and `tee`, and neither
+      # can be a target — the fallback excludes both by name, and no forwarded
+      # argument carries `swiftpm-testing`, `xctest` or `TBDPackageTests` — so
+      # this closes a documented invariant rather than a reachable path, which
+      # is why the harness has no fixture for it.
+      if is_target "$pid"; then
+        continue
+      fi
       comm=$(ps -o comm= -p "$pid" 2>/dev/null || true)
       case "${comm##*/}" in
         tee) tee_pids="$tee_pids $pid" ;;

--- a/scripts/ci/watched-test-pass.sh
+++ b/scripts/ci/watched-test-pass.sh
@@ -138,7 +138,8 @@
 # Both sweeps rebuild the order from a fresh walk rather than reusing an earlier
 # snapshot: sampling several targets takes 20 s or more and the grace window is
 # another 30 s, and the EXIT trap's own cleanup spawns processes during exactly
-# that window.
+# that window. Each order is also written into the ps file before it is acted
+# on, because an ordering nobody can observe is an ordering nobody can check.
 #
 # WHY 30 SECONDS OF GRACE. That is what `scripts/test.sh`'s EXIT trap gets to
 # run its tmux `kill-server` sweep and fence checks — generous against the few
@@ -412,7 +413,23 @@ if kill -0 "$pipeline" 2>/dev/null; then
     done
     kill_order="$deeper_first $direct_others $tee_pids"
   }
+  # The order is written into the artifact as well as acted on. It is the only
+  # way to check after the fact that `tee` really was signalled last and the
+  # deepest descendants first — the property the block above claims — and on a
+  # real stall it also tells a reader which processes each sweep reached.
+  record_kill_order() {
+    local label="$1" pid comm line=""
+    for pid in $kill_order; do
+      comm=$(ps -o comm= -p "$pid" 2>/dev/null || true)
+      line="$line $pid(${comm##*/})"
+    done
+    {
+      echo
+      echo "=== $label order, deepest first and tee last ===$line"
+    } >> "$stall_ps_file"
+  }
   build_kill_order
+  record_kill_order SIGTERM
   for pid in $kill_order; do
     kill -TERM "$pid" 2>/dev/null || true
   done
@@ -423,6 +440,7 @@ if kill -0 "$pipeline" 2>/dev/null; then
   done
   if kill -0 "$pipeline" 2>/dev/null; then
     build_kill_order
+    record_kill_order SIGKILL
     for pid in $kill_order; do
       kill -KILL "$pid" 2>/dev/null || true
     done

--- a/scripts/ci/watched-test-pass.sh
+++ b/scripts/ci/watched-test-pass.sh
@@ -1,0 +1,447 @@
+#!/usr/bin/env bash
+#
+# Run one test pass under a stall watchdog, and turn its outcome into a verdict.
+#
+#   scripts/ci/watched-test-pass.sh --name <name> --budget-seconds <N> \
+#     --floor <N> --floor-message '<text>' [--out-dir <dir>] \
+#     -- <arguments forwarded to scripts/test.sh>
+#
+# `--name` names every file the pass writes, under `--out-dir` (default /tmp):
+# `<name>.log`, `<name>.rc`, `<name>-stall-ps.txt` and, per sampled process,
+# `<name>-stall-sample-<pid>.txt`. It also names the pass in every `::error::`
+# line and in the closing "executed N tests" line, so a reader of the job log
+# knows which pass spoke without matching step boundaries.
+#
+# Every test step in `.github/workflows/test.yml` goes through here. The design
+# is `docs/specs/2026-09-04-quiet-pass-stall-watchdog-design.md`; the rationale
+# below is the part a reader of THIS file needs, and the spec carries the
+# evidence and the rejected alternatives.
+#
+# ---------------------------------------------------------------------------
+# WHAT IT IS FOR
+#
+# GitHub's step timeout leaves no evidence. A stall is a thread blocked
+# somewhere no Swift Testing time limit can reach — a wedged cooperative pool,
+# or a blocking wait off it — so the step timeout is the only bound, and being
+# killed by it records nothing about which test or which frame. The watchdog
+# bounds the run itself: on expiry it captures every thread's stack of the
+# processes executing the tests, plus a picture of the machine around them,
+# then fails the step while the platform timeout still has margin left.
+#
+# ---------------------------------------------------------------------------
+# WHY A PTY
+#
+# On the serial (`--no-parallel`) path SwiftPM relays the test binary's output
+# through `print($0, terminator: "")` on its own stdout
+# (`SwiftTestCommand.runTestProducts`). `scripts/test.sh` runs
+# `scripts/swift-safe` with no pipe of its own and `swift-safe` `os.execv`s the
+# toolchain driver, so whatever this script hands the wrapper becomes SwiftPM's
+# stdout. Piping into `tee` makes that stdout a pipe, and C stdio then fully
+# buffers it in 16 KB blocks (a pipe's `st_blksize` on macOS). The quiet pass
+# emits roughly 16 KB per minute, so its log lagged the run by about a minute
+# and was cut at an arbitrary byte boundary: runs 33797806278 (stalled) and
+# 33787142345 (green) both stopped at exactly byte 16384, mid-way through the
+# same `keepsTheReaderForAJobThatIsStillRunning()` line. The last line a wedged
+# step showed was the buffer boundary, not the hung test. The fast passes only
+# look real-time because they emit 16 KB a second.
+#
+# `TERM=dumb script -q /dev/null … < /dev/null` makes SwiftPM's stdout a
+# terminal, so C stdio line-buffers it and every line lands as it is produced.
+# Each part earns its place: `script` propagates the child's exit status, so the
+# verdict still reaches the caller; `< /dev/null` guarantees nothing ever waits
+# on the pty for input; `TERM=dumb` keeps SwiftPM's build progress line-oriented
+# instead of cursor-rewriting animations. The pty translates `\n` to `\r\n`,
+# which is harmless both to the runner log and to the `grep -oE 'Test run with
+# [0-9]+ tests?'` floor check below.
+#
+# ---------------------------------------------------------------------------
+# WHY LINEAGE, NEVER NAMES
+#
+# On expiry the whole machine's process listing is written first and
+# unconditionally. The runner is single-tenant, so that listing is both the
+# record of the fixture's holder, tmux and job processes and the way we learn
+# what anything is really called.
+#
+# The processes to sample are then found structurally, by descending the
+# pipeline subshell's own tree with `pgrep -P`, and never by name: a CI probe of
+# this watchdog matched `pgrep -x TBDPackageTests` against a live pass and found
+# nothing, because the swift-testing binary does not run under its bundle name.
+# A name match fails silently — it samples nothing and reports success at having
+# collected nothing — whereas a tree walk finds whatever the pipeline actually
+# spawned.
+#
+# WHY THE ARGV MATCH. The test binary is picked out of those descendants by
+# matching `swiftpm-testing`, `xctest` or `TBDPackageTests` anywhere in the full
+# argv from `ps -o command=`, not against a name: SwiftPM's
+# `TestRunner.args(forTestAt:)` runs a swift-testing bundle as
+# `<toolchain>/swiftpm-testing-helper --test-bundle-path <bundle> …
+# --testing-library swift-testing` and an XCTest bundle as `<toolchain>/xctest
+# <bundle>`, so the process executing the tests is the helper and never carries
+# the bundle's own name — and the kernel truncates `p_comm` to 15 characters,
+# which would render the helper as `swiftpm-testing` anyway. Matching unanchored
+# against argv — read with `-ww` so ps never clips the long toolchain path —
+# sidesteps both the truncation and the path prefix.
+#
+# WHY A FALLBACK. When no descendant matches, every descendant that is not known
+# plumbing (`script`, the shells, `tee`, `sleep`, python, `swift-safe`) is worth
+# a stack, and the list is short enough that sampling all of them costs nothing.
+# SwiftPM's own driver is included deliberately: when nothing looks like a test
+# runner, the driver's stack is evidence about what it was waiting on, which is
+# exactly the question such a stall poses.
+#
+# WHY A CAP OF FOUR. Both selection paths take at most `sample_target_cap`
+# processes, in walk order (parents before children, so SwiftPM's driver comes
+# ahead of the compiler processes it spawns — in a stall during compilation the
+# driver's own stack is the more informative one). A match count is not a
+# process count: while the package is compiling, the bundle path
+# `.build/<triple>/debug/TBDPackageTests.build/…` appears in the argv of every
+# concurrent compiler process, so the argv match can select a dozen at once, and
+# at ~5 s of serial sampling each that would eat the margin and leave the step
+# to be killed by `timeout-minutes` after all. Whatever a cap drops is recorded
+# in the ps file, and the whole-machine listing still names every matching
+# process, so nothing disappears from the artifact — only from the sampling.
+#
+# Measured on a probe of the fallback path with the argv match disabled (run
+# 33902144920): three of the four slots used — SwiftPM's `swift-test` driver at
+# 87 KB, `swiftpm-testing-helper` at 796 KB symbolicated, and a fixture
+# `TBDHolder` that exited mid-sample and was reported as failed — and the whole
+# expiry path, from the whole-machine ps through the tree walk, the three serial
+# samples and the SIGTERM sweep to the step exiting, took 42 s.
+#
+# WHY FIVE SECONDS OF `sample`. `/usr/bin/sample` — part of macOS, present on
+# the runner image — captures every thread's stack of each target. Five seconds
+# at sample's 1 ms interval is what it takes to show a blocked thread's stack
+# unambiguously: a parked thread looks identical in every sample so a longer
+# capture buys nothing, while a shorter one risks reading a scheduler blip as
+# the stall — and symbolicating the ~200 MB debug helper still finishes well
+# inside the margin the budget leaves.
+#
+# ---------------------------------------------------------------------------
+# WHY THE KILL ORDER IS BUILT AND NOT REVERSED, AND WHY `tee` DIES LAST
+#
+# Each sampled target is SIGKILLed the moment its stacks are captured: it is
+# wedged, and it has already given up everything it has to give. They are then
+# filtered out of every order built from here on — signalling a dead pid is
+# inert at best and reaches whatever reused the number at worst.
+#
+# The remaining processes get a graceful pass, because `scripts/test.sh` has an
+# EXIT trap that sweeps tmux servers and checks its filesystem fence, and that
+# cleanup is worth running. `tee` is a direct child of the subshell and owns the
+# far end of the log pipe, so anything still writing when `tee` dies writes to a
+# closed pipe — and the EXIT trap's cleanup output is exactly what the log
+# wants. The walk is preorder (`script`, then all of script's subtree, then the
+# sibling `tee`), so a plain reversal would signal `tee` FIRST, precisely
+# backwards. The order is therefore built explicitly: everything below the
+# direct children first (that subset reversed, so deepest-first), then the
+# direct children other than `tee`, then `tee`.
+#
+# Both sweeps rebuild the order from a fresh walk rather than reusing an earlier
+# snapshot: sampling several targets takes 20 s or more and the grace window is
+# another 30 s, and the EXIT trap's own cleanup spawns processes during exactly
+# that window.
+#
+# WHY 30 SECONDS OF GRACE. That is what `scripts/test.sh`'s EXIT trap gets to
+# run its tmux `kill-server` sweep and fence checks — generous against the few
+# seconds those take, and still inside the margin the budget leaves. SIGTERM
+# goes first for the same reason; SIGKILL follows only if the subshell is still
+# alive after the grace, to a rebuilt order and then to the subshell itself.
+# Taking the pipeline down within a bounded window is the point: leaving `wait`
+# to block until `timeout-minutes` fires is the very outcome this budget exists
+# to avoid.
+#
+# ---------------------------------------------------------------------------
+# WHY THE STATUS IS VALIDATED, AND WHY IT COMES BEFORE THE FLOOR
+#
+# The pipeline's status is written to the rc file by the background subshell.
+# An unreadable status fails closed, the same way the floor guards its own empty
+# `count`: the `|| echo 1` covers only a missing file, and a writer that died
+# mid-write leaves an empty or non-numeric one, on which `[ "$rc" -ne 0 ]`
+# errors — and an erroring `if` condition reads as false, letting a failed run
+# walk on to the floor check as though it had succeeded.
+#
+# THE STATUS IS THEN RETURNED UNTOUCHED, and that matters beyond tidiness:
+# `scripts/swift-safe` exits 75 for an abandoned queue wait and 76 for "yielded
+# the queue, verify remotely", and the remote verification valve
+# (docs/specs/2026-08-16-remote-verification-valve-design.md) routes on 76 and
+# only on 76. Flattening either to 1, or conflating the two, is a silent wrong
+# answer. The status also comes FIRST, before the floor: a build error, an early
+# crash, or a 75/76 all log fewer tests than any floor, and reporting them
+# through the floor's message would both misdiagnose them and flatten them. The
+# floor only means anything for a run that claims to have succeeded.
+#
+# ---------------------------------------------------------------------------
+# STRICTNESS
+#
+# `set -uo pipefail`, deliberately WITHOUT errexit. This script's whole output is
+# a verdict, and under errexit any incidental non-zero — a `ps` on a process
+# that just exited, a `grep` that found no summary line — would abort it and
+# report the failing command's status in place of the pass's own. Every step
+# that can fail is therefore guarded explicitly, and the `|| true` guards below
+# are kept so the code stays correct if errexit is ever added around it.
+#
+# The pipeline subshell nevertheless says `set +e` out loud: its only job is to
+# run the pipeline and record `PIPESTATUS[0]`, and errexit there would abort it
+# before the `echo` on exactly the runs whose status matters most.
+#
+# Bash 3.2 compatible, because macOS ships 3.2 as /bin/bash and the harness
+# `scripts/ci/watched-test-pass.test.sh` is verified against it.
+
+set -uo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+usage: watched-test-pass.sh --name <name> --budget-seconds <N> --floor <N>
+                            --floor-message <text> [--out-dir <dir>]
+                            -- <arguments forwarded to scripts/test.sh>
+
+  --name           names the log, rc and stall files, and the pass in messages.
+                   Letters, digits, dot, dash and underscore only.
+  --budget-seconds how long the pass may run before it is sampled and killed.
+  --floor          the smallest test count a run claiming success may report.
+  --floor-message  the explanation appended to the floor's ::error:: line.
+  --out-dir        where the files are written (default: /tmp).
+  --               everything after this is forwarded to scripts/test.sh.
+USAGE
+}
+
+die_usage() {
+  echo "watched-test-pass.sh: $1" >&2
+  usage
+  exit 64
+}
+
+name=""
+budget_seconds=""
+floor=""
+floor_message=""
+out_dir="/tmp"
+forwarded=()
+saw_separator=0
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --name) [ "$#" -ge 2 ] || die_usage "--name needs a value"; name="$2"; shift 2 ;;
+    --budget-seconds) [ "$#" -ge 2 ] || die_usage "--budget-seconds needs a value"; budget_seconds="$2"; shift 2 ;;
+    --floor) [ "$#" -ge 2 ] || die_usage "--floor needs a value"; floor="$2"; shift 2 ;;
+    --floor-message) [ "$#" -ge 2 ] || die_usage "--floor-message needs a value"; floor_message="$2"; shift 2 ;;
+    --out-dir) [ "$#" -ge 2 ] || die_usage "--out-dir needs a value"; out_dir="$2"; shift 2 ;;
+    --) saw_separator=1; shift; forwarded=("$@"); break ;;
+    -h|--help) usage; exit 0 ;;
+    *) die_usage "unrecognised argument '$1'" ;;
+  esac
+done
+
+[ -n "$name" ] || die_usage "--name is required"
+case "$name" in
+  *[!A-Za-z0-9._-]*) die_usage "--name '$name' must be letters, digits, dot, dash or underscore" ;;
+esac
+case "$budget_seconds" in
+  ''|*[!0-9]*) die_usage "--budget-seconds must be a whole number of seconds (got '$budget_seconds')" ;;
+esac
+[ "$budget_seconds" -gt 0 ] || die_usage "--budget-seconds must be greater than zero"
+case "$floor" in
+  ''|*[!0-9]*) die_usage "--floor must be a whole number (got '$floor')" ;;
+esac
+[ -n "$floor_message" ] || die_usage "--floor-message is required"
+[ -d "$out_dir" ] || die_usage "--out-dir '$out_dir' is not a directory"
+[ "$saw_separator" -eq 1 ] || die_usage "the -- separator is required, even with nothing after it"
+
+# Resolved to an absolute path, so the pass does not depend on the caller's
+# working directory. `scripts/test.sh` cds to the repository root itself.
+here="$(cd "$(dirname "$0")" && pwd)"
+test_script="$(cd "$here/.." && pwd)/test.sh"
+if [ ! -x "$test_script" ]; then
+  echo "::error::$name cannot run: $test_script is missing or not executable."
+  exit 1
+fi
+
+log_file="$out_dir/$name.log"
+rc_file="$out_dir/$name.rc"
+stall_ps_file="$out_dir/$name-stall-ps.txt"
+
+rm -f "$rc_file"
+(
+  # This subshell's only job is to run the pipeline and record its status, so
+  # errexit is wrong here: on a red run it would abort the subshell before the
+  # `echo` below and discard the very status we came to capture (a real
+  # failure, or swift-safe's 75/76).
+  set +e
+  TERM=dumb script -q /dev/null "$test_script" ${forwarded[@]+"${forwarded[@]}"} \
+    < /dev/null 2>&1 | tee "$log_file"
+  echo "${PIPESTATUS[0]}" > "$rc_file"
+) &
+pipeline=$!
+waited=0
+while kill -0 "$pipeline" 2>/dev/null && [ "$waited" -lt "$budget_seconds" ]; do
+  sleep 5
+  waited=$((waited + 5))
+done
+
+# Collect a process tree by parent pid, so targets are found by lineage from the
+# pipeline rather than by executable name.
+descendants() {
+  local parent="$1" child
+  for child in $(pgrep -P "$parent" || true); do
+    echo "$child"
+    descendants "$child"
+  done
+}
+
+if kill -0 "$pipeline" 2>/dev/null; then
+  echo "::error::$name has been running for ${budget_seconds}s and is being sampled before it is killed."
+  {
+    echo "=== whole-machine process listing at stall (pass $name, budget ${budget_seconds}s) ==="
+    ps -ww -axo pid,ppid,pgid,stat,%cpu,etime,comm,command || true
+  } > "$stall_ps_file"
+  kids=$(descendants "$pipeline" || true)
+  {
+    echo
+    echo "=== descendants of the pipeline subshell (pid $pipeline) ==="
+  } >> "$stall_ps_file"
+  if [ -n "$kids" ]; then
+    kid_list=$(printf '%s\n' "$kids" | paste -sd, -)
+    ps -ww -o pid,ppid,pgid,stat,%cpu,etime,comm,command -p "$kid_list" >> "$stall_ps_file" || true
+  else
+    echo "(none)" >> "$stall_ps_file"
+  fi
+  sample_target_cap=4
+  targets=""
+  primary_taken=0
+  primary_skipped=0
+  for pid in $kids; do
+    argv=$(ps -ww -o command= -p "$pid" 2>/dev/null || true)
+    case "$argv" in
+      *swiftpm-testing*|*xctest*|*TBDPackageTests*) ;;
+      *) continue ;;
+    esac
+    if [ "$primary_taken" -lt "$sample_target_cap" ]; then
+      targets="$targets $pid"
+      primary_taken=$((primary_taken + 1))
+    else
+      primary_skipped=$((primary_skipped + 1))
+    fi
+  done
+  if [ "$primary_skipped" -gt 0 ]; then
+    echo "(primary sampling capped at $sample_target_cap targets; $primary_skipped further candidates skipped)" >> "$stall_ps_file"
+  fi
+  if [ -z "$targets" ]; then
+    fallback_taken=0
+    fallback_skipped=0
+    for pid in $kids; do
+      comm=$(ps -o comm= -p "$pid" 2>/dev/null || true)
+      case "${comm##*/}" in
+        ""|script|bash|sh|tee|sleep|Python|python3|swift-safe) continue ;;
+      esac
+      if [ "$fallback_taken" -lt "$sample_target_cap" ]; then
+        targets="$targets $pid"
+        fallback_taken=$((fallback_taken + 1))
+      else
+        fallback_skipped=$((fallback_skipped + 1))
+      fi
+    done
+    if [ "$fallback_skipped" -gt 0 ]; then
+      echo "(fallback sampling capped at $sample_target_cap targets; $fallback_skipped further candidates skipped)" >> "$stall_ps_file"
+    fi
+  fi
+  if [ -z "$targets" ]; then
+    echo "The pipeline has no sampleable descendants — $stall_ps_file carries the whole-machine listing instead."
+  else
+    {
+      echo
+      echo "=== sampled processes ==="
+    } >> "$stall_ps_file"
+    for pid in $targets; do
+      ps -ww -o pid,comm,command -p "$pid" >> "$stall_ps_file" || true
+      sample "$pid" 5 -mayDie -file "$out_dir/$name-stall-sample-$pid.txt" || echo "sample $pid failed"
+    done
+    for pid in $targets; do
+      kill -KILL "$pid" 2>/dev/null || true
+    done
+  fi
+  is_target() {
+    local needle="$1" candidate
+    for candidate in $targets; do
+      if [ "$candidate" = "$needle" ]; then
+        return 0
+      fi
+    done
+    return 1
+  }
+  is_direct_child() {
+    local needle="$1" child
+    for child in $direct_children; do
+      if [ "$child" = "$needle" ]; then
+        return 0
+      fi
+    done
+    return 1
+  }
+  build_kill_order() {
+    local pid comm remaining="" deeper_first="" direct_others="" tee_pids=""
+    kids=$(descendants "$pipeline" || true)
+    for pid in $kids; do
+      if is_target "$pid"; then
+        continue
+      fi
+      remaining="$remaining $pid"
+    done
+    kids="$remaining"
+    direct_children=$(pgrep -P "$pipeline" || true)
+    for pid in $kids; do
+      if is_direct_child "$pid"; then
+        continue
+      fi
+      deeper_first="$pid $deeper_first"
+    done
+    for pid in $direct_children; do
+      comm=$(ps -o comm= -p "$pid" 2>/dev/null || true)
+      case "${comm##*/}" in
+        tee) tee_pids="$tee_pids $pid" ;;
+        *) direct_others="$direct_others $pid" ;;
+      esac
+    done
+    kill_order="$deeper_first $direct_others $tee_pids"
+  }
+  build_kill_order
+  for pid in $kill_order; do
+    kill -TERM "$pid" 2>/dev/null || true
+  done
+  teardown_waited=0
+  while kill -0 "$pipeline" 2>/dev/null && [ "$teardown_waited" -lt 30 ]; do
+    sleep 1
+    teardown_waited=$((teardown_waited + 1))
+  done
+  if kill -0 "$pipeline" 2>/dev/null; then
+    build_kill_order
+    for pid in $kill_order; do
+      kill -KILL "$pid" 2>/dev/null || true
+    done
+    kill -KILL "$pipeline" 2>/dev/null || true
+  fi
+  wait "$pipeline" || true
+  exit 1
+fi
+
+wait "$pipeline" || true
+rc=$(cat "$rc_file" 2>/dev/null || echo 1)
+case "$rc" in
+  ''|*[!0-9]*)
+    echo "::error::$name left no readable exit status (got '$rc'); treating the run as failed."
+    exit 1 ;;
+esac
+if [ "$rc" -ne 0 ]; then
+  echo "::error::$name exited $rc"
+  exit "$rc"
+fi
+# `|| true`: a log with no summary line makes the first `grep` exit 1, and under
+# a surrounding errexit a failing command substitution in an assignment kills
+# the shell — so the truncated-run case this floor exists for would die before
+# ever reaching the `::error::` below.
+count=$(grep -oE 'Test run with [0-9]+ tests?' "$log_file" | grep -oE '[0-9]+' | head -1 || true)
+# A `--filter`/`--skip` regex exits GREEN on zero matches, so a bad regex or a
+# renamed target would otherwise silently run nothing and pass.
+if [ -z "$count" ] || [ "$count" -lt "$floor" ]; then
+  echo "::error::$name ran ${count:-no} tests (floor $floor) — $floor_message"
+  exit 1
+fi
+echo "$name executed $count tests."

--- a/scripts/ci/watched-test-pass.test.sh
+++ b/scripts/ci/watched-test-pass.test.sh
@@ -30,8 +30,11 @@
 #
 # EACH COMPLETED-RUN CASE COSTS ABOUT FIVE SECONDS, because the script polls the
 # pipeline in 5-second steps and a stub that finishes instantly is still
-# observed alive on the first look. The whole file is well under a minute.
+# observed alive on the first look. The escalation case costs the 30-second
+# grace window on top, because that window is the thing it is measuring, which
+# puts the whole file at about 90 seconds.
 # shellcheck disable=SC2329 # test_* are dispatched dynamically via `declare -F` below
+# shellcheck disable=SC2016 # the sed mutation expression must NOT expand here
 set -uo pipefail
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
@@ -43,7 +46,8 @@ assert_contains() { case "$2" in *"$3"*) echo "ok   - $1" ;; *) echo "FAIL - $1:
 assert_file_has() { if [ -f "$2" ] && grep -q -- "$3" "$2"; then echo "ok   - $1"; else echo "FAIL - $1: $2 lacks [$3]"; FAIL=1; fi; }
 assert_true()     { local label="$1"; shift; if "$@"; then echo "ok   - $label"; else echo "FAIL - $label"; FAIL=1; fi; }
 assert_ok()       { if [ "$2" = "0" ]; then echo "ok   - $1"; else echo "FAIL - $1: expected exit 0, got $2"; FAIL=1; fi; }
-assert_dead()     { if kill -0 "$2" 2>/dev/null; then echo "FAIL - $1: pid $2 is still alive"; FAIL=1; else echo "ok   - $1"; fi; }
+assert_dead()     { case "$2" in ''|*[!0-9]*) echo "FAIL - $1: '$2' is not a pid, so nothing was checked"; FAIL=1; return ;; esac
+                    if kill -0 "$2" 2>/dev/null; then echo "FAIL - $1: pid $2 is still alive"; FAIL=1; else echo "ok   - $1"; fi; }
 mktmpd()          { mktemp -d "${TMPDIR:-/tmp}/watched-pass-test.XXXXXX"; }
 
 # Fixtures and any sleeper this file started, reclaimed on the way out. The
@@ -101,6 +105,19 @@ mkfix() {
 #   stall    record this pid (the exec below keeps it) and block until killed.
 #            STUB_SLEEPER names the executable, which decides whether the
 #            script's primary argv match or its fallback selection picks it up.
+#   cap      spawn STUB_SLEEPER_COUNT sleepers that all match the primary path,
+#            record every pid, and wait on them. More candidates than the
+#            sampling cap, so the cap's counting and its skip line are driven.
+#   escalate stop the PIPELINE SUBSHELL — the script's own background job, this
+#            stub's grandparent — then block on a sleeper nothing will sample.
+#            The sweep signals only the subshell's descendants, so a stopped
+#            subshell is alive when the grace window opens and still alive when
+#            it closes, which is the one shape that reaches the SIGKILL
+#            escalation. Stopping the pty wrapper instead does NOT work and it
+#            is worth knowing why: a stopped process does not hold a fatal
+#            signal pending on this platform, the kernel wakes it to die, so the
+#            sweep's SIGTERM takes the wrapper down, `tee` sees EOF and the
+#            subshell finishes inside the grace like any healthy teardown.
 set -u
 echo "stub test.sh argv: $*"
 case "${STUB_MODE:-summary}" in
@@ -113,6 +130,23 @@ case "${STUB_MODE:-summary}" in
   stall)
     echo "$$" > "$STUB_PID_FILE"
     exec "$STUB_SLEEPER" -t 60
+    ;;
+  cap)
+    spawned=0
+    while [ "$spawned" -lt "${STUB_SLEEPER_COUNT:-6}" ]; do
+      "$STUB_SLEEPER" -t 60 &
+      echo "$!" >> "$STUB_PID_FILE"
+      spawned=$((spawned + 1))
+    done
+    wait
+    ;;
+  escalate)
+    echo "$$" > "$STUB_PID_FILE"
+    # $PPID is the pty wrapper; its parent is the pipeline subshell.
+    subshell=$(ps -o ppid= -p "$PPID" | tr -d ' ')
+    echo "$subshell" > "$STUB_PIPELINE_FILE"
+    kill -STOP "$subshell"
+    exec "$STUB_PLAIN_SLEEPER" 60
     ;;
 esac
 STUB
@@ -140,16 +174,37 @@ SAMPLE
 
 # Run the script under test against a fixture. Sets RUN_OUT and RUN_RC.
 # Extra environment for the stub goes in RUN_ENV before the call.
+#
+# RUN_SCRIPT names the copy to run, so a case can run a MUTANT of the script in
+# place of the real one. Empty means the fixture's faithful copy, which is every
+# case but the ordering mutation.
 RUN_ENV=()
+RUN_SCRIPT=""
 run_pass() {
   local fix="$1"; shift
   RUN_OUT="$(PATH="$fix/bin:$PATH" \
     SAMPLE_ARGV_FILE="$fix/sample-argv" \
     STUB_PID_FILE="$fix/sleeper.pid" \
+    STUB_PIPELINE_FILE="$fix/pipeline.pid" \
     STUB_SLEEPER="/usr/bin/caffeinate" \
+    STUB_PLAIN_SLEEPER="/bin/sleep" \
     env ${RUN_ENV[@]+"${RUN_ENV[@]}"} \
-    /bin/bash "$fix/scripts/ci/watched-test-pass.sh" "$@" 2>&1)"
+    /bin/bash "${RUN_SCRIPT:-$fix/scripts/ci/watched-test-pass.sh}" "$@" 2>&1)"
   RUN_RC=$?
+}
+
+# A copy of the script with one guard weakened by `sed`, run exactly as the real
+# one is. A green mutant means the assertion above it was not testing that guard.
+# It is written NEXT TO the fixture's faithful copy, because the script resolves
+# `scripts/test.sh` relative to its own directory.
+MUTANT_SEQ=0
+mutant_of() {
+  local fix="$1" sed_expr="$2" out
+  MUTANT_SEQ=$((MUTANT_SEQ + 1))
+  out="$fix/scripts/ci/mutant.$MUTANT_SEQ.sh"
+  sed -E "$sed_expr" "$SCRIPT" > "$out"
+  chmod +x "$out"
+  echo "$out"
 }
 
 # ---------------------------------------------------------------------------
@@ -298,7 +353,163 @@ test_stall_via_the_primary_argv_match() {
 }
 
 # ---------------------------------------------------------------------------
-# 5. A malformed invocation is refused by name, and never runs anything
+# 5. More candidates than the cap: four get stacks, the rest get swept
+# ---------------------------------------------------------------------------
+
+# The line the script writes into the ps file before each sweep, e.g.
+# "=== SIGTERM order, deepest first and tee last === 900(sleep) 890(sh) …".
+kill_order_line_of() { grep -m1 "=== $2 order" "$1" 2>/dev/null; }
+
+# One entry of that line, by position, with the pid stripped so only the process
+# name is compared — the pids differ every run.
+order_entry() {
+  printf '%s\n' "$1" | sed 's/.*=== //' | awk -v want="$2" '
+    { n = NF
+      if (want == "first")       { print $1 }
+      else if (want == "last")   { print $n }
+      else if (want == "penultimate" && n > 1) { print $(n - 1) } }
+  ' | sed 's/^[0-9]*//'
+}
+
+# Six sleepers whose argv all match the primary path, against a cap of four. The
+# cap's arithmetic, its skip line and the split between "sampled, then SIGKILLed"
+# and "left to the graceful sweep" are only reachable with more candidates than
+# the cap, which the one-descendant cases above cannot produce.
+test_sampling_cap_takes_four_and_sweeps_the_rest() {
+  local fix started ps_file order spawned sampled pid swept=""
+  fix="$(mkfix)"
+  RUN_ENV=(STUB_MODE=cap STUB_SLEEPER="$fix/TBDPackageTests-bin/sleep" STUB_SLEEPER_COUNT=6)
+  started=$(date +%s)
+  run_pass "$fix" --name capped --budget-seconds 3 --floor 35 \
+    --floor-message 'the regex matched nothing.' --out-dir "$fix/out" -- --fingerprint
+  RUN_ENV=()
+  spawned="$(cat "$fix/sleeper.pid" 2>/dev/null | tr '\n' ' ')"
+  SLEEPERS="$SLEEPERS $spawned"
+  ps_file="$fix/out/capped-stall-ps.txt"
+
+  assert_eq "cap: a stall is red" "1" "$RUN_RC"
+  assert_eq "cap: six candidates were spawned" "6" "$(echo "$spawned" | wc -w | tr -d ' ')"
+  assert_eq "cap: exactly four were sampled" "4" \
+    "$(wc -l < "$fix/sample-argv" 2>/dev/null | tr -d ' ')"
+  assert_eq "cap: exactly four sample files were written" "4" \
+    "$(find "$fix/out" -name 'capped-stall-sample-*.txt' | wc -l | tr -d ' ')"
+  assert_file_has "cap: the ps file records what the cap dropped" "$ps_file" \
+    'primary sampling capped at 4 targets; 2 further candidates skipped'
+
+  sampled="$(cut -d' ' -f1 "$fix/sample-argv" 2>/dev/null | tr '\n' ' ')"
+  for pid in $sampled; do
+    case " $spawned " in
+      *" $pid "*) ;;
+      *) echo "FAIL - cap: sampled pid $pid is not one of the spawned sleepers"; FAIL=1 ;;
+    esac
+  done
+  echo "ok   - cap: every sampled pid is one of the spawned sleepers"
+  for pid in $spawned; do
+    case " $sampled " in
+      *" $pid "*) ;;
+      *) swept="$swept $pid" ;;
+    esac
+  done
+  assert_eq "cap: the two the cap dropped were left to the sweep" "2" \
+    "$(echo "$swept" | wc -w | tr -d ' ')"
+  # The four sampled die to the sampling loop's own SIGKILL, the other two to
+  # the graceful sweep — either way none may survive the step.
+  for pid in $spawned; do
+    assert_dead "cap: sleeper $pid is gone" "$pid"
+  done
+
+  # The order the sweep was built in, which is also the tee-dies-last property:
+  # `tee` owns the far end of the log pipe, so it must be signalled after the
+  # pty wrapper and after everything below it.
+  order="$(kill_order_line_of "$ps_file" SIGTERM)"
+  assert_contains "cap: the sweep order is recorded for a reader" "$order" "=== SIGTERM order"
+  assert_eq "cap: tee is signalled last" "(tee)" "$(order_entry "$order" last)"
+  assert_eq "cap: the pty wrapper is signalled just before tee" "(script)" \
+    "$(order_entry "$order" penultimate)"
+}
+
+# The same fixture against a copy of the script whose kill order is the naive
+# reversal the comment warns about — `tee` first, deepest last. The assertion
+# above has to flip, or it was not testing the ordering.
+test_reversing_the_kill_order_puts_tee_first() {
+  local fix order spawned
+  fix="$(mkfix)"
+  RUN_SCRIPT="$(mutant_of "$fix" \
+    's/kill_order="\$deeper_first \$direct_others \$tee_pids"/kill_order="$tee_pids $direct_others $deeper_first"/')"
+  RUN_ENV=(STUB_MODE=cap STUB_SLEEPER="$fix/TBDPackageTests-bin/sleep" STUB_SLEEPER_COUNT=6)
+  run_pass "$fix" --name reversed --budget-seconds 3 --floor 35 \
+    --floor-message 'the regex matched nothing.' --out-dir "$fix/out" -- --fingerprint
+  RUN_ENV=()
+  RUN_SCRIPT=""
+  spawned="$(cat "$fix/sleeper.pid" 2>/dev/null | tr '\n' ' ')"
+  SLEEPERS="$SLEEPERS $spawned"
+  order="$(kill_order_line_of "$fix/out/reversed-stall-ps.txt" SIGTERM)"
+  assert_contains "mutant: the reversed order was recorded" "$order" "=== SIGTERM order"
+  assert_eq "mutant: tee is signalled FIRST, which is the bug" "(tee)" \
+    "$(order_entry "$order" first)"
+  if [ "$(order_entry "$order" last)" = "(tee)" ]; then
+    echo "FAIL - mutant: tee is still last — the ordering assertion proves nothing"
+    FAIL=1
+  else
+    echo "ok   - mutant: tee is no longer last, so the ordering assertion discriminates"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# 6. A pipeline still alive after the grace window is SIGKILLed
+# ---------------------------------------------------------------------------
+
+# The pipeline subshell's pid, which the escalate stub records before stopping it.
+pipeline_pid_of() { cat "$1/pipeline.pid" 2>/dev/null; }
+
+# The stub stops the pipeline subshell, which the sweep never signals — it walks
+# and signals only that subshell's DESCENDANTS. So the subshell is alive when the
+# grace window opens and still alive when it closes, and the only thing that can
+# end the step is the escalation's `kill -KILL "$pipeline"`. That line is the
+# guarantee the whole budget rests on: without it the script would sit in `wait`
+# until the platform timeout, which is the outcome the budget exists to prevent.
+#
+# Nothing is sampled here on purpose — the sleeper's argv carries none of the
+# matched tokens and its `comm` is `sleep`, which the fallback skips as plumbing,
+# as do `script`, `sh` and `tee`. So the run also covers the
+# "no sampleable descendants" path.
+test_a_pipeline_outliving_the_grace_is_killed() {
+  local fix started elapsed pipeline sleeper
+  fix="$(mkfix)"
+  RUN_ENV=(STUB_MODE=escalate)
+  started=$(date +%s)
+  run_pass "$fix" --name escalated --budget-seconds 3 --floor 35 \
+    --floor-message 'the regex matched nothing.' --out-dir "$fix/out" -- --fingerprint
+  RUN_ENV=()
+  elapsed=$(( $(date +%s) - started ))
+  pipeline="$(pipeline_pid_of "$fix")"
+  sleeper="$(sleeper_pid_of "$fix")"
+  SLEEPERS="$SLEEPERS $pipeline $sleeper"
+
+  assert_eq "escalation: a stall is red" "1" "$RUN_RC"
+  assert_contains "escalation: nothing was sampleable" "$RUN_OUT" \
+    "The pipeline has no sampleable descendants"
+  assert_eq "escalation: no sample file was written" "0" \
+    "$(find "$fix/out" -name 'escalated-stall-sample-*.txt' | wc -l | tr -d ' ')"
+  # Under 30 s would mean the graceful sweep ended it and the escalation never
+  # ran; 60 s or more would mean something other than the grace window was being
+  # waited on.
+  if [ "$elapsed" -ge 30 ] && [ "$elapsed" -lt 60 ]; then
+    echo "ok   - escalation: the step took ${elapsed}s, the grace window plus the poll"
+  else
+    echo "FAIL - escalation: the step took ${elapsed}s, which is not the 30 s grace"
+    FAIL=1
+  fi
+  assert_file_has "escalation: the SIGKILL order was recorded" \
+    "$fix/out/escalated-stall-ps.txt" "=== SIGKILL order"
+  # The subshell was stopped and is signalled by nothing but the escalation, so
+  # its death is proof that `kill -KILL "$pipeline"` ran.
+  assert_dead "escalation: the stopped pipeline subshell was SIGKILLed" "$pipeline"
+  assert_dead "escalation: its sleeper is gone too" "$sleeper"
+}
+
+# ---------------------------------------------------------------------------
+# 7. A malformed invocation is refused by name, and never runs anything
 # ---------------------------------------------------------------------------
 
 test_usage_rejects_a_missing_name() {

--- a/scripts/ci/watched-test-pass.test.sh
+++ b/scripts/ci/watched-test-pass.test.sh
@@ -1,0 +1,332 @@
+#!/usr/bin/env bash
+# Tests for scripts/ci/watched-test-pass.sh — run: /bin/bash scripts/ci/watched-test-pass.test.sh
+#
+# MACOS ONLY, AND VERIFIED WITH `/bin/bash`, WHICH ON MACOS IS 3.2. The script
+# under test drives BSD `ps`, BSD `script(1)` and `/usr/bin/sample`, all of
+# which take different arguments or do not exist on Linux — which is why this
+# harness runs in the macOS `test` job rather than joining the Linux collection
+# in `plans-guard`. A developer with Homebrew's bash first on `PATH` is running
+# 5.x, where constructs 3.2 cannot parse work fine and fail at RUN time from
+# inside a command substitution, where `bash -n` on 5.x never sees them.
+#
+# ZERO BUILDS, ZERO SwiftPM, AND NOTHING REAL IS TOUCHED. Every case runs the
+# script against a fixture directory holding a STUB `scripts/test.sh` this file
+# controls, a stub `sample` first on PATH, and its own out-dir. Nothing here
+# compiles, reads `~/tbd`, or signals a process it did not itself start.
+#
+# THE STUB SLEEPER IS `caffeinate -t 60`, NOT `sleep`, AND THAT IS LOAD-BEARING.
+# The script's fallback selection skips known plumbing by `comm` basename, and
+# `sleep` is on that list — a `sleep` sleeper would be filtered out and the
+# stall cases would assert nothing. `/usr/bin/caffeinate` ships with macOS,
+# needs no privileges, self-terminates after its `-t` seconds so a case that
+# dies early cannot leak it, and its basename is on no exclusion list. The
+# primary-path case execs it through a SYMLINK under a `TBDPackageTests`-bearing
+# directory, so the process's argv matches the same way a real
+# `swiftpm-testing-helper` does.
+#
+# ALL SIGNALS GO TO CAPTURED PIDS. The sleeper writes its own pid to a file
+# before it execs, the EXIT trap kills exactly those, and no case ever matches a
+# process by name — see `Tests/CLAUDE.md` "The kill hazards".
+#
+# EACH COMPLETED-RUN CASE COSTS ABOUT FIVE SECONDS, because the script polls the
+# pipeline in 5-second steps and a stub that finishes instantly is still
+# observed alive on the first look. The whole file is well under a minute.
+# shellcheck disable=SC2329 # test_* are dispatched dynamically via `declare -F` below
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$HERE/watched-test-pass.sh"
+
+FAIL=0
+assert_eq()       { if [ "$2" = "$3" ]; then echo "ok   - $1"; else echo "FAIL - $1: expected [$2] got [$3]"; FAIL=1; fi; }
+assert_contains() { case "$2" in *"$3"*) echo "ok   - $1" ;; *) echo "FAIL - $1: [$2] lacks [$3]"; FAIL=1 ;; esac; }
+assert_file_has() { if [ -f "$2" ] && grep -q -- "$3" "$2"; then echo "ok   - $1"; else echo "FAIL - $1: $2 lacks [$3]"; FAIL=1; fi; }
+assert_true()     { local label="$1"; shift; if "$@"; then echo "ok   - $label"; else echo "FAIL - $label"; FAIL=1; fi; }
+assert_ok()       { if [ "$2" = "0" ]; then echo "ok   - $1"; else echo "FAIL - $1: expected exit 0, got $2"; FAIL=1; fi; }
+assert_dead()     { if kill -0 "$2" 2>/dev/null; then echo "FAIL - $1: pid $2 is still alive"; FAIL=1; else echo "ok   - $1"; fi; }
+mktmpd()          { mktemp -d "${TMPDIR:-/tmp}/watched-pass-test.XXXXXX"; }
+
+# Fixtures and any sleeper this file started, reclaimed on the way out. The
+# sleepers are killed BY THE PID THEY RECORDED, never by name, and each would
+# expire on its own within a minute anyway.
+FIXTURES=""
+SLEEPERS=""
+cleanup() {
+  local pid dir
+  for pid in $SLEEPERS; do
+    kill -KILL "$pid" 2>/dev/null || true
+  done
+  for dir in $FIXTURES; do
+    rm -rf "$dir"
+  done
+}
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+# A throwaway world: a copy of the script under test at the same relative
+# position it occupies in the repo (so its `$(dirname "$0")/../test.sh` resolves
+# to the stub next to it), the stub itself, a stub `sample`, an out-dir, and a
+# symlink whose name carries the argv token the primary selection path matches.
+mkfix() {
+  local d; d="$(mktmpd)"
+  FIXTURES="$FIXTURES $d"
+  mkdir -p "$d/scripts/ci" "$d/bin" "$d/out"
+  cp "$SCRIPT" "$d/scripts/ci/watched-test-pass.sh"
+  chmod +x "$d/scripts/ci/watched-test-pass.sh"
+  # The primary-path sleeper: its `comm` basename is `sleep`, which IS on the
+  # fallback's plumbing list, while its argv carries `TBDPackageTests`. Only the
+  # primary argv match can select it, so that case goes red outright if the argv
+  # match stops working rather than quietly passing through the fallback.
+  mkdir -p "$d/TBDPackageTests-bin"
+  ln -s /usr/bin/caffeinate "$d/TBDPackageTests-bin/sleep"
+
+  cat > "$d/scripts/test.sh" <<'STUB'
+# Stands in for scripts/test.sh, run through the pty exactly as the real one is.
+#
+# DELIBERATELY WITHOUT A SHEBANG, so the exec falls back to `/bin/sh <file>`.
+# Exec'ing a freshly created file goes through the system's provenance check
+# before its first instruction runs, and on a developer machine whose
+# `syspolicyd` is saturated that check does not return: the child sits in dyld
+# and the pty session wedges before the stub's first line. Reading the file
+# through an interpreter that is already validated sidesteps it entirely, costs
+# nothing, and changes nothing this harness is testing. Keep this file POSIX sh.
+#
+# STUB_MODE picks the shape:
+#   summary  print the population line six floor consumers grep for, then exit
+#            STUB_RC. STUB_COUNT unset prints no summary line at all, which is
+#            the truncated-run shape the floor exists to catch.
+#   stall    record this pid (the exec below keeps it) and block until killed.
+#            STUB_SLEEPER names the executable, which decides whether the
+#            script's primary argv match or its fallback selection picks it up.
+set -u
+echo "stub test.sh argv: $*"
+case "${STUB_MODE:-summary}" in
+  summary)
+    if [ -n "${STUB_COUNT:-}" ]; then
+      echo "Test run with ${STUB_COUNT} tests in 3 suites passed after 1.0 seconds."
+    fi
+    exit "${STUB_RC:-0}"
+    ;;
+  stall)
+    echo "$$" > "$STUB_PID_FILE"
+    exec "$STUB_SLEEPER" -t 60
+    ;;
+esac
+STUB
+  chmod +x "$d/scripts/test.sh"
+
+  cat > "$d/bin/sample" <<'SAMPLE'
+# Stands in for /usr/bin/sample: records the argv it was handed and writes a
+# file at the -file path, so a case can assert WHICH pid was sampled without
+# waiting five seconds for a real stack capture.
+#
+# Shebang-less for the same reason the stub wrapper above is — see there.
+echo "$*" >> "$SAMPLE_ARGV_FILE"
+prev=""
+for arg in "$@"; do
+  if [ "$prev" = "-file" ]; then
+    echo "fake sample of $1" > "$arg"
+  fi
+  prev="$arg"
+done
+exit 0
+SAMPLE
+  chmod +x "$d/bin/sample"
+  echo "$d"
+}
+
+# Run the script under test against a fixture. Sets RUN_OUT and RUN_RC.
+# Extra environment for the stub goes in RUN_ENV before the call.
+RUN_ENV=()
+run_pass() {
+  local fix="$1"; shift
+  RUN_OUT="$(PATH="$fix/bin:$PATH" \
+    SAMPLE_ARGV_FILE="$fix/sample-argv" \
+    STUB_PID_FILE="$fix/sleeper.pid" \
+    STUB_SLEEPER="/usr/bin/caffeinate" \
+    env ${RUN_ENV[@]+"${RUN_ENV[@]}"} \
+    /bin/bash "$fix/scripts/ci/watched-test-pass.sh" "$@" 2>&1)"
+  RUN_RC=$?
+}
+
+# ---------------------------------------------------------------------------
+# 1. A green pass hands back its verdict, its count and its log
+# ---------------------------------------------------------------------------
+
+test_green_passthrough() {
+  local fix; fix="$(mkfix)"
+  RUN_ENV=(STUB_MODE=summary STUB_COUNT=40 STUB_RC=0)
+  run_pass "$fix" --name green --budget-seconds 60 --floor 35 \
+    --floor-message 'the regex matched nothing.' --out-dir "$fix/out" \
+    -- --fingerprint --marker-argument
+  RUN_ENV=()
+  assert_ok "green pass exits 0" "$RUN_RC"
+  assert_contains "green pass names itself and its count" "$RUN_OUT" "green executed 40 tests."
+  assert_file_has "the log keeps the summary line" "$fix/out/green.log" "Test run with 40 tests"
+  # The `--` separator forwards everything after it to the wrapper untouched.
+  assert_file_has "forwarded arguments reach the wrapper" "$fix/out/green.log" "--marker-argument"
+  assert_file_has "the recorded status is the pass's own" "$fix/out/green.rc" "^0$"
+}
+
+# ---------------------------------------------------------------------------
+# 2. A non-zero status reaches the caller untouched — 75 and 76 are the reason
+# ---------------------------------------------------------------------------
+
+test_status_76_survives() {
+  local fix; fix="$(mkfix)"
+  RUN_ENV=(STUB_MODE=summary STUB_COUNT=40 STUB_RC=76)
+  run_pass "$fix" --name yielded --budget-seconds 60 --floor 35 \
+    --floor-message 'the regex matched nothing.' --out-dir "$fix/out" -- --fingerprint
+  RUN_ENV=()
+  assert_eq "a 76 is returned as 76, not flattened to 1" "76" "$RUN_RC"
+  assert_contains "the 76 is named in the error line" "$RUN_OUT" "::error::yielded exited 76"
+}
+
+test_status_3_survives() {
+  local fix; fix="$(mkfix)"
+  RUN_ENV=(STUB_MODE=summary STUB_COUNT=40 STUB_RC=3)
+  run_pass "$fix" --name failed --budget-seconds 60 --floor 35 \
+    --floor-message 'the regex matched nothing.' --out-dir "$fix/out" -- --fingerprint
+  RUN_ENV=()
+  assert_eq "an ordinary red status is returned as itself" "3" "$RUN_RC"
+  assert_contains "the red status is named in the error line" "$RUN_OUT" "::error::failed exited 3"
+}
+
+# ---------------------------------------------------------------------------
+# 3. The floor catches a run that claims success while executing nothing
+# ---------------------------------------------------------------------------
+
+test_floor_catches_a_short_run() {
+  local fix; fix="$(mkfix)"
+  RUN_ENV=(STUB_MODE=summary STUB_COUNT=5 STUB_RC=0)
+  run_pass "$fix" --name shortrun --budget-seconds 60 --floor 35 \
+    --floor-message 'the --filter regex matched nothing or the target was renamed.' \
+    --out-dir "$fix/out" -- --fingerprint
+  RUN_ENV=()
+  assert_eq "a run under the floor is red" "1" "$RUN_RC"
+  assert_contains "the floor error names the count and the floor" "$RUN_OUT" \
+    "::error::shortrun ran 5 tests (floor 35)"
+  assert_contains "the floor error carries its explanation" "$RUN_OUT" \
+    "the --filter regex matched nothing or the target was renamed."
+}
+
+test_floor_catches_a_missing_summary() {
+  local fix; fix="$(mkfix)"
+  # STUB_COUNT unset: a truncated run that printed no population line at all.
+  RUN_ENV=(STUB_MODE=summary STUB_RC=0)
+  run_pass "$fix" --name nosummary --budget-seconds 60 --floor 35 \
+    --floor-message 'the --filter regex matched nothing or the target was renamed.' \
+    --out-dir "$fix/out" -- --fingerprint
+  RUN_ENV=()
+  assert_eq "a run with no summary line is red" "1" "$RUN_RC"
+  assert_contains "the floor error says no tests were seen" "$RUN_OUT" \
+    "::error::nosummary ran no tests (floor 35)"
+}
+
+# ---------------------------------------------------------------------------
+# 4. A stall is sampled, killed and failed well before the platform timeout
+# ---------------------------------------------------------------------------
+
+# The pid the sample stub was handed, from its recorded argv.
+sampled_pid_of() { sed -n '1s/ .*//p' "$1/sample-argv" 2>/dev/null; }
+
+# The sleeper's own pid, recorded before it exec'd, so the case can also reclaim
+# it if an assertion fails and the script never got to.
+sleeper_pid_of() { cat "$1/sleeper.pid" 2>/dev/null; }
+
+assert_stall() {
+  local label="$1" fix="$2" name="$3" started="$4" elapsed sampled sleeper
+  elapsed=$(( $(date +%s) - started ))
+  assert_eq "$label: a stall is red" "1" "$RUN_RC"
+  assert_contains "$label: the stall error names the pass and its budget" "$RUN_OUT" \
+    "::error::$name has been running for 3s"
+  # Ends on the watchdog's own budget, not on the 60-second sleeper expiring.
+  if [ "$elapsed" -lt 30 ]; then
+    echo "ok   - $label: the step ended after ${elapsed}s, well inside the sleeper's 60"
+  else
+    echo "FAIL - $label: the step took ${elapsed}s, which is not the watchdog acting"
+    FAIL=1
+  fi
+  assert_file_has "$label: the ps file carries the lineage header" \
+    "$fix/out/$name-stall-ps.txt" "descendants of the pipeline subshell"
+  sampled="$(sampled_pid_of "$fix")"
+  sleeper="$(sleeper_pid_of "$fix")"
+  case "$sampled" in
+    ''|*[!0-9]*) echo "FAIL - $label: no pid was sampled (got '$sampled')"; FAIL=1 ;;
+    *) echo "ok   - $label: a pid was sampled" ;;
+  esac
+  assert_eq "$label: the sampled pid is the pipeline's own descendant" "$sleeper" "$sampled"
+  if [ -n "$sampled" ]; then
+    assert_true "$label: the sample landed at the -file path" \
+      test -f "$fix/out/$name-stall-sample-$sampled.txt"
+    assert_dead "$label: the sampled process was killed" "$sampled"
+  fi
+}
+
+# The sleeper's argv is `/usr/bin/caffeinate -t 60`, which matches none of
+# `swiftpm-testing`, `xctest` or `TBDPackageTests` — so this case exercises the
+# FALLBACK selection, the one that samples every descendant that is not known
+# plumbing.
+test_stall_via_the_fallback_path() {
+  local fix started; fix="$(mkfix)"
+  RUN_ENV=(STUB_MODE=stall)
+  started=$(date +%s)
+  run_pass "$fix" --name stallfallback --budget-seconds 3 --floor 35 \
+    --floor-message 'the regex matched nothing.' --out-dir "$fix/out" -- --fingerprint
+  RUN_ENV=()
+  SLEEPERS="$SLEEPERS $(sleeper_pid_of "$fix")"
+  assert_stall "fallback stall" "$fix" stallfallback "$started"
+}
+
+# Same stall through a symlink under a `TBDPackageTests`-bearing directory, so
+# the sleeper's argv carries the token the PRIMARY selection path matches — the
+# shape a real `swiftpm-testing-helper` has. The symlink is named `sleep` on
+# purpose: the fallback would skip it as plumbing, so only the argv match can
+# reach it.
+test_stall_via_the_primary_argv_match() {
+  local fix started; fix="$(mkfix)"
+  RUN_ENV=(STUB_MODE=stall STUB_SLEEPER="$fix/TBDPackageTests-bin/sleep")
+  started=$(date +%s)
+  run_pass "$fix" --name stallprimary --budget-seconds 3 --floor 35 \
+    --floor-message 'the regex matched nothing.' --out-dir "$fix/out" -- --fingerprint
+  RUN_ENV=()
+  SLEEPERS="$SLEEPERS $(sleeper_pid_of "$fix")"
+  assert_stall "primary stall" "$fix" stallprimary "$started"
+}
+
+# ---------------------------------------------------------------------------
+# 5. A malformed invocation is refused by name, and never runs anything
+# ---------------------------------------------------------------------------
+
+test_usage_rejects_a_missing_name() {
+  local fix; fix="$(mkfix)"
+  run_pass "$fix" --budget-seconds 60 --floor 35 \
+    --floor-message 'the regex matched nothing.' --out-dir "$fix/out" -- --fingerprint
+  assert_eq "a missing --name exits 64" "64" "$RUN_RC"
+  assert_contains "the refusal names the missing argument" "$RUN_OUT" "--name is required"
+}
+
+test_usage_rejects_a_non_numeric_budget() {
+  local fix; fix="$(mkfix)"
+  run_pass "$fix" --name bogus --budget-seconds soon --floor 35 \
+    --floor-message 'the regex matched nothing.' --out-dir "$fix/out" -- --fingerprint
+  assert_eq "a non-numeric --budget-seconds exits 64" "64" "$RUN_RC"
+  assert_contains "the refusal quotes the value it refused" "$RUN_OUT" "got 'soon'"
+}
+
+# ---------------------------------------------------------------------------
+
+for t in $(declare -F | awk '{print $3}' | grep '^test_'); do
+  echo "--- $t"
+  "$t"
+done
+
+if [ "$FAIL" -eq 0 ]; then
+  echo "All watched-test-pass tests passed."
+else
+  echo "Some watched-test-pass tests FAILED."
+fi
+exit "$FAIL"


### PR DESCRIPTION
## Summary

A red CI run should tell you what you broke. For most of 2026-09-08 it did not:
nearly every run of the `test` workflow reddened at least once on a test that
had nothing to do with the change under review, always in the tail of one of the
fast parallel passes — `SocketServerSocketOwnershipTests`,
`AttachReplayOrchestratorTests`, `AppearanceDebounceTests`,
`ArchivedWorktreeSearchTests`, `TerminalTeardownReapTests`,
`BoundedGateWaitTests`, `BoundedProcessRunnerTests`,
`WorktreeArchiveDeletionQueueTests`, `HolderLifecycleTests`, `TBDHolderTests`.
One pull request needed seven reruns before it landed. Twelve feature-branch
reds classified by step came out five in pass 1/2 and seven in pass 2/2, and two
of the latter were not test failures at all: the process went silent about five
seconds into the run with roughly 1,965 tests started, none finishing, zero
issues recorded and no time limit firing, then died thirty minutes later on the
platform timeout with no stack and nothing naming a frame (runs 34174344530 and
34176996067). That is the cooperative-pool wedge signature
`Tests/TestSupport/BoundedGateSupport.swift` describes — every thread the pool
has parked on a gate, where cooperative cancellation cannot reach.

Zero reds landed in the quiet pass, which was then the only step with a stall
watchdog. And because a red fast pass skipped every step after it, one flake in
pass 1 hid the live verdict for the whole run, so the rerun learned nothing new.

After this PR every test pass is watched, so a wedge hands back the stacks
instead of a blank timeout; the daemon pass runs as two steps instead of one, so
the scheduling tail that produces those unrelated reds is halved; and a red pass
no longer suppresses the passes behind it.

## Why this shape

The watchdog already existed — for one step. `docs/specs/2026-09-04-quiet-pass-stall-watchdog-design.md`
scoped it to the quiet pass on the premise that the parallel passes never stall
and emit output fast enough for buffering to be invisible. The second half is
still true; the first is now false twice over, and the spec is rewritten around
the scope the evidence supports. Nothing about the mechanism was ever specific
to the serial pass: a per-test `.timeLimit` cannot reach a blocked thread, so
the platform timeout is the only bound in a parallel pass too, and it records
just as little.

Splitting the daemon pass is the remedy `test.yml`'s own comment already named
and `Tests/CLAUDE.md` states as a principle: population is the scheduler. Swift
Testing runs every non-serialized test in one process with no concurrency cap,
so per-test latency scales with the total population. Pass 1 was running ~5,529
tests and pass 2 ~5,269, up from 4,988 and 4,645 on the 2026-09-04 green run of
`main` and from the ~4,350 and ~2,800 the deadline triple was originally derived
against. Pass-1 test time was 247 s and 231 s on the red runs against 153 s and
195 s on the green ones, and every hang-catcher in the suite is sized per
scheduling hop — `TestDeadlines.saturatedPass` 90 s, `TestGate.deadline` 120 s,
the clock guards 45 s, the suite limit 240 s — so the reds are the slow-runner
tail of one distribution rather than ten separate bugs. Raising those deadlines
instead would re-derive four coupled constants and wants a spec of its own.

This is the investigation's minimal proposal, deliberately: no new deadlines, no
new retries, no sharding across runners (that was rejected in
`docs/specs/2026-07-24-test-hardening-design.md` §1 and remains rejected — it
pays the five-concurrent-macOS-job cap and a second build). Three sequential
invocations in one job sharing one build pay neither.

Two smaller shape decisions. **1b is a complement, not `[M-Z]`** — a suite
renamed to start with a digit or an underscore would otherwise fall out of both
halves and run nowhere, and `--filter` exits green on zero matches, so nothing
would go red. **The watchdog is a script, not inlined YAML** — four copies of a
hundred lines of shell would drift apart, and a `run:` block cannot have a
harness.

## What this PR does

- Adds `scripts/ci/watched-test-pass.sh`, the quiet pass's watchdog factored out
  of its `run:` block with its logic unchanged in every reachable state (the one addition is an `is_target` skip on the direct-children set, closing a documented invariant): the pty, the background subshell
  recording `PIPESTATUS[0]`, the budget poll, the whole-machine `ps`, the
  lineage walk, the argv match and its fallback, the cap of four, `sample`, the
  explicit kill order with `tee` last, SIGTERM then 30 s then SIGKILL, the
  validated status file, status before floor. It takes `--name`,
  `--budget-seconds`, `--floor`, `--floor-message` and an optional `--out-dir`,
  and forwards everything after `--` to `scripts/test.sh`. The rationale that
  lived in the step's YAML comments moved into the script's header.
- Adds `scripts/ci/watched-test-pass.test.sh`, its harness.
- Splits fast pass 1 into `fast-pass-daemon-a` (`^TBDDaemonTests\.[A-O]`, budget
  1800 s, floor 1200) and `fast-pass-daemon-b` (that filter's complement within
  the daemon target, budget 600 s, floor 1500), sharing the same build.
- Routes all four test steps through the script, renames pass 2 to
  `fast-pass-app` (budget 600 s) and keeps the quiet pass at budget 720 s,
  floor 35.
- Replaces the 30-minute step timeouts on the fast passes with 15 (35 on 1a,
  which pays the compile) and raises the job bound from 90 to 100. The 30
  existed to let per-test limits fire first and name a test; the watchdog does
  that sooner and with a stack.
- Makes 1b, pass 2 and the quiet pass run when an earlier pass is red — but not
  when the job was cancelled or when setup never reached 1a.
- Renames the stall artifact to `test-stall-diagnostics` over
  `/tmp/*-stall-*.txt`, so it collects whichever pass wedged.
- Records each sweep's kill order in the stall artifact, so a reader can see
  which processes it reached and in what order.
- Rewrites the watchdog spec around all four passes — including a section on why
  a red pass no longer hides the passes behind it — and updates the three-steps
  paragraph in `Tests/CLAUDE.md`.

## Assumptions

- **The floors are provisional, and so is the cut.** Counting `@Test` against
  the top-level suite that declares it predicted 1919 tests for `[A-L]` where CI
  executed 1918, so that heuristic is trustworthy to within a test; it puts M, N
  and O at 582 between them, hence `[A-O]` and an expected split near
  2,500 / 3,120. The floors at 1200 and 1500 sit deliberately far below either
  half and should be recalibrated from the counts this PR's own CI run prints,
  which is the only source that measures what actually executes.
- **Pass 2 is now the biggest population, and this PR does not touch it.** It
  executed 5,370 tests, more than either daemon half and more than the whole
  package ran a month ago. Splitting it was outside what the investigation
  proposed — that named pass 1 — so it stays whole here, and it is the obvious
  next candidate if pass-2 tails persist after this lands.
- **`swift test --filter` and `--skip` compose.** 1b relies on `--filter
  '^TBDDaemonTests\.' --skip '^TBDDaemonTests\.[A-O]'` selecting exactly the
  daemon suites 1a did not run. If that ever stopped holding, the two floors
  would catch a collapse but not a silent overlap.
- **`script(1)` propagates the child's exit status.** The quiet pass has relied
  on this since the watchdog landed; the harness now asserts it for a 3 and a 76.
- **The runner keeps `/usr/bin/sample` and keeps executing tests in a descendant
  of its test command.** Both are stated in the spec with the failure mode if
  they stop holding — in each case a louder red, never a false green.
- **Two more passes on a red run cost 2–4 minutes.** Worth it against a rerun.

## Evidence & verification

The shape of this change was measured on CI before it was tuned. Run
34305400310, green on this branch, printed four counts and step times:
`fast-pass-daemon-a` 1918 tests (51 s of test time), `fast-pass-daemon-b` 3703
(114 s), `fast-pass-app` 5370, `quiet-pass` 246. That run is what moved the
daemon cut from `[A-L]` to `[A-O]` — a third and two thirds is not the halving
the split exists for — and it confirmed the wiring end to end: four watched
steps, four xUnit files, the harness step green, no stall artifact.

The rerun at `[A-O]`, 34306746034, confirmed the expectation: `fast-pass-daemon-a`
2531 tests, `fast-pass-daemon-b` 3111, `fast-pass-app` 5370, `quiet-pass` 251,
against a prediction of about 2,500 and 3,120 — within 1% on each half. Step
times were 8m28s for 1a (which pays the compile), 1m52s for 1b, 1m17s for pass 2
and 3m04s for the quiet pass, all far inside their budgets, and the watchdog
harness step was green.

Separately, the first test step was measured across the 45 most recent concluded
runs of `test.yml` (2026-09-05 to 2026-09-09), from 73 s to 1250 s. The three
slowest are exactly the runs whose cache step finished in 1–4 s — a miss, where
a hit spends 25–56 s restoring — so 1250 s is the cold-cache figure 1a's 1800 s
budget is sized against, with 45% of headroom over a pass that ran more tests
than 1a now does.

The script's behavior is pinned by `scripts/ci/watched-test-pass.test.sh`, which
runs against fixture directories with a stub `scripts/test.sh` and a stub
`sample`: no build, no SwiftPM, no real store touched, ~90 s — most of it the
30-second grace window the escalation case has to wait out to measure. Its
cases:

- a green pass exits 0, prints `executed 40 tests`, keeps the summary line in
  its log, and forwards the arguments after `--` to the wrapper unchanged;
- a stub exiting 76 comes back as 76 and a stub exiting 3 comes back as 3, each
  named in its own `::error::` line — the swift-safe statuses the remote
  verification valve routes on must not be flattened;
- a run reporting 5 tests against a floor of 35 goes red naming the count, and
  so does a run that printed no summary line at all;
- a stall through the **primary** argv match: the sleeper's `comm` is `sleep`,
  which the fallback skips as plumbing, so only the argv match can reach it —
  disabling that match in a mutated copy turns this case red while the fallback
  case stays green;
- a stall through the **fallback** selection, whose sleeper carries none of the
  matched tokens. Both assert the step ends on its own budget rather than on the
  60-second sleeper, that the ps file carries the lineage header, that the pid
  handed to `sample` is the pipeline's own descendant, that the sample file
  landed at the `-file` path, and that the sampled process is dead afterwards;
- six candidates against the cap of four: exactly four stacks are captured, the
  ps file records that two were skipped, every sampled pid is one of the six,
  and all six are dead afterwards — the four to the sampling loop's own SIGKILL
  and the other two to the graceful sweep;
- the sweep order, asserted from the artifact: `tee` last and the pty wrapper
  just before it. A mutated copy that reverses the order puts `tee` first, so
  the assertion flips;
- a pipeline that outlives the grace window, which only the SIGKILL escalation
  can end: the step takes the grace window rather than ending early, the SIGKILL
  order is recorded, and the process that could not be reached by SIGTERM is
  dead afterwards;
- two malformed invocations exit 64 and name what was wrong.

Locally: `bash -n` and `shellcheck` clean on both scripts, the harness green
under `/bin/bash` (macOS 3.2), the workflow parsed and `actionlint` clean apart
from one pre-existing `SC2086` note on an untouched line.

The verification is this PR's own CI run, and it is unusually direct: a workflow
change runs the PR's copy of `test.yml`, so each run verifies itself — which is
how the two runs above settled first the cut and then the split. What to read
from any later one: four test steps present, each printing its own `<name>
executed N tests` line; two daemon counts within a few percent of each other and
summing to about what the single pass used to report; the `Test the stall
watchdog` step green; the xUnit upload carrying four files
(`scripts/remote_verify.py` discovers results with `rglob("*.xml")`, so the
fourth needs no change there); and no `test-stall-diagnostics` artifact, because
a healthy run produces no stall files. Those printed counts are also what the
floors get recalibrated against, and what says whether the halves have drifted
far enough apart to want re-cutting again.

**Sightings on this PR's own runs.** Run 34308893069 (the third, at 2c975e4c8)
went red in pass 1b on `WorktreeArchiveDeletionQueueTests.theFallbackRemovalArmsItsOwnRaisedTimeout`
— one of the 2026-09-08 list — after 44.8 s: its control assertion expects a
1 ms `GitManager` deadline to kill `git worktree remove` before the directory
is gone, but under load the kill lands after git has already finished while
`runBoundedProcess` still reports the timeout, so the control worktree is
missing when the test looks. A wall-clock race in the test, outside this PR's
scope; noted for the test-support follow-up. The run itself is the first field
demonstration of the continue-on-red change: pass 2, the quiet pass and the
watchdog harness all ran and reported after the red step. The job was rerun
once.

https://claude.ai/code/session_01TggE2eESL3BcvSgFcLZkpk
[ci flake fixes](https://cheapsteak.github.io/tbd/open/?worktree=94096C42-383A-4889-8ABE-3131F1220DAA)
