### PR TITLE
Feat: revive, fork, and hook tabs spawn on the pty holder when the flag is on

### DIFF
--- a/Sources/TBDDaemon/Claude/SessionRecaptureScheduler.swift
+++ b/Sources/TBDDaemon/Claude/SessionRecaptureScheduler.swift
@@ -1,10 +1,25 @@
 import Foundation
 
+/// Where a post-resume session-id recapture looks for the Claude process whose
+/// session file it must read.
+///
+/// One case per transport, because the two address the same process
+/// differently and neither address is meaningful to the other: a tmux session
+/// is reached through its pane (the pid is `#{pane_pid}`, resolved on demand),
+/// a holder-backed one through the pid the holder recorded when it forked the
+/// job. A holder row's pane id is the empty string by construction, so a
+/// recapture that carried only a pane would poll a coordinate that can never
+/// resolve.
+public enum SessionRecaptureTarget: Sendable, Equatable {
+    case tmuxPane(server: String, paneID: String)
+    case holderChild(pid: Int32)
+}
+
 struct SessionRecaptureScheduler: Sendable {
     let db: TBDDatabase
     let tmux: TmuxManager
     let clock: any Clock<Duration>
-    private let captureSessionID: @Sendable (String, String) async -> String?
+    private let captureSessionID: @Sendable (SessionRecaptureTarget) async -> String?
 
     init(
         db: TBDDatabase,
@@ -15,15 +30,15 @@ struct SessionRecaptureScheduler: Sendable {
         self.tmux = tmux
         self.clock = clock
         let detector = ClaudeStateDetector(tmux: tmux)
-        self.captureSessionID = { server, paneID in
-            await detector.captureSessionID(server: server, paneID: paneID)
+        self.captureSessionID = { target in
+            await detector.captureSessionID(target: target)
         }
     }
 
     init(
         db: TBDDatabase,
         tmux: TmuxManager,
-        captureSessionID: @escaping @Sendable (String, String) async -> String?,
+        captureSessionID: @escaping @Sendable (SessionRecaptureTarget) async -> String?,
         clock: any Clock<Duration>
     ) {
         self.db = db
@@ -35,18 +50,32 @@ struct SessionRecaptureScheduler: Sendable {
     @discardableResult
     func schedule(
         terminalID: UUID,
-        paneID: String,
-        server: String,
+        target: SessionRecaptureTarget,
         expectedIncarnationID: UUID?
     ) -> Task<Void, Never> {
         Task {
             guard (try? await clock.sleep(for: .seconds(5))) != nil else { return }
-            if let sessionID = await captureSessionID(server, paneID) {
+            if let sessionID = await captureSessionID(target) {
                 _ = try? await db.terminals.updateSessionIDIfIncarnationMatches(
                     id: terminalID,
                     expectedIncarnationID: expectedIncarnationID,
                     sessionID: sessionID)
             }
         }
+    }
+
+    /// The tmux spelling of `schedule(terminalID:target:expectedIncarnationID:)`,
+    /// for the call sites that address a pane and nothing else.
+    @discardableResult
+    func schedule(
+        terminalID: UUID,
+        paneID: String,
+        server: String,
+        expectedIncarnationID: UUID?
+    ) -> Task<Void, Never> {
+        schedule(
+            terminalID: terminalID,
+            target: .tmuxPane(server: server, paneID: paneID),
+            expectedIncarnationID: expectedIncarnationID)
     }
 }

--- a/Sources/TBDDaemon/Holder/HolderRegistry.swift
+++ b/Sources/TBDDaemon/Holder/HolderRegistry.swift
@@ -633,10 +633,25 @@ actor HolderRegistry {
     /// pid. Each one leaks a live process, so each is reported rather than
     /// swallowed.
     func abandon(terminal: Terminal) async -> String? {
+        await abandon(
+            terminalID: terminal.id,
+            holderPID: terminal.holderPID,
+            childPID: terminal.childPID)
+    }
+
+    /// The same teardown for a caller that no longer has a row to read the pids
+    /// back from.
+    ///
+    /// The pre-session hook tab is the case: its worktree row can be cascaded
+    /// away mid-wait, taking every terminal row with it, and what is left is
+    /// the descriptor phase 2b returned. The rendezvous still comes from this
+    /// registry's own environment, so the caller needs nothing but the pids it
+    /// was handed at spawn.
+    func abandon(terminalID: UUID, holderPID: Int32?, childPID: Int32?) async -> String? {
         let socketPath: String
         do {
             socketPath = try HolderRendezvous.socketPath(
-                sessionID: terminal.id, environment: environment)
+                sessionID: terminalID, environment: environment)
         } catch {
             return "\(error)"
         }
@@ -647,13 +662,13 @@ actor HolderRegistry {
         // signal — deliberately, since `kill(0, …)` would signal the daemon's
         // own process group.
         await abandon(
-            terminalID: terminal.id,
+            terminalID: terminalID,
             handle: HolderHandle(
-                holderPID: terminal.holderPID ?? 0,
-                childPID: terminal.childPID ?? 0,
+                holderPID: holderPID ?? 0,
+                childPID: childPID ?? 0,
                 socketPath: socketPath))
-        guard terminal.childPID != nil else {
-            return "terminal \(terminal.id) recorded no child pid, so its holder was told to "
+        guard childPID != nil else {
+            return "terminal \(terminalID) recorded no child pid, so its holder was told to "
                 + "let go but the job it forked was not killed"
         }
         return nil

--- a/Sources/TBDDaemon/Holder/HolderRegistry.swift
+++ b/Sources/TBDDaemon/Holder/HolderRegistry.swift
@@ -237,6 +237,14 @@ actor HolderRegistry {
     /// pretending it could have spawned one. Adoption does not need it: an
     /// already-running holder is reached through its socket.
     private let spawner: HolderSpawner?
+    /// How this registry asks the kernel about, and signals, a pid.
+    ///
+    /// Injected rather than reached for statically because the one path that
+    /// *verifies* a pid before signalling it — `abandonVerifiedJob` — is only
+    /// testable if the process table can be scripted: the whole point of that
+    /// check is what it does about a pid the kernel has handed to somebody
+    /// else, and that is not a state a test can arrange with real processes.
+    private let signaller: any ProcessSignaller
     /// Whether this registry can start a holder at all — that is, whether
     /// `spawn` can do anything but throw `.holderExecutableUnavailable`.
     ///
@@ -425,6 +433,7 @@ actor HolderRegistry {
         environment: [String: String] = ProcessInfo.processInfo.environment,
         listTerminals: @escaping @Sendable () async throws -> [Terminal],
         spawner: HolderSpawner? = nil,
+        signaller: any ProcessSignaller = ProductionProcessSignaller(),
         busyRetryBudget: Duration = HolderRegistry.defaultBusyRetryBudget,
         adoptAllBudget: Duration = HolderRegistry.defaultAdoptAllBudget,
         clock: any Clock<Duration> = ContinuousClock()
@@ -433,6 +442,7 @@ actor HolderRegistry {
         self.environment = environment
         self.listTerminals = listTerminals
         self.spawner = spawner
+        self.signaller = signaller
         self.canSpawn = spawner != nil
         self.busyRetryBudget = busyRetryBudget
         self.adoptAllBudget = adoptAllBudget
@@ -672,6 +682,133 @@ actor HolderRegistry {
                 + "let go but the job it forked was not killed"
         }
         return nil
+    }
+
+    /// The hook-tab spelling of the teardown above: the same `forget`, the
+    /// same reap, and a job kill that happens **only** once the pid has been
+    /// proved to still name the process this session recorded.
+    ///
+    /// A hook tab is the one holder session whose job has usually already
+    /// exited by the time anything tears it down — the setup tab's auto-close
+    /// fires *because* the hook finished — so the window between the job's
+    /// death and this teardown is wide open, and a pid the kernel reissued in
+    /// it is the pid `dispose` would signal. `jobProcessGroup`'s `pgid ==
+    /// childPID` test does not close that: a reissued pid that is its own
+    /// session leader (any shell a stranger's `forkpty` made) passes it, and
+    /// the group-widening `SIGKILL` then takes that whole stranger's session.
+    ///
+    /// So the identity check the reaper's holder leg and the park ladder both
+    /// apply is applied here too, against the same anchor and the same window,
+    /// and with the same asymmetry: **every answer but `.same` keeps.** A
+    /// missed job is one process a later sweep can still find; a wrong kill
+    /// destroys somebody else's work on a machine running dozens of sessions.
+    ///
+    /// It is deliberately *not* `dispose`'s behaviour, and must not be folded
+    /// into it. `isHolderChildExecutable` admits agents and login shells only,
+    /// so a plain holder terminal whose shell exec'd into `htop` would never be
+    /// killed on `terminal.delete` if the general path adopted this gate. Hook
+    /// tabs are narrower by construction: their job is the shell wrapper this
+    /// daemon composed, and it is the only thing that may ever run there.
+    ///
+    /// The holder is told to let go, and reaped, on every path — including the
+    /// ones that decline to kill. Leaving the daemon holding a pty whose job it
+    /// cannot identify would keep a reader alive over a session nobody can
+    /// describe, and the holder is this daemon's own child, so nothing else can
+    /// collect it.
+    ///
+    /// Returns a description of what was left running, or nil when the whole
+    /// teardown was carried out.
+    func abandonVerifiedJob(
+        terminalID: UUID, holderPID: Int32?, childPID: Int32?, childStartedAt: Date?
+    ) async -> String? {
+        let socketPath: String
+        do {
+            socketPath = try HolderRendezvous.socketPath(
+                sessionID: terminalID, environment: environment)
+        } catch {
+            return "\(error)"
+        }
+        await release(terminalID: terminalID)
+        statuses[terminalID] = nil
+
+        let client = HolderClient(socketPath: socketPath)
+        try? await client.forget()
+        await client.close()
+
+        // `dispose` resolves the job's process group *before* the `forget`, so
+        // that a group member which ignored the hangup is still reachable after
+        // the leader died of it. There is no such pre-resolve here, and there
+        // cannot be: this path may only signal a pid it has identified, and a
+        // group whose leader is gone is a group whose members it cannot
+        // identify at all. `signaller.forceKill` widens to the group on its own
+        // when the pid is still there to name one, which is every case this
+        // path is allowed to kill in.
+        let left = killVerifiedJob(
+            terminalID: terminalID, childPID: childPID, childStartedAt: childStartedAt)
+        await reap(holderPID: holderPID ?? 0)
+        return left
+    }
+
+    /// The decision half of `abandonVerifiedJob`: whether this pid may be
+    /// signalled, and what to say when it may not.
+    ///
+    /// Split out so the ladder reads top to bottom in the order its gates
+    /// actually fail — no pid, no anchor, a corpse, a stranger — and so the
+    /// `forget`/reap either side of it stay unconditional.
+    private func killVerifiedJob(
+        terminalID: UUID, childPID: Int32?, childStartedAt: Date?
+    ) -> String? {
+        guard let childPID, childPID > 1 else {
+            // `0` is the sentinel a row that never recorded a pid decodes to,
+            // and signalling it would reach the daemon's own process group —
+            // the hazard `jobProcessGroup` guards in the same words.
+            return "terminal \(terminalID) recorded no child pid, so its holder was told to "
+                + "let go but the job it forked was not killed"
+        }
+        guard let childStartedAt else {
+            Self.logger.warning(
+                """
+                hook terminal \(terminalID, privacy: .public) recorded no child start time, so \
+                pid \(childPID, privacy: .public) could not be identified and was left alone
+                """)
+            return "terminal \(terminalID) recorded no child start time, so the job at pid "
+                + "\(childPID) could not be proved to be ours and was left running"
+        }
+        // A corpse first, and for the reason `holderChildDisposition` asks it
+        // first: `ps` prints a zombie's command in parentheses, which the
+        // executable gate below would read as a stranger's. A zombie is past
+        // its last instruction and its number cannot be reissued while the
+        // entry stands, so there is nothing here to kill and nothing to fear.
+        if signaller.stat(childPID)?.hasPrefix("Z") == true { return nil }
+        let verdict = ProcessIdentityCheck.verify(
+            pid: childPID,
+            startedWithin: AgentReaper.defaultHolderIdentityWindow,
+            of: childStartedAt,
+            executableIsAcceptable: AgentReaper.isHolderChildExecutable,
+            signaller: signaller)
+        switch verdict {
+        case .same:
+            // `forceKill` widens to the process group exactly as `killJob`
+            // does — `ProductionProcessSignaller.signal` group-kills when the
+            // pid is its own group leader, which a `forkpty` job always is —
+            // so a job that declined the hangup is still reclaimed with its
+            // descendants.
+            signaller.forceKill(childPID)
+            return nil
+        case .notRunning:
+            // The job exited on its own, which on the auto-close path is the
+            // ordinary case rather than an exception.
+            return nil
+        case .startTimeUnreadable, .startTimeMismatch, .commandUnreadable, .foreignExecutable:
+            Self.logger.warning(
+                """
+                hook terminal \(terminalID, privacy: .public) left pid \
+                \(childPID, privacy: .public) running: it did not verify as this session's job \
+                (\(String(describing: verdict), privacy: .public))
+                """)
+            return "terminal \(terminalID) left its job running: pid \(childPID) did not verify "
+                + "(\(String(describing: verdict)))"
+        }
     }
 
     /// `forget`, kill, reap: the holder closes the pty master and winds down,

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator+Holder.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator+Holder.swift
@@ -1112,9 +1112,12 @@ extension HibernationCoordinator {
         broadcastHibernation(
             terminal: currentTerminal, hibernated: false, keepWarm: currentTerminal.keepWarm,
             tmuxWindowID: "", tmuxPaneID: "")
-        // No `SessionRecaptureScheduler`: it re-reads the session id off a tmux
-        // pane's screen, and this row has no pane. A holder session's resumed
-        // id is recaptured the way every other fact about it is — from hooks.
+        // No `SessionRecaptureScheduler`: a holder wake knows the id it resumed
+        // and hooks report the id the agent settles on, so there is nothing for
+        // a recapture to discover. Should that change, `SessionRecaptureTarget`
+        // has a `.holderChild(pid:)` case that addresses this row's job
+        // directly — the absence here is a decision about what is worth
+        // reading, not a coordinate the scheduler lacks.
         logger.info("woke holder-backed terminal \(terminal.id, privacy: .public) (resume \(sessionID, privacy: .public), holder \(handle.holderPID, privacy: .public), child \(handle.childPID, privacy: .public))")
         // The incarnation this wake minted for the replacement agent, the same
         // fact the tmux arm reports: it is what scopes a caller's wait to the

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -1347,18 +1347,22 @@ extension WorktreeLifecycle {
         // and another for an extra one. See `TerminalSpawnTransport.decide`.
         let transport = TerminalSpawnTransport.decide(config: config, registry: holderRegistry)
 
-        // The tmux server is ensured LAZILY on the holder path, and eagerly —
-        // in exactly the place it always was — on the tmux path.
+        // The tmux server is ensured for the tmux transport and not at all for
+        // the holder one.
         //
         // That asymmetry is the point of the transport. A holder-backed session
-        // needs no tmux server at all, and calling `ensureServer` anyway would
+        // needs no tmux server, and calling `ensureServer` anyway would
         // resurrect the very resource this design exists to remove: a server
-        // process, its socket, and a window nobody reads. But the setup-hook
-        // terminal below is still tmux for Milestone A, so the holder path can
-        // still end up needing one — and when it does, it must get the same
-        // server, the same control-mode wiring, and the same untracked-initial-
-        // window cleanup the tmux path gets. Hence one memoized ensure rather
-        // than two spellings that could drift.
+        // process, its socket, and a window nobody reads. Every tab this
+        // function opens — the primary, the setup-hook tab, the archived-
+        // session restores — is born onto the transport the gate chose, so on
+        // the holder path nothing below asks for a server.
+        //
+        // The ensure stays memoized because the tmux path reaches it from more
+        // than one place: eagerly here, and again from the restore loop, which
+        // must get the same server, the same control-mode wiring and the same
+        // untracked-initial-window cleanup rather than a second spelling that
+        // could drift.
         var initialWindowID: String?
         var tmuxServerEnsured = false
         func ensureTmuxServerOnce() async throws {
@@ -1679,21 +1683,20 @@ extension WorktreeLifecycle {
                 TBDConstants.hookPath(repoID: $0, eventName: HookEvent.setup.rawValue)
             }
         )
-        // The setup terminal stays on tmux for Milestone A, whatever the
-        // primary's transport. It is a hook runner, not an agent surface, and
-        // moving it would mean a second holder per worktree before anything has
-        // soaked one.
+        // The setup tab is born onto the same transport as the primary, through
+        // the same gate and the same spawn.
         //
-        // The cost is that on the holder path it is the ONLY thing that wants a
-        // tmux server. So it is spawned there only when the repo actually has a
-        // setup hook: without one this tab is a bare shell, and starting a tmux
-        // server, a session and a window for a bare shell is exactly the cost
-        // the transport exists to remove. On the tmux path the server exists
+        // On the holder it is spawned only when the repo actually has a setup
+        // hook: without one this tab is a bare shell, and a second holder
+        // process for a bare shell nobody asked for is exactly the cost the
+        // transport exists to remove. On the tmux path the server exists
         // regardless and the tab is created unconditionally, as it always has
         // been — the flag must not change what the flag-off path does.
         let wantsSetupTerminal = repo != nil && (!transport.isHolder || setupHookPath != nil)
         if let repo, wantsSetupTerminal {
-            try await ensureTmuxServerOnce()
+            if !transport.isHolder {
+                try await ensureTmuxServerOnce()
+            }
             let plannedTerminalID2 = UUID()
             createdTerminalIDs.append(plannedTerminalID2)
             let setupCommand: String
@@ -1732,49 +1735,52 @@ extension WorktreeLifecycle {
                 "TBD_REPO_PATH": repo.path,
                 "TBD_BRANCH": worktree.branch,
             ]
-            let window2 = try await tmux.createWindow(
-                server: tmuxServer,
-                session: "main",
-                cwd: worktreePath,
-                shellCommand: setupCommand,
+            let setupTerminal = try await spawnTerminal(
+                id: plannedTerminalID2,
+                worktreeID: worktreeID,
+                tmuxServer: tmuxServer,
+                workingDirectory: worktreePath,
+                command: setupCommand,
                 env: setupEnv,
                 sensitiveEnv: setupSensitiveEnv,
                 cols: resolvedCols,
-                rows: resolvedRows
-            )
-            do {
-                _ = try await db.terminals.create(
-                    id: plannedTerminalID2,
-                    worktreeID: worktreeID,
-                    tmuxWindowID: window2.windowID,
-                    tmuxPaneID: window2.paneID,
-                    label: TerminalLabel.setup,
-                    kind: .shell
-                )
-            } catch {
-                try? await tmux.killWindow(server: tmuxServer, windowID: window2.windowID)
-                throw error
-            }
+                rows: resolvedRows,
+                label: TerminalLabel.setup,
+                claudeSessionID: nil,
+                profileID: nil,
+                kind: .shell,
+                transport: transport,
+                attachment: nil,
+                modelProxySupervisor: modelProxySupervisor)
             createdTerminals.append((id: plannedTerminalID2, label: TerminalLabel.setup))
             if let setupMarkerPath, let setupHookPath {
-                // The auto-close wrapper lets the pane EXIT on hook success,
-                // and tmux destroys the window the instant it does — before
-                // the watcher's teardown can capture the scrollback for
+                // `remain-on-exit` is a tmux property and only tmux needs it:
+                // the auto-close wrapper lets the pane EXIT on hook success and
+                // tmux destroys the window the instant it does, before the
+                // watcher's teardown can capture the scrollback for
                 // closed-terminal history. Keep the dead pane around; the
-                // teardown's killWindow removes it after capturing.
+                // teardown's killWindow removes it after capturing. On the
+                // holder that teardown captures nothing at all (see
+                // `closeHookTerminal`), so nothing there needs a dead job kept.
                 // Best-effort: a failure only costs the captured history.
-                do {
-                    try await tmux.setRemainOnExit(server: tmuxServer, windowID: window2.windowID)
-                } catch {
-                    logger.warning("setup auto-close: remain-on-exit failed for window \(window2.windowID, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                if !transport.isHolder {
+                    do {
+                        try await tmux.setRemainOnExit(
+                            server: tmuxServer, windowID: setupTerminal.tmuxWindowID)
+                    } catch {
+                        logger.warning("setup auto-close: remain-on-exit failed for window \(setupTerminal.tmuxWindowID, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                    }
                 }
                 setupAutoCloseSpawn = PreSessionSpawn(
                     terminalID: plannedTerminalID2,
                     tmuxServer: tmuxServer,
-                    windowID: window2.windowID,
-                    paneID: window2.paneID,
+                    windowID: setupTerminal.tmuxWindowID,
+                    paneID: setupTerminal.tmuxPaneID,
                     markerPath: setupMarkerPath,
-                    hookPath: setupHookPath
+                    hookPath: setupHookPath,
+                    transport: setupTerminal.transport,
+                    holderPID: setupTerminal.holderPID,
+                    childPID: setupTerminal.childPID
                 )
             }
         }
@@ -1840,38 +1846,38 @@ extension WorktreeLifecycle {
                     "TBD_WORKTREE_ID": worktreeID.uuidString,
                     "TBD_TERMINAL_ID": plannedID.uuidString,
                 ]
-                // Archived-session restores stay on tmux for Milestone A, for
-                // the same reason as the setup terminal: one holder per
-                // worktree is the shape being soaked. They therefore need the
-                // server, which the holder path has not started.
-                try await ensureTmuxServerOnce()
-                let window = try await tmux.createWindow(
-                    server: tmuxServer,
-                    session: "main",
-                    cwd: worktreePath,
-                    shellCommand: spawn.command,
+                // A restored archived session is born onto the same transport
+                // as the primary, through the same gate and the same spawn, so
+                // only the tmux one wants a server.
+                //
+                // It is NOT routed through the model proxy — and neither are
+                // revive-from-history tabs or fork-session tabs. A route has to
+                // be minted before the command is composed, because the command
+                // re-exports the profile's own routing keys over it, and these
+                // three sites do not compose their commands that way yet. That
+                // is a follow-up rather than a regression: a tmux spawn was
+                // never routed either, so nothing loses a route it used to have.
+                if !transport.isHolder {
+                    try await ensureTmuxServerOnce()
+                }
+                _ = try await spawnTerminal(
+                    id: plannedID,
+                    worktreeID: worktreeID,
+                    tmuxServer: tmuxServer,
+                    workingDirectory: worktreePath,
+                    command: spawn.command,
                     env: perTermEnv,
                     // Same free-form-under-auth layering as the primary terminal.
                     sensitiveEnv: mergedEnvOverrides.merging(spawn.sensitiveEnv) { _, builder in builder },
                     cols: resolvedCols,
-                    rows: resolvedRows
-                )
-                do {
-                    _ = try await db.terminals.create(
-                        id: plannedID,
-                        worktreeID: worktreeID,
-                        tmuxWindowID: window.windowID,
-                        tmuxPaneID: window.paneID,
-                        label: TerminalLabel.claudeCode,
-                        claudeSessionID: sessionID,
-                        profileID: resolvedProfile?.profileID,
-                        kind: .claude
-                    )
-                } catch {
-                    try? await tmux.killWindow(
-                        server: tmuxServer, windowID: window.windowID)
-                    throw error
-                }
+                    rows: resolvedRows,
+                    label: TerminalLabel.claudeCode,
+                    claudeSessionID: sessionID,
+                    profileID: resolvedProfile?.profileID,
+                    kind: .claude,
+                    transport: transport,
+                    attachment: nil,
+                    modelProxySupervisor: modelProxySupervisor)
                 createdTerminals.append((id: plannedID, label: TerminalLabel.claudeCode))
             }
         }

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -1780,7 +1780,8 @@ extension WorktreeLifecycle {
                     hookPath: setupHookPath,
                     transport: setupTerminal.transport,
                     holderPID: setupTerminal.holderPID,
-                    childPID: setupTerminal.childPID
+                    childPID: setupTerminal.childPID,
+                    childStartedAt: setupTerminal.holderChildStartedAt
                 )
             }
         }

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
@@ -289,6 +289,14 @@ extension WorktreeLifecycle {
     /// killed directly leaves the row untouched, and nothing else here would
     /// notice. A spawn that recorded no child pid answers on the row alone
     /// rather than reporting a dead tab it cannot see.
+    ///
+    /// **Only a nil result means the tab is gone.** A read that THREW says
+    /// nothing about the row, and reading it as a deletion would report
+    /// `.paneKilled` for a hook that is still running — after which phase 3
+    /// starts the primary agent on a tree the hook has not finished preparing.
+    /// A transient database error is answered "assume alive", the same way the
+    /// worktree-row existence check in `runPreSessionPhase3` answers it, so the
+    /// wait simply continues and the next poll asks again.
     private func hookTerminalIsAlive(
         preSession: PreSessionSpawn, tmuxServer: String
     ) async -> Bool {
@@ -297,9 +305,14 @@ extension WorktreeLifecycle {
             return await tmux.windowExists(
                 server: tmuxServer, windowID: preSession.windowID)
         case .holder:
-            guard (try? await db.terminals.get(id: preSession.terminalID)) != nil else {
-                return false
+            let row: Terminal?
+            do {
+                row = try await db.terminals.get(id: preSession.terminalID)
+            } catch {
+                logger.warning("hook terminal \(preSession.terminalID, privacy: .public) liveness check failed: \(error.localizedDescription, privacy: .public) — assuming its tab is still there and continuing the wait")
+                return true
             }
+            guard row != nil else { return false }
             guard let childPID = preSession.childPID else { return true }
             return processSignaller.isAlive(childPID)
         }
@@ -407,7 +420,10 @@ extension WorktreeLifecycle {
                 // be named, and the descriptor phase 2b returned is where they
                 // are. A hook tab is never routed through the model proxy, so
                 // there is no route to retire here.
-                await abandonHookHolder(preSession)
+                await abandonHookHolder(
+                    terminalID: preSession.terminalID,
+                    holderPID: preSession.holderPID,
+                    childPID: preSession.childPID)
             }
             return
         }
@@ -519,36 +535,86 @@ extension WorktreeLifecycle {
     /// Best-effort: a failure here must never take down the worktree, whose
     /// checkout and agent terminals are already valid.
     func closePreSessionTerminal(worktree: Worktree, preSession: PreSessionSpawn) async {
+        await closeHookTerminal(worktree: worktree, preSession: preSession)
+    }
+
+    /// Shared hook-tab teardown (pre-session and auto-closed setup tabs), from
+    /// the descriptor the tab's spawn returned.
+    ///
+    /// The row is the authority on the transport for as long as it can be read;
+    /// the descriptor answers when it cannot. Both halves are load-bearing. A
+    /// row that has already been deleted — or one whose read threw — would
+    /// otherwise fall into the tmux arm and issue `kill-window` against a
+    /// `windowID` that is the empty string for a holder tab, while the holder,
+    /// the job it forked and its rendezvous files outlive the only record of
+    /// their pids. The descriptor is where those pids are, which is why the
+    /// rowless case is reclaimable at all.
+    func closeHookTerminal(worktree: Worktree, preSession: PreSessionSpawn) async {
         await closeHookTerminal(
             worktree: worktree,
             tmuxServer: preSession.tmuxServer,
             terminalID: preSession.terminalID,
-            windowID: preSession.windowID
+            windowID: preSession.windowID,
+            unreadableRowTransport: preSession.transport,
+            holderPID: preSession.holderPID,
+            childPID: preSession.childPID
         )
     }
 
-    /// Shared hook-tab teardown (pre-session and auto-closed setup tabs):
-    /// kill the tmux window, delete the terminal + tab rows, prune the tab
-    /// from the persisted tab order, broadcast `.terminalRemoved`. The prune
-    /// is a no-op on the create-success path (the primary spawn already set
-    /// an order without the hook tab) and keeps the stored order consistent
-    /// on the paths that appended the tab (manual re-run, setup auto-close).
+    /// The tmux spelling, for a caller holding tmux coordinates rather than a
+    /// descriptor: a row it cannot read can only have been the tmux tab those
+    /// coordinates describe.
     func closeHookTerminal(
         worktree: Worktree, tmuxServer: String, terminalID: UUID, windowID: String
     ) async {
+        await closeHookTerminal(
+            worktree: worktree,
+            tmuxServer: tmuxServer,
+            terminalID: terminalID,
+            windowID: windowID,
+            unreadableRowTransport: .tmux,
+            holderPID: nil,
+            childPID: nil
+        )
+    }
+
+    /// The teardown itself: tear the session down in the terms its transport
+    /// uses, delete the terminal + tab rows, prune the tab from the persisted
+    /// tab order, broadcast `.terminalRemoved`. The prune is a no-op on the
+    /// create-success path (the primary spawn already set an order without the
+    /// hook tab) and keeps the stored order consistent on the paths that
+    /// appended the tab (manual re-run, setup auto-close).
+    private func closeHookTerminal(
+        worktree: Worktree,
+        tmuxServer: String,
+        terminalID: UUID,
+        windowID: String,
+        unreadableRowTransport: TerminalTransport,
+        holderPID: Int32?,
+        childPID: Int32?
+    ) async {
         let terminal = try? await db.terminals.get(id: terminalID)
-        if let terminal, terminal.transport == .holder {
+        switch terminal?.transport ?? unreadableRowTransport {
+        case .holder:
             // No Closed Terminals capture for a holder hook tab: the holder has
             // no scrollback dump yet (issue #851 §4, Phase 2 item "Closed-
             // terminal history on holder dispose"), which is exactly what
             // `disposeHolder` already does on every other teardown of a holder
-            // row. The kill below would be worse than a no-op here — a holder
+            // row. The tmux kill would be worse than a no-op here — a holder
             // row's `windowID` names nothing, and the holder, its job and its
             // rendezvous files would outlive the row that is their only record.
-            if let left = await disposeHolder(for: terminal) {
-                logger.warning("hook terminal \(terminalID, privacy: .public) holder teardown incomplete: \(left, privacy: .public)")
+            if let terminal {
+                if let left = await disposeHolder(for: terminal) {
+                    logger.warning("hook terminal \(terminalID, privacy: .public) holder teardown incomplete: \(left, privacy: .public)")
+                }
+            } else {
+                // No row to read the pids back from, so the descriptor's own
+                // pids are all there is — the same reclaim phase 3 does when a
+                // cascading worktree delete takes the terminal row with it.
+                await abandonHookHolder(
+                    terminalID: terminalID, holderPID: holderPID, childPID: childPID)
             }
-        } else {
+        case .tmux:
             // Preserve the hook tab's output before the window dies so a user
             // can read an auto-closed setup/pre-session run later (Session
             // History → Closed Terminals). Best-effort: captureOnClose logs
@@ -584,17 +650,17 @@ extension WorktreeLifecycle {
     /// the pids off a row that no longer exists. A daemon with no registry is
     /// reported rather than passed over — it is exactly the daemon whose holder
     /// and job nothing else would ever find.
-    private func abandonHookHolder(_ preSession: PreSessionSpawn) async {
+    private func abandonHookHolder(
+        terminalID: UUID, holderPID: Int32?, childPID: Int32?
+    ) async {
         guard let holderRegistry else {
-            logger.warning("phase-3: hook terminal \(preSession.terminalID, privacy: .public) runs on the holder transport but this daemon has no holder registry, so its holder and job were left running")
+            logger.warning("hook terminal \(terminalID, privacy: .public) runs on the holder transport but this daemon has no holder registry, so its holder and job were left running")
             return
         }
         if let left = await holderRegistry.abandon(
-            terminalID: preSession.terminalID,
-            holderPID: preSession.holderPID,
-            childPID: preSession.childPID
+            terminalID: terminalID, holderPID: holderPID, childPID: childPID
         ) {
-            logger.warning("phase-3: hook terminal \(preSession.terminalID, privacy: .public) holder teardown incomplete: \(left, privacy: .public)")
+            logger.warning("hook terminal \(terminalID, privacy: .public) holder teardown incomplete: \(left, privacy: .public)")
         }
     }
 

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
@@ -23,6 +23,14 @@ struct PreSessionSpawn: Sendable {
     /// Nil on the tmux transport.
     let holderPID: Int32?
     let childPID: Int32?
+    /// When the job behind `childPID` started, as the row recorded it.
+    ///
+    /// The teardown may not signal that pid without it: a pid on its own is not
+    /// an identity, and the start time is the one fact `execve` cannot move.
+    /// Nil on the tmux transport, and nil for a row written before the column
+    /// existed — which the readers spell `holderChildStartedAt ?? createdAt`,
+    /// the same fallback the reaper's holder leg and the park ladder use.
+    let childStartedAt: Date?
 
     /// Written out rather than synthesized so every existing caller — the
     /// recovery sweep, which resumes a wait from a row, and the tests that
@@ -37,7 +45,8 @@ struct PreSessionSpawn: Sendable {
         hookPath: String,
         transport: TerminalTransport = .tmux,
         holderPID: Int32? = nil,
-        childPID: Int32? = nil
+        childPID: Int32? = nil,
+        childStartedAt: Date? = nil
     ) {
         self.terminalID = terminalID
         self.tmuxServer = tmuxServer
@@ -48,6 +57,7 @@ struct PreSessionSpawn: Sendable {
         self.transport = transport
         self.holderPID = holderPID
         self.childPID = childPID
+        self.childStartedAt = childStartedAt
     }
 }
 
@@ -262,7 +272,8 @@ extension WorktreeLifecycle {
             hookPath: hookPath,
             transport: terminal.transport,
             holderPID: terminal.holderPID,
-            childPID: terminal.childPID
+            childPID: terminal.childPID,
+            childStartedAt: terminal.holderChildStartedAt
         )
     }
 
@@ -423,7 +434,8 @@ extension WorktreeLifecycle {
                 await abandonHookHolder(
                     terminalID: preSession.terminalID,
                     holderPID: preSession.holderPID,
-                    childPID: preSession.childPID)
+                    childPID: preSession.childPID,
+                    childStartedAt: preSession.childStartedAt)
             }
             return
         }
@@ -553,15 +565,13 @@ extension WorktreeLifecycle {
     /// A read that *throws* is deliberately folded into "unreadable" rather
     /// than retried or surfaced: the answer then comes from the descriptor,
     /// which is a strictly safer place to take it from than the alternative of
-    /// giving up on a teardown whose whole purpose is reclamation. What that
-    /// costs is the one step the row-shaped teardown adds over the descriptor
-    /// one — `disposeHolder(for:)` retires the row's model-proxy route before
-    /// abandoning the holder, and `abandonHookHolder` only abandons. A hook tab
-    /// is spawned with no attachment (`attachment: nil` at both hook-tab spawn
-    /// sites), so it is never routed and there is nothing to retire; the two
-    /// paths reclaim exactly the same things here. A row-backed *agent* tab
-    /// would not be safe to answer this way, which is why this reasoning is
-    /// local to hook tabs.
+    /// giving up on a teardown whose whole purpose is reclamation. The two
+    /// halves then differ only in where the pids are read from — both reclaim
+    /// through `abandonHookHolder`, and neither retires a model-proxy route,
+    /// because a hook tab is spawned with no attachment (`attachment: nil` at
+    /// both hook-tab spawn sites) and so is never routed. A row-backed *agent*
+    /// tab would not be safe to tear down this way, which is why this
+    /// reasoning is local to hook tabs.
     func closeHookTerminal(worktree: Worktree, preSession: PreSessionSpawn) async {
         await closeHookTerminal(
             worktree: worktree,
@@ -570,7 +580,8 @@ extension WorktreeLifecycle {
             windowID: preSession.windowID,
             unreadableRowTransport: preSession.transport,
             holderPID: preSession.holderPID,
-            childPID: preSession.childPID
+            childPID: preSession.childPID,
+            childStartedAt: preSession.childStartedAt
         )
     }
 
@@ -593,7 +604,8 @@ extension WorktreeLifecycle {
             windowID: windowID,
             unreadableRowTransport: .tmux,
             holderPID: nil,
-            childPID: nil
+            childPID: nil,
+            childStartedAt: nil
         )
     }
 
@@ -610,7 +622,8 @@ extension WorktreeLifecycle {
         windowID: String,
         unreadableRowTransport: TerminalTransport,
         holderPID: Int32?,
-        childPID: Int32?
+        childPID: Int32?,
+        childStartedAt: Date?
     ) async {
         let terminal = try? await db.terminals.get(id: terminalID)
         switch terminal?.transport ?? unreadableRowTransport {
@@ -622,16 +635,32 @@ extension WorktreeLifecycle {
             // row. The tmux kill would be worse than a no-op here — a holder
             // row's `windowID` names nothing, and the holder, its job and its
             // rendezvous files would outlive the row that is their only record.
+            //
+            // Reclaimed through `abandonHookHolder` on both halves, not
+            // through `disposeHolder`: a hook tab is spawned with
+            // `attachment: nil`, so it is never routed through the model proxy
+            // and there is no route for the row-shaped teardown to retire —
+            // what is left of it is an unverified kill by recorded pid, which
+            // is exactly what a hook tab must not do (see
+            // `HolderRegistry.abandonVerifiedJob`). The row is still the better
+            // source for the pids while it can be read.
             if let terminal {
-                if let left = await disposeHolder(for: terminal) {
-                    logger.warning("hook terminal \(terminalID, privacy: .public) holder teardown incomplete: \(left, privacy: .public)")
-                }
+                await abandonHookHolder(
+                    terminalID: terminal.id,
+                    holderPID: terminal.holderPID,
+                    childPID: terminal.childPID,
+                    // The anchor every other reader of a holder row uses, and
+                    // the reason the fallback is `createdAt`: a row written
+                    // before the start-time column existed still has to be
+                    // reclaimable.
+                    childStartedAt: terminal.holderChildStartedAt ?? terminal.createdAt)
             } else {
                 // No row to read the pids back from, so the descriptor's own
                 // pids are all there is — the same reclaim phase 3 does when a
                 // cascading worktree delete takes the terminal row with it.
                 await abandonHookHolder(
-                    terminalID: terminalID, holderPID: holderPID, childPID: childPID)
+                    terminalID: terminalID, holderPID: holderPID, childPID: childPID,
+                    childStartedAt: childStartedAt)
             }
         case .tmux:
             // Preserve the hook tab's output before the window dies so a user
@@ -662,22 +691,31 @@ extension WorktreeLifecycle {
         }
     }
 
-    /// Reclaims a holder-backed hook tab whose terminal row is already gone,
-    /// from the pids its spawn recorded.
+    /// Reclaims a holder-backed hook tab from the pids its spawn recorded —
+    /// identity-checking the job before signalling it.
     ///
-    /// The row-shaped teardown (`disposeHolder`) cannot serve here: it reads
-    /// the pids off a row that no longer exists. A daemon with no registry is
-    /// reported rather than passed over — it is exactly the daemon whose holder
-    /// and job nothing else would ever find.
+    /// `abandonVerifiedJob` rather than the general `abandon`, and that is the
+    /// point of this method existing. A hook tab's job has very often exited
+    /// before anything tears the tab down — the setup tab auto-closes *because*
+    /// the hook finished — so the recorded pid may by then belong to whatever
+    /// the kernel handed the number to next, and the general path would kill it
+    /// and its process group on a recorded number alone.
+    ///
+    /// It also serves the case where the row is already gone: the row-shaped
+    /// teardown (`disposeHolder`) reads its pids off a row that no longer
+    /// exists. A daemon with no registry is reported rather than passed over —
+    /// it is exactly the daemon whose holder and job nothing else would ever
+    /// find.
     private func abandonHookHolder(
-        terminalID: UUID, holderPID: Int32?, childPID: Int32?
+        terminalID: UUID, holderPID: Int32?, childPID: Int32?, childStartedAt: Date?
     ) async {
         guard let holderRegistry else {
             logger.warning("hook terminal \(terminalID, privacy: .public) runs on the holder transport but this daemon has no holder registry, so its holder and job were left running")
             return
         }
-        if let left = await holderRegistry.abandon(
-            terminalID: terminalID, holderPID: holderPID, childPID: childPID
+        if let left = await holderRegistry.abandonVerifiedJob(
+            terminalID: terminalID, holderPID: holderPID, childPID: childPID,
+            childStartedAt: childStartedAt
         ) {
             logger.warning("hook terminal \(terminalID, privacy: .public) holder teardown incomplete: \(left, privacy: .public)")
         }

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
@@ -13,6 +13,42 @@ struct PreSessionSpawn: Sendable {
     let paneID: String
     let markerPath: String
     let hookPath: String
+    /// The transport the hook tab was born onto. Both the liveness probe and
+    /// the teardown branch on it: a holder-backed tab has no window to look for
+    /// and no pane to kill, and its `windowID`/`paneID` are the empty string by
+    /// construction, exactly as its row's columns are.
+    let transport: TerminalTransport
+    /// The pids the holder spawn recorded, for the one path that must reclaim
+    /// them after the terminal row is gone (a worktree cascaded away mid-wait).
+    /// Nil on the tmux transport.
+    let holderPID: Int32?
+    let childPID: Int32?
+
+    /// Written out rather than synthesized so every existing caller — the
+    /// recovery sweep, which resumes a wait from a row, and the tests that
+    /// describe a wait without spawning one — keeps constructing a tmux
+    /// descriptor unchanged.
+    init(
+        terminalID: UUID,
+        tmuxServer: String,
+        windowID: String,
+        paneID: String,
+        markerPath: String,
+        hookPath: String,
+        transport: TerminalTransport = .tmux,
+        holderPID: Int32? = nil,
+        childPID: Int32? = nil
+    ) {
+        self.terminalID = terminalID
+        self.tmuxServer = tmuxServer
+        self.windowID = windowID
+        self.paneID = paneID
+        self.markerPath = markerPath
+        self.hookPath = hookPath
+        self.transport = transport
+        self.holderPID = holderPID
+        self.childPID = childPID
+    }
 }
 
 /// How a pre-session hook run ended.
@@ -137,7 +173,14 @@ extension WorktreeLifecycle {
             markerPath: markerPath,
             shell: defaultShell
         )
-        let (window, tmuxServer) = try await tmux.withWorktreeServerLock(
+        // The transport gate, the same one every other spawn asks. A hook tab is
+        // a session like any other once it is running: it holds a pty, it is
+        // read through the same surfaces, and nothing about running a hook
+        // wants a tmux server of its own.
+        let preSessionConfig = try? await db.config.get()
+        let transport = TerminalSpawnTransport.decide(
+            config: preSessionConfig, registry: holderRegistry)
+        let (terminal, tmuxServer) = try await tmux.withWorktreeServerLock(
             db: db, worktreeID: worktreeID, allowedStatuses: [worktree.status]
         ) { currentWorktree in
             let currentPath = currentWorktree.path
@@ -150,43 +193,44 @@ extension WorktreeLifecycle {
                 "TBD_REPO_PATH": repo?.path ?? currentPath,
                 "TBD_BRANCH": currentWorktree.branch,
             ]
-            let initialWindowID = try await tmux.ensureServer(
-                server: currentWorktree.tmuxServer,
-                session: "main",
-                cwd: currentPath,
-                cols: resolvedCols,
-                rows: resolvedRows)
-            let window = try await tmux.createWindow(
-                server: currentWorktree.tmuxServer,
-                session: "main",
-                cwd: currentPath,
-                shellCommand: command,
+            // Only the tmux transport needs a server — and then the untracked
+            // window `new-session` creates has to be killed once the real one
+            // exists, exactly as before.
+            var initialWindowID: String?
+            if !transport.isHolder {
+                initialWindowID = try await tmux.ensureServer(
+                    server: currentWorktree.tmuxServer,
+                    session: "main",
+                    cwd: currentPath,
+                    cols: resolvedCols,
+                    rows: resolvedRows)
+            }
+            // The one spawn-and-record step every path shares: it creates the
+            // window or the holder job, writes the row that records which, and
+            // owns both rollbacks.
+            let terminal = try await spawnTerminal(
+                id: terminalID,
+                worktreeID: worktreeID,
+                tmuxServer: currentWorktree.tmuxServer,
+                workingDirectory: currentPath,
+                command: command,
                 env: env,
                 sensitiveEnv: Self.hookPaneEnv,
                 cols: resolvedCols,
-                rows: resolvedRows
-            )
-            do {
-                _ = try await db.terminals.create(
-                    id: terminalID,
-                    worktreeID: worktreeID,
-                    tmuxWindowID: window.windowID,
-                    tmuxPaneID: window.paneID,
-                    label: TerminalLabel.preSession,
-                    kind: .shell
-                )
-            } catch {
-                try? await tmux.killWindow(
-                    server: currentWorktree.tmuxServer,
-                    windowID: window.windowID)
-                throw error
-            }
+                rows: resolvedRows,
+                label: TerminalLabel.preSession,
+                claudeSessionID: nil,
+                profileID: nil,
+                kind: .shell,
+                transport: transport,
+                attachment: nil,
+                modelProxySupervisor: modelProxySupervisor)
             if let initialWindowID {
                 try? await tmux.killWindow(
                     server: currentWorktree.tmuxServer,
                     windowID: initialWindowID)
             }
-            return (window, currentWorktree.tmuxServer)
+            return (terminal, currentWorktree.tmuxServer)
         }
         if claimsFocus {
             // The pre-session terminal is the only tab until phase 3 runs.
@@ -212,10 +256,13 @@ extension WorktreeLifecycle {
         return PreSessionSpawn(
             terminalID: terminalID,
             tmuxServer: tmuxServer,
-            windowID: window.windowID,
-            paneID: window.paneID,
+            windowID: terminal.tmuxWindowID,
+            paneID: terminal.tmuxPaneID,
             markerPath: markerPath,
-            hookPath: hookPath
+            hookPath: hookPath,
+            transport: terminal.transport,
+            holderPID: terminal.holderPID,
+            childPID: terminal.childPID
         )
     }
 
@@ -231,8 +278,35 @@ extension WorktreeLifecycle {
         return .completed(exitCode: code)
     }
 
-    /// Polls for the completion marker. Short-circuits when the hook's tmux
-    /// window disappears (user killed the pane). Reads + deletes the marker.
+    /// Whether the hook's own terminal is still there to finish the run — the
+    /// "did the user close it" probe, asked in the terms each transport has.
+    ///
+    /// On tmux that is the window: killing the pane destroys it, and the row
+    /// outlives it. On the holder there is no window, so the analogue of a
+    /// killed pane is the *tab* going away — a holder-backed tab is closed by
+    /// deleting its row, and the teardown that does it disposes the holder in
+    /// the same step. The job's own pid is the second half: a hook that was
+    /// killed directly leaves the row untouched, and nothing else here would
+    /// notice. A spawn that recorded no child pid answers on the row alone
+    /// rather than reporting a dead tab it cannot see.
+    private func hookTerminalIsAlive(
+        preSession: PreSessionSpawn, tmuxServer: String
+    ) async -> Bool {
+        switch preSession.transport {
+        case .tmux:
+            return await tmux.windowExists(
+                server: tmuxServer, windowID: preSession.windowID)
+        case .holder:
+            guard (try? await db.terminals.get(id: preSession.terminalID)) != nil else {
+                return false
+            }
+            guard let childPID = preSession.childPID else { return true }
+            return processSignaller.isAlive(childPID)
+        }
+    }
+
+    /// Polls for the completion marker. Short-circuits when the hook's terminal
+    /// disappears (user closed it). Reads + deletes the marker.
     func waitForPreSessionCompletion(
         preSession: PreSessionSpawn, tmuxServer: String
     ) async -> PreSessionOutcome {
@@ -244,10 +318,9 @@ extension WorktreeLifecycle {
             if let outcome = Self.consumeMarker(atPath: preSession.markerPath) {
                 return outcome
             }
-            let windowAlive = await tmux.windowExists(
-                server: tmuxServer, windowID: preSession.windowID
-            )
-            if !windowAlive {
+            let hookTabAlive = await hookTerminalIsAlive(
+                preSession: preSession, tmuxServer: tmuxServer)
+            if !hookTabAlive {
                 // Same-iteration race: the hook can write the marker after the
                 // fileExists check above and exit (closing the pane) before the
                 // windowExists check. Re-check the marker once so a hook that
@@ -323,9 +396,19 @@ extension WorktreeLifecycle {
         }
         guard rowExists else {
             logger.warning("phase-3: worktree \(worktree.id, privacy: .public) row disappeared mid-wait — skipping primary spawn and cleaning up")
-            try? await tmux.killWindow(
-                server: preSession.tmuxServer, windowID: preSession.windowID
-            )
+            switch preSession.transport {
+            case .tmux:
+                try? await tmux.killWindow(
+                    server: preSession.tmuxServer, windowID: preSession.windowID
+                )
+            case .holder:
+                // The terminal row went with the worktree, so nothing can read
+                // the pids back any more — this is the last moment either can
+                // be named, and the descriptor phase 2b returned is where they
+                // are. A hook tab is never routed through the model proxy, so
+                // there is no route to retire here.
+                await abandonHookHolder(preSession)
+            }
             return
         }
 
@@ -453,17 +536,31 @@ extension WorktreeLifecycle {
     func closeHookTerminal(
         worktree: Worktree, tmuxServer: String, terminalID: UUID, windowID: String
     ) async {
-        // Preserve the hook tab's output before the window dies so a user can
-        // read an auto-closed setup/pre-session run later (Session History →
-        // Closed Terminals). Best-effort: captureOnClose logs failures and
-        // the teardown proceeds unchanged.
-        if let terminal = try? await db.terminals.get(id: terminalID) {
-            await db.terminalHistory.captureOnClose(terminal: terminal) {
-                try await tmux.capturePaneScrollback(
-                    server: tmuxServer, paneID: terminal.tmuxPaneID)
+        let terminal = try? await db.terminals.get(id: terminalID)
+        if let terminal, terminal.transport == .holder {
+            // No Closed Terminals capture for a holder hook tab: the holder has
+            // no scrollback dump yet (issue #851 §4, Phase 2 item "Closed-
+            // terminal history on holder dispose"), which is exactly what
+            // `disposeHolder` already does on every other teardown of a holder
+            // row. The kill below would be worse than a no-op here — a holder
+            // row's `windowID` names nothing, and the holder, its job and its
+            // rendezvous files would outlive the row that is their only record.
+            if let left = await disposeHolder(for: terminal) {
+                logger.warning("hook terminal \(terminalID, privacy: .public) holder teardown incomplete: \(left, privacy: .public)")
             }
+        } else {
+            // Preserve the hook tab's output before the window dies so a user
+            // can read an auto-closed setup/pre-session run later (Session
+            // History → Closed Terminals). Best-effort: captureOnClose logs
+            // failures and the teardown proceeds unchanged.
+            if let terminal {
+                await db.terminalHistory.captureOnClose(terminal: terminal) {
+                    try await tmux.capturePaneScrollback(
+                        server: tmuxServer, paneID: terminal.tmuxPaneID)
+                }
+            }
+            try? await tmux.killWindow(server: tmuxServer, windowID: windowID)
         }
-        try? await tmux.killWindow(server: tmuxServer, windowID: windowID)
         do {
             try await db.terminals.delete(id: terminalID)
             try await db.tabs.delete(tabID: terminalID)
@@ -477,6 +574,27 @@ extension WorktreeLifecycle {
             )))
         } catch {
             logger.warning("failed to close hook terminal \(terminalID, privacy: .public): \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    /// Reclaims a holder-backed hook tab whose terminal row is already gone,
+    /// from the pids its spawn recorded.
+    ///
+    /// The row-shaped teardown (`disposeHolder`) cannot serve here: it reads
+    /// the pids off a row that no longer exists. A daemon with no registry is
+    /// reported rather than passed over — it is exactly the daemon whose holder
+    /// and job nothing else would ever find.
+    private func abandonHookHolder(_ preSession: PreSessionSpawn) async {
+        guard let holderRegistry else {
+            logger.warning("phase-3: hook terminal \(preSession.terminalID, privacy: .public) runs on the holder transport but this daemon has no holder registry, so its holder and job were left running")
+            return
+        }
+        if let left = await holderRegistry.abandon(
+            terminalID: preSession.terminalID,
+            holderPID: preSession.holderPID,
+            childPID: preSession.childPID
+        ) {
+            logger.warning("phase-3: hook terminal \(preSession.terminalID, privacy: .public) holder teardown incomplete: \(left, privacy: .public)")
         }
     }
 

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
@@ -549,6 +549,19 @@ extension WorktreeLifecycle {
     /// the job it forked and its rendezvous files outlive the only record of
     /// their pids. The descriptor is where those pids are, which is why the
     /// rowless case is reclaimable at all.
+    ///
+    /// A read that *throws* is deliberately folded into "unreadable" rather
+    /// than retried or surfaced: the answer then comes from the descriptor,
+    /// which is a strictly safer place to take it from than the alternative of
+    /// giving up on a teardown whose whole purpose is reclamation. What that
+    /// costs is the one step the row-shaped teardown adds over the descriptor
+    /// one — `disposeHolder(for:)` retires the row's model-proxy route before
+    /// abandoning the holder, and `abandonHookHolder` only abandons. A hook tab
+    /// is spawned with no attachment (`attachment: nil` at both hook-tab spawn
+    /// sites), so it is never routed and there is nothing to retire; the two
+    /// paths reclaim exactly the same things here. A row-backed *agent* tab
+    /// would not be safe to answer this way, which is why this reasoning is
+    /// local to hook tabs.
     func closeHookTerminal(worktree: Worktree, preSession: PreSessionSpawn) async {
         await closeHookTerminal(
             worktree: worktree,
@@ -564,6 +577,12 @@ extension WorktreeLifecycle {
     /// The tmux spelling, for a caller holding tmux coordinates rather than a
     /// descriptor: a row it cannot read can only have been the tmux tab those
     /// coordinates describe.
+    ///
+    /// No production caller: every hook tab is torn down from the descriptor
+    /// its spawn returned. It is kept because the tmux-coordinate tests
+    /// (`TerminalHistoryTests.closeHookTerminalCapturesBeforeTeardown`,
+    /// `HookTabTransportGateTests`) address the teardown the way a caller
+    /// without a descriptor would, and that is a shape worth keeping reachable.
     func closeHookTerminal(
         worktree: Worktree, tmuxServer: String, terminalID: UUID, windowID: String
     ) async {

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Recovery.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Recovery.swift
@@ -163,7 +163,13 @@ extension WorktreeLifecycle {
                 // closed pane.
                 transport: preSessionTerminal.transport,
                 holderPID: preSessionTerminal.holderPID,
-                childPID: preSessionTerminal.childPID
+                childPID: preSessionTerminal.childPID,
+                // A resumed wait anchors the identity check the same way every
+                // other reader of a holder row does: the recorded start time,
+                // falling back to the row's own `createdAt` for a row written
+                // before that column existed.
+                childStartedAt: preSessionTerminal.holderChildStartedAt
+                    ?? preSessionTerminal.createdAt
             )
             // Distinguish an interrupted CREATE from an interrupted REVIVE:
             // a mid-revive row still carries its archived Claude sessions

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Recovery.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Recovery.swift
@@ -155,7 +155,15 @@ extension WorktreeLifecycle {
                         repoID: rid,
                         eventName: HookEvent.preSession.rawValue
                     )
-                ) ?? ""
+                ) ?? "",
+                // Carried from the row: a resumed wait must probe the hook tab
+                // in the terms its own transport has. A holder-backed tab has
+                // no tmux window, so a descriptor that claimed `.tmux` would
+                // ask a server that was never started and read the answer as a
+                // closed pane.
+                transport: preSessionTerminal.transport,
+                holderPID: preSessionTerminal.holderPID,
+                childPID: preSessionTerminal.childPID
             )
             // Distinguish an interrupted CREATE from an interrupted REVIVE:
             // a mid-revive row still carries its archived Claude sessions

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+SetupAutoClose.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+SetupAutoClose.swift
@@ -60,12 +60,7 @@ extension WorktreeLifecycle {
         switch outcome {
         case .completed(exitCode: 0):
             logger.info("setup hook completed cleanly for worktree \(worktree.id, privacy: .public) — closing its tab")
-            await closeHookTerminal(
-                worktree: worktree,
-                tmuxServer: setup.tmuxServer,
-                terminalID: setup.terminalID,
-                windowID: setup.windowID
-            )
+            await closeHookTerminal(worktree: worktree, preSession: setup)
         case .completed(let exitCode):
             logger.info("setup hook failed (exit \(exitCode, privacy: .public)) for worktree \(worktree.id, privacy: .public) — leaving its tab open")
         case .timedOut:

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+SpawnTerminal.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+SpawnTerminal.swift
@@ -57,10 +57,12 @@ extension WorktreeLifecycle {
     /// **The one place a terminal is spawned and its row written, on either
     /// transport.**
     ///
-    /// Every spawn path — the primary terminal at worktree creation, the extra
-    /// terminals `terminal.create` opens, and `terminal.continueInCodex` —
-    /// decides *what* to run on its own (the command, the two environments, the
-    /// label and kind) and hands the result here, because the part that
+    /// Every spawn path — the primary terminal at worktree creation, the setup
+    /// and pre-session hook tabs, restored archived sessions, the extra
+    /// terminals `terminal.create` opens, `terminal.continueInCodex`,
+    /// revive-from-history tabs and fork-session tabs — decides *what* to run on
+    /// its own (the command, the two environments, the label and kind) and
+    /// hands the result here, because the part that
     /// diverges by transport is the same at all of them and subtle enough that
     /// a second copy is a second thing to get wrong: the holder launch
     /// composition, the row that records the transport and the pids, the stamp
@@ -71,9 +73,9 @@ extension WorktreeLifecycle {
     /// The tmux server is the caller's to ensure, and only on the tmux
     /// transport: a holder-backed session needs no server at all, and ensuring
     /// one anyway would resurrect the very resource the transport exists to
-    /// remove. The primary path memoizes that ensure because its setup-hook tab
-    /// can still want a server on the holder path; the RPC handlers make it
-    /// once, under the same lock they call this from.
+    /// remove. The primary path memoizes that ensure because it opens several
+    /// tabs and any of them may be the first to need one; the RPC handlers make
+    /// it once, under the same lock they call this from.
     ///
     /// - Parameters:
     ///   - env: inlined as `export K='v';` in front of the command on both

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -1264,6 +1264,14 @@ extension RPCRouter {
         let plannedTerminalID = UUID()
         let defaultShell = ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
 
+        // One config read for the whole revive, and the transport gate asked
+        // once from it. Both branches below spawn exactly one terminal, so a
+        // second reading of the flag could only disagree with this one and
+        // leave the row recording a transport the spawn did not take.
+        let reviveConfig = try? await db.config.get()
+        let transport = TerminalSpawnTransport.decide(
+            config: reviveConfig, registry: holderRegistry)
+
         // Request row after the terminal ID is minted and before the first
         // tmux act, so it names the session it is about to bring back.
         let actuationID = try await beginActuation(
@@ -1280,7 +1288,6 @@ extension RPCRouter {
             } else {
                 repo = nil
             }
-            let reviveConfig = try? await db.config.get()
             var resolvedProfile: ResolvedModelProfile? = nil
             do {
                 resolvedProfile = try await modelProfileResolver.resolve(repoID: worktree.repoID)
@@ -1349,7 +1356,8 @@ extension RPCRouter {
                     claudeSessionID: sessionID,
                     profileID: resolvedProfile?.profileID,
                     cols: resolvedCols,
-                    rows: resolvedRows
+                    rows: resolvedRows,
+                    transport: transport
                 )
             }
             logger.info("revive: resumed claude session \(sessionID, privacy: .public) as terminal \(terminal.id, privacy: .public) in worktree \(worktree.id, privacy: .public)")
@@ -1384,7 +1392,8 @@ extension RPCRouter {
                 claudeSessionID: nil,
                 profileID: nil,
                 cols: resolvedCols,
-                rows: resolvedRows
+                rows: resolvedRows,
+                transport: transport
             )
         }
         logger.info("revive: opened shell terminal \(terminal.id, privacy: .public) from history entry \(entry.id, privacy: .public) (capture present: \(haveCapture, privacy: .public))")
@@ -1393,9 +1402,9 @@ extension RPCRouter {
     }
 
     /// Shared plumbing for spawning an ADDITIONAL terminal into a live worktree
-    /// during revive: create the window, insert the row, append it to the
-    /// persisted tab order as the new active tab, and broadcast the same
-    /// `.terminalCreated` delta the normal create path emits.
+    /// during revive: spawn it, insert the row, append it to the persisted tab
+    /// order as the new active tab, and broadcast the same `.terminalCreated`
+    /// delta the normal create path emits.
     private func spawnRevivedTerminal(
         worktree: Worktree,
         plannedTerminalID: UUID,
@@ -1407,17 +1416,16 @@ extension RPCRouter {
         claudeSessionID: String?,
         profileID: UUID?,
         cols: Int,
-        rows: Int
+        rows: Int,
+        transport: TerminalSpawnTransport
     ) async throws -> Terminal {
-        // Revived terminals stay on tmux: a revive restores a session's tab
-        // from history, and the transport it is restored onto is unchanged by
-        // this port. Pinned rather than decided, so the spawn still goes
-        // through the one spawn-and-record step every path shares.
+        // The transport is decided like every other spawn's — once, by the
+        // caller, from the same gate — and carried here rather than re-asked.
         let terminal = try await tmux.withWorktreeServerLock(
             db: db, worktreeID: worktree.id, allowedStatuses: [worktree.status]
         ) { currentWorktree in
             try await prepareTmuxServer(
-                for: .tmux, worktree: currentWorktree, cols: cols, rows: rows)
+                for: transport, worktree: currentWorktree, cols: cols, rows: rows)
             return try await lifecycle.spawnTerminal(
                 id: plannedTerminalID,
                 worktreeID: currentWorktree.id,
@@ -1432,7 +1440,7 @@ extension RPCRouter {
                 claudeSessionID: claudeSessionID,
                 profileID: profileID,
                 kind: kind,
-                transport: .tmux,
+                transport: transport,
                 attachment: nil,
                 modelProxySupervisor: modelProxySupervisor)
         }
@@ -2368,6 +2376,13 @@ extension RPCRouter {
         // the row would disagree in the other direction.
         let swapDeskRole: WatchDeskRole? = mode == .inPlace ? oldTerminal.watchDeskRole : nil
         let swapConfig = try? await db.config.get()
+        // The transport gate, asked once per swap from that one config read.
+        // Only `.fork` spawns anything — `.inPlace` respawns the row it already
+        // has, and refused above on a holder row — so this is the transport the
+        // fork tab is born onto, decided before the command is composed and
+        // carried into the spawn rather than re-derived there.
+        let forkTransport = TerminalSpawnTransport.decide(
+            config: swapConfig, registry: holderRegistry)
         var env = SystemPromptBuilder.promptLayers(
             repo: repo, worktree: worktree.worktree, scratchInstructions: swapConfig?.scratchInstructions,
             scratchRenamePrompt: swapConfig?.scratchRenamePrompt)
@@ -2562,7 +2577,8 @@ extension RPCRouter {
                     profileID: resolved?.profileID,
                     scheduleRecapture: scheduleRecapture,
                     cols: resolvedCols,
-                    rows: resolvedRows
+                    rows: resolvedRows,
+                    transport: forkTransport
                 )
 
             case .inPlace:
@@ -2624,17 +2640,16 @@ extension RPCRouter {
         profileID: UUID?,
         scheduleRecapture: Bool,
         cols: Int,
-        rows: Int
+        rows: Int,
+        transport: TerminalSpawnTransport
     ) async throws -> RPCResponse {
-        // A fork tab stays on tmux: it is an in-worktree copy of a session
-        // that is already running, and the transport it is copied onto is
-        // unchanged by this port. Pinned rather than decided, so the spawn
-        // still goes through the one spawn-and-record step every path shares.
+        // The transport is decided like every other spawn's — once, by the
+        // caller, from the same gate — and carried here rather than re-asked.
         let (newTerminal, currentServer) = try await tmux.withWorktreeServerLock(
             db: db, worktreeID: worktree.id, allowedStatuses: [worktree.status]
         ) { currentWorktree in
             try await prepareTmuxServer(
-                for: .tmux, worktree: currentWorktree, cols: cols, rows: rows)
+                for: transport, worktree: currentWorktree, cols: cols, rows: rows)
             let terminal = try await lifecycle.spawnTerminal(
                 id: plannedTerminalID,
                 worktreeID: currentWorktree.id,
@@ -2649,7 +2664,7 @@ extension RPCRouter {
                 claudeSessionID: storedSessionID,
                 profileID: profileID,
                 kind: .claude,
-                transport: .tmux,
+                transport: transport,
                 attachment: nil,
                 modelProxySupervisor: modelProxySupervisor)
             return (terminal, currentWorktree.tmuxServer)
@@ -2660,12 +2675,32 @@ extension RPCRouter {
         )))
 
         if scheduleRecapture {
-            scheduleSessionRecapture(
-                terminalID: newTerminal.id,
-                paneID: newTerminal.tmuxPaneID,
-                server: currentServer,
-                expectedIncarnationID: newTerminal.sessionIncarnationID
-            )
+            // The recapture has to address the process it will read, and the
+            // two transports address it differently: a tmux row through its
+            // pane, a holder row through the pid the holder recorded for the
+            // job it forked (its pane id is the empty string by construction).
+            // A holder row with no child pid cannot happen through
+            // `spawnTerminal`, which writes both pids out of the handle the
+            // spawn returned — so this is a report, not a fallback.
+            let target: SessionRecaptureTarget?
+            if newTerminal.transport == .holder {
+                if let childPID = newTerminal.childPID {
+                    target = .holderChild(pid: childPID)
+                } else {
+                    logger.warning(
+                        "fork swap: holder terminal \(newTerminal.id, privacy: .public) recorded no child pid — skipping session recapture")
+                    target = nil
+                }
+            } else {
+                target = .tmuxPane(server: currentServer, paneID: newTerminal.tmuxPaneID)
+            }
+            if let target {
+                scheduleSessionRecapture(
+                    terminalID: newTerminal.id,
+                    target: target,
+                    expectedIncarnationID: newTerminal.sessionIncarnationID
+                )
+            }
         }
 
         guard let updated = try await db.terminals.get(id: newTerminal.id) else {
@@ -2793,8 +2828,7 @@ extension RPCRouter {
         if scheduleRecapture, respawnError == nil {
             scheduleSessionRecapture(
                 terminalID: oldTerminal.id,
-                paneID: paneID,
-                server: server,
+                target: .tmuxPane(server: server, paneID: paneID),
                 expectedIncarnationID: incarnationID
             )
         }
@@ -2839,19 +2873,20 @@ extension RPCRouter {
     /// Schedule the post-resume session-id recapture. `claude --resume <id>
     /// --fork-session` (the `.fork` swap path) forks the conversation into a NEW
     /// session file with a fresh UUID; mirror the wake path's pattern — wait ~5s
-    /// for Claude to settle, then capture the new id from the pane and persist it
-    /// against `terminalID`. (On the `.inPlace` path there is no `--fork-session`,
-    /// so the id is unchanged and the recapture is a harmless no-op.)
+    /// for Claude to settle, then capture the new id from whatever the `target`
+    /// names and persist it against `terminalID`. (On the `.inPlace` path there
+    /// is no `--fork-session`, so the id is unchanged and the recapture is a
+    /// harmless no-op.)
     private func scheduleSessionRecapture(
         terminalID: UUID,
-        paneID: String,
-        server: String,
+        target: SessionRecaptureTarget,
         expectedIncarnationID: UUID?
     ) {
-        SessionRecaptureScheduler(db: db, tmux: tmux).schedule(
+        let scheduler = sessionRecaptureFactory?(db, tmux)
+            ?? SessionRecaptureScheduler(db: db, tmux: tmux)
+        scheduler.schedule(
             terminalID: terminalID,
-            paneID: paneID,
-            server: server,
+            target: target,
             expectedIncarnationID: expectedIncarnationID
         )
     }

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -248,6 +248,22 @@ public final class RPCRouter: Sendable {
     /// cannot route.
     nonisolated(unsafe) var modelProxySupervisor: (any ModelProxySupervising)?
 
+    /// How the swap paths build the scheduler that recaptures a resumed
+    /// session's ID. `nil` in production, which builds the ordinary
+    /// `SessionRecaptureScheduler(db:tmux:)`. The mirror of
+    /// `WorktreeLifecycle.sessionRecaptureFactory`, for the same reason.
+    ///
+    /// A seam because the branch it feeds — which target a fork tab's recapture
+    /// is scheduled against — is otherwise unobservable from outside. A real
+    /// scheduler's only trace is a database write five wall seconds later, made
+    /// only if a live Claude process answers; "it was scheduled against the
+    /// pane" and "it was scheduled against the holder's child" look identical
+    /// from the row. Injecting the scheduler makes the decision itself the
+    /// observable, on virtual time.
+    nonisolated(unsafe) var sessionRecaptureFactory: (
+        @Sendable (TBDDatabase, TmuxManager) -> SessionRecaptureScheduler
+    )?
+
     /// Delivers `terminal.send` to a holder-backed session, routed by who is
     /// reading its pty. Set by `Daemon` after construction, beside the registry
     /// and the sidecar it is built from. `nil` in mock mode and in tests that

--- a/Sources/TBDDaemon/Tmux/ClaudeStateDetector.swift
+++ b/Sources/TBDDaemon/Tmux/ClaudeStateDetector.swift
@@ -64,34 +64,55 @@ public struct ClaudeStateDetector: Sendable {
             .appendingPathComponent("\(pid).json")
     }
 
+    /// The session id of the Claude process a recapture target names, on either
+    /// transport.
+    public func captureSessionID(target: SessionRecaptureTarget) async -> String? {
+        switch target {
+        case .tmuxPane(let server, let paneID):
+            return await captureSessionID(server: server, paneID: paneID)
+        case .holderChild(let pid):
+            return await captureSessionID(rootPID: Int(pid))
+        }
+    }
+
     public func captureSessionID(server: String, paneID: String) async -> String? {
+        guard let pidStr = try? await tmux.panePID(server: server, paneID: paneID),
+              let panePID = Int(pidStr) else { return nil }
+        return await captureSessionID(rootPID: panePID)
+    }
+
+    /// Resolve a session id from the root pid of a session's own process tree.
+    ///
+    /// The same ladder serves both transports because the pid means the same
+    /// shape of thing on each. On tmux the root is `#{pane_pid}`: with
+    /// `zsh -i -l -c "claude …"` (see `TmuxManager.shellFlags(forShell:)`) zsh
+    /// may exec into Claude directly, so that pid IS the Claude process, and
+    /// otherwise it is the shell that started one. On the holder the root is
+    /// the job the holder forked — the `zsh -c` shell composed by
+    /// `holderLaunch`, or Claude itself once that shell execs into it — which
+    /// is the identical pair of cases. So: read the root's session file first,
+    /// and fall back to the single `claude` child beneath it.
+    func captureSessionID(rootPID: Int) async -> String? {
+        if let id = readSessionID(forPID: rootPID) { return id }
+
+        // Fallback: the root is a shell and Claude is a child process.
+        let process = Process()
+        let pipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/pgrep")
+        process.arguments = ["-P", String(rootPID), "-x", "claude"]
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
         do {
-            let pidStr = try await tmux.panePID(server: server, paneID: paneID)
-            guard let panePID = Int(pidStr) else { return nil }
-
-            // With `zsh -i -l -c "claude ..."` (see
-            // TmuxManager.shellFlags(forShell:)), zsh may exec into Claude directly,
-            // so pane_pid IS the Claude process (not a shell parent).
-            // Try the pane PID's session file first.
-            if let id = readSessionID(forPID: panePID) { return id }
-
-            // Fallback: pane_pid is a shell, Claude is a child process.
-            let process = Process()
-            let pipe = Pipe()
-            process.executableURL = URL(fileURLWithPath: "/usr/bin/pgrep")
-            process.arguments = ["-P", String(panePID), "-x", "claude"]
-            process.standardOutput = pipe
-            process.standardError = FileHandle.nullDevice
             try process.run()
-            process.waitUntilExit()
-
-            let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-            let pids = output.trimmingCharacters(in: .whitespacesAndNewlines)
-                .split(separator: "\n").compactMap { Int($0) }
-            guard pids.count == 1, let claudePID = pids.first else { return nil }
-
-            return readSessionID(forPID: claudePID)
         } catch { return nil }
+        process.waitUntilExit()
+
+        let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        let pids = output.trimmingCharacters(in: .whitespacesAndNewlines)
+            .split(separator: "\n").compactMap { Int($0) }
+        guard pids.count == 1, let claudePID = pids.first else { return nil }
+
+        return readSessionID(forPID: claudePID)
     }
 
     /// Read a Claude session file for a given PID. Returns nil if file doesn't exist or is invalid.

--- a/Tests/TBDDaemonLiveTests/Holder/HolderSpawnGateTests.swift
+++ b/Tests/TBDDaemonLiveTests/Holder/HolderSpawnGateTests.swift
@@ -1070,6 +1070,16 @@ private final class GateFixture {
     /// inside one of those windows would let a teardown that reclaimed nothing
     /// pass on the job's natural exit. Every holder started here is killed by
     /// `tearDown`, so the length costs a run nothing.
+    ///
+    /// The sleep is deliberately **not** `exec`ed. A hook tab's teardown
+    /// identity-checks the job before signalling it
+    /// (`HolderRegistry.abandonVerifiedJob`), and that check accepts only an
+    /// agent binary or a login shell — so a job that replaced its own image
+    /// with `sleep` would be refused as a stranger and the teardown tests would
+    /// prove the refusal rather than the kill. Left un-`exec`ed, the job's
+    /// command line is `/bin/sh <path> …` courtesy of the shebang, whose
+    /// basename `sh` is one the check admits; the shell is the pty session's
+    /// leader, so the group-widening `SIGKILL` takes the `sleep` with it.
     private static func writeGateShell(in home: String) throws -> String {
         try FileManager.default.createDirectory(
             atPath: home, withIntermediateDirectories: true,
@@ -1078,7 +1088,7 @@ private final class GateFixture {
         try """
         #!/bin/sh
         printf 'GATE-OK\\n'
-        exec sleep 600
+        sleep 600
         """.write(toFile: path, atomically: true, encoding: .utf8)
         try FileManager.default.setAttributes(
             [.posixPermissions: 0o700], ofItemAtPath: path)
@@ -1400,13 +1410,22 @@ private final class GateFixture {
     /// Kills one holder and the job it forked. Signalling a pid that is already
     /// gone is how this is expected to end on the passing path: the process has
     /// been reaped, `kill` answers `ESRCH`, and nothing happens.
+    ///
+    /// The job is killed by **group** where it leads one, by the same rule
+    /// `HolderRegistry.jobProcessGroup` applies: a `forkpty` job is the session
+    /// leader of its own pty, so its group id is its own pid, and a group id
+    /// that is anything else names a group this fixture did not create and must
+    /// not signal. The gate shell runs its `sleep` as an ordinary child rather
+    /// than `exec`ing it, so a pid-exact kill here would leave that child
+    /// behind for the rest of its ten minutes.
     private func reclaim(holderPID: Int32?, childPID: Int32?) {
         if let holderPID, holderPID > 0 {
             kill(holderPID, SIGKILL)
             var ignored: Int32 = 0
             _ = waitpid(holderPID, &ignored, 0)
         }
-        if let childPID, childPID > 0, holderProcessIsAlive(childPID) {
+        if let childPID, childPID > 1, holderProcessIsAlive(childPID) {
+            if getpgid(childPID) == childPID { kill(-childPID, SIGKILL) }
             kill(childPID, SIGKILL)
         }
     }

--- a/Tests/TBDDaemonLiveTests/Holder/HolderSpawnGateTests.swift
+++ b/Tests/TBDDaemonLiveTests/Holder/HolderSpawnGateTests.swift
@@ -423,8 +423,9 @@ struct HolderSpawnGateTests {
     /// first, and the probe's clock is immediate, so a recapture armed for it
     /// would have recorded its pane before the tmux control's did; observing
     /// the control's write is therefore proof that the holder's absence is real
-    /// and not merely early. The pane list is asserted whole rather than
-    /// searched, so a holder pane appearing alongside the tmux one still fails.
+    /// and not merely early. The target list is asserted whole rather than
+    /// searched, so a recapture armed for the holder session alongside the tmux
+    /// one still fails — whichever coordinate it was given.
     @Test func recaptureIsScheduledForTmuxSessionsAndNotForHolderOnes() async throws {
         let recapture = RecaptureProbe()
         let fixture = try await GateFixture.make(flagEnabled: true, recapture: recapture)
@@ -459,7 +460,9 @@ struct HolderSpawnGateTests {
                 == RecaptureProbe.detectedSessionID
         }
         #expect(landed)
-        #expect(recapture.panes == [tmuxRow.tmuxPaneID])
+        #expect(recapture.targets == [
+            .tmuxPane(server: fixture.worktree.tmuxServer, paneID: tmuxRow.tmuxPaneID)
+        ])
 
         let holderAfter = try #require(try await fixture.db.terminals.get(id: holderID))
         #expect(
@@ -709,6 +712,122 @@ struct HolderSpawnGateTests {
         #expect(
             !issued.contains(where: { $0.contains("new-window") }),
             "the setup hook tab created a tmux window: \(issued)")
+    }
+
+    /// Setup auto-close on the holder: the tab closes, and closing it reclaims
+    /// the holder instead of addressing a tmux window that never existed.
+    ///
+    /// Three facts, and the two after the row are what a row assertion alone
+    /// would miss. `remain-on-exit` must never be issued: it is a tmux
+    /// property, and the reason for setting it — keep the dead pane so the
+    /// teardown can capture its scrollback — has no holder counterpart, because
+    /// a holder teardown captures nothing. Then the job must be dead and the
+    /// rendezvous socket gone, which together say `closeHookTerminal` reached
+    /// `disposeHolder`: a teardown that deleted the row through the tmux arm
+    /// would satisfy every assertion about the row while leaving a holder, a
+    /// job and a socket that nothing names any more.
+    ///
+    /// The other arm of that same `remain-on-exit` decision is
+    /// `AutoCloseSetupTests.flagOnCleanExitClosesSetupTab`, which asserts the
+    /// property is set exactly once and targets the setup window.
+    @Test func setupAutoCloseOnTheHolderClosesTheTabAndReclaimsItsHolder() async throws {
+        let fixture = try await GateFixture.make(flagEnabled: true)
+        defer { fixture.tearDown() }
+        try await fixture.db.config.setAutoCloseSetup(enabled: true)
+        try fixture.installWorktreeHook(.setup)
+
+        let created = try await fixture.spawnPrimaryTerminals()
+
+        #expect(created.count == 2)
+        #expect(created[1].label == TerminalLabel.setup)
+        let setup = try #require(try await fixture.db.terminals.get(id: created[1].id))
+        #expect(setup.transport == .holder)
+        let holderPID = try #require(setup.holderPID)
+        let childPID = try #require(setup.childPID)
+        #expect(holderPID != childPID)
+        #expect(holderProcessIsAlive(holderPID))
+        #expect(holderProcessIsAlive(childPID))
+
+        let socketPath = try HolderRendezvous.socketPath(
+            sessionID: setup.id, environment: fixture.environment)
+        #expect(
+            FileManager.default.fileExists(atPath: socketPath),
+            "no holder rendezvous at \(socketPath) for an auto-closing setup tab")
+
+        let issued = fixture.tmuxCommands()
+        #expect(
+            !issued.contains(where: { $0.contains("remain-on-exit") }),
+            "the holder setup tab asked tmux to keep a pane it never had: \(issued)")
+        #expect(
+            !issued.contains(where: { $0.contains("new-window") }),
+            "the auto-closing setup tab created a tmux window: \(issued)")
+        #expect(
+            !issued.contains(where: { $0.contains("new-session") }),
+            "the auto-closing setup tab started a tmux server: \(issued)")
+
+        // Stand in for the hook's clean exit: the job is the pinned gate shell,
+        // which ignores the wrapper's argv, so the marker never lands on its
+        // own. The spawn deleted any stale one, so this goes after it.
+        try fixture.writeHookMarker(
+            at: WorktreeLifecycle.setupMarkerPath(worktreeID: fixture.worktree.id),
+            exitCode: 0)
+
+        let closed = try await pollUntil("the auto-closed setup tab's row to be deleted") {
+            try await fixture.db.terminals.get(id: setup.id) == nil
+        }
+        #expect(closed)
+        let jobGone = await pollUntil("the setup tab's job to be killed") {
+            !holderProcessIsAlive(childPID)
+        }
+        #expect(jobGone)
+        let socketGone = await pollUntil("the setup holder's rendezvous socket to go") {
+            !FileManager.default.fileExists(atPath: socketPath)
+        }
+        #expect(socketGone)
+    }
+
+    /// A holder-backed pre-session tab is reclaimed when the worktree row
+    /// vanishes mid-wait.
+    ///
+    /// The cascade is what makes this the hard case: it takes the terminal row
+    /// with it, so the wait returns at once AND `disposeHolder` — which reads
+    /// the pids off a row — has nothing to read. The descriptor phase 2b
+    /// returned is the only remaining route to that holder, and a dead job with
+    /// a removed rendezvous socket is the proof it was taken. No `kill-window`,
+    /// because a holder row's window id names nothing.
+    @Test func phase3ReclaimsAHolderHookTabWhenTheWorktreeRowVanishes() async throws {
+        let fixture = try await GateFixture.make(flagEnabled: true)
+        defer { fixture.tearDown() }
+        try fixture.installWorktreeHook(.preSession)
+
+        let spawn = try #require(try await fixture.spawnPreSessionTerminal())
+        #expect(spawn.transport == .holder)
+        let childPID = try #require(spawn.childPID)
+        #expect(holderProcessIsAlive(childPID))
+        let socketPath = try HolderRendezvous.socketPath(
+            sessionID: spawn.terminalID, environment: fixture.environment)
+        #expect(FileManager.default.fileExists(atPath: socketPath))
+
+        try await fixture.deleteWorktreeRow()
+        await fixture.runPreSessionPhase3(spawn)
+
+        let remaining = try await fixture.db.terminals.list(worktreeID: fixture.worktree.id)
+        #expect(
+            remaining.isEmpty,
+            "phase 3 spawned terminals into a worktree that no longer exists")
+        let issued = fixture.tmuxCommands()
+        #expect(
+            !issued.contains(where: { $0.contains("kill-window") }),
+            "the holder hook tab was torn down through tmux: \(issued)")
+
+        let jobGone = await pollUntil("the hook tab's job to be killed") {
+            !holderProcessIsAlive(childPID)
+        }
+        #expect(jobGone)
+        let socketGone = await pollUntil("the hook holder's rendezvous socket to go") {
+            !FileManager.default.fileExists(atPath: socketPath)
+        }
+        #expect(socketGone)
     }
 
     /// The setup tab's other arm: with the flag off it is a tmux window, hook
@@ -982,7 +1101,15 @@ private final class GateFixture {
                 .appendingPathComponent("claude", isDirectory: true))
         var lifecycle = WorktreeLifecycle(
             db: db, git: GitManager(), tmux: tmux, hooks: HookResolver(),
-            configDirManager: configDirManager)
+            configDirManager: configDirManager,
+            // The hook-tab waits this fixture arms are polled, not slept
+            // through: the setup auto-close watcher has to see a marker written
+            // by the test (the job here is the pinned gate shell, which ignores
+            // the wrapper's argv, so nothing writes one on its own). 0.05 keeps
+            // that turnaround off the production half-second, and the timeout is
+            // a hang bound rather than a budget anything is expected to use.
+            preSessionTimeout: 30,
+            preSessionPollInterval: 0.05)
         lifecycle.holderRegistry = registry
         if let recapture {
             lifecycle.sessionRecaptureFactory = { db, tmux in
@@ -1141,6 +1268,37 @@ private final class GateFixture {
     func spawnPreSessionTerminal() async throws -> PreSessionSpawn? {
         try await router.lifecycle.spawnPreSessionTerminal(
             worktree: worktree, repo: repo, worktreePath: worktree.localPath)
+    }
+
+    /// Phase 3 of the create path, entered with the descriptor phase 2b
+    /// returned — the marker wait, then the primary spawn or the bail-out.
+    func runPreSessionPhase3(_ spawn: PreSessionSpawn) async {
+        await router.lifecycle.runPreSessionPhase3(
+            preSession: spawn,
+            worktree: worktree, repo: repo,
+            worktreePath: worktree.localPath,
+            skipClaude: true,
+            completionAction: .markActive)
+    }
+
+    /// Writes the completion marker a hook would have written.
+    ///
+    /// Standing in for the hook is not a shortcut here: the job every holder in
+    /// this fixture runs is the pinned gate shell, which ignores the `-c`
+    /// command it is handed, so the wrapper's marker never lands on its own.
+    /// Both spawns delete a stale marker before starting, so this must be
+    /// called only after the spawn has returned.
+    func writeHookMarker(at path: String, exitCode: Int) throws {
+        try FileManager.default.createDirectory(
+            atPath: (path as NSString).deletingLastPathComponent,
+            withIntermediateDirectories: true)
+        try "\(exitCode)\n".write(toFile: path, atomically: true, encoding: .utf8)
+    }
+
+    /// Deletes the worktree row, cascading every terminal row with it — what a
+    /// repo removal does to a worktree whose hook tab is still being waited on.
+    func deleteWorktreeRow() async throws {
+        try await db.worktrees.delete(id: worktree.id)
     }
 
     /// The `terminalHistory.revive` RPC, through the router.

--- a/Tests/TBDDaemonLiveTests/Holder/HolderSpawnGateTests.swift
+++ b/Tests/TBDDaemonLiveTests/Holder/HolderSpawnGateTests.swift
@@ -633,10 +633,20 @@ struct HolderSpawnGateTests {
         #expect(holderProcessIsAlive(childPID))
         #expect(forked.tmuxWindowID.isEmpty)
 
-        let landed = await pollUntil("the fork's session recapture to be scheduled") {
+        // Through the one bounded poll the suite keeps (`Tests/CLAUDE.md`
+        // rule 5), and reported the one way a CI summary preserves: a timeout
+        // carries its own description on the primary failure line, while a
+        // harness cancellation says nothing at all — attribution for that
+        // belongs to whatever did the cancelling.
+        let landed = await pollUntilTrue(timeout: TestDeadlines.saturatedPass) {
             !recapture.targets.isEmpty
         }
-        #expect(landed)
+        if landed == .timedOut {
+            Issue.record(BoundedWaitTimeout(
+                what: "the fork's session recapture to be scheduled",
+                observed: "\(recapture.targets)",
+                deadline: TestDeadlines.saturatedPass))
+        }
         #expect(recapture.targets == [.holderChild(pid: childPID)])
         #expect(recapture.panes.isEmpty, "a holder fork scheduled a pane recapture")
 
@@ -744,6 +754,9 @@ struct HolderSpawnGateTests {
         #expect(setup.transport == .holder)
         let holderPID = try #require(setup.holderPID)
         let childPID = try #require(setup.childPID)
+        // This test deletes the row teardown would otherwise sweep from, so the
+        // pids are handed over the moment they are read.
+        fixture.rememberHolder(holderPID: holderPID, childPID: childPID)
         #expect(holderPID != childPID)
         #expect(holderProcessIsAlive(holderPID))
         #expect(holderProcessIsAlive(childPID))
@@ -772,18 +785,36 @@ struct HolderSpawnGateTests {
             at: WorktreeLifecycle.setupMarkerPath(worktreeID: fixture.worktree.id),
             exitCode: 0)
 
-        let closed = try await pollUntil("the auto-closed setup tab's row to be deleted") {
-            try await fixture.db.terminals.get(id: setup.id) == nil
+        let closed = await pollUntilTrue(timeout: TestDeadlines.saturatedPass) {
+            // A read that throws is not a deletion — only a row that is
+            // genuinely absent ends this wait.
+            do {
+                return try await fixture.db.terminals.get(id: setup.id) == nil
+            } catch {
+                return false
+            }
         }
-        #expect(closed)
-        let jobGone = await pollUntil("the setup tab's job to be killed") {
+        if closed == .timedOut {
+            Issue.record(BoundedWaitTimeout(
+                what: "the auto-closed setup tab's row to be deleted",
+                observed: nil, deadline: TestDeadlines.saturatedPass))
+        }
+        let jobGone = await pollUntilTrue(timeout: TestDeadlines.saturatedPass) {
             !holderProcessIsAlive(childPID)
         }
-        #expect(jobGone)
-        let socketGone = await pollUntil("the setup holder's rendezvous socket to go") {
+        if jobGone == .timedOut {
+            Issue.record(BoundedWaitTimeout(
+                what: "the setup tab's job (pid \(childPID)) to be killed",
+                observed: nil, deadline: TestDeadlines.saturatedPass))
+        }
+        let socketGone = await pollUntilTrue(timeout: TestDeadlines.saturatedPass) {
             !FileManager.default.fileExists(atPath: socketPath)
         }
-        #expect(socketGone)
+        if socketGone == .timedOut {
+            Issue.record(BoundedWaitTimeout(
+                what: "the setup holder's rendezvous socket at \(socketPath) to go",
+                observed: nil, deadline: TestDeadlines.saturatedPass))
+        }
     }
 
     /// A holder-backed pre-session tab is reclaimed when the worktree row
@@ -803,6 +834,8 @@ struct HolderSpawnGateTests {
         let spawn = try #require(try await fixture.spawnPreSessionTerminal())
         #expect(spawn.transport == .holder)
         let childPID = try #require(spawn.childPID)
+        // The cascade below takes the row teardown would otherwise sweep from.
+        fixture.rememberHolder(holderPID: spawn.holderPID, childPID: childPID)
         #expect(holderProcessIsAlive(childPID))
         let socketPath = try HolderRendezvous.socketPath(
             sessionID: spawn.terminalID, environment: fixture.environment)
@@ -820,14 +853,22 @@ struct HolderSpawnGateTests {
             !issued.contains(where: { $0.contains("kill-window") }),
             "the holder hook tab was torn down through tmux: \(issued)")
 
-        let jobGone = await pollUntil("the hook tab's job to be killed") {
+        let jobGone = await pollUntilTrue(timeout: TestDeadlines.saturatedPass) {
             !holderProcessIsAlive(childPID)
         }
-        #expect(jobGone)
-        let socketGone = await pollUntil("the hook holder's rendezvous socket to go") {
+        if jobGone == .timedOut {
+            Issue.record(BoundedWaitTimeout(
+                what: "the hook tab's job (pid \(childPID)) to be killed",
+                observed: nil, deadline: TestDeadlines.saturatedPass))
+        }
+        let socketGone = await pollUntilTrue(timeout: TestDeadlines.saturatedPass) {
             !FileManager.default.fileExists(atPath: socketPath)
         }
-        #expect(socketGone)
+        if socketGone == .timedOut {
+            Issue.record(BoundedWaitTimeout(
+                what: "the hook holder's rendezvous socket at \(socketPath) to go",
+                observed: nil, deadline: TestDeadlines.saturatedPass))
+        }
     }
 
     /// The setup tab's other arm: with the flag off it is a tmux window, hook
@@ -979,6 +1020,8 @@ private final class GateFixture {
     private let capturePaneCounter: Counter
     private let recordedCommands: CommandLog
     private var torndown = false
+    private let rememberedLock = NSLock()
+    private var remembered: [(holderPID: Int32?, childPID: Int32?)] = []
 
     /// A thread-safe tally. The dry-run hooks are `@Sendable` closures called
     /// from whatever executor the handler happens to be on.
@@ -1021,6 +1064,12 @@ private final class GateFixture {
     /// production composition hands it, which is the point: the job is a
     /// controlled two-line program instead of whatever the developer's `$SHELL`
     /// would have done with it.
+    ///
+    /// It sleeps far longer than any wait in this suite deliberately. The
+    /// teardown tests wait for this job to *die*, and a sleep that could expire
+    /// inside one of those windows would let a teardown that reclaimed nothing
+    /// pass on the job's natural exit. Every holder started here is killed by
+    /// `tearDown`, so the length costs a run nothing.
     private static func writeGateShell(in home: String) throws -> String {
         try FileManager.default.createDirectory(
             atPath: home, withIntermediateDirectories: true,
@@ -1029,7 +1078,7 @@ private final class GateFixture {
         try """
         #!/bin/sh
         printf 'GATE-OK\\n'
-        exec sleep 30
+        exec sleep 600
         """.write(toFile: path, atomically: true, encoding: .utf8)
         try FileManager.default.setAttributes(
             [.posixPermissions: 0o700], ofItemAtPath: path)
@@ -1333,24 +1382,56 @@ private final class GateFixture {
                     terminalID: terminalID, newProfileID: nil, mode: .fork)))
     }
 
+    /// Records a holder and its job so `tearDown` can reclaim them from
+    /// something other than a terminal row.
+    ///
+    /// The row-derived sweep is the normal route, and it is enough for every
+    /// test that leaves its rows in place. It is not enough for the teardown
+    /// tests: they assert that a row was DELETED, so the very regression they
+    /// exist to catch — a teardown that removed the row and reclaimed nothing —
+    /// would leave the holder and its job running for the rest of the run with
+    /// nothing left naming their pids. Call this as soon as the pids are read.
+    func rememberHolder(holderPID: Int32?, childPID: Int32?) {
+        rememberedLock.lock()
+        defer { rememberedLock.unlock() }
+        remembered.append((holderPID: holderPID, childPID: childPID))
+    }
+
+    /// Kills one holder and the job it forked. Signalling a pid that is already
+    /// gone is how this is expected to end on the passing path: the process has
+    /// been reaped, `kill` answers `ESRCH`, and nothing happens.
+    private func reclaim(holderPID: Int32?, childPID: Int32?) {
+        if let holderPID, holderPID > 0 {
+            kill(holderPID, SIGKILL)
+            var ignored: Int32 = 0
+            _ = waitpid(holderPID, &ignored, 0)
+        }
+        if let childPID, childPID > 0, holderProcessIsAlive(childPID) {
+            kill(childPID, SIGKILL)
+        }
+    }
+
     /// Kills every holder this fixture started AND every job those holders
     /// forked, then clears the scratch roots. A test that leaves either behind
     /// leaks a process for the rest of the run — bounded at the job's own
-    /// `sleep 30`, but it compounds across runs.
+    /// `sleep`, but that is ten minutes and it compounds across runs.
+    ///
+    /// Two sources, because neither covers the other: the terminal rows name
+    /// every holder still on the books, and `rememberHolder` names the ones
+    /// whose rows a test deleted on purpose.
     func tearDown() {
         guard !torndown else { return }
         torndown = true
 
         let rows = (try? blockingTerminals()) ?? []
         for row in rows where row.transport == .holder {
-            if let holderPID = row.holderPID, holderPID > 0 {
-                kill(holderPID, SIGKILL)
-                var ignored: Int32 = 0
-                _ = waitpid(holderPID, &ignored, 0)
-            }
-            if let childPID = row.childPID, childPID > 0, holderProcessIsAlive(childPID) {
-                kill(childPID, SIGKILL)
-            }
+            reclaim(holderPID: row.holderPID, childPID: row.childPID)
+        }
+        rememberedLock.lock()
+        let recorded = remembered
+        rememberedLock.unlock()
+        for entry in recorded {
+            reclaim(holderPID: entry.holderPID, childPID: entry.childPID)
         }
         let registry = self.registry
         Task.detached { await registry.releaseAll() }

--- a/Tests/TBDDaemonLiveTests/Holder/HolderSpawnGateTests.swift
+++ b/Tests/TBDDaemonLiveTests/Holder/HolderSpawnGateTests.swift
@@ -470,16 +470,15 @@ struct HolderSpawnGateTests {
             """)
     }
 
-    /// Archived-session restores stay on tmux even when the primary is a
-    /// holder — and the holder path starts the tmux server they need.
+    /// Archived-session restores follow the primary's transport.
     ///
-    /// Milestone A soaks exactly one holder per worktree, so the extra restored
-    /// sessions are tmux windows. That is only sound if the server exists: the
-    /// holder path skips the eager `ensureServer` the tmux path does, so the
-    /// restore loop must ask for one itself. The `new-session` assertion is
-    /// what holds it to that — a restore issued into a server nobody started
-    /// would still produce a row here and fail only in production.
-    @Test func archivedSessionRestoresStayOnTmuxUnderAHolderPrimary() async throws {
+    /// The restore decides through the same gate and spawns through the same
+    /// function as every other tab, so under a holder primary the restored row
+    /// is a holder row too — and, critically, NO tmux server is started for it.
+    /// The `new-session` assertion is the one that would catch a restore that
+    /// still asked for a server it no longer needs: the row would look right
+    /// and a tmux server would be running behind it.
+    @Test func archivedSessionRestoresFollowTheHolderPrimary() async throws {
         let fixture = try await GateFixture.make(flagEnabled: true)
         defer { fixture.tearDown() }
 
@@ -495,22 +494,237 @@ struct HolderSpawnGateTests {
                 .first { $0.claudeSessionID == "ARCHIVED-RESTORED" },
             "the second archived session was never restored")
         #expect(
-            restored.transport == .tmux,
-            "an archived-session restore was put on the holder transport")
+            restored.transport == .holder,
+            "an archived-session restore was left on tmux under a holder primary")
+        let holderPID = try #require(restored.holderPID)
+        let childPID = try #require(restored.childPID)
+        #expect(holderPID != childPID)
+        #expect(holderProcessIsAlive(holderPID))
+        #expect(holderProcessIsAlive(childPID))
+        #expect(restored.tmuxWindowID.isEmpty)
+        #expect(restored.tmuxPaneID.isEmpty)
+
+        let issued = fixture.tmuxCommands()
+        #expect(
+            !issued.contains(where: { $0.contains("new-session") }),
+            "the restore started a tmux server it does not need: \(issued)")
+        #expect(
+            !issued.contains(where: { $0.contains("new-window") }),
+            "the restore created a tmux window: \(issued)")
+    }
+
+    /// The other arm: with the flag off a restore is a tmux window, resuming
+    /// the session it was archived with. Without this, a restore that always
+    /// took the holder — or never restored at all — would pass above.
+    @Test func archivedSessionRestoresStayOnTmuxWithTheFlagOff() async throws {
+        let fixture = try await GateFixture.make(flagEnabled: false)
+        defer { fixture.tearDown() }
+
+        _ = try await fixture.spawnClaudePrimaryTerminals(
+            archivedClaudeSessions: ["ARCHIVED-PRIMARY", "ARCHIVED-RESTORED"])
+
+        let restored = try #require(
+            try await fixture.db.terminals.list(worktreeID: fixture.worktree.id)
+                .first { $0.claudeSessionID == "ARCHIVED-RESTORED" },
+            "the second archived session was never restored")
+        #expect(restored.transport == .tmux)
         #expect(!restored.tmuxWindowID.isEmpty)
-        #expect(!restored.tmuxPaneID.isEmpty)
         #expect(restored.holderPID == nil)
         #expect(restored.childPID == nil)
 
         let issued = fixture.tmuxCommands()
         #expect(
             issued.contains(where: { $0.contains("new-session") }),
-            "the restore ran without the holder path ever starting a tmux server: \(issued)")
+            "the restore ran without a tmux server: \(issued)")
         #expect(
             issued.contains(where: {
                 $0.contains("new-window") && $0.contains("--resume ARCHIVED-RESTORED")
             }),
             "no tmux window was created to resume the archived session: \(issued)")
+    }
+
+    // MARK: - Revive from history
+
+    /// `terminalHistory.revive` with the flag on: the revived tab is born onto
+    /// a real holder, with no tmux server anywhere behind it.
+    @Test func historyReviveFlagOnSpawnsOntoTheHolder() async throws {
+        let fixture = try await GateFixture.make(flagEnabled: true)
+        defer { fixture.tearDown() }
+        let entryID = try await fixture.seedClosedShellHistoryEntry()
+
+        let revived = try await fixture.historyRevive(entryID: entryID)
+
+        let row = try #require(try await fixture.db.terminals.get(id: revived.id))
+        #expect(row.transport == .holder)
+        let holderPID = try #require(row.holderPID)
+        let childPID = try #require(row.childPID)
+        #expect(holderPID != childPID)
+        #expect(holderProcessIsAlive(holderPID))
+        #expect(holderProcessIsAlive(childPID))
+        #expect(row.tmuxWindowID.isEmpty)
+        #expect(row.tmuxPaneID.isEmpty)
+
+        let socketPath = try HolderRendezvous.socketPath(
+            sessionID: row.id, environment: fixture.environment)
+        #expect(
+            FileManager.default.fileExists(atPath: socketPath),
+            "no holder rendezvous at \(socketPath) for a revived holder tab")
+
+        let issued = fixture.tmuxCommands()
+        #expect(
+            !issued.contains(where: { $0.contains("new-window") }),
+            "the revive created a tmux window: \(issued)")
+        #expect(
+            !issued.contains(where: { $0.contains("new-session") }),
+            "the revive started a tmux server: \(issued)")
+    }
+
+    /// The other arm, unchanged: a revive with the flag off is a tmux window
+    /// in a tmux server.
+    @Test func historyReviveFlagOffStaysOnTmux() async throws {
+        let fixture = try await GateFixture.make(flagEnabled: false)
+        defer { fixture.tearDown() }
+        let entryID = try await fixture.seedClosedShellHistoryEntry()
+
+        let revived = try await fixture.historyRevive(entryID: entryID)
+
+        let row = try #require(try await fixture.db.terminals.get(id: revived.id))
+        #expect(row.transport == .tmux)
+        #expect(!row.tmuxWindowID.isEmpty)
+        #expect(row.holderPID == nil)
+        #expect(row.childPID == nil)
+        let socketPath = try HolderRendezvous.socketPath(
+            sessionID: row.id, environment: fixture.environment)
+        #expect(
+            !FileManager.default.fileExists(atPath: socketPath),
+            "a holder rendezvous was created for a tmux-transport revive")
+    }
+
+    // MARK: - Fork-session swap
+
+    /// A `.fork` swap with the flag on lands on a real holder, and its session
+    /// recapture addresses the holder's CHILD rather than a pane.
+    ///
+    /// The target assertion is the load-bearing half. A holder row's pane id is
+    /// the empty string by construction, so a fork that kept scheduling
+    /// `.tmuxPane` would poll a coordinate that can never resolve — and would
+    /// write whatever it happened to find onto the row.
+    @Test func forkSwapFlagOnSpawnsOntoTheHolderAndRecapturesItsChild() async throws {
+        let recapture = RecaptureProbe()
+        let fixture = try await GateFixture.make(flagEnabled: true, recapture: recapture)
+        defer { fixture.tearDown() }
+        let source = try await fixture.seedClaudeSourceTerminal()
+
+        let response = try await fixture.forkSwap(terminalID: source.id)
+        #expect(response.success, "\(response.error ?? "")")
+
+        let forked = try #require(
+            try await fixture.db.terminals.list(worktreeID: fixture.worktree.id)
+                .first { $0.id != source.id },
+            "the fork created no new terminal row")
+        #expect(forked.transport == .holder)
+        let holderPID = try #require(forked.holderPID)
+        let childPID = try #require(forked.childPID)
+        #expect(holderPID != childPID)
+        #expect(holderProcessIsAlive(holderPID))
+        #expect(holderProcessIsAlive(childPID))
+        #expect(forked.tmuxWindowID.isEmpty)
+
+        let landed = await pollUntil("the fork's session recapture to be scheduled") {
+            !recapture.targets.isEmpty
+        }
+        #expect(landed)
+        #expect(recapture.targets == [.holderChild(pid: childPID)])
+        #expect(recapture.panes.isEmpty, "a holder fork scheduled a pane recapture")
+
+        // The source tab is untouched — a fork copies, it does not move.
+        #expect(try await fixture.db.terminals.get(id: source.id) != nil)
+    }
+
+    // MARK: - Hook tabs
+
+    /// The pre-session hook tab is born onto the holder with the flag on, and
+    /// the descriptor phase 3 carries records the pids it will need.
+    @Test func preSessionHookTabSpawnsOntoTheHolder() async throws {
+        let fixture = try await GateFixture.make(flagEnabled: true)
+        defer { fixture.tearDown() }
+        try fixture.installWorktreeHook(.preSession)
+
+        let spawn = try #require(try await fixture.spawnPreSessionTerminal())
+
+        #expect(spawn.transport == .holder)
+        let holderPID = try #require(spawn.holderPID)
+        let childPID = try #require(spawn.childPID)
+        #expect(holderPID != childPID)
+        #expect(holderProcessIsAlive(holderPID))
+        #expect(holderProcessIsAlive(childPID))
+        #expect(spawn.windowID.isEmpty)
+        #expect(spawn.paneID.isEmpty)
+
+        let row = try #require(try await fixture.db.terminals.get(id: spawn.terminalID))
+        #expect(row.transport == .holder)
+        #expect(row.label == TerminalLabel.preSession)
+
+        let issued = fixture.tmuxCommands()
+        #expect(
+            !issued.contains(where: { $0.contains("new-session") }),
+            "the pre-session hook tab started a tmux server: \(issued)")
+        #expect(
+            !issued.contains(where: { $0.contains("new-window") }),
+            "the pre-session hook tab created a tmux window: \(issued)")
+    }
+
+    /// With a setup hook installed, the setup tab is a holder row beside the
+    /// primary — still no tmux server, and two holders rather than one.
+    ///
+    /// The hook-less case is `flagOnSpawnsOntoHolder`'s `created.count == 1`:
+    /// without a hook the tab is a bare shell and a second holder process
+    /// nobody asked for.
+    @Test func setupHookTabFollowsTheHolderPrimary() async throws {
+        let fixture = try await GateFixture.make(flagEnabled: true)
+        defer { fixture.tearDown() }
+        try fixture.installWorktreeHook(.setup)
+
+        let created = try await fixture.spawnPrimaryTerminals()
+
+        #expect(created.count == 2)
+        #expect(created[1].label == TerminalLabel.setup)
+        let setup = try #require(try await fixture.db.terminals.get(id: created[1].id))
+        #expect(setup.transport == .holder)
+        let holderPID = try #require(setup.holderPID)
+        let childPID = try #require(setup.childPID)
+        #expect(holderPID != childPID)
+        #expect(holderProcessIsAlive(holderPID))
+        #expect(holderProcessIsAlive(childPID))
+        #expect(setup.tmuxWindowID.isEmpty)
+
+        let primary = try #require(try await fixture.db.terminals.get(id: created[0].id))
+        #expect(primary.transport == .holder)
+        #expect(primary.holderPID != setup.holderPID, "both tabs share one holder")
+
+        let issued = fixture.tmuxCommands()
+        #expect(
+            !issued.contains(where: { $0.contains("new-session") }),
+            "the setup hook tab started a tmux server: \(issued)")
+        #expect(
+            !issued.contains(where: { $0.contains("new-window") }),
+            "the setup hook tab created a tmux window: \(issued)")
+    }
+
+    /// The setup tab's other arm: with the flag off it is a tmux window, hook
+    /// or no hook, exactly as it always has been.
+    @Test func setupHookTabStaysOnTmuxWithTheFlagOff() async throws {
+        let fixture = try await GateFixture.make(flagEnabled: false)
+        defer { fixture.tearDown() }
+        try fixture.installWorktreeHook(.setup)
+
+        let created = try await fixture.spawnPrimaryTerminals()
+
+        #expect(created.count == 2)
+        let setup = try #require(try await fixture.db.terminals.get(id: created[1].id))
+        #expect(setup.transport == .tmux)
+        #expect(!setup.tmuxWindowID.isEmpty)
+        #expect(setup.holderPID == nil)
     }
 }
 
@@ -530,11 +744,20 @@ private final class RecaptureProbe: @unchecked Sendable {
     static let detectedSessionID = "RECAPTURED-BY-THE-PROBE"
 
     private let lock = NSLock()
-    private var recorded: [String] = []
+    private var recorded: [SessionRecaptureTarget] = []
 
-    /// The panes recapture was scheduled against, in order.
-    var panes: [String] {
+    /// Every target recapture was scheduled against, in order.
+    var targets: [SessionRecaptureTarget] {
         lock.withLock { recorded }
+    }
+
+    /// The panes recapture was scheduled against, in order — the tmux targets
+    /// only, so an assertion about panes keeps meaning what it always did.
+    var panes: [String] {
+        targets.compactMap {
+            if case .tmuxPane(_, let paneID) = $0 { return paneID }
+            return nil
+        }
     }
 
     func scheduler(db: TBDDatabase, tmux: TmuxManager) -> SessionRecaptureScheduler {
@@ -543,8 +766,8 @@ private final class RecaptureProbe: @unchecked Sendable {
             tmux: tmux,
             // `withLock` rather than `lock()`/`unlock()`: this closure is
             // `async`, where the unscoped pair is unavailable.
-            captureSessionID: { [self] _, paneID in
-                lock.withLock { recorded.append(paneID) }
+            captureSessionID: { [self] target in
+                lock.withLock { recorded.append(target) }
                 return Self.detectedSessionID
             },
             clock: ImmediateClock())
@@ -771,6 +994,13 @@ private final class GateFixture {
             configDirManager: configDirManager,
             actuationLog: makeTestActuationLog())
         router.holderRegistry = registry
+        if let recapture {
+            // The router builds its own scheduler for the swap paths, so the
+            // probe has to be wired into both seams to observe a fork.
+            router.sessionRecaptureFactory = { db, tmux in
+                recapture.scheduler(db: db, tmux: tmux)
+            }
+        }
         // Codex is never launched here: the job is the pinned gate shell,
         // which ignores its argv. The stubs only have to satisfy the handlers'
         // pre-spawn resolution, so the Codex branches can reach the gate.
@@ -886,6 +1116,64 @@ private final class GateFixture {
 
     func capturePaneCalls() -> Int { capturePaneCounter.count }
     func tmuxCommands() -> [String] { recordedCommands.all }
+
+    /// Installs an executable `.worktree-hooks/<event>` in the worktree's
+    /// checkout. `HookResolver` only looks at the filesystem, and this fixture's
+    /// worktree path IS the repo checkout, so no commit is needed.
+    ///
+    /// The script itself never runs the hook tab's *program* — the job is the
+    /// pinned gate shell, which ignores its argv — so what this installs is the
+    /// fact that a hook RESOLVES, which is what both hook-tab decisions read.
+    @discardableResult
+    func installWorktreeHook(_ event: HookEvent) throws -> String {
+        let dir = URL(fileURLWithPath: worktree.localPath)
+            .appendingPathComponent(".worktree-hooks", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let path = dir.appendingPathComponent(event.rawValue).path
+        try "#!/bin/sh\nexit 0\n".write(toFile: path, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755], ofItemAtPath: path)
+        return path
+    }
+
+    /// The production pre-session spawn, entered exactly as worktree creation
+    /// enters it.
+    func spawnPreSessionTerminal() async throws -> PreSessionSpawn? {
+        try await router.lifecycle.spawnPreSessionTerminal(
+            worktree: worktree, repo: repo, worktreePath: worktree.localPath)
+    }
+
+    /// The `terminalHistory.revive` RPC, through the router.
+    func historyRevive(entryID: UUID) async throws -> Terminal {
+        let response = await router.handle(
+            try RPCRequest(
+                method: RPCMethod.terminalHistoryRevive,
+                params: TerminalHistoryReviveParams(
+                    worktreeID: worktree.id, id: entryID)))
+        if let error = response.error {
+            Issue.record("terminalHistory.revive failed: \(error)")
+        }
+        return try response.decodeResult(Terminal.self)
+    }
+
+    /// A closed SHELL terminal in this worktree's history, ready to revive.
+    func seedClosedShellHistoryEntry() async throws -> UUID {
+        let closed = Terminal(
+            worktreeID: worktree.id, tmuxWindowID: "@closed", tmuxPaneID: "%closed",
+            label: nil, kind: .shell)
+        await db.terminalHistory.store(
+            terminal: closed, text: "prior shell output\n", closedAt: Date())
+        return closed.id
+    }
+
+    /// The `terminal.swapProfile` RPC in `.fork` mode, through the router.
+    func forkSwap(terminalID: UUID) async throws -> RPCResponse {
+        await router.handle(
+            try RPCRequest(
+                method: RPCMethod.terminalSwapProfile,
+                params: TerminalSwapProfileParams(
+                    terminalID: terminalID, newProfileID: nil, mode: .fork)))
+    }
 
     /// Kills every holder this fixture started AND every job those holders
     /// forked, then clears the scratch roots. A test that leaves either behind

--- a/Tests/TBDDaemonTests/ClaudeStateDetectorTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeStateDetectorTests.swift
@@ -128,69 +128,126 @@ struct ClaudeStateDetectorSessionPathTests {
 /// runs beside it in this suite so a resolver that answered only for holders —
 /// or ignored the target's payload entirely — cannot pass.
 ///
+/// Both arms are asserted positively. A pane target on a dry-run manager
+/// answers `0` unless a test says otherwise, and `0` names no session file and
+/// no `claude` child, so a "returns nil" tmux test passes for a detector that
+/// resolves nothing at all — including one that never consulted its target. The
+/// pid hook is therefore injected and its answer is what the assertion is built
+/// on, with the failure to read a pane pid as the separate negative case.
+///
 /// Explicit environment dictionaries, never `setenv`: this suite is not nested
 /// under `TBDHomeSerialized`, and mutating the process-global variable would
 /// hand every concurrently running suite the real `~/.claude`.
 @Suite("ClaudeStateDetector recapture targets")
 struct ClaudeStateDetectorTargetTests {
 
-    /// Thread-safe tally of the tmux argv a dry-run manager was asked to run.
-    private final class ArgvRecorder: @unchecked Sendable {
+    /// A pane-pid query that cannot be answered — what a `list-panes` against a
+    /// pane that is gone amounts to.
+    private struct PaneQueryFailed: Error {}
+
+    /// Thread-safe tally of the pane-pid queries a dry-run manager was asked
+    /// for. The hook is a `@Sendable` closure called from whatever executor the
+    /// detector happens to be on.
+    ///
+    /// It counts the query `panePID` itself makes, which is the only tmux call
+    /// either arm of this resolution can produce — `dryRunRecorder` cannot see
+    /// it, because `panePID` answers from this hook in dry run without
+    /// recording any argv, so a recorder-based assertion here is vacuous.
+    private final class PanePIDProbe: @unchecked Sendable {
         private let lock = NSLock()
-        private var argvs: [[String]] = []
-        func record(_ argv: [String]) {
+        private var recorded: [[String]] = []
+        func record(server: String, paneID: String) {
             lock.lock(); defer { lock.unlock() }
-            argvs.append(argv)
+            recorded.append([server, paneID])
         }
-        var all: [[String]] {
+        /// Every `(server, paneID)` the manager was asked about, in order.
+        /// Asserted whole rather than counted, so a query that reached tmux
+        /// with the wrong coordinate fails here rather than passing a tally.
+        var queries: [[String]] {
             lock.lock(); defer { lock.unlock() }
-            return argvs
+            return recorded
         }
+    }
+
+    /// A host store with one session file in it, written the way Claude writes
+    /// one for the process at `pid`.
+    private static func makeHostStore(
+        pid: Int32, sessionID: String
+    ) throws -> URL {
+        let host = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("tbd-detector-target-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: host.appendingPathComponent("sessions", isDirectory: true),
+            withIntermediateDirectories: true)
+        try #"{"pid":\#(pid),"sessionId":"\#(sessionID)"}"#.write(
+            to: host.appendingPathComponent("sessions/\(pid).json"),
+            atomically: true, encoding: .utf8)
+        return host
     }
 
     @Test("a holder-child target reads the job's own session file, without tmux")
     func holderChildTargetReadsTheSessionFile() async throws {
-        let fm = FileManager.default
-        let host = URL(fileURLWithPath: NSTemporaryDirectory())
-            .appendingPathComponent("tbd-detector-holder-\(UUID().uuidString)", isDirectory: true)
-        defer { try? fm.removeItem(at: host) }
-        try fm.createDirectory(
-            at: host.appendingPathComponent("sessions", isDirectory: true),
-            withIntermediateDirectories: true)
         // A pid the holder would have recorded for the job it forked. Nothing
         // is signalled or inspected — only the file at its path is read.
         let childPID: Int32 = 424242
-        try #"{"pid":424242,"sessionId":"holder-child-session"}"#.write(
-            to: host.appendingPathComponent("sessions/\(childPID).json"),
-            atomically: true, encoding: .utf8)
+        let host = try Self.makeHostStore(pid: childPID, sessionID: "holder-child-session")
+        defer { try? FileManager.default.removeItem(at: host) }
 
-        let recorder = ArgvRecorder()
+        let probe = PanePIDProbe()
         let detector = ClaudeStateDetector(
-            tmux: TmuxManager(dryRun: true, dryRunRecorder: { recorder.record($0) }),
+            tmux: TmuxManager(dryRun: true, dryRunPanePID: { server, paneID in
+                probe.record(server: server, paneID: paneID)
+                return "0"
+            }),
             environment: ["TBD_CLAUDE_HOST_HOME": host.path])
 
         let captured = await detector.captureSessionID(target: .holderChild(pid: childPID))
 
         #expect(captured == "holder-child-session")
         #expect(
-            recorder.all.isEmpty,
-            "a holder recapture shelled out to tmux: \(recorder.all)")
+            probe.queries.isEmpty,
+            "a holder recapture resolved a tmux pane pid: \(probe.queries)")
     }
 
-    /// The other arm, on the same detector shape: a pane target still resolves
-    /// through `panePID`, which a dry-run manager answers `0` for — a pid with
-    /// no session file and no `claude` child — so the answer is nil rather than
-    /// a session id borrowed from somewhere else.
-    @Test("a tmux-pane target with no live pane resolves to nil")
-    func tmuxPaneTargetWithoutAPaneIsNil() async throws {
-        let fm = FileManager.default
-        let host = URL(fileURLWithPath: NSTemporaryDirectory())
-            .appendingPathComponent("tbd-detector-pane-\(UUID().uuidString)", isDirectory: true)
-        defer { try? fm.removeItem(at: host) }
-        try fm.createDirectory(at: host, withIntermediateDirectories: true)
+    /// The other arm, on the same detector shape: a pane target resolves the
+    /// pane's pid first and reads the session file of whatever that names.
+    @Test("a tmux-pane target resolves through the pane's own pid")
+    func tmuxPaneTargetResolvesThroughThePanePID() async throws {
+        let panePID: Int32 = 515151
+        let host = try Self.makeHostStore(pid: panePID, sessionID: "pane-session")
+        defer { try? FileManager.default.removeItem(at: host) }
+
+        let probe = PanePIDProbe()
+        let detector = ClaudeStateDetector(
+            tmux: TmuxManager(dryRun: true, dryRunPanePID: { server, paneID in
+                probe.record(server: server, paneID: paneID)
+                return String(panePID)
+            }),
+            environment: ["TBD_CLAUDE_HOST_HOME": host.path])
+
+        let captured = await detector.captureSessionID(
+            target: .tmuxPane(server: "tbd-detector", paneID: "%7"))
+
+        #expect(captured == "pane-session")
+        // The target's payload has to reach the query, or the pid above says
+        // nothing about which pane was asked for.
+        #expect(probe.queries == [["tbd-detector", "%7"]])
+    }
+
+    /// And the failure this arm has to answer for: a pane whose pid cannot be
+    /// read at all resolves to nil rather than to a session id borrowed from
+    /// somewhere else.
+    @Test("a tmux-pane target whose pane pid cannot be read is nil")
+    func tmuxPaneTargetWithoutAPanePIDIsNil() async throws {
+        // The same store as the positive case, so a detector that answered from
+        // anything other than the pane's pid would still find a file to read.
+        let host = try Self.makeHostStore(pid: 515151, sessionID: "pane-session")
+        defer { try? FileManager.default.removeItem(at: host) }
 
         let detector = ClaudeStateDetector(
-            tmux: TmuxManager(dryRun: true),
+            tmux: TmuxManager(dryRun: true, dryRunPanePID: { _, _ in
+                throw PaneQueryFailed()
+            }),
             environment: ["TBD_CLAUDE_HOST_HOME": host.path])
 
         let captured = await detector.captureSessionID(

--- a/Tests/TBDDaemonTests/ClaudeStateDetectorTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeStateDetectorTests.swift
@@ -118,3 +118,84 @@ struct ClaudeStateDetectorSessionPathTests {
                 .sessionFilePath(forPID: 7).path == expected)
     }
 }
+
+/// The two shapes a recapture target can take, resolved through the one ladder
+/// that serves both transports.
+///
+/// The holder arm is the new half: a holder-backed session has no pane, so its
+/// recapture addresses the pid the holder recorded for the job it forked, and
+/// the read has to land in the same host store the tmux arm reads. The tmux arm
+/// runs beside it in this suite so a resolver that answered only for holders —
+/// or ignored the target's payload entirely — cannot pass.
+///
+/// Explicit environment dictionaries, never `setenv`: this suite is not nested
+/// under `TBDHomeSerialized`, and mutating the process-global variable would
+/// hand every concurrently running suite the real `~/.claude`.
+@Suite("ClaudeStateDetector recapture targets")
+struct ClaudeStateDetectorTargetTests {
+
+    /// Thread-safe tally of the tmux argv a dry-run manager was asked to run.
+    private final class ArgvRecorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var argvs: [[String]] = []
+        func record(_ argv: [String]) {
+            lock.lock(); defer { lock.unlock() }
+            argvs.append(argv)
+        }
+        var all: [[String]] {
+            lock.lock(); defer { lock.unlock() }
+            return argvs
+        }
+    }
+
+    @Test("a holder-child target reads the job's own session file, without tmux")
+    func holderChildTargetReadsTheSessionFile() async throws {
+        let fm = FileManager.default
+        let host = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("tbd-detector-holder-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fm.removeItem(at: host) }
+        try fm.createDirectory(
+            at: host.appendingPathComponent("sessions", isDirectory: true),
+            withIntermediateDirectories: true)
+        // A pid the holder would have recorded for the job it forked. Nothing
+        // is signalled or inspected — only the file at its path is read.
+        let childPID: Int32 = 424242
+        try #"{"pid":424242,"sessionId":"holder-child-session"}"#.write(
+            to: host.appendingPathComponent("sessions/\(childPID).json"),
+            atomically: true, encoding: .utf8)
+
+        let recorder = ArgvRecorder()
+        let detector = ClaudeStateDetector(
+            tmux: TmuxManager(dryRun: true, dryRunRecorder: { recorder.record($0) }),
+            environment: ["TBD_CLAUDE_HOST_HOME": host.path])
+
+        let captured = await detector.captureSessionID(target: .holderChild(pid: childPID))
+
+        #expect(captured == "holder-child-session")
+        #expect(
+            recorder.all.isEmpty,
+            "a holder recapture shelled out to tmux: \(recorder.all)")
+    }
+
+    /// The other arm, on the same detector shape: a pane target still resolves
+    /// through `panePID`, which a dry-run manager answers `0` for — a pid with
+    /// no session file and no `claude` child — so the answer is nil rather than
+    /// a session id borrowed from somewhere else.
+    @Test("a tmux-pane target with no live pane resolves to nil")
+    func tmuxPaneTargetWithoutAPaneIsNil() async throws {
+        let fm = FileManager.default
+        let host = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("tbd-detector-pane-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fm.removeItem(at: host) }
+        try fm.createDirectory(at: host, withIntermediateDirectories: true)
+
+        let detector = ClaudeStateDetector(
+            tmux: TmuxManager(dryRun: true),
+            environment: ["TBD_CLAUDE_HOST_HOME": host.path])
+
+        let captured = await detector.captureSessionID(
+            target: .tmuxPane(server: "tbd-detector", paneID: "%7"))
+
+        #expect(captured == nil)
+    }
+}

--- a/Tests/TBDDaemonTests/Holder/ForkSwapTransportGateTests.swift
+++ b/Tests/TBDDaemonTests/Holder/ForkSwapTransportGateTests.swift
@@ -280,6 +280,14 @@ struct ForkSwapTransportGateTests {
                 terminalID: holderSource.id, newProfileID: nil, mode: .inPlace)))
 
         #expect(!response.success)
+        // The refusal itself, not merely a failure: `.inPlace` on a holder row
+        // has several other ways to fail (an unresolvable profile, a missing
+        // source session), and only this text says the transport was what
+        // stopped it.
+        #expect(
+            response.error?.contains(
+                RPCRouter.holderInPlaceSwapRefusal(terminalID: holderSource.id)) == true,
+            "the swap failed for some other reason: \(response.error ?? "success")")
         #expect(fixture.recorder.count("new-window") == 0)
     }
 }

--- a/Tests/TBDDaemonTests/Holder/ForkSwapTransportGateTests.swift
+++ b/Tests/TBDDaemonTests/Holder/ForkSwapTransportGateTests.swift
@@ -146,6 +146,10 @@ struct ForkSwapTransportGateTests {
         // A live tmux Claude tab with a NON-blank transcript: a blank session
         // plans `.fresh`, which schedules no recapture at all, and the target
         // is what this suite is about.
+        // `fencedScratchRoot` mints a path and creates nothing; the atomic
+        // write below needs the directory to exist.
+        try FileManager.default.createDirectory(
+            atPath: home, withIntermediateDirectories: true)
         let transcript = (home as NSString).appendingPathComponent("source.jsonl")
         try #"{"type":"user","message":{"content":"fork this"}}"#
             .write(toFile: transcript, atomically: true, encoding: .utf8)

--- a/Tests/TBDDaemonTests/Holder/ForkSwapTransportGateTests.swift
+++ b/Tests/TBDDaemonTests/Holder/ForkSwapTransportGateTests.swift
@@ -1,0 +1,285 @@
+import Clocks
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+import TestSupport
+
+/// The transport gate as a `.fork` profile swap asks it, and the recapture
+/// target that follows from it — the branches that need no `TBDHolder` binary.
+/// The branch that does, a fork landing on a real holder, is
+/// `HolderSpawnGateTests` in the live target.
+///
+/// The recapture half is the reason this suite exists rather than a row
+/// assertion alone. A real scheduler's only trace is a database write five wall
+/// seconds later, made only if a live Claude process answers, so "scheduled
+/// against the pane" and "scheduled against the holder's child" are
+/// indistinguishable from the row. `router.sessionRecaptureFactory` makes the
+/// decision itself the observable, on virtual time.
+@Suite("terminal.swapProfile fork transport gate")
+struct ForkSwapTransportGateTests {
+
+    // MARK: - Probe
+
+    /// The scheduler the swap path is given in place of the real one, and the
+    /// record of every target it was asked about. `ImmediateClock` so the
+    /// branch is asserted without waiting out the production five seconds; it
+    /// never reaches `ClaudeStateDetector`, which would read a session file at
+    /// a process-wide path.
+    private final class RecaptureProbe: @unchecked Sendable {
+        static let detectedSessionID = "FORK-RECAPTURED-BY-THE-PROBE"
+
+        private let lock = NSLock()
+        private var recorded: [SessionRecaptureTarget] = []
+
+        var targets: [SessionRecaptureTarget] {
+            lock.withLock { recorded }
+        }
+
+        func scheduler(db: TBDDatabase, tmux: TmuxManager) -> SessionRecaptureScheduler {
+            SessionRecaptureScheduler(
+                db: db,
+                tmux: tmux,
+                // `withLock` rather than `lock()`/`unlock()`: this closure is
+                // `async`, where the unscoped pair is unavailable.
+                captureSessionID: { [self] target in
+                    lock.withLock { recorded.append(target) }
+                    return Self.detectedSessionID
+                },
+                clock: ImmediateClock())
+        }
+    }
+
+    // MARK: - Fixture
+
+    private final class TmuxArgvRecorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var argvs: [[String]] = []
+        func record(_ argv: [String]) {
+            lock.lock(); defer { lock.unlock() }
+            argvs.append(argv)
+        }
+        var all: [[String]] {
+            lock.lock(); defer { lock.unlock() }
+            return argvs
+        }
+        func count(_ subcommand: String) -> Int {
+            all.filter { $0.contains(subcommand) }.count
+        }
+    }
+
+    private struct Fixture {
+        let db: TBDDatabase
+        let router: RPCRouter
+        let recorder: TmuxArgvRecorder
+        let probe: RecaptureProbe
+        let environment: [String: String]
+        let worktree: Worktree
+        let source: Terminal
+        let home: String
+        let worktreePath: String
+
+        func tearDown() {
+            try? FileManager.default.removeItem(atPath: home)
+            try? FileManager.default.removeItem(atPath: worktreePath)
+        }
+
+        func fork() async throws -> RPCResponse {
+            await router.handle(try RPCRequest(
+                method: RPCMethod.terminalSwapProfile,
+                params: TerminalSwapProfileParams(
+                    terminalID: source.id, newProfileID: nil, mode: .fork)))
+        }
+    }
+
+    private static func unspawnableSpawner() -> HolderSpawner {
+        HolderSpawner(executableURL: URL(fileURLWithPath: "/nonexistent/TBDHolder"))
+    }
+
+    private static func makeFixture(
+        holderFlag: Bool,
+        spawner: HolderSpawner?
+    ) async throws -> Fixture {
+        let home = fencedScratchRoot(prefix: "tbdfsg")
+        let environment = [
+            "TBD_HOME": home,
+            "PATH": "/usr/bin:/bin",
+            "SHELL": "/bin/sh",
+        ]
+        let recorder = TmuxArgvRecorder()
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunRecorder: { recorder.record($0) },
+            dryRunCapturePane: { _, _ in "" })
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setPtyHolderEnabled(holderFlag)
+
+        let configDirManager = makeIsolatedConfigDirManager(tag: "fork-swap-gate")
+        let lifecycle = WorktreeLifecycle(
+            db: db, git: GitManager(), tmux: tmux, hooks: HookResolver(),
+            configDirManager: configDirManager)
+        let router = RPCRouter(
+            db: db, lifecycle: lifecycle, tmux: tmux, startTime: Date(),
+            configDirManager: configDirManager,
+            actuationLog: makeTestActuationLog())
+        router.holderRegistry = HolderRegistry(
+            owner: HolderOwnerToken(rawValue: "acme-installation"),
+            environment: environment,
+            listTerminals: { [] },
+            spawner: spawner)
+        let probe = RecaptureProbe()
+        router.sessionRecaptureFactory = { db, tmux in
+            probe.scheduler(db: db, tmux: tmux)
+        }
+
+        let repo = try await db.repos.create(
+            path: "/tmp/tbd-fsg-repo-\(UUID().uuidString)",
+            displayName: "acme", defaultBranch: "main")
+        let worktreePath = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-fsg-wt-\(UUID().uuidString)").path
+        try FileManager.default.createDirectory(
+            atPath: worktreePath, withIntermediateDirectories: true)
+        let worktree = try await db.worktrees.create(
+            repoID: repo.id, name: "wt", branch: "tbd/wt",
+            path: worktreePath, tmuxServer: "tbd-fsg-test")
+
+        // A live tmux Claude tab with a NON-blank transcript: a blank session
+        // plans `.fresh`, which schedules no recapture at all, and the target
+        // is what this suite is about.
+        let transcript = (home as NSString).appendingPathComponent("source.jsonl")
+        try #"{"type":"user","message":{"content":"fork this"}}"#
+            .write(toFile: transcript, atomically: true, encoding: .utf8)
+        let created = try await db.terminals.create(
+            worktreeID: worktree.id,
+            tmuxWindowID: "@source",
+            tmuxPaneID: "%source",
+            label: TerminalLabel.claudeCode,
+            claudeSessionID: "fork-source-session",
+            kind: .claude)
+        try await db.terminals.updateSession(
+            id: created.id, sessionID: "fork-source-session", transcriptPath: transcript)
+        let source = try #require(try await db.terminals.get(id: created.id))
+
+        return Fixture(
+            db: db, router: router, recorder: recorder, probe: probe,
+            environment: environment, worktree: worktree, source: source,
+            home: home, worktreePath: worktreePath)
+    }
+
+    /// The forked row, which is the one row in the worktree that is not the
+    /// source.
+    private func forkedRow(in fixture: Fixture) async throws -> Terminal {
+        let rows = try await fixture.db.terminals.list(worktreeID: fixture.worktree.id)
+        return try #require(
+            rows.first { $0.id != fixture.source.id },
+            "the fork created no new terminal row")
+    }
+
+    // MARK: - Flag off
+
+    /// Today's behaviour, exactly: a tmux window, a tmux row, and a recapture
+    /// scheduled against that row's own pane.
+    @Test("flag off: a fork tab spawns onto tmux and recaptures through its pane")
+    func flagOffForksOntoTmux() async throws {
+        let fixture = try await Self.makeFixture(
+            holderFlag: false, spawner: Self.unspawnableSpawner())
+        defer { fixture.tearDown() }
+
+        let response = try await fixture.fork()
+        #expect(response.success, "\(response.error ?? "")")
+
+        let forked = try await forkedRow(in: fixture)
+        #expect(forked.transport == .tmux)
+        #expect(!forked.tmuxPaneID.isEmpty)
+        #expect(forked.holderPID == nil)
+        #expect(forked.childPID == nil)
+        #expect(fixture.recorder.count("new-window") == 1)
+
+        let landed = await waitUntil { !fixture.probe.targets.isEmpty }
+        #expect(landed, "the fork scheduled no session recapture")
+        #expect(fixture.probe.targets == [
+            .tmuxPane(server: fixture.worktree.tmuxServer, paneID: forked.tmuxPaneID)
+        ])
+
+        // The source tab is untouched — a fork copies, it does not move.
+        #expect(try await fixture.db.terminals.get(id: fixture.source.id) != nil)
+    }
+
+    // MARK: - Flag on, nothing to spawn with
+
+    /// A registry with no spawner falls back to tmux whole: a tmux row AND a
+    /// pane-addressed recapture, not a half-taken holder path.
+    @Test("flag on with a registry that cannot spawn falls back to tmux")
+    func flagOnWithoutASpawnerFallsBackToTmux() async throws {
+        let fixture = try await Self.makeFixture(holderFlag: true, spawner: nil)
+        defer { fixture.tearDown() }
+
+        let response = try await fixture.fork()
+        #expect(response.success, "\(response.error ?? "")")
+
+        let forked = try await forkedRow(in: fixture)
+        #expect(forked.transport == .tmux)
+        #expect(fixture.recorder.count("new-window") == 1)
+
+        let landed = await waitUntil { !fixture.probe.targets.isEmpty }
+        #expect(landed, "the fork scheduled no session recapture")
+        #expect(fixture.probe.targets == [
+            .tmuxPane(server: fixture.worktree.tmuxServer, paneID: forked.tmuxPaneID)
+        ])
+    }
+
+    // MARK: - Flag on, the holder spawn fails
+
+    /// The fork takes the holder path and fails there, leaving no new row, no
+    /// tmux window and no tmux server — `prepareTmuxServer` is a no-op for a
+    /// holder decision, and the fork must not have started one anyway.
+    @Test("a holder fork spawn failure fails the swap and starts no tmux server")
+    func holderSpawnFailureFailsTheFork() async throws {
+        let fixture = try await Self.makeFixture(
+            holderFlag: true, spawner: Self.unspawnableSpawner())
+        defer { fixture.tearDown() }
+
+        let response = try await fixture.fork()
+        #expect(!response.success)
+        #expect(
+            response.error?.contains("/nonexistent/TBDHolder") == true,
+            "the fork did not take the holder path: \(response.error ?? "success")")
+        let rows = try await fixture.db.terminals.list(worktreeID: fixture.worktree.id)
+        #expect(rows.map(\.id) == [fixture.source.id], "a failed fork left a row behind")
+        #expect(
+            fixture.recorder.count("new-window") == 0,
+            "a failed holder fork fell through to tmux: \(fixture.recorder.all)")
+        #expect(
+            fixture.recorder.count("new-session") == 0,
+            "a holder fork started a tmux server: \(fixture.recorder.all)")
+        #expect(fixture.probe.targets.isEmpty, "a fork that never spawned scheduled a recapture")
+    }
+
+    // MARK: - The in-place refusal is untouched
+
+    /// The holder refusal for `.inPlace` is scoped to that mode and stays put:
+    /// a holder source row cannot be respawned in place, whatever the flag
+    /// says about new spawns.
+    @Test("an in-place swap on a holder row is still refused")
+    func inPlaceOnAHolderRowIsStillRefused() async throws {
+        let fixture = try await Self.makeFixture(holderFlag: true, spawner: nil)
+        defer { fixture.tearDown() }
+        let holderSource = try await fixture.db.terminals.create(
+            worktreeID: fixture.worktree.id,
+            tmuxWindowID: "", tmuxPaneID: "",
+            label: TerminalLabel.claudeCode,
+            claudeSessionID: "holder-source-session",
+            kind: .claude,
+            transport: .holder,
+            holderPID: 4242,
+            childPID: 4243)
+
+        let response = await fixture.router.handle(try RPCRequest(
+            method: RPCMethod.terminalSwapProfile,
+            params: TerminalSwapProfileParams(
+                terminalID: holderSource.id, newProfileID: nil, mode: .inPlace)))
+
+        #expect(!response.success)
+        #expect(fixture.recorder.count("new-window") == 0)
+    }
+}

--- a/Tests/TBDDaemonTests/Holder/HolderHookJobIdentityTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HolderHookJobIdentityTests.swift
@@ -1,0 +1,215 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+import TestSupport
+
+/// `HolderRegistry.abandonVerifiedJob` — the hook-tab teardown's decision about
+/// whether the pid it wrote down may still be signalled.
+///
+/// Every fact the decision rests on is dictated by `FakeProcessSignaller`,
+/// because the case that matters cannot be arranged with real processes: the
+/// point of the check is what it does when the kernel has handed the recorded
+/// number to somebody else, and a test cannot make the kernel reissue a pid on
+/// demand. Scripting the process table is the only way to state that at all.
+///
+/// The rendezvous socket never exists in any of these: the `forget` is
+/// best-effort and its failure to connect is not what is under test. What is
+/// under test is which pids get signalled, so `forceKill` is the observable
+/// throughout — never `terminate`, since this path escalates straight to
+/// `SIGKILL` exactly as `killJob` does.
+@Suite("Holder hook-tab job identity")
+struct HolderHookJobIdentityTests {
+
+    private static let childPID: Int32 = 8801
+    /// The row's recorded `holderChildStartedAt`, and the anchor every verdict
+    /// below is measured against.
+    private static let anchor = Date(timeIntervalSince1970: 1_800_000_000)
+
+    /// A registry whose process table the caller scripts, and whose rendezvous
+    /// paths resolve to a short scratch root so the socket derivation can never
+    /// be what fails (`sun_path` is 104 bytes).
+    private static func registry(
+        signaller: FakeProcessSignaller, home: String
+    ) -> HolderRegistry {
+        HolderRegistry(
+            owner: HolderOwnerToken(rawValue: "acme-installation"),
+            environment: [
+                "TBD_HOME": home,
+                "PATH": "/usr/bin:/bin",
+                "SHELL": "/bin/sh",
+            ],
+            listTerminals: { [] },
+            spawner: nil,
+            signaller: signaller)
+    }
+
+    private static func scratchHome() throws -> String {
+        let home = fencedScratchRoot(prefix: "tbdhji")
+        try FileManager.default.createDirectory(
+            atPath: home, withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700])
+        return home
+    }
+
+    /// A signaller scripted with a job that IS ours: alive, started when the
+    /// row says it started, presenting the login shell the holder forks. Each
+    /// test below breaks exactly one of those.
+    private static func ourJob() -> FakeProcessSignaller {
+        let signaller = FakeProcessSignaller()
+        signaller.behaviors[childPID] = .init(
+            aliveInitially: true, aliveAfterTerminate: true, aliveAfterKill: false)
+        signaller.startTimes[childPID] = anchor
+        signaller.cmdlines[childPID] = "/bin/zsh -i -l -c hook"
+        return signaller
+    }
+
+    // MARK: - The case the check exists for
+
+    /// A pid the kernel reissued between the job's exit and the teardown is not
+    /// signalled, and the teardown says so.
+    ///
+    /// This is the whole finding: on the setup auto-close path the hook has
+    /// usually finished — which is *why* the tab is closing — so the recorded
+    /// pid is free for the kernel to hand out again, and the stranger holding
+    /// it looks like an ordinary shell. Only the start time separates them.
+    @Test("a recycled pid is never signalled")
+    func aRecycledPIDIsLeftAlone() async throws {
+        let home = try Self.scratchHome()
+        defer { try? FileManager.default.removeItem(atPath: home) }
+        let signaller = Self.ourJob()
+        // An hour past the anchor: a different process, wearing a shell's
+        // command line so nothing but the start time can refuse it.
+        signaller.startTimes[Self.childPID] = Self.anchor.addingTimeInterval(3600)
+        signaller.cmdlines[Self.childPID] = "zsh -c make"
+
+        let left = await Self.registry(signaller: signaller, home: home)
+            .abandonVerifiedJob(
+                terminalID: UUID(), holderPID: nil, childPID: Self.childPID,
+                childStartedAt: Self.anchor)
+
+        #expect(signaller.killed.isEmpty, "a recycled pid was killed")
+        #expect(signaller.terminated.isEmpty)
+        let reported = try #require(left, "a refused kill was not reported")
+        #expect(reported.contains("startTimeMismatch"), "the report did not name the verdict: \(reported)")
+        #expect(reported.contains("\(Self.childPID)"))
+    }
+
+    /// The job that really is ours is still reclaimed — otherwise the check
+    /// above would be indistinguishable from never killing anything.
+    @Test("a job that verifies is force-killed")
+    func aVerifiedJobIsKilled() async throws {
+        let home = try Self.scratchHome()
+        defer { try? FileManager.default.removeItem(atPath: home) }
+        let signaller = Self.ourJob()
+
+        let left = await Self.registry(signaller: signaller, home: home)
+            .abandonVerifiedJob(
+                terminalID: UUID(), holderPID: nil, childPID: Self.childPID,
+                childStartedAt: Self.anchor)
+
+        #expect(signaller.killed == [Self.childPID])
+        #expect(left == nil)
+    }
+
+    // MARK: - The answers that are not failures
+
+    /// The ordinary auto-close case: the hook finished, the job exited, and
+    /// nothing holds the number. Nothing is signalled and nothing is reported —
+    /// a teardown that found its job already gone did its whole job.
+    @Test("a job that has already exited is neither signalled nor reported")
+    func anExitedJobIsNotReported() async throws {
+        let home = try Self.scratchHome()
+        defer { try? FileManager.default.removeItem(atPath: home) }
+        let signaller = Self.ourJob()
+        signaller.behaviors[Self.childPID] = .init(aliveInitially: false)
+
+        let left = await Self.registry(signaller: signaller, home: home)
+            .abandonVerifiedJob(
+                terminalID: UUID(), holderPID: nil, childPID: Self.childPID,
+                childStartedAt: Self.anchor)
+
+        #expect(signaller.killed.isEmpty)
+        #expect(left == nil)
+    }
+
+    /// A corpse is read as gone rather than as a stranger. `ps` prints a
+    /// zombie's command in parentheses, so the executable gate would refuse it
+    /// — naming the wrong reason for the right decision — which is why the
+    /// zombie is asked about first.
+    @Test("a zombie is read as gone, not as a foreign executable")
+    func aZombieIsReadAsGone() async throws {
+        let home = try Self.scratchHome()
+        defer { try? FileManager.default.removeItem(atPath: home) }
+        let signaller = Self.ourJob()
+        signaller.stats[Self.childPID] = "Z+"
+        signaller.cmdlines[Self.childPID] = "(zsh)"
+
+        let left = await Self.registry(signaller: signaller, home: home)
+            .abandonVerifiedJob(
+                terminalID: UUID(), holderPID: nil, childPID: Self.childPID,
+                childStartedAt: Self.anchor)
+
+        #expect(signaller.killed.isEmpty)
+        #expect(left == nil, "a corpse was reported as a job left running: \(left ?? "")")
+    }
+
+    // MARK: - The other ways an identity fails to hold
+
+    /// A stranger that started inside the window is still refused, because the
+    /// executable is one no holder job could present.
+    @Test("a foreign executable at the recorded pid is left alone")
+    func aForeignExecutableIsLeftAlone() async throws {
+        let home = try Self.scratchHome()
+        defer { try? FileManager.default.removeItem(atPath: home) }
+        let signaller = Self.ourJob()
+        signaller.cmdlines[Self.childPID] = "htop"
+
+        let left = await Self.registry(signaller: signaller, home: home)
+            .abandonVerifiedJob(
+                terminalID: UUID(), holderPID: nil, childPID: Self.childPID,
+                childStartedAt: Self.anchor)
+
+        #expect(signaller.killed.isEmpty, "a stranger's process was killed")
+        let reported = try #require(left)
+        #expect(reported.contains("foreignExecutable"), "unexpected report: \(reported)")
+    }
+
+    /// No anchor, no signal. A row that never recorded a start time cannot be
+    /// used to tell its own job from a stranger, and "we are not certain" is
+    /// spelled keep on this path exactly as it is on the reaper's.
+    @Test("a spawn with no recorded start time is left alone and reported")
+    func aMissingAnchorRefusesTheKill() async throws {
+        let home = try Self.scratchHome()
+        defer { try? FileManager.default.removeItem(atPath: home) }
+        let signaller = Self.ourJob()
+
+        let left = await Self.registry(signaller: signaller, home: home)
+            .abandonVerifiedJob(
+                terminalID: UUID(), holderPID: nil, childPID: Self.childPID,
+                childStartedAt: nil)
+
+        #expect(signaller.killed.isEmpty)
+        let reported = try #require(left)
+        #expect(reported.contains("start time"), "unexpected report: \(reported)")
+    }
+
+    /// The sentinel a row that never recorded a child pid decodes to is refused
+    /// before any identity question is asked: `kill(0, …)` reaches the daemon's
+    /// own process group.
+    @Test("a missing child pid is reported and nothing is signalled")
+    func aMissingChildPIDIsReported() async throws {
+        let home = try Self.scratchHome()
+        defer { try? FileManager.default.removeItem(atPath: home) }
+        let signaller = Self.ourJob()
+
+        let left = await Self.registry(signaller: signaller, home: home)
+            .abandonVerifiedJob(
+                terminalID: UUID(), holderPID: nil, childPID: nil,
+                childStartedAt: Self.anchor)
+
+        #expect(signaller.killed.isEmpty)
+        let reported = try #require(left)
+        #expect(reported.contains("no child pid"), "unexpected report: \(reported)")
+    }
+}

--- a/Tests/TBDDaemonTests/Holder/HookTabTransportGateTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HookTabTransportGateTests.swift
@@ -1,0 +1,327 @@
+import Foundation
+import TestSupport
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+// Nested under TBDHomeSerialized: `isolateTBDHome()` mutates the process-global
+// `TBD_HOME` env var to isolate hook resolution and the runtime/presession
+// marker directory from the developer's real ~/tbd. See
+// TBDHomeSerializedSuites.swift.
+extension TBDHomeSerialized {
+
+/// The transport gate as the pre-session hook tab asks it, plus the two places
+/// a hook tab's *transport* changes what the lifecycle does to it: the liveness
+/// probe that decides `.paneKilled`, and the teardown.
+///
+/// A real holder needs a `TBDHolder` binary, so the flag-on branch is reached
+/// the way `TerminalCreateTransportGateTests` reaches it — a registry that
+/// cannot spawn (tmux fallback) and a spawner whose executable does not exist
+/// (the holder path is taken, and fails). The probe and the teardown are
+/// asserted against holder ROWS, which need no live process at all.
+@Suite("Hook-tab transport gate")
+struct HookTabTransportGateTests {
+
+    /// A spawner whose executable is not there. The registry built on it
+    /// reports `canSpawn`, so the gate takes the holder path; the spawn then
+    /// fails at `posix_spawn`, before any holder exists.
+    private static func unspawnableSpawner() -> HolderSpawner {
+        HolderSpawner(executableURL: URL(fileURLWithPath: "/nonexistent/TBDHolder"))
+    }
+
+    private static func registry(spawner: HolderSpawner?, home: String) -> HolderRegistry {
+        HolderRegistry(
+            owner: HolderOwnerToken(rawValue: "acme-installation"),
+            environment: [
+                "TBD_HOME": home,
+                "PATH": "/usr/bin:/bin",
+                "SHELL": "/bin/sh",
+            ],
+            listTerminals: { [] },
+            spawner: spawner)
+    }
+
+    // MARK: - Spawn
+
+    /// Flag on, nothing to spawn with: the hook tab is created on tmux, the
+    /// same fallback every other spawn path takes. A refusal here would block
+    /// worktree creation outright.
+    @Test("flag on with a registry that cannot spawn puts the hook tab on tmux")
+    func flagOnWithoutASpawnerFallsBackToTmux() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let fx = try await makeWorktreeFixture()
+        defer { try? FileManager.default.removeItem(at: fx.repoDir.deletingLastPathComponent()) }
+        try await fx.db.config.setPtyHolderEnabled(true)
+        try await installPreSessionHook(repoDir: fx.repoDir)
+        let scratch = fencedScratchRoot(prefix: "tbdhtg")
+        defer { try? FileManager.default.removeItem(atPath: scratch) }
+
+        var lifecycle = makeLifecycle(db: fx.db)
+        lifecycle.holderRegistry = Self.registry(spawner: nil, home: scratch)
+
+        let spawn = try #require(try await lifecycle.spawnPreSessionTerminal(
+            worktree: fx.worktree, repo: fx.repo, worktreePath: fx.repoDir.path))
+
+        #expect(spawn.transport == .tmux)
+        #expect(spawn.holderPID == nil)
+        #expect(spawn.childPID == nil)
+        #expect(!spawn.windowID.isEmpty)
+        let row = try #require(try await fx.db.terminals.get(id: spawn.terminalID))
+        #expect(row.transport == .tmux)
+        #expect(row.label == TerminalLabel.preSession)
+    }
+
+    /// Flag on with a spawner that cannot start anything: the holder path IS
+    /// taken — that is what the throw proves — and it fails before any row, so
+    /// nothing is left claiming a tab that never opened.
+    @Test("a holder hook-tab spawn failure throws and leaves no terminal row")
+    func holderSpawnFailureLeavesNoRow() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let fx = try await makeWorktreeFixture()
+        defer { try? FileManager.default.removeItem(at: fx.repoDir.deletingLastPathComponent()) }
+        try await fx.db.config.setPtyHolderEnabled(true)
+        try await installPreSessionHook(repoDir: fx.repoDir)
+        let scratch = fencedScratchRoot(prefix: "tbdhtg")
+        defer { try? FileManager.default.removeItem(atPath: scratch) }
+
+        let recorder = PreSessionRecordedCommands()
+        var lifecycle = makeLifecycle(db: fx.db, recorder: recorder)
+        lifecycle.holderRegistry = Self.registry(
+            spawner: Self.unspawnableSpawner(), home: scratch)
+
+        var thrown: (any Error)?
+        do {
+            _ = try await lifecycle.spawnPreSessionTerminal(
+                worktree: fx.worktree, repo: fx.repo, worktreePath: fx.repoDir.path)
+        } catch {
+            thrown = error
+        }
+        #expect(
+            thrown != nil,
+            "the hook-tab spawn did not take the holder path — it succeeded on tmux instead")
+
+        #expect(try await fx.db.terminals.list(worktreeID: fx.worktree.id).isEmpty)
+        #expect(
+            !recorder.snapshot().contains { $0.contains("new-window") },
+            "a failed holder hook-tab spawn fell through to tmux: \(recorder.snapshot())")
+        #expect(
+            !recorder.snapshot().contains { $0.contains("new-session") },
+            "a holder hook-tab spawn started a tmux server: \(recorder.snapshot())")
+    }
+
+    // MARK: - The liveness probe
+
+    private func holderSpawnDescriptor(
+        terminalID: UUID, worktreeID: UUID, childPID: Int32?
+    ) -> PreSessionSpawn {
+        PreSessionSpawn(
+            terminalID: terminalID,
+            tmuxServer: "tbd-test",
+            windowID: "",
+            paneID: "",
+            markerPath: WorktreeLifecycle.preSessionMarkerPath(worktreeID: worktreeID),
+            hookPath: "/dev/null",
+            transport: .holder,
+            holderPID: 1111,
+            childPID: childPID)
+    }
+
+    /// The holder analogue of a killed pane, half one: the job is gone. The
+    /// row still exists, so nothing else in the wait would notice.
+    @Test("a dead holder job reports .paneKilled")
+    func deadHolderJobIsPaneKilled() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let fx = try await makeWorktreeFixture()
+        defer { try? FileManager.default.removeItem(at: fx.repoDir.deletingLastPathComponent()) }
+
+        let signaller = FakeProcessSignaller()
+        signaller.behaviors[9001] = .init(aliveInitially: false)
+        // A window probe that reports ALIVE: if the wait consulted tmux for a
+        // holder tab it would never short-circuit, and this test would hang
+        // out to its timeout rather than pass.
+        let lifecycle = makeLifecycle(
+            db: fx.db, timeout: 2, windowIsDead: { _ in false },
+            processSignaller: signaller)
+        let terminal = try await fx.db.terminals.create(
+            worktreeID: fx.worktree.id, tmuxWindowID: "", tmuxPaneID: "",
+            label: TerminalLabel.preSession, kind: .shell,
+            transport: .holder, holderPID: 1111, childPID: 9001)
+
+        let outcome = await lifecycle.waitForPreSessionCompletion(
+            preSession: holderSpawnDescriptor(
+                terminalID: terminal.id, worktreeID: fx.worktree.id, childPID: 9001),
+            tmuxServer: "tbd-test")
+
+        #expect(outcome == .paneKilled)
+    }
+
+    /// Half two: the tab itself is gone. Closing a holder-backed tab deletes
+    /// its row, so a row that is no longer there is the holder's "the user
+    /// closed it" — even with the job's pid still reporting alive.
+    @Test("a deleted holder row reports .paneKilled")
+    func deletedHolderRowIsPaneKilled() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let fx = try await makeWorktreeFixture()
+        defer { try? FileManager.default.removeItem(at: fx.repoDir.deletingLastPathComponent()) }
+
+        let signaller = FakeProcessSignaller()
+        signaller.behaviors[9002] = .init(aliveInitially: true)
+        let lifecycle = makeLifecycle(
+            db: fx.db, timeout: 2, windowIsDead: { _ in false },
+            processSignaller: signaller)
+
+        // No row is ever created for this terminal id.
+        let outcome = await lifecycle.waitForPreSessionCompletion(
+            preSession: holderSpawnDescriptor(
+                terminalID: UUID(), worktreeID: fx.worktree.id, childPID: 9002),
+            tmuxServer: "tbd-test")
+
+        #expect(outcome == .paneKilled)
+    }
+
+    /// The marker-first ordering is transport-independent: a hook that
+    /// recorded its exit code wins over both halves of the holder probe, so a
+    /// hook that finished and then had its tab closed is not misreported.
+    @Test("a marker beats a dead holder job and a missing row")
+    func markerBeatsTheHolderProbe() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let fx = try await makeWorktreeFixture()
+        defer { try? FileManager.default.removeItem(at: fx.repoDir.deletingLastPathComponent()) }
+        try writeMarker(worktreeID: fx.worktree.id, exitCode: 0)
+
+        let signaller = FakeProcessSignaller()
+        signaller.behaviors[9003] = .init(aliveInitially: false)
+        let lifecycle = makeLifecycle(
+            db: fx.db, timeout: 2, windowIsDead: { _ in false },
+            processSignaller: signaller)
+
+        let outcome = await lifecycle.waitForPreSessionCompletion(
+            preSession: holderSpawnDescriptor(
+                terminalID: UUID(), worktreeID: fx.worktree.id, childPID: 9003),
+            tmuxServer: "tbd-test")
+
+        #expect(outcome == .completed(exitCode: 0))
+        #expect(!FileManager.default.fileExists(
+            atPath: WorktreeLifecycle.preSessionMarkerPath(worktreeID: fx.worktree.id)))
+    }
+
+    // MARK: - Teardown
+
+    /// A thread-safe tally. The dry-run hooks are `@Sendable` closures called
+    /// from whatever executor the teardown happens to be on.
+    private final class CaptureCounter: @unchecked Sendable {
+        private let lock = NSLock()
+        private var value = 0
+        func increment() {
+            lock.lock(); defer { lock.unlock() }
+            value += 1
+        }
+        var count: Int {
+            lock.lock(); defer { lock.unlock() }
+            return value
+        }
+    }
+
+    /// A lifecycle whose dry-run tmux both records its argv and answers
+    /// `capture-pane` with real text — `capturePaneScrollback` returns the
+    /// closure's value in dry run and records no argv, so the counter is the
+    /// only way to see the call, and non-empty text is what makes a Closed
+    /// Terminals row observable at all.
+    private static func teardownLifecycle(
+        db: TBDDatabase,
+        recorder: PreSessionRecordedCommands,
+        captureCalls: CaptureCounter
+    ) -> WorktreeLifecycle {
+        WorktreeLifecycle(
+            db: db,
+            git: GitManager(),
+            tmux: TmuxManager(
+                dryRun: true,
+                dryRunRecorder: { recorder.append($0) },
+                dryRunCapturePane: { _, _ in
+                    captureCalls.increment()
+                    return "hook output\n"
+                }),
+            hooks: HookResolver())
+    }
+
+    /// A holder hook tab is torn down through the holder, never through tmux.
+    ///
+    /// Both negatives matter. `capture-pane` would read a pane that is the
+    /// empty string, and `kill-window` would address a window id naming
+    /// nothing — while the holder, its job and its rendezvous files outlive the
+    /// row that is their only record. With no registry wired the teardown can
+    /// only report that; the row, tab and order cleanup still has to run, or
+    /// the worktree keeps a tab whose terminal is gone.
+    @Test("closing a holder hook tab issues no capture-pane and no kill-window")
+    func holderHookTabTeardownSkipsTmux() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let fx = try await makeWorktreeFixture(status: .active)
+        defer { try? FileManager.default.removeItem(at: fx.repoDir.deletingLastPathComponent()) }
+
+        let recorder = PreSessionRecordedCommands()
+        let captureCalls = CaptureCounter()
+        let lifecycle = Self.teardownLifecycle(
+            db: fx.db, recorder: recorder, captureCalls: captureCalls)
+        let terminal = try await fx.db.terminals.create(
+            worktreeID: fx.worktree.id, tmuxWindowID: "", tmuxPaneID: "",
+            label: TerminalLabel.preSession, kind: .shell,
+            transport: .holder, holderPID: 1111, childPID: 2222)
+        try await fx.db.worktrees.setTabOrder(
+            worktreeID: fx.worktree.id, tabIDs: [terminal.id])
+
+        await lifecycle.closeHookTerminal(
+            worktree: fx.worktree, tmuxServer: "tbd-test",
+            terminalID: terminal.id, windowID: "")
+
+        #expect(
+            captureCalls.count == 0,
+            "a holder hook tab was captured through tmux capture-pane")
+        #expect(
+            !recorder.snapshot().contains { $0.contains("kill-window") },
+            "a holder hook tab was killed through tmux: \(recorder.snapshot())")
+        #expect(try await fx.db.terminals.get(id: terminal.id) == nil)
+        #expect(try await fx.db.worktrees.getTabOrder(worktreeID: fx.worktree.id).isEmpty)
+        #expect(try await fx.db.terminalHistory.list(worktreeID: fx.worktree.id).isEmpty,
+                "a holder hook tab was written to Closed Terminals")
+    }
+
+    /// The tmux arm, unchanged, so a teardown that took the holder branch for
+    /// everybody could not pass: a tmux hook tab is still captured and its
+    /// window still killed.
+    @Test("closing a tmux hook tab still captures and kills its window")
+    func tmuxHookTabTeardownIsUnchanged() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let fx = try await makeWorktreeFixture(status: .active)
+        defer { try? FileManager.default.removeItem(at: fx.repoDir.deletingLastPathComponent()) }
+
+        let recorder = PreSessionRecordedCommands()
+        let captureCalls = CaptureCounter()
+        let lifecycle = Self.teardownLifecycle(
+            db: fx.db, recorder: recorder, captureCalls: captureCalls)
+        let terminal = try await fx.db.terminals.create(
+            worktreeID: fx.worktree.id, tmuxWindowID: "@hook", tmuxPaneID: "%hook",
+            label: TerminalLabel.preSession, kind: .shell)
+
+        await lifecycle.closeHookTerminal(
+            worktree: fx.worktree, tmuxServer: "tbd-test",
+            terminalID: terminal.id, windowID: "@hook")
+
+        #expect(captureCalls.count == 1)
+        #expect(recorder.snapshot().contains {
+            $0.contains("kill-window") && $0.contains("@hook")
+        })
+        #expect(try await fx.db.terminals.get(id: terminal.id) == nil)
+        #expect(
+            try await fx.db.terminalHistory.list(worktreeID: fx.worktree.id).count == 1,
+            "a tmux hook tab's scrollback was not preserved for Closed Terminals")
+    }
+}
+}

--- a/Tests/TBDDaemonTests/Holder/HookTabTransportGateTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HookTabTransportGateTests.swift
@@ -329,10 +329,11 @@ struct HookTabTransportGateTests {
             skipClaude: true,
             completionAction: .markActive)
 
-        let remaining = try await fx.db.terminals.list(worktreeID: fx.worktree.id)
-        #expect(
-            remaining.isEmpty,
-            "phase 3 created terminal rows for a worktree that no longer exists")
+        // No assertion that the worktree's terminal rows are empty: the
+        // cascade above emptied them before phase 3 ran, and the foreign key
+        // would refuse a row for a deleted worktree anyway, so it cannot fail
+        // whatever phase 3 does. The `new-window` assertion below is the one
+        // the code under test can actually break.
         #expect(
             !recorder.snapshot().contains { $0.contains("kill-window") },
             "a holder hook tab was torn down through tmux: \(recorder.snapshot())")

--- a/Tests/TBDDaemonTests/Holder/HookTabTransportGateTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HookTabTransportGateTests.swift
@@ -29,6 +29,22 @@ struct HookTabTransportGateTests {
         HolderSpawner(executableURL: URL(fileURLWithPath: "/nonexistent/TBDHolder"))
     }
 
+    /// A signaller for which no pid is ever alive.
+    ///
+    /// Its whole job is to make one assertion discriminate: a descriptor that
+    /// recorded no child pid must answer "still there" on the row alone, and
+    /// stating the alternative as "every pid this could be asked about is dead"
+    /// leaves the probe nowhere else to get a yes from.
+    private struct AlwaysDeadProcessSignaller: ProcessSignaller {
+        func isAlive(_ pid: Int32) -> Bool { false }
+        func terminate(_ pid: Int32) {}
+        func forceKill(_ pid: Int32) {}
+        func children(ofServerPID serverPID: Int32) -> [Int32] { [] }
+        func commandLine(_ pid: Int32) -> String? { nil }
+        func stat(_ pid: Int32) -> String? { nil }
+        func startTime(_ pid: Int32) -> Date? { nil }
+    }
+
     private static func registry(spawner: HolderSpawner?, home: String) -> HolderRegistry {
         HolderRegistry(
             owner: HolderOwnerToken(rawValue: "acme-installation"),
@@ -208,6 +224,121 @@ struct HookTabTransportGateTests {
         #expect(outcome == .completed(exitCode: 0))
         #expect(!FileManager.default.fileExists(
             atPath: WorktreeLifecycle.preSessionMarkerPath(worktreeID: fx.worktree.id)))
+    }
+
+    /// A spawn that recorded no child pid answers on the row alone.
+    ///
+    /// `spawnTerminal` always records one, so this is a row a defect would
+    /// produce rather than one the product writes — and the safe answer to "is
+    /// a tab whose job I cannot name still running" is yes. Reading the missing
+    /// pid as a dead job would report `.paneKilled` for every such tab, and
+    /// phase 3 would then start the primary agent on a tree the hook had not
+    /// finished preparing.
+    ///
+    /// The wait therefore has to run out its budget for this to pass, which is
+    /// what the short timeout buys: nothing here can end it early, and one poll
+    /// is enough for the misreading to show.
+    @Test("a holder spawn with no child pid keeps waiting instead of reporting a killed pane")
+    func holderSpawnWithoutAChildPIDKeepsWaiting() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let fx = try await makeWorktreeFixture()
+        defer { try? FileManager.default.removeItem(at: fx.repoDir.deletingLastPathComponent()) }
+
+        let lifecycle = makeLifecycle(
+            db: fx.db, timeout: 0.2, windowIsDead: { _ in false },
+            processSignaller: AlwaysDeadProcessSignaller())
+        let terminal = try await fx.db.terminals.create(
+            worktreeID: fx.worktree.id, tmuxWindowID: "", tmuxPaneID: "",
+            label: TerminalLabel.preSession, kind: .shell,
+            transport: .holder, holderPID: 1111)
+
+        let outcome = await lifecycle.waitForPreSessionCompletion(
+            preSession: holderSpawnDescriptor(
+                terminalID: terminal.id, worktreeID: fx.worktree.id, childPID: nil),
+            tmuxServer: "tbd-test")
+
+        #expect(outcome == .timedOut)
+    }
+
+    /// A liveness read that THREW is not a deleted tab.
+    ///
+    /// Closing the database connection makes the row read fail rather than
+    /// answer nil — the same transient shape
+    /// `PreSessionHookTests.dbErrorDuringRowCheckDoesNotTearDownPreSessionWindow`
+    /// induces for the worktree-row check one layer up. Only nil means the tab
+    /// is gone; an error says nothing about it, and treating it as a deletion
+    /// would abandon a hook that is still running.
+    @Test("a failed row read keeps the holder wait going")
+    func failedRowReadIsNotReadAsAClosedTab() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let fx = try await makeWorktreeFixture()
+        defer { try? FileManager.default.removeItem(at: fx.repoDir.deletingLastPathComponent()) }
+
+        let signaller = FakeProcessSignaller()
+        signaller.behaviors[9004] = .init(aliveInitially: true)
+        let lifecycle = makeLifecycle(
+            db: fx.db, timeout: 0.2, windowIsDead: { _ in false },
+            processSignaller: signaller)
+        try fx.db.writerForTests.close()
+
+        let outcome = await lifecycle.waitForPreSessionCompletion(
+            preSession: holderSpawnDescriptor(
+                terminalID: UUID(), worktreeID: fx.worktree.id, childPID: 9004),
+            tmuxServer: "tbd-test")
+
+        #expect(outcome == .timedOut, "a database error was read as a closed holder tab")
+    }
+
+    // MARK: - Abandoning a hook tab whose row is already gone
+
+    /// A holder hook tab left by a daemon with no registry is reported, and
+    /// never killed through tmux.
+    ///
+    /// This is the branch that separates the two transports on the phase-3
+    /// bail-out. The tmux arm's whole cleanup is a `kill-window`; issuing one
+    /// for a holder tab addresses the empty string, so its absence is the only
+    /// observable that says the holder arm was taken. With no registry there is
+    /// nothing left to reclaim the holder with — that is a report, not a
+    /// crash — and phase 3 must still return without spawning anything into a
+    /// worktree that no longer exists.
+    @Test("a holder hook tab with no registry is never torn down through tmux")
+    func holderHookTabWithoutARegistryIssuesNoKillWindow() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let fx = try await makeWorktreeFixture()
+        defer { try? FileManager.default.removeItem(at: fx.repoDir.deletingLastPathComponent()) }
+
+        let recorder = PreSessionRecordedCommands()
+        var lifecycle = makeLifecycle(db: fx.db, recorder: recorder, timeout: 2)
+        // Pinned rather than assumed: the branch under test is the one a daemon
+        // in mock mode takes, and it must stay reachable if `makeLifecycle`
+        // ever starts wiring a registry.
+        lifecycle.holderRegistry = nil
+
+        // The cascade a repo removal performs mid-wait: the worktree row goes,
+        // and every terminal row goes with it. The descriptor is what is left.
+        try await fx.db.worktrees.delete(id: fx.worktree.id)
+
+        await lifecycle.runPreSessionPhase3(
+            preSession: holderSpawnDescriptor(
+                terminalID: UUID(), worktreeID: fx.worktree.id, childPID: 2222),
+            worktree: fx.worktree, repo: fx.repo,
+            worktreePath: fx.repoDir.path,
+            skipClaude: true,
+            completionAction: .markActive)
+
+        let remaining = try await fx.db.terminals.list(worktreeID: fx.worktree.id)
+        #expect(
+            remaining.isEmpty,
+            "phase 3 created terminal rows for a worktree that no longer exists")
+        #expect(
+            !recorder.snapshot().contains { $0.contains("kill-window") },
+            "a holder hook tab was torn down through tmux: \(recorder.snapshot())")
+        #expect(
+            !recorder.snapshot().contains { $0.contains("new-window") },
+            "phase 3 spawned primaries after the row vanished: \(recorder.snapshot())")
     }
 
     // MARK: - Teardown

--- a/Tests/TBDDaemonTests/Holder/HookTabTransportGateTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HookTabTransportGateTests.swift
@@ -45,7 +45,10 @@ struct HookTabTransportGateTests {
         func startTime(_ pid: Int32) -> Date? { nil }
     }
 
-    private static func registry(spawner: HolderSpawner?, home: String) -> HolderRegistry {
+    private static func registry(
+        spawner: HolderSpawner?, home: String,
+        signaller: any ProcessSignaller = ProductionProcessSignaller()
+    ) -> HolderRegistry {
         HolderRegistry(
             owner: HolderOwnerToken(rawValue: "acme-installation"),
             environment: [
@@ -54,8 +57,15 @@ struct HookTabTransportGateTests {
                 "SHELL": "/bin/sh",
             ],
             listTerminals: { [] },
-            spawner: spawner)
+            spawner: spawner,
+            signaller: signaller)
     }
+
+    /// The pid the teardown tests' rows record, and the start time they record
+    /// beside it. A pid this daemon never spawned and a stamp far in the past:
+    /// nothing here may be answered by the real process table.
+    private static let jobPID: Int32 = 8802
+    private static let jobStartedAt = Date(timeIntervalSince1970: 1_800_000_000)
 
     // MARK: - Spawn
 
@@ -422,6 +432,100 @@ struct HookTabTransportGateTests {
         #expect(try await fx.db.worktrees.getTabOrder(worktreeID: fx.worktree.id).isEmpty)
         #expect(try await fx.db.terminalHistory.list(worktreeID: fx.worktree.id).isEmpty,
                 "a holder hook tab was written to Closed Terminals")
+    }
+
+    /// A holder hook tab whose recorded child pid now belongs to somebody else
+    /// is torn down without signalling anything.
+    ///
+    /// The window this closes is real and routine: a hook tab is closed
+    /// *because* its hook finished, so its job has usually already exited and
+    /// the kernel is free to hand the number out again. The row cleanup still
+    /// has to happen — a tab whose terminal is gone must not survive it — and
+    /// so does the absence of every tmux gesture, so this discriminates against
+    /// both a teardown that kills blind and one that fell into the tmux arm.
+    @Test("closing a holder hook tab never signals a recycled child pid")
+    func holderHookTabTeardownSkipsARecycledPID() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let fx = try await makeWorktreeFixture(status: .active)
+        defer { try? FileManager.default.removeItem(at: fx.repoDir.deletingLastPathComponent()) }
+
+        let recorder = PreSessionRecordedCommands()
+        let captureCalls = CaptureCounter()
+        let signaller = FakeProcessSignaller()
+        signaller.behaviors[Self.jobPID] = .init(aliveInitially: true)
+        // Alive, wearing a shell's command line, and started an hour away from
+        // the anchor the row recorded: only the start time separates it.
+        signaller.cmdlines[Self.jobPID] = "zsh -c make"
+        signaller.startTimes[Self.jobPID] = Self.jobStartedAt.addingTimeInterval(3600)
+
+        let scratch = fencedScratchRoot(prefix: "tbdhtg")
+        defer { try? FileManager.default.removeItem(atPath: scratch) }
+        var lifecycle = Self.teardownLifecycle(
+            db: fx.db, recorder: recorder, captureCalls: captureCalls)
+        lifecycle.holderRegistry = Self.registry(
+            spawner: nil, home: scratch, signaller: signaller)
+
+        let terminal = try await fx.db.terminals.create(
+            worktreeID: fx.worktree.id, tmuxWindowID: "", tmuxPaneID: "",
+            label: TerminalLabel.preSession, kind: .shell,
+            transport: .holder, holderPID: nil, childPID: Self.jobPID,
+            holderChildStartedAt: Self.jobStartedAt)
+        try await fx.db.worktrees.setTabOrder(
+            worktreeID: fx.worktree.id, tabIDs: [terminal.id])
+
+        await lifecycle.closeHookTerminal(
+            worktree: fx.worktree, tmuxServer: "tbd-test",
+            terminalID: terminal.id, windowID: "")
+
+        #expect(signaller.killed.isEmpty, "a recycled pid was force-killed by the hook teardown")
+        #expect(signaller.terminated.isEmpty, "a recycled pid was signalled by the hook teardown")
+        #expect(captureCalls.count == 0)
+        #expect(
+            !recorder.snapshot().contains { $0.contains("kill-window") },
+            "a holder hook tab was killed through tmux: \(recorder.snapshot())")
+        #expect(try await fx.db.terminals.get(id: terminal.id) == nil)
+        #expect(try await fx.db.worktrees.getTabOrder(worktreeID: fx.worktree.id).isEmpty)
+    }
+
+    /// The other half of the same decision, and the reason the one above is not
+    /// simply "never kill anything": a job whose pid still verifies against the
+    /// row's recorded start time is reclaimed.
+    @Test("closing a holder hook tab force-kills a job that verifies")
+    func holderHookTabTeardownKillsAVerifiedJob() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let fx = try await makeWorktreeFixture(status: .active)
+        defer { try? FileManager.default.removeItem(at: fx.repoDir.deletingLastPathComponent()) }
+
+        let recorder = PreSessionRecordedCommands()
+        let captureCalls = CaptureCounter()
+        let signaller = FakeProcessSignaller()
+        signaller.behaviors[Self.jobPID] = .init(
+            aliveInitially: true, aliveAfterTerminate: true, aliveAfterKill: false)
+        signaller.cmdlines[Self.jobPID] = "/bin/zsh -i -l -c hook"
+        signaller.startTimes[Self.jobPID] = Self.jobStartedAt
+
+        let scratch = fencedScratchRoot(prefix: "tbdhtg")
+        defer { try? FileManager.default.removeItem(atPath: scratch) }
+        var lifecycle = Self.teardownLifecycle(
+            db: fx.db, recorder: recorder, captureCalls: captureCalls)
+        lifecycle.holderRegistry = Self.registry(
+            spawner: nil, home: scratch, signaller: signaller)
+
+        let terminal = try await fx.db.terminals.create(
+            worktreeID: fx.worktree.id, tmuxWindowID: "", tmuxPaneID: "",
+            label: TerminalLabel.preSession, kind: .shell,
+            transport: .holder, holderPID: nil, childPID: Self.jobPID,
+            holderChildStartedAt: Self.jobStartedAt)
+
+        await lifecycle.closeHookTerminal(
+            worktree: fx.worktree, tmuxServer: "tbd-test",
+            terminalID: terminal.id, windowID: "")
+
+        #expect(signaller.killed == [Self.jobPID])
+        #expect(captureCalls.count == 0)
+        #expect(try await fx.db.terminals.get(id: terminal.id) == nil)
     }
 
     /// The tmux arm, unchanged, so a teardown that took the holder branch for

--- a/Tests/TBDDaemonTests/Holder/TerminalReviveTransportGateTests.swift
+++ b/Tests/TBDDaemonTests/Holder/TerminalReviveTransportGateTests.swift
@@ -202,19 +202,4 @@ struct TerminalReviveTransportGateTests {
             fixture.recorder.count("new-session") == 0,
             "a holder revive started a tmux server: \(fixture.recorder.all)")
     }
-
-    /// The history row survives a refused revive, so the tab can still be
-    /// brought back once the flag is off or the binary is back.
-    @Test("a failed holder revive keeps the history entry")
-    func failedHolderReviveKeepsHistory() async throws {
-        let fixture = try await Self.makeFixture(
-            holderFlag: true, spawner: Self.unspawnableSpawner())
-        defer { fixture.tearDown() }
-
-        _ = try await fixture.revive()
-
-        let entries = try await fixture.db.terminalHistory.list(
-            worktreeID: fixture.worktree.id)
-        #expect(entries.contains { $0.id == fixture.closedTerminalID })
-    }
 }

--- a/Tests/TBDDaemonTests/Holder/TerminalReviveTransportGateTests.swift
+++ b/Tests/TBDDaemonTests/Holder/TerminalReviveTransportGateTests.swift
@@ -1,0 +1,220 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+import TestSupport
+
+/// The transport gate as `terminalHistory.revive` asks it — the branches that
+/// need no `TBDHolder` binary. The branch that does, a real holder behind a
+/// revived tab, is `HolderSpawnGateTests` in the live target.
+///
+/// A revive used to be pinned to tmux whatever the flag said. What is pinned
+/// here instead is that it decides like every other spawn, and that the
+/// decision reaches the *tmux* half of the spawn too: the flag-on failure case
+/// asserts no `new-session` was issued, because `prepareTmuxServer` is a no-op
+/// for a holder decision and a revive that started a server before failing
+/// would leave the very resource the transport exists to remove.
+///
+/// The failing spawner is a `HolderSpawner` whose executable does not exist:
+/// `canSpawn` is decided from the spawner's presence alone, so the gate takes
+/// the holder path, and `posix_spawn` then fails before any holder exists.
+@Suite("terminalHistory.revive transport gate")
+struct TerminalReviveTransportGateTests {
+
+    // MARK: - Fixture
+
+    private final class TmuxArgvRecorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var argvs: [[String]] = []
+        func record(_ argv: [String]) {
+            lock.lock(); defer { lock.unlock() }
+            argvs.append(argv)
+        }
+        var all: [[String]] {
+            lock.lock(); defer { lock.unlock() }
+            return argvs
+        }
+        func count(_ subcommand: String) -> Int {
+            all.filter { $0.contains(subcommand) }.count
+        }
+    }
+
+    private struct Fixture {
+        let db: TBDDatabase
+        let router: RPCRouter
+        let recorder: TmuxArgvRecorder
+        let environment: [String: String]
+        let worktree: Worktree
+        let closedTerminalID: UUID
+        let home: String
+        let worktreePath: String
+
+        func tearDown() {
+            try? FileManager.default.removeItem(atPath: home)
+            try? FileManager.default.removeItem(atPath: worktreePath)
+        }
+
+        func revive() async throws -> RPCResponse {
+            await router.handle(try RPCRequest(
+                method: RPCMethod.terminalHistoryRevive,
+                params: TerminalHistoryReviveParams(
+                    worktreeID: worktree.id, id: closedTerminalID)))
+        }
+    }
+
+    /// A spawner whose executable is not there. The registry built on it
+    /// reports `canSpawn`, so the gate takes the holder path; the spawn then
+    /// fails at `posix_spawn`, before any holder, socket or lock outlives it.
+    private static func unspawnableSpawner() -> HolderSpawner {
+        HolderSpawner(executableURL: URL(fileURLWithPath: "/nonexistent/TBDHolder"))
+    }
+
+    private static func makeFixture(
+        holderFlag: Bool,
+        spawner: HolderSpawner?
+    ) async throws -> Fixture {
+        // Short and under the run's scratch root: the rendezvous socket the
+        // failing spawn would bind lives under it, against `sun_path`'s cap.
+        let home = fencedScratchRoot(prefix: "tbdtrg")
+        let environment = [
+            "TBD_HOME": home,
+            "PATH": "/usr/bin:/bin",
+            "SHELL": "/bin/sh",
+        ]
+        let recorder = TmuxArgvRecorder()
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunRecorder: { recorder.record($0) },
+            dryRunCapturePane: { _, _ in "" })
+        let db = try TBDDatabase(
+            inMemory: true,
+            terminalHistoryDir: (home as NSString).appendingPathComponent("history"))
+        try await db.config.setPtyHolderEnabled(holderFlag)
+
+        let configDirManager = makeIsolatedConfigDirManager(tag: "terminal-revive-gate")
+        let lifecycle = WorktreeLifecycle(
+            db: db, git: GitManager(), tmux: tmux, hooks: HookResolver(),
+            configDirManager: configDirManager)
+        let router = RPCRouter(
+            db: db, lifecycle: lifecycle, tmux: tmux, startTime: Date(),
+            configDirManager: configDirManager,
+            actuationLog: makeTestActuationLog())
+        router.holderRegistry = HolderRegistry(
+            owner: HolderOwnerToken(rawValue: "acme-installation"),
+            environment: environment,
+            listTerminals: { [] },
+            spawner: spawner)
+
+        let repo = try await db.repos.create(
+            path: "/tmp/tbd-trg-repo-\(UUID().uuidString)",
+            displayName: "acme", defaultBranch: "main")
+        // A revive refuses to spawn into a missing directory.
+        let worktreePath = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-trg-wt-\(UUID().uuidString)").path
+        try FileManager.default.createDirectory(
+            atPath: worktreePath, withIntermediateDirectories: true)
+        let worktree = try await db.worktrees.create(
+            repoID: repo.id, name: "wt", branch: "tbd/wt",
+            path: worktreePath, tmuxServer: "tbd-trg-test")
+
+        // A closed SHELL terminal with captured scrollback: the branch that
+        // reopens a fresh shell, chosen because it resolves no profile and
+        // reads no transcript — the transport decision is what is under test.
+        let closed = Terminal(
+            worktreeID: worktree.id, tmuxWindowID: "@9", tmuxPaneID: "%9",
+            label: nil, kind: .shell)
+        await db.terminalHistory.store(
+            terminal: closed, text: "prior shell output\n", closedAt: Date())
+
+        return Fixture(
+            db: db, router: router, recorder: recorder, environment: environment,
+            worktree: worktree, closedTerminalID: closed.id, home: home,
+            worktreePath: worktreePath)
+    }
+
+    private func expectTmuxRow(_ terminal: Terminal, in fixture: Fixture) async throws {
+        let row = try #require(try await fixture.db.terminals.get(id: terminal.id))
+        #expect(row.transport == .tmux)
+        #expect(!row.tmuxWindowID.isEmpty)
+        #expect(row.holderPID == nil)
+        #expect(row.childPID == nil)
+        #expect(fixture.recorder.count("new-window") == 1)
+        let socketPath = try HolderRendezvous.socketPath(
+            sessionID: terminal.id, environment: fixture.environment)
+        #expect(
+            !FileManager.default.fileExists(atPath: socketPath),
+            "a holder rendezvous was created for a tmux-transport revive")
+    }
+
+    // MARK: - Flag off
+
+    /// Today's behaviour, exactly: a tmux server, one tmux window, a tmux row.
+    @Test("flag off: a revived terminal spawns onto tmux")
+    func flagOffSpawnsOntoTmux() async throws {
+        let fixture = try await Self.makeFixture(
+            holderFlag: false, spawner: Self.unspawnableSpawner())
+        defer { fixture.tearDown() }
+
+        let response = try await fixture.revive()
+        #expect(response.success, "\(response.error ?? "")")
+        let terminal = try response.decodeResult(Terminal.self)
+        try await expectTmuxRow(terminal, in: fixture)
+        #expect(terminal.kind == .shell)
+    }
+
+    // MARK: - Flag on, nothing to spawn with
+
+    /// A registry with no spawner — a daemon whose `TBDHolder` binary an
+    /// upgrade moved away. The flag is on and the answer is still tmux, the
+    /// same fallback every other spawn path takes.
+    @Test("flag on with a registry that cannot spawn falls back to tmux")
+    func flagOnWithoutASpawnerFallsBackToTmux() async throws {
+        let fixture = try await Self.makeFixture(holderFlag: true, spawner: nil)
+        defer { fixture.tearDown() }
+
+        let response = try await fixture.revive()
+        #expect(response.success, "\(response.error ?? "")")
+        let terminal = try response.decodeResult(Terminal.self)
+        try await expectTmuxRow(terminal, in: fixture)
+    }
+
+    // MARK: - Flag on, the holder spawn fails
+
+    /// The request fails the way a tmux spawn failure fails today — an error
+    /// response and no row — and, because the decision reached
+    /// `prepareTmuxServer` too, no tmux server was started on the way there.
+    @Test("a holder revive spawn failure fails the request and starts no tmux server")
+    func holderSpawnFailureFailsTheRevive() async throws {
+        let fixture = try await Self.makeFixture(
+            holderFlag: true, spawner: Self.unspawnableSpawner())
+        defer { fixture.tearDown() }
+
+        let response = try await fixture.revive()
+        #expect(!response.success)
+        #expect(
+            response.error?.contains("/nonexistent/TBDHolder") == true,
+            "the revive did not take the holder path: \(response.error ?? "success")")
+        #expect(try await fixture.db.terminals.list(worktreeID: fixture.worktree.id).isEmpty)
+        #expect(
+            fixture.recorder.count("new-window") == 0,
+            "a failed holder revive fell through to tmux: \(fixture.recorder.all)")
+        #expect(
+            fixture.recorder.count("new-session") == 0,
+            "a holder revive started a tmux server: \(fixture.recorder.all)")
+    }
+
+    /// The history row survives a refused revive, so the tab can still be
+    /// brought back once the flag is off or the binary is back.
+    @Test("a failed holder revive keeps the history entry")
+    func failedHolderReviveKeepsHistory() async throws {
+        let fixture = try await Self.makeFixture(
+            holderFlag: true, spawner: Self.unspawnableSpawner())
+        defer { fixture.tearDown() }
+
+        _ = try await fixture.revive()
+
+        let entries = try await fixture.db.terminalHistory.list(
+            worktreeID: fixture.worktree.id)
+        #expect(entries.contains { $0.id == fixture.closedTerminalID })
+    }
+}

--- a/Tests/TBDDaemonTests/Holder/TerminalReviveTransportGateTests.swift
+++ b/Tests/TBDDaemonTests/Holder/TerminalReviveTransportGateTests.swift
@@ -43,7 +43,6 @@ struct TerminalReviveTransportGateTests {
         let db: TBDDatabase
         let router: RPCRouter
         let recorder: TmuxArgvRecorder
-        let environment: [String: String]
         let worktree: Worktree
         let closedTerminalID: UUID
         let home: String
@@ -127,7 +126,7 @@ struct TerminalReviveTransportGateTests {
             terminal: closed, text: "prior shell output\n", closedAt: Date())
 
         return Fixture(
-            db: db, router: router, recorder: recorder, environment: environment,
+            db: db, router: router, recorder: recorder,
             worktree: worktree, closedTerminalID: closed.id, home: home,
             worktreePath: worktreePath)
     }
@@ -139,11 +138,11 @@ struct TerminalReviveTransportGateTests {
         #expect(row.holderPID == nil)
         #expect(row.childPID == nil)
         #expect(fixture.recorder.count("new-window") == 1)
-        let socketPath = try HolderRendezvous.socketPath(
-            sessionID: terminal.id, environment: fixture.environment)
-        #expect(
-            !FileManager.default.fileExists(atPath: socketPath),
-            "a holder rendezvous was created for a tmux-transport revive")
+        // No rendezvous-absence assertion here: every fixture in this suite is
+        // built with either no spawner or one whose executable does not exist,
+        // so nothing in it can bind a socket and the absence would hold for a
+        // revive that had taken the holder path too. The live suite
+        // (`HolderSpawnGateTests`) is where that assertion discriminates.
     }
 
     // MARK: - Flag off

--- a/Tests/TBDDaemonTests/PreSessionTestSupport.swift
+++ b/Tests/TBDDaemonTests/PreSessionTestSupport.swift
@@ -59,7 +59,12 @@ func makeLifecycle(
     subscriptions: StateSubscriptionManager? = nil,
     timeout: TimeInterval = WorktreeLifecycle.defaultPreSessionTimeout,
     windowIsDead: (@Sendable (String) -> Bool)? = nil,
-    listWindows: (@Sendable (String, String) -> [(windowID: String, paneID: String)])? = nil
+    listWindows: (@Sendable (String, String) -> [(windowID: String, paneID: String)])? = nil,
+    // The liveness seam the holder branch of the hook-tab wait reads: a
+    // holder-backed tab has no tmux window to look for, so "is it still there"
+    // is the row plus the job's own pid. Defaulted so no existing caller
+    // changes; only the holder suites pass one.
+    processSignaller: ProcessSignaller = ProductionProcessSignaller()
 ) -> WorktreeLifecycle {
     var dryRunRecorder: (@Sendable ([String]) -> Void)?
     if let recorder {
@@ -77,7 +82,8 @@ func makeLifecycle(
         hooks: HookResolver(),
         subscriptions: subscriptions,
         preSessionTimeout: timeout,
-        preSessionPollInterval: 0.05
+        preSessionPollInterval: 0.05,
+        processSignaller: processSignaller
     )
 }
 

--- a/Tests/TBDDaemonTests/SessionRecaptureSchedulerTests.swift
+++ b/Tests/TBDDaemonTests/SessionRecaptureSchedulerTests.swift
@@ -15,8 +15,8 @@ struct SessionRecaptureSchedulerTests {
         let scheduler = SessionRecaptureScheduler(
             db: fixture.db,
             tmux: TmuxManager(dryRun: true),
-            captureSessionID: { server, paneID in
-                guard server == "tbd-recapture", paneID == "%7" else { return nil }
+            captureSessionID: { target in
+                guard target == .tmuxPane(server: "tbd-recapture", paneID: "%7") else { return nil }
                 return detectedSessionID
             },
             clock: clock
@@ -41,7 +41,7 @@ struct SessionRecaptureSchedulerTests {
         let scheduler = SessionRecaptureScheduler(
             db: fixture.db,
             tmux: TmuxManager(dryRun: true),
-            captureSessionID: { _, _ in nil },
+            captureSessionID: { _ in nil },
             clock: clock
         )
 
@@ -65,7 +65,7 @@ struct SessionRecaptureSchedulerTests {
         let scheduler = SessionRecaptureScheduler(
             db: fixture.db,
             tmux: TmuxManager(dryRun: true),
-            captureSessionID: { _, _ in capture.capture() },
+            captureSessionID: { _ in capture.capture() },
             clock: clock)
 
         let recapture = scheduler.schedule(
@@ -103,7 +103,7 @@ struct SessionRecaptureSchedulerTests {
         let scheduler = SessionRecaptureScheduler(
             db: fixture.db,
             tmux: TmuxManager(dryRun: true),
-            captureSessionID: { _, _ in capture.capture() },
+            captureSessionID: { _ in capture.capture() },
             clock: clock)
 
         let recapture = scheduler.schedule(
@@ -132,6 +132,38 @@ struct SessionRecaptureSchedulerTests {
         let stored = try #require(try await fixture.db.terminals.get(id: fixture.terminal.id))
         #expect(stored.pendingSessionIncarnationID != nil)
         #expect(stored.claudeSessionID == fixture.sourceSessionID)
+    }
+
+    /// A holder target reaches the detector unchanged and persists exactly as a
+    /// pane target does. The scheduler carries the target; it never inspects it,
+    /// so the fact worth pinning is that the case survives the hop and the write
+    /// still lands.
+    @Test func holderChildTargetReachesTheDetectorAndPersists() async throws {
+        let fixture = try await makeFixture()
+        let clock = TestClock<Duration>()
+        let detectedSessionID = UUID().uuidString
+        let seen = ObservedTargets()
+        let scheduler = SessionRecaptureScheduler(
+            db: fixture.db,
+            tmux: TmuxManager(dryRun: true),
+            captureSessionID: { target in
+                seen.append(target)
+                return detectedSessionID
+            },
+            clock: clock
+        )
+
+        let recapture = scheduler.schedule(
+            terminalID: fixture.terminal.id,
+            target: .holderChild(pid: 4242),
+            expectedIncarnationID: fixture.terminal.sessionIncarnationID
+        )
+
+        await clock.advanceWhenSuspended(by: .seconds(5))
+        await recapture.value
+        #expect(seen.all == [.holderChild(pid: 4242)])
+        let updated = try #require(try await fixture.db.terminals.get(id: fixture.terminal.id))
+        #expect(updated.claudeSessionID == detectedSessionID)
     }
 
     private func makeFixture() async throws -> (
@@ -187,5 +219,19 @@ private final class BlockingSessionCapture: @unchecked Sendable {
 
     func release() {
         releaseGate.signal()
+    }
+}
+
+/// Lock-guarded record of the targets a scheduler handed its detector closure.
+private final class ObservedTargets: @unchecked Sendable {
+    private let lock = NSLock()
+    private var targets: [SessionRecaptureTarget] = []
+
+    func append(_ target: SessionRecaptureTarget) {
+        lock.withLock { targets.append(target) }
+    }
+
+    var all: [SessionRecaptureTarget] {
+        lock.withLock { targets }
     }
 }

--- a/docs/specs/2026-08-30-pty-holder-session-transport-design.md
+++ b/docs/specs/2026-08-30-pty-holder-session-transport-design.md
@@ -925,17 +925,15 @@ flag with a soak and a stated graduation plan.
   The sessions the flag reaches ask it through one gate
   (`TerminalSpawnTransport.decide`) and spawn through one function
   (`WorktreeLifecycle.spawnTerminal`): the primary terminal at worktree
-  creation, and the extra terminals `terminal.create` and
-  `terminal.continueInCodex` open — Claude, Codex and shell alike, since the
-  holder runs any command. A wake respawns onto the transport its row
-  recorded. Every other tab still opens on tmux whatever the flag says, and
-  each has its own reason: a profile login tab, because its auto-`/login`
-  pump reads and types through a tmux pane; the setup and pre-session hook
-  tabs, which are hook runners rather than agent surfaces; restored archived
-  sessions, revive-from-history tabs and fork-session tabs, which are not yet
-  ported. Those still spawn through the same function, with the transport
-  pinned to tmux, so the flag reaching them later is a one-line change at
-  each site rather than a second spawn implementation.
+  creation, the setup and pre-session hook tabs, restored archived sessions,
+  revive-from-history tabs, fork-session tabs, and the extra terminals
+  `terminal.create` and `terminal.continueInCodex` open — Claude, Codex and
+  shell alike, since the holder runs any command. A wake respawns onto the
+  transport its row recorded. The one spawn kind pinned to tmux whatever the
+  flag says is the profile login tab, because its auto-`/login` pump reads and
+  types through a tmux pane. It spawns through the same function with the
+  transport pinned, so the flag reaching it later is a one-line change at that
+  site rather than a second spawn implementation.
 
   The flag therefore gates **spawning, not servicing**: the flag is consulted
   only when a session is created, and both transports' machinery (attach


### PR DESCRIPTION
## Summary

Part of #851 (Phase 1 of the tmux removal). With `pty_holder_enabled` on, four more kinds of tab now open on the pty holder instead of a tmux window: revive-from-history tabs, fork-session tabs, the setup and pre-session hook tabs, and restored archived sessions. Until now each of those was pinned to tmux whatever the flag said, so a worktree on the holder transport still started a tmux server the moment its repo had a setup hook or the user revived a closed terminal. After this change the only spawn kind still pinned to tmux is the profile login tab, which waits on the holder named-key work (#851 Phase 1 item 4) and is deliberately untouched here.

## Why this shape

The spec's Rollout section (`docs/specs/2026-08-30-pty-holder-session-transport-design.md`, "Granularity: spawn time only") already routes every spawn through one gate (`TerminalSpawnTransport.decide`) and one spawn function (`WorktreeLifecycle.spawnTerminal`); the pinned sites were the ones that had not yet asked the gate. #851 §2 established that none of them had a tmux capability underneath except fork's post-spawn session-id recapture, which resolved the agent pid through `tmux.panePID` and could answer nothing for a holder row whose pane id is the empty string. So the change is: ask the gate at each site, and give the recapture a transport-neutral address.

- **Recapture addresses a process, not a pane.** `SessionRecaptureTarget` has one case per transport (`.tmuxPane(server:paneID:)`, `.holderChild(pid:)`), and `ClaudeStateDetector` resolves both through the same ladder (read `sessions/<pid>.json` for the root pid, else the single `claude` child under it via `pgrep -P`). On the holder the root pid is the job the holder forked, which is the same shape as `#{pane_pid}`: the `zsh -c` shell, or Claude itself once the shell execs into it. `isClaudeProcess` is untouched.
- **Hook tabs keep their behaviour on both transports.** The completion poll asks "is the hook's terminal still there" in each transport's terms: the tmux window for a tmux row, and for a holder row the terminal row still existing plus the recorded child pid still alive (through the existing `ProcessSignaller` seam). Teardown of a tmux hook tab still captures scrollback into Closed Terminals and kills the window; teardown of a holder hook tab does what `disposeHolder` does everywhere else, which is no capture, because the holder has no scrollback dump yet (#851 §4, Phase 2 item "Closed-terminal history on holder dispose").
- **The setup tab on the holder is still spawned only when a setup hook resolves.** That is the existing holder-path behaviour; the reason changes from "it would start a tmux server" to "a second holder process for a bare shell nobody asked for". The flag-off path still creates the tab unconditionally.
- **Not routed through the model proxy.** Revive-claude, fork and archived-restore spawns on the holder get no proxy route. The primary's route is minted before its command is composed and these three sites do not compose their commands that way yet. A tmux spawn was never routed either, so nothing loses a route it had. Follow-up, tracked under #851.

No new spec: this is Phase 1 of a plan already written down in #851 and the holder spec; the spec's Rollout section is updated to list what is still pinned.

## What this PR does

- `RPCRouter+TerminalHandlers.swift`: `handleTerminalHistoryRevive` reads config once and decides the transport from it; `spawnRevivedTerminal` takes the decided transport, prepares the tmux server only for a tmux decision. `handleTerminalSwapProfile` decides the fork's transport beside its one config read; `forkSwapNewTab` spawns onto it and schedules recapture against `.holderChild(pid:)` for a holder row (from the row's `childPID`) or `.tmuxPane` otherwise. `.inPlace` and its holder refusal are unchanged.
- `SessionRecaptureScheduler.swift`: `SessionRecaptureTarget`; `schedule(terminalID:target:expectedIncarnationID:)` with a tmux convenience overload so the create path and hibernation callers are unchanged. `RPCRouter.sessionRecaptureFactory` mirrors the lifecycle's seam so tests can observe which target a fork scheduled.
- `ClaudeStateDetector.swift`: `captureSessionID(target:)` and `captureSessionID(rootPID:)`; the tmux entry resolves the pane pid and delegates.
- `WorktreeLifecycle+PreSession.swift`: `spawnPreSessionTerminal` asks the gate and spawns through `spawnTerminal` (which owns the row insert and both rollbacks); the tmux server is ensured only for a tmux decision. `PreSessionSpawn` carries `transport`, `holderPID`, `childPID` (explicit init keeps every existing constructor call unchanged). `waitForPreSessionCompletion` probes liveness per transport; `closeHookTerminal` disposes a holder row instead of capture-and-kill; the phase-3 "worktree row vanished mid-wait" cleanup abandons the holder by the pids the spawn recorded.
- `WorktreeLifecycle+Create.swift`: the setup tab and archived-session restores spawn through `spawnTerminal` on the decided transport; `ensureTmuxServerOnce` runs only for a tmux decision; `remain-on-exit` is set only on tmux.
- `WorktreeLifecycle+Recovery.swift`: a resumed pre-session wait carries the row's transport and pids, so a daemon restart mid-hook does not probe a tmux window a holder tab never had.
- `HolderRegistry.swift`: `abandon(terminalID:holderPID:childPID:)`, factored out of `abandon(terminal:)`; and `abandonVerifiedJob(terminalID:holderPID:childPID:childStartedAt:)`, the hook-tab reclaim, which tells the holder to let go, runs `ProcessIdentityCheck` on the recorded child pid against the row's `holderChildStartedAt` and the reaper's executable predicate, signals only a pid that verifies as ours, and reaps the holder either way. The registry takes an injected `ProcessSignaller` for it, defaulted to the production one. `PreSessionSpawn` carries `childStartedAt` for the rowless case.
- Spec: the Rollout section's list of what is pinned now names the login tab alone.

## Flag & rollout

`pty_holder_enabled`, unchanged, default off. No new flag. Flag off is today's behaviour: every one of these tabs is a tmux window created with the same argv, in the same order, with the same `env` / `-e` split as before, because `spawnTerminal`'s tmux arm calls the same `tmux.createWindow` the sites used to call directly. Enable for the soak the way the primary and extra terminals are soaked today: the pty holder toggle in Settings, which calls the `config.setPtyHolderEnabled` RPC. Graduation is the holder spec's Phase 3 in #851 and is not changed by this PR.

## Assumptions

- Assumes a holder row written by `spawnTerminal` always carries `childPID`; if a holder row could exist without one, the fork's recapture is skipped with a warning rather than scheduled against a pid it does not have.
- Assumes the hook tab's job is the process whose pid the holder recorded, so `ProcessSignaller.isAlive(childPID)` is the right liveness probe for "the hook was killed"; if the holder ever re-parented or replaced the job, the poll would report a live tab for a dead hook until the marker or the timeout resolved it.
- Assumes Closed Terminals history for holder hook tabs is acceptable to lose until #851 Phase 2 item 6 lands; a user reading Session History after an auto-closed setup run on the holder sees no entry.
- The new spawn sites inherit `spawnTerminal`'s row-insert-failure rollback unchanged, including the minor gap #848 shipped with; this PR touches only that function's doc comments.
- On the auto-close path a hook tab's job exits on its own before teardown, which is the highest-exposure shape for pid reuse. That path therefore verifies the recorded child pid's identity before any signal, through `HolderRegistry.abandonVerifiedJob`: the same `ProcessIdentityCheck` the reaper's holder leg runs (start time within the reaper's window of the row's `holderChildStartedAt`, executable a shell or an agent), and a pid that is gone, a zombie, or not provably ours is left alone while the holder is still told to let go and reaped. The general holder teardown (`disposeHolder`, used by `terminal.delete` and friends) keeps its process-group-only check: its executable predicate would refuse a shell that exec'd into an arbitrary command, and a job there is expected to be alive at teardown.

## Evidence & verification

Unit target (`Tests/TBDDaemonTests`, dry-run tmux, in-memory database):

- `Holder/TerminalReviveTransportGateTests.swift`: flag off spawns onto tmux with exactly one `new-window` and no rendezvous; flag on with a registry that cannot spawn falls back to tmux; flag on with a spawner whose binary is missing fails the request, leaves no row, keeps the history entry, and issues neither `new-window` nor `new-session`.
- `Holder/ForkSwapTransportGateTests.swift`: flag off forks onto tmux and the injected scheduler records `.tmuxPane` for the new row; flag on without a spawner falls back to tmux; a failed holder fork fails the swap and starts no tmux server; the in-place holder refusal still stands.
- `Holder/HookTabTransportGateTests.swift`: the pre-session tab's fallback and failure branches; the holder liveness probe (dead child pid, deleted row, marker wins over both, a holder descriptor with no child pid keeps waiting, and a database read that throws mid-poll is treated as "still alive" rather than as a closed tab); closing a holder hook tab issues no `capture-pane` and no `kill-window`, closing a tmux one still does both; phase 3 on a holder hook tab whose worktree row vanished, in a daemon with no holder registry, returns without any `kill-window`.
- `Holder/HolderHookJobIdentityTests.swift` (fake `ProcessSignaller`): a recycled pid (start time off the anchor) is never signalled and the refusal is reported; a still-running hook job (start time on the anchor, shell command line) is force-killed once; a pid that is gone, a foreign executable, and a descriptor with no start time each get no signal. `HookTabTransportGateTests` closes a holder hook tab through the same fake: the recycled pid gets no `terminate`/`forceKill` while the row is still deleted, and a verifying pid is killed.
- `ClaudeStateDetectorTests.swift`: a `.holderChild` target reads the job's session file without any tmux call and never asks for a pane pid; a `.tmuxPane` target resolves through the injected pane-pid probe to the session file, and a probe that throws resolves to nil.
- `SessionRecaptureSchedulerTests.swift`: updated to the target shape, plus a `.holderChild` target reaching the closure and updating the row on virtual time.

Live target (`Tests/TBDDaemonLiveTests/Holder/HolderSpawnGateTests.swift`, a real `TBDHolder` beside the bundle): flag on puts a history revive, a fork (with the recapture probe recording `.holderChild(pid:)` equal to the row's `childPID`), the pre-session tab, the setup tab and a restored archived session each on a holder row with distinct live holder and child pids and empty tmux coordinates, and no `new-session` or `new-window` is issued; flag off siblings assert the tmux window (including `--resume ARCHIVED-RESTORED` in the restore's `new-window` argv). The existing `flagOnSpawnsOntoHolder` still asserts that a repo without a setup hook gets no setup tab on the holder. Two more live tests cover the holder teardown paths end to end: with `auto_close_setup_enabled` on, a setup hook on the holder gets no `remain-on-exit` and, once its marker lands, the watcher deletes the tab, the job is dead and its rendezvous socket is gone; and a pre-session hook tab whose worktree row is deleted mid-wait is reclaimed by phase 3 the same way (job dead, socket gone, no `kill-window`). The tmux arm of the `remain-on-exit` guard is the existing `AutoCloseSetupTests.flagOnCleanExitClosesSetupTab`.

Nothing was built or run on the development machine; CI is the verifier for this PR.

https://claude.ai/code/session_01TggE2eESL3BcvSgFcLZkpk
[tmux phase 1 unpins](https://cheapsteak.github.io/tbd/open/?worktree=272BBFEA-44C4-4A03-910B-B6EE7AD042B0)
