### PR TITLE
Feat: named-key sends reach the pty holder

### DIFF
--- a/Sources/TBDCLI/Commands/TerminalCommands.swift
+++ b/Sources/TBDCLI/Commands/TerminalCommands.swift
@@ -134,7 +134,7 @@ struct TerminalSend: AsyncParsableCommand {
                                   standing unless --submit is also passed.
               --text "…" --submit  the message, submitted. This is the pair every
                                   delivery uses.
-              --keys "Escape Enter"  whitespace-separated tmux key names, sent one
+              --keys "Escape Enter"  whitespace-separated key names, sent one
                                   at a time. Interrupt is a keys payload
                                   (--keys "C-c"). Enter is itself a key, so
                                   --submit does not apply here.
@@ -164,7 +164,7 @@ struct TerminalSend: AsyncParsableCommand {
     @Option(name: .long, help: "Text to send")
     var text: String?
 
-    @Option(name: .long, help: "Whitespace-separated tmux key names to send, e.g. \"Escape Enter\" or \"C-c\"")
+    @Option(name: .long, help: "Whitespace-separated key names to send, e.g. \"Escape Enter\" or \"C-c\"")
     var keys: String?
 
     @Flag(name: .long, help: "Press Enter after sending text")

--- a/Sources/TBDDaemon/Server/HolderNamedKeys.swift
+++ b/Sources/TBDDaemon/Server/HolderNamedKeys.swift
@@ -1,0 +1,114 @@
+import Foundation
+import TBDShared
+
+/// The holder transport's named-key table: one `terminal.send --keys` name to
+/// the exact bytes a child reads for that key.
+///
+/// Split out of the send path for the same reason `HolderSendComposition` is —
+/// it is the whole of a decision and none of the plumbing. Given a key's name
+/// and the child's tracked modes there is exactly one right answer in bytes,
+/// and a pure function over `Data` is the only thing worth asserting: `Up`
+/// under DECCKM is `ESC O A` and nothing else, `Escape` is `ESC` in every mode.
+///
+/// The names are tmux's own `send-keys` spellings, because that is the
+/// vocabulary every existing caller already types and the bytes below are the
+/// ones tmux would have sent for them — the holder is a new transport for the
+/// same key, not a new key. An unknown name returns `nil` so the caller can
+/// refuse the whole send by that name, having written nothing.
+///
+/// **Two families depend on the child's modes; the rest do not.** With DECCKM
+/// (`applicationCursor`) on, the arrows and Home/End take their SS3 forms
+/// (`ESC O A`), which is what a full-screen TUI has asked for by turning the
+/// mode on; off — and when no store answered, so `modes` is `nil` — they take
+/// their CSI forms (`ESC [ A`), which a shell at its prompt reads. Every other
+/// key is one fixed sequence regardless of mode, so a `nil` reading changes
+/// nothing for it.
+enum HolderNamedKeys {
+    /// The bytes for one key name against the child's modes, or `nil` when the
+    /// name is not one this table knows.
+    static func bytes(for name: String, modes: TerminalScreen.ChildModes?) -> Data? {
+        // A `C-x` control combo is its own small grammar, tried first so a name
+        // like `C-[` never falls through to the named-key switch.
+        if let controlByte = controlByte(for: name) {
+            return Data([controlByte])
+        }
+
+        let applicationCursor = modes?.applicationCursor ?? false
+        switch name {
+        case "Enter", "Return": return Data([0x0d])
+        case "Escape", "Esc": return Data([0x1b])
+        case "Tab": return Data([0x09])
+        case "BTab": return escaped("[Z")
+        case "BSpace", "BackSpace": return Data([0x7f])
+        case "Space": return Data([0x20])
+        // The cursor-key family: SS3 under DECCKM, CSI otherwise.
+        case "Up": return cursorKey("A", applicationCursor: applicationCursor)
+        case "Down": return cursorKey("B", applicationCursor: applicationCursor)
+        case "Right": return cursorKey("C", applicationCursor: applicationCursor)
+        case "Left": return cursorKey("D", applicationCursor: applicationCursor)
+        case "Home": return cursorKey("H", applicationCursor: applicationCursor)
+        case "End": return cursorKey("F", applicationCursor: applicationCursor)
+        // The editing and paging keys are `ESC [ … ~` in every mode.
+        case "PageUp", "PPage": return escaped("[5~")
+        case "PageDown", "NPage": return escaped("[6~")
+        case "Insert", "IC": return escaped("[2~")
+        case "Delete", "DC": return escaped("[3~")
+        // F1–F4 are SS3; F5 up are `ESC [ … ~` with the usual gaps (no 16, 22).
+        case "F1": return escaped("OP")
+        case "F2": return escaped("OQ")
+        case "F3": return escaped("OR")
+        case "F4": return escaped("OS")
+        case "F5": return escaped("[15~")
+        case "F6": return escaped("[17~")
+        case "F7": return escaped("[18~")
+        case "F8": return escaped("[19~")
+        case "F9": return escaped("[20~")
+        case "F10": return escaped("[21~")
+        case "F11": return escaped("[23~")
+        case "F12": return escaped("[24~")
+        default: return nil
+        }
+    }
+
+    // MARK: - Building blocks
+
+    /// `ESC` followed by the given ASCII tail.
+    private static func escaped(_ tail: String) -> Data {
+        var bytes = Data([0x1b])
+        bytes.append(contentsOf: tail.utf8)
+        return bytes
+    }
+
+    /// A cursor-key sequence for the trailing letter (`A`…`D`, `H`, `F`): `ESC O
+    /// <final>` under DECCKM, `ESC [ <final>` otherwise. `0x4f` is `O`, `0x5b`
+    /// is `[`.
+    private static func cursorKey(_ final: Character, applicationCursor: Bool) -> Data {
+        var bytes = Data([0x1b, applicationCursor ? 0x4f : 0x5b])
+        bytes.append(contentsOf: String(final).utf8)
+        return bytes
+    }
+
+    /// The single control byte for a `C-x` combo, or `nil` when `name` is not a
+    /// `C-` combo this table knows.
+    ///
+    /// `C-a`…`C-z` are `0x01`…`0x1a`; the letter is case-insensitive, as it is
+    /// in tmux. `C-Space` and `C-@` are NUL. The five punctuation combos are
+    /// the C0 controls above the letters: `C-[` is ESC, then `C-\`, `C-]`,
+    /// `C-^`, `C-_` are `0x1c`…`0x1f`.
+    private static func controlByte(for name: String) -> UInt8? {
+        guard name.hasPrefix("C-") else { return nil }
+        let rest = name.dropFirst(2)
+        if rest == "Space" || rest == "@" { return 0x00 }
+        guard rest.count == 1, let ch = rest.first, let ascii = ch.asciiValue else { return nil }
+        switch ch {
+        case "a"..."z": return ascii - 0x60  // 'a' (0x61) → 0x01
+        case "A"..."Z": return ascii - 0x40  // 'A' (0x41) → 0x01
+        case "[": return 0x1b
+        case "\\": return 0x1c
+        case "]": return 0x1d
+        case "^": return 0x1e
+        case "_": return 0x1f
+        default: return nil
+        }
+    }
+}

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -2894,17 +2894,19 @@ extension RPCRouter {
             + "--verify."
     }
 
-    /// The refusal `terminal.send --keys` returns for a holder-backed row.
+    /// The refusal `terminal.send --keys` returns when a name in the sequence
+    /// is not one the holder's named-key table knows.
     ///
-    /// Named keys are tmux key names (`Escape`, `C-c`, `Enter`), resolved by
-    /// tmux itself into the bytes a terminal expects. Writing them to a pty
-    /// master needs that table on this side, and there is no holder mapping
-    /// yet — so this refuses rather than guessing at bytes, which would type
-    /// something nobody asked for into a live session.
-    static func holderKeysRefusal(terminalID: UUID) -> String {
+    /// The names are tmux's own `send-keys` spellings (`Escape`, `C-c`,
+    /// `Enter`); `HolderNamedKeys` maps each to the bytes a child reads. A name
+    /// outside that table has no defined bytes, so the whole send is refused by
+    /// that name rather than guessing — and refused before any byte is written,
+    /// so a valid key earlier in the sequence does not land half a request.
+    static func holderUnknownKeyRefusal(terminalID: UUID, key: String) -> String {
         "terminal.send --keys was refused: terminal \(terminalID) runs on the pty-holder "
-            + "transport, which has no named-key mapping yet — nothing was sent. Send the "
-            + "literal text instead (--text, with --submit for Enter)."
+            + "transport, which has no mapping for the key name \"\(key)\" — nothing was "
+            + "sent. Check the spelling against tmux's send-keys names, or send the literal "
+            + "text instead (--text, with --submit for Enter)."
     }
 
     /// The refusal `terminal.send` returns for a holder-backed row in a daemon
@@ -3707,9 +3709,9 @@ extension RPCRouter {
             text = body
             submit = submitting
             envelopeEligible = true
-        case .keys:
-            return await refuseHolderSend(
-                actuationID, Self.holderKeysRefusal(terminalID: terminal.id))
+        case .keys(let names, _):
+            return await deliverHolderKeys(
+                names: names, terminal: terminal, actuationID: actuationID, courier: courier)
         case .parts(let parts, let submitting) where parts.count == 1:
             // Shape-valid and NOT composite — `performTerminalSend`'s
             // `holderCompositeRefusal` gate already turned away a multi-part or
@@ -3855,6 +3857,71 @@ extension RPCRouter {
                 modesObserved: modesObserved)
             return RPCResponse(error: reason)
         }
+    }
+
+    /// Deliver a named-key sequence to a holder-backed row, paced.
+    ///
+    /// The mode reading is taken once, up front, for the same reason the text
+    /// path takes it: the cursor-key family's bytes depend on DECCKM, so the
+    /// answer must be the same for every key in the sequence. Every name is
+    /// resolved against that one reading before any byte is written, so an
+    /// unknown name refuses the whole send having typed nothing — a valid
+    /// `Enter` ahead of a misspelled key never lands half a request.
+    ///
+    /// Past that gate the pacing is `PacedKeySender`'s, one key at a time, and
+    /// each key is one courier write: a single-byte control (`ESC`, `C-c`) in
+    /// its own write, a multi-byte sequence (`ESC O A`) contiguous. The first
+    /// write the courier cannot make stops the sequence and is recorded as a
+    /// transport failure, matching the text path — a partial send is never
+    /// dressed up as success.
+    private func deliverHolderKeys(
+        names: [String], terminal: Terminal, actuationID: String,
+        courier: HolderInjectionCourier
+    ) async -> RPCResponse {
+        let reading = await holderModeReading(terminalID: terminal.id)
+        let modeSource = reading.map { ActuationModeSource($0.source) } ?? .unavailable
+        let modeAge = reading?.ageMilliseconds
+        let modesObserved = reading?.modesObserved
+        let modes = reading?.modes
+
+        // Validate the whole sequence before writing a byte: an unknown name
+        // refuses the send by that name and records a refusal, not a transport
+        // failure — nothing was attempted against the transport.
+        for name in names where HolderNamedKeys.bytes(for: name, modes: modes) == nil {
+            return await refuseHolderSend(
+                actuationID, Self.holderUnknownKeyRefusal(terminalID: terminal.id, key: name))
+        }
+
+        do {
+            try await pacedKeySender.send(names) { key in
+                // Unreachable after the validation above — the modes captured
+                // here are the same reading — but the closure must resolve to
+                // bytes, and a defensive throw beats a force-unwrap.
+                guard let bytes = HolderNamedKeys.bytes(for: key, modes: modes) else {
+                    throw HolderInjectionFailure(
+                        reason: "no holder byte mapping for key \(key)")
+                }
+                switch await courier.deliver(terminalID: terminal.id, bytes: bytes) {
+                case .viewerWrote, .daemonWrote:
+                    return
+                case .notDelivered(let reason):
+                    throw HolderInjectionFailure(reason: reason)
+                }
+            }
+        } catch {
+            let reason = (error as? HolderInjectionFailure)?.reason ?? "\(error)"
+            await finishActuation(
+                actuationID, .transportFailed, error: reason,
+                modeSource: modeSource, modeAgeMilliseconds: modeAge,
+                modesObserved: modesObserved)
+            return RPCResponse(error: reason)
+        }
+
+        await finishActuation(
+            actuationID, .dispatched,
+            modeSource: modeSource, modeAgeMilliseconds: modeAge,
+            modesObserved: modesObserved)
+        return .ok()
     }
 
     /// What the child's modes are, as best this daemon can say.
@@ -5304,4 +5371,9 @@ extension RPCRouter {
             text: params.includeBody ? (detail.text ?? "Output no longer available.") : "",
             attachment: detail.attachment))
     }
+}
+
+private struct HolderInjectionFailure: LocalizedError {
+    let reason: String
+    var errorDescription: String? { reason }
 }

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -2528,7 +2528,7 @@ public struct TerminalSendParams: Codable, Sendable {
     /// An empty string keeps its existing meaning: nothing is pasted, and a
     /// bare `--submit` still presses Enter.
     public let text: String?
-    /// Whitespace-separated tmux key names — `"Escape"`, `"C-c"`,
+    /// Whitespace-separated key names — `"Escape"`, `"C-c"`,
     /// `"Escape Enter"` — sent one at a time, paced. Mutually exclusive with
     /// `text`. Carries no envelope (a key sequence has nowhere to put a line of
     /// text) and cannot be verified (keys reach no transcript).

--- a/Tests/TBDDaemonTests/Holder/HolderNamedKeysTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HolderNamedKeysTests.swift
@@ -1,0 +1,158 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// `HolderNamedKeys.bytes(for:modes:)` is entirely branches — a table lookup
+/// with two families whose answer depends on DECCKM and the rest fixed per
+/// name — so there is no computation for a test to exercise except "is this
+/// literal byte sequence the one that comes out." A byte transposed in one
+/// escape sequence (`ESC O A` vs `ESC [ A`, an `~` dropped from a paging key,
+/// an off-by-one in a function-key CSI number) would still return non-nil and
+/// still look plausible, so nothing short of asserting the exact bytes for
+/// every branch — including both DECCKM states and the `nil`-modes default —
+/// catches it. This file walks every case in the table plus the unknown-name
+/// fallthrough to `nil`.
+@Suite struct HolderNamedKeysTests {
+
+    private static let cursorOn = TerminalScreen.ChildModes(
+        bracketedPaste: false, applicationCursor: true, alternateScreen: false)
+    private static let cursorOff = TerminalScreen.ChildModes(
+        bracketedPaste: false, applicationCursor: false, alternateScreen: false)
+
+    // MARK: - Control combos
+
+    @Test(arguments: [
+        ("C-Space", Data([0x00])),
+        ("C-@", Data([0x00])),
+        ("C-a", Data([0x01])),
+        ("C-z", Data([0x1a])),
+        ("C-A", Data([0x01])),
+        ("C-Z", Data([0x1a])),
+        ("C-[", Data([0x1b])),
+        ("C-\\", Data([0x1c])),
+        ("C-]", Data([0x1d])),
+        ("C-^", Data([0x1e])),
+        ("C-_", Data([0x1f])),
+    ])
+    func controlCombosProduceTheirC0Byte(name: String, expected: Data) {
+        let actual = HolderNamedKeys.bytes(for: name, modes: nil)
+        #expect(actual == expected, """
+            \(name) → \(actual.map({ Array($0) }) as Any), expected \(Array(expected))
+            """)
+    }
+
+    // MARK: - Fixed-byte named keys (mode-independent)
+
+    @Test(arguments: [
+        ("Enter", Data([0x0d])),
+        ("Return", Data([0x0d])),
+        ("Escape", Data([0x1b])),
+        ("Esc", Data([0x1b])),
+        ("Tab", Data([0x09])),
+        ("BTab", Data([0x1b, 0x5b, 0x5a])),
+        ("BSpace", Data([0x7f])),
+        ("BackSpace", Data([0x7f])),
+        ("Space", Data([0x20])),
+    ])
+    func fixedByteKeysAreModeIndependent(name: String, expected: Data) {
+        let actual = HolderNamedKeys.bytes(for: name, modes: nil)
+        #expect(actual == expected, """
+            \(name) → \(actual.map({ Array($0) }) as Any), expected \(Array(expected))
+            """)
+    }
+
+    // MARK: - Cursor family, DECCKM on: SS3 (`ESC O <final>`)
+
+    @Test(arguments: [
+        ("Up", Data([0x1b, 0x4f, 0x41])),
+        ("Down", Data([0x1b, 0x4f, 0x42])),
+        ("Right", Data([0x1b, 0x4f, 0x43])),
+        ("Left", Data([0x1b, 0x4f, 0x44])),
+        ("Home", Data([0x1b, 0x4f, 0x48])),
+        ("End", Data([0x1b, 0x4f, 0x46])),
+    ])
+    func cursorKeysUnderApplicationCursorTakeSS3Form(name: String, expected: Data) {
+        let actual = HolderNamedKeys.bytes(for: name, modes: Self.cursorOn)
+        #expect(actual == expected, """
+            \(name) under DECCKM → \(actual.map({ Array($0) }) as Any), expected \(Array(expected))
+            """)
+    }
+
+    // MARK: - Cursor family, DECCKM off (and the `nil`-modes default): CSI (`ESC [ <final>`)
+
+    @Test(arguments: [
+        ("Up", Data([0x1b, 0x5b, 0x41])),
+        ("Down", Data([0x1b, 0x5b, 0x42])),
+        ("Right", Data([0x1b, 0x5b, 0x43])),
+        ("Left", Data([0x1b, 0x5b, 0x44])),
+        ("Home", Data([0x1b, 0x5b, 0x48])),
+        ("End", Data([0x1b, 0x5b, 0x46])),
+    ])
+    func cursorKeysWithoutApplicationCursorTakeCSIForm(name: String, expected: Data) {
+        let actual = HolderNamedKeys.bytes(for: name, modes: Self.cursorOff)
+        #expect(actual == expected, """
+            \(name) without DECCKM → \(actual.map({ Array($0) }) as Any), expected \(Array(expected))
+            """)
+    }
+
+    /// `modes: nil` must read as DECCKM off, not as some third state — this is
+    /// the `applicationCursor = modes?.applicationCursor ?? false` default.
+    @Test func nilModesDefaultsToCSICursorForm() {
+        let actual = HolderNamedKeys.bytes(for: "Up", modes: nil)
+        #expect(actual == Data([0x1b, 0x5b, 0x41]), """
+            Up with nil modes → \(actual.map({ Array($0) }) as Any), expected the CSI form \
+            [0x1b, 0x5b, 0x41] — nil must default to DECCKM off
+            """)
+    }
+
+    // MARK: - Paging and editing keys (mode-independent)
+
+    @Test(arguments: [
+        ("PageUp", Data([0x1b, 0x5b, 0x35, 0x7e])),
+        ("PPage", Data([0x1b, 0x5b, 0x35, 0x7e])),
+        ("PageDown", Data([0x1b, 0x5b, 0x36, 0x7e])),
+        ("NPage", Data([0x1b, 0x5b, 0x36, 0x7e])),
+        ("Insert", Data([0x1b, 0x5b, 0x32, 0x7e])),
+        ("IC", Data([0x1b, 0x5b, 0x32, 0x7e])),
+        ("Delete", Data([0x1b, 0x5b, 0x33, 0x7e])),
+        ("DC", Data([0x1b, 0x5b, 0x33, 0x7e])),
+    ])
+    func pagingAndEditingKeysAreModeIndependent(name: String, expected: Data) {
+        let actual = HolderNamedKeys.bytes(for: name, modes: nil)
+        #expect(actual == expected, """
+            \(name) → \(actual.map({ Array($0) }) as Any), expected \(Array(expected))
+            """)
+    }
+
+    // MARK: - Function keys (mode-independent)
+
+    @Test(arguments: [
+        ("F1", Data([0x1b, 0x4f, 0x50])),
+        ("F2", Data([0x1b, 0x4f, 0x51])),
+        ("F3", Data([0x1b, 0x4f, 0x52])),
+        ("F4", Data([0x1b, 0x4f, 0x53])),
+        ("F5", Data([0x1b, 0x5b, 0x31, 0x35, 0x7e])),
+        ("F6", Data([0x1b, 0x5b, 0x31, 0x37, 0x7e])),
+        ("F7", Data([0x1b, 0x5b, 0x31, 0x38, 0x7e])),
+        ("F8", Data([0x1b, 0x5b, 0x31, 0x39, 0x7e])),
+        ("F9", Data([0x1b, 0x5b, 0x32, 0x30, 0x7e])),
+        ("F10", Data([0x1b, 0x5b, 0x32, 0x31, 0x7e])),
+        ("F11", Data([0x1b, 0x5b, 0x32, 0x33, 0x7e])),
+        ("F12", Data([0x1b, 0x5b, 0x32, 0x34, 0x7e])),
+    ])
+    func functionKeysAreModeIndependent(name: String, expected: Data) {
+        let actual = HolderNamedKeys.bytes(for: name, modes: nil)
+        #expect(actual == expected, """
+            \(name) → \(actual.map({ Array($0) }) as Any), expected \(Array(expected))
+            """)
+    }
+
+    // MARK: - Unknown names
+
+    @Test(arguments: ["Bogus", "", "C-", "C-ab", "up"])
+    func unknownOrMalformedNamesReturnNil(name: String) {
+        let actual = HolderNamedKeys.bytes(for: name, modes: nil)
+        #expect(actual == nil, "\(name) → \(actual.map({ Array($0) }) as Any), expected nil")
+    }
+}

--- a/Tests/TBDDaemonTests/Holder/HolderTmuxAssumptionGateTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HolderTmuxAssumptionGateTests.swift
@@ -1539,6 +1539,7 @@ struct HolderTmuxAssumptionGateTests {
     /// live; this is how the composition's own branches are pinned.
     private func oracle(
         bracketedPaste: Bool,
+        applicationCursor: Bool = false,
         modesObserved: Bool = true,
         source: TerminalScreen.Source = .daemon,
         ageMilliseconds: Int = 0
@@ -1547,7 +1548,7 @@ struct HolderTmuxAssumptionGateTests {
             TerminalModeReading(
                 modes: TerminalScreen.ChildModes(
                     bracketedPaste: bracketedPaste,
-                    applicationCursor: false,
+                    applicationCursor: applicationCursor,
                     alternateScreen: false),
                 modesObserved: modesObserved,
                 source: source,
@@ -1845,8 +1846,42 @@ struct HolderTmuxAssumptionGateTests {
         #expect(recorded.snapshot().isEmpty)
     }
 
-    @Test("terminal.send --keys refuses a holder row by naming the missing key mapping")
-    func sendKeysRefusesHolderRow() async throws {
+    @Test("terminal.send --keys types the mode-independent keys as their fixed bytes")
+    func sendKeysTypesFixedBytesIntoHolderRow() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let recorded = RecordedTmuxArgs()
+        let tmux = deadWindowTmux(recorded)
+        let (wt, dir) = try await seedWorktree(db)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let terminal = try await seedClaudeTerminal(
+            db, worktreeID: wt.id, transport: .holder)
+        let writes = HolderWrites()
+
+        // No oracle and no registry: nothing can answer the child's modes. That
+        // is the point — `Escape` and `Enter` are one fixed sequence in every
+        // mode, so a mode-blind daemon still types them exactly, and the send
+        // records itself as a guess made blind rather than refusing.
+        let rpc = router(db, tmux: tmux)
+        rpc.holderInjectionCourier = writes.courier()
+        let response = await rpc.handle(try RPCRequest(
+            method: RPCMethod.terminalSend,
+            params: TerminalSendParams(terminalID: terminal.id, keys: "Escape Enter")))
+
+        #expect(response.success, "error: \(response.error ?? "nil")")
+        // Two keys, two writes, in order: `ESC` then carriage return. Each key
+        // is its own courier write — a paced sequence, not one concatenated
+        // blob — so the child sees the same boundaries a keyboard would give it.
+        #expect(writes.all == [Data([0x1b]), Data([0x0d])],
+                "expected ESC then CR as two writes, got \(writes.all.map({ Array($0) }))")
+        let outcome = try #require(await Self.outcomeRow(of: rpc))
+        #expect(outcome["result"] as? String == "dispatched")
+        #expect(outcome["modeSource"] as? String == "unavailable")
+        #expect(recorded.snapshot().isEmpty,
+                "terminal.send --keys reached tmux for a holder row: \(recorded.snapshot())")
+    }
+
+    @Test("terminal.send --keys sends the cursor keys in SS3 form under application-cursor mode")
+    func sendKeysUpUsesApplicationCursorForm() async throws {
         let db = try TBDDatabase(inMemory: true)
         let recorded = RecordedTmuxArgs()
         let tmux = deadWindowTmux(recorded)
@@ -1858,12 +1893,72 @@ struct HolderTmuxAssumptionGateTests {
 
         let rpc = router(db, tmux: tmux)
         rpc.holderInjectionCourier = writes.courier()
+        rpc.holderModeOracle = oracle(bracketedPaste: false, applicationCursor: true)
         let response = await rpc.handle(try RPCRequest(
             method: RPCMethod.terminalSend,
-            params: TerminalSendParams(terminalID: terminal.id, keys: "Escape Enter")))
+            params: TerminalSendParams(terminalID: terminal.id, keys: "Up")))
+
+        #expect(response.success, "error: \(response.error ?? "nil")")
+        // DECCKM on: the child asked for SS3, so `Up` is `ESC O A` and nothing
+        // else. `0x4f` is `O`, `0x41` is `A`.
+        #expect(writes.all == [Data([0x1b, 0x4f, 0x41])],
+                "expected ESC O A, got \(writes.all.map({ Array($0) }))")
+        let outcome = try #require(await Self.outcomeRow(of: rpc))
+        #expect(outcome["result"] as? String == "dispatched")
+        #expect(recorded.snapshot().isEmpty)
+    }
+
+    @Test("terminal.send --keys sends the cursor keys in CSI form without application-cursor mode")
+    func sendKeysUpUsesCsiFormWithoutApplicationCursor() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let recorded = RecordedTmuxArgs()
+        let tmux = deadWindowTmux(recorded)
+        let (wt, dir) = try await seedWorktree(db)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let terminal = try await seedClaudeTerminal(
+            db, worktreeID: wt.id, transport: .holder)
+        let writes = HolderWrites()
+
+        let rpc = router(db, tmux: tmux)
+        rpc.holderInjectionCourier = writes.courier()
+        rpc.holderModeOracle = oracle(bracketedPaste: false, applicationCursor: false)
+        let response = await rpc.handle(try RPCRequest(
+            method: RPCMethod.terminalSend,
+            params: TerminalSendParams(terminalID: terminal.id, keys: "Up")))
+
+        #expect(response.success, "error: \(response.error ?? "nil")")
+        // DECCKM off — a shell at its prompt: `Up` is the CSI form `ESC [ A`.
+        // `0x5b` is `[`.
+        #expect(writes.all == [Data([0x1b, 0x5b, 0x41])],
+                "expected ESC [ A, got \(writes.all.map({ Array($0) }))")
+        let outcome = try #require(await Self.outcomeRow(of: rpc))
+        #expect(outcome["result"] as? String == "dispatched")
+        #expect(recorded.snapshot().isEmpty)
+    }
+
+    @Test("terminal.send --keys refuses an unknown key name, having written nothing")
+    func sendKeysRefusesUnknownKeyName() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let recorded = RecordedTmuxArgs()
+        let tmux = deadWindowTmux(recorded)
+        let (wt, dir) = try await seedWorktree(db)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let terminal = try await seedClaudeTerminal(
+            db, worktreeID: wt.id, transport: .holder)
+        let writes = HolderWrites()
+
+        let rpc = router(db, tmux: tmux)
+        rpc.holderInjectionCourier = writes.courier()
+        // `Escape` is a valid name, `Bogus` is not. The whole send is refused
+        // by the unknown name — nothing is typed, not even the valid key ahead
+        // of it, so a bad request never lands half a sequence.
+        let response = await rpc.handle(try RPCRequest(
+            method: RPCMethod.terminalSend,
+            params: TerminalSendParams(terminalID: terminal.id, keys: "Escape Bogus")))
 
         #expect(!response.success)
-        #expect(response.error == RPCRouter.holderKeysRefusal(terminalID: terminal.id))
+        #expect(response.error
+            == RPCRouter.holderUnknownKeyRefusal(terminalID: terminal.id, key: "Bogus"))
         #expect(writes.all.isEmpty, "a refused key send must type nothing")
         #expect(recorded.snapshot().isEmpty)
     }


### PR DESCRIPTION
## Summary

`terminal.send --keys` — the way a caller presses named keys like `Escape`, `Enter`, `C-c`, or an arrow, rather than pasting literal text — worked on tmux-backed rows but was refused outright on rows that run on the newer pty-holder transport. A holder row would answer any `--keys` request with "this transport has no named-key mapping yet." That blocked every keyboard-shaped actuation against a holder session, including the login-tab port that needs to press keys.

This PR gives the holder transport its own named-key table and wires `--keys` through it, so pressing a key on a holder row now does the same thing it does on a tmux row: the named key is turned into the exact bytes a terminal child reads, and written to the session.

## Why this shape

The names are tmux's own `send-keys` spellings on purpose — that is the vocabulary every existing caller already types, and the holder is a new transport for the same key, not a new key. tmux used to own the name→bytes translation; on the holder side that table has to live in this process, so `HolderNamedKeys` is it: a pure function from a key name and the child's tracked modes to `Data`. It is split out of the send path because it is the whole of a decision and none of the plumbing — `Up` under application-cursor mode is `ESC O A` and nothing else, and that is the only thing worth asserting.

Two key families depend on the child's modes and the rest do not. The cursor keys (arrows, Home, End) take their SS3 form (`ESC O A`) when DECCKM/application-cursor mode is on — what a full-screen TUI asks for — and their CSI form (`ESC [ A`) otherwise, which a shell at its prompt reads. Every other key is one fixed sequence in every mode. So the mode reading is taken once, up front, and the whole sequence is validated against it before a single byte is written: an unknown name refuses the entire send by that name, having typed nothing, so a valid `Enter` ahead of a misspelled key never lands half a request.

Part of #851 (Remove tmux), Phase 2, "Input injection". This is the first of two PRs; composite/multi-part sends and `--verify` re-reads follow in a second PR stacked on this one.

## What this PR does

- **New `Sources/TBDDaemon/Server/HolderNamedKeys.swift`** — the named-key table: control combos (`C-a`…`C-z`, `C-Space`, `C-[`…`C-_`), the cursor family (SS3 vs CSI by DECCKM), editing/paging keys, and F1–F12. Unknown name → `nil`.
- **`RPCRouter+TerminalHandlers.swift`** — `terminal.send --keys` on a holder row now routes to a new `deliverHolderKeys`, which reads the child's modes once, validates every name, then pays each key out through the existing paced courier one write at a time. The old blanket `holderKeysRefusal` becomes `holderUnknownKeyRefusal(terminalID:key:)`, refusing only an unknown name. The first courier write that fails stops the sequence and is recorded as a transport failure, matching the text path.
- **CLI help + RPC doc** — `--keys` help text no longer says "tmux key names" (the names are the same, but the transport no longer needs tmux to interpret them).
- tmux-backed rows keep sending their keys through tmux, unchanged.

## Flag & rollout

No new flag. This rides the existing `pty_holder_enabled` flag (default OFF): the holder path only runs for rows already on the holder transport, which only exist when that flag is on. On a tmux row `--keys` still goes through tmux exactly as before.

## Evidence & verification

`swiftlint --strict` passes clean over the whole tree. No local Swift build/test on this machine — the build and test verdict is CI's.

Two test files carry the verification:

**`HolderNamedKeysTests`** (new) asserts the byte table directly — the finding a code-review pass raised, since the function is entirely branches and a transposed byte (`ESC O A` vs `ESC [ A`, a dropped `~`, an off-by-one in a function-key number) would return a plausible non-nil and pass CI unnoticed. It walks every case against independently-derived literal bytes: control combos, both DECCKM cursor forms (and that `nil` modes reads as off), paging/editing keys, all twelve function keys, and the unknown-name fallthrough to `nil`.

**`HolderTmuxAssumptionGateTests`** covers the send path end to end, one test per branch of the new behavior:
- **Mode-independent keys** — `Escape Enter` with no mode oracle and no registry (a mode-blind daemon) types exactly `ESC` then `CR` as two paced writes, records `dispatched` with `modeSource = unavailable`, and reaches tmux for nothing.
- **Cursor key, application-cursor on** — with an oracle reporting DECCKM on, `Up` is `ESC O A`.
- **Cursor key, application-cursor off** — with DECCKM off, `Up` is `ESC [ A`.
- **Unknown name** — `Escape Bogus` is refused by naming `Bogus`, and writes nothing — not even the valid `Escape` ahead of it.

[20260909-impressed-kiwi](https://cheapsteak.github.io/tbd/open/?worktree=B3A0F1F4-5868-4B98-B61E-121462E760AD)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for sending named keys through terminal sessions, including control, cursor, editing, paging, and function keys.
  * Cursor keys now adapt to the terminal’s application-cursor mode.
  * Unknown key names are rejected without sending partial input.

* **Documentation**
  * Updated help text and documentation to refer to “key names” consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->