### PR TITLE
DX: fast-pass tests stop measuring the runner — off-pool child waits, event-driven poller clocks, a forkpty retry

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -386,6 +386,13 @@ let package = Package(
             dependencies: [
                 "TBDHolder",
                 "TBDShared",
+                // `collectOutput(of:)`, which runs a spawned binary to
+                // completion without parking a cooperative-pool thread on
+                // `waitUntilExit()`. It brings `TBDDaemonLib` in behind it,
+                // which nothing here needs; the alternative is a second
+                // hand-rolled blocking wait in a target that spawns children,
+                // which is the thing that helper exists to end.
+                "TestSupport",
             ]
         ),
         // The model proxy's own suite, carrying the same load-bearing

--- a/Package.swift
+++ b/Package.swift
@@ -422,10 +422,6 @@ let package = Package(
                 .product(name: "NIO", package: "swift-nio"),
                 .product(name: "NIOPosix", package: "swift-nio"),
                 .product(name: "NIOHTTP1", package: "swift-nio"),
-                // `TestClock`, for the retention watch. Its production window
-                // is 24 hours, and the only honest way to cross one in a test
-                // is virtual time.
-                .product(name: "Clocks", package: "swift-clocks"),
             ]
         ),
     ]

--- a/Tests/CLAUDE.md
+++ b/Tests/CLAUDE.md
@@ -329,6 +329,21 @@ which advances for as long as the code keeps re-arming and fails with a named
 diagnostic carrying the advance count. Keep explicit single advances where the
 *number* of advances is the property under test.
 
+**`TestClock.advanceUntil` is for one-shot waits only, though — under the
+saturated fast pass it starves the very re-arm it is waiting for.** Its loop
+probes `checkSuspension()` every 25 ms, and each of those probes is a
+`megaYield`: twenty serially-awaited **background-QoS** tasks. Forty-five
+seconds of probing therefore floods the cooperative pool with exactly the
+low-priority work a re-arming poller needs a turn from, and macOS starves
+background QoS hardest under precisely the load that makes the wait necessary.
+The field signature is a diagnostic reading **"observed 1 clock advance"** —
+the first tick landed, the second re-arm was never seen — and on 2026-09-08 it
+reddened `ModelProxySupervisorTests` on three consecutive dispatches of one
+unrelated SHA. So a **re-arming** loop belongs on `EventDrivenTestClock`
+instead, driven by an explicit ladder of `requireAdvanceWhenArmed` with a
+closing `requireSleeperArmed` — the re-arm being the proof that the tick before
+it finished. See "The event-driven alternative" below.
+
 On that basis, the deepest chains in the tree are the poller tests, and their
 paper tallies do not all fit under the ceiling:
 

--- a/Tests/CLAUDE.md
+++ b/Tests/CLAUDE.md
@@ -334,12 +334,11 @@ saturated fast pass it starves the very re-arm it is waiting for.** Its loop
 probes `checkSuspension()` every 25 ms, and each of those probes is a
 `megaYield`: twenty serially-awaited **background-QoS** tasks. Forty-five
 seconds of probing therefore floods the cooperative pool with exactly the
-low-priority work a re-arming poller needs a turn from, and macOS starves
-background QoS hardest under precisely the load that makes the wait necessary.
+low-priority work a re-arming poller needs a turn from.
 The field signature is a diagnostic reading **"observed 1 clock advance"** —
 the first tick landed, the second re-arm was never seen — and on 2026-09-08 it
 reddened `ModelProxySupervisorTests` on three consecutive dispatches of one
-unrelated SHA. So a **re-arming** loop belongs on `EventDrivenTestClock`
+SHA. So a **re-arming** loop belongs on `EventDrivenTestClock`
 instead, driven by an explicit ladder of `requireAdvanceWhenArmed` with a
 closing `requireSleeperArmed` — the re-arm being the proof that the tick before
 it finished. See "The event-driven alternative" below.

--- a/Tests/TBDAppTests/TerminalTeardownReapTests.swift
+++ b/Tests/TBDAppTests/TerminalTeardownReapTests.swift
@@ -275,6 +275,9 @@ struct TerminalTeardownReapTests {
             }
             usleep(10_000)
         }
+        // Unreachable: the last attempt always leaves through the `guard` above,
+        // whatever it produced. Present because the loop's bound is a constant
+        // the compiler will not reason about.
         return StartedChild(pid: pid, failureErrno: failureErrno)
     }
 

--- a/Tests/TBDAppTests/TerminalTeardownReapTests.swift
+++ b/Tests/TBDAppTests/TerminalTeardownReapTests.swift
@@ -224,24 +224,65 @@ struct TerminalTeardownReapTests {
     /// size, and both coordinators answer inside `MainActor.assumeIsolated` —
     /// which traps off main. Production starts every PTY from a main-isolated
     /// context, so this matches it; only the waiting below happens off main.
+    ///
+    /// **`ENXIO` gets a syscall retry, and nothing else does.** The two
+    /// "a second cleanup() tears nothing down" tests close a pty master and
+    /// immediately `forkpty` again; the kernel hands back the lowest free pty
+    /// number, which is the one just closed and still being revoked, and the
+    /// slave open answers `ENXIO`. The test's own diagnostic caught it in the
+    /// act on run 34178198566 — `/dev/ttys* entries: 31; kern.tty.ptmx_max:
+    /// 511; open fds: 118` — so nothing was exhausted and the next attempt
+    /// gets a different number. A retry of the *syscall* on one named errno is
+    /// not the blanket test retry `Tests/CLAUDE.md` bans under "Quarantine":
+    /// it does not re-run a body or suppress a failure, every other errno
+    /// falls straight through to ``ForkptyProducedNoPid``, and three attempts
+    /// that all answer `ENXIO` still fail with the machine state that decides
+    /// the cause.
+    ///
+    /// The 10 ms `usleep` between attempts is a real sleep on the main thread,
+    /// which this synchronous `@MainActor` helper cannot avoid: it has no
+    /// suspension point to yield at, and the revoke it is waiting out is a
+    /// kernel-side transition rather than anything scheduling can hurry. It is
+    /// on the failure path only, so a healthy run never reaches it.
     @MainActor
     private func startChild(
         delegate: LocalProcessDelegate, lifetime: String, assign: @MainActor (LocalProcess) -> Void
     ) -> StartedChild {
-        // Production configuration (see the suite comment): exit monitor on
-        // main, data delivered inline on the IO thread.
-        let process = LocalProcess(delegate: delegate, dispatchQueue: .main, directDelivery: true)
-        process.startProcess(
-            executable: "/bin/sleep", args: [lifetime], environment: nil, execName: nil)
-        // Read `shellPid` and `errno` before anything else can clobber the
-        // thread's errno: a nil `PseudoTerminalHelpers.fork` is the only way
-        // `shellPid` stays 0 here, and this is the last statement at which its
-        // cause is still legible. See `StartedChild`.
-        let pid = process.shellPid
-        let failureErrno = pid <= 0 ? errno : 0
-        assign(process)
+        var pid: pid_t = 0
+        var failureErrno: Int32 = 0
+        for attempt in 1...Self.forkptyAttempts {
+            // A fresh `LocalProcess` per attempt: the one that failed has a
+            // half-built pty of its own, and reusing it would ask a second
+            // `startProcess` to fix up state the first left behind.
+            //
+            // Production configuration (see the suite comment): exit monitor on
+            // main, data delivered inline on the IO thread.
+            let process = LocalProcess(delegate: delegate, dispatchQueue: .main, directDelivery: true)
+            process.startProcess(
+                executable: "/bin/sleep", args: [lifetime], environment: nil, execName: nil)
+            // Read `shellPid` and `errno` before anything else can clobber the
+            // thread's errno: a nil `PseudoTerminalHelpers.fork` is the only way
+            // `shellPid` stays 0 here, and this is the last statement at which its
+            // cause is still legible. See `StartedChild`.
+            pid = process.shellPid
+            failureErrno = pid <= 0 ? errno : 0
+            guard pid <= 0, failureErrno == ENXIO, attempt < Self.forkptyAttempts else {
+                // Assigned only for the attempt whose result is returned, so
+                // the coordinator never ends up owning a `LocalProcess` this
+                // helper has already given up on.
+                assign(process)
+                return StartedChild(pid: pid, failureErrno: failureErrno)
+            }
+            usleep(10_000)
+        }
         return StartedChild(pid: pid, failureErrno: failureErrno)
     }
+
+    /// How many times a `forkpty` that answered `ENXIO` is asked again. Three,
+    /// because the race it covers is one revoke wide: the number is free by the
+    /// next attempt or the machine has a different problem, which the
+    /// diagnostic then names.
+    private static let forkptyAttempts = 3
 
     /// Throws ``ForkptyProducedNoPid`` when any of the named children came back
     /// without a pid, sampling the machine state that names the cause.

--- a/Tests/TBDAppTests/TranscriptSourceStreamTests.swift
+++ b/Tests/TBDAppTests/TranscriptSourceStreamTests.swift
@@ -610,6 +610,16 @@ struct TranscriptStreamPollSchedulingTests {
 
     private static let userLine = #"{"type":"user","uuid":"a","timestamp":"2026-08-26T10:00:00.000Z","message":{"role":"user","content":"hello"}}"#
 
+    /// **On `EventDrivenTestClock`, because the poll task is a
+    /// sleep-then-tick loop.** Every advance past the first is a re-arm, and on
+    /// `TestClock` a re-arm can only be observed by polling
+    /// `checkSuspension()`, whose `megaYield` is 20 serially-awaited
+    /// background-QoS tasks — under the saturated fast pass that probe floods
+    /// the cooperative pool with exactly the low-priority work the poll task
+    /// needs a turn from. One tick is enough here (the stream line is written
+    /// before the advance), and the re-arm after it is what proves the tick
+    /// finished: this clock's `advance` does no yielding, so it promises only
+    /// that the sleeper's continuation was resumed.
     @Test("a registered stream file is polled at the tier cadence, and its change alone is news")
     func streamChangeAloneIsNews() async throws {
         let dir = fencedScratchRoot(prefix: "tbdstrsch")
@@ -622,7 +632,7 @@ struct TranscriptStreamPollSchedulingTests {
         try "".write(toFile: streamPath, atomically: true, encoding: .utf8)
 
         let source = TranscriptSource()
-        let clock = TestClock()
+        let clock = EventDrivenTestClock()
         let scheduler = TranscriptPollScheduler(source: source, clock: clock)
         let news = NewsLog()
         await scheduler.setOnChangeIfUnset { sessionID in await news.record(sessionID) }
@@ -645,11 +655,8 @@ struct TranscriptStreamPollSchedulingTests {
         try handle.write(contentsOf: Data((line + "\n").utf8))
         try handle.close()
 
-        let sawNews = await clock.advanceUntil(
-            "the scheduler to report the stream file's change",
-            by: TranscriptPollPolicy.background
-        ) { await news.count > 0 }
-        #expect(sawNews)
+        try await clock.requireAdvanceWhenArmed(by: TranscriptPollPolicy.background)
+        try await clock.requireSleeperArmed()
 
         #expect(await news.sessions == ["s1"],
                 "only the stream file moved, and it moved once")
@@ -659,6 +666,8 @@ struct TranscriptStreamPollSchedulingTests {
 
     /// The off branch: a registration with no stream path touches no second
     /// file and builds no provisional, however long it polls.
+    /// On `EventDrivenTestClock` with the ladder the test above describes: one
+    /// tick, waited for rather than polled for.
     @Test("a registration with no stream path never builds a provisional")
     func noStreamPathBuildsNoProvisional() async throws {
         let dir = fencedScratchRoot(prefix: "tbdstrsch")
@@ -667,7 +676,7 @@ struct TranscriptStreamPollSchedulingTests {
         try (Self.userLine + "\n").write(toFile: transcriptPath, atomically: true, encoding: .utf8)
 
         let source = TranscriptSource()
-        let clock = TestClock()
+        let clock = EventDrivenTestClock()
         let scheduler = TranscriptPollScheduler(source: source, clock: clock)
         let news = NewsLog()
         await scheduler.setOnChangeIfUnset { sessionID in await news.record(sessionID) }
@@ -676,11 +685,9 @@ struct TranscriptStreamPollSchedulingTests {
             sessionID: "s1", path: transcriptPath, tier: .background,
             token: TranscriptPaneToken())
 
-        let sawNews = await clock.advanceUntil(
-            "the scheduler to report the transcript's first read",
-            by: TranscriptPollPolicy.background
-        ) { await news.count > 0 }
-        #expect(sawNews, "the transcript itself must still be polled")
+        try await clock.requireAdvanceWhenArmed(by: TranscriptPollPolicy.background)
+        try await clock.requireSleeperArmed()
+        #expect(await news.count > 0, "the transcript itself must still be polled")
         #expect(await source.provisional(sessionID: "s1") == nil)
         #expect(await source.trackedStreamSessionCount == 0)
     }

--- a/Tests/TBDDaemonTests/BoundedProcessRunnerTests.swift
+++ b/Tests/TBDDaemonTests/BoundedProcessRunnerTests.swift
@@ -283,21 +283,29 @@ struct BoundedProcessRunnerTests {
     /// it a single process: `SIG_IGN` survives `exec`, so the sleeping process
     /// itself ignores SIGTERM, holds the stdout pipe, and strands no grandchild.
     ///
-    /// **What discriminates here is the child, and the fixture is sized so that
-    /// stays true.** The sleeper outlives `TestDeadlines.saturatedPass` several
-    /// times over (`Self.childLifetimeSeconds`), so "the escalation ran" and
-    /// "the call waited its child out" can never produce the same observation:
-    /// a call that waits its child out cannot return inside the bound, and a
-    /// child nobody killed cannot be gone inside it either. A 30 s sleeper —
-    /// what this fixture used to be — collapsed that distinction, because
-    /// natural exit beat the bound.
+    /// **What discriminates here is the child, and both bounds are read off it
+    /// rather than off a stopwatch.** The two diagnoses this test separates are
+    /// "the escalation ran" and "the call waited its child out", and the child's
+    /// own lifetime is what tells them apart: a call that waits its child out
+    /// cannot return before `Self.childLifetimeSeconds` have passed, and a child
+    /// nobody killed is still alive when the `waitFor` below looks for it. So
+    /// the elapsed bound is the lifetime itself — an observable of the code
+    /// under test — and not a wall-clock ceiling.
     ///
-    /// Both bounds are therefore `TestDeadlines.saturatedPass` rather than a
-    /// snappier number. A wall-clock ceiling tuned to the healthy path (~1.2 s)
-    /// measures the runner instead of the code: fast pass 1 runs ~1800 tests in
-    /// parallel on a loaded macOS runner whose per-test latency has a p50 near
-    /// 65 s, and the 20 s ceiling this used to carry went red at 31.3 s on green
-    /// code.
+    /// **A ceiling sized against the pass is still a ceiling on the runner.**
+    /// `TestDeadlines.saturatedPass` (90 s) sat close enough to fast pass 1's
+    /// own numbers — p50 65.6 s, p99 92.1 s, max 95.5 s reported per test on a
+    /// **green** run — that this test reddened twice in a row on an unrelated
+    /// PR at elapsed 103–107 s, on a runner shared with two other runs (runs
+    /// 34284111508 attempt 3 and 34286874077). Its predecessor, a 20 s ceiling
+    /// tuned to the healthy path's ~1.2 s, had gone red at 31.3 s for the same
+    /// reason. Neither number was ever an assertion about the code.
+    ///
+    /// `childLifetimeSeconds` is 600 so that the bound derived from it clears
+    /// those sightings and that pacing by roughly six times over, while staying
+    /// a bound a genuinely stuck call still trips: a call that really did wait
+    /// its child out returns at ten minutes, and this fails at ten minutes with
+    /// the elapsed time in the message.
     ///
     /// The *wedged-snapshot* property — that a blocking snapshot cannot cost
     /// another call its deadline — is pinned deterministically by
@@ -321,8 +329,12 @@ struct BoundedProcessRunnerTests {
             Issue.record("expected .timedOut, got \(outcome)")
             return
         }
-        #expect(elapsed < TestDeadlines.saturatedPass,
-                "a 300 ms deadline resolved after \(elapsed) — the call waited its child out")
+        #expect(elapsed < .seconds(Self.childLifetimeSeconds),
+                """
+                a 300 ms deadline resolved after \(elapsed), which is past the \
+                \(Self.childLifetimeSeconds)s the child would have slept — the call waited its \
+                child out instead of killing it
+                """)
 
         let recorded = Self.readPid(from: pidFile)
         defer { if let recorded { kill(recorded, SIGKILL) } }
@@ -460,12 +472,23 @@ struct BoundedProcessRunnerTests {
         func set() { value = true }
     }
 
-    /// How long the TERM-ignoring sleeper lives. It must dominate every bound in
-    /// this suite — all of which are `TestDeadlines.saturatedPass` (90 s) — so a
-    /// child that is gone is a child something KILLED, never one that finished
-    /// its sleep inside the wait. Each such child is signalled by the escalation
-    /// under test and, failing that, by its test's own `defer`.
-    private static let childLifetimeSeconds = 300
+    /// How long the TERM-ignoring sleeper lives. Two jobs, and the second is why
+    /// the number is this large.
+    ///
+    /// It must dominate every `waitFor` in this suite — all of which are
+    /// `TestDeadlines.saturatedPass` (90 s) — so a child that is gone is a child
+    /// something KILLED, never one that finished its sleep inside the wait. Each
+    /// such child is signalled by the escalation under test and, failing that,
+    /// by its test's own `defer`.
+    ///
+    /// It is also the elapsed bound in
+    /// `aTermIgnoringChildIsKilledByTheEscalationAtItsDeadline`, which is what
+    /// makes that bound an observable of the code rather than a stopwatch on the
+    /// runner. That use is what sets the value: it has to dominate a saturated
+    /// fast pass 1, whose green-run per-test latency is p50 65.6 s / p99 92.1 s
+    /// and which produced two 103–107 s sightings of that test against a 90 s
+    /// ceiling. 600 s clears both by roughly six times.
+    private static let childLifetimeSeconds = 600
 
     /// A `sh -c` body that records its own pid, then becomes a long-lived sleeper
     /// that ignores SIGTERM. `SIG_IGN` is inherited across `exec`, so the

--- a/Tests/TBDDaemonTests/ModelProxy/ModelProxySupervisorTests.swift
+++ b/Tests/TBDDaemonTests/ModelProxy/ModelProxySupervisorTests.swift
@@ -424,11 +424,16 @@ struct ModelProxySupervisorTests {
     /// finishing — at which point the proxy is retired and the supervisor
     /// stops.
     ///
-    /// The one ladder in this file that cannot end on a re-arm: the tick this
-    /// advance fires ends in `finishDraining`, which calls `stop()` and cancels
-    /// the watch, so no sleeper ever registers again. The proof that the tick
-    /// finished is therefore the observable it produced — a bounded wait on a
-    /// positive fact, in the same shape ``respawnsAfterDeath`` uses.
+    /// The one ladder in this file that cannot end on a re-arm. The proxy here
+    /// is **adopted**, so nothing is pending collection when the drain
+    /// finishes: `enterReapOnlyIdle` takes its empty-`pendingReap` branch and
+    /// stops the watch outright, and no sleeper ever registers again. (A drain
+    /// that retired a child of this daemon's leaves the watch running in the
+    /// reap-only idle instead — that is
+    /// `aDrainedChildIsCollectedByTheWatchThatOutlivesTheRetire`, and it is why
+    /// this comment names the branch rather than the method.) The proof that
+    /// the tick finished is therefore the observable it produced — a bounded
+    /// wait on a positive fact, in the same shape ``respawnsAfterDeath`` uses.
     @Test("the last route retiring retires the proxy and stops the watch")
     func drainingEndsWhenTheLastRouteGoes() async throws {
         let fixture = try SupervisorFixture.make()

--- a/Tests/TBDDaemonTests/ModelProxy/ModelProxySupervisorTests.swift
+++ b/Tests/TBDDaemonTests/ModelProxy/ModelProxySupervisorTests.swift
@@ -24,8 +24,12 @@ import Testing
 ///   - **the process table** is a `StubIdentity` that can admit a pid, deny
 ///     one, or forget one between polls, which is what a proxy dying looks
 ///     like from the supervisor's side;
-///   - **the clock** is a `TestClock`, so the watch interval and the respawn
-///     backoff are advanced rather than waited out.
+///   - **the clock** is virtual, so the watch interval and the respawn backoff
+///     are advanced rather than waited out. Most cases take an
+///     `EventDrivenTestClock`, whose arming handshake is a signal rather than
+///     a poll; the three that advance a fixed number of times and then assert
+///     that nothing further happened keep the fixture's `TestClock`.
+///     `SupervisorFixture.supervisor(clock:)` has the split and the reason.
 ///
 /// The rendezvous is not stubbed: `FakeProxyProcess` writes a real
 /// `<home>/proxy/proxy.pid` the way the real binary does, and the adoption
@@ -373,14 +377,20 @@ struct ModelProxySupervisorTests {
     /// drain never reads a route count: what is observed here is only the
     /// respawn, which the old retire-on-off behaviour could not have produced —
     /// it stopped the watch and dropped the proxy before any of this.
+    ///
+    /// On `EventDrivenTestClock` for the reason ``respawnsAfterDeath`` spells
+    /// out: the watch is a fire-then-re-arm loop, so a wait that observes the
+    /// re-arm by polling `checkSuspension()` competes with the very task it is
+    /// waiting for.
     @Test("a proxy that dies while draining is still respawned")
     func drainingStillRespawnsAProxyThatDies() async throws {
         let fixture = try SupervisorFixture.make()
         defer { fixture.tearDown() }
+        let clock = EventDrivenTestClock()
 
         try await fixture.db.config.setModelProxyEnabled(true)
         await fixture.spawner.answer(.success(pid: 6150, port: SupervisorFixture.deadPort))
-        let supervisor = fixture.supervisor()
+        let supervisor = fixture.supervisor(clock: clock)
         await supervisor.startIfEnabled()
         #expect(await supervisor.current?.pid == 6150)
 
@@ -390,12 +400,18 @@ struct ModelProxySupervisorTests {
 
         await fixture.spawner.reap(pid: 6150, status: 0)
         await fixture.spawner.answer(.success(pid: 6151, port: SupervisorFixture.deadPort))
-        let respawned = await fixture.clock.advanceUntil(
-            "the draining proxy to be respawned", by: fixture.watchInterval,
-            { await supervisor.current?.pid == 6151 })
+        // One tick: it collects the dead child and the immediate respawn
+        // attempt succeeds, so `respawn`'s backoff never arms and exactly one
+        // sleeper — the watch interval — is in the ledger at each step.
+        try await clock.requireAdvanceWhenArmed(by: fixture.watchInterval)
+        // The re-arm is the proof that tick finished; advancing on this clock
+        // does not run the resumed task's post-sleep code.
+        try await clock.requireSleeperArmed()
         await supervisor.stop()
 
-        #expect(respawned)
+        #expect(
+            await supervisor.current?.pid == 6151,
+            "a proxy that dies while draining is respawned rather than dropped")
         #expect(
             await fixture.spawner.calls()
                 == [0, SupervisorFixture.deadPort],
@@ -407,10 +423,17 @@ struct ModelProxySupervisorTests {
     /// route as it exits, so the count reaching zero is the last of them
     /// finishing — at which point the proxy is retired and the supervisor
     /// stops.
+    ///
+    /// The one ladder in this file that cannot end on a re-arm: the tick this
+    /// advance fires ends in `finishDraining`, which calls `stop()` and cancels
+    /// the watch, so no sleeper ever registers again. The proof that the tick
+    /// finished is therefore the observable it produced — a bounded wait on a
+    /// positive fact, in the same shape ``respawnsAfterDeath`` uses.
     @Test("the last route retiring retires the proxy and stops the watch")
     func drainingEndsWhenTheLastRouteGoes() async throws {
         let fixture = try SupervisorFixture.make()
         defer { fixture.tearDown() }
+        let clock = EventDrivenTestClock()
 
         let proxy = try FakeProxyProcess(
             version: fixture.ownVersion, pid: 6160, home: fixture.home, routeCount: 2)
@@ -419,15 +442,20 @@ struct ModelProxySupervisorTests {
         try await fixture.db.config.setModelProxyEnabled(true)
         fixture.identity.admit(pid: 6160, startTime: proxy.processStartTime)
 
-        let supervisor = fixture.supervisor()
+        let supervisor = fixture.supervisor(clock: clock)
         await supervisor.startIfEnabled()
         try await fixture.db.config.setModelProxyEnabled(false)
         await supervisor.beginDraining()
         #expect(await supervisor.current?.pid == 6160, "two routes in flight keep it")
 
         proxy.setRouteCount(0)
-        let retired = await fixture.clock.advanceUntil(
-            "the drained proxy to be retired", by: fixture.watchInterval,
+        try await clock.requireAdvanceWhenArmed(by: fixture.watchInterval)
+        let retired = try await waitFor(
+            "the drained proxy to be retired",
+            observed: {
+                let pid = await supervisor.current?.pid
+                return pid.map { "still holding pid \($0)" } ?? "no proxy"
+            },
             { await supervisor.current == nil })
         await supervisor.stop()
 
@@ -444,10 +472,14 @@ struct ModelProxySupervisorTests {
     /// The zero route count is the discriminating half: it is exactly the input
     /// that retires the proxy in `drainingEndsWhenTheLastRouteGoes`, and here it
     /// must not.
+    ///
+    /// On `EventDrivenTestClock` with the ladder ``respawnsAfterDeath``
+    /// describes: one tick, waited for rather than polled for.
     @Test("turning the flag back on while draining keeps the proxy")
     func drainingIsClearedByTheFlagComingBackOn() async throws {
         let fixture = try SupervisorFixture.make()
         defer { fixture.tearDown() }
+        let clock = EventDrivenTestClock()
 
         let proxy = try FakeProxyProcess(
             version: fixture.ownVersion, pid: 6170, home: fixture.home, routeCount: 1)
@@ -456,7 +488,7 @@ struct ModelProxySupervisorTests {
         try await fixture.db.config.setModelProxyEnabled(true)
         fixture.identity.admit(pid: 6170, startTime: proxy.processStartTime)
 
-        let supervisor = fixture.supervisor()
+        let supervisor = fixture.supervisor(clock: clock)
         await supervisor.startIfEnabled()
         try await fixture.db.config.setModelProxyEnabled(false)
         await supervisor.beginDraining()
@@ -467,12 +499,13 @@ struct ModelProxySupervisorTests {
         proxy.setRouteCount(0)
 
         let pollsBefore = proxy.requests().filter { $0.path == "/tbd/status" }.count
-        let polled = await fixture.clock.advanceUntil(
-            "a watch poll after the flag came back on", by: fixture.watchInterval,
-            { proxy.requests().filter { $0.path == "/tbd/status" }.count > pollsBefore })
+        try await clock.requireAdvanceWhenArmed(by: fixture.watchInterval)
+        try await clock.requireSleeperArmed()
         await supervisor.stop()
 
-        #expect(polled)
+        #expect(
+            proxy.requests().filter { $0.path == "/tbd/status" }.count > pollsBefore,
+            "the watch kept polling after the flag came back on")
         #expect(
             proxy.requests().allSatisfy { $0.path != "/tbd/retire" },
             "a supervisor that is no longer draining must not retire on an empty route table")
@@ -1195,24 +1228,31 @@ struct ModelProxySupervisorTests {
     /// on its next tick. This is the discriminating half of the two tests
     /// above — without it, a supervisor that gave up on every failed spawn
     /// would pass them both.
+    ///
+    /// On `EventDrivenTestClock` with the ladder ``respawnsAfterDeath``
+    /// describes. One tick: the reconcile it runs finds no proxy and takes the
+    /// second stubbed answer, and `reconcile` arms no sleep of its own, so the
+    /// watch interval is the only sleeper in the ledger.
     @Test("a spawn that failed for a transient reason is retried by the watch")
     func retriesATransientSpawnFailure() async throws {
         let fixture = try SupervisorFixture.make()
         defer { fixture.tearDown() }
+        let clock = EventDrivenTestClock()
 
         await fixture.spawner.answer(.failure(.childExited(status: -9)))
         await fixture.spawner.answer(.success(pid: 7, port: SupervisorFixture.deadPort))
 
-        let supervisor = fixture.supervisor()
+        let supervisor = fixture.supervisor(clock: clock)
         await supervisor.start()
         #expect(await supervisor.current == nil)
 
-        let landed = await fixture.clock.advanceUntil(
-            "the watch to retry the spawn", by: fixture.watchInterval,
-            { await supervisor.current?.pid == 7 })
+        try await clock.requireAdvanceWhenArmed(by: fixture.watchInterval)
+        try await clock.requireSleeperArmed()
         await supervisor.stop()
 
-        #expect(landed)
+        #expect(
+            await supervisor.current?.pid == 7,
+            "a transient spawn failure is retried on the next tick")
     }
 
     /// No binary beside the daemon means no proxy, and that is a supported
@@ -1374,20 +1414,40 @@ struct ModelProxySupervisorTests {
     /// A proxy that is alive but slow to answer must not be replaced. This is
     /// the discriminating half of `respawnsAfterDeath`: the status probe fails
     /// in both, and only the process table tells them apart.
+    ///
+    /// **On `EventDrivenTestClock`, and for the same mechanism as its sibling.**
+    /// Three ticks is three re-arms, and on `TestClock` each one can only be
+    /// observed by polling `checkSuspension()`, whose `megaYield` is 20
+    /// serially-awaited background-QoS tasks — under the saturated fast pass
+    /// that probe floods the cooperative pool with exactly the low-priority
+    /// work the watch task needs a turn from. `advanceWhenSuspended` is also
+    /// the *soft* wait: a missed re-arm records an issue and advances anyway,
+    /// which moves `now` past a deadline that is not in the ledger yet and
+    /// desyncs the clock for every step after it. The strict ladder below
+    /// throws before anything advances instead.
+    ///
+    /// Exactly one sleeper is in the ledger at each step: every poll fails and
+    /// there is no identity anchor yet, so `tick` takes the "keep it" branch
+    /// and reaches no other `clock.sleep`.
     @Test("a live proxy that misses a status poll is kept, not replaced")
     func doesNotRespawnAProxyThatIsStillAlive() async throws {
         let fixture = try SupervisorFixture.make()
         defer { fixture.tearDown() }
+        let clock = EventDrivenTestClock()
 
         await fixture.spawner.answer(.success(pid: 810, port: SupervisorFixture.deadPort))
-        let supervisor = fixture.supervisor()  // no listener: every status poll fails
+        // No listener: every status poll fails.
+        let supervisor = fixture.supervisor(clock: clock)
         await supervisor.start()
         #expect(await supervisor.current?.pid == 810)
 
         // `reapIfExited` reports nothing, so the child is still running.
-        for _ in 0..<3 {
-            await fixture.clock.advanceWhenSuspended(by: fixture.watchInterval)
+        for _ in 1...3 {
+            try await clock.requireAdvanceWhenArmed(by: fixture.watchInterval)
         }
+        // The re-arm after the third tick is what makes the absence below an
+        // observation rather than a guess about whether that tick had run yet.
+        try await clock.requireSleeperArmed()
         await supervisor.stop()
 
         #expect(await supervisor.current?.pid == 810)
@@ -1609,10 +1669,16 @@ struct ModelProxySupervisorTests {
     /// An **adopted** proxy is not this daemon's child, so `waitpid` can never
     /// collect it: its death is read off the process table instead. The
     /// supervisor spawns a replacement on the port it held.
+    ///
+    /// On `EventDrivenTestClock` with the ladder ``respawnsAfterDeath``
+    /// describes. One tick: the poll fails, the process table refuses the
+    /// anchor, and the immediate respawn attempt succeeds — so `respawn`'s
+    /// backoff never arms and the watch interval is the only sleeper.
     @Test("an adopted proxy that leaves the process table is replaced")
     func replacesAnAdoptedProxyThatDied() async throws {
         let fixture = try SupervisorFixture.make()
         defer { fixture.tearDown() }
+        let clock = EventDrivenTestClock()
 
         let proxy = try FakeProxyProcess(version: fixture.ownVersion, pid: 9090, home: fixture.home)
         // Stopped again below, on purpose; the defer is for the paths where an
@@ -1621,7 +1687,7 @@ struct ModelProxySupervisorTests {
         try await fixture.db.config.setModelProxyPort(proxy.port)
         fixture.identity.admit(pid: 9090, startTime: proxy.processStartTime)
 
-        let supervisor = fixture.supervisor()
+        let supervisor = fixture.supervisor(clock: clock)
         await supervisor.start()
         #expect(await supervisor.current?.adopted == true)
 
@@ -1630,12 +1696,13 @@ struct ModelProxySupervisorTests {
         fixture.identity.forget(pid: 9090)
         await fixture.spawner.answer(.success(pid: 9091, port: adoptedPort))
 
-        let landed = await fixture.clock.advanceUntil(
-            "the dead adopted proxy to be replaced", by: fixture.watchInterval,
-            { await supervisor.current?.pid == 9091 })
+        try await clock.requireAdvanceWhenArmed(by: fixture.watchInterval)
+        try await clock.requireSleeperArmed()
         await supervisor.stop()
 
-        #expect(landed)
+        #expect(
+            await supervisor.current?.pid == 9091,
+            "an adopted proxy gone from the process table is replaced")
         #expect(await fixture.spawner.calls() == [adoptedPort])
     }
 
@@ -1648,10 +1715,18 @@ struct ModelProxySupervisorTests {
     /// the first and keep a dead proxy forever, with `current` naming a port
     /// nothing is listening on. The process table is what tells them apart,
     /// for a child exactly as for an adopted proxy.
+    ///
+    /// On `EventDrivenTestClock` with the ladder ``respawnsAfterDeath``
+    /// describes, and two ticks rather than one: the first is the quiet poll
+    /// that records the identity anchor, the second is the death. Each waits
+    /// for the re-arm the previous tick left behind, which is what proves that
+    /// tick finished — the anchor especially, since the second tick is
+    /// meaningless without it.
     @Test("a spawned proxy that leaves the process table is replaced, waitpid or not")
     func replacesASpawnedProxyWaitpidCannotCollect() async throws {
         let fixture = try SupervisorFixture.make()
         defer { fixture.tearDown() }
+        let clock = EventDrivenTestClock()
 
         let proxy = try FakeProxyProcess(version: fixture.ownVersion, pid: 8080, home: fixture.home)
         defer { proxy.stop() }
@@ -1662,13 +1737,14 @@ struct ModelProxySupervisorTests {
         fixture.identity.admit(pid: 8080, startTime: proxy.processStartTime)
         await fixture.spawner.answer(.success(pid: 8080, port: proxy.port))
 
-        let supervisor = fixture.supervisor()
+        let supervisor = fixture.supervisor(clock: clock)
         await supervisor.start()
         #expect(await supervisor.current?.adopted == false)
 
         // One quiet poll, which is where a spawned proxy gets the identity
         // anchor the death check reads: the start time it answered with.
-        await fixture.clock.advanceWhenSuspended(by: fixture.watchInterval)
+        try await clock.requireAdvanceWhenArmed(by: fixture.watchInterval)
+        try await clock.requireSleeperArmed()
         #expect(await supervisor.current?.pid == 8080)
 
         let heldPort = proxy.port
@@ -1678,12 +1754,13 @@ struct ModelProxySupervisorTests {
         // process cannot collect, so `reapIfExited` keeps answering nothing.
         await fixture.spawner.answer(.success(pid: 8081, port: heldPort))
 
-        let landed = await fixture.clock.advanceUntil(
-            "the lost child to be replaced", by: fixture.watchInterval,
-            { await supervisor.current?.pid == 8081 })
+        try await clock.requireAdvanceWhenArmed(by: fixture.watchInterval)
+        try await clock.requireSleeperArmed()
         await supervisor.stop()
 
-        #expect(landed, "a child waitpid cannot collect must not collapse into keep-forever")
+        #expect(
+            await supervisor.current?.pid == 8081,
+            "a child waitpid cannot collect must not collapse into keep-forever")
         #expect(await fixture.spawner.calls() == [heldPort, heldPort])
     }
 
@@ -1703,10 +1780,17 @@ struct ModelProxySupervisorTests {
     /// the second by the spawn the restart performs when adoption refuses the
     /// corpse. A supervisor that queued only on the first path leaks the
     /// second, and it leaks it on exactly the toggle path B2.3 will use.
+    ///
+    /// On `EventDrivenTestClock` with the ladder ``respawnsAfterDeath``
+    /// describes. One tick: the poll answers with a version that differs, and
+    /// the replacement happens inside that tick — `replaceIfVersionDiffers`
+    /// retires and spawns without sleeping, so the watch interval stays the
+    /// only sleeper in the ledger.
     @Test("a proxy this daemon replaced is collected, and a restart never adopts it back")
     func replacedProxyIsReapedAndNeverAdoptedBack() async throws {
         let fixture = try SupervisorFixture.make()
         defer { fixture.tearDown() }
+        let clock = EventDrivenTestClock()
 
         // The fake answers for pid 7075 throughout — a listener that outlives
         // the process it claims to be is exactly what a corpse looks like from
@@ -1720,17 +1804,18 @@ struct ModelProxySupervisorTests {
         await fixture.spawner.answer(.success(pid: 7075, port: proxy.port))
         await fixture.spawner.answer(.success(pid: 7076, port: proxy.port))
 
-        let supervisor = fixture.supervisor()
+        let supervisor = fixture.supervisor(clock: clock)
         await supervisor.start()
         #expect(await supervisor.current?.pid == 7075)
         #expect(await supervisor.current?.adopted == false, "a child of ours is never adopted")
 
         // The first poll reads the version the proxy actually reports, which
         // differs, so this daemon retires and replaces its own child.
-        let replaced = await fixture.clock.advanceUntil(
-            "the mismatched child to be replaced", by: fixture.watchInterval,
-            { await supervisor.current?.pid == 7076 })
-        #expect(replaced)
+        try await clock.requireAdvanceWhenArmed(by: fixture.watchInterval)
+        try await clock.requireSleeperArmed()
+        #expect(
+            await supervisor.current?.pid == 7076,
+            "a child whose version differs is retired and replaced")
 
         // What the runtime toggle does. Nothing is advanced across it: the
         // whole question is what `start()` decides, not what a watch tick
@@ -1773,10 +1858,15 @@ struct ModelProxySupervisorTests {
     /// daemon spawned to one it did not: the successor has to come out
     /// adopted, and the predecessor has to be queued for collection on the way
     /// past rather than dropped on the floor.
+    ///
+    /// On `EventDrivenTestClock` with the ladder ``respawnsAfterDeath``
+    /// describes. One tick: the poll answers for another pid, and the drop and
+    /// the fresh adoption both happen inside it, neither of them sleeping.
     @Test("a port that begins answering for another process is adopted afresh")
     func aMovedPidIsReadoptedRatherThanRenamed() async throws {
         let fixture = try SupervisorFixture.make()
         defer { fixture.tearDown() }
+        let clock = EventDrivenTestClock()
 
         let proxy = try FakeProxyProcess(version: fixture.ownVersion, pid: 9100, home: fixture.home)
         defer { proxy.stop() }
@@ -1788,7 +1878,7 @@ struct ModelProxySupervisorTests {
         fixture.identity.admit(pid: 9101, startTime: proxy.processStartTime)
         await fixture.spawner.answer(.success(pid: 9100, port: proxy.port))
 
-        let supervisor = fixture.supervisor()
+        let supervisor = fixture.supervisor(clock: clock)
         await supervisor.start()
         #expect(await supervisor.current?.pid == 9100)
         #expect(await supervisor.current?.adopted == false, "a child of ours is never adopted")
@@ -1796,11 +1886,12 @@ struct ModelProxySupervisorTests {
         // The port changes hands: another daemon replaced the proxy, or ours
         // went and something else bound the port it held.
         proxy.becomePid(9101)
-        let moved = await fixture.clock.advanceUntil(
-            "the port to be re-adopted for its new process", by: fixture.watchInterval,
-            { await supervisor.current?.pid == 9101 })
+        try await clock.requireAdvanceWhenArmed(by: fixture.watchInterval)
+        try await clock.requireSleeperArmed()
 
-        #expect(moved, "a status answer naming another pid must not be ignored")
+        #expect(
+            await supervisor.current?.pid == 9101,
+            "a status answer naming another pid must not be ignored")
         #expect(
             await supervisor.current?.adopted == true,
             "a pid this daemon never spawned is not its child, whatever the last one was")
@@ -2102,10 +2193,15 @@ private struct SupervisorFixture {
     /// names it, so nothing has to be redirected for the client to reach it —
     /// and a probe of a port with no listener fails for the real reason.
     ///
-    /// `clock` defaults to this fixture's `TestClock`; a test whose handshake
-    /// with the watch is more than one hop passes an `EventDrivenTestClock`
-    /// instead — see `respawnsAfterDeath` for why that is not a blanket
-    /// migration.
+    /// `clock` defaults to this fixture's `TestClock`, which now serves only
+    /// the three cases that advance a fixed number of times and then assert
+    /// that **nothing further happened**. Every case that waits for the watch to *do*
+    /// something passes an `EventDrivenTestClock` instead: the watch is a
+    /// fire-then-re-arm loop, and on `TestClock` a re-arm can only be observed
+    /// by polling `checkSuspension()`, whose `megaYield` is 20 serially-awaited
+    /// background-QoS tasks — the probe starves the very task it waits for
+    /// under the saturated fast pass. See `respawnsAfterDeath` for the field
+    /// evidence and `hungProxyEscalatesToSignalsThenRespawns` for the ladder.
     /// `routedSessionsAlive` answers "no session is routed" unless a case says
     /// otherwise, which is the answer that makes a flag-off boot run nothing —
     /// the shipped install.

--- a/Tests/TBDDaemonTests/PRStatusManagerBindingTests.swift
+++ b/Tests/TBDDaemonTests/PRStatusManagerBindingTests.swift
@@ -993,7 +993,20 @@ struct PRStatusManagerBindingTests {
         // and the recheck task plus that project's single-flight gate stay
         // wedged for as long as it lives — well past the 60 s the design leans
         // on to argue no reconciler is needed.
-        let clock = TestClock()
+        //
+        // **On `EventDrivenTestClock`, because the second sleep is armed
+        // somewhere the test cannot reach.** The deadline's expiry cancels the
+        // runner task, whose cancellation handler sends SIGTERM and then hands
+        // the escalation to a `Task.detached` that sleeps `childKillGrace` —
+        // three or four scheduling hops from this body. On `TestClock` the only
+        // way to see that arming is to poll `checkSuspension()`, whose
+        // `megaYield` is 20 serially-awaited background-QoS tasks, and under
+        // the saturated fast pass that probe competes with the very hops it is
+        // waiting on. `EventDrivenTestClock` signals the arming from inside the
+        // critical section that registers the sleeper, so the second advance
+        // lands on a sleeper that is provably in the ledger. The grace sleep
+        // fires once and is never re-armed, so the count here is exactly two.
+        let clock = EventDrivenTestClock()
         let gl = GitLabFake()
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("tbd-glab-kill-\(UUID().uuidString)")
@@ -1037,9 +1050,19 @@ struct PRStatusManagerBindingTests {
         #expect(kill(childPID, 0) == 0, "the child was not running for the deadline to end")
 
         // Virtual time: the deadline fires, then the grace after SIGTERM.
-        await clock.advanceWhenSuspended(by: PRStatusManager.recheckTimeout)
-        let died = await clock.advanceUntil(
-            "the SIGTERM-immune recheck child to be killed", by: PRStatusManager.childKillGrace
+        try await clock.requireAdvanceWhenArmed(by: PRStatusManager.recheckTimeout)
+        // `TestDeadlines.saturatedPass` rather than the 45 s default: the
+        // arming this waits for is several hops from here (see above), and 45 s
+        // sits inside the fast pass's own per-test latency, so the default
+        // would measure the runner.
+        try await clock.requireAdvanceWhenArmed(
+            by: PRStatusManager.childKillGrace, timeout: TestDeadlines.saturatedPass)
+        // The SIGKILL and the kernel's reap are real, so the verdict is a
+        // bounded wait on the observable rather than a read taken the instant
+        // virtual time moved.
+        let died = try await waitFor(
+            "the SIGTERM-immune recheck child to be killed",
+            observed: { kill(childPID, 0) == 0 ? "pid \(childPID) still alive" : "pid \(childPID) gone" }
         ) { kill(childPID, 0) != 0 && errno == ESRCH }
 
         #expect(died, "the child outlived its deadline: SIGTERM alone cannot end it")

--- a/Tests/TBDDaemonTests/RosterWatcherTests.swift
+++ b/Tests/TBDDaemonTests/RosterWatcherTests.swift
@@ -616,13 +616,22 @@ struct RosterWatcherTickTests {
     /// between ticks is announced on the next one.
     ///
     /// The registry is written **after** the loop has armed its first sleep, so
-    /// the opening scan provably cannot be what announced it, and the advancing
-    /// is done by `advanceUntil` rather than by a fixed count — the loop is a
-    /// poll-and-re-arm, which is the exact shape a single advance turns into a
-    /// hang.
+    /// the opening scan provably cannot be what announced it.
+    ///
+    /// **On `EventDrivenTestClock`, because the loop is a scan-then-re-arm.**
+    /// `run()` refreshes and then sleeps, so every arming is the far side of a
+    /// completed scan — which is exactly what makes the ladder below readable:
+    /// the arming this test waits for before writing proves the opening scan
+    /// ran, and the arming it waits for after advancing proves the tick did.
+    /// On `TestClock` those two facts can only be observed by polling
+    /// `checkSuspension()`, whose `megaYield` is 20 serially-awaited
+    /// background-QoS tasks — under the saturated fast pass that probe floods
+    /// the cooperative pool with exactly the low-priority work the roster task
+    /// needs a turn from, and starves the thing it is waiting for. The
+    /// signature is "observed 1 clock advance" against a 45 s budget.
     @Test func theTickRescansOnTheInjectedInterval() async throws {
         try await withRegistry { directory in
-            let clock = TestClock<Duration>()
+            let clock = EventDrivenTestClock()
             let sink = FrameSink()
             let subject = watcher(
                 directory: directory,
@@ -637,17 +646,16 @@ struct RosterWatcherTickTests {
             // interval. Waiting for that arm before writing the record is what
             // makes the tick load-bearing: the session cannot have been picked
             // up by the opening scan.
-            await clock.waitForSuspension()
+            try await clock.requireSleeperArmed()
             #expect(await sink.frames.isEmpty)
 
             try write(registryRecord(), pid: 4242, in: directory)
-            let announced = await clock.advanceUntil(
-                "the roster to announce a session that appeared between ticks", by: .seconds(2)
-            ) {
-                !peers(await sink.frames).isEmpty
-            }
+            try await clock.requireAdvanceWhenArmed(by: .seconds(2))
+            // The re-arm is the proof the scan finished: this clock's `advance`
+            // does no yielding, so it promises only that the sleeper's
+            // continuation was resumed.
+            try await clock.requireSleeperArmed()
 
-            #expect(announced)
             #expect(peers(await sink.frames).map(\.name) == ["laptop:useful-swallow %3541"])
         }
     }

--- a/Tests/TBDHolderTests/HolderBinaryTests.swift
+++ b/Tests/TBDHolderTests/HolderBinaryTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import TestSupport
 import Testing
 @testable import TBDHolder
 @testable import TBDShared
@@ -42,18 +43,21 @@ struct HolderBinaryTests {
     /// forever, so a spawner that sees it must fix them or give up rather than
     /// retry — and either way it must never get back a session whose pty nobody
     /// owns.
-    @Test func aBadInvocationExitsTwoWithAUsageDiagnostic() throws {
+    ///
+    /// `async` on `collectOutput(of:)` rather than synchronous on
+    /// `readDataToEndOfFile()` + `waitUntilExit()`: both of those park the
+    /// calling thread until the child is done, and in a synchronous test body
+    /// that thread belongs to the cooperative pool CI's runner has three of
+    /// (`Tests/CLAUDE.md`, "Thread-blocking gates run off the cooperative
+    /// pool"). This target holds two such waits and `TBDModelProxyTests` a
+    /// third, which is as many as the pool is wide.
+    @Test func aBadInvocationExitsTwoWithAUsageDiagnostic() async throws {
         let executable = try #require(Self.locateExecutable())
         let process = Process()
         process.executableURL = executable
-        let stderrPipe = Pipe()
-        process.standardError = stderrPipe
-        process.standardOutput = Pipe()
-        try process.run()
-        let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
-        process.waitUntilExit()
-        #expect(process.terminationStatus == 2)
-        let diagnostic = String(decoding: stderrData, as: UTF8.self)
+        let output = try await collectOutput(of: process)
+        #expect(output.status == 2)
+        let diagnostic = String(decoding: output.stderr, as: UTF8.self)
         #expect(diagnostic.contains("--session is required"))
         #expect(diagnostic.contains("--lock-fd"), "the usage line must name the descriptor flag")
     }
@@ -68,7 +72,7 @@ struct HolderBinaryTests {
     /// no permissions games and leaving nothing behind. A bootstrap `sh` opens
     /// the lock descriptor the holder demands and then `exec`s, so the status
     /// observed here is the holder's own.
-    @Test func anEnvironmentFailureExitsThreeRatherThanTwo() throws {
+    @Test func anEnvironmentFailureExitsThreeRatherThanTwo() async throws {
         let executable = try #require(Self.locateExecutable())
         let launch = HolderLaunchRequest(
             executable: "/bin/sh",
@@ -98,17 +102,13 @@ struct HolderBinaryTests {
         // Explicit and rc-free: nothing here may come from the developer's
         // shell, and the holder must not find a real TBD home to write into.
         process.environment = ["PATH": "/usr/bin:/bin"]
-        let stderrPipe = Pipe()
-        process.standardError = stderrPipe
-        process.standardOutput = Pipe()
-        try process.run()
-        let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
-        process.waitUntilExit()
+        // Off the cooperative pool, for the reason given on the test above.
+        let output = try await collectOutput(of: process)
 
         #expect(
-            process.terminationStatus == 3,
+            output.status == 3,
             "an environment failure must not be reported as a bad command line")
-        let diagnostic = String(decoding: stderrData, as: UTF8.self)
+        let diagnostic = String(decoding: output.stderr, as: UTF8.self)
         #expect(diagnostic.contains("could not create the holder rendezvous directory"))
     }
 

--- a/Tests/TBDModelProxyTests/FakeUpstream.swift
+++ b/Tests/TBDModelProxyTests/FakeUpstream.swift
@@ -67,8 +67,16 @@ final class FakeUpstream: @unchecked Sendable {
     }
 
     /// Binds loopback on a kernel-assigned port and returns it.
+    ///
+    /// `async` on the bind future's `get()` rather than synchronous on
+    /// `wait()`: `EventLoopFuture.wait()` parks the calling thread until the
+    /// bind completes, and every caller here is a test body running on Swift's
+    /// cooperative pool — three threads wide on CI's runner, and shared with
+    /// every other suspended task in the process. `Tests/CLAUDE.md`
+    /// ("Thread-blocking gates run off the cooperative pool") has the wedge
+    /// this produces when a few such holds coincide.
     @discardableResult
-    func start() throws -> Int {
+    func start() async throws -> Int {
         let script = self.script
         let record: @Sendable (HTTPRequestHead, [UInt8]) -> Void = { [weak self] head, body in
             guard let self else { return }
@@ -87,7 +95,7 @@ final class FakeUpstream: @unchecked Sendable {
                 }
             }
 
-        let bound = try bootstrap.bind(host: "127.0.0.1", port: 0).wait()
+        let bound = try await bootstrap.bind(host: "127.0.0.1", port: 0).get()
         channel = bound
         // Thrown rather than defaulted: port 0 is a legal thing to *ask* for
         // and means "the kernel picks one", so handing it back as the bound
@@ -99,14 +107,26 @@ final class FakeUpstream: @unchecked Sendable {
         return port
     }
 
-    /// Closes the listener and shuts the event loop down. Safe to call twice,
-    /// and safe to call after a `start()` that threw — which is why callers
-    /// register their `defer { stop() }` *before* starting, so a failed bind
-    /// cannot leak the event-loop group.
+    /// Asks the listener to close and the event loop group to shut down, and
+    /// returns immediately. Safe to call twice, and safe to call after a
+    /// `start()` that threw — which is why callers register their
+    /// `defer { stop() }` *before* starting, so a failed bind cannot leak the
+    /// event-loop group.
+    ///
+    /// **Nothing here blocks**, which is what lets it stay in a `defer` (a
+    /// `defer` cannot `await`). The previous shape did both halves
+    /// synchronously — `close().wait()` and `syncShutdownGracefully()` — and a
+    /// `defer` in a test body runs on a cooperative-pool thread, which is the
+    /// hold `Tests/CLAUDE.md` names under "Thread-blocking gates run off the
+    /// cooperative pool". Neither half has a result any caller reads: the
+    /// close is a teardown, and `shutdownGracefully` reports through a callback
+    /// on a background queue that discards it. What a test observes about this
+    /// fake — `requests`, and the bytes it already served — is lock-guarded and
+    /// unaffected by when the loops actually stop.
     func stop() {
-        try? channel?.close().wait()
+        channel?.close(promise: nil)
         channel = nil
-        try? group.syncShutdownGracefully()
+        group.shutdownGracefully { _ in }
     }
 }
 

--- a/Tests/TBDModelProxyTests/FakeUpstreamTests.swift
+++ b/Tests/TBDModelProxyTests/FakeUpstreamTests.swift
@@ -16,7 +16,7 @@ struct FakeUpstreamTests {
         // safe on an unstarted server, and a bind that throws would otherwise
         // leave the event-loop group running for the rest of the test process.
         defer { upstream.stop() }
-        let port = try upstream.start()
+        let port = try await upstream.start()
 
         let requestBody = Data(#"{"model":"claude-stub","stream":true}"#.utf8)
         var request = URLRequest(url: try #require(URL(string: "http://127.0.0.1:\(port)/v1/messages")))

--- a/Tests/TBDModelProxyTests/ProxyBinaryTests.swift
+++ b/Tests/TBDModelProxyTests/ProxyBinaryTests.swift
@@ -1,4 +1,3 @@
-import Clocks
 import Darwin
 import Foundation
 import NIOCore
@@ -193,10 +192,22 @@ extension ProxyBinaryTests {
     ///
     /// The window is virtual on two axes, and they are different seams on
     /// purpose. The *pacing* — how often the watch wakes — rides the injected
-    /// `Clock`, so a `TestClock` crosses it without a real sleep. The *window*
+    /// `Clock`, so virtual time crosses it without a real sleep. The *window*
     /// is a span between two `Date`s, which is what the production check
     /// compares, and the test moves that wall clock by hand. `Duration` is
     /// behavior, `Date` is data.
+    ///
+    /// **The pacing clock is an `EventDrivenTestClock`, because `run()` is a
+    /// sleep-then-sample loop.** Every advance past the first is a re-arm, and
+    /// on `TestClock` a re-arm can only be observed by polling
+    /// `checkSuspension()`, whose `megaYield` is 20 serially-awaited
+    /// background-QoS tasks — under the saturated fast pass that probe floods
+    /// the cooperative pool with exactly the low-priority work the watch task
+    /// needs a turn from. The helper these tests used instead advanced blindly
+    /// up to 40 times and re-checked a sample counter, which is 80 megaYields
+    /// of the same work; here each advance waits for the arming that makes it
+    /// sound, and the arming that follows a sample is what proves the sample
+    /// happened.
     @Suite("Proxy retention watch")
     struct ProxyRetentionTests {
 
@@ -205,13 +216,14 @@ extension ProxyBinaryTests {
             let start = Date(timeIntervalSince1970: 1_800_000_000)
             let wall = MovableWallClock(start)
             let retires = TestCounter()
-            let clock = TestClock()
+            let clock = EventDrivenTestClock()
+            let interval = Duration.seconds(60)
 
             let watch = ProxyRetireWatch(
                 lastDaemonContact: { start },
                 streamsInFlight: { 0 },
                 onRetire: { retires.increment() },
-                checkInterval: .seconds(60),
+                checkInterval: interval,
                 unattendedAfter: 24 * 60 * 60,
                 now: { wall.read() },
                 clock: clock)
@@ -220,20 +232,29 @@ extension ProxyBinaryTests {
 
             // First sample: the contact is fresh, so nothing happens. This is
             // the discriminating leg — a watch that retired on its first tick
-            // would satisfy every assertion below and fail here.
-            await advanceUntilSampled(clock, wall)
+            // would satisfy every assertion below and fail here. The re-arm
+            // after the advance is what proves the sample was taken.
+            try await clock.requireAdvanceWhenArmed(by: interval)
+            try await clock.requireSleeperArmed()
             #expect(retires.value == 0, "the watch retired a proxy contacted a moment ago")
 
-            // A day passes on the wall clock while the daemon says nothing.
+            // A day passes on the wall clock while the daemon says nothing. No
+            // re-arm follows this sample — `run()` hands over and returns — so
+            // the observable is what proves it landed.
             wall.advance(24 * 60 * 60)
-            await advanceUntilSampled(clock, wall)
+            try await clock.requireAdvanceWhenArmed(by: interval)
             await waitUntil(
-                "the watch retired the unattended proxy", sample: { retires.value },
-                isSatisfied: { $0 >= 1 })
+                "the watch retired the unattended proxy",
+                seconds: TestDeadlines.saturatedPassSeconds,
+                sample: { retires.value }, isSatisfied: { $0 >= 1 })
 
             // Once, and then the loop is done: `onRetire` ends the process, and
-            // a second call would be a second exit.
-            await clock.advance(by: .seconds(600))
+            // a second call would be a second exit. A watch that kept looping
+            // would arm another sleep, which is what this rules out — watched
+            // for rather than settled for, so a late arming is still caught.
+            #expect(
+                await watchForSleeper(on: clock) == false,
+                "the retention watch armed another sleep after it had retired")
             #expect(retires.value == 1)
         }
 
@@ -247,13 +268,14 @@ extension ProxyBinaryTests {
             let inFlight = TestCounter()
             inFlight.set(1)
             let retires = TestCounter()
-            let clock = TestClock()
+            let clock = EventDrivenTestClock()
+            let interval = Duration.seconds(60)
 
             let watch = ProxyRetireWatch(
                 lastDaemonContact: { start },
                 streamsInFlight: { inFlight.value },
                 onRetire: { retires.increment() },
-                checkInterval: .seconds(60),
+                checkInterval: interval,
                 unattendedAfter: 24 * 60 * 60,
                 now: { wall.read() },
                 clock: clock)
@@ -261,15 +283,19 @@ extension ProxyBinaryTests {
             defer { task.cancel() }
 
             wall.advance(48 * 60 * 60)
-            await advanceUntilSampled(clock, wall)
+            try await clock.requireAdvanceWhenArmed(by: interval)
+            try await clock.requireSleeperArmed()
             #expect(retires.value == 0, "a turn in flight was cut by the retention watch")
 
-            // The turn ends; the next sample retires.
+            // The turn ends; the next sample retires, and that sample is the
+            // last — `run()` returns rather than re-arming, so the observable
+            // is what proves it landed.
             inFlight.set(0)
-            await advanceUntilSampled(clock, wall)
+            try await clock.requireAdvanceWhenArmed(by: interval)
             await waitUntil(
-                "the watch retired once the last stream ended", sample: { retires.value },
-                isSatisfied: { $0 >= 1 })
+                "the watch retired once the last stream ended",
+                seconds: TestDeadlines.saturatedPassSeconds,
+                sample: { retires.value }, isSatisfied: { $0 >= 1 })
         }
 
         /// The predicate without the loop, at the boundary, and against the
@@ -294,29 +320,6 @@ extension ProxyBinaryTests {
             #expect(!watch.isUnattendedAndIdle(at: start.addingTimeInterval(window * 10)))
         }
 
-        /// Advances virtual time until the watch has taken one more sample.
-        ///
-        /// A plain `advance` is not enough on its own: `TestClock.advance` moves
-        /// `now` whether or not a sleeper is armed, and an advance that lands
-        /// before the watch has parked leaves the clock permanently ahead of a
-        /// sleep scheduled afterwards. Retrying is self-healing — a later
-        /// advance passes the deadline the sleeper eventually registered — and
-        /// the sample count makes "it never ran at all" a named failure rather
-        /// than an assertion that passes vacuously.
-        ///
-        /// The count comes from the wall clock: `run()` reads `now()` exactly
-        /// once per iteration, after its sleep returns.
-        private func advanceUntilSampled(
-            _ clock: TestClock<Duration>, _ wall: MovableWallClock,
-            interval: Duration = .seconds(60)
-        ) async {
-            let before = wall.reads
-            for _ in 0..<40 {
-                await clock.advance(by: interval)
-                if wall.reads > before { return }
-            }
-            Issue.record("the retention watch never took a sample")
-        }
     }
 }
 
@@ -1005,25 +1008,20 @@ extension ModelProxySuites {
 
 // MARK: - Test doubles
 
-/// A wall clock the test moves by hand, counting reads.
+/// A wall clock the test moves by hand.
 ///
-/// The count is what makes the retention watch observable: `run()` reads
-/// `now()` exactly once per iteration, so a change in `reads` is proof it took
-/// a sample rather than an assumption that it did.
+/// The `Date` half of the retention watch's two seams: the window it compares
+/// is a span between two `Date`s, and this is what lets a test cross a
+/// twenty-four-hour one without waiting. The pacing half rides the injected
+/// `Clock` instead — `Duration` is behavior, `Date` is data.
 final class MovableWallClock: @unchecked Sendable {
     private let lock = NSLock()
     private var now: Date
-    private var readCount = 0
 
     init(_ start: Date) { self.now = start }
 
-    var reads: Int { lock.withLock { readCount } }
-
     func read() -> Date {
-        lock.withLock {
-            readCount += 1
-            return now
-        }
+        lock.withLock { now }
     }
 
     func advance(_ interval: TimeInterval) {

--- a/Tests/TBDModelProxyTests/ProxyBinaryTests.swift
+++ b/Tests/TBDModelProxyTests/ProxyBinaryTests.swift
@@ -3,6 +3,7 @@ import Darwin
 import Foundation
 import NIOCore
 import NIOHTTP1
+import TestSupport
 import Testing
 
 @testable import TBDModelProxy
@@ -46,27 +47,28 @@ struct ProxyBinaryTests {
     /// one refuses before it can touch a home or bind anything. The environment
     /// is explicit and rc-free for the same reason every holder bootstrap is —
     /// nothing here may come from the developer's shell.
+    ///
+    /// `async` on `collectOutput(of:)` rather than synchronous on two
+    /// `readDataToEndOfFile()` calls plus `waitUntilExit()`: each of those
+    /// parks the calling thread until the child is done, and in a synchronous
+    /// test body that thread belongs to the cooperative pool CI's runner has
+    /// three of (`Tests/CLAUDE.md`, "Thread-blocking gates run off the
+    /// cooperative pool"). This one test held three of the three, and two runs
+    /// went silent for ~30 minutes with no failing test to name.
     @Test("a bad invocation exits 2 with a usage diagnostic and a silent stdout")
-    func aBadInvocationExitsTwoWithAUsageDiagnostic() throws {
+    func aBadInvocationExitsTwoWithAUsageDiagnostic() async throws {
         let executable = try #require(ProxyExecutable.locate())
         let process = Process()
         process.executableURL = executable
         process.arguments = ["--stream-dir", "/tmp"]
         process.environment = ["PATH": "/usr/bin:/bin"]
-        let stderrPipe = Pipe()
-        let stdoutPipe = Pipe()
-        process.standardError = stderrPipe
-        process.standardOutput = stdoutPipe
-        try process.run()
-        let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
-        let stdoutData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
-        process.waitUntilExit()
+        let output = try await collectOutput(of: process)
 
-        #expect(process.terminationStatus == TBDModelProxyExit.badArguments)
-        let diagnostic = String(decoding: stderrData, as: UTF8.self)
+        #expect(output.status == TBDModelProxyExit.badArguments)
+        let diagnostic = String(decoding: output.stderr, as: UTF8.self)
         #expect(diagnostic.contains("unknown argument --stream-dir"))
         #expect(diagnostic.contains("--lock-fd"), "the usage line must name the descriptor flag")
-        #expect(stdoutData.isEmpty, "a proxy must never write to stdout")
+        #expect(output.stdout.isEmpty, "a proxy must never write to stdout")
     }
 
     /// The exit taxonomy Part B2's supervisor branches on. Pinned as a set of
@@ -504,7 +506,7 @@ extension ModelProxySuites {
                 (delayMs: 400, bytes: Array("event: tick\ndata: {\"n\":\(index)}\n\n".utf8))
             }
             let upstream = FakeUpstream { _, _ in FakeUpstream.Script(events: ticks) }
-            let upstreamPort = try upstream.start()
+            let upstreamPort = try await upstream.start()
             defer { upstream.stop() }
 
             let home = proxyScratchRoot(prefix: "pxsigd").path
@@ -607,7 +609,7 @@ extension ModelProxySuites {
                 (delayMs: 500, bytes: Array("event: tick\ndata: {\"n\":\(index)}\n\n".utf8))
             }
             let upstream = FakeUpstream { _, _ in FakeUpstream.Script(events: ticks) }
-            let upstreamPort = try upstream.start()
+            let upstreamPort = try await upstream.start()
             defer { upstream.stop() }
 
             let home = proxyScratchRoot(prefix: "pxsig2").path
@@ -723,7 +725,7 @@ extension ModelProxySuites {
             // connections linger — does not let two *listeners* share a port on
             // BSD, which is what makes this reachable at all.
             let squatter = FakeUpstream { _, _ in FakeUpstream.Script(events: []) }
-            let takenPort = try squatter.start()
+            let takenPort = try await squatter.start()
             defer { squatter.stop() }
 
             let home = proxyScratchRoot(prefix: "pxbind").path
@@ -751,7 +753,7 @@ extension ModelProxySuites {
                     headers: [("content-type", "application/json")],
                     events: [(delayMs: 0, bytes: Array(#"{"ok":true}"#.utf8))])
             }
-            let upstreamPort = try upstream.start()
+            let upstreamPort = try await upstream.start()
             defer { upstream.stop() }
 
             let home = proxyScratchRoot(prefix: "pxload").path
@@ -861,7 +863,7 @@ extension ModelProxySuites {
                 (delayMs: 1000, bytes: Array("event: tick\ndata: {\"n\":\(index)}\n\n".utf8))
             }
             let upstream = FakeUpstream { _, _ in FakeUpstream.Script(events: ticks) }
-            let upstreamPort = try upstream.start()
+            let upstreamPort = try await upstream.start()
             defer { upstream.stop() }
 
             let home = proxyScratchRoot(prefix: "pxrelk").path

--- a/Tests/TBDModelProxyTests/ProxyControlTests.swift
+++ b/Tests/TBDModelProxyTests/ProxyControlTests.swift
@@ -294,6 +294,20 @@ extension ModelProxySuites {
                         // The "no stream was cut" half of the test does not come out
                         // of this wait either: it is the in-flight count above and
                         // the six events below.
+                        //
+                        // **Thirty, and deliberately not `TestDeadlines
+                        // .saturatedPass`**, which `Tests/CLAUDE.md` otherwise
+                        // asks of every bounded wait in a fast-pass target. This
+                        // one is coupled to a resource it does not own: the
+                        // response the drain below reads is still open on
+                        // `harness.session`, whose `timeoutIntervalForResource` is
+                        // 30 seconds (`withProxy`). A bind wait allowed to run
+                        // past that kills the stream it is holding up, and turns
+                        // one diagnosed failure into a second, unrelated one —
+                        // which is the cascade the skip-when-not-free check above
+                        // was added to stop. Raising this number means raising
+                        // that one too, for every test the harness serves; until
+                        // then the pair moves together or not at all.
                         let poll = await pollUntilTrue(
                             timeout: .seconds(30), pollInterval: .milliseconds(50)
                         ) {

--- a/Tests/TBDModelProxyTests/ProxyForwardingTests.swift
+++ b/Tests/TBDModelProxyTests/ProxyForwardingTests.swift
@@ -1094,22 +1094,22 @@ func withProxy(
     let sessionBox = ClientSessionBox()
 
     func teardown() async {
-        // Both of these can block: `ProxyServer.stop()` shuts an event-loop
-        // group down, and `FakeUpstream.stop()` does it synchronously. They run
-        // under their own deadlines so a teardown that wedges reports rather
-        // than eating the job's whole budget.
+        // `ProxyServer.stop()` can block — it shuts an event-loop group down —
+        // so it runs under its own deadline, and a teardown that wedges reports
+        // rather than eating the job's whole budget. `FakeUpstream.stop()`
+        // needs neither: it asks the listener and the group to close and
+        // returns at once (see its doc comment), so there is nothing to bound
+        // and nothing to move off the cooperative pool.
         if let server = serverBox.take() {
             _ = try? await withPhaseDeadline("proxy stop", seconds: 20) { await server.stop() }
         }
-        _ = try? await withPhaseDeadline("upstream stop", seconds: 20) {
-            await offCooperativePool { upstream.stop() }
-        }
+        upstream.stop()
         sessionBox.take()?.invalidateAndCancel()
         try? FileManager.default.removeItem(at: root)
     }
 
     do {
-        let upstreamPort = try upstream.start()
+        let upstreamPort = try await upstream.start()
 
         let routesDir = root.appendingPathComponent("proxy/routes")
         let streamsDir = root.appendingPathComponent("streams")
@@ -1230,18 +1230,6 @@ func withPhaseDeadline<Value: Sendable>(
     work.cancel()
     timer.cancel()
     return try result.get()
-}
-
-/// Runs a blocking call on a `DispatchQueue` rather than on the cooperative
-/// pool, which has one thread per core and is what every other test in the
-/// process is also running on.
-func offCooperativePool(_ work: @escaping @Sendable () -> Void) async {
-    await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-        DispatchQueue.global().async {
-            work()
-            continuation.resume()
-        }
-    }
 }
 
 /// A one-shot value: the first `finish` wins and wakes whoever is awaiting.

--- a/Tests/TBDModelProxyTests/ProxyForwardingTests.swift
+++ b/Tests/TBDModelProxyTests/ProxyForwardingTests.swift
@@ -336,75 +336,100 @@ extension ModelProxySuites {
             // proxy learns the connection is gone when a later write to it fails.
             // A script that ended near that moment would let a relay which
             // reported nothing on cancellation still be rescued by the stream
-            // finishing on its own, and the test would pass for the wrong reason.
-            // 40 events at 1 s is 40 seconds of stream against the 20-second
-            // waits below. The ratio is what matters and it is a discriminating
-            // threshold rather than a hang guard, so it is sized by moving the
-            // *script* out rather than by shortening the wait: at 250 ms an
-            // event the stream ran out after 10 s, which left only a 5-second
-            // wait, and 5 seconds is inside the scheduling latency fast pass 2
-            // routinely shows — it went red on CI with the count still at 1
-            // while nothing was wrong with the relay. Nothing waits for this
-            // script to finish: the client cuts after the first event, and
-            // `ScriptedUpstreamHandler` stops rescheduling as soon as its
-            // channel goes inactive.
-            let events = (1...40).map { index in
+            // finishing on its own, and the test would pass for the wrong
+            // reason. So the ratio between the script and the waits is the
+            // whole assertion, and it is kept by moving the *script* out rather
+            // than by shortening the waits.
+            //
+            // 200 events at 1 s is 200 seconds of stream against the
+            // `TestDeadlines.saturatedPass` (90 s) waits below. Both earlier
+            // sizings failed the same way and from the same end: at 250 ms an
+            // event the stream ran out after 10 s, leaving a 5-second wait, and
+            // 5 seconds is well inside the scheduling latency fast pass 2
+            // shows — it went red with the count still at 1 and nothing wrong
+            // with the relay. Forty seconds of script and 20-second waits then
+            // went red twice more, on two unrelated PRs (runs 34302602847 and
+            // 34296850539 attempt 1), for the same reason: what these waits
+            // observe is released by production code queued on the same
+            // cooperative pool as every other test in the pass, so a bound
+            // below that pass's own per-test latency measures the runner rather
+            // than the relay. 90 s is the shared constant for exactly that, and
+            // 200 s keeps the ratio it needs.
+            //
+            // Nothing waits for this script to finish: the client cuts after
+            // the first event, and `ScriptedUpstreamHandler` stops rescheduling
+            // as soon as its channel goes inactive.
+            let events = (1...200).map { index in
                 (delayMs: 1000, bytes: Array("event: tick\ndata: {\"n\":\(index)}\n\n".utf8))
             }
 
             try await withProxy(
                 prefix: "pxcd",
                 script: { _, _ in FakeUpstream.Script(events: events) },
-                tee: recorder
-            ) { harness in
-                let requestBody = #"{"stream":true}"#
-                let request = """
-                    POST /r/\(harness.token)/v1/messages HTTP/1.1\r
-                    Host: 127.0.0.1\r
-                    Content-Type: application/json\r
-                    Content-Length: \(requestBody.utf8.count)\r
-                    \r
-                    \(requestBody)
-                    """
-                let port = harness.port
-                // A raw socket rather than a cancelled `URLSession` task: the
-                // moment the client's FIN goes out has to be the test's to choose,
-                // because every assertion below is about what the proxy does after
-                // it.
-                let seen = try await withPhaseDeadline("cut after first event", seconds: 30) {
-                    try await withCheckedThrowingContinuation {
-                        (continuation: CheckedContinuation<String, any Error>) in
-                        DispatchQueue.global().async {
-                            continuation.resume(
-                                with: Result {
-                                    try rawHTTPCutAfterMarker(
-                                        port: port, request: request, marker: "event: tick")
-                                })
+                tee: recorder,
+                // Only the cut — the request this phase is named for. The two
+                // waits that follow it run in `afterRequest`, outside
+                // "request"'s 60-second deadline: at 90 s apiece they would
+                // otherwise trip the generic `ProxyPhaseTimeout("request", 60)`
+                // instead of their own diagnosed message, because nested phases
+                // share "request"'s window rather than getting one each. See
+                // `withProxy`'s doc comment.
+                body: { harness in
+                    let requestBody = #"{"stream":true}"#
+                    let request = """
+                        POST /r/\(harness.token)/v1/messages HTTP/1.1\r
+                        Host: 127.0.0.1\r
+                        Content-Type: application/json\r
+                        Content-Length: \(requestBody.utf8.count)\r
+                        \r
+                        \(requestBody)
+                        """
+                    let port = harness.port
+                    // A raw socket rather than a cancelled `URLSession` task: the
+                    // moment the client's FIN goes out has to be the test's to
+                    // choose, because every assertion below is about what the
+                    // proxy does after it.
+                    let seen = try await withPhaseDeadline("cut after first event", seconds: 30) {
+                        try await withCheckedThrowingContinuation {
+                            (continuation: CheckedContinuation<String, any Error>) in
+                            DispatchQueue.global().async {
+                                continuation.resume(
+                                    with: Result {
+                                        try rawHTTPCutAfterMarker(
+                                            port: port, request: request, marker: "event: tick")
+                                    })
+                            }
                         }
                     }
+                    #expect(seen.contains("event: tick"), "the client never saw a first event")
+                    // The stream is still running upstream — 199 more events, a
+                    // second apart, are scripted — so nothing below can be
+                    // explained by the response having finished on its own.
+                    #expect(harness.upstream.requests.count == 1)
+                },
+                afterRequest: { harness in
+                    // Bounded well below the script's own 200 seconds, so a relay
+                    // that only ends because the upstream ran out of events cannot
+                    // pass. `TestDeadlines.saturatedPass` rather than a literal:
+                    // both of these are released by production code queued on the
+                    // pass's own cooperative pool.
+                    await waitUntil(
+                        "the relay released its in-flight stream",
+                        seconds: TestDeadlines.saturatedPassSeconds,
+                        sample: { harness.server.streamsInFlight }, isSatisfied: { $0 == 0 })
+                    await waitUntil(
+                        "the tee was told the stream ended",
+                        seconds: TestDeadlines.saturatedPassSeconds,
+                        sample: { recorder.endCount }, isSatisfied: { $0 == 1 })
+                    #expect(recorder.beginCount == 1)
+                    // Exactly once: `relayEnd` deduplicates, and a second end would
+                    // reach a tee that has already written its terminal line.
+                    #expect(recorder.endCount == 1)
+                    #expect(
+                        recorder.lastEndError != nil,
+                        "a hung-up turn is an aborted one, so the tee's end carries an error")
                 }
-                #expect(seen.contains("event: tick"), "the client never saw a first event")
-                // The stream is still running upstream — 39 more events, a second
-                // apart, are scripted — so nothing below can be explained by the
-                // response having finished on its own.
-                #expect(harness.upstream.requests.count == 1)
-
-                // Bounded well below the script's own 40 seconds, so a relay that
-                // only ends because the upstream ran out of events cannot pass.
-                await waitUntil(
-                    "the relay released its in-flight stream", seconds: 20,
-                    sample: { harness.server.streamsInFlight }, isSatisfied: { $0 == 0 })
-                await waitUntil(
-                    "the tee was told the stream ended", seconds: 20,
-                    sample: { recorder.endCount }, isSatisfied: { $0 == 1 })
-                #expect(recorder.beginCount == 1)
-                // Exactly once: `relayEnd` deduplicates, and a second end would
-                // reach a tee that has already written its terminal line.
-                #expect(recorder.endCount == 1)
-                #expect(
-                    recorder.lastEndError != nil,
-                    "a hung-up turn is an aborted one, so the tee's end carries an error")
-            }
+            )
         }
 
         @Test("a stream in flight is counted while it runs and released when it ends")

--- a/Tests/TestSupport/ClockTestSupport.swift
+++ b/Tests/TestSupport/ClockTestSupport.swift
@@ -273,6 +273,28 @@ public extension TestClock {
     /// as the code re-arms, which would dissolve that proof. Use the explicit
     /// `advanceWhenSuspended` pair there.
     ///
+    /// **And — the sharper limit — where the loop under test re-arms under a
+    /// saturated fast pass, because this helper starves the re-arm it is
+    /// waiting for.** Each turn probes `isArmed()`, which is
+    /// `checkSuspension()`, which opens with a `megaYield`: twenty
+    /// serially-awaited **background-QoS** tasks. At a 25 ms poll interval that
+    /// is ~1,800 probes and ~36,000 background tasks over the 45 s budget,
+    /// queued on the same cooperative pool the poller needs a turn from — and
+    /// macOS starves background QoS hardest under exactly the load that makes
+    /// the wait necessary. The field signature is this helper's own diagnostic
+    /// reading **"observed 1 clock advance"**: the first tick landed and the
+    /// re-arm after it was never seen. On 2026-09-08 that reddened
+    /// `ModelProxySupervisorTests` on three consecutive CI dispatches of one
+    /// unrelated SHA, over 45–170 s, with nothing wrong with the supervisor.
+    ///
+    /// So this helper is for a **one-shot** wait — something that arms once and
+    /// fires once. A re-arming loop belongs on `EventDrivenTestClock`
+    /// (`Tests/TestSupport/EventDrivenTestClock.swift`), whose arming signal is
+    /// emitted from inside the critical section that registers the sleeper, as
+    /// an explicit ladder of `requireAdvanceWhenArmed` closed by a
+    /// `requireSleeperArmed` — the re-arm being the proof that the tick before
+    /// it finished. `Tests/CLAUDE.md`, "The event-driven alternative".
+    ///
     /// - Parameters:
     ///   - what: names the effect being waited for, for the timeout diagnostic.
     ///   - interval: virtual time per step — normally the pacing the code under

--- a/Tests/TestSupport/ClockTestSupport.swift
+++ b/Tests/TestSupport/ClockTestSupport.swift
@@ -279,13 +279,12 @@ public extension TestClock {
     /// `checkSuspension()`, which opens with a `megaYield`: twenty
     /// serially-awaited **background-QoS** tasks. At a 25 ms poll interval that
     /// is ~1,800 probes and ~36,000 background tasks over the 45 s budget,
-    /// queued on the same cooperative pool the poller needs a turn from — and
-    /// macOS starves background QoS hardest under exactly the load that makes
-    /// the wait necessary. The field signature is this helper's own diagnostic
+    /// queued on the same cooperative pool the poller needs a turn from. The
+    /// field signature is this helper's own diagnostic
     /// reading **"observed 1 clock advance"**: the first tick landed and the
     /// re-arm after it was never seen. On 2026-09-08 that reddened
     /// `ModelProxySupervisorTests` on three consecutive CI dispatches of one
-    /// unrelated SHA, over 45–170 s, with nothing wrong with the supervisor.
+    /// SHA, over 45–170 s, with nothing wrong with the supervisor.
     ///
     /// So this helper is for a **one-shot** wait — something that arms once and
     /// fires once. A re-arming loop belongs on `EventDrivenTestClock`

--- a/Tests/TestSupport/ProcessOutputSupport.swift
+++ b/Tests/TestSupport/ProcessOutputSupport.swift
@@ -1,0 +1,155 @@
+import Darwin
+import Foundation
+
+// Running a child process from a test without blocking a cooperative thread.
+//
+// `Process.waitUntilExit()` and `FileHandle.readDataToEndOfFile()` both park
+// the calling thread until the child is done. In a synchronous test body that
+// thread is one of Swift's cooperative pool, which is only as wide as the
+// machine has cores — three on CI's `macos-26-arm64` runner. Every suspended
+// task in the process draws on that pool, so a handful of such holds landing
+// together is the wedge `Tests/CLAUDE.md` documents under "Thread-blocking
+// gates run off the cooperative pool": the pass goes silent, dies on the
+// step's `timeout-minutes` with zero failing tests, and no per-test
+// `.timeLimit` fires, because a blocked thread is where cooperative
+// cancellation cannot reach. Two runs died that way (34174344530 and
+// 34176996067) with three such holds live at once.
+//
+// ``collectOutput(of:)`` is the seam that keeps those holds off the pool: the
+// waiting is a continuation, and the only threads that block are libdispatch's
+// own.
+
+/// What a finished child process produced.
+public struct ProcessOutput: Sendable {
+    public let status: Int32
+    public let stdout: Data
+    public let stderr: Data
+}
+
+/// Runs `process` to completion and returns its exit status and both output
+/// streams, without blocking the thread that called it.
+///
+/// The caller configures `executableURL`, `arguments`, `environment` and
+/// anything else it needs, and does **not** call `run()`: this helper installs
+/// its own pipes on `standardOutput` and `standardError` (replacing whatever
+/// was set), arms the termination handler, and starts the child itself.
+///
+/// Three properties are load-bearing rather than incidental:
+///
+/// - **The termination handler is armed before `run()`.** A short-lived child
+///   can exit before `run()` returns, and a handler installed afterwards would
+///   never fire — the wait would then be bounded by nothing at all.
+/// - **Both pipes are drained concurrently, on libdispatch threads.** A single
+///   reader deadlocks on a child that fills the other pipe's buffer, and a
+///   reader on a cooperative thread is the hold this helper exists to remove.
+/// - **The continuation is resumed exactly once**, when the exit status and
+///   both end-of-file reads have all landed — or immediately, with the error,
+///   if `run()` throws.
+///
+/// - Throws: whatever `Process.run()` throws (a missing or non-executable
+///   binary, most often).
+public func collectOutput(of process: Process) async throws -> ProcessOutput {
+    let collector = ProcessOutputCollector(process: process)
+    return try await collector.run()
+}
+
+/// The state one `collectOutput(of:)` call needs, in one place so nothing
+/// non-`Sendable` has to cross a closure boundary.
+///
+/// `@unchecked Sendable` because every stored property is either immutable or
+/// guarded by `lock`; the `Process` and `Pipe` it owns are touched from the
+/// dispatch queues below and from the termination handler, which is exactly
+/// what the lock serializes.
+private final class ProcessOutputCollector: @unchecked Sendable {
+    private let lock = NSLock()
+    private let process: Process
+    private let outPipe = Pipe()
+    private let errPipe = Pipe()
+
+    private var continuation: CheckedContinuation<ProcessOutput, any Error>?
+    private var status: Int32?
+    private var stdout: Data?
+    private var stderr: Data?
+
+    init(process: Process) {
+        self.process = process
+    }
+
+    func run() async throws -> ProcessOutput {
+        try await withCheckedThrowingContinuation { continuation in
+            start(continuation)
+        }
+    }
+
+    private func start(_ continuation: CheckedContinuation<ProcessOutput, any Error>) {
+        lock.withLock { self.continuation = continuation }
+        process.standardOutput = outPipe
+        process.standardError = errPipe
+        // Armed before `run()`: see the doc comment. `[weak self]` rather than a
+        // strong capture because the handler is stored on the process, which
+        // this object owns — a strong capture would be a retain cycle that only
+        // a child that actually exits could break.
+        process.terminationHandler = { [weak self] finished in
+            let code = finished.terminationStatus
+            self?.deliver { $0.status = code }
+        }
+        do {
+            try process.run()
+        } catch {
+            process.terminationHandler = nil
+            let waiting: CheckedContinuation<ProcessOutput, any Error>? = lock.withLock {
+                let pending = self.continuation
+                self.continuation = nil
+                return pending
+            }
+            waiting?.resume(throwing: error)
+            return
+        }
+        // Read to end-of-file on libdispatch threads. Both closures capture
+        // only `self`, so no non-`Sendable` value crosses the boundary.
+        DispatchQueue.global().async { [self] in
+            let data = Self.readToEnd(descriptor: outPipe.fileHandleForReading.fileDescriptor)
+            deliver { $0.stdout = data }
+        }
+        DispatchQueue.global().async { [self] in
+            let data = Self.readToEnd(descriptor: errPipe.fileHandleForReading.fileDescriptor)
+            deliver { $0.stderr = data }
+        }
+    }
+
+    /// Records one of the three parts and resumes the waiter once all three are
+    /// in. The resume happens outside the lock, because a continuation resumes
+    /// into arbitrary caller code.
+    private func deliver(_ record: (ProcessOutputCollector) -> Void) {
+        let ready: (CheckedContinuation<ProcessOutput, any Error>, ProcessOutput)? = lock.withLock {
+            record(self)
+            guard let status, let stdout, let stderr, let waiting = continuation else { return nil }
+            continuation = nil
+            return (waiting, ProcessOutput(status: status, stdout: stdout, stderr: stderr))
+        }
+        guard let ready else { return }
+        ready.0.resume(returning: ready.1)
+    }
+
+    /// `read(2)` in a loop rather than `readDataToEndOfFile()`, so the only
+    /// thing crossing into the dispatch closure is a descriptor number. `EINTR`
+    /// is retried; any other error ends the read with what was collected, which
+    /// is what the caller's assertions want to see anyway.
+    private static func readToEnd(descriptor: Int32) -> Data {
+        var collected = Data()
+        var buffer = [UInt8](repeating: 0, count: 16 * 1024)
+        while true {
+            let count = buffer.withUnsafeMutableBytes { raw -> Int in
+                guard let base = raw.baseAddress else { return -1 }
+                return Darwin.read(descriptor, base, raw.count)
+            }
+            if count > 0 {
+                collected.append(contentsOf: buffer[0..<count])
+            } else if count == 0 {
+                return collected
+            } else if errno != EINTR {
+                return collected
+            }
+        }
+    }
+}

--- a/Tests/TestSupport/ProcessOutputSupport.swift
+++ b/Tests/TestSupport/ProcessOutputSupport.swift
@@ -1,4 +1,5 @@
 import Darwin
+import Dispatch
 import Foundation
 
 // Running a child process from a test without blocking a cooperative thread.
@@ -123,9 +124,11 @@ private final class ProcessOutputCollector: @unchecked Sendable {
     private func deliver(_ record: (ProcessOutputCollector) -> Void) {
         let ready: (CheckedContinuation<ProcessOutput, any Error>, ProcessOutput)? = lock.withLock {
             record(self)
-            guard let status, let stdout, let stderr, let waiting = continuation else { return nil }
-            continuation = nil
-            return (waiting, ProcessOutput(status: status, stdout: stdout, stderr: stderr))
+            guard let exitStatus = self.status, let out = self.stdout, let err = self.stderr,
+                let waiting = self.continuation
+            else { return nil }
+            self.continuation = nil
+            return (waiting, ProcessOutput(status: exitStatus, stdout: out, stderr: err))
         }
         guard let ready else { return }
         ready.0.resume(returning: ready.1)


### PR DESCRIPTION
## Summary

On 2026-09-08 nearly every CI run reddened on a test that had nothing to do with the change under review, and always in the tail of the fast parallel passes. Anyone opening a PR that day paid for it twice: once in the rerun, and once in the doubt about whether the red was theirs. This PR takes six such tests off the instruments that were producing those reds and puts them on observables of the code they are testing, so a green run stays green under load and a red one names something real.

Five sightings drove it, and they fall into three mechanisms.

**A wait that starves what it waits for.** `TestClock.advanceUntil` probes `checkSuspension()` every 25 ms, and swift-clocks' `megaYield` inside that probe is twenty serially awaited background-QoS tasks. Forty-five seconds of probing floods the cooperative pool with exactly the low-priority work a re-arming poller needs a turn from. The signature is the helper's own diagnostic reading **"observed 1 clock advance"** — the first tick landed, the re-arm after it was never seen. It reddened `ModelProxySupervisorTests` on three consecutive CI dispatches of one SHA (runs 34228498880, 34229870098, 34231920213), over 45 to 170 seconds. PR #844 moved that suite's hang-ladder tests off it; this finishes the job for every remaining site of the same shape.

**Wall-clock upper bounds on work that itself has to be scheduled.** `BoundedProcessRunnerTests.aTermIgnoringChildIsKilledByTheEscalationAtItsDeadline` bounded a call by `TestDeadlines.saturatedPass` (90 s) and went red twice in a row on PR #843 at elapsed 103–107 s, on a runner shared with two other runs (runs 34284111508 attempt 3 and 34286874077). Fast pass 1's own green-run per-test latency is p50 65.6 s, p99 92.1 s, max 95.5 s — the bound was inside the noise it was measuring. `ProxyForwardingTests`' "a client that hangs up mid-stream still ends the relay and the tee" failed the same way with 20-second waits, on two more unrelated PRs (runs 34302602847 and 34296850539 attempt 1).

**Threads parked where the pool cannot spare them.** Five waits in the fast pass blocked a cooperative-pool thread apiece until a child process or a NIO bind finished, and CI's runner has three such threads. Three holds coinciding is the wedge `Tests/CLAUDE.md` documents: runs 34174344530 and 34176996067 went silent for ~30 minutes and died on the step's `timeout-minutes` with zero failing tests.

One more, unrelated to load: `TerminalTeardownReapTests`' two "a second cleanup() tears nothing down" tests close a pty master and immediately `forkpty` again, and the kernel hands back the pty number just closed while it is still being revoked — the slave open answers `ENXIO`.

## Why this shape

**No spec, and deliberately.** These are test-support fixes that restore the suite to its existing theory rather than revising it. Every rule they apply is already written down in `Tests/CLAUDE.md` — "no bounded wait in a fast-pass target carries a literal deadline", "thread-blocking gates run off the cooperative pool", "a bound cannot buy a hop its turn" — and the event-driven clock these conversions move onto has its own committed design (`docs/specs/2026-08-11-event-driven-test-clock-design.md`), which explicitly anticipates suites migrating onto it "on field evidence, one at a time". This PR is that evidence being acted on. No product code changes.

**No new clock helper.** The brief allowed adding an event-driven `advanceUntil` for sites whose advance count cannot be known ahead of time. Reading the supervisor, the roster watcher, the poll scheduler, the retention watch and `PRStatusManager` showed every converted site has a **deterministic** count — one tick, two, or three — so the conversions are explicit strict ladders that say what the code does instead of converging on it. A converging helper would have re-introduced, in a new place, the thing that makes a wrong tick count invisible.

**Strict rather than soft waits, everywhere.** `requireAdvanceWhenArmed` throws before virtual time moves, so a missed arming ends the chain instead of desyncing the clock and hanging later with no attribution. Its soft twin records and advances anyway, which *is* the desync.

**The proof that a tick finished is always an observable.** `EventDrivenTestClock.advance` does no yielding, so it promises only that a continuation was resumed. Where the loop re-arms, the re-arm is that proof (`requireSleeperArmed`). Where it does not — a watch that stops itself, an effect delivered off the loop — the proof is a bounded `waitFor` on the positive fact, never a read taken the instant virtual time moved.

## What this PR does

**Blocking waits off the cooperative pool.** A new `TestSupport` helper, `collectOutput(of:)`, runs a spawned binary to completion and returns its status and both streams: it installs its own pipes, arms the termination handler *before* `run()`, drains both pipes concurrently on libdispatch threads with raw `read(2)` loops, and resumes one continuation when all three parts have landed. Everything non-`Sendable` lives inside a single collector object, so nothing crosses a closure boundary. Three tests move onto it — one in `ProxyBinaryTests`, two in `HolderBinaryTests` — and `TBDHolderTests` gains the `TestSupport` dependency that needs. `FakeUpstream.start()` becomes `async` on the bind future's `get()`, and `stop()` stops blocking at all so it can stay in a `defer` that cannot await; its seven call sites follow, and `withProxy`'s teardown drops the phase deadline and the off-pool hop it no longer needs.

**A syscall retry for one named errno.** `TerminalTeardownReapTests.startChild` asks `forkpty` again — three attempts, 10 ms apart, a fresh `LocalProcess` each time — but only when `shellPid <= 0` and the errno read immediately after `startProcess` is `ENXIO`. Every other errno falls straight through to the existing diagnostic, and three `ENXIO`s in a row still fail with the machine state that decides the cause. This is a retry of one syscall on one errno, not the blanket test retry `Tests/CLAUDE.md` bans.

**A bound read off the child instead of the clock.** `aTermIgnoringChildIsKilledByTheEscalationAtItsDeadline` now asserts the call returned before its child could have finished sleeping, and the child's lifetime rises to 600 s so that bound dominates a saturated pass with margin. The `waitFor` on the child being reaped keeps `TestDeadlines.saturatedPass`: it is a hang-catcher on a positive observable, which is what the shared constant is for.

**Clock conversions to `EventDrivenTestClock`**, each an explicit ladder with the tick count derived from the code under test:

- `ModelProxySupervisorTests` — all eight remaining `advanceUntil` sites (draining respawn, drain end, flag-back-on, transient spawn retry, adopted death, spawned death, version replacement, moved pid) plus `doesNotRespawnAProxyThatIsStillAlive`, the sibling of the tests #844 moved.
- `RosterWatcherTests.theTickRescansOnTheInjectedInterval`, whose own comment already named the poll-and-re-arm shape.
- `TranscriptSourceStreamTests`' two poll-scheduling tests.
- `ProxyBinaryTests`' two retention-watch tests, which drop a local helper that advanced blindly up to 40 times against a sample counter — 80 megaYields of the very work that starves the watch — and the counter with it. The "loop is done" assertion becomes `watchForSleeper`, which keeps looking, rather than an advance against an empty ledger.
- `PRStatusManagerBindingTests.recheckChildIsKilledWhenItIgnoresSIGTERM`, where the second sleep is armed three or four hops away inside a `Task.detached` a cancellation handler starts. Its arming wait takes `TestDeadlines.saturatedPass` rather than the 45 s default, and the SIGKILL is observed through a bounded `waitFor`.

**The hang-up test's waits.** Both move to `TestDeadlines.saturatedPass`, the script grows from 40 events to 200 so the ratio that makes them discriminating survives, and they move into `afterRequest` because at 90 s apiece they would trip `withProxy`'s 60-second "request" phase instead of their own diagnosed message.

**Documentation.** `Tests/CLAUDE.md` and `advanceUntil`'s own doc comment now say that the helper is for one-shot waits, that under a saturated pass its probes starve the re-arm it waits for, and that a re-arming loop belongs on `EventDrivenTestClock`.

## Assumptions

**The proxy's retire cannot answer before its listener is closed.** `ControlEndpoints.retire()` awaits `closeListener()`, which awaits the listener channel's `close()` future, and only then returns the 200; the drain is handed back as an `afterAnswer` callback rather than started inline. So the ordering the retire test asserts is a property of the code, and the reds that test produced were never it. **No product change was made, and none is needed.**

**The hang-up test's waits measured the runner, not a slow release.** `UpstreamForwarder.forward` delivers `onEnd` from a `for await event in events` loop over an `AsyncStream`, and the tee's `end` crosses a second continuation into a task of its own. Both hops queue on the same cooperative pool as every other test in the pass, whose green-run p90 per-test latency in fast pass 2 is 51.4 s. A 20-second bound therefore sat below the latency of the hop it was guarding. The release itself does no waiting: `relayEnd` decrements the in-flight count synchronously under a lock. **Not a product defect.**

**The retire test's successor-bind wait keeps its literal 30 seconds, against the general rule.** It is coupled to a resource it does not own: the response the drain after it reads is still open on `harness.session`, whose `timeoutIntervalForResource` is also 30. A bind wait allowed to run past that kills the stream it is holding up and turns one diagnosed failure into two — the cascade the skip-when-not-free probe was added to stop. Raising it means raising the session's resource timeout for every test the harness serves, which is a change of its own. The reason is now written at the call site so the next reader does not "fix" it.

**Deliberately not converted, and why:**

- **`PaneRepairCoordinatorTests`** — same shape (14 waits on the predecessor helpers, four `advanceUntil` sites, `.clockDriven`), but converting it is a suite-wide migration with its own hang risk, and it was not among the 2026-09-08 sightings. Recorded here as the next candidate.
- **`QueuedPromptDeliveryTests`** — its `advancePastSettle` helper cannot move without rewriting waits it does not own: its own doc comment records that the readiness ceiling sleeps on the same clock, so "some task is suspended" can be true of the wrong sleeper. Its literal 20-second helper deadlines are the same class as the ones this PR raises and are worth a follow-up on their own terms.
- **Three `advanceWhenSuspended` sites in `ModelProxySupervisorTests`** (`doesNotRespawnOnHomeUnusable`, `doesNotRespawnOnBadArguments`, `buildsOneClientPerPort`) — fixed-count advances that then assert nothing further happened. They keep the fixture's `TestClock`, which is why `supervisor(clock:)` keeps its override parameter.
- **Live-target sites** (`Tests/TBDDaemonLiveTests`) — the quiet pass runs `--no-parallel` on an idle machine and never sees this saturation; the instruments this PR replaces are not misreading anything there.
- **`TestSupport.shell(_:at:)`** still blocks on `waitUntilExit()`. It is reached only from git-fixture setup, not from a wait a test is racing, so it is left as remaining work rather than folded in here.

## Evidence & verification

**CI is the compile and the verdict.** Nothing was built or run locally; this machine is shared and the suite it would run is the one under repair.

**What discriminates, per change:**

- Every converted ladder would **throw, not hang**, if its tick count were wrong: `requireAdvanceWhenArmed` refuses to advance without a registered sleeper and names the step that gave up. A conversion that mis-read the code under test therefore fails loudly on the first CI run rather than passing for the wrong reason. The three cases whose loop stops re-arming — the drain end, and the two retention-watch retires — are the ones that would hang if that reasoning were wrong, so each ends on a bounded `waitFor` or `waitUntil` with an observed-state diagnostic instead.
- The `ENXIO` retry is gated on `pid <= 0 && errno == ENXIO`, so a healthy start never reaches it and any other failure produces exactly the diagnostic it produced before. The condition is what makes it a fix rather than a mask.
- The `childLifetimeSeconds` bound still fails a call that waits its child out — that call returns at ten minutes, and the assertion fires with the elapsed time in the message. Raising the lifetime strengthens the *other* half too: the `waitFor` that finds the child gone can only be satisfied by something having killed it.
- The hang-up test's 200-second script preserves the property that motivated its length: a relay that ended only because the upstream ran out of events still cannot satisfy a 90-second wait.
- `collectOutput(of:)` is exercised by the three tests that adopt it, each of which asserts a specific exit status *and* the diagnostic text on the stream it reads — so a helper that dropped output, resumed twice, or returned a status before the reads finished reddens those tests rather than passing quietly.
- `swiftlint --strict` over the whole tree: clean.

https://claude.ai/code/session_01TggE2eESL3BcvSgFcLZkpk
[ci flake fixes](https://cheapsteak.github.io/tbd/open/?worktree=94096C42-383A-4889-8ABE-3131F1220DAA)
