### PR TITLE
Feat: composite sends and verified delivery on the pty holder

### DIFF
--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -3644,9 +3644,6 @@ extension RPCRouter {
                 return await refuseHolderSend(actuationID, message)
             }
         }
-        let effectiveVerifyArmed = payload.isVerifyArmed
-            || (actor?.kind == ActuationActor.Kind.daemon && verifyEnabled
-                && Self.supportsDeliveryObservation(terminal) && deliveryVerifier != nil)
         let text: String
         let submit: Bool
         // Whether `text` is allowed to carry the dispatch envelope at all,
@@ -3714,6 +3711,15 @@ extension RPCRouter {
                     terminalID: terminal.id, cause: "a message in more than one part"))
         }
 
+        // Resolved HERE rather than beside the gate above, so it cannot outlive
+        // the payload shapes it means anything for: a `.keys` payload has
+        // already returned through `deliverHolderKeys`, and a key sequence
+        // reaches no transcript for an observation to read. Every precondition
+        // the daemon default needs is carried in the term itself — see the
+        // gate's comment for why it arms rather than refuses.
+        let effectiveVerifyArmed = payload.isVerifyArmed
+            || (actor?.kind == ActuationActor.Kind.daemon && verifyEnabled
+                && Self.supportsDeliveryObservation(terminal) && deliveryVerifier != nil)
         return await deliverHolderText(
             text, submit: submit, terminal: terminal, actuationID: actuationID,
             actor: actor, envelope: envelope, envelopeEligible: envelopeEligible,

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -4004,6 +4004,60 @@ extension RPCRouter {
         if let sessionID, terminal.claudeSessionID != sessionID {
             return .refused(.targetMismatch)
         }
+        // ─── The holder transport's re-delivery ───
+        //
+        // A holder row has no pane to consult and no tmux server to paste
+        // through; it re-injects through the same courier the first send used.
+        // Everything the tmux arm below reaches for — `worktree.tmuxServer`,
+        // `consultPaneBeforeTyping`, `tmux.pasteText` — is meaningless here, so
+        // the retry lives entirely in this branch and returns before that body.
+        if terminal.transport == .holder {
+            // No courier means no input path at all — the same condition
+            // `performHolderSend` turns into `holderInputUnavailable`, which it
+            // classifies as `.notEligible` (via `refuseHolderSend`). The retry
+            // classifies it the same way rather than as a transport failure it
+            // never actually attempted.
+            guard let courier = holderInjectionCourier else {
+                return .refused(.notEligible)
+            }
+            // A child the holder has already reported dead cannot receive a
+            // retry. Only a reported `.exited` refuses — `.alive`,
+            // `.exitedStatusUnknown` and a status never reported (nil) are all
+            // uncertainty, and uncertainty proceeds: the courier's own write is
+            // the authority on whether the pty still takes bytes.
+            if case .exited = await holderRegistry?.lastKnownStatus(for: terminalID) {
+                return .refused(.notEligible)
+            }
+            // Recompose the paste-wrapping from a FRESH reading rather than
+            // replaying the exact bytes the first send wrote. A minute has
+            // passed since the observation, and the child's bracketed-paste
+            // mode can have flipped in it — a viewer attaching or detaching, a
+            // full-screen redraw — so the wrapping the first send baked in may
+            // now be wrong for the pty as it stands. `payload` is the composed
+            // body (envelope and text, before any paste marker), so it is the
+            // `body` argument here and takes no second envelope; only the
+            // wrapping is recomputed, exactly as `deliverHolderText` composes it.
+            let reading = await holderModeReading(terminalID: terminalID)
+            let message = HolderSendComposition.compose(
+                body: payload, submit: submit,
+                bracketedPaste: HolderSendComposition.bracketedPaste(
+                    for: reading, unobservedShouldWrap: Self.carriesDispatchEnvelope(terminal)))
+            // An empty composition has no delivery to redo — `--text "" --submit`
+            // composes to a bare Enter with no body, and a body that was only
+            // paste markers composes to nothing at all. `deliverHolderText`
+            // treats the same emptiness as `.dispatched`; the retry returns the
+            // same, because there is nothing to re-deliver — not because a write
+            // succeeded. Verification is NOT re-armed here: this call IS the
+            // verifier's retry, and re-arming would make it observe its own
+            // re-delivery and retry that in turn.
+            guard !message.isEmpty else { return .dispatched }
+            switch await courier.deliver(terminalID: terminalID, bytes: message) {
+            case .viewerWrote, .daemonWrote:
+                return .dispatched
+            case .notDelivered:
+                return .transportFailed
+            }
+        }
         let outcome: ActuationOutcome
         do {
             outcome = try await terminalSendSerializer.run(terminalID: terminalID) {

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -3494,11 +3494,14 @@ extension RPCRouter {
     /// verify-armed send to an observable agent session is composed here,
     /// delivered by the courier, and armed for observation exactly as the tmux
     /// arm arms it — the observation reads the child's transcript tail, not a
-    /// pane, so it is transport-blind. The gate near the top of this function
-    /// refuses only the three states in which no observation could be produced
-    /// — a target with no transcript, the flag off, or no verifier wired —
-    /// mirroring the tmux arm's gate condition for condition. `--keys` composes
-    /// through `deliverHolderKeys`, which owns the named-key → bytes mapping.
+    /// pane, so it is transport-blind. The daemon's own supervision rails arm
+    /// it by default whenever `delivery_verification_enabled` is on — a
+    /// holder-transport rule the child-as-contract-party design states
+    /// deliberately. The gate near the top of this function refuses only the
+    /// three states in which no observation could be produced — an explicit
+    /// `--verify` at a target with no transcript, the flag off, or no verifier
+    /// wired — mirroring the tmux arm's gate. `--keys` composes through
+    /// `deliverHolderKeys`, which owns the named-key → bytes mapping.
     ///
     /// A daemon with no courier has no input path at all, and says so.
     ///
@@ -3571,20 +3574,32 @@ extension RPCRouter {
         //
         // The observation is transport-blind — it reads the child's transcript
         // tail, not a pane — so the same three preconditions the tmux arm
-        // checks apply on the holder arm too, and this gate mirrors it
+        // checks apply on the holder arm too, and the gate below mirrors it
         // condition for condition, in the same order and the same words.
         //
-        // **Arming is the caller's decision, on both transports.** Only an
-        // explicit `--verify` arms an observation; a daemon rail's own send is
-        // not armed behind the caller's back because the flag happens to be on.
-        // Arming one would spend the mechanism's single evidence-bounded retry
-        // — a second injection into a live composer — on a send nobody asked to
-        // have verified, and it would make the same rail behave differently
-        // depending on which transport its target happens to run.
+        // What differs is who arms it: an explicit `--verify` from any actor,
+        // or the daemon's own supervision rails by default whenever the flag is
+        // on and the target can be observed. That default is a deliberate
+        // holder-transport rule, not an oversight — the rails are the senders
+        // whose silence costs hours, and the tmux arm keeps its per-send opt-in
+        // because it already delivers with explicit bracketing and a separate
+        // Enter, so it lacks the failure shape that motivates the default. See
+        // `2026-09-05-child-as-contract-party-design.md`, "Delivery
+        // verification on holder sends" → "What changes".
+        // `effectiveVerifyArmed` folds both in, and the arm seam in
+        // `deliverHolderText` reads the same value.
         //
-        // Read per call and only when `--verify` was armed, so an ordinary send
-        // pays no config read — the same economy the tmux gate keeps.
-        if payload.isVerifyArmed {
+        // The daemon-default term carries `supportsDeliveryObservation` so it
+        // stays false for a shell holder: a shell is still SERVED by the oracle
+        // (bare bytes), it just cannot be observed, so a daemon rail's send to
+        // one proceeds unarmed rather than refusing. Only an explicit `--verify`
+        // on a shell reaches the first refusal below — because only then is
+        // `effectiveVerifyArmed` true while the target cannot be observed.
+        let verifyEnabled = (try? await db.config.get())?.deliveryVerificationEnabled ?? false
+        let effectiveVerifyArmed = payload.isVerifyArmed
+            || (actor?.kind == ActuationActor.Kind.daemon
+                && verifyEnabled && Self.supportsDeliveryObservation(terminal))
+        if effectiveVerifyArmed {
             if !Self.supportsDeliveryObservation(terminal) {
                 let kindName = (terminal.kind ?? .shell).rawValue
                 let message = """
@@ -3595,7 +3610,6 @@ extension RPCRouter {
                     """
                 return await refuseHolderSend(actuationID, message)
             }
-            let verifyEnabled = (try? await db.config.get())?.deliveryVerificationEnabled ?? false
             if !verifyEnabled {
                 let message = """
                     terminal.send --verify was refused: delivery verification is disabled \
@@ -3685,7 +3699,7 @@ extension RPCRouter {
         return await deliverHolderText(
             text, submit: submit, terminal: terminal, actuationID: actuationID,
             actor: actor, envelope: envelope, envelopeEligible: envelopeEligible,
-            verifyArmed: payload.isVerifyArmed, courier: courier)
+            verifyArmed: effectiveVerifyArmed, courier: courier)
     }
 
     /// Deliver one body of text to a holder-backed session: the same envelope
@@ -3699,8 +3713,9 @@ extension RPCRouter {
     /// image part passes `false` so the quoted path it built from is never
     /// prefixed, no matter what those two would otherwise decide.
     ///
-    /// `verifyArmed` is the caller's own `--verify`, already checked against
-    /// the three preconditions in `performHolderSend`'s gate. On a successful write it
+    /// `verifyArmed` is the resolved arming decision from `performHolderSend`'s
+    /// gate — an explicit `--verify` or the daemon rails' default — already
+    /// checked against the three preconditions there. On a successful write it
     /// hands the composed `body` (envelope and text, before paste-marker
     /// wrapping) to the verifier, exactly as the tmux arm does. An empty body
     /// arms nothing: `--text "" --submit` presses Enter and has no delivery to

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -3016,23 +3016,20 @@ extension RPCRouter {
         // a row and a refusal outcome, unlike a malformed payload that names
         // no act.
         if terminal.transport == .holder {
-            // ─── What the holder arm cannot carry yet ───
+            // ─── What the holder arm cannot frame in one write ───
             //
             // Computed ahead of the call to `performHolderSend` below so that
-            // function sees only payloads it can deliver, and so nothing
-            // inside that arm changes: PR #816 owns it.
+            // function sees only payloads it can deliver. A single body of
+            // text — one line or many — composes into the holder's one write
+            // cleanly, wrapped in bracketed paste when the child's mode calls
+            // for it. What has no single-write framing yet is a message that is
+            // more than one body: several parts, or a lone image whose write
+            // would also have to carry the dispatch envelope. See
+            // `holderCompositeRefusal`.
             let compositeCause: String?
             switch payload {
             case .parts(let parts, _) where parts.count > 1:
                 compositeCause = "a message in more than one part"
-            case .parts(let parts, _)
-                where parts.contains(where: { part in
-                    if case .text(let value) = part { return value.contains("\n") }
-                    return false
-                }):
-                compositeCause = "a message containing a newline"
-            case .text(let body, _, _) where body.contains("\n"):
-                compositeCause = "a message containing a newline"
             case .parts, .text, .keys:
                 compositeCause = nil
             }

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -2808,33 +2808,28 @@ extension RPCRouter {
             + "input path wired for it. Nothing was typed and its session is unchanged."
     }
 
-    /// The refusal a multi-part or multi-line `terminal.send` gets for a
-    /// holder-backed row, until bracketed-paste wrapping lands there.
+    /// The refusal a multi-part `terminal.send` gets for a holder-backed row.
     ///
     /// It names the missing capability rather than "the holder transport",
-    /// because typing a single-line message into a holder session works and a
-    /// caller told otherwise would stop trying.
+    /// because sending a single body of text — one line or many — into a holder
+    /// session works, and a caller told otherwise would stop trying.
     ///
-    /// The measurement: the holder arm writes body and carriage return in ONE
-    /// delivery with no bracketed-paste wrapping. Against 2.1.261 under a real
-    /// pty, a single unwrapped write of 63 bytes submits and 64 or more does not
-    /// — past that the carriage return is swallowed into the text and the whole
-    /// string sits unsent in Claude's composer. Splitting the message into
-    /// several deliveries instead would reopen the at-least-once and routing
-    /// questions that one delivery avoids, so this refuses rather than guessing.
-    /// It carries one more cause than "composite" suggests: an image-only
-    /// message whose write would also have to carry the dispatch envelope. The
-    /// tmux arm gives the envelope a separate leading paste; this transport has
-    /// no second delivery to give, and the envelope alone is 68 bytes, so the
-    /// combined write lands past the 64-byte cliff too.
-    ///
-    /// PR #816 (child-as-contract-party) wraps in bracketed paste when the
-    /// child's mode is on, in one write, and this refusal lifts with it.
+    /// The holder arm delivers a message in one write to the child's pty, and a
+    /// single text body composes into that write cleanly: wrapped in bracketed
+    /// paste when the child's mode calls for it, so the submitting carriage
+    /// return lands outside the paste. What this refuses is a message that is
+    /// more than one body — several parts, or a lone image whose write would
+    /// also have to carry the dispatch envelope that attributes the turn. The
+    /// tmux arm frames those as separate pastes; this transport has only the one
+    /// write, and how a single write could frame a multi-body message — image
+    /// and envelope included — is deliberately out of scope until a spec settles
+    /// it. Refused rather than guessing at a framing, because a wrong guess
+    /// submits an unintended turn.
     static func holderCompositeRefusal(terminalID: UUID, cause: String) -> String {
         "terminal.send was refused: terminal \(terminalID) runs on the pty-holder transport, "
-            + "which delivers a message in one unwrapped write — and \(cause) cannot submit that "
-            + "way (past 64 bytes the carriage return is swallowed and the text sits unsent). "
-            + "Nothing was typed. Send a single-line message, or move the session to tmux."
+            + "which delivers a message in a single write — and \(cause) cannot be carried in "
+            + "that one write. Nothing was typed. Send the message as a single body of text, "
+            + "or move the session to tmux."
     }
 
     /// The refusal a text `terminal.send` gets for a terminal whose Claude

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -3663,8 +3663,8 @@ extension RPCRouter {
                 // So this refuses while an envelope would be attached, and
                 // delivers the bare path when none would be — an authenticated
                 // suppression, or a row that carries no envelope at all.
-                // PR #816's bracketed-paste wrapping lifts it, exactly as it
-                // lifts the composite refusal.
+                // How one write could frame both the image and the envelope
+                // attributing it is deliberately out of scope until a spec settles it.
                 guard envelope != .attached || !Self.carriesDispatchEnvelope(terminal) else {
                     return await refuseHolderSend(
                         actuationID, Self.holderCompositeRefusal(

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -3733,6 +3733,20 @@ extension RPCRouter {
         // An explicit `--verify` keeps its existing meaning on both transports,
         // suppression included: that combination is the caller's own, it
         // predates this arm, and changing it is not this change's business.
+        //
+        // **`actor.kind` is a declaration, not an authentication**, and this is
+        // the first place in the tree that branches behavior on it rather than
+        // only labeling a row — so the assumption is stated rather than
+        // enforced. Any process on the daemon socket can call itself `daemon`
+        // (see `ActuationActor`'s own doc: "ambient declaration, never
+        // authentication"), and one that does, on a send whose envelope rides,
+        // reaches this branch. What it gets is bounded to what a rail gets: an
+        // observation it did not ask for, and at most one re-delivery of its
+        // own message. Nothing here refuses, deletes, or redirects on the
+        // strength of the claim, so the fail-open shape is the same as
+        // everywhere else this field is read. The envelope-suppression check
+        // the daemon DOES authenticate is `authenticatesEnvelopeSuppression`,
+        // and it stays the one gate that requires proof.
         let envelopeWillRide = envelopeEligible && envelope == .attached
             && Self.carriesDispatchEnvelope(terminal) && !text.isEmpty
         let effectiveVerifyArmed = payload.isVerifyArmed

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -961,7 +961,7 @@ extension RPCRouter {
     }
 
     /// The refusal `terminal.delete`'s activity rails return for a busy row
-    /// they will not close. Named beside its verb, like `holderVerifyRefusal`
+    /// they will not close. Named beside its verb, like `holderCompositeRefusal`
     /// and its siblings, so the CLI, the app and this handler's tests name the same
     /// reason rather than three near-misses.
     ///
@@ -2770,22 +2770,6 @@ extension RPCRouter {
         case suppressed
     }
 
-    /// The refusal `terminal.send --verify` returns for a holder-backed row.
-    ///
-    /// It names *verification*, not the transport, and the distinction is the
-    /// whole point: typing into a holder session works, and a caller told
-    /// otherwise would stop trying. What has no holder implementation is the
-    /// delivery *observation* — the verifier re-reads the pane through tmux
-    /// (`redeliverVerifiedPayload` and `consultPaneBeforeTyping` both speak
-    /// tmux), and a holder session has no pane to re-read. Refused rather than
-    /// downgraded to an unverified send, per the rule that a request for
-    /// evidence is never answered with a silence that reads like confirmation.
-    static func holderVerifyRefusal(terminalID: UUID) -> String {
-        "terminal.send --verify was refused: terminal \(terminalID) runs on the pty-holder "
-            + "transport, which has no delivery observation — nothing was sent. Resend without "
-            + "--verify."
-    }
-
     /// The refusal `terminal.send --keys` returns when a name in the sequence
     /// is not one the holder's named-key table knows.
     ///
@@ -3490,23 +3474,33 @@ extension RPCRouter {
     /// actuation row, the same dispatch envelope, the same per-terminal
     /// serializer lane (this runs inside it). What changes is the destination —
     /// `HolderInjectionCourier` routes by whether a viewer owns the pty — and
-    /// four things this transport cannot do yet, each refused by name rather
+    /// two things this transport cannot frame yet, each refused by name rather
     /// than by "the holder transport", so a caller learns which capability is
     /// missing:
     ///
-    /// - `--verify` has no delivery observation here.
-    /// - `--keys` has no named-key → bytes mapping here (tmux owns that table).
-    /// - A composite send — more than one part, or a payload containing a
-    ///   newline — has no framing here at all; it is refused ahead of this
-    ///   function, by the composite gate in `performTerminalSend` (see "What
-    ///   the holder arm cannot carry yet" there). The `.parts` case below
-    ///   still turns away a multi-part payload defensively, but that gate
-    ///   means it should never see one.
+    /// - A composite send — more than one part — has no single-write framing
+    ///   here at all; it is refused ahead of this function, by the composite
+    ///   gate in `performTerminalSend` (see "What the holder arm cannot frame
+    ///   in one write" there). The `.parts` case below still turns away a
+    ///   multi-part payload defensively, but that gate means it should never
+    ///   see one.
     /// - An image-only message that would carry the dispatch envelope has
     ///   nowhere to put it: the envelope cannot ride ahead of a path that
     ///   attaches only when the paste is the path and nothing else, and there
     ///   is no second write to give it. Refused in the `.parts` arm below,
     ///   where the disposition is known.
+    ///
+    /// `--verify` flows through, it is not refused as a transport limit: a
+    /// verify-armed send to an observable agent session is composed here,
+    /// delivered by the courier, and armed for observation exactly as the tmux
+    /// arm arms it — the observation reads the child's transcript tail, not a
+    /// pane, so it is transport-blind. The daemon's own supervision rails arm
+    /// it by default whenever `delivery_verification_enabled` is on. The gate
+    /// near the top of this function refuses only the three states in which no
+    /// observation could be produced — an explicit `--verify` at a target with
+    /// no transcript, the flag off, or no verifier wired — mirroring the tmux
+    /// arm's gate. `--keys` composes through `deliverHolderKeys`, which owns
+    /// the named-key → bytes mapping.
     ///
     /// A daemon with no courier has no input path at all, and says so.
     ///
@@ -3574,9 +3568,56 @@ extension RPCRouter {
             return await refuseHolderSend(
                 actuationID, Self.holderInputUnavailable(terminalID: terminal.id))
         }
-        if payload.isVerifyArmed {
-            return await refuseHolderSend(
-                actuationID, Self.holderVerifyRefusal(terminalID: terminal.id))
+
+        // ─── Can this send be verified here? ───
+        //
+        // The observation is transport-blind — it reads the child's transcript
+        // tail, not a pane — so the same three preconditions the tmux arm
+        // checks apply on the holder arm too, and the gate below mirrors it.
+        // What differs is who arms it: an explicit `--verify` from any actor,
+        // or the daemon's own supervision rails by default whenever the flag is
+        // on and the target can be observed. `effectiveVerifyArmed` folds both
+        // in, and the arm seam in `deliverHolderText` reads the same value.
+        //
+        // The daemon-default term carries `supportsDeliveryObservation` so it
+        // stays false for a shell holder: a shell is still SERVED by the oracle
+        // (bare bytes), it just cannot be observed, so a daemon rail's send to
+        // one proceeds unarmed rather than refusing. Only an explicit `--verify`
+        // on a shell reaches the first refusal below — because only then is
+        // `effectiveVerifyArmed` true while the target cannot be observed.
+        let verifyEnabled = (try? await db.config.get())?.deliveryVerificationEnabled ?? false
+        let effectiveVerifyArmed = payload.isVerifyArmed
+            || (actor?.kind == ActuationActor.Kind.daemon
+                && verifyEnabled && Self.supportsDeliveryObservation(terminal))
+        if effectiveVerifyArmed {
+            if !Self.supportsDeliveryObservation(terminal) {
+                let kindName = (terminal.kind ?? .shell).rawValue
+                let message = """
+                    terminal.send --verify was refused: terminal \
+                    \(terminal.id.uuidString) is a \(kindName) session, and delivery can only \
+                    be observed for a Claude session today — nothing was sent. Resend without \
+                    --verify.
+                    """
+                return await refuseHolderSend(actuationID, message)
+            }
+            if !verifyEnabled {
+                let message = """
+                    terminal.send --verify was refused: delivery verification is disabled \
+                    (config.delivery_verification_enabled is off) — nothing was sent. Enable \
+                    it with the config.setDeliveryVerification RPC and restart the daemon, or \
+                    resend without --verify to accept an unverified send.
+                    """
+                return await refuseHolderSend(actuationID, message)
+            }
+            if deliveryVerifier == nil {
+                let message = """
+                    terminal.send --verify was refused: delivery verification is enabled but \
+                    this daemon has no verifier wired, so the flag was turned on after it \
+                    started — nothing was sent. Restart the daemon to arm the observation, or \
+                    resend without --verify to accept an unverified send.
+                    """
+                return await refuseHolderSend(actuationID, message)
+            }
         }
         let text: String
         let submit: Bool
@@ -3647,7 +3688,8 @@ extension RPCRouter {
 
         return await deliverHolderText(
             text, submit: submit, terminal: terminal, actuationID: actuationID,
-            actor: actor, envelope: envelope, envelopeEligible: envelopeEligible, courier: courier)
+            actor: actor, envelope: envelope, envelopeEligible: envelopeEligible,
+            verifyArmed: effectiveVerifyArmed, courier: courier)
     }
 
     /// Deliver one body of text to a holder-backed session: the same envelope
@@ -3660,10 +3702,18 @@ extension RPCRouter {
     /// ahead of `envelope`'s disposition and `carriesDispatchEnvelope`: a lone
     /// image part passes `false` so the quoted path it built from is never
     /// prefixed, no matter what those two would otherwise decide.
+    ///
+    /// `verifyArmed` is the resolved arming decision from `performHolderSend`'s
+    /// gate — an explicit `--verify` or the daemon rails' default — already
+    /// checked against the three preconditions there. On a successful write it
+    /// hands the composed `body` (envelope and text, before paste-marker
+    /// wrapping) to the verifier, exactly as the tmux arm does. An empty body
+    /// arms nothing: `--text "" --submit` presses Enter and has no delivery to
+    /// observe.
     private func deliverHolderText(
         _ text: String, submit: Bool, terminal: Terminal, actuationID: String,
         actor: ActuationActor?, envelope: DispatchEnvelopeDisposition,
-        envelopeEligible: Bool, courier: HolderInjectionCourier
+        envelopeEligible: Bool, verifyArmed: Bool, courier: HolderInjectionCourier
     ) async -> RPCResponse {
         // Asked BEFORE anything is composed, because the answer decides the
         // bytes. Two sources, in order: the test seam if one is installed, then
@@ -3729,6 +3779,22 @@ extension RPCRouter {
                 actuationID, .dispatched,
                 modeSource: modeSource, modeAgeMilliseconds: modeAge,
                 modesObserved: modesObserved)
+            // Hand off to the observation, exactly as the tmux arm does after
+            // `.dispatched`: reached only on a successful write, only when the
+            // send was verify-armed, and only for a non-empty body — a
+            // verify-less send, a refusal, a transport failure and a bare Enter
+            // all arm nothing. The delivered payload is `body`: the envelope
+            // and text as composed, before paste-marker wrapping, so the
+            // verifier observes the transcript for what the child received, not
+            // for the control bytes that framed it.
+            if verifyArmed, !body.isEmpty {
+                await deliveryVerifier?.armVerification(
+                    actuationID: actuationID,
+                    terminalID: terminal.id,
+                    sessionID: terminal.claudeSessionID,
+                    deliveredPayload: body,
+                    submit: submit)
+            }
             return .ok()
         case .notDelivered(let reason):
             // The transport, not a decision: the daemon tried to write and

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -3494,13 +3494,11 @@ extension RPCRouter {
     /// verify-armed send to an observable agent session is composed here,
     /// delivered by the courier, and armed for observation exactly as the tmux
     /// arm arms it — the observation reads the child's transcript tail, not a
-    /// pane, so it is transport-blind. The daemon's own supervision rails arm
-    /// it by default whenever `delivery_verification_enabled` is on. The gate
-    /// near the top of this function refuses only the three states in which no
-    /// observation could be produced — an explicit `--verify` at a target with
-    /// no transcript, the flag off, or no verifier wired — mirroring the tmux
-    /// arm's gate. `--keys` composes through `deliverHolderKeys`, which owns
-    /// the named-key → bytes mapping.
+    /// pane, so it is transport-blind. The gate near the top of this function
+    /// refuses only the three states in which no observation could be produced
+    /// — a target with no transcript, the flag off, or no verifier wired —
+    /// mirroring the tmux arm's gate condition for condition. `--keys` composes
+    /// through `deliverHolderKeys`, which owns the named-key → bytes mapping.
     ///
     /// A daemon with no courier has no input path at all, and says so.
     ///
@@ -3573,23 +3571,20 @@ extension RPCRouter {
         //
         // The observation is transport-blind — it reads the child's transcript
         // tail, not a pane — so the same three preconditions the tmux arm
-        // checks apply on the holder arm too, and the gate below mirrors it.
-        // What differs is who arms it: an explicit `--verify` from any actor,
-        // or the daemon's own supervision rails by default whenever the flag is
-        // on and the target can be observed. `effectiveVerifyArmed` folds both
-        // in, and the arm seam in `deliverHolderText` reads the same value.
+        // checks apply on the holder arm too, and this gate mirrors it
+        // condition for condition, in the same order and the same words.
         //
-        // The daemon-default term carries `supportsDeliveryObservation` so it
-        // stays false for a shell holder: a shell is still SERVED by the oracle
-        // (bare bytes), it just cannot be observed, so a daemon rail's send to
-        // one proceeds unarmed rather than refusing. Only an explicit `--verify`
-        // on a shell reaches the first refusal below — because only then is
-        // `effectiveVerifyArmed` true while the target cannot be observed.
-        let verifyEnabled = (try? await db.config.get())?.deliveryVerificationEnabled ?? false
-        let effectiveVerifyArmed = payload.isVerifyArmed
-            || (actor?.kind == ActuationActor.Kind.daemon
-                && verifyEnabled && Self.supportsDeliveryObservation(terminal))
-        if effectiveVerifyArmed {
+        // **Arming is the caller's decision, on both transports.** Only an
+        // explicit `--verify` arms an observation; a daemon rail's own send is
+        // not armed behind the caller's back because the flag happens to be on.
+        // Arming one would spend the mechanism's single evidence-bounded retry
+        // — a second injection into a live composer — on a send nobody asked to
+        // have verified, and it would make the same rail behave differently
+        // depending on which transport its target happens to run.
+        //
+        // Read per call and only when `--verify` was armed, so an ordinary send
+        // pays no config read — the same economy the tmux gate keeps.
+        if payload.isVerifyArmed {
             if !Self.supportsDeliveryObservation(terminal) {
                 let kindName = (terminal.kind ?? .shell).rawValue
                 let message = """
@@ -3600,6 +3595,7 @@ extension RPCRouter {
                     """
                 return await refuseHolderSend(actuationID, message)
             }
+            let verifyEnabled = (try? await db.config.get())?.deliveryVerificationEnabled ?? false
             if !verifyEnabled {
                 let message = """
                     terminal.send --verify was refused: delivery verification is disabled \
@@ -3689,7 +3685,7 @@ extension RPCRouter {
         return await deliverHolderText(
             text, submit: submit, terminal: terminal, actuationID: actuationID,
             actor: actor, envelope: envelope, envelopeEligible: envelopeEligible,
-            verifyArmed: effectiveVerifyArmed, courier: courier)
+            verifyArmed: payload.isVerifyArmed, courier: courier)
     }
 
     /// Deliver one body of text to a holder-backed session: the same envelope
@@ -3703,9 +3699,8 @@ extension RPCRouter {
     /// image part passes `false` so the quoted path it built from is never
     /// prefixed, no matter what those two would otherwise decide.
     ///
-    /// `verifyArmed` is the resolved arming decision from `performHolderSend`'s
-    /// gate — an explicit `--verify` or the daemon rails' default — already
-    /// checked against the three preconditions there. On a successful write it
+    /// `verifyArmed` is the caller's own `--verify`, already checked against
+    /// the three preconditions in `performHolderSend`'s gate. On a successful write it
     /// hands the composed `body` (envelope and text, before paste-marker
     /// wrapping) to the verifier, exactly as the tmux arm does. An empty body
     /// arms nothing: `--text "" --submit` presses Enter and has no delivery to
@@ -3967,8 +3962,10 @@ extension RPCRouter {
     ///
     /// It runs the same pane consultation the first send ran, through the same
     /// helper: a minute has passed, and the pane may have died or been reused
-    /// since. And it queues in the same per-terminal lane, so a retry can never
-    /// splice itself into a concurrent send's paste.
+    /// since. A holder row has no pane, so its liveness question is the holder's
+    /// last reported child status instead. And both arms queue in the same
+    /// per-terminal lane, so a retry can never splice itself into a concurrent
+    /// send's write.
     func redeliverVerifiedPayload(
         terminalID: UUID, sessionID: String?, payload: String, submit: Bool
     ) async -> ActuationOutcome {
@@ -4020,43 +4017,58 @@ extension RPCRouter {
             guard let courier = holderInjectionCourier else {
                 return .refused(.notEligible)
             }
-            // A child the holder has already reported dead cannot receive a
-            // retry. Only a reported `.exited` refuses — `.alive`,
-            // `.exitedStatusUnknown` and a status never reported (nil) are all
-            // uncertainty, and uncertainty proceeds: the courier's own write is
-            // the authority on whether the pty still takes bytes.
-            if case .exited = await holderRegistry?.lastKnownStatus(for: terminalID) {
-                return .refused(.notEligible)
+            // And it queues in the terminal's own lane, exactly as the tmux
+            // body below does: the retry is a SECOND writer to a pty another
+            // send may be mid-write on, and a write to a tty is not atomic. The
+            // liveness check goes inside the lane for the same reason the tmux
+            // arm consults the pane inside it — the answer must not be
+            // separated from the write it authorizes.
+            let outcome = try? await terminalSendSerializer.run(terminalID: terminalID) {
+                // A child the holder has already reported dead cannot receive a
+                // retry. Only a reported `.exited` refuses — `.alive`,
+                // `.exitedStatusUnknown` and a status never reported (nil) are
+                // all uncertainty, and uncertainty proceeds: the courier's own
+                // write is the authority on whether the pty still takes bytes.
+                if case .exited = await self.holderRegistry?.lastKnownStatus(for: terminalID) {
+                    return ActuationOutcome.refused(.notEligible)
+                }
+                // Recompose the paste-wrapping from a FRESH reading rather than
+                // replaying the exact bytes the first send wrote. A minute has
+                // passed since the observation, and the child's bracketed-paste
+                // mode can have flipped in it — a viewer attaching or
+                // detaching, a full-screen redraw — so the wrapping the first
+                // send baked in may now be wrong for the pty as it stands.
+                // `payload` is the composed body (envelope and text, before any
+                // paste marker), so it is the `body` argument here and takes no
+                // second envelope; only the wrapping is recomputed, exactly as
+                // `deliverHolderText` composes it.
+                let reading = await self.holderModeReading(terminalID: terminalID)
+                let message = HolderSendComposition.compose(
+                    body: payload, submit: submit,
+                    bracketedPaste: HolderSendComposition.bracketedPaste(
+                        for: reading,
+                        unobservedShouldWrap: Self.carriesDispatchEnvelope(terminal)))
+                // An empty composition has no delivery to redo —
+                // `--text "" --submit` composes to a bare Enter with no body,
+                // and a body that was only paste markers composes to nothing at
+                // all. `deliverHolderText` treats the same emptiness as
+                // `.dispatched`; the retry returns the same, because there is
+                // nothing to re-deliver — not because a write succeeded.
+                // Verification is NOT re-armed here: this call IS the verifier's
+                // retry, and re-arming would make it observe its own
+                // re-delivery and retry that in turn.
+                guard !message.isEmpty else { return ActuationOutcome.dispatched }
+                switch await courier.deliver(terminalID: terminalID, bytes: message) {
+                case .viewerWrote, .daemonWrote:
+                    return ActuationOutcome.dispatched
+                case .notDelivered:
+                    return ActuationOutcome.transportFailed
+                }
             }
-            // Recompose the paste-wrapping from a FRESH reading rather than
-            // replaying the exact bytes the first send wrote. A minute has
-            // passed since the observation, and the child's bracketed-paste
-            // mode can have flipped in it — a viewer attaching or detaching, a
-            // full-screen redraw — so the wrapping the first send baked in may
-            // now be wrong for the pty as it stands. `payload` is the composed
-            // body (envelope and text, before any paste marker), so it is the
-            // `body` argument here and takes no second envelope; only the
-            // wrapping is recomputed, exactly as `deliverHolderText` composes it.
-            let reading = await holderModeReading(terminalID: terminalID)
-            let message = HolderSendComposition.compose(
-                body: payload, submit: submit,
-                bracketedPaste: HolderSendComposition.bracketedPaste(
-                    for: reading, unobservedShouldWrap: Self.carriesDispatchEnvelope(terminal)))
-            // An empty composition has no delivery to redo — `--text "" --submit`
-            // composes to a bare Enter with no body, and a body that was only
-            // paste markers composes to nothing at all. `deliverHolderText`
-            // treats the same emptiness as `.dispatched`; the retry returns the
-            // same, because there is nothing to re-deliver — not because a write
-            // succeeded. Verification is NOT re-armed here: this call IS the
-            // verifier's retry, and re-arming would make it observe its own
-            // re-delivery and retry that in turn.
-            guard !message.isEmpty else { return .dispatched }
-            switch await courier.deliver(terminalID: terminalID, bytes: message) {
-            case .viewerWrote, .daemonWrote:
-                return .dispatched
-            case .notDelivered:
-                return .transportFailed
-            }
+            // The lane rethrows only what the closure threw, and this one
+            // throws nothing — a nil here is cancellation, which reached no
+            // transport and is classified as the failed write it would have been.
+            return outcome ?? .transportFailed
         }
         let outcome: ActuationOutcome
         do {

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -3717,9 +3717,28 @@ extension RPCRouter {
         // reaches no transcript for an observation to read. Every precondition
         // the daemon default needs is carried in the term itself — see the
         // gate's comment for why it arms rather than refuses.
+        //
+        // **The envelope is one of those preconditions.** The observation
+        // searches the transcript for this row's dispatch id and for nothing
+        // else (`DeliveryVerifier.envelopeAppears`), so a send that carries no
+        // envelope is one it cannot possibly find: arming that would guarantee
+        // a not-landed verdict at the deadline and spend the single
+        // evidence-bounded retry re-typing the message into the session a
+        // second time. And the queued-prompt rail — the production caller this
+        // default is for — sends `.suppressed` by design, so the operator's own
+        // words arrive byte-identically. It therefore goes unarmed, the same
+        // way a target that cannot be observed does. Spelled exactly as
+        // `deliverHolderText` spells it when it decides whether to compose one.
+        //
+        // An explicit `--verify` keeps its existing meaning on both transports,
+        // suppression included: that combination is the caller's own, it
+        // predates this arm, and changing it is not this change's business.
+        let envelopeWillRide = envelopeEligible && envelope == .attached
+            && Self.carriesDispatchEnvelope(terminal) && !text.isEmpty
         let effectiveVerifyArmed = payload.isVerifyArmed
             || (actor?.kind == ActuationActor.Kind.daemon && verifyEnabled
-                && Self.supportsDeliveryObservation(terminal) && deliveryVerifier != nil)
+                && Self.supportsDeliveryObservation(terminal) && deliveryVerifier != nil
+                && envelopeWillRide)
         return await deliverHolderText(
             text, submit: submit, terminal: terminal, actuationID: actuationID,
             actor: actor, envelope: envelope, envelopeEligible: envelopeEligible,

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -3497,11 +3497,13 @@ extension RPCRouter {
     /// pane, so it is transport-blind. The daemon's own supervision rails arm
     /// it by default whenever `delivery_verification_enabled` is on — a
     /// holder-transport rule the child-as-contract-party design states
-    /// deliberately. The gate near the top of this function refuses only the
-    /// three states in which no observation could be produced — an explicit
-    /// `--verify` at a target with no transcript, the flag off, or no verifier
-    /// wired — mirroring the tmux arm's gate. `--keys` composes through
-    /// `deliverHolderKeys`, which owns the named-key → bytes mapping.
+    /// deliberately — and it arms opportunistically, never refusing a rail's
+    /// send for a mechanism the rail did not ask for. The gate near the top of
+    /// this function refuses only an EXPLICIT `--verify` in the three states in
+    /// which no observation could be produced — a target with no transcript,
+    /// the flag off, or no verifier wired — mirroring the tmux arm's gate.
+    /// `--keys` composes through `deliverHolderKeys`, which owns the named-key
+    /// → bytes mapping.
     ///
     /// A daemon with no courier has no input path at all, and says so.
     ///
@@ -3589,17 +3591,30 @@ extension RPCRouter {
         // `effectiveVerifyArmed` folds both in, and the arm seam in
         // `deliverHolderText` reads the same value.
         //
-        // The daemon-default term carries `supportsDeliveryObservation` so it
-        // stays false for a shell holder: a shell is still SERVED by the oracle
-        // (bare bytes), it just cannot be observed, so a daemon rail's send to
-        // one proceeds unarmed rather than refusing. Only an explicit `--verify`
-        // on a shell reaches the first refusal below — because only then is
-        // `effectiveVerifyArmed` true while the target cannot be observed.
-        let verifyEnabled = (try? await db.config.get())?.deliveryVerificationEnabled ?? false
-        let effectiveVerifyArmed = payload.isVerifyArmed
-            || (actor?.kind == ActuationActor.Kind.daemon
-                && verifyEnabled && Self.supportsDeliveryObservation(terminal))
-        if effectiveVerifyArmed {
+        // **Only an explicit `--verify` can be REFUSED here; the default arms
+        // opportunistically and never refuses.** The three checks below exist
+        // to keep a caller that asked for evidence from being handed a silence
+        // that reads like confirmation — and a rail that did not ask has no
+        // such expectation to protect. So they gate on `payload.isVerifyArmed`,
+        // and the default term carries every precondition itself: a rail's
+        // ordinary send to a shell holder, or during the window between the
+        // flag going on and the daemon restarting to wire a verifier, proceeds
+        // UNARMED rather than failing closed. A supervision send that refuses
+        // because supervision's own witness is not ready is the exact failure
+        // this design exists to prevent.
+        //
+        // `supportsDeliveryObservation` is one of those preconditions: a shell
+        // is still SERVED by the oracle (bare bytes), it just cannot be
+        // observed.
+        //
+        // The config column is read only when the send could arm — an explicit
+        // `--verify`, or a daemon actor — so an ordinary app or CLI send pays
+        // no read, the same economy the tmux gate keeps.
+        let mayArm = payload.isVerifyArmed || actor?.kind == ActuationActor.Kind.daemon
+        let verifyEnabled = mayArm
+            ? ((try? await db.config.get())?.deliveryVerificationEnabled ?? false)
+            : false
+        if payload.isVerifyArmed {
             if !Self.supportsDeliveryObservation(terminal) {
                 let kindName = (terminal.kind ?? .shell).rawValue
                 let message = """
@@ -3629,6 +3644,9 @@ extension RPCRouter {
                 return await refuseHolderSend(actuationID, message)
             }
         }
+        let effectiveVerifyArmed = payload.isVerifyArmed
+            || (actor?.kind == ActuationActor.Kind.daemon && verifyEnabled
+                && Self.supportsDeliveryObservation(terminal) && deliveryVerifier != nil)
         let text: String
         let submit: Bool
         // Whether `text` is allowed to carry the dispatch envelope at all,

--- a/Tests/TBDDaemonTests/Holder/HolderTmuxAssumptionGateTests.swift
+++ b/Tests/TBDDaemonTests/Holder/HolderTmuxAssumptionGateTests.swift
@@ -1811,8 +1811,15 @@ struct HolderTmuxAssumptionGateTests {
         #expect(outcome["modeAgeMilliseconds"] as? Int == 0)
     }
 
-    @Test("terminal.send --verify refuses a holder row by naming verification")
-    func sendVerifyRefusesHolderRow() async throws {
+    /// **`--verify` is no longer a transport refusal.** It is refused here for
+    /// the reason it is refused on a tmux row with the same config:
+    /// `delivery_verification_enabled` is off, which is the shipped default and
+    /// what an in-memory database seeds. The refusal names the flag and the RPC
+    /// that flips it — never the transport, because a caller told "this
+    /// transport has no delivery observation" would stop asking for one when it
+    /// now works. Nothing is typed, and no tmux command is issued.
+    @Test("terminal.send --verify refuses a holder row by naming the flag, not the transport")
+    func sendVerifyRefusesHolderRowWhileTheFlagIsOff() async throws {
         let db = try TBDDatabase(inMemory: true)
         let recorded = RecordedTmuxArgs()
         let tmux = deadWindowTmux(recorded)
@@ -1830,10 +1837,13 @@ struct HolderTmuxAssumptionGateTests {
                 terminalID: terminal.id, text: "hello", submit: true, verify: true)))
 
         #expect(!response.success)
-        #expect(response.error == RPCRouter.holderVerifyRefusal(terminalID: terminal.id))
-        // What is missing is the OBSERVATION, not the transport — a caller told
-        // "this transport cannot be typed into" would stop trying.
-        #expect(response.error?.contains("delivery observation") == true)
+        let message = try #require(response.error)
+        #expect(message.contains("delivery verification is disabled"))
+        #expect(message.contains("config.delivery_verification_enabled is off"))
+        #expect(message.contains("config.setDeliveryVerification"))
+        // What is missing is the FLAG, not the transport — a caller told "this
+        // transport has no delivery observation" would stop asking for one.
+        #expect(!message.contains("pty-holder"))
         #expect(writes.all.isEmpty, "a refused verify must type nothing")
         #expect(recorded.snapshot().isEmpty)
     }

--- a/Tests/TBDDaemonTests/HolderCompositeSendRefusalTests.swift
+++ b/Tests/TBDDaemonTests/HolderCompositeSendRefusalTests.swift
@@ -3,19 +3,40 @@ import Testing
 @testable import TBDDaemonLib
 import TBDShared
 
-/// Until bracketed-paste wrapping lands on the holder arm (PR #816), a
-/// multi-line or multi-part message to a holder-backed session is refused BY
-/// NAME rather than delivered and silently lost.
+/// What the holder transport's ONE write can and cannot frame.
 ///
-/// The measurement behind it, against 2.1.261 under a real pty: a single
-/// unwrapped write of 63 bytes submits, and a write of 64 bytes or more does not
-/// — the tokenizer splits control bytes into key events only while the pending
-/// chunk is under 64 bytes, so past that the carriage return is swallowed into
-/// the text and the whole string sits unsent in Claude's composer. Several
-/// deliveries instead of one would reopen the at-least-once and routing
-/// questions that one delivery avoids, so refusing is the honest answer.
-@Suite("holder composite send refusal")
+/// A single body of text — one line or many — composes into that write cleanly:
+/// `HolderSendComposition` wraps it in `ESC[200~`…`ESC[201~` when the child's
+/// bracketed-paste mode calls for it and puts the submitting `\r` after the end
+/// marker, which is the same "the Enter is provably outside the paste" property
+/// the tmux arm gets from pasting and pressing Enter as two separate acts. So a
+/// multi-line message is DELIVERED here, not refused.
+///
+/// What is still refused is a message that is more than one body: several
+/// parts, or a lone image whose write would also have to carry the dispatch
+/// envelope attributing the turn. The tmux arm frames those as separate pastes;
+/// this transport has only the one write, and how a single write could frame a
+/// multi-body message is out of scope until a spec settles it.
+@Suite("holder composite send: what one write can frame")
 struct HolderCompositeSendRefusalTests {
+
+    /// `ESC [ 2 0 0 ~` — the start of a bracketed paste.
+    private static let pasteStart = Data([0x1b, 0x5b, 0x32, 0x30, 0x30, 0x7e])
+    /// `ESC [ 2 0 1 ~` — the end of a bracketed paste.
+    private static let pasteEnd = Data([0x1b, 0x5b, 0x32, 0x30, 0x31, 0x7e])
+    /// Carriage return: what `send-keys Enter` puts on a pty.
+    private static let submitByte: UInt8 = 0x0d
+
+    /// A child that has asked for bracketed paste, witnessed by the daemon's own
+    /// live emulator — the reading that makes the composition wrap.
+    private static func bracketingChild(_ on: Bool) -> TerminalModeReading {
+        TerminalModeReading(
+            modes: TerminalScreen.ChildModes(
+                bracketedPaste: on, applicationCursor: false, alternateScreen: false),
+            modesObserved: true,
+            source: TerminalScreen.Source.daemon,
+            ageMilliseconds: 0)
+    }
 
     @Test func aPartsSendToAHolderRowIsRefused() async throws {
         let harness = try await SendHarness.make(transport: .holder)
@@ -28,16 +49,100 @@ struct HolderCompositeSendRefusalTests {
         let error = try #require(response.error)
         #expect(error.contains("pty-holder"))
         #expect(error.contains("more than one part"))
+        // The reworded refusal names the framing, not the old 64-byte cliff.
+        #expect(error.contains("a single write"))
+        #expect(!error.contains("64 bytes"))
     }
 
-    @Test func aMultiLineTextSendToAHolderRowIsRefused() async throws {
-        let harness = try await SendHarness.make(transport: .holder)
+    /// **The multi-line send this suite used to prove was refused.**
+    ///
+    /// Discriminates against `origin/main`, where `performTerminalSend`'s
+    /// composite gate matched `body.contains("\n")` and returned
+    /// `holderCompositeRefusal` having written nothing. Here the message is
+    /// delivered, in one write, wrapped — so the assertion is on the bytes, not
+    /// on the absence of an error string.
+    @Test func aMultiLineTextSendToAHolderRowIsDeliveredInOneWrappedWrite() async throws {
+        let recorder = HolderWriteRecorder()
+        let harness = try await SendHarness.make(
+            transport: .holder, holderDeliveryRecorder: { recorder.record($0) })
+        harness.router.holderModeOracle = { _ in Self.bracketingChild(true) }
+
         let response = try await harness.send(TerminalSendParams(
             terminalID: harness.terminal.id, text: "line one\nline two", submit: true),
             actor: .app)
 
-        #expect(!response.success)
-        #expect(try #require(response.error).contains("newline"))
+        #expect(response.success, "error was: \(response.error ?? "none")")
+        #expect(recorder.writes.count == 1, "the whole send is one message")
+        let data = try #require(recorder.writes.first)
+        #expect(data.starts(with: Self.pasteStart))
+        #expect(data.last == Self.submitByte)
+        // The submitting carriage return sits AFTER the end marker — the whole
+        // point of the wrapping, and a substring check could not see it.
+        let tail = data.suffix(Self.pasteEnd.count + 1)
+        #expect(Data(tail) == Self.pasteEnd + Data([Self.submitByte]))
+        let inner = data
+            .dropFirst(Self.pasteStart.count)
+            .dropLast(Self.pasteEnd.count + 1)
+        let body = String(decoding: inner, as: UTF8.self)
+        #expect(body.hasPrefix("<tbd-dispatch"))
+        #expect(body.hasSuffix("\nline one\nline two"))
+    }
+
+    /// **Both transports carry the same message.** The tmux arm pastes the
+    /// composed body and then presses Enter; the holder arm writes the same
+    /// composed body wrapped, with the same Enter after the end marker. Asserted
+    /// side by side, with the envelope's first line dropped from each because it
+    /// carries that harness's own actuation id.
+    ///
+    /// Discriminates: on `origin/main` the holder leg is refused and writes
+    /// nothing, so there is no body to compare.
+    @Test func aMultiLineSendCarriesTheSameMessageOnBothTransports() async throws {
+        let params = { (id: UUID) in
+            TerminalSendParams(terminalID: id, text: "line one\nline two", submit: true)
+        }
+
+        let tmuxHarness = try await SendHarness.make(transport: .tmux)
+        #expect(try await tmuxHarness.send(params(tmuxHarness.terminal.id), actor: .app).success)
+        #expect(tmuxHarness.tmux.pastedBodies.count == 1)
+        #expect(tmuxHarness.tmux.sentKeys == ["Enter"])
+        let tmuxBody = try #require(tmuxHarness.tmux.pastedBodies.first)
+
+        let recorder = HolderWriteRecorder()
+        let holderHarness = try await SendHarness.make(
+            transport: .holder, holderDeliveryRecorder: { recorder.record($0) })
+        holderHarness.router.holderModeOracle = { _ in Self.bracketingChild(true) }
+        #expect(
+            try await holderHarness.send(params(holderHarness.terminal.id), actor: .app).success)
+        let data = try #require(recorder.writes.first)
+        let holderBody = String(
+            decoding: data.dropFirst(Self.pasteStart.count)
+                .dropLast(Self.pasteEnd.count + 1),
+            as: UTF8.self)
+
+        // Everything after the envelope line, which is the caller's message
+        // verbatim on both transports.
+        #expect(
+            String(holderBody.drop(while: { $0 != "\n" }))
+                == String(tmuxBody.drop(while: { $0 != "\n" })))
+        #expect(String(holderBody.drop(while: { $0 != "\n" })) == "\nline one\nline two")
+    }
+
+    /// A child that never asked for bracketing gets bare bytes — markers it does
+    /// not understand are markers it prints. The multi-line body still goes.
+    @Test func aMultiLineSendToAChildWithBracketingOffIsBare() async throws {
+        let recorder = HolderWriteRecorder()
+        let harness = try await SendHarness.make(
+            transport: .holder, kind: .shell,
+            holderDeliveryRecorder: { recorder.record($0) })
+        harness.router.holderModeOracle = { _ in Self.bracketingChild(false) }
+
+        let response = try await harness.send(TerminalSendParams(
+            terminalID: harness.terminal.id, text: "one\ntwo", submit: true),
+            actor: .app)
+
+        #expect(response.success, "error was: \(response.error ?? "none")")
+        // A shell carries no envelope, so this is the whole message.
+        #expect(try #require(recorder.writes.first) == Data("one\ntwo\r".utf8))
     }
 
     /// A single-part, single-line message is exactly what the holder arm can
@@ -55,12 +160,12 @@ struct HolderCompositeSendRefusalTests {
 
         let error = response.error ?? ""
         #expect(!error.contains("more than one part"))
-        #expect(!error.contains("newline"))
         #expect(response.success, "error was: \(error)")
         // `actor: .app` against a `.claude` row carries the dispatch envelope —
         // mirroring the exact assertion `aSinglePartTextSendToAHolderRowIsNotRefused`
         // makes for its single text part, since both paths converge on the same
-        // `deliverHolderText` call.
+        // `deliverHolderText` call. No oracle is installed, so nothing answered
+        // and the composition goes bare.
         #expect(recorder.writes.count == 1)
         let body = String(bytes: try #require(recorder.writes.first), encoding: .utf8) ?? ""
         #expect(body.hasPrefix("<tbd-dispatch"))
@@ -69,8 +174,8 @@ struct HolderCompositeSendRefusalTests {
 
     /// A single-part `.parts` payload is exactly the remainder that reaches
     /// `performHolderSend`'s `.parts` arm once the composite gate above has
-    /// turned away anything bigger — and Fix round 1's ruling is that a single
-    /// text part is delivered the same way `--text` delivers a body. Modeled on
+    /// turned away anything bigger — and a single text part is delivered the
+    /// same way `--text` delivers a body. Modeled on
     /// `aSingleLineTextSendToAHolderRowIsNotRefused`: SendHarness wires a real
     /// (test-only) injection courier here, so this asserts the exact bytes
     /// delivered rather than only "got past the gate".
@@ -84,7 +189,6 @@ struct HolderCompositeSendRefusalTests {
 
         let error = response.error ?? ""
         #expect(!error.contains("more than one part"))
-        #expect(!error.contains("newline"))
         #expect(!error.contains("parts"))
         #expect(response.success, "error was: \(error)")
         // `actor: .app` against a `.claude` row carries the dispatch envelope,
@@ -96,16 +200,43 @@ struct HolderCompositeSendRefusalTests {
         #expect(body.hasSuffix("\nhello\r"))
     }
 
+    /// A single text part may itself be multi-line, and takes the same wrapped
+    /// write the `.text` arm takes — the two arms converge on `deliverHolderText`.
+    ///
+    /// Discriminates: on `origin/main` the composite gate matched a newline
+    /// inside a `.parts` payload too, so this was refused.
+    @Test func aSingleMultiLineTextPartIsDelivered() async throws {
+        let recorder = HolderWriteRecorder()
+        let harness = try await SendHarness.make(
+            transport: .holder, holderDeliveryRecorder: { recorder.record($0) })
+        harness.router.holderModeOracle = { _ in Self.bracketingChild(true) }
+
+        let response = try await harness.send(TerminalSendParams(
+            terminalID: harness.terminal.id, submit: true, parts: [.text("one\ntwo")]),
+            actor: .app)
+
+        #expect(response.success, "error was: \(response.error ?? "none")")
+        let data = try #require(recorder.writes.first)
+        #expect(data.starts(with: Self.pasteStart))
+        #expect(Data(data.suffix(Self.pasteEnd.count + 1))
+            == Self.pasteEnd + Data([Self.submitByte]))
+        let body = String(
+            decoding: data.dropFirst(Self.pasteStart.count).dropLast(Self.pasteEnd.count + 1),
+            as: UTF8.self)
+        #expect(body.hasSuffix("\none\ntwo"))
+    }
+
     /// **An image-only send that would carry an envelope is refused here.**
     ///
-    /// The holder arm writes the whole message in ONE unwrapped write, and that
-    /// one write cannot carry both a dispatch envelope and a bare image path:
-    /// Claude Code attaches an image only when the whole paste is the quoted
-    /// path and nothing else (measured on 2.1.261), so prefixing it attaches
-    /// nothing — and dropping the envelope instead would let any local process
-    /// submit an unattributed user turn carrying an image. The tmux arm escapes
-    /// the dilemma by pasting the envelope separately; this transport has no
-    /// second write to give. PR #816's bracketed-paste wrapping lifts it.
+    /// The holder arm writes the whole message in ONE write, and that one write
+    /// cannot carry both a dispatch envelope and a bare image path: Claude Code
+    /// attaches an image only when the whole paste is the quoted path and
+    /// nothing else (measured on 2.1.261), so prefixing it attaches nothing —
+    /// and dropping the envelope instead would let any local process submit an
+    /// unattributed user turn carrying an image. The tmux arm escapes the
+    /// dilemma by pasting the envelope separately; this transport has no second
+    /// write to give, and how one write could frame both is out of scope until a
+    /// spec settles it.
     ///
     /// `connection: nil` (unauthenticated, asking for no suppression) is the
     /// disposition an envelope attaches under.
@@ -122,6 +253,9 @@ struct HolderCompositeSendRefusalTests {
         let error = try #require(response.error)
         #expect(error.contains("pty-holder"))
         #expect(error.contains("image"))
+        // The reworded out-of-scope note: framing, not the retired byte cliff.
+        #expect(error.contains("a single write"))
+        #expect(!error.contains("unwrapped write"))
         #expect(recorder.writes.isEmpty, "nothing may be written")
     }
 

--- a/Tests/TBDDaemonTests/HolderVerifiedSendTests.swift
+++ b/Tests/TBDDaemonTests/HolderVerifiedSendTests.swift
@@ -91,8 +91,10 @@ struct HolderVerifiedSendTests {
             == Self.expected(body: armed.deliveredPayload, wrapped: true, submit: true))
     }
 
-    /// The off branch of the same conditional: a send that did not ask for
-    /// verification arms nothing, even with the flag on and a verifier wired.
+    /// The off branch of the same conditional: a send from a person's app that
+    /// did not ask for verification arms nothing, even with the flag on and a
+    /// verifier wired. Only the daemon's own rails get the default (below); a
+    /// person or a script keeps opting in per send.
     @Test("a verify-less send to a holder row arms nothing")
     func aVerifylessHolderSendArmsNothing() async throws {
         let writes = HolderVerifyWriteRecorder()
@@ -111,16 +113,23 @@ struct HolderVerifiedSendTests {
         #expect(armings.armings.isEmpty)
     }
 
-    /// **Arming is the caller's decision on both transports.** A daemon rail's
-    /// own send is not armed behind the caller's back merely because the flag is
-    /// on: that would spend the mechanism's one retry re-injecting input nobody
-    /// asked to have verified, and it would make the two transports disagree
-    /// about what the same rail's send does.
+    /// **The daemon's own rails arm verification by default — on holder only.**
     ///
-    /// Asserted for holder and tmux side by side, because "the two agree" is the
-    /// property, not "holder happens to be quiet".
-    @Test("a daemon rail's unverified send arms nothing on either transport")
-    func aDaemonRailSendArmsNothingOnEitherTransport() async throws {
+    /// The rails are the senders whose silence costs hours: nobody is watching
+    /// the screen when a desk nudges an agent at three in the morning, and the
+    /// record is the only witness. So a rail's send to a holder-backed agent
+    /// session is armed without `--verify` whenever the flag is on. A rail
+    /// sending to a **tmux** session keeps today's per-send opt-in: that arm
+    /// already delivers with explicit bracketing and a separate Enter, so it
+    /// lacks the failure shape that motivates the default, and widening the
+    /// soak to both transports at once widens the blast radius of any
+    /// re-delivery bug to the whole fleet. Both halves are stated in
+    /// `docs/specs/2026-09-05-child-as-contract-party-design.md`, "Delivery
+    /// verification on holder sends" → "What changes".
+    ///
+    /// The asymmetry is the property, so both legs are asserted here.
+    @Test("a daemon rail's send is armed by default on holder and not on tmux")
+    func aDaemonRailSendIsArmedByDefaultOnHolderOnly() async throws {
         let writes = HolderVerifyWriteRecorder()
         let holder = try await SendHarness.make(
             transport: .holder, holderDeliveryRecorder: { writes.record($0) })
@@ -139,13 +148,63 @@ struct HolderVerifiedSendTests {
             TerminalSendParams(terminalID: tmux.terminal.id, text: "nudge", submit: true),
             actor: .daemon(rail: "queued-prompt"))
 
-        // Both delivered, neither armed.
         #expect(holderResponse.success, "error was: \(holderResponse.error ?? "none")")
         #expect(tmuxResponse.success, "error was: \(tmuxResponse.error ?? "none")")
         #expect(writes.writes.count == 1)
         #expect(tmux.tmux.pastedBodies.count == 1)
-        #expect(holderArmings.armings.isEmpty)
+        // Armed on holder, on the same composed body an explicit `--verify`
+        // would have armed.
+        #expect(holderArmings.armings.count == 1)
+        let armed = try #require(holderArmings.armings.first)
+        #expect(armed.deliveredPayload.hasSuffix("\nnudge"))
+        #expect(armed.terminalID == holder.terminal.id)
+        // Not armed on tmux: the per-send opt-in stands there.
         #expect(tmuxArmings.armings.isEmpty)
+    }
+
+    /// **The default does not fire where nothing could be observed, and does not
+    /// refuse there either.** A shell holder row is still served by the oracle
+    /// — bare bytes — so a rail's send to one goes through unarmed rather than
+    /// hitting the "only a Claude session can be observed" refusal, which is
+    /// reachable only from an explicit `--verify`.
+    @Test("a daemon rail's send to a holder shell row proceeds unarmed rather than refusing")
+    func aDaemonRailSendToAHolderShellRowIsUnarmed() async throws {
+        let writes = HolderVerifyWriteRecorder()
+        let harness = try await SendHarness.make(
+            transport: .holder, kind: .shell,
+            holderDeliveryRecorder: { writes.record($0) })
+        try await harness.db.config.setDeliveryVerification(enabled: true)
+        let armings = ArmingRecorder()
+        harness.router.deliveryVerifier = armings
+
+        let response = try await harness.send(
+            TerminalSendParams(terminalID: harness.terminal.id, text: "nudge", submit: true),
+            actor: .daemon(rail: "queued-prompt"))
+
+        #expect(response.success, "error was: \(response.error ?? "none")")
+        #expect(writes.writes == [Self.expected(body: "nudge", wrapped: false, submit: true)])
+        #expect(armings.armings.isEmpty)
+    }
+
+    /// And the flag is still the switch: with `delivery_verification_enabled`
+    /// off — the shipped default — a rail's holder send arms nothing, so the
+    /// default arming has an off branch and it is the shipped one.
+    @Test("a daemon rail's holder send arms nothing while the flag is off")
+    func aDaemonRailSendArmsNothingWithTheFlagOff() async throws {
+        let writes = HolderVerifyWriteRecorder()
+        let harness = try await SendHarness.make(
+            transport: .holder, holderDeliveryRecorder: { writes.record($0) })
+        #expect(try await harness.db.config.get().deliveryVerificationEnabled == false)
+        let armings = ArmingRecorder()
+        harness.router.deliveryVerifier = armings
+
+        let response = try await harness.send(
+            TerminalSendParams(terminalID: harness.terminal.id, text: "nudge", submit: true),
+            actor: .daemon(rail: "queued-prompt"))
+
+        #expect(response.success, "error was: \(response.error ?? "none")")
+        #expect(writes.writes.count == 1)
+        #expect(armings.armings.isEmpty)
     }
 
     // MARK: - The three states in which no observation could be produced

--- a/Tests/TBDDaemonTests/HolderVerifiedSendTests.swift
+++ b/Tests/TBDDaemonTests/HolderVerifiedSendTests.swift
@@ -186,6 +186,31 @@ struct HolderVerifiedSendTests {
         #expect(armings.armings.isEmpty)
     }
 
+    /// **The default never refuses.** Between the flag going on and the daemon
+    /// restarting to wire a verifier, there is a window where the column says
+    /// yes and there is nothing to arm. An explicit `--verify` is refused there
+    /// — the caller asked for evidence and must not be handed a silence that
+    /// reads like confirmation. A rail's ordinary send asked for nothing, so it
+    /// is delivered unarmed instead: a supervision send that failed closed
+    /// because supervision's own witness was not ready is the exact failure
+    /// this design exists to prevent.
+    @Test("a daemon rail's send is delivered unarmed when no verifier is wired")
+    func aDaemonRailSendIsNotRefusedWithoutAWiredVerifier() async throws {
+        let writes = HolderVerifyWriteRecorder()
+        let harness = try await SendHarness.make(
+            transport: .holder, holderDeliveryRecorder: { writes.record($0) })
+        try await harness.db.config.setDeliveryVerification(enabled: true)
+        #expect(harness.router.deliveryVerifier == nil)
+
+        let response = try await harness.send(
+            TerminalSendParams(terminalID: harness.terminal.id, text: "nudge", submit: true),
+            actor: .daemon(rail: "queued-prompt"))
+
+        #expect(response.success, "error was: \(response.error ?? "none")")
+        #expect(!(response.error ?? "").contains("Restart the daemon"))
+        #expect(writes.writes.count == 1)
+    }
+
     /// And the flag is still the switch: with `delivery_verification_enabled`
     /// off — the shipped default — a rail's holder send arms nothing, so the
     /// default arming has an off branch and it is the shipped one.

--- a/Tests/TBDDaemonTests/HolderVerifiedSendTests.swift
+++ b/Tests/TBDDaemonTests/HolderVerifiedSendTests.swift
@@ -211,6 +211,36 @@ struct HolderVerifiedSendTests {
         #expect(writes.writes.count == 1)
     }
 
+    /// **A send that carries no dispatch envelope is never armed by the
+    /// default.** The observation searches the transcript for this row's
+    /// dispatch id and for nothing else, so an envelope-suppressed send is one
+    /// it cannot possibly find: arming it would guarantee a not-landed verdict
+    /// at the deadline and spend the single retry re-typing the message into
+    /// the session a second time.
+    ///
+    /// Driven through `sendQueuedPromptVerbatim` — the real production caller,
+    /// and the only caller of `.suppressed` — rather than through the RPC entry
+    /// point, which resolves the disposition to `.attached` and so would never
+    /// reach this shape.
+    @Test("a queued prompt's envelope-suppressed send is delivered verbatim and arms nothing")
+    func aQueuedPromptSendArmsNothing() async throws {
+        let writes = HolderVerifyWriteRecorder()
+        let harness = try await SendHarness.make(
+            transport: .holder, holderDeliveryRecorder: { writes.record($0) })
+        try await harness.db.config.setDeliveryVerification(enabled: true)
+        let armings = ArmingRecorder()
+        harness.router.deliveryVerifier = armings
+
+        let delivered = await harness.router.sendQueuedPromptVerbatim(
+            terminalID: harness.terminal.id, text: "the operator's own words", submit: true)
+
+        #expect(delivered)
+        // Verbatim: no envelope in the bytes, hence nothing to observe.
+        #expect(writes.writes
+            == [Self.expected(body: "the operator's own words", wrapped: false, submit: true)])
+        #expect(armings.armings.isEmpty)
+    }
+
     /// And the flag is still the switch: with `delivery_verification_enabled`
     /// off — the shipped default — a rail's holder send arms nothing, so the
     /// default arming has an off branch and it is the shipped one.

--- a/Tests/TBDDaemonTests/HolderVerifiedSendTests.swift
+++ b/Tests/TBDDaemonTests/HolderVerifiedSendTests.swift
@@ -1,0 +1,492 @@
+import Foundation
+import TestSupport
+import Testing
+@testable import TBDDaemonLib
+import TBDShared
+
+/// `terminal.send --verify`, and the verifier's one retry, on a holder-backed
+/// row.
+///
+/// **The observation is transport-blind.** It reads the child's transcript
+/// JSONL for the dispatch envelope the send delivered — never the rendered
+/// screen, which this codebase forbids reading for state — so nothing about it
+/// depends on there being a tmux pane to re-read. What the holder arm owed was
+/// the two ends of that: arming the observation after a successful write, and
+/// giving the verifier a way to re-deliver through the courier rather than
+/// through `tmux.pasteText`.
+///
+/// Every test here that asserts a delivery or a holder-specific classification
+/// discriminates against `origin/main`, where a `--verify` send to a holder row
+/// was refused outright by `holderVerifyRefusal` and `redeliverVerifiedPayload`
+/// had no holder branch at all — it fell through to the tmux body and pasted at
+/// the empty pane id a holder row carries by construction.
+@Suite("holder verified sends and the verifier's re-delivery")
+struct HolderVerifiedSendTests {
+
+    /// `ESC [ 2 0 0 ~` / `ESC [ 2 0 1 ~`, and the carriage return that submits.
+    private static let pasteStart = Data([0x1b, 0x5b, 0x32, 0x30, 0x30, 0x7e])
+    private static let pasteEnd = Data([0x1b, 0x5b, 0x32, 0x30, 0x31, 0x7e])
+    private static let submitByte: UInt8 = 0x0d
+
+    /// The expected bytes, assembled step by step rather than as a `+` chain:
+    /// `Data`'s concatenation operators are generic over `Sequence`, and a
+    /// four-term chain of them takes the type checker past its budget.
+    private static func expected(body: String, wrapped: Bool, submit: Bool) -> Data {
+        var data = Data()
+        if !body.isEmpty {
+            if wrapped { data.append(pasteStart) }
+            data.append(Data(body.utf8))
+            if wrapped { data.append(pasteEnd) }
+        }
+        if submit { data.append(submitByte) }
+        return data
+    }
+
+    /// A child whose bracketed-paste mode the daemon's own live emulator has
+    /// witnessed — so the composition obeys the flag rather than guessing.
+    private static func reading(bracketedPaste: Bool) -> TerminalModeReading {
+        TerminalModeReading(
+            modes: TerminalScreen.ChildModes(
+                bracketedPaste: bracketedPaste, applicationCursor: false,
+                alternateScreen: false),
+            modesObserved: true,
+            source: TerminalScreen.Source.daemon,
+            ageMilliseconds: 0)
+    }
+
+    // MARK: - Arming a verified send
+
+    /// The happy path: flag on, verifier wired, a Claude holder row. The write
+    /// happens, and the observation is armed with the composed body — envelope
+    /// and text, before the paste markers that framed it, because the child's
+    /// transcript records the message and not the control bytes.
+    @Test("a verified send to a holder row is delivered and armed on the composed body")
+    func aVerifiedHolderSendIsDeliveredAndArmed() async throws {
+        let writes = HolderVerifyWriteRecorder()
+        let harness = try await SendHarness.make(
+            transport: .holder, holderDeliveryRecorder: { writes.record($0) })
+        try await harness.db.config.setDeliveryVerification(enabled: true)
+        let armings = ArmingRecorder()
+        harness.router.deliveryVerifier = armings
+        let bracketing = Self.reading(bracketedPaste: true)
+        harness.router.holderModeOracle = { _ in bracketing }
+
+        let response = try await harness.send(
+            TerminalSendParams(
+                terminalID: harness.terminal.id, text: "status?", submit: true, verify: true),
+            actor: .app)
+
+        #expect(response.success, "error was: \(response.error ?? "none")")
+        #expect(writes.writes.count == 1)
+        #expect(armings.armings.count == 1)
+        let armed = try #require(armings.armings.first)
+        #expect(armed.terminalID == harness.terminal.id)
+        #expect(armed.sessionID == "sess-1")
+        #expect(armed.submit)
+        // The envelope rides inside the paste, so it is part of the payload the
+        // transcript will carry — and the paste markers are not.
+        #expect(armed.deliveredPayload.hasPrefix("<tbd-dispatch"))
+        #expect(armed.deliveredPayload.hasSuffix("\nstatus?"))
+        #expect(try #require(writes.writes.first)
+            == Self.expected(body: armed.deliveredPayload, wrapped: true, submit: true))
+    }
+
+    /// The off branch of the same conditional: a send that did not ask for
+    /// verification arms nothing, even with the flag on and a verifier wired.
+    @Test("a verify-less send to a holder row arms nothing")
+    func aVerifylessHolderSendArmsNothing() async throws {
+        let writes = HolderVerifyWriteRecorder()
+        let harness = try await SendHarness.make(
+            transport: .holder, holderDeliveryRecorder: { writes.record($0) })
+        try await harness.db.config.setDeliveryVerification(enabled: true)
+        let armings = ArmingRecorder()
+        harness.router.deliveryVerifier = armings
+
+        let response = try await harness.send(
+            TerminalSendParams(terminalID: harness.terminal.id, text: "status?", submit: true),
+            actor: .app)
+
+        #expect(response.success, "error was: \(response.error ?? "none")")
+        #expect(writes.writes.count == 1)
+        #expect(armings.armings.isEmpty)
+    }
+
+    /// **Arming is the caller's decision on both transports.** A daemon rail's
+    /// own send is not armed behind the caller's back merely because the flag is
+    /// on: that would spend the mechanism's one retry re-injecting input nobody
+    /// asked to have verified, and it would make the two transports disagree
+    /// about what the same rail's send does.
+    ///
+    /// Asserted for holder and tmux side by side, because "the two agree" is the
+    /// property, not "holder happens to be quiet".
+    @Test("a daemon rail's unverified send arms nothing on either transport")
+    func aDaemonRailSendArmsNothingOnEitherTransport() async throws {
+        let writes = HolderVerifyWriteRecorder()
+        let holder = try await SendHarness.make(
+            transport: .holder, holderDeliveryRecorder: { writes.record($0) })
+        try await holder.db.config.setDeliveryVerification(enabled: true)
+        let holderArmings = ArmingRecorder()
+        holder.router.deliveryVerifier = holderArmings
+        let holderResponse = try await holder.send(
+            TerminalSendParams(terminalID: holder.terminal.id, text: "nudge", submit: true),
+            actor: .daemon(rail: "queued-prompt"))
+
+        let tmux = try await SendHarness.make(transport: .tmux)
+        try await tmux.db.config.setDeliveryVerification(enabled: true)
+        let tmuxArmings = ArmingRecorder()
+        tmux.router.deliveryVerifier = tmuxArmings
+        let tmuxResponse = try await tmux.send(
+            TerminalSendParams(terminalID: tmux.terminal.id, text: "nudge", submit: true),
+            actor: .daemon(rail: "queued-prompt"))
+
+        // Both delivered, neither armed.
+        #expect(holderResponse.success, "error was: \(holderResponse.error ?? "none")")
+        #expect(tmuxResponse.success, "error was: \(tmuxResponse.error ?? "none")")
+        #expect(writes.writes.count == 1)
+        #expect(tmux.tmux.pastedBodies.count == 1)
+        #expect(holderArmings.armings.isEmpty)
+        #expect(tmuxArmings.armings.isEmpty)
+    }
+
+    // MARK: - The three states in which no observation could be produced
+
+    /// A shell keeps no transcript, so there is nothing an observation could
+    /// read. Refused by KIND, in the same words the tmux arm uses — the holder
+    /// gate mirrors it rather than naming the transport.
+    @Test("a verified send to a holder shell row is refused as unobservable, as on tmux")
+    func aVerifiedHolderShellSendIsRefusedByKind() async throws {
+        let writes = HolderVerifyWriteRecorder()
+        let holder = try await SendHarness.make(
+            transport: .holder, kind: .shell,
+            holderDeliveryRecorder: { writes.record($0) })
+        try await holder.db.config.setDeliveryVerification(enabled: true)
+        holder.router.deliveryVerifier = ArmingRecorder()
+        let holderResponse = try await holder.send(
+            TerminalSendParams(
+                terminalID: holder.terminal.id, text: "hi", submit: true, verify: true),
+            actor: .app)
+
+        let tmux = try await SendHarness.make(transport: .tmux, kind: .shell)
+        try await tmux.db.config.setDeliveryVerification(enabled: true)
+        tmux.router.deliveryVerifier = ArmingRecorder()
+        let tmuxResponse = try await tmux.send(
+            TerminalSendParams(
+                terminalID: tmux.terminal.id, text: "hi", submit: true, verify: true),
+            actor: .app)
+
+        #expect(!holderResponse.success)
+        #expect(!tmuxResponse.success)
+        let message = try #require(holderResponse.error)
+        #expect(message.contains("is a shell session"))
+        #expect(message.contains("only be observed for a Claude session"))
+        // The same refusal on both transports, differing only in the id it names.
+        let holderNormalized = message.replacingOccurrences(
+            of: holder.terminal.id.uuidString, with: "<id>")
+        let tmuxNormalized = try #require(tmuxResponse.error).replacingOccurrences(
+            of: tmux.terminal.id.uuidString, with: "<id>")
+        #expect(holderNormalized == tmuxNormalized)
+        #expect(writes.writes.isEmpty, "nothing may be written")
+    }
+
+    /// The flag is the second precondition, and it is refused rather than
+    /// silently downgraded to an unverified send: a caller that asked for
+    /// evidence is never answered with a silence that reads like confirmation.
+    @Test("a verified send to a holder row is refused while the flag is off, as on tmux")
+    func aVerifiedHolderSendIsRefusedWithTheFlagOff() async throws {
+        let writes = HolderVerifyWriteRecorder()
+        let holder = try await SendHarness.make(
+            transport: .holder, holderDeliveryRecorder: { writes.record($0) })
+        #expect(try await holder.db.config.get().deliveryVerificationEnabled == false)
+        let holderResponse = try await holder.send(
+            TerminalSendParams(
+                terminalID: holder.terminal.id, text: "status?", submit: true, verify: true),
+            actor: .app)
+
+        let tmux = try await SendHarness.make(transport: .tmux)
+        let tmuxResponse = try await tmux.send(
+            TerminalSendParams(
+                terminalID: tmux.terminal.id, text: "status?", submit: true, verify: true),
+            actor: .app)
+
+        #expect(!holderResponse.success)
+        let message = try #require(holderResponse.error)
+        #expect(message.contains("delivery verification is disabled"))
+        #expect(message.contains("config.delivery_verification_enabled is off"))
+        // On `origin/main` this named the transport instead.
+        #expect(!message.contains("pty-holder"))
+        #expect(message == (try #require(tmuxResponse.error)))
+        #expect(writes.writes.isEmpty, "nothing may be written")
+    }
+
+    /// The flag and the machinery it enables are read at different times — the
+    /// column per call, the verifier once at daemon start — so the window where
+    /// the column says yes and nothing is wired refuses too, on both transports.
+    @Test("a verified holder send is refused when the flag is on but no verifier is wired")
+    func aVerifiedHolderSendIsRefusedWithoutAWiredVerifier() async throws {
+        let writes = HolderVerifyWriteRecorder()
+        let holder = try await SendHarness.make(
+            transport: .holder, holderDeliveryRecorder: { writes.record($0) })
+        try await holder.db.config.setDeliveryVerification(enabled: true)
+        #expect(holder.router.deliveryVerifier == nil)
+        let holderResponse = try await holder.send(
+            TerminalSendParams(
+                terminalID: holder.terminal.id, text: "status?", submit: true, verify: true),
+            actor: .app)
+
+        let tmux = try await SendHarness.make(transport: .tmux)
+        try await tmux.db.config.setDeliveryVerification(enabled: true)
+        let tmuxResponse = try await tmux.send(
+            TerminalSendParams(
+                terminalID: tmux.terminal.id, text: "status?", submit: true, verify: true),
+            actor: .app)
+
+        #expect(!holderResponse.success)
+        let message = try #require(holderResponse.error)
+        #expect(message.contains("Restart the daemon"))
+        #expect(message == (try #require(tmuxResponse.error)))
+        #expect(writes.writes.isEmpty, "nothing may be written")
+    }
+
+    // MARK: - The verifier's one re-delivery
+
+    /// The retry re-injects through the same courier the first send used, and
+    /// recomposes the paste wrapping from a FRESH mode reading rather than
+    /// replaying the bytes the first send wrote — a minute has passed and the
+    /// child's bracketed-paste mode can have flipped in it.
+    ///
+    /// `payload` is the composed body (envelope and text, before any marker), so
+    /// it takes no second envelope.
+    @Test("a holder retry re-injects through the courier, rewrapped for the child as it is now")
+    func aHolderRetryReinjectsThroughTheCourier() async throws {
+        let writes = HolderVerifyWriteRecorder()
+        let harness = try await SendHarness.make(
+            transport: .holder, holderDeliveryRecorder: { writes.record($0) })
+        let bracketing = Self.reading(bracketedPaste: true)
+        harness.router.holderModeOracle = { _ in bracketing }
+        let payload = "<tbd-dispatch id=\"a1\" from=\"app\"/>\nstatus?"
+
+        let outcome = await harness.router.redeliverVerifiedPayload(
+            terminalID: harness.terminal.id, sessionID: "sess-1",
+            payload: payload, submit: true)
+
+        #expect(outcome == .dispatched)
+        #expect(writes.writes == [Self.expected(body: payload, wrapped: true, submit: true)])
+        // Nothing reached tmux: the holder branch returns before that body.
+        #expect(harness.tmux.pastedBodies.isEmpty)
+        #expect(harness.tmux.sentKeys.isEmpty)
+    }
+
+    /// A child whose bracketing is off gets the same body bare — which is the
+    /// whole reason the wrapping is recomputed rather than replayed.
+    @Test("a holder retry composes bare for a child that wants no brackets")
+    func aHolderRetryComposesBareForAChildWithoutBrackets() async throws {
+        let writes = HolderVerifyWriteRecorder()
+        let harness = try await SendHarness.make(
+            transport: .holder, holderDeliveryRecorder: { writes.record($0) })
+        let bare = Self.reading(bracketedPaste: false)
+        harness.router.holderModeOracle = { _ in bare }
+
+        let outcome = await harness.router.redeliverVerifiedPayload(
+            terminalID: harness.terminal.id, sessionID: "sess-1", payload: "hi", submit: true)
+
+        #expect(outcome == .dispatched)
+        #expect(writes.writes == [Self.expected(body: "hi", wrapped: false, submit: true)])
+    }
+
+    /// The eligibility that admitted the first send has to still hold for the
+    /// second: a `recreateWindow` between the observation and the retry can turn
+    /// an agent row into a shell while keeping its id, and the payload being held
+    /// opens with an envelope a shell would run as a command line of its own.
+    @Test("a holder retry to a row that is now a shell is not eligible")
+    func aHolderRetryToAShellRowIsNotEligible() async throws {
+        let writes = HolderVerifyWriteRecorder()
+        let harness = try await SendHarness.make(
+            transport: .holder, kind: .shell,
+            holderDeliveryRecorder: { writes.record($0) })
+
+        let outcome = await harness.router.redeliverVerifiedPayload(
+            terminalID: harness.terminal.id, sessionID: nil, payload: "hi", submit: true)
+
+        #expect(outcome == .refused(.notEligible))
+        #expect(writes.writes.isEmpty)
+    }
+
+    /// No courier is no input path at all — the same condition
+    /// `performHolderSend` turns into `holderInputUnavailable` and classifies as
+    /// `.notEligible`. The retry classifies it the same way rather than as a
+    /// transport failure it never attempted.
+    ///
+    /// Discriminates: on `origin/main` this fell through to the tmux body and
+    /// answered `.dispatched` after pasting at the empty pane id.
+    @Test("a holder retry with no courier is not eligible, and pastes nothing")
+    func aHolderRetryWithNoCourierIsNotEligible() async throws {
+        let harness = try await SendHarness.make(transport: .holder)
+        #expect(harness.router.holderInjectionCourier == nil)
+
+        let outcome = await harness.router.redeliverVerifiedPayload(
+            terminalID: harness.terminal.id, sessionID: "sess-1", payload: "hi", submit: true)
+
+        #expect(outcome == .refused(.notEligible))
+        #expect(harness.tmux.pastedBodies.isEmpty)
+    }
+
+    /// A write the courier could not make is the transport, not a decision.
+    @Test("a holder retry the courier cannot write is a transport failure")
+    func aHolderRetryThatCannotBeWrittenIsATransportFailure() async throws {
+        let harness = try await SendHarness.make(transport: .holder)
+        harness.router.holderInjectionCourier = HolderInjectionCourier(
+            sendFrame: { _ in },
+            viewerAttachment: { _ in nil },
+            writeDirectly: { _, _ in throw HolderRetryWriteFailure() })
+
+        let outcome = await harness.router.redeliverVerifiedPayload(
+            terminalID: harness.terminal.id, sessionID: "sess-1", payload: "hi", submit: true)
+
+        #expect(outcome == .transportFailed)
+    }
+
+    /// A session id that no longer matches is a stranger, and the retry is the
+    /// one send that must never reach one. Asserted on a holder row because the
+    /// holder branch returns before the tmux body that used to be the only thing
+    /// after this check.
+    @Test("a holder retry to a rebound conversation is a target mismatch")
+    func aHolderRetryToAReboundConversationIsRefused() async throws {
+        let writes = HolderVerifyWriteRecorder()
+        let harness = try await SendHarness.make(
+            transport: .holder, holderDeliveryRecorder: { writes.record($0) })
+
+        let outcome = await harness.router.redeliverVerifiedPayload(
+            terminalID: harness.terminal.id, sessionID: "someone-else", payload: "hi",
+            submit: true)
+
+        #expect(outcome == .refused(.targetMismatch))
+        #expect(writes.writes.isEmpty)
+    }
+
+    /// **The retry arms nothing.** This call IS the verifier's retry; re-arming
+    /// would make it observe its own re-delivery and retry that in turn.
+    @Test("a holder retry arms no further verification")
+    func aHolderRetryArmsNoFurtherVerification() async throws {
+        let writes = HolderVerifyWriteRecorder()
+        let harness = try await SendHarness.make(
+            transport: .holder, holderDeliveryRecorder: { writes.record($0) })
+        try await harness.db.config.setDeliveryVerification(enabled: true)
+        let armings = ArmingRecorder()
+        harness.router.deliveryVerifier = armings
+
+        let outcome = await harness.router.redeliverVerifiedPayload(
+            terminalID: harness.terminal.id, sessionID: "sess-1", payload: "hi", submit: true)
+
+        #expect(outcome == .dispatched)
+        #expect(writes.writes.count == 1)
+        #expect(armings.armings.isEmpty)
+    }
+
+    /// **Two payloads spliced into one composer is a transport bug**, and the
+    /// retry is a second writer to the same pty. It queues in the terminal's own
+    /// lane exactly as the tmux retry does — proven by holding the lane from
+    /// outside and watching the retry write nothing until it is released.
+    @Test("a holder retry queues behind the terminal's send lane")
+    func aHolderRetryQueuesBehindTheLane() async throws {
+        let writes = HolderVerifyWriteRecorder()
+        let harness = try await SendHarness.make(
+            transport: .holder, holderDeliveryRecorder: { writes.record($0) })
+        let gate = RetryLaneGate()
+
+        // Occupy this terminal's lane the way an in-flight send would.
+        async let laneHolder: Void = harness.router.terminalSendSerializer
+            .run(terminalID: harness.terminal.id) { await gate.wait() }
+        // Hang guard on the lane holder reaching the gate, bounded at the shared
+        // saturated-pass budget rather than a literal: it is a structured child
+        // on the cooperative pool, so one hop can cost tens of seconds.
+        let deadline = ContinuousClock.now + TestDeadlines.saturatedPass
+        while await !gate.hasEntered && ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(await gate.hasEntered)
+
+        async let outcome = harness.router.redeliverVerifiedPayload(
+            terminalID: harness.terminal.id, sessionID: "sess-1", payload: "hi", submit: true)
+        // Bounded window: with the lane held, the retry must write nothing.
+        try await Task.sleep(for: .milliseconds(100))
+        #expect(writes.writes.isEmpty, "a retry must not splice into another send's write")
+
+        await gate.open()
+        try await laneHolder
+        #expect(await outcome == .dispatched)
+        #expect(writes.writes.count == 1)
+    }
+
+    /// The tmux retry is untouched: it still consults the pane and pastes
+    /// through tmux, then presses Enter as a separate act.
+    @Test("a tmux retry still pastes through tmux")
+    func aTmuxRetryStillPastesThroughTmux() async throws {
+        let harness = try await SendHarness.make(transport: .tmux)
+
+        let outcome = await harness.router.redeliverVerifiedPayload(
+            terminalID: harness.terminal.id, sessionID: "sess-1", payload: "hi", submit: true)
+
+        #expect(outcome == .dispatched)
+        #expect(harness.tmux.pastedBodies == ["hi"])
+        #expect(harness.tmux.sentKeys == ["Enter"])
+    }
+}
+
+/// What the courier was asked to write. Lock-guarded because `writeDirectly`
+/// runs off the test's task.
+private final class HolderVerifyWriteRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _writes: [Data] = []
+    var writes: [Data] { lock.withLock { _writes } }
+    func record(_ bytes: Data) { lock.withLock { _writes.append(bytes) } }
+}
+
+/// A verifier that records what it was armed with and does nothing else, so a
+/// test can assert the arming without a transcript, a clock or a retry.
+private final class ArmingRecorder: DeliveryVerificationArming, @unchecked Sendable {
+    struct Arming: Sendable {
+        let actuationID: String
+        let terminalID: UUID
+        let sessionID: String?
+        let deliveredPayload: String
+        let submit: Bool
+    }
+
+    private let lock = NSLock()
+    private var _armings: [Arming] = []
+    var armings: [Arming] { lock.withLock { _armings } }
+
+    func armVerification(
+        actuationID: String, terminalID: UUID, sessionID: String?,
+        deliveredPayload: String, submit: Bool
+    ) async {
+        let arming = Arming(
+            actuationID: actuationID, terminalID: terminalID, sessionID: sessionID,
+            deliveredPayload: deliveredPayload, submit: submit)
+        lock.withLock { _armings.append(arming) }
+    }
+}
+
+/// The failure a courier whose direct write cannot land reports.
+private struct HolderRetryWriteFailure: Error {}
+
+/// A one-shot gate a test can open from the outside.
+private actor RetryLaneGate {
+    private var opened = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+    private var entered = false
+
+    func open() {
+        opened = true
+        for waiter in waiters { waiter.resume() }
+        waiters.removeAll()
+    }
+
+    func wait() async {
+        entered = true
+        if opened { return }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+
+    var hasEntered: Bool { entered }
+}


### PR DESCRIPTION
## Summary

Send a message with a newline in it to a session running on the pty-holder
transport and, until this PR, it bounced: `terminal.send was refused: … which
delivers a message in one unwrapped write`. Ask for `--verify` on the same
session and it bounced too, with a different reason — the transport had "no
delivery observation". Both are things a person and every daemon rail do
routinely on a tmux-backed session, so a holder-backed one was a session you
could talk to only in single lines and never get a receipt from.

This PR closes both gaps. A holder-backed session now takes a multi-line
message, and `terminal.send --verify` works there on the same terms it works on
tmux — including the verifier's one re-delivery when the first send is not
observed.

It is the second half of issue #851's Phase 2 item 7 ("Composite / multi-part
`terminal.send`, named keys, and `--verify` re-read"). #854 shipped the named
keys; this ships the composite/multi-line body and the verified send. What
stays open in that item after this is the genuinely multi-body message — see
"still refused" below.

## Why this shape

**A multi-line body needs no second write, only the right framing.** The
refusal this replaces was written against a measurement of *unwrapped* writes:
past 64 bytes a bare `\r` in the same chunk as the text is swallowed by the
receiving TUI's paste-burst heuristic and the message sits unsent. That is a
property of the bytes, not of the transport — and `HolderSendComposition`
already answers it, by wrapping the body in `ESC[200~`…`ESC[201~` when the
child's bracketed-paste mode calls for it and putting the submitting `\r`
*after* the end marker. That is exactly the property the tmux arm buys by
pasting and pressing Enter as two separate acts, obtained here without
splitting the message across two writes — so a payload is still never split
across a routing decision. Nothing new had to be built for it; the composite
gate simply had to stop matching on `\n`.

**`--verify` was refused for a reason that turns out not to be true.** The
inventory in #851 §5 records the verified re-delivery as needing "a holder
re-read of the emulator screen". It does not: the observation is
`DeliveryVerifier` reading the child's transcript JSONL for the dispatch
envelope the send delivered. It never reads a rendered screen — which this
repo forbids for state anyway — so it is transport-blind, and the holder arm
owed only the two ends of it: arm the observation after a successful write,
and give the verifier a way to re-deliver through `HolderInjectionCourier`
instead of `tmux.pasteText`. The holder verify gate is therefore a mirror of
the tmux one rather than a transport rule of its own: the same three states in
which no observation could be produced, in the same order, in the same words.

**The re-delivery recomposes rather than replays.** The tmux retry re-pastes
the exact payload because tmux decides the bracketing at paste time. Here the
daemon decides it, and a minute has passed since the observation — a viewer may
have attached or detached and the child's mode flipped — so the retry asks the
oracle again and rewraps. The body it is handed is the composed body (envelope
and text, before any marker), so it takes no second envelope.

No new spec: this is feature-parity work against an existing one,
[`docs/specs/2026-08-30-pty-holder-session-transport-design.md`](docs/specs/2026-08-30-pty-holder-session-transport-design.md)
— "Input injection" under Feature parity, and "Input is not arbitrated, but it
is serialized" for the lane the re-delivery now queues in.

## What this PR does

All in `Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift`.

- **The composite gate stops refusing newlines.** `performTerminalSend`'s
  holder arm no longer matches `body.contains("\n")`, nor a newline inside a
  single text part. A single body of text — one line or many — goes to
  `performHolderSend`.
- **`--verify` is no longer a transport refusal.** `holderVerifyRefusal` is
  deleted. `performHolderSend` gains a gate that mirrors the tmux arm's: refuse
  a target with no transcript (a shell, or a non-Claude agent), refuse while
  `delivery_verification_enabled` is off, refuse when the flag is on but no
  verifier is wired. Each refusal is the tmux arm's own wording.
- **A verified holder send arms the observation.** `deliverHolderText` takes
  the arming decision and, on a successful write of a non-empty body, hands
  `deliveryVerifier` the composed body — envelope and text, before the paste
  markers, because what the transcript records is the message and not the
  control bytes that framed it. A bare `--text "" --submit` arms nothing.
- **`redeliverVerifiedPayload` gains a holder branch.** It re-injects through
  the courier inside the terminal's own send lane, recomposing the wrapping
  from a fresh mode reading; classifies "no courier" and a child the holder has
  reported exited as `.refused(.notEligible)`, and a write the courier could
  not make as `.transportFailed`; and arms nothing further, because this call
  *is* the verifier's retry.
- **Two refusal texts reworded** to describe the framing that is missing rather
  than the 64-byte cliff that no longer applies, and to say the multi-body case
  is out of scope until a spec settles it rather than pointing at a specific
  future PR.

**What is still refused on a holder row**, by name:

- A message in more than one part — several parts have no single-write framing.
- An image on its own *when the dispatch envelope would be attached*: the image
  attaches only when the whole paste is the quoted path and nothing else, the
  envelope cannot ride ahead of it, and there is no second write to give it.
  The same image-only send to a shell row, or under an authenticated envelope
  suppression, is delivered.

**Who arms an observation.** An explicit `--verify` from any caller, plus the
daemon's own supervision rails by default on a holder row whenever
`delivery_verification_enabled` is on. That default is a deliberate
holder-transport rule from
[`docs/specs/2026-09-05-child-as-contract-party-design.md`](docs/specs/2026-09-05-child-as-contract-party-design.md)
("Delivery verification on holder sends" → "What changes"): the rails are the
senders whose silence costs hours, and a rail sending to a **tmux** session
keeps today's per-send opt-in, because that arm already delivers with explicit
bracketing and a separate Enter and so lacks the failure shape that motivates
the default. A person or a script opts in per send on both transports.

Two limits on that default are worth stating plainly:

- **It arms opportunistically and never refuses.** Only an explicit `--verify`
  can be refused by the gate; a rail's ordinary send to a shell holder, or in
  the window between the flag going on and the daemon restarting to wire a
  verifier, is delivered *unarmed*. A supervision send that failed closed
  because supervision's own witness was not ready would be the exact failure
  the mechanism exists to prevent.
- **It never arms a send that carries no dispatch envelope.** The observation
  searches the transcript for this row's dispatch id and for nothing else
  (`DeliveryVerifier.envelopeAppears`), so an envelope-suppressed send is one
  it structurally cannot find — arming it would guarantee a not-landed verdict
  at the deadline and spend the single retry re-typing the message into the
  session a second time. The queued prompt sends `.suppressed` by design, so
  the operator's own words arrive byte-identically, and it therefore goes
  unarmed. An explicit `--verify` keeps its existing meaning on both
  transports, suppression included.
- **It reaches only the rails that actually send through the `terminal.send`
  handler**, which today means the queued prompt
  (`sendQueuedPromptVerbatim` → `performTerminalSend`) — and, per the bullet
  above, that one goes unarmed. In practice the default therefore arms nothing
  in today's tree; it is the seam a rail gets by routing through the handler
  with its envelope attached. Two rails the spec's "What changes" bullet names
  are *not* covered by this PR, and neither is touched by it:
  - `LimitResumeActuator.sendHolderContinue` writes to
    `HolderInjectionCourier` directly rather than through `performHolderSend`,
    so limit-resume's holder auto-continues arm nothing; that rail keeps its
    own `verifyResumed` polling loop as its witness.
  - `DeskSessionManager.nudgeDeskSession` and `postShiftWrapUp` call
    `tmux.pasteText`/`tmux.sendKey` with no transport branch at all (unlike
    `closeDeskSession` in the same file), so a holder-backed supervision
    session gets neither the arming nor a transport-aware send from them.
    That is the pre-existing gap issue #851 §5 already records for the
    supervision desk.

  Routing those two through the handler is follow-up work under issue #851
  Phase 2 item 7, deliberately not done here.

One defect the tests exposed is fixed in its own commit (`8f7bf4e65`): the
holder re-delivery returned *before* the `terminalSendSerializer.run` the tmux
body queues in, so the verifier's retry could write to a pty a concurrent send
was mid-write on — which `redeliverVerifiedPayload`'s own documentation
already promised it could not. The holder branch now runs inside the lane, with
the holder's last reported child status asked inside it too, for the same
reason the tmux arm consults the pane inside it.

## Flag & rollout

**No new flag.** Both behaviours sit behind flags that already exist and
already default off:

- Holder-backed rows only exist where `pty_holder_enabled` spawned them — the
  transport's soak gate, still default-off. A tmux-backed row reaches none of
  this code.
- Delivery verification is gated by `delivery_verification_enabled`, also
  default-off, and its off branch is a refusal rather than a silent downgrade.
  Nothing here changes either default or either graduation plan.

## Assumptions

- **`actor.kind == "daemon"` is a declaration, not an authentication.** This is
  the first place in the tree that branches *behavior* on that field rather
  than only labeling a record row, and `ActuationActor`'s own doc is explicit
  that it is "ambient declaration, never authentication" — any process on the
  daemon socket can claim it. So a local caller that calls itself `daemon` on a
  send whose envelope rides reaches the default-arming branch. What it gets is
  bounded to what a rail gets: an observation it did not ask for, and at most
  one re-delivery of its own message. Nothing here refuses, deletes or
  redirects on the strength of the claim, so the fail-open shape matches every
  other reader of the field; the one gate that does require proof,
  `authenticatesEnvelopeSuppression`, is unchanged. Stated at the call site as
  well, so a future reader is not left to infer it from today's callers.
- **The observation is transport-blind.** This takes `DeliveryVerifier` to keep
  observing through the transcript tail rather than any screen read. If a
  future observation source were made to read a pane, the holder arm's verify
  gate would be promising evidence it could not produce.
- **The mode oracle's answer is good enough to compose against.** A
  `staleDaemon` reading can be hours old, so a wrapped body can reach a child
  that turned bracketing off since (it prints the markers) or a bare body can
  reach one that turned it on (its heuristic can absorb the `\r`). That
  trade-off is the spec's "Proceeding on stale modes" ruling, unchanged here
  and now also applied to the re-delivery.
- **One courier write is one uninterrupted write.** The whole message is handed
  to `HolderInjectionCourier.deliver` in a single call, which is what keeps a
  payload from being split across a routing decision.

## Evidence & verification

No live verification: this branch's daemon changes are exercised through the
`SendHarness` fixture, which runs the production handler with a recording
courier rather than a stub, so the assertions are on the exact bytes composed.

New and updated tests, all in `Tests/TBDDaemonTests`:

`HolderCompositeSendRefusalTests` (rewritten around what one write *can* frame):

- `aMultiLineTextSendToAHolderRowIsDeliveredInOneWrappedWrite` — the case this
  suite previously asserted was refused. Asserts the whole message: start
  marker, envelope, both lines, end marker, then the `\r` **outside** it.
- `aMultiLineSendCarriesTheSameMessageOnBothTransports` — the same params on a
  tmux harness and a holder harness; the caller's message past the envelope
  line is byte-identical, and tmux's separate `Enter` is the holder's trailing
  `\r`.
- `aSingleMultiLineTextPartIsDelivered` — the same for a one-part `.parts`
  payload, which the old gate also matched on.
- `aMultiLineSendToAChildWithBracketingOffIsBare` — the off branch of the
  wrapping conditional.
- `aPartsSendToAHolderRowIsRefused`,
  `anUnauthenticatedSingleImagePartSendToAHolderRowIsRefused` — what is still
  refused, asserted against the reworded text.
- `aTmuxRowStillAcceptsMultiLineAndParts` — tmux unchanged.

`HolderVerifiedSendTests` (new):

- `aVerifiedHolderSendIsDeliveredAndArmed` — flag on, verifier wired: the write
  happens and the observation is armed on the composed body, with the paste
  markers excluded from the payload handed to the verifier.
- `aVerifylessHolderSendArmsNothing` — a person's app send that did not ask,
  the off branch of the arming conditional.
- `aDaemonRailSendIsArmedByDefaultOnHolderOnly` — both halves of the spec's
  default-arming rule: armed on holder, not armed on tmux.
- `aDaemonRailSendToAHolderShellRowIsUnarmed`,
  `aDaemonRailSendIsNotRefusedWithoutAWiredVerifier` — the default arms
  opportunistically: where nothing could be observed it delivers unarmed rather
  than refusing, unlike an explicit `--verify` in the same states.
- `aQueuedPromptSendArmsNothing` — driven through `sendQueuedPromptVerbatim`,
  the real production caller and the only caller of `.suppressed`: delivered
  verbatim, armed for nothing, because an envelope-less send is one the
  observation cannot find.
- `aDaemonRailSendArmsNothingWithTheFlagOff` — the shipped-default off branch
  of that same rule.
- `aVerifiedHolderShellSendIsRefusedByKind`,
  `aVerifiedHolderSendIsRefusedWithTheFlagOff`,
  `aVerifiedHolderSendIsRefusedWithoutAWiredVerifier` — the three states in
  which no observation could be produced, each asserted to produce the *same*
  message the tmux arm produces for the same state, and each asserted to write
  nothing.
- `aHolderRetryReinjectsThroughTheCourier`,
  `aHolderRetryComposesBareForAChildWithoutBrackets` — the re-delivery's bytes,
  rewrapped from a fresh reading, with nothing reaching tmux.
- `aHolderRetryWithNoCourierIsNotEligible`,
  `aHolderRetryThatCannotBeWrittenIsATransportFailure`,
  `aHolderRetryToAShellRowIsNotEligible`,
  `aHolderRetryToAReboundConversationIsRefused` — the retry's classifications.
  On `main` the first two answered `.dispatched` after pasting at the empty
  pane id a holder row carries by construction.
- `aHolderRetryArmsNoFurtherVerification` — no observe-your-own-retry loop.
- `aHolderRetryQueuesBehindTheLane` — holds the terminal's lane from outside
  and proves the retry writes nothing until it is released; fails without the
  fix commit.
- `aTmuxRetryStillPastesThroughTmux` — the tmux retry unchanged.

`HolderTmuxAssumptionGateTests` (the suite that pinned the old behaviour):

- `sendVerifyRefusesHolderRow` asserted the deleted `holderVerifyRefusal`
  verbatim and is replaced by
  `sendVerifyRefusesHolderRowWhileTheFlagIsOff`, which pins the same send
  refused for the reason a tmux row with the same config is refused — the flag
  — and asserts the message does **not** name the transport, since a caller
  told "this transport has no delivery observation" would stop asking for one.

`swiftlint --strict` is clean over the tree (0 violations in 1077 files). The
suite itself was not run on this machine — it is under heavy memory pressure
and local Swift builds were off-limits for this work — so CI's `test.yml` run
on this branch is the verdict.

https://claude.ai/code/session_01TggE2eESL3BcvSgFcLZkpk

[holder injection gaps](https://cheapsteak.github.io/tbd/open/?worktree=B3A0F1F4-5868-4B98-B61E-121462E760AD)
